### PR TITLE
Remove source on Import(IEnumerable<string> paths), Import(string path)

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -40,8 +41,16 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (HeadlessGameHost host = new HeadlessGameHost())
             {
                 var osu = loadOsu(host);
-                osu.Dependencies.Get<BeatmapDatabase>().Import(osz_path);
+
+                var temp = prepareTempCopy(osz_path);
+
+                Assert.IsTrue(File.Exists(temp));
+
+                osu.Dependencies.Get<BeatmapDatabase>().Import(temp);
+
                 ensureLoaded(osu);
+
+                Assert.IsFalse(File.Exists(temp));
             }
         }
 
@@ -56,12 +65,24 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                 var osu = loadOsu(host);
 
+                var temp = prepareTempCopy(osz_path);
+
+                Assert.IsTrue(File.Exists(temp));
+
                 var importer = new BeatmapImporter(client);
-                if (!importer.ImportAsync(osz_path).Wait(1000))
+                if (!importer.ImportAsync(temp).Wait(1000))
                     Assert.Fail(@"IPC took too long to send");
 
                 ensureLoaded(osu);
+
+                Assert.IsFalse(File.Exists(temp));
             }
+        }
+
+        private string prepareTempCopy(string path)
+        {
+            var temp = Path.GetTempFileName();
+            return new FileInfo(osz_path).CopyTo(temp, true).FullName;
         }
 
         private OsuGameBase loadOsu(GameHost host)

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -79,6 +79,31 @@ namespace osu.Game.Tests.Beatmaps.IO
             }
         }
 
+        [Test]
+        public void TestImportWhenFileOpen()
+        {
+            //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
+            using (HeadlessGameHost host = new HeadlessGameHost())
+            {
+                var osu = loadOsu(host);
+
+                var temp = prepareTempCopy(osz_path);
+
+                Assert.IsTrue(File.Exists(temp));
+
+                using (FileStream stream = File.OpenRead(temp))
+                    osu.Dependencies.Get<BeatmapDatabase>().Import(temp);
+
+                ensureLoaded(osu);
+
+                Assert.IsTrue(File.Exists(temp));
+                
+                File.Delete(temp);
+
+                Assert.IsFalse(File.Exists(temp));
+            }
+        }
+
         private string prepareTempCopy(string path)
         {
             var temp = Path.GetTempFileName();

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -125,7 +125,8 @@ namespace osu.Game.Database
                 {
                     BeatmapSetInfo set = getBeatmapSet(p);
 
-                    sets.Push(set);
+                    if (set.ID == 0)
+                        sets.Push(set);
 
                     // We may or may not want to delete the file depending on where it is stored.
                     //  e.g. reconstructing/repairing database with beatmaps from default storage.
@@ -193,7 +194,7 @@ namespace osu.Game.Database
                     BeatmapSetAdded?.Invoke(existing);
                 }
 
-                return null;
+                return existing;
             }
 
             var beatmapSet = new BeatmapSetInfo
@@ -233,11 +234,10 @@ namespace osu.Game.Database
                 connection.BeginTransaction();
 
                 foreach (var s in beatmapSets)
-                    if (s != null)
-                    {
-                        connection.InsertWithChildren(s, true);
-                        BeatmapSetAdded?.Invoke(s);
-                    }
+                {
+                    connection.InsertWithChildren(s, true);
+                    BeatmapSetAdded?.Invoke(s);
+                }
 
                 connection.Commit();
             }

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -116,6 +116,10 @@ namespace osu.Game.Database
             connection.DeleteAll<BeatmapInfo>();
         }
 
+        /// <summary>
+        /// Import multiple <see cref="BeatmapSetInfo"/> from <paramref name="paths"/>.
+        /// </summary>
+        /// <param name="paths">Multiple locations on disk</param>
         public void Import(IEnumerable<string> paths)
         {
             Stack<BeatmapSetInfo> sets = new Stack<BeatmapSetInfo>();
@@ -151,6 +155,10 @@ namespace osu.Game.Database
             Import(sets);
         }
 
