### PR TITLE
Fix incorrect sizing of login button.

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarUserArea.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserArea.cs
@@ -17,8 +17,6 @@ namespace osu.Game.Overlays.Toolbar
 
         public override bool Contains(Vector2 screenSpacePos) => true;
 
-        public override Vector2 Size => button.Size;
-
         public ToolbarUserArea()
         {
             RelativeSizeAxes = Axes.Y;
@@ -31,6 +29,7 @@ namespace osu.Game.Overlays.Toolbar
                 },
                 loginOverlay = new LoginOverlay
                 {
+                    BypassAutoSizeAxes = Axes.Both,
                     Position = new Vector2(0, 1),
                     RelativePositionAxes = Axes.Y,
                     Anchor = Anchor.TopRight,


### PR DESCRIPTION
When logging in or out the size of the login button would not correctly update,
resulting in a messed-up flow of toolbar buttons. This branch fixes the problem
by avoiding an invalidation-chain-breaking override of Size. Instead, the loginOverlay
bypasses auto sizing by using a new framework feature.

Depends on https://github.com/ppy/osu-framework/pull/434