### PR TITLE
Key counter

### DIFF
--- a/osu.Desktop.VisualTests/Tests/TestCaseKeyCounter.cs
+++ b/osu.Desktop.VisualTests/Tests/TestCaseKeyCounter.cs
@@ -1,0 +1,57 @@
+﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+//Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using OpenTK.Input;
+using osu.Framework.GameModes.Testing;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.MathUtils;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Desktop.Tests
+{
+    class TestCaseKeyCounter : TestCase
+    {
+        public override string Name => @"KeyCounter";
+
+        public override string Description => @"Key counter test";
+
+        KeyCounter kc;
+
+        public override void Reset()
+        {
+            base.Reset();
+            Add(
+                kc = new KeyCounter
+                {
+                    Position = new Vector2(50, 50)
+                }
+            );
+            kc.AddKey(new KeyCount(@"Z", Key.Z));
+            kc.AddKey(new KeyCount(@"X", Key.X));
+            kc.AddKey(new MouseCount(@"M1", MouseButton.Left));
+            kc.AddKey(new MouseCount(@"M2", MouseButton.Right));
+        }
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
+        {
+            kc.TriggerMouseDown(state, args);
+            return false;
+        }
+
+        protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
+        {
+            kc.TriggerMouseUp(state, args);
+            return false;
+        }
+    }
+}

--- a/osu.Desktop.VisualTests/osu.Desktop.VisualTests.csproj
+++ b/osu.Desktop.VisualTests/osu.Desktop.VisualTests.csproj
@@ -150,6 +150,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
+    <Compile Include="Tests\TestCaseKeyCounter.cs" />
     <Compile Include="Tests\TestCaseTextAwesome.cs" />
     <Compile Include="VisualTestGame.cs" />
   </ItemGroup>

