### PR TITLE
Minor improvements to combo counters

### DIFF
--- a/osu.Game/GameModes/Play/Catch/CatchComboCounter.cs
+++ b/osu.Game/GameModes/Play/Catch/CatchComboCounter.cs
@@ -19,7 +19,7 @@ namespace osu.Game.GameModes.Play.Catch
         protected override bool CanPopOutWhileRolling => true;
 
         protected virtual double FadeOutDelay => 1000;
-        protected virtual double FadeOutDuration => 300;
+        protected override double FadeOutDuration => 300;
 
         protected override string FormatCount(ulong count)
         {

--- a/osu.Game/GameModes/Play/ComboCounter.cs
+++ b/osu.Game/GameModes/Play/ComboCounter.cs
@@ -31,6 +31,8 @@ namespace osu.Game.GameModes.Play
         protected virtual EasingTypes PopOutEasing => EasingTypes.None;
         protected virtual float PopOutInitialAlpha => 0.75f;
 
+        protected virtual double FadeOutDuration => 100;
+
         /// <summary>
         /// Duration in milliseconds for the counter roll-up animation for each element.
         /// </summary>
@@ -60,7 +62,6 @@ namespace osu.Game.GameModes.Play
             }
         }
 
-        protected ulong prevCount;
         protected ulong count;
 
         /// <summary>
@@ -204,7 +205,7 @@ namespace osu.Game.GameModes.Play
 
         private void updateCount(ulong value, bool rolling = false)
         {
-            prevCount = count;
+            ulong prevCount = count;
             count = value;
             if (!rolling)
             {

--- a/osu.Game/GameModes/Play/Osu/OsuComboCounter.cs
+++ b/osu.Game/GameModes/Play/Osu/OsuComboCounter.cs
@@ -92,6 +92,11 @@ namespace osu.Game.GameModes.Play.Osu
         protected override void OnCountRolling(ulong currentValue, ulong newValue)
         {
             ScheduledPopOutCurrentId++;
+
+            // Hides displayed count if was increasing from 0 to 1 but didn't finish
+            if (currentValue == 0 && newValue == 0)
+                DisplayedCountSpriteText.FadeOut(FadeOutDuration);
+
             base.OnCountRolling(currentValue, newValue);
         }
 
@@ -116,13 +121,17 @@ namespace osu.Game.GameModes.Play.Osu
         protected override void OnCountChange(ulong currentValue, ulong newValue)
         {
             ScheduledPopOutCurrentId++;
+
+            if (newValue == 0)
+                DisplayedCountSpriteText.FadeOut();
+
             base.OnCountChange(currentValue, newValue);
         }
 
         protected override void OnDisplayedCountRolling(ulong currentValue, ulong newValue)
         {
             if (newValue == 0)
-                DisplayedCountSpriteText.FadeOut(PopOutDuration);
+                DisplayedCountSpriteText.FadeOut(FadeOutDuration);
             else
                 DisplayedCountSpriteText.Show();
 

--- a/osu.Game/GameModes/Play/Taiko/TaikoComboCounter.cs
+++ b/osu.Game/GameModes/Play/Taiko/TaikoComboCounter.cs
@@ -43,7 +43,7 @@ namespace osu.Game.GameModes.Play.Taiko
         protected override void OnDisplayedCountRolling(ulong currentValue, ulong newValue)
         {
             if (newValue == 0)
-                DisplayedCountSpriteText.FadeOut(AnimationDuration);
+                DisplayedCountSpriteText.FadeOut(FadeOutDuration);
             else
                 DisplayedCountSpriteText.Show();
 


### PR DESCRIPTION
Just squashed a nasty bug where displayed combo was not fading out properly (sorry) + a fade-out duration independent from the pop-out animation duration.
