### PR TITLE
Improved beatmaps

### DIFF
--- a/osu.Desktop/Beatmaps/IO/LegacyFilesystemReader.cs
+++ b/osu.Desktop/Beatmaps/IO/LegacyFilesystemReader.cs
@@ -31,7 +31,8 @@ namespace osu.Desktop.Beatmaps.IO
             using (var stream = new StreamReader(ReadFile(beatmaps[0])))
             {
                 var decoder = BeatmapDecoder.GetDecoder(stream);
-                firstMap = decoder.Decode(stream);
+                firstMap = new Beatmap();
+                decoder.Decode(stream, firstMap);
             }
         }
 

--- a/osu.Desktop/Beatmaps/IO/LegacyFilesystemReader.cs
+++ b/osu.Desktop/Beatmaps/IO/LegacyFilesystemReader.cs
@@ -21,7 +21,7 @@ namespace osu.Desktop.Beatmaps.IO
         private string basePath { get; set; }
         private string[] beatmaps { get; set; }
         private Beatmap firstMap { get; set; }
-    
+
         public LegacyFilesystemReader(string path)
         {
             basePath = path;

--- a/osu.Game.Tests/Beatmaps/Formats/OsuLegacyDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuLegacyDecoderTest.cs
@@ -3,6 +3,7 @@ using System.IO;
 using NUnit.Framework;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Beatmaps.Objects.Osu;
 using osu.Game.Beatmaps.Samples;
@@ -25,7 +26,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decoder = new OsuLegacyDecoder();
             using (var stream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             {
-                var beatmap = decoder.Decode(new StreamReader(stream));
+                Beatmap beatmap = new Beatmap();
+                decoder.Decode(new StreamReader(stream), beatmap);
                 var meta = beatmap.Metadata;
                 Assert.AreEqual(241526, meta.BeatmapSetID);
                 Assert.AreEqual("Soleily", meta.Artist);
@@ -47,7 +49,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decoder = new OsuLegacyDecoder();
             using (var stream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             {
-                var beatmap = decoder.Decode(new StreamReader(stream));
+                Beatmap beatmap = new Beatmap();
+                decoder.Decode(new StreamReader(stream), beatmap);
                 Assert.AreEqual(0, beatmap.AudioLeadIn);
                 Assert.AreEqual(false, beatmap.Countdown);
                 Assert.AreEqual(SampleSet.Soft, beatmap.SampleSet);
@@ -65,7 +68,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decoder = new OsuLegacyDecoder();
             using (var stream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             {
-                var beatmap = decoder.Decode(new StreamReader(stream));
+                Beatmap beatmap = new Beatmap();
+                decoder.Decode(new StreamReader(stream), beatmap);
                 int[] expectedBookmarks =
                 {
                     11505, 22054, 32604, 43153, 53703, 64252, 74802, 85351,
@@ -88,7 +92,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decoder = new OsuLegacyDecoder();
             using (var stream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             {
-                var beatmap = decoder.Decode(new StreamReader(stream));
+                Beatmap beatmap = new Beatmap();
+                decoder.Decode(new StreamReader(stream), beatmap);
                 var difficulty = beatmap.BaseDifficulty;
                 Assert.AreEqual(6.5f, difficulty.DrainRate);
                 Assert.AreEqual(4, difficulty.CircleSize);
@@ -105,7 +110,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decoder = new OsuLegacyDecoder();
             using (var stream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             {
-                var beatmap = decoder.Decode(new StreamReader(stream));
+                Beatmap beatmap = new Beatmap();
+                decoder.Decode(new StreamReader(stream), beatmap);
                 Color4[] expected =
                 {
                     new Color4(142, 199, 255, 255),
@@ -126,7 +132,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             var decoder = new OsuLegacyDecoder();
             using (var stream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             {
-                var beatmap = decoder.Decode(new StreamReader(stream));
+                Beatmap beatmap = new Beatmap();
+                decoder.Decode(new StreamReader(stream), beatmap);
                 var slider = beatmap.HitObjects[0] as Slider;
                 Assert.IsNotNull(slider);
                 Assert.AreEqual(new Vector2(192, 168), slider.Position);

--- a/osu.Game/Beatmaps/BeatmapSet.cs
+++ b/osu.Game/Beatmaps/BeatmapSet.cs
@@ -22,5 +22,7 @@ namespace osu.Game.Beatmaps
         public BeatmapMetadata Metadata { get; set; }
         [Ignore]
         public User Creator { get; set; }
+        public string Hash { get; set; }
+        public string Path { get; set; }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapSet.cs
+++ b/osu.Game/Beatmaps/BeatmapSet.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Beatmaps
         [NotNull, Indexed]
         public int BeatmapMetadataID { get; set; }
         [Ignore]
-        public List<Beatmap> Beatmaps { get; protected set; }
+        public List<Beatmap> Beatmaps { get; protected set; } = new List<Beatmap>();
         [Ignore]
         public BeatmapMetadata Metadata { get; set; }
         [Ignore]

--- a/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
@@ -20,6 +20,6 @@ namespace osu.Game.Beatmaps.Formats
             decoders[magic] = typeof(T);
         }
     
-        public abstract Beatmap Decode(TextReader stream);
+        public abstract void Decode(TextReader stream, Beatmap beatmap);
     }
 }

--- a/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
@@ -202,16 +202,16 @@ namespace osu.Game.Beatmaps.Formats
             });
         }
 
-        public override Beatmap Decode(TextReader stream)
+        public override void Decode(TextReader stream, Beatmap beatmap)
         {
-            var beatmap = new Beatmap
-            {
-                Metadata = new BeatmapMetadata(),
-                BaseDifficulty = new BaseDifficulty(),
-                HitObjects = new List<HitObject>(),
-                ControlPoints = new List<ControlPoint>(),
-                ComboColors = new List<Color4>(),
-            };
+            // We don't overwrite these two because they're DB bound
+            if (beatmap.Metadata == null) beatmap.Metadata = new BeatmapMetadata();
+            if (beatmap.BaseDifficulty == null) beatmap.BaseDifficulty = new BaseDifficulty();
+            // These are fine though
+            beatmap.HitObjects = new List<HitObject>();
+            beatmap.ControlPoints = new List<ControlPoint>();
+            beatmap.ComboColors = new List<Color4>();
+            
             var section = Section.None;
             string line;
             while (true)
@@ -266,7 +266,6 @@ namespace osu.Game.Beatmaps.Formats
                         break;
                 }
             }
-            return beatmap;
         }
     }
 }

--- a/osu.Game/Beatmaps/IO/OszArchiveReader.cs
+++ b/osu.Game/Beatmaps/IO/OszArchiveReader.cs
@@ -33,7 +33,8 @@ namespace osu.Game.Beatmaps.IO
             using (var stream = new StreamReader(ReadFile(beatmaps[0])))
             {
                 var decoder = BeatmapDecoder.GetDecoder(stream);
-                firstMap = decoder.Decode(stream);
+                firstMap = new Beatmap();
+                decoder.Decode(stream, firstMap);
             }
         }
 

--- a/osu.Game/Beatmaps/IO/OszArchiveReader.cs
+++ b/osu.Game/Beatmaps/IO/OszArchiveReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using Ionic.Zip;
 using osu.Game.Beatmaps.Formats;
 

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
@@ -12,9 +13,11 @@ namespace osu.Game.Database
     public class BeatmapDatabase
     {
         private static SQLiteConnection connection { get; set; }
+        private BasicStorage storage;
         
         public BeatmapDatabase(BasicStorage storage)
         {
+            this.storage = storage;
             if (connection == null)
             {
                 connection = storage.GetDatabase(@"beatmaps");
@@ -24,17 +27,39 @@ namespace osu.Game.Database
                 connection.CreateTable<Beatmap>();
             }
         }
-        public void AddBeatmap(ArchiveReader input)
+        public void AddBeatmap(string path)
         {
-            var metadata = input.ReadMetadata();
+            string hash = null;
+            ArchiveReader reader;
+            if (File.Exists(path)) // Not always the case, i.e. for LegacyFilesystemReader
+            {
+                using (var md5 = MD5.Create())
+                using (var input = storage.GetStream(path))
+                {
+                    hash = BitConverter.ToString(md5.ComputeHash(input)).Replace("-", "").ToLowerInvariant();
+                    input.Seek(0, SeekOrigin.Begin);
+                    var outputPath = Path.Combine(@"beatmaps", hash.Remove(1), hash.Remove(2), hash);
+                    using (var output = storage.GetStream(outputPath, FileAccess.Write))
+                        input.CopyTo(output);
+                    reader = ArchiveReader.GetReader(storage, path = outputPath);
+                }
+            }
+            else
+                reader = ArchiveReader.GetReader(storage, path);
+            var metadata = reader.ReadMetadata();
             if (connection.Table<BeatmapSet>().Count(b => b.BeatmapSetID == metadata.BeatmapSetID) != 0)
                 return;
-            string[] mapNames = input.ReadBeatmaps();
-            var beatmapSet = new BeatmapSet { BeatmapSetID = metadata.BeatmapSetID };
+            string[] mapNames = reader.ReadBeatmaps();
+            var beatmapSet = new BeatmapSet
+            {
+                BeatmapSetID = metadata.BeatmapSetID,
+                Path = path,
+                Hash = hash,
+            };
             var maps = new List<Beatmap>();
             foreach (var name in mapNames)
             {
-                using (var stream = new StreamReader(input.ReadFile(name)))
+                using (var stream = new StreamReader(reader.ReadFile(name)))
                 {
                     var decoder = BeatmapDecoder.GetDecoder(stream);
                     var beatmap = decoder.Decode(stream);
@@ -45,6 +70,13 @@ namespace osu.Game.Database
             beatmapSet.BeatmapMetadataID = connection.Insert(metadata);
             connection.Insert(beatmapSet);
             connection.InsertAll(maps);
+        }
+
+        /// <summary>
+        /// Given a BeatmapSet pulled from the database, loads the rest of its data from disk.
+        /// </summary>        public void PopulateBeatmap(BeatmapSet beatmap)
+        {
+            // TODO
         }
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -73,8 +73,7 @@ namespace osu.Game
             {
                 try
                 {
-                    var reader = ArchiveReader.GetReader(Host.Storage, message.Path);
-                    Beatmaps.AddBeatmap(reader);
+                    Beatmaps.AddBeatmap(message.Path);
                     // TODO: Switch to beatmap list and select the new song
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Imported beatmaps are now copied into beatmap storage, plus updates based on feedback from @peppy.

Note: you have to delete your existing beatmaps.db if you already have one from testing this behavior before.

Hydrating a beatmap now looks like this:

``` c#
BeatmapDatabase db = /* grab db from whatever */;
BeatmapSet set = /* grab unhydrated set from db */;
db.PopulateBeatmap(set);
```

This will load from disk the hit objects and such. You can also do this:

``` c#
ArchiveReader reader = db.GetReader(set);
```

Which you can then i.e. `reader.GetStream(set.Metadata.BackgroundFile)` or `reader.GetStream(set.Metadata.AudioFile)`.
