### PR TITLE
Better vscode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,25 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch",
+            "name": "Launch VisualTests",
             "type": "mono",
             "request": "launch",
             "program": "${workspaceRoot}/osu.Desktop.VisualTests/bin/Debug/osu!.exe",
             "args": [],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "",
+            "preLaunchTask": "build",
+            "runtimeExecutable": null,
+            "env": {},
+            "externalConsole": false
+        },
+        {
+            "name": "Launch Desktop",
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceRoot}/osu.Desktop/bin/Debug/osu!.exe",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "build",
             "runtimeExecutable": null,
             "env": {},
             "externalConsole": false


### PR DESCRIPTION
There are now 2 buttons for debugging in visual studio code: `Launch VisualTests` and `Launch Desktop` which launch their respective projects. Also these buttons now compile before debugging which feels more like an IDE. Makes it a lot easier to get into development for people on linux without MonoDevelop or for people who prefer vscode if running just works