### PR TITLE
Basic error handling in Import(params string[] paths)

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -13,7 +13,6 @@ using osu.Game.Modes.Catch;
 using osu.Game.Modes.Mania;
 using osu.Game.Modes.Osu;
 using osu.Game.Modes.Taiko;
-using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Beatmaps.IO
 {
@@ -21,6 +20,15 @@ namespace osu.Game.Tests.Beatmaps.IO
     public class ImportBeatmapTest
     {
         const string osz_path = @"../../../osu-resources/osu.Game.Resources/Beatmaps/241526 Soleily - Renatus.osz";
+
+        public string OszCopyPath
+        {
+            get
+            {
+                var original = new FileInfo(osz_path);
+                return original.CopyTo(Path.GetFileName(original.FullName), true).FullName;
+            }
+        }
 
         [OneTimeSetUp]
         public void SetUp()
@@ -38,7 +46,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (HeadlessGameHost host = new HeadlessGameHost())
             {
                 var osu = loadOsu(host);
-                osu.Dependencies.Get<BeatmapDatabase>().Import(osz_path);
+                osu.Dependencies.Get<BeatmapDatabase>().Import(OszCopyPath);
                 ensureLoaded(osu);
             }
         }
@@ -55,7 +63,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 var osu = loadOsu(host);
 
                 var importer = new BeatmapImporter(client);
-                if (!importer.Import(osz_path).Wait(1000))
+                if (!importer.Import(OszCopyPath).Wait(1000))
                     Assert.Fail(@"IPC took too long to send");
 
                 ensureLoaded(osu, 10000);

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -21,15 +21,6 @@ namespace osu.Game.Tests.Beatmaps.IO
     {
         const string osz_path = @"../../../osu-resources/osu.Game.Resources/Beatmaps/241526 Soleily - Renatus.osz";
 
-        public string OszCopyPath
-        {
-            get
-            {
-                var original = new FileInfo(osz_path);
-                return original.CopyTo(Path.GetFileName(original.FullName), true).FullName;
-            }
-        }
-
         [OneTimeSetUp]
         public void SetUp()
         {
@@ -46,7 +37,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (HeadlessGameHost host = new HeadlessGameHost())
             {
                 var osu = loadOsu(host);
-                osu.Dependencies.Get<BeatmapDatabase>().Import(OszCopyPath);
+                osu.Dependencies.Get<BeatmapDatabase>().Import(prepareOszFileForTest());
                 ensureLoaded(osu);
             }
         }
@@ -63,7 +54,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 var osu = loadOsu(host);
 
                 var importer = new BeatmapImporter(client);
-                if (!importer.Import(OszCopyPath).Wait(1000))
+                if (!importer.Import(prepareOszFileForTest()).Wait(1000))
                     Assert.Fail(@"IPC took too long to send");
 
                 ensureLoaded(osu, 10000);
@@ -128,6 +119,16 @@ namespace osu.Game.Tests.Beatmaps.IO
             var beatmap = osu.Dependencies.Get<BeatmapDatabase>().GetBeatmap(set.Beatmaps.First(b => b.Mode == PlayMode.Osu));
 
             Assert.IsTrue(beatmap.HitObjects.Count > 0);
+        }
+
+        /// <summary>
+        /// Creates a copy of the original .osz file
+        /// </summary>
+        /// <returns>Path to the created copy</returns>
+        private string prepareOszFileForTest()
+        {
+            var original = new FileInfo(osz_path);
+            return original.CopyTo(Path.GetFileName(original.FullName), true).FullName;
         }
     }
 }

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -117,9 +117,6 @@ namespace osu.Game.Database
                 }
                 catch
                 {
-                    using (var source = File.OpenRead(p))
-                    using (var target = storage.GetStream(Path.Combine(@"beatmaps", @"Failed", Path.GetFileName(p)), FileAccess.Write))
-                        source.CopyTo(target);
                 }
                 finally
                 {


### PR DESCRIPTION
- Handle error which may occur on db insert(move bad .osz file to "Failed" folder).
- Delete .OSZ file after successful import.

Problematic sample(somehow it does not have BeatmapSetID):
[monotone - Totsugeki! Glass no Kneesocks Hime! (mapped by Reisen Udongein)](https://1drv.ms/u/s!Apf5hjtqa5Zbj_xCQWlSJsSjls3mMg)