### PR TITLE
Fix volume control input handling.

### DIFF
--- a/osu.Game/GameModes/Menu/ButtonSystem.cs
+++ b/osu.Game/GameModes/Menu/ButtonSystem.cs
@@ -133,7 +133,7 @@ namespace osu.Game.GameModes.Menu
                     return true;
             }
 
-            return true;
+            return false;
         }
 
         private void onPlay()

--- a/osu.Game/Graphics/UserInterface/Volume/VolumeControlReceptor.cs
+++ b/osu.Game/Graphics/UserInterface/Volume/VolumeControlReceptor.cs
@@ -1,0 +1,42 @@
+﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+//Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using OpenTK.Input;
+using OpenTK;
+
+namespace osu.Game.Graphics.UserInterface.Volume
+{
+    class VolumeControlReceptor : Container
+    {
+        public Action ActivateRequested;
+
+        protected override bool OnWheelDown(InputState state)
+        {
+            ActivateRequested?.Invoke();
+            return true;
+        }
+
+        protected override bool OnWheelUp(InputState state)
+        {
+            ActivateRequested?.Invoke();
+            return true;
+        }
+
+        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        {
+            switch (args.Key)
+            {
+                case Key.Up:
+                case Key.Down:
+                    ActivateRequested?.Invoke();
+                    return true;
+            }
+
+            return base.OnKeyDown(state, args);
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/Volume/VolumeMeter.cs
+++ b/osu.Game/Graphics/UserInterface/Volume/VolumeMeter.cs
@@ -1,4 +1,5 @@
-﻿using osu.Framework.Configuration;
+﻿using osu.Framework;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -6,9 +7,8 @@ using osu.Framework.Graphics.Transformations;
 using osu.Framework.Input;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework;
 
-namespace osu.Game
+namespace osu.Game.Graphics.UserInterface.Volume
 {
     internal class VolumeMeter : Container
     {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -23,6 +23,7 @@ using OpenTK.Input;
 using System.IO;
 using osu.Game.Beatmaps.IO;
 using osu.Framework.Logging;
+using osu.Game.Graphics.UserInterface.Volume;
 
 namespace osu.Game
 {
@@ -39,6 +40,8 @@ namespace osu.Game
         private Intro intro;
         private string[] args;
         private IpcChannel<ImportBeatmap> BeatmapIPC;
+
+        private VolumeControl volume;
 
         public Bindable<PlayMode> PlayMode;
 
@@ -92,6 +95,11 @@ namespace osu.Game
             Audio.VolumeTrack.Weld(Config.GetBindable<double>(OsuConfig.VolumeMusic));
 
             Add(new Drawable[] {
+                new VolumeControlReceptor
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    ActivateRequested = delegate { volume.Show(); }
+                },
                 intro = new Intro(),
                 Toolbar = new Toolbar
                 {
@@ -100,7 +108,7 @@ namespace osu.Game
                     OnPlayModeChange = delegate (PlayMode m) { PlayMode.Value = m; },
                 },
                 Chat = new ChatConsole(API),
-                new VolumeControl
+                volume = new VolumeControl
                 {
                     VolumeGlobal = Audio.Volume,
                     VolumeSample = Audio.VolumeSample,

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -138,6 +138,7 @@
     <Compile Include="GameModes\Play\ComboResultCounter.cs" />
     <Compile Include="Graphics\UserInterface\RollingCounter.cs" />
     <Compile Include="GameModes\Play\Taiko\TaikoComboCounter.cs" />
+    <Compile Include="Graphics\UserInterface\Volume\VolumeControlReceptor.cs" />
     <Compile Include="Input\GlobalHotkeys.cs" />
     <Compile Include="Graphics\Background\Background.cs" />
     <Compile Include="Graphics\Containers\ParallaxContainer.cs" />
@@ -176,14 +177,14 @@
     <Compile Include="Overlays\ToolbarModeSelector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Users\User.cs" />
-    <Compile Include="VolumeControl.cs" />
+    <Compile Include="Graphics\UserInterface\Volume\VolumeControl.cs" />
     <Compile Include="Database\BeatmapDatabase.cs" />
     <Compile Include="Beatmaps\IO\ArchiveReader.cs" />
     <Compile Include="Beatmaps\Formats\BeatmapDecoder.cs" />
     <Compile Include="Beatmaps\Formats\OsuLegacyDecoder.cs" />
     <Compile Include="Beatmaps\IO\OszArchiveReader.cs" />
     <Compile Include="Beatmaps\Events\EventType.cs" />
-    <Compile Include="VolumeMeter.cs" />
+    <Compile Include="Graphics\UserInterface\Volume\VolumeMeter.cs" />
     <Compile Include="Database\BeatmapSetInfo.cs" />
     <Compile Include="Database\BeatmapMetadata.cs" />
     <Compile Include="Database\BeatmapInfo.cs" />


### PR DESCRIPTION
- Volume controls now derive from OverlayContainer as they should.
- Volume controls now forfeit mouse wheel input to everything else.
- Once visible, they will still handle global mouse wheel input until they are done.
- Keyboard input isn't yet fully implemented (just for visibility for now).

Depends on https://github.com/ppy/osu-framework/pull/232
