### PR TITLE
Add spinners and improve TestCaseHitObjects.

### DIFF
--- a/osu.Desktop.VisualTests/Tests/TestCaseHitObjects.cs
+++ b/osu.Desktop.VisualTests/Tests/TestCaseHitObjects.cs
@@ -1,18 +1,23 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Collections.Generic;
 using osu.Framework;
 using osu.Framework.GameModes.Testing;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
 using OpenTK;
 using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Game.Modes.Objects;
 using osu.Game.Modes.Objects.Drawables;
 using osu.Game.Modes.Osu.Objects;
 using osu.Game.Modes.Osu.Objects.Drawables;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Modes;
+using OpenTK.Graphics;
 
 namespace osu.Desktop.VisualTests.Tests
 {
@@ -20,44 +25,124 @@ namespace osu.Desktop.VisualTests.Tests
     {
         public override string Name => @"Hit Objects";
 
+        private StopwatchClock rateAdjustClock;
+        private FramedClock framedClock;
+
+        bool auto = false;
+
         public TestCaseHitObjects()
         {
-            var swClock = new StopwatchClock(true) { Rate = 0.2f };
-            Clock = new FramedClock(swClock);
+            rateAdjustClock = new StopwatchClock(true);
+            framedClock = new FramedClock(rateAdjustClock);
+            playbackSpeed.ValueChanged += delegate { rateAdjustClock.Rate = playbackSpeed.Value; };
+        }
+
+        HitObjectType mode = HitObjectType.Spinner;
+
+        BindableNumber<double> playbackSpeed = new BindableDouble(0.5) { MinValue = 0, MaxValue = 1 };
+        private Container playfieldContainer;
+        private Container approachContainer;
+
+        private void load(HitObjectType mode)
+        {
+            this.mode = mode;
+
+            switch (mode)
+            {
+                case HitObjectType.Circle:
+                    const int count = 10;
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        var h = new HitCircle
+                        {
+                            StartTime = framedClock.CurrentTime + 600 + i * 80,
+                            Position = new Vector2((i - count / 2) * 14),
+                        };
+
+                        add(new DrawableHitCircle(h));
+                    }
+                    break;
+                case HitObjectType.Slider:
+                    add(new DrawableSlider(new Slider
+                    {
+                        StartTime = framedClock.CurrentTime + 600,
+                        ControlPoints = new List<Vector2>()
+                        {
+                            new Vector2(-200, 0),
+                            new Vector2(400, 0),
+                        },
+                        Length = 400,
+                        Position = new Vector2(-200, 0),
+                        Velocity = 1,
+                    }));
+                    break;
+                case HitObjectType.Spinner:
+                    add(new DrawableSpinner(new Spinner
+                    {
+                        StartTime = framedClock.CurrentTime + 600,
+                        Length = 1000,
+                        Position = new Vector2(0, 0),
+                    }));
+                    break;
+            }
         }
 
         public override void Reset()
         {
             base.Reset();
 
-            Clock.ProcessFrame();
+            playbackSpeed.TriggerChange();
 
-            Container approachContainer = new Container { Depth = float.MinValue, };
+            AddButton(@"circles", () => load(HitObjectType.Circle));
+            AddButton(@"slider", () => load(HitObjectType.Slider));
+            AddButton(@"spinner", () => load(HitObjectType.Spinner));
 
-            Add(approachContainer);
+            AddToggle(@"auto", () => { auto = !auto; load(mode); });
 
-            const int count = 10;
-
-            for (int i = 0; i < count; i++)
+            ButtonsContainer.Add(new SpriteText { Text = "Playback Speed" });
+            ButtonsContainer.Add(new BasicSliderBar<double>
             {
-                var h = new HitCircle
+                Width = 150,
+                Height = 10,
+                SelectionColor = Color4.Orange,
+                Bindable = playbackSpeed
+            });
+
+            framedClock.ProcessFrame();
+
+            var clockAdjustContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Clock = framedClock,
+                Children = new[]
                 {
-                    StartTime = Clock.CurrentTime + 600 + i * 80,
-                    Position = new Vector2((i - count / 2) * 14),
-                };
+                    playfieldContainer = new Container { RelativeSizeAxes = Axes.Both },
+                    approachContainer = new Container { RelativeSizeAxes = Axes.Both }
+                }
+            };
 
