### PR TITLE
Changed Texture.Draw to Texture.DrawQuad in CursorTrail

### DIFF
--- a/osu.Game/Graphics/Cursor/CursorTrail.cs
+++ b/osu.Game/Graphics/Cursor/CursorTrail.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Graphics.Cursor
                         colour.BottomLeft.Linear.A = Parts[i].Time + colour.BottomLeft.Linear.A;
                         colour.BottomRight.Linear.A = Parts[i].Time + colour.BottomRight.Linear.A;
 
-                        Texture.Draw(
+                        Texture.DrawQuad(
                             new Quad(pos.X - Size.X / 2, pos.Y - Size.Y / 2, Size.X, Size.Y),
                             colour,
                             null,


### PR DESCRIPTION
In commit c0a56c1 of osu-framework, Texture.Draw was removed to make way for Texture.DrawTriangle and Texture.DrawQuad. However, a reference in the CursorTrail class to the old Texture.Draw method remained, thus preventing the build from completing. This commit addresses the issue.