### PR TITLE
Specify ScoreProcessor.Judgements.Capacity

### DIFF
--- a/osu.Game.Modes.Catch/CatchRuleset.cs
+++ b/osu.Game.Modes.Catch/CatchRuleset.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Modes.Catch
 
         protected override PlayMode PlayMode => PlayMode.Catch;
 
-        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => null;
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectCount) => null;
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
     }

--- a/osu.Game.Modes.Catch/CatchRuleset.cs
+++ b/osu.Game.Modes.Catch/CatchRuleset.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Modes.Catch
 
         protected override PlayMode PlayMode => PlayMode.Catch;
 
-        public override ScoreProcessor CreateScoreProcessor() => null;
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => null;
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
     }

--- a/osu.Game.Modes.Mania/ManiaRuleset.cs
+++ b/osu.Game.Modes.Mania/ManiaRuleset.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Modes.Mania
 
         protected override PlayMode PlayMode => PlayMode.Mania;
 
-        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => null;
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectCount) => null;
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
     }

--- a/osu.Game.Modes.Mania/ManiaRuleset.cs
+++ b/osu.Game.Modes.Mania/ManiaRuleset.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Modes.Mania
 
         protected override PlayMode PlayMode => PlayMode.Mania;
 
-        public override ScoreProcessor CreateScoreProcessor() => null;
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => null;
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
     }

--- a/osu.Game.Modes.Osu/OsuRuleset.cs
+++ b/osu.Game.Modes.Osu/OsuRuleset.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Modes.Osu
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
 
-        public override ScoreProcessor CreateScoreProcessor() => new OsuScoreProcessor();
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => new OsuScoreProcessor(hitObjectsNumber);
 
         protected override PlayMode PlayMode => PlayMode.Osu;
     }

--- a/osu.Game.Modes.Osu/OsuRuleset.cs
+++ b/osu.Game.Modes.Osu/OsuRuleset.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Modes.Osu
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
 
-        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => new OsuScoreProcessor(hitObjectsNumber);
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectCount) => new OsuScoreProcessor(hitObjectCount);
 
         protected override PlayMode PlayMode => PlayMode.Osu;
     }

--- a/osu.Game.Modes.Osu/OsuScoreProcessor.cs
+++ b/osu.Game.Modes.Osu/OsuScoreProcessor.cs
@@ -8,8 +8,8 @@ namespace osu.Game.Modes.Osu
 {
     class OsuScoreProcessor : ScoreProcessor
     {
-        public OsuScoreProcessor(int hitObjectsNumber)
-            : base(hitObjectsNumber)
+        public OsuScoreProcessor(int hitObjectCount)
+            : base(hitObjectCount)
         {
         }
 

--- a/osu.Game.Modes.Osu/OsuScoreProcessor.cs
+++ b/osu.Game.Modes.Osu/OsuScoreProcessor.cs
@@ -1,11 +1,6 @@
 ﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
 //Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using osu.Game.Modes.Objects.Drawables;
 using osu.Game.Modes.Osu.Objects.Drawables;
 
@@ -13,6 +8,11 @@ namespace osu.Game.Modes.Osu
 {
     class OsuScoreProcessor : ScoreProcessor
     {
+        public OsuScoreProcessor(int hitObjectsNumber)
+            : base(hitObjectsNumber)
+        {
+        }
+
         protected override void UpdateCalculations(JudgementInfo judgement)
         {
             if (judgement != null)

--- a/osu.Game.Modes.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Modes.Taiko/TaikoRuleset.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Modes.Taiko
 
         protected override PlayMode PlayMode => PlayMode.Taiko;
 
-        public override ScoreProcessor CreateScoreProcessor() => null;
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => null;
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
     }

--- a/osu.Game.Modes.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Modes.Taiko/TaikoRuleset.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Modes.Taiko
 
         protected override PlayMode PlayMode => PlayMode.Taiko;
 
-        public override ScoreProcessor CreateScoreProcessor(int hitObjectsNumber) => null;
+        public override ScoreProcessor CreateScoreProcessor(int hitObjectCount) => null;
 
         public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
     }

--- a/osu.Game/Modes/Ruleset.cs
+++ b/osu.Game/Modes/Ruleset.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Modes
 
         public abstract ScoreOverlay CreateScoreOverlay();
 
-        public abstract ScoreProcessor CreateScoreProcessor();
+        public abstract ScoreProcessor CreateScoreProcessor(int hitObjectsNumber);
 
         public abstract HitRenderer CreateHitRendererWith(List<HitObject> objects);
 

--- a/osu.Game/Modes/Ruleset.cs
+++ b/osu.Game/Modes/Ruleset.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Modes
 
         public abstract ScoreOverlay CreateScoreOverlay();
 
-        public abstract ScoreProcessor CreateScoreProcessor(int hitObjectsNumber);
+        public abstract ScoreProcessor CreateScoreProcessor(int hitObjectCount);
 
         public abstract HitRenderer CreateHitRendererWith(List<HitObject> objects);
 

--- a/osu.Game/Modes/ScoreProcesssor.cs
+++ b/osu.Game/Modes/ScoreProcesssor.cs
@@ -31,10 +31,14 @@ namespace osu.Game.Modes
 
         public readonly List<JudgementInfo> Judgements;
 
-        public ScoreProcessor(int hitObjectsNumber)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScoreProcessor"/> class.
+        /// </summary>
+        /// <param name="hitObjectCount">Number of HitObjects. It is used for specifying Judgements collection Capacity</param>
+        public ScoreProcessor(int hitObjectCount = 0)
         {
             Combo.ValueChanged += delegate { HighestCombo.Value = Math.Max(HighestCombo.Value, Combo.Value); };
-            Judgements = new List<JudgementInfo>(hitObjectsNumber);
+            Judgements = new List<JudgementInfo>(hitObjectCount);
         }
 
         public void AddJudgement(JudgementInfo judgement)

--- a/osu.Game/Modes/ScoreProcesssor.cs
+++ b/osu.Game/Modes/ScoreProcesssor.cs
@@ -29,11 +29,12 @@ namespace osu.Game.Modes
 
         public readonly BindableInt HighestCombo = new BindableInt();
 
-        public readonly List<JudgementInfo> Judgements = new List<JudgementInfo>();
+        public readonly List<JudgementInfo> Judgements;
 
-        public ScoreProcessor()
+        public ScoreProcessor(int hitObjectsNumber)
         {
             Combo.ValueChanged += delegate { HighestCombo.Value = Math.Max(HighestCombo.Value, Combo.Value); };
+            Judgements = new List<JudgementInfo>(hitObjectsNumber);
         }
 
         public void AddJudgement(JudgementInfo judgement)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.Play
             ruleset = Ruleset.GetRuleset(usablePlayMode);
 
             var scoreOverlay = ruleset.CreateScoreOverlay();
-            scoreOverlay.BindProcessor(scoreProcessor = ruleset.CreateScoreProcessor());
+            scoreOverlay.BindProcessor(scoreProcessor = ruleset.CreateScoreProcessor(beatmap.HitObjects.Count));
 
             hitRenderer = ruleset.CreateHitRendererWith(beatmap.HitObjects);
 


### PR DESCRIPTION
This is how the `Judgements.Capacity` changed during playing [this map](https://osu.ppy.sh/b/1028286&m=0)(I checked `Judgements` properties after each `AddJudgement` method execution):
[Without specifying Capacity](http://pastebin.com/UyuAkWtm)
[With specified Capacity](http://pastebin.com/FYJ8gLjr)

As far as I understand, these resizes are not free and I guess it is better not to pay for them.