-                DrawableHitCircle d = new DrawableHitCircle(h)
-                {
-                    Anchor = Anchor.Centre,
-                    Depth = i,
-                    State = ArmedState.Hit,
-                    Judgement = new OsuJudgementInfo { Result = HitResult.Hit }
-                };
+            Add(clockAdjustContainer);
 
+            load(mode);
+        }
 
-                approachContainer.Add(d.ApproachCircle.CreateProxy());
-                Add(d);
+        int depth;
+        void add(DrawableHitObject h)
+        {
+            h.Anchor = Anchor.Centre;
+            h.Depth = depth++;
+
+            if (auto)
+            {
+                h.State = ArmedState.Hit;
+                h.Judgement = new OsuJudgementInfo { Result = HitResult.Hit };
             }
+
+            playfieldContainer.Add(h);
+            var proxyable = h as IDrawableHitObjectWithProxiedApproach;
+            if (proxyable != null)
+                approachContainer.Add(proxyable.ProxiedLayer.CreateProxy());
         }
     }
 }

--- a/osu.Game.Modes.Catch/CatchRuleset.cs
+++ b/osu.Game.Modes.Catch/CatchRuleset.cs
@@ -24,6 +24,6 @@ namespace osu.Game.Modes.Catch
 
         public override ScoreProcessor CreateScoreProcessor(int hitObjectCount) => null;
 
-        public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
+        public override HitObjectParser CreateHitObjectParser() => new NullHitObjectParser();
     }
 }

--- a/osu.Game.Modes.Mania/ManiaRuleset.cs
+++ b/osu.Game.Modes.Mania/ManiaRuleset.cs
@@ -25,6 +25,6 @@ namespace osu.Game.Modes.Mania
 
         public override ScoreProcessor CreateScoreProcessor(int hitObjectCount) => null;
 
-        public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
+        public override HitObjectParser CreateHitObjectParser() => new NullHitObjectParser();
     }
 }

--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
-using System.ComponentModel;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Transformations;
 using osu.Game.Modes.Objects.Drawables;
@@ -13,7 +12,7 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
 {
     public class DrawableHitCircle : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
-        private HitCircle osuObject;
+        private OsuHitObject osuObject;
 
         public ApproachCircle ApproachCircle;
         private CirclePiece circle;
@@ -23,11 +22,12 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
         private NumberPiece number;
         private GlowPiece glow;
 
-        public DrawableHitCircle(HitCircle h) : base(h)
+        public DrawableHitCircle(OsuHitObject h) : base(h)
         {
+            Origin = Anchor.Centre;
+
             osuObject = h;
 
-            Origin = Anchor.Centre;
             Position = osuObject.StackedPosition;
             Scale = new Vector2(osuObject.Scale);
 

--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -11,7 +11,7 @@ using OpenTK;
 
 namespace osu.Game.Modes.Osu.Objects.Drawables
 {
-    public class DrawableHitCircle : DrawableOsuHitObject
+    public class DrawableHitCircle : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
         private HitCircle osuObject;
 
@@ -156,5 +156,7 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
                     break;
             }
         }
+
+        public Drawable ProxiedLayer => ApproachCircle;
     }
 }

--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using osu.Game.Modes.Objects;
 using osu.Game.Modes.Objects.Drawables;
+using osu.Framework.Graphics;
 
 namespace osu.Game.Modes.Osu.Objects.Drawables
 {

--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableSlider.cs
@@ -6,11 +6,10 @@ using osu.Framework.Graphics;
 using osu.Game.Modes.Objects.Drawables;
 using osu.Game.Modes.Osu.Objects.Drawables.Pieces;
 using OpenTK;
-using osu.Framework.Input;
 
 namespace osu.Game.Modes.Osu.Objects.Drawables
 {
-    class DrawableSlider : DrawableOsuHitObject
+    public class DrawableSlider : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
         private Slider slider;
 
@@ -133,6 +132,8 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
 
             FadeOut(800);
         }
+
+        public Drawable ProxiedLayer => initialCircle.ApproachCircle;
     }
 
     internal interface ISliderProgress

