### PR TITLE
Fix beatmap import crash when the first timingPoint starts later than…

### DIFF
--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Beatmaps
                     }
                     else overridePoint = controlPoint;
                 }
+                // Some beatmaps have the first timingPoint (accidentally) start after the first HitObject(s).
+                // This branch makes it so that the first ControlPoint that makes a timing change is used as the timingPoint for the HitObject(s).
                 else if (timingPoint == null && controlPoint.TimingChange)
                 {
                     timingPoint = controlPoint;

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Beatmaps
 
             ControlPoint timingPoint = null;
             foreach (var controlPoint in ControlPoints)
+            {
                 if (controlPoint.Time <= time)
                 {
                     if (controlPoint.TimingChange)
@@ -48,7 +49,15 @@ namespace osu.Game.Beatmaps
                     }
                     else overridePoint = controlPoint;
                 }
-                else break;
+                else if (timingPoint == null && controlPoint.TimingChange)
+                {
+                    timingPoint = controlPoint;
+                }
+                else
+                {
+                    break;
+                }
+            }
 
             return timingPoint;
         }


### PR DESCRIPTION
… a slider

Some beatmaps such as [this](https://osu.ppy.sh/s/401790) have the first timingPoint start after the first slider (usually by accident). Current osu! uses the first timingPoint it sees for these sliders. This commit makes it so lazer does the same so that a NullReferenceException is avoided during beatmap import when calculating Velocity in Slider.cs.