### PR TITLE
Use DrawSize instead of Size whereever Size was previously read due t…

### DIFF
--- a/osu.Game/GameModes/BackgroundMode.cs
+++ b/osu.Game/GameModes/BackgroundMode.cs
@@ -35,7 +35,7 @@ namespace osu.Game.GameModes
         {
             base.Load(game);
 
-            Content.Scale *= 1 + (x_movement_amount / Size.X) * 2;
+            Content.Scale *= 1 + (x_movement_amount / DrawSize.X) * 2;
         }
 
         protected override void OnEntering(GameMode last)

--- a/osu.Game/GameModes/GameModeWhiteBox.cs
+++ b/osu.Game/GameModes/GameModeWhiteBox.cs
@@ -39,7 +39,7 @@ namespace osu.Game.GameModes
                 popButton.Alpha = 1;
 
             Content.Alpha = 0;
-            textContainer.Position = new Vector2(Size.X / 16, 0);
+            textContainer.Position = new Vector2(DrawSize.X / 16, 0);
 
             box.ScaleTo(0.2f);
             box.RotateTo(-20);
@@ -55,7 +55,7 @@ namespace osu.Game.GameModes
 
         protected override bool OnExiting(GameMode next)
         {
-            textContainer.MoveTo(new Vector2((Size.X / 16), 0), transition_time, EasingTypes.OutExpo);
+            textContainer.MoveTo(new Vector2((DrawSize.X / 16), 0), transition_time, EasingTypes.OutExpo);
             Content.FadeOut(transition_time, EasingTypes.OutExpo);
 
             return base.OnExiting(next);
@@ -65,7 +65,7 @@ namespace osu.Game.GameModes
         {
             base.OnSuspending(next);
 
-            textContainer.MoveTo(new Vector2(-(Size.X / 16), 0), transition_time, EasingTypes.OutExpo);
+            textContainer.MoveTo(new Vector2(-(DrawSize.X / 16), 0), transition_time, EasingTypes.OutExpo);
             Content.FadeOut(transition_time, EasingTypes.OutExpo);
         }
 

--- a/osu.Game/GameModes/Menu/Button.cs
+++ b/osu.Game/GameModes/Menu/Button.cs
@@ -136,7 +136,7 @@ namespace osu.Game.GameModes.Menu
                 LoopDelay = duration
             });
 
-            icon.Transforms.Add(new TransformScaleVector(Clock)
+            icon.Transforms.Add(new TransformScale(Clock)
             {
                 StartValue = new Vector2(1, 0.9f),
                 EndValue = Vector2.One,
@@ -158,7 +158,7 @@ namespace osu.Game.GameModes.Menu
                 LoopDelay = duration
             });
 
-            icon.Transforms.Add(new TransformScaleVector(Clock)
+            icon.Transforms.Add(new TransformScale(Clock)
             {
                 StartValue = Vector2.One,
                 EndValue = new Vector2(1, 0.9f),

--- a/osu.Game/GameModes/Menu/ButtonSystem.cs
+++ b/osu.Game/GameModes/Menu/ButtonSystem.cs
@@ -210,7 +210,7 @@ namespace osu.Game.GameModes.Menu
                     case MenuState.TopLevel:
                         buttonAreaBackground.ScaleTo(Vector2.One, 200, EasingTypes.Out);
 
-                        osuLogo.MoveTo(buttonFlow.Position, 200, EasingTypes.In);
+                        osuLogo.MoveTo(buttonFlow.DrawPosition, 200, EasingTypes.In);
                         osuLogo.ScaleTo(0.5f, 200, EasingTypes.In);
 
                         buttonArea.FadeIn(300);

--- a/osu.Game/GameModes/Menu/FlowContainerWithOrigin.cs
+++ b/osu.Game/GameModes/Menu/FlowContainerWithOrigin.cs
@@ -24,7 +24,7 @@ namespace osu.Game.GameModes.Menu
                 if (CentreTarget == null)
                     return base.OriginPosition;
 
-                return CentreTarget.Position + CentreTarget.Size / 2;
+                return CentreTarget.DrawPosition + CentreTarget.DrawSize / 2;
             }
         }
     }

--- a/osu.Game/GameModes/Menu/OsuLogo.cs
+++ b/osu.Game/GameModes/Menu/OsuLogo.cs
@@ -24,7 +24,7 @@ namespace osu.Game.GameModes.Menu
 
         public Action Action;
 
-        public float SizeForFlow => logo == null ? 0 : logo.Size.X * logo.Scale.X * logoBounceContainer.Scale.X * 0.8f;
+        public float SizeForFlow => logo == null ? 0 : logo.DrawSize.X * logo.Scale.X * logoBounceContainer.Scale.X * 0.8f;
 
         private Sprite ripple;
 

--- a/osu.Game/Graphics/Background/Background.cs
+++ b/osu.Game/Graphics/Background/Background.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Graphics.Background
         protected override void Update()
         {
             base.Update();
-            BackgroundSprite.Scale = new Vector2(Math.Max(Size.X / BackgroundSprite.Size.X, Size.Y / BackgroundSprite.Size.Y));
+            BackgroundSprite.Scale = new Vector2(Math.Max(DrawSize.X / BackgroundSprite.DrawSize.X, DrawSize.Y / BackgroundSprite.DrawSize.Y));
         }
     }
 }