--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transformations;
+using osu.Framework.MathUtils;
+using osu.Game.Modes.Objects.Drawables;
+using osu.Game.Modes.Osu.Objects.Drawables.Pieces;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Game.Modes.Osu.Objects.Drawables
+{
+    public class DrawableSpinner : DrawableOsuHitObject
+    {
+        private Spinner spinner;
+
+        private SpinnerDisc disc;
+        private SpinnerBackground background;
+        private DrawableHitCircle circle;
+        private NumberPiece number;
+
+        public DrawableSpinner(Spinner s) : base(s)
+        {
+            Origin = Anchor.Centre;
+            Position = s.Position;
+
+            //take up full playfield.
+            Size = new Vector2(512);
+
+            spinner = s;
+
+            Children = new Drawable[]
+            {
+                background = new SpinnerBackground
+                {
+                    Alpha = 0,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    DiscColour = Color4.Black
+                },
+                disc = new SpinnerDisc
+                {
+                    Alpha = 0,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    DiscColour = s.Colour
+                },
+                circle = new DrawableHitCircle(s)
+                {
+                    Interactive = false,
+                    Position = Vector2.Zero,
+                    Anchor = Anchor.Centre,
+                }
+            };
+
+            circle.ApproachCircle.Colour = Color4.Transparent;
+
+            background.Scale = scaleToCircle;
+            disc.Scale = scaleToCircle;
+        }
+
+        public override bool Contains(Vector2 screenSpacePos) => true;
+
+        protected override void CheckJudgement(bool userTriggered)
+        {
+            if (Time.Current < HitObject.StartTime) return;
+
+            var j = Judgement as OsuJudgementInfo;
+
+            disc.ScaleTo(Interpolation.ValueAt(Math.Sqrt(Progress), scaleToCircle, Vector2.One, 0, 1), 100);
+
+            if (!userTriggered && Time.Current >= HitObject.EndTime)
+            {
+                if (Progress >= 1)
+                {
+                    j.Score = OsuScoreResult.Hit300;
+                    j.Result = HitResult.Hit;
+                }
+                else if (Progress > .9)
+                {
+                    j.Score = OsuScoreResult.Hit100;
+                    j.Result = HitResult.Hit;
+                }
+                else if (Progress > .75)
+                {
+                    j.Score = OsuScoreResult.Hit50;
+                    j.Result = HitResult.Hit;
+                }
+                else
+                {
+                    j.Score = OsuScoreResult.Miss;
+                    j.Result = HitResult.Miss;
+                }
+            }
+        }
+
+        private Vector2 scaleToCircle => new Vector2(circle.Scale * circle.DrawWidth / DrawWidth) * 0.95f;
+
+        private float spinsPerMinuteNeeded = 100 + (5 * 15); //TODO: read per-map OD and place it on the 5
+
+        private float rotationsNeeded => (float)(spinsPerMinuteNeeded * (spinner.EndTime - spinner.StartTime) / 60000f);
+
+        public float Progress => MathHelper.Clamp(disc.RotationAbsolute / 360 / rotationsNeeded, 0, 1);
+
+        protected override void UpdatePreemptState()
+        {
+            base.UpdatePreemptState();
+
+            FadeIn(200);
+
+            background.Delay(TIME_PREEMPT - 100);
+            background.FadeIn(200);
+            background.ScaleTo(1, 200, EasingTypes.OutQuint);
+
+            disc.Delay(TIME_PREEMPT - 50);
+            disc.FadeIn(200);
+        }
+
+        protected override void UpdateState(ArmedState state)
+        {
+            base.UpdateState(state);
+
+            Delay(HitObject.Duration, true);
+
+            FadeOut(160);
+            
+            switch (state)
+            {
+                case ArmedState.Hit:
+                    ScaleTo(Scale * 1.2f, 320, EasingTypes.Out);
+                    break;
+                case ArmedState.Miss:
+                    ScaleTo(Scale * 0.8f, 320, EasingTypes.In);
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Modes.Osu/Objects/Drawables/Pieces/SpinnerBackground.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/Pieces/SpinnerBackground.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Game.Modes.Osu.Objects.Drawables.Pieces
+{
+    public class SpinnerBackground : SpinnerDisc
+    {
+        public override bool HandleInput => false;
+    }
+}

--- a/osu.Game.Modes.Osu/Objects/Drawables/Pieces/SpinnerDisc.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/Pieces/SpinnerDisc.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Transformations;
+using osu.Framework.Input;
+using osu.Framework.Logging;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Game.Modes.Osu.Objects.Drawables.Pieces
+{
+    public class SpinnerDisc : CircularContainer
+    {
+        public override bool Contains(Vector2 screenSpacePos) => true;
+
+        protected Sprite Disc;
+
+        public SRGBColour DiscColour
+        {
+            get { return Disc.Colour; }
+            set { Disc.Colour = value; }
+        }
+
+        class SpinnerBorder : Container
+        {
+            public SpinnerBorder()
+            {
+                Origin = Anchor.Centre;
+                Anchor = Anchor.Centre;
+                RelativeSizeAxes = Axes.Both;
+
+                layout();
+            }
+
+            private int lastLayoutDotCount;
+            private void layout()
+            {
+                int count = (int)(MathHelper.Pi * ScreenSpaceDrawQuad.Width / 9);
+
+                if (count == lastLayoutDotCount) return;
+
+                lastLayoutDotCount = count;
+
+                while (Children.Count() < count)
+                {
+                    Add(new CircularContainer
+                    {
+                        Colour = Color4.White,
+                        RelativePositionAxes = Axes.Both,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(1 / ScreenSpaceDrawQuad.Width * 2000),
+                        Children = new[]
+                        {
+                            new Box
+                            {
+                                Origin = Anchor.Centre,
+                                Anchor = Anchor.Centre,
+                                RelativeSizeAxes = Axes.Both,
+                            }
+                        }
+                    });
+                }
+
+                var size = new Vector2(1 / ScreenSpaceDrawQuad.Width * 2000);
+
+                int i = 0;
+                foreach (var d in Children)
+                {
+                    d.Size = size;
+                    d.Position = new Vector2(
+                        0.5f + (float)Math.Sin((float)i / count * 2 * MathHelper.Pi) / 2,
+                        0.5f + (float)Math.Cos((float)i / count * 2 * MathHelper.Pi) / 2
+                    );
+
+                    i++;
+                }
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+                layout();
+            }
+        }
+
+        public SpinnerDisc()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            Children = new Drawable[]
+            {
+                Disc = new Box
+                {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.2f,
+                },
+                new SpinnerBorder()
+            };
+        }
+
+        bool tracking;
+        public bool Tracking
+        {
+            get { return tracking; }
+            set
+            {
+                if (value == tracking) return;
+
+                tracking = value;
+
+                Disc.FadeTo(tracking ? 0.5f : 0.2f, 100);
+            }
+        }
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
+        {
+            Tracking = true;
+            return base.OnMouseDown(state, args);
+        }
+
+        protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
+        {
+            Tracking = false;
+            return base.OnMouseUp(state, args);
+        }
+
+        protected override bool OnMouseMove(InputState state)
+        {
+            Tracking |= state.Mouse.HasMainButtonPressed;
+            mousePosition = state.Mouse.Position;
+            return base.OnMouseMove(state);
+        }
+
+        private Vector2 mousePosition;
+
+        private float lastAngle;
+        private float currentRotation;
+        public float RotationAbsolute;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var thisAngle = -(float)MathHelper.RadiansToDegrees(Math.Atan2(mousePosition.X - DrawSize.X / 2, mousePosition.Y - DrawSize.Y / 2));
+            if (tracking)
+            {
+                if (thisAngle - lastAngle > 180)
+                    lastAngle += 360;
+                else if (lastAngle - thisAngle > 180)
+                    lastAngle -= 360;
+
+                currentRotation += thisAngle - lastAngle;
+                RotationAbsolute += Math.Abs(thisAngle - lastAngle);
+            }
+            lastAngle = thisAngle;
+
+            RotateTo(currentRotation, 100, EasingTypes.OutExpo);
+        }
+    }
+}

--- a/osu.Game.Modes.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Modes.Osu/Objects/OsuHitObject.cs
@@ -31,19 +31,19 @@ namespace osu.Game.Modes.Osu.Objects
 
             Scale = (1.0f - 0.7f * (beatmap.BeatmapInfo.BaseDifficulty.CircleSize - 5) / 5) / 2;
         }
+    }
 
