### PR TITLE
Make backgrounds load more asynchronously

### DIFF
--- a/osu.Game/Screens/Backgrounds/BackgroundModeBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundModeBeatmap.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Screens.Backgrounds
         [BackgroundDependencyLoader]
         private void load()
         {
+            //this should be "background?.IsLoaded != true" but this will cause the schedule above to never be run.
             while (beatmap == null && !HasExited)
                 Thread.Sleep(1);
         }

--- a/osu.Game/Screens/Backgrounds/BackgroundModeBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundModeBeatmap.cs
@@ -1,6 +1,7 @@
 ﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
 //Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Threading;
 using osu.Framework.Allocation;
 using OpenTK;
 using osu.Framework.Graphics.Transformations;
@@ -30,32 +31,41 @@ namespace osu.Game.Screens.Backgrounds
 
                 beatmap = value;
 
-                Schedule(() =>
-                {
-                    Background newBackground = new BeatmapBackground(beatmap);
-
-                    newBackground.Preload(Game, delegate
-                    {
-                        Background oldBackground = background;
-
-                        Add(background = newBackground);
-                        background.BlurSigma = blurTarget;
-
-                        if (oldBackground != null)
-                        {
-                            oldBackground.Depth = 1;
-                            oldBackground.Flush();
-                            oldBackground.FadeOut(250);
-                            oldBackground.Expire();
-                        }
-                    });
-                });
+                Schedule(updateBeatmapBackground);
             }
+        }
+
+        private void updateBeatmapBackground()
+        {
+            Background newBackground = beatmap != null ? new BeatmapBackground(beatmap) : new Background(@"Backgrounds/bg1");
+
+            newBackground.Preload(Game, delegate
+            {
+                Background oldBackground = background;
+
+                Add(background = newBackground);
+                background.BlurSigma = blurTarget;
+
+                if (oldBackground != null)
+                {
+                    oldBackground.Depth = 1;
+                    oldBackground.Flush();
+                    oldBackground.FadeOut(250);
+                    oldBackground.Expire();
+                }
+            });
         }
 
         public BackgroundModeBeatmap(WorkingBeatmap beatmap)
         {
             Beatmap = beatmap;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            while (beatmap == null && !HasExited)
+                Thread.Sleep(1);
         }
 
         public void BlurTo(Vector2 sigma, double duration)


### PR DESCRIPTION
Delays beatmap backgrounds from transitioning in until they are ready to be displayed.

Not too happy with this logic (see comment commit for a current flaw which needs to be addressed).