### PR TITLE
Hide Options and MusicController when switching to Player

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -162,6 +162,8 @@ namespace osu.Game
             {
                 Toolbar.State = Visibility.Hidden;
                 Chat.State = Visibility.Hidden;
+                MusicController.State = Visibility.Hidden;
+                Options.State = Visibility.Hidden;
             }
             else
             {


### PR DESCRIPTION
Just something I noticed while playing around with the MusicController, as it can't be hidden without the corresponding toolbar button (yet) and it stays on screen when playing a beatmap.

This PR just hides the Options and MusicController overlays on switching to the Player GameMode and so prevents the user from causing exceptions due to seeking in the Player mode.