-        [Flags]
-        internal enum HitObjectType
-        {
-            Circle = 1,
-            Slider = 2,
-            NewCombo = 4,
-            CircleNewCombo = 5,
-            SliderNewCombo = 6,
-            Spinner = 8,
-            ColourHax = 122,
-            Hold = 128,
-            ManiaLong = 128,
-        }
+    [Flags]
+    public enum HitObjectType
+    {
+        Circle = 1,
+        Slider = 2,
+        NewCombo = 4,
+        CircleNewCombo = 5,
+        SliderNewCombo = 6,
+        Spinner = 8,
+        ColourHax = 122,
+        Hold = 128,
+        ManiaLong = 128,
     }
 }

--- a/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
+++ b/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
@@ -26,7 +26,10 @@ namespace osu.Game.Modes.Osu.Objects
             switch (type)
             {
                 case HitObjectType.Circle:
-                    result = new HitCircle();
+                    result = new HitCircle
+                    {
+                        Position = new Vector2(int.Parse(split[0]), int.Parse(split[1]))
+                    };
                     break;
                 case HitObjectType.Slider:
                     CurveTypes curveType = CurveTypes.Catmull;
@@ -82,18 +85,22 @@ namespace osu.Game.Modes.Osu.Objects
                         ControlPoints = points,
                         Length = length,
                         CurveType = curveType,
-                        RepeatCount = repeatCount
+                        RepeatCount = repeatCount,
+                        Position = new Vector2(int.Parse(split[0]), int.Parse(split[1]))
                     };
                     break;
                 case HitObjectType.Spinner:
