### PR TITLE
Fixed accuracy's counter first value change.

### DIFF
--- a/osu.Game.Modes.Osu/OsuScoreProcessor.cs
+++ b/osu.Game.Modes.Osu/OsuScoreProcessor.cs
@@ -12,6 +12,7 @@ namespace osu.Game.Modes.Osu
             : base(hitObjectCount)
         {
             Health.Value = 1;
+            Accuracy.Value = 1;
         }
 
         protected override void UpdateCalculations(JudgementInfo judgement)

--- a/osu.Game/Graphics/UserInterface/PercentageCounter.cs
+++ b/osu.Game/Graphics/UserInterface/PercentageCounter.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Graphics.UserInterface
         public PercentageCounter()
         {
             DisplayedCountSpriteText.FixedWidth = true;
-            Count = 1.0f;
+            Count = DisplayedCount = 1.0f;
         }
 
         protected override string FormatCount(float count)


### PR DESCRIPTION
Before, the counter was initialized appearing 100%, after the first 300 hit, the counter went from 0 to 100%. Also, if you didn't hit any note, the accuracy wouldn't go down to 0%, now fixed. 