### PR TITLE
Make DrawableHitObject expires explicit.

### DIFF
--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -128,9 +128,11 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
                 case ArmedState.Idle:
                     Delay(duration + TIME_PREEMPT);
                     FadeOut(TIME_FADEOUT);
+                    Expire(true);
                     break;
                 case ArmedState.Miss:
                     FadeOut(TIME_FADEOUT / 5);
+                    Expire();
                     break;
                 case ArmedState.Hit:
                     const double flash_in = 40;
@@ -150,6 +152,7 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
 
                     FadeOut(800);
                     ScaleTo(Scale * 1.5f, 400, EasingTypes.OutQuad);
+                    Expire();
                     break;
             }
         }

--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableSlider.cs
@@ -168,6 +168,8 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
             ball.FadeOut(160);
 
             FadeOut(800);
+
+            Expire();
         }
 
         public Drawable ProxiedLayer => initialCircle.ApproachCircle;

--- a/osu.Game.Modes.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Modes.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -146,9 +146,11 @@ namespace osu.Game.Modes.Osu.Objects.Drawables
             {
                 case ArmedState.Hit:
                     ScaleTo(Scale * 1.2f, 320, EasingTypes.Out);
+                    Expire();
                     break;
                 case ArmedState.Miss:
                     ScaleTo(Scale * 0.8f, 320, EasingTypes.In);
+                    Expire();
                     break;
             }
         }

--- a/osu.Game/Modes/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Modes/Objects/Drawables/DrawableHitObject.cs
@@ -34,12 +34,11 @@ namespace osu.Game.Modes.Objects.Drawables
 
             set
             {
-                if (state == value) return;
+                if (state == value)
+                    return;
                 state = value;
 
                 UpdateState(state);
-                if (IsLoaded)
-                    Expire();
 
                 if (State == ArmedState.Hit)
                     PlaySample();
@@ -63,8 +62,6 @@ namespace osu.Game.Modes.Objects.Drawables
 
             //force application of the state that was set before we loaded.
             UpdateState(State);
-
-            Expire(true);
         }
     }
 


### PR DESCRIPTION
Most other game modes, including osu!taiko, osu!mania and osu!catch will all be using some sort of constant-velocity scrolling method, which means those game mods will probably not use .Expire(), and instead define LifeTimeStart/LifeTimeEnd manually.

Explicit Expire()s are okay to use where LifeTimeStart/LifeTimeEnd isn't defined manually, but that's game mode specific.