-                    result = new Spinner();
+                    result = new Spinner
+                    {
+                        Length = Convert.ToDouble(split[5], CultureInfo.InvariantCulture) - Convert.ToDouble(split[2], CultureInfo.InvariantCulture),
+                        Position = new Vector2(512, 384) / 2,
+                    };
                     break;
                 default:
                     //throw new InvalidOperationException($@"Unknown hit object type {type}");
                     return null;
             }
-            result.Position = new Vector2(int.Parse(split[0]), int.Parse(split[1]));
-            result.StartTime = double.Parse(split[2]);
+            result.StartTime = Convert.ToDouble(split[2], CultureInfo.InvariantCulture);
             result.Sample = new HitSampleInfo
             {
                 Type = (SampleType)int.Parse(split[4]),

--- a/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
+++ b/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
@@ -18,17 +18,17 @@ namespace osu.Game.Modes.Osu.Objects
         public override HitObject Parse(string text)
         {
             string[] split = text.Split(',');
-            var type = (OsuHitObject.HitObjectType)int.Parse(split[3]);
-            bool combo = type.HasFlag(OsuHitObject.HitObjectType.NewCombo);
-            type &= (OsuHitObject.HitObjectType)0xF;
-            type &= ~OsuHitObject.HitObjectType.NewCombo;
+            var type = (HitObjectType)int.Parse(split[3]);
+            bool combo = type.HasFlag(HitObjectType.NewCombo);
+            type &= (HitObjectType)0xF;
+            type &= ~HitObjectType.NewCombo;
             OsuHitObject result;
             switch (type)
             {
-                case OsuHitObject.HitObjectType.Circle:
+                case HitObjectType.Circle:
                     result = new HitCircle();
                     break;
-                case OsuHitObject.HitObjectType.Slider:
+                case HitObjectType.Slider:
                     Slider s = new Slider();
 
                     CurveTypes curveType = CurveTypes.Catmull;
@@ -92,7 +92,7 @@ namespace osu.Game.Modes.Osu.Objects
 
                     result = s;
                     break;
-                case OsuHitObject.HitObjectType.Spinner:
+                case HitObjectType.Spinner:
                     result = new Spinner();
                     break;
                 default:

--- a/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
+++ b/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Modes.Osu.Objects
                     break;
                 case HitObjectType.Slider:
                     CurveTypes curveType = CurveTypes.Catmull;
-                    int repeatCount = 0;
+                    int repeatCount;
                     double length = 0;
                     List<Vector2> points = new List<Vector2>();
 

--- a/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
+++ b/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
@@ -29,8 +29,6 @@ namespace osu.Game.Modes.Osu.Objects
                     result = new HitCircle();
                     break;
                 case HitObjectType.Slider:
-                    Slider s = new Slider();
-
                     CurveTypes curveType = CurveTypes.Catmull;
                     int repeatCount = 0;
                     double length = 0;
@@ -79,18 +77,13 @@ namespace osu.Game.Modes.Osu.Objects
                     if (split.Length > 7)
                         length = Convert.ToDouble(split[7], CultureInfo.InvariantCulture);
 
-                    s.RepeatCount = repeatCount;
-
-                    s.Curve = new SliderCurve
+                    result = new Slider
                     {
                         ControlPoints = points,
                         Length = length,
-                        CurveType = curveType
+                        CurveType = curveType,
+                        RepeatCount = repeatCount
                     };
-
-                    s.Curve.Calculate();
-
-                    result = s;
                     break;
                 case HitObjectType.Spinner:
                     result = new Spinner();
@@ -101,7 +94,8 @@ namespace osu.Game.Modes.Osu.Objects
             }
             result.Position = new Vector2(int.Parse(split[0]), int.Parse(split[1]));
             result.StartTime = double.Parse(split[2]);
-            result.Sample = new HitSampleInfo {
+            result.Sample = new HitSampleInfo
+            {
                 Type = (SampleType)int.Parse(split[4]),
                 Set = SampleSet.Soft,
             };

--- a/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
+++ b/osu.Game.Modes.Osu/Objects/OsuHitObjectParser.cs
@@ -97,8 +97,7 @@ namespace osu.Game.Modes.Osu.Objects
                     };
                     break;
                 default:
-                    //throw new InvalidOperationException($@"Unknown hit object type {type}");
-                    return null;
+                    throw new InvalidOperationException($@"Unknown hit object type {type}");
             }
             result.StartTime = Convert.ToDouble(split[2], CultureInfo.InvariantCulture);
             result.Sample = new HitSampleInfo

--- a/osu.Game.Modes.Osu/Objects/Slider.cs
+++ b/osu.Game.Modes.Osu/Objects/Slider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using OpenTK;
 
@@ -19,9 +20,26 @@ namespace osu.Game.Modes.Osu.Objects
             set
             {
                 stackHeight = value;
-                if (Curve != null)
-                    Curve.Offset = StackOffset;
+                Curve.Offset = StackOffset;
             }
+        }
+
+        public List<Vector2> ControlPoints
+        {
+            get { return Curve.ControlPoints; }
+            set { Curve.ControlPoints = value; }
+        }
+
+        public double Length
+        {
+            get { return Curve.Length; }
+            set { Curve.Length = value; }
+        }
+
+        public CurveTypes CurveType
+        {
+            get { return Curve.CurveType; }
+            set { Curve.CurveType = value; }
         }
 
         public double Velocity;
