### PR TITLE
Add resiliency to update process when delta patching fails.

### DIFF
--- a/osu.Desktop/Overlays/VersionManager.cs
+++ b/osu.Desktop/Overlays/VersionManager.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -174,6 +175,25 @@ namespace osu.Desktop.Overlays
                     return true;
                 }
             };
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                IconContent.Add(new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        ColourInfo = ColourInfo.GradientVertical(colours.YellowDark, colours.Yellow)
+                    },
+                    new TextAwesome
+                    {
+                        Anchor = Anchor.Centre,
+                        Icon = FontAwesome.fa_upload,
+                        Colour = Color4.White,
+                    }
+                });
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -89,7 +89,6 @@ namespace osu.Game.Overlays.Notifications
                                 IconContent = new Container
                                 {
                                     Size = new Vector2(40),
-                                    Colour = Color4.DarkGray,
                                     Masking = true,
                                     CornerRadius = 5,
                                 },

--- a/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using osu.Framework.Allocation;
 using osu.Game.Graphics;
+using osu.Framework.Graphics.Colour;
+using OpenTK.Graphics;
+
 
 namespace osu.Game.Overlays.Notifications
 {
@@ -13,6 +17,12 @@ namespace osu.Game.Overlays.Notifications
         {
             this.progressNotification = progressNotification;
             Icon = FontAwesome.fa_check;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            IconBackgound.ColourInfo = ColourInfo.GradientVertical(colours.GreenDark, colours.GreenLight);
         }
     }
 }

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -37,19 +37,21 @@ namespace osu.Game.Overlays.Notifications
         private SpriteText textDrawable;
         private TextAwesome iconDrawable;
 
+        protected Box IconBackgound;
+
         public SimpleNotification()
         {
             IconContent.Add(new Drawable[]
             {
-                new Box
+                IconBackgound = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    ColourInfo = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.5f))
+                    ColourInfo = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.6f))
                 },
                 iconDrawable = new TextAwesome
                 {
                     Anchor = Anchor.Centre,
-                    Icon = icon ,
+                    Icon = icon,
                 }
             });
 


### PR DESCRIPTION
As per https://github.com/Squirrel/Squirrel.Windows/issues/959, it looks like adding retry logic at our end is the correct way to go about this (for now).

This adds a fallback path when delta patching fails - usually due to missing deltas - and will attempt updating a second time using a full release in such cases.