### PR TITLE
Working beatmap background scaling fix

### DIFF
--- a/osu.Game/Beatmaps/Drawable/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawable/BeatmapSetHeader.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Beatmaps.Drawable
                     Texture = working.Background,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Scale = new Vector2(0.5f),
+                    Scale = new Vector2((working.Background.Width >= 1366) ? 0.5f : 0.6f),
                     Colour = new Color4(200, 200, 200, 255),
                 },
                 new FlowContainer

--- a/osu.Game/Beatmaps/Drawable/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawable/BeatmapSetHeader.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Beatmaps.Drawable
                     Texture = working.Background,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Scale = new Vector2((working.Background.Width >= 1366) ? 0.5f : 0.6f),
+                    Scale = new Vector2(1366 / working.Background.Width * 0.6f),
                     Colour = new Color4(200, 200, 200, 255),
                 },
                 new FlowContainer


### PR DESCRIPTION
Add a check for the working beatmap background width and assign a proper
scaling value to cover the whole box

![1](https://cloud.githubusercontent.com/assets/8558077/20035113/9e048524-a3d7-11e6-91b3-71c15c8bbd32.PNG)
![2](https://cloud.githubusercontent.com/assets/8558077/20035150/81de36aa-a3d8-11e6-876f-eeba6605f5b7.PNG)
