### PR TITLE
Fix memory leak from Player's InputManager.

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -84,16 +84,16 @@ namespace osu.Game.Tests.Beatmaps.IO
             Action waitAction = () =>
             {
                 while ((resultSets = osu.Dependencies.Get<BeatmapDatabase>()
-                    .Query<BeatmapSetInfo>().Where(s => s.OnlineBeatmapSetID == 241526)).Count() != 1)
-                    Thread.Sleep(1);
+                    .Query<BeatmapSetInfo>().Where(s => s.OnlineBeatmapSetID == 241526)).Count() == 0)
+                    Thread.Sleep(50);
             };
 
             Assert.IsTrue(waitAction.BeginInvoke(null, null).AsyncWaitHandle.WaitOne(timeout),
-                @"BeatmapSet did not import to the database");
+                $@"BeatmapSet did not import to the database in allocated time.");
 
             //ensure we were stored to beatmap database backing...
 
-            Assert.IsTrue(resultSets.Count() == 1);
+            Assert.IsTrue(resultSets.Count() == 1, $@"Incorrect result count found ({resultSets.Count()} but should be 1).");
 
             IEnumerable<BeatmapInfo> resultBeatmaps = null;
 

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 if (!importer.ImportAsync(osz_path).Wait(1000))
                     Assert.Fail(@"IPC took too long to send");
 
-                ensureLoaded(osu, 10000);
+                ensureLoaded(osu);
             }
         }
 
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             return osu;
         }
 
-        private void ensureLoaded(OsuGameBase osu, int timeout = 100)
+        private void ensureLoaded(OsuGameBase osu, int timeout = 10000)
         {
             IEnumerable<BeatmapSetInfo> resultSets = null;
 

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -102,16 +102,17 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 while ((resultBeatmaps = osu.Dependencies.Get<BeatmapDatabase>()
                     .Query<BeatmapInfo>().Where(s => s.OnlineBeatmapSetID == 241526 && s.BaseDifficultyID > 0)).Count() != 12)
-                    Thread.Sleep(1);
+                    Thread.Sleep(50);
             };
 
             Assert.IsTrue(waitAction.BeginInvoke(null, null).AsyncWaitHandle.WaitOne(timeout),
-                @"Beatmaps did not import to the database");
+                @"Beatmaps did not import to the database in allocated time");
 
             //fetch children and check we can load from the post-storage path...
             var set = osu.Dependencies.Get<BeatmapDatabase>().GetChildren(resultSets.First());
 
-            Assert.IsTrue(set.Beatmaps.Count == resultBeatmaps.Count());
+            Assert.IsTrue(set.Beatmaps.Count == resultBeatmaps.Count(),
+                $@"Incorrect database beatmap count post-import ({resultBeatmaps.Count()} but should be {set.Beatmaps.Count}).");
 
             foreach (BeatmapInfo b in resultBeatmaps)
                 Assert.IsTrue(set.Beatmaps.Any(c => c.OnlineBeatmapID == b.OnlineBeatmapID));

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -222,12 +222,6 @@ namespace osu.Game.Screens.Play
             if (IsPaused) Pause(); else Resume();
         }
 
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-            playerInputManager?.Dispose();
-        }
-
         public void Restart()
         {
             sourceClock.Stop(); // If the clock is running and Restart is called the game will lag until relaunch

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -222,6 +222,12 @@ namespace osu.Game.Screens.Play
             if (IsPaused) Pause(); else Resume();
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            playerInputManager?.Dispose();
+        }
+
         public void Restart()
         {
             sourceClock.Stop(); // If the clock is running and Restart is called the game will lag until relaunch
@@ -312,6 +318,9 @@ namespace osu.Game.Screens.Play
             }
             else
             {
+                FadeOut(250);
+                Content.ScaleTo(0.7f, 750, EasingTypes.InQuint);
+
                 dimLevel.ValueChanged -= dimChanged;
                 Background?.FadeTo(1f, 200);
                 return base.OnExiting(next);

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -89,6 +89,12 @@ namespace osu.Game.Screens.Play
         {
             Content.ScaleTo(0.7f, 150, EasingTypes.InQuint);
             FadeOut(150);
+
+            //this is required to clean up the InputManager in Player.
+            //can be removed once we solve that one.
+            if (player != null && player.LoadState != LoadState.Alive)
+                player.Dispose();
+
             return base.OnExiting(next);
         }
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -80,6 +80,8 @@ namespace osu.Game.Screens.Play
 
             Schedule(() =>
             {
+                if (!IsCurrentScreen) return;
+
                 if (!Push(player))
                     Exit();
             });

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Play
             Content.ScaleTo(0.7f, 150, EasingTypes.InQuint);
             FadeOut(150);
 
-            //this is required to clean up the InputManager in Player.
+            //OsuScreens are currently never finalised due to the Bindable<Beatmap> bindings.
             //can be removed once we solve that one.
             if (player != null && player.LoadState != LoadState.Alive)
                 player.Dispose();


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/516.
- [x] Depends on https://github.com/ppy/osu-framework/pull/515 (for extra resiliency).

Hopefully we can resolve this another way eventually, but this is a working interim solution. Comments to make sure we know it needs to be changed.