### PR TITLE
Enhanced app.manifest for Windows 10.

### DIFF
--- a/osu.Desktop/Properties/app.manifest
+++ b/osu.Desktop/Properties/app.manifest
@@ -25,14 +25,16 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      *  <!-- Windows 8.1 -->
-      *  <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />
       <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
       <!-- Windows 8 -->
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
   <asmv3:application>
@@ -40,4 +42,16 @@
       <dpiAware>true</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
 </asmv1:assembly>


### PR DESCRIPTION
- Supported OS:
  - If Windows 10 is not listed, querying Windows version will get Windows 8.1.
- Microsoft.Windows.Common-Controls:
  - If a Windows MessageBox is called, get a modern one instead of a classic one.

These may not be called often, but since we have app.manifest, we can set them correctly.