@@ -35,7 +53,7 @@ namespace osu.Game.Modes.Osu.Objects
 
         public int RepeatCount;
 
-        public SliderCurve Curve;
+        internal readonly SliderCurve Curve = new SliderCurve();
     }
 
     public enum CurveTypes

--- a/osu.Game.Modes.Osu/Objects/Slider.cs
+++ b/osu.Game.Modes.Osu/Objects/Slider.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Modes.Osu.Objects
             Velocity = 100 / beatmap.BeatLengthAt(StartTime, true) * beatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier;
         }
 
-        public int RepeatCount;
+        public int RepeatCount = 1;
 
         internal readonly SliderCurve Curve = new SliderCurve();
     }

--- a/osu.Game.Modes.Osu/Objects/SliderCurve.cs
+++ b/osu.Game.Modes.Osu/Objects/SliderCurve.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Modes.Osu.Objects
 
         public List<Vector2> ControlPoints;
 
-        public CurveTypes CurveType;
+        public CurveTypes CurveType = CurveTypes.PerfectCurve;
 
         public Vector2 Offset;
 

--- a/osu.Game.Modes.Osu/Objects/SliderCurve.cs
+++ b/osu.Game.Modes.Osu/Objects/SliderCurve.cs
@@ -172,6 +172,9 @@ namespace osu.Game.Modes.Osu.Objects
         /// <param name="p1">End progress. Ranges from 0 (beginning of the slider) to 1 (end of the slider).</param>
         public void GetPathToProgress(List<Vector2> path, double p0, double p1)
         {
+            if (calculatedPath.Count == 0 && ControlPoints.Count > 0)
+                Calculate();
+
             double d0 = progressToDistance(p0);
             double d1 = progressToDistance(p1);
 
@@ -196,6 +199,9 @@ namespace osu.Game.Modes.Osu.Objects
         /// <returns></returns>
         public Vector2 PositionAt(double progress)
         {
+            if (calculatedPath.Count == 0 && ControlPoints.Count > 0)
+                Calculate();
+
             double d = progressToDistance(progress);
             return interpolateVertices(indexOfDistance(d), d) + Offset;
         }

--- a/osu.Game.Modes.Osu/Objects/Spinner.cs
+++ b/osu.Game.Modes.Osu/Objects/Spinner.cs
@@ -1,9 +1,14 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using osu.Game.Beatmaps;
+
 namespace osu.Game.Modes.Osu.Objects
 {
     public class Spinner : OsuHitObject
     {
+        public double Length;
+
+        public override double EndTime => StartTime + Length;
     }
 }

--- a/osu.Game.Modes.Osu/UI/OsuHitRenderer.cs
+++ b/osu.Game.Modes.Osu/UI/OsuHitRenderer.cs
@@ -21,7 +21,8 @@ namespace osu.Game.Modes.Osu.UI
                 return new DrawableHitCircle(h as HitCircle);
             if (h is Slider)
                 return new DrawableSlider(h as Slider);
-
+            if (h is Spinner)
+                return new DrawableSpinner(h as Spinner);
             return null;
         }
     }