--- a/osu.Game/Graphics/UserInterface/Count.cs
+++ b/osu.Game/Graphics/UserInterface/Count.cs
@@ -1,0 +1,146 @@
+﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+//Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class Count : Container
+    {
+        protected const double FadingTime = 200;
+
+        protected Sprite glow;
+        protected Sprite hit;
+        protected Sprite up;
+        protected Container text;
+        protected SpriteText headerText;
+        protected SpriteText countText;
+
+        protected string header;
+        public string Header
+        {
+            get { return header; }
+            set
+            {
+                header = value;
+                if (headerText != null)
+                    headerText.Text = value;
+            }
+        }
+
+        public int counter = 0;
+        public int Counter
+        {
+            get { return counter; }
+            protected set
+            {
+                counter = value;
+                if (countText != null)
+                    countText.Text = value.ToString("#,##0");
+            }
+        }
+
+        public bool lit = false;
+        public bool IsLit
+        {
+            get { return lit; }
+            set
+            {
+                if (IsCounting)
+                {
+                    if (!lit && value)
+                    {
+                        Counter++;
+                        hit.Alpha = 1;
+                        text.Colour = OpenTK.Graphics.Color4.DimGray;
+                        glow.FadeIn(FadingTime);
+                    }
+                    if (lit && !value)
+                    {
+                        hit.Alpha = 0;
+                        text.Colour = OpenTK.Graphics.Color4.White;
+                        glow.FadeOut(FadingTime);
+                    }
+                    lit = value;
+                }
+            }
+        }
+
+        public bool counting = true;
+        public bool IsCounting
+        {
+            get { return counting; }
+            set
+            {
+                if (!value)
+                    IsLit = false;
+                counting = value;
+            }
+        }
+
+        public override void Load()
+        {
+            base.Load();
+
+            Children = new Drawable[]
+            {
+                glow = new Sprite
+                {
+                    Texture = Game.Textures.Get(@"KeyCounter/key-glow"),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Alpha = 0
+                },
+                hit = new Sprite
+                {
+                    Texture = Game.Textures.Get(@"KeyCounter/key-hit"),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Alpha = 0
+                },
+                up = new Sprite
+                {
+                    Texture = Game.Textures.Get(@"KeyCounter/key-up"),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                },
+                text = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    SizeMode = InheritMode.XY,
+                    Children = new Drawable[]
+                    {
+                        headerText = new SpriteText
+                        {
+                            Text = header,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            PositionMode = InheritMode.XY,
+                            Position = new Vector2(0, 0.125f)
+                        },
+                        countText = new SpriteText
+                        {
+                            Text = Counter.ToString("#,##0"),
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            PositionMode = InheritMode.XY,
+                            Position = new Vector2(0, 0.125f)
+                        }
+                    }
+                }
+            };
+
+            Width = hit.Width;
+            Height = hit.Height;
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/KeyCount.cs
+++ b/osu.Game/Graphics/UserInterface/KeyCount.cs
@@ -1,0 +1,43 @@
+﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+//Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK.Input;
+using osu.Framework.Graphics;
+using osu.Framework.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class KeyCount : Count
+    {
+        public Key Key { get; private set; }
+
+        public KeyCount(String header, Key key)
+        {
+            Header = header;
+            Key = key;
+        }
+
+        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        {
+            if (args.Key == Key)
+            {
+                IsLit = true;
+            }
+            return false;
+        }
+
+        protected override bool OnKeyUp(InputState state, KeyUpEventArgs args)
+        {
+            if (args.Key == Key)
+            {
+                IsLit = false;
+            }
+            return false;
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/KeyCounter.cs
+++ b/osu.Game/Graphics/UserInterface/KeyCounter.cs
@@ -1,0 +1,64 @@
+﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+//Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class KeyCounter : FlowContainer
+    {
+        private List<Count> Counts = new List<Count>();
+
+        public bool counting = true;
+        public bool IsCounting
+        {
+            get { return counting; }
+            set
+            {
+                foreach (Count count in Counts)
+                {
+                    count.IsCounting = value;
+                }
+                counting = value;
+            }
+        }
+
+        public void AddKey(Count count)
+        {
+            count.IsCounting = IsCounting;
+            base.Add(count);
+            Counts.Add(count);
+        }
+
+        public override void Load()
+        {
+            base.Load();
+            Direction = FlowDirection.HorizontalOnly;
+        }
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
+        {
+            foreach (Count count in Counts)
+            {
+                count.TriggerMouseDown(state, args);
+            }
+            return false;
+        }
+
+        protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
+        {
+            foreach (Count count in Counts)
+            {
+                count.TriggerMouseUp(state, args);
+            }
+            return false;
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/MouseCount.cs
+++ b/osu.Game/Graphics/UserInterface/MouseCount.cs
@@ -1,0 +1,43 @@
+﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+//Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK.Input;
+using osu.Framework.Graphics;
+using osu.Framework.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class MouseCount : Count
+    {
+        public MouseButton Button { get; private set; }
+
+        public MouseCount(String header, MouseButton button)
+        {
+            Header = header;
+            Button = button;
+        }
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
+        {
+            if (args.Button == Button)
+            {
+                IsLit = true;
+            }
+            return false;
+        }
+
+        protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
+        {
+            if (args.Button == Button)
+            {
+                IsLit = false;
+            }
+            return false;
+        }
+    }
+}

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -53,6 +53,10 @@
     <Compile Include="Graphics\Containers\OsuLargeComponent.cs" />
     <Compile Include="Graphics\Processing\RatioAdjust.cs" />
     <Compile Include="Graphics\TextAwesome.cs" />
+    <Compile Include="Graphics\UserInterface\Count.cs" />
+    <Compile Include="Graphics\UserInterface\KeyCount.cs" />
+    <Compile Include="Graphics\UserInterface\KeyCounter.cs" />
+    <Compile Include="Graphics\UserInterface\MouseCount.cs" />
     <Compile Include="Online\API\APIAccess.cs" />
     <Compile Include="Online\API\APIRequest.cs" />
     <Compile Include="Online\API\OAuth.cs" />


### PR DESCRIPTION
Implementation of #29 

Counting is done automagically when `IsLit` is toogled from `false` to `true`. TBH, I'm not sure it's good idea to abuse getters and setters for what I've done. I've done it, though, trying to avoid creating unnecessary functions to handle one-time transitions between states, but I can change it if you don't like it.

Expecting feedback, peace out.