--- a/osu.Game/Graphics/Containers/ParallaxContainer.cs
+++ b/osu.Game/Graphics/Containers/ParallaxContainer.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Graphics.Containers
 
         protected override bool OnMouseMove(InputState state)
         {
-            content.Position = (state.Mouse.Position - Size / 2) * ParallaxAmount;
+            content.Position = (state.Mouse.Position - DrawSize / 2) * ParallaxAmount;
             return base.OnMouseMove(state);
         }
 

--- a/osu.Game/Graphics/Processing/RatioAdjust.cs
+++ b/osu.Game/Graphics/Processing/RatioAdjust.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Graphics.Processing
         protected override void Update()
         {
             base.Update();
-            Vector2 parent = Parent.Size;
+            Vector2 parent = Parent.DrawSize;
 
             Scale = new Vector2(Math.Min(parent.Y / 768f, parent.X / 1024f));
             Size = new Vector2(1 / Scale.X);

--- a/osu.Game/Graphics/UserInterface/KeyCounter.cs
+++ b/osu.Game/Graphics/UserInterface/KeyCounter.cs
@@ -107,8 +107,8 @@ namespace osu.Game.Graphics.UserInterface
             };
             //Set this manually because an element with Alpha=0 won't take it size to AutoSizeContainer,
             //so the size can be changing between buttonSprite and glowSprite.
-            Height = buttonSprite.Height;
-            Width = buttonSprite.Width;
+            Height = buttonSprite.DrawHeight;
+            Width = buttonSprite.DrawWidth;
         }
 
         private void updateGlowSprite(bool show)

--- a/osu.Game/Overlays/ChatConsole.cs
+++ b/osu.Game/Overlays/ChatConsole.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Overlays
 
         protected override void PopOut()
         {
-            MoveToY(-Size.Y, transition_length, EasingTypes.InQuint);
+            MoveToY(-DrawSize.Y, transition_length, EasingTypes.InQuint);
             FadeOut(transition_length, EasingTypes.InQuint);
         }
     }

--- a/osu.Game/Overlays/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays
 
         protected override void PopOut()
         {
-            MoveToY(-Size.Y, transition_time, EasingTypes.InQuint);
+            MoveToY(-DrawSize.Y, transition_time, EasingTypes.InQuint);
             FadeOut(transition_time, EasingTypes.InQuint);
         }
 

--- a/osu.Game/Overlays/ToolbarButton.cs
+++ b/osu.Game/Overlays/ToolbarButton.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Overlays
             base.Update();
 
             //todo: find a way to avoid using this (autosize needs to be able to ignore certain drawables.. in this case the tooltip)
-            Size = new Vector2(WIDTH + (DrawableText.IsVisible ? DrawableText.Size.X : 0), 1);
+            Size = new Vector2(WIDTH + (DrawableText.IsVisible ? DrawableText.DrawSize.X : 0), 1);
         }
 
         protected override bool OnClick(InputState state)

--- a/osu.Game/Overlays/ToolbarModeSelector.cs
+++ b/osu.Game/Overlays/ToolbarModeSelector.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Overlays
             base.UpdateLayout();
 
             if (!activeMode.EnsureValid())
-                activeMode.Refresh(() => modeButtonLine.MoveToX(activeButton.Position.X + activeButton.Size.X / 2 + padding, 200, EasingTypes.OutQuint));
+                activeMode.Refresh(() => modeButtonLine.MoveToX(activeButton.DrawPosition.X + activeButton.DrawSize.X / 2 + padding, 200, EasingTypes.OutQuint));
         }
     }
 }


### PR DESCRIPTION
…o framework changes.

Note, that this was just stupid replacement. Many components will likely want to actually read Size and not DrawSize. We may want to do a pass over this at some point, but for now everything is working like this. (Old behavior.)

This depends on https://github.com/ppy/osu-framework/pull/184