+        /// <summary>
+        /// Import <see cref="BeatmapSetInfo"/> from <paramref name="path"/>.
+        /// </summary>
+        /// <param name="path">Location on disk</param>
         public void Import(string path)
         {
             Import(new [] { path });

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Database
             foreach (string p in paths)
                 try
                 {
-                    BeatmapSetInfo set = importBeatmapSet(p);
+                    BeatmapSetInfo set = getBeatmapSet(p);
 
                     sets.Push(set);
 
@@ -153,7 +153,13 @@ namespace osu.Game.Database
             Import(new [] { path });
         }
 
-        private BeatmapSetInfo importBeatmapSet(string path)
+        /// <summary>
+        /// Duplicates content from <paramref name="path"/> to storage and returns a representing <see cref="BeatmapSetInfo"/>.
+        /// Returns null if a representation already exists.
+        /// </summary>
+        /// <param name="path">Content location</param>
+        /// <returns><see cref="BeatmapSetInfo"/> or null</returns>
+        private BeatmapSetInfo getBeatmapSet(string path)
         {
             string hash = null;
 

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Database
                 {
                     BeatmapSetInfo set = getBeatmapSet(p);
 
+                    //If we have an ID then we already exist in the database.
                     if (set.ID == 0)
                         sets.Push(set);
 

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -126,13 +126,7 @@ namespace osu.Game.Database
                     BeatmapSetInfo set = importBeatmapSet(p);
 
                     sets.Push(set);
-                }
-                catch (Exception e)
-                {
-                    Logger.Error(e, $@"Could not import beatmap set");
-                }
-                finally
-                {
+
                     // We may or may not want to delete the file depending on where it is stored.
                     //  e.g. reconstructing/repairing database with beatmaps from default storage.
                     // TODO: Add a check to prevent files from storage to be deleted.
@@ -144,6 +138,10 @@ namespace osu.Game.Database
                     {
                         Logger.Error(e, $@"Could not delete file at {p}");
                     }
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, $@"Could not import beatmap set");
                 }
             
             // Batch commit with multiple sets to database

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Database
                 }
                 catch (Exception e)
                 {
+                    e = e.InnerException ?? e;
                     Logger.Error(e, $@"Could not import beatmap set");
                 }
             

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -203,7 +203,6 @@ namespace osu.Game.Database
             {
                 string[] mapNames = reader.BeatmapFilenames;
                 foreach (var name in mapNames)
-                {
                     using (var stream = new StreamReader(reader.GetStream(name)))
                     {
                         var decoder = BeatmapDecoder.GetDecoder(stream);
@@ -215,8 +214,7 @@ namespace osu.Game.Database
 
                         beatmapSet.Beatmaps.Add(beatmap.BeatmapInfo);
                     }
-                    beatmapSet.StoryboardFile = reader.StoryboardFilename;
-                }
+                beatmapSet.StoryboardFile = reader.StoryboardFilename;
             }
 
             return beatmapSet;

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -130,6 +130,7 @@ namespace osu.Game.Database
 
                     // We may or may not want to delete the file depending on where it is stored.
                     //  e.g. reconstructing/repairing database with beatmaps from default storage.
+                    // Also, not always a single file, i.e. for LegacyFilesystemReader
                     // TODO: Add a check to prevent files from storage to be deleted.
                     try
                     {
@@ -156,10 +157,9 @@ namespace osu.Game.Database
 
         /// <summary>
         /// Duplicates content from <paramref name="path"/> to storage and returns a representing <see cref="BeatmapSetInfo"/>.
-        /// Returns null if a representation already exists.
         /// </summary>
         /// <param name="path">Content location</param>
-        /// <returns><see cref="BeatmapSetInfo"/> or null</returns>
+        /// <returns><see cref="BeatmapSetInfo"/></returns>
         private BeatmapSetInfo getBeatmapSet(string path)
         {
             string hash = null;


### PR DESCRIPTION
- Won't throw on unsupported beatmap
- Deletes file __only__ on a successful import.
- Writes to log if import or removal fails.

Alternative for removal of source file on import, also handles errors. Replaces #245.