--- a/osu.Game.Modes.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Modes.Osu/UI/OsuPlayfield.cs
@@ -60,10 +60,10 @@ namespace osu.Game.Modes.Osu.UI
         public override void Add(DrawableHitObject h)
         {
             h.Depth = (float)h.HitObject.StartTime;
-            DrawableHitCircle c = h as DrawableHitCircle;
+            IDrawableHitObjectWithProxiedApproach c = h as IDrawableHitObjectWithProxiedApproach;
             if (c != null)
             {
-                approachCircles.Add(c.ApproachCircle.CreateProxy());
+                approachCircles.Add(c.ProxiedLayer.CreateProxy());
             }
 
             h.OnJudgement += judgement;

--- a/osu.Game.Modes.Osu/osu.Game.Modes.Osu.csproj
+++ b/osu.Game.Modes.Osu/osu.Game.Modes.Osu.csproj
@@ -49,9 +49,11 @@
     <Compile Include="Objects\Drawables\Connections\ConnectionRenderer.cs" />
     <Compile Include="Objects\Drawables\Connections\FollowPointRenderer.cs" />
     <Compile Include="Objects\Drawables\Pieces\ApproachCircle.cs" />
+    <Compile Include="Objects\Drawables\Pieces\SpinnerBackground.cs" />
     <Compile Include="Objects\Drawables\Pieces\CirclePiece.cs" />
     <Compile Include="Objects\Drawables\DrawableSlider.cs" />
     <Compile Include="Objects\Drawables\Connections\FollowPoint.cs" />
+    <Compile Include="Objects\Drawables\DrawableSpinner.cs" />
     <Compile Include="Objects\Drawables\Pieces\ExplodePiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\FlashPiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\GlowPiece.cs" />
@@ -59,6 +61,7 @@
     <Compile Include="Objects\Drawables\Pieces\NumberPiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\RingPiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\SliderBouncer.cs" />
+    <Compile Include="Objects\Drawables\Pieces\SpinnerDisc.cs" />
     <Compile Include="Objects\Drawables\Pieces\Triangles.cs" />
     <Compile Include="Objects\Drawables\Pieces\SliderBall.cs" />
     <Compile Include="Objects\Drawables\Pieces\SliderBody.cs" />

--- a/osu.Game.Modes.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Modes.Taiko/TaikoRuleset.cs
@@ -25,6 +25,6 @@ namespace osu.Game.Modes.Taiko
 
         public override ScoreProcessor CreateScoreProcessor(int hitObjectCount) => null;
 
-        public override HitObjectParser CreateHitObjectParser() => new OsuHitObjectParser();
+        public override HitObjectParser CreateHitObjectParser() => new NullHitObjectParser();
     }
 }

--- a/osu.Game/Modes/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Modes/Objects/Drawables/DrawableHitObject.cs
@@ -19,6 +19,10 @@ namespace osu.Game.Modes.Objects.Drawables
     {
         public event Action<DrawableHitObject, JudgementInfo> OnJudgement;
 
+        public override bool HandleInput => Interactive;
+
+        public bool Interactive = true;
+
         public Container<DrawableHitObject> ChildObjects;
 
         public JudgementInfo Judgement;

--- a/osu.Game/Modes/Objects/Drawables/IDrawableHitObjectWithProxiedApproach.cs
+++ b/osu.Game/Modes/Objects/Drawables/IDrawableHitObjectWithProxiedApproach.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Modes.Objects.Drawables
+{
+    public interface IDrawableHitObjectWithProxiedApproach
+    {
+        Drawable ProxiedLayer { get; }
+    }
+}

--- a/osu.Game/Modes/Objects/NullHitObjectParser.cs
+++ b/osu.Game/Modes/Objects/NullHitObjectParser.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+
+namespace osu.Game.Modes.Objects
+{
+    /// <summary>
+    /// Returns null HitObjects but at least allows us to run.
+    /// </summary>
+    public class NullHitObjectParser : HitObjectParser
+    {
+        public override HitObject Parse(string text) => null;
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -25,6 +25,7 @@ using OpenTK;
 using System.Linq;
 using osu.Framework.Graphics.Primitives;
 using System.Collections.Generic;
+using osu.Game.Overlays.Notifications;
 
 namespace osu.Game
 {
@@ -129,6 +130,16 @@ namespace osu.Game
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
             }).Preload(this, overlayContent.Add);
+
+            Logger.NewEntry += entry =>
+            {
+                if (entry.Level < LogLevel.Important) return;
+
+                notificationManager.Post(new SimpleNotification
+                {
+                    Text = $@"{entry.Level}: {entry.Message}"
+                });
+            };
 
             Dependencies.Cache(options);
             Dependencies.Cache(musicController);

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Screens.Select
                 {
                     Name = "Length",
                     Icon = FontAwesome.fa_clock_o,
-                    Content = TimeSpan.FromMilliseconds(beatmap.Beatmap.HitObjects.Last().EndTime - beatmap.Beatmap.HitObjects.First().StartTime).ToString(@"m\:ss"),
+                    Content = beatmap.Beatmap.HitObjects.Count == 0 ? "-" : TimeSpan.FromMilliseconds(beatmap.Beatmap.HitObjects.Last().EndTime - beatmap.Beatmap.HitObjects.First().StartTime).ToString(@"m\:ss"),
                 }));
 
                 labels.Add(new InfoLabel(new BeatmapStatistic

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Graphics\UserInterface\TwoLayerButton.cs" />
     <Compile Include="Modes\Objects\Drawables\IDrawableHitObjectWithProxiedApproach.cs" />
     <Compile Include="Modes\Objects\HitObjectParser.cs" />
+    <Compile Include="Modes\Objects\NullHitObjectParser.cs" />
     <Compile Include="Modes\Score.cs" />
     <Compile Include="Modes\ScoreProcesssor.cs" />
     <Compile Include="Modes\UI\HealthDisplay.cs" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Graphics\UserInterface\OsuSliderBar.cs" />
     <Compile Include="Graphics\UserInterface\OsuTextBox.cs" />
     <Compile Include="Graphics\UserInterface\TwoLayerButton.cs" />
+    <Compile Include="Modes\Objects\Drawables\IDrawableHitObjectWithProxiedApproach.cs" />
     <Compile Include="Modes\Objects\HitObjectParser.cs" />
     <Compile Include="Modes\Score.cs" />
     <Compile Include="Modes\ScoreProcesssor.cs" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/357. Will rebase after this is merged.
- [x] Depends on https://github.com/ppy/osu-framework/pull/481.

Replaces #269 and (partially) #272 with a more sound implementation.

![](https://puu.sh/u2EgE/5ba98e7032.gif)

The dotted borders are currently quite inefficient, but as the design may be changing I'm not going to spend more time on improving performance for the moment.