### PR TITLE
Song select performance / code cleanup.

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -63,8 +63,6 @@ namespace osu.Game.Beatmaps.Drawables
         {
             BeatmapSet = beatmapSet;
             WorkingBeatmap beatmap = database.GetWorkingBeatmap(BeatmapSet.Beatmaps.FirstOrDefault());
-            foreach (var b in BeatmapSet.Beatmaps)
-                b.StarDifficulty = (float)(database.GetWorkingBeatmap(b).Beatmap?.CalculateStarDifficulty() ?? -1f);
 
             Header = new BeatmapSetHeader(beatmap)
             {

--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -10,7 +10,7 @@ using osu.Game.Database;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    internal class BeatmapGroup : IStateful<BeatmapGroupState>
+    public class BeatmapGroup : IStateful<BeatmapGroupState>
     {
         public BeatmapPanel SelectedPanel;
 

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -59,6 +59,8 @@ namespace osu.Game.Beatmaps.Drawables
 
         protected override void ApplyState(PanelSelectedState last = PanelSelectedState.Hidden)
         {
+            if (!IsLoaded) return;
+
             base.ApplyState(last);
 
             if (last == PanelSelectedState.Hidden && State != last)

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Beatmaps.Drawables
                                 },
                                 starCounter = new StarCounter
                                 {
-                                    Count = beatmap.StarDifficulty,
+                                    Count = (float)beatmap.StarDifficulty,
                                     Scale = new Vector2(0.8f),
                                 }
                             }

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -18,7 +18,7 @@ using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    internal class BeatmapPanel : Panel
+    public class BeatmapPanel : Panel
     {
         public BeatmapInfo Beatmap;
         private Sprite background;

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -17,7 +17,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    internal class BeatmapSetHeader : Panel
+    public class BeatmapSetHeader : Panel
     {
         public Action<BeatmapSetHeader> GainedSelection;
         private SpriteText title, artist;

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -32,10 +32,6 @@ namespace osu.Game.Beatmaps.Drawables
 
             Children = new Drawable[]
             {
-                new PanelBackground(beatmap)
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
                 new FillFlowContainer
                 {
                     Direction = FillDirection.Vertical,
@@ -74,13 +70,23 @@ namespace osu.Game.Beatmaps.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, OsuGameBase game)
         {
             this.config = config;
 
             preferUnicode = config.GetBindable<bool>(OsuConfig.ShowUnicode);
             preferUnicode.ValueChanged += preferUnicode_changed;
             preferUnicode_changed(preferUnicode, null);
+
+            new PanelBackground(beatmap)
+            {
+                RelativeSizeAxes = Axes.Both,
+                Depth = 1,
+            }.LoadAsync(game, b =>
+            {
+                Add(b);
+                b.FadeInFromZero(200);
+            });
         }
 
         private void preferUnicode_changed(object sender, EventArgs e)
@@ -98,16 +104,18 @@ namespace osu.Game.Beatmaps.Drawables
 
         private class PanelBackground : BufferedContainer
         {
-            private readonly WorkingBeatmap working;
-
             public PanelBackground(WorkingBeatmap working)
             {
-                this.working = working;
-
                 CacheDrawnFrameBuffer = true;
 
-                Children = new[]
+                Children = new Drawable[]
                 {
+                    new BeatmapBackgroundSprite(working)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        FillMode = FillMode.Fill,
+                    },
                     new FillFlowContainer
                     {
                         Depth = -1,
@@ -150,21 +158,6 @@ namespace osu.Game.Beatmaps.Drawables
                         }
                     },
                 };
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OsuGameBase game)
-            {
-                new BeatmapBackgroundSprite(working)
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    FillMode = FillMode.Fill,
-                }.LoadAsync(game, bg =>
-                {
-                    Add(bg);
-                    ForceRedraw();
-                });
             }
         }
 

--- a/osu.Game/Beatmaps/Drawables/Panel.cs
+++ b/osu.Game/Beatmaps/Drawables/Panel.cs
@@ -12,7 +12,7 @@ using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    internal class Panel : Container, IStateful<PanelSelectedState>
+    public class Panel : Container, IStateful<PanelSelectedState>
     {
         public const float MAX_HEIGHT = 80;
 
@@ -117,7 +117,7 @@ namespace osu.Game.Beatmaps.Drawables
         }
     }
 
-    internal enum PanelSelectedState
+    public enum PanelSelectedState
     {
         Hidden,
         NotSelected,

--- a/osu.Game/Beatmaps/Drawables/Panel.cs
+++ b/osu.Game/Beatmaps/Drawables/Panel.cs
@@ -51,6 +51,8 @@ namespace osu.Game.Beatmaps.Drawables
 
         protected virtual void ApplyState(PanelSelectedState last = PanelSelectedState.Hidden)
         {
+            if (!IsLoaded) return;
+
             switch (state)
             {
                 case PanelSelectedState.Hidden:

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -236,6 +236,8 @@ namespace osu.Game.Database
                         // TODO: Diff beatmap metadata with set metadata and leave it here if necessary
                         beatmap.BeatmapInfo.Metadata = null;
 
+                        beatmap.BeatmapInfo.StarDifficulty = beatmap.CalculateStarDifficulty();
+
                         beatmapSet.Beatmaps.Add(beatmap.BeatmapInfo);
                     }
                 beatmapSet.StoryboardFile = archive.StoryboardFilename;

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -123,16 +123,15 @@ namespace osu.Game.Database
         /// <param name="paths">Multiple locations on disk</param>
         public void Import(IEnumerable<string> paths)
         {
-            Stack<BeatmapSetInfo> sets = new Stack<BeatmapSetInfo>();
-
             foreach (string p in paths)
+            {
                 try
                 {
                     BeatmapSetInfo set = getBeatmapSet(p);
 
                     //If we have an ID then we already exist in the database.
                     if (set.ID == 0)
-                        sets.Push(set);
+                        Import(new[] { set });
 
                     // We may or may not want to delete the file depending on where it is stored.
                     //  e.g. reconstructing/repairing database with beatmaps from default storage.
@@ -152,9 +151,7 @@ namespace osu.Game.Database
                     e = e.InnerException ?? e;
                     Logger.Error(e, @"Could not import beatmap set");
                 }
-
-            // Batch commit with multiple sets to database
-            Import(sets);
+            }
         }
 
         /// <summary>

--- a/osu.Game/Database/BeatmapInfo.cs
+++ b/osu.Game/Database/BeatmapInfo.cs
@@ -75,16 +75,7 @@ namespace osu.Game.Database
         // Metadata
         public string Version { get; set; }
 
-        private float starDifficulty = -1;
-        public float StarDifficulty
-        {
-            get
-            {
-                return starDifficulty < 0 ? (Difficulty?.OverallDifficulty ?? 5) : starDifficulty;
-            }
-
-            set { starDifficulty = value; }
-        }
+        public double StarDifficulty { get; set; }
 
         public bool Equals(BeatmapInfo other)
         {

--- a/osu.Game/Database/BeatmapSetInfo.cs
+++ b/osu.Game/Database/BeatmapSetInfo.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Database
         [OneToMany(CascadeOperations = CascadeOperation.All)]
         public List<BeatmapInfo> Beatmaps { get; set; }
 
-        public float MaxStarDifficulty => Beatmaps.Max(b => b.StarDifficulty);
+        public double MaxStarDifficulty => Beatmaps.Max(b => b.StarDifficulty);
 
         public bool DeletePending { get; set; }
 

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Screens.Menu
         internal override bool ShowOverlays => buttons.State != MenuState.Initial;
 
         private BackgroundScreen background;
+        private Screen songSelect;
 
         protected override BackgroundScreen CreateBackground() => background;
 
@@ -46,7 +47,7 @@ namespace osu.Game.Screens.Menu
                             OnChart = delegate { Push(new ChartListing()); },
                             OnDirect = delegate { Push(new OnlineListing()); },
                             OnEdit = delegate { Push(new Editor()); },
-                            OnSolo = delegate { Push(new PlaySongSelect()); },
+                            OnSolo = delegate { Push(consumeSongSelect()); },
                             OnMulti = delegate { Push(new Lobby()); },
                             OnTest  = delegate { Push(new TestBrowser()); },
                             OnExit = delegate { Exit(); },
@@ -62,6 +63,24 @@ namespace osu.Game.Screens.Menu
             background.LoadAsync(game);
 
             buttons.OnSettings = game.ToggleOptions;
+
+            preloadSongSelect();
+        }
+
+        private void preloadSongSelect()
+        {
+            if (songSelect == null)
+            {
+                songSelect = new PlaySongSelect();
+                songSelect.LoadAsync(Game);
+            }
+        }
+
+        private Screen consumeSongSelect()
+        {
+            var s = songSelect;
+            songSelect = null;
+            return s;
         }
 
         protected override void OnEntering(Screen last)
@@ -85,6 +104,9 @@ namespace osu.Game.Screens.Menu
         protected override void OnResuming(Screen last)
         {
             base.OnResuming(last);
+
+            //we may have consumed our preloaded instance, so let's make another.
+            preloadSongSelect();
 
             const float length = 300;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -201,7 +201,7 @@ namespace osu.Game.Screens.Select
 
                 computeYPositions();
 
-                if (selectedGroup.State == BeatmapGroupState.Hidden)
+                if (selectedGroup == null || selectedGroup.State == BeatmapGroupState.Hidden)
                     SelectNext();
             };
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -21,7 +21,7 @@ using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select
 {
-    internal class CarouselContainer : ScrollContainer, IEnumerable<BeatmapGroup>
+    internal class BeatmapCarousel : ScrollContainer, IEnumerable<BeatmapGroup>
     {
         public BeatmapInfo SelectedBeatmap => selectedPanel?.Beatmap;
 
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.Select
 
         private BeatmapPanel selectedPanel;
 
-        public CarouselContainer()
+        public BeatmapCarousel()
         {
             Add(scrollableContent = new Container<Panel>
             {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Screens.Select
 
         private readonly Bindable<PlayMode> playMode = new Bindable<PlayMode>();
 
-        [BackgroundDependencyLoader]
+        [BackgroundDependencyLoader(permitNulls:true)]
         private void load(OsuColour colours, OsuGame osu)
         {
             sortTabs.AccentColour = colours.GreenLight;

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Select
                 if (sort != value)
                 {
                     sort = value;
-                    FilterChanged?.Invoke(Criteria);
+                    FilterChanged?.Invoke(CreateCriteria());
                 }
             }
         }
@@ -51,12 +51,12 @@ namespace osu.Game.Screens.Select
                 if (group != value)
                 {
                     group = value;
-                    FilterChanged?.Invoke(Criteria);
+                    FilterChanged?.Invoke(CreateCriteria());
                 }
             }
         }
 
-        public FilterCriteria Criteria => new FilterCriteria
+        public FilterCriteria CreateCriteria() => new FilterCriteria
         {
             Group = group,
             Sort = sort,
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.Select
                             OnChange = (sender, newText) =>
                             {
                                 if (newText)
-                                    FilterChanged?.Invoke(Criteria);
+                                    FilterChanged?.Invoke(CreateCriteria());
                             },
                             Exit = () => Exit?.Invoke(),
                         },

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -5,6 +5,7 @@ using System;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -15,14 +16,13 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Select.Filter;
 using Container = osu.Framework.Graphics.Containers.Container;
 using osu.Framework.Input;
+using osu.Game.Modes;
 
 namespace osu.Game.Screens.Select
 {
     public class FilterControl : Container
     {
-        public Action FilterChanged;
-
-        public string Search => searchTextBox.Text;
+        public Action<FilterCriteria> FilterChanged;
 
         private OsuTabControl<SortMode> sortTabs;
 
@@ -30,16 +30,16 @@ namespace osu.Game.Screens.Select
 
         private SortMode sort = SortMode.Title;
         public SortMode Sort
-        { 
-            get { return sort; } 
+        {
+            get { return sort; }
             set
             {
                 if (sort != value)
                 {
                     sort = value;
-                    FilterChanged?.Invoke();
+                    FilterChanged?.Invoke(Criteria);
                 }
-            } 
+            }
         }
 
         private GroupMode group = GroupMode.All;
@@ -51,10 +51,18 @@ namespace osu.Game.Screens.Select
                 if (group != value)
                 {
                     group = value;
-                    FilterChanged?.Invoke();
+                    FilterChanged?.Invoke(Criteria);
                 }
             }
         }
+
+        public FilterCriteria Criteria => new FilterCriteria
+        {
+            Group = group,
+            Sort = sort,
+            SearchText = searchTextBox.Text,
+            Mode = playMode
+        };
 
         public Action Exit;
 
@@ -88,7 +96,7 @@ namespace osu.Game.Screens.Select
                             OnChange = (sender, newText) =>
                             {
                                 if (newText)
-                                    FilterChanged?.Invoke();
+                                    FilterChanged?.Invoke(Criteria);
                             },
                             Exit = () => Exit?.Invoke(),
                         },
@@ -152,16 +160,21 @@ namespace osu.Game.Screens.Select
             searchTextBox.HoldFocus = false;
             searchTextBox.TriggerFocusLost();
         }
-        
+
         public void Activate()
         {
             searchTextBox.HoldFocus = true;
         }
 
+        private readonly Bindable<PlayMode> playMode = new Bindable<PlayMode>();
+
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, OsuGame osu)
         {
             sortTabs.AccentColour = colours.GreenLight;
+
+            if (osu != null)
+                playMode.BindTo(osu.PlayMode);
         }
 
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => true;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps.Drawables;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps.Drawables;
+using osu.Game.Modes;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Screens.Select
+{
+    public class FilterCriteria
+    {
+        public GroupMode Group;
+        public SortMode Sort;
+        public string SearchText;
+        public PlayMode Mode;
+
+        public void Filter(List<BeatmapGroup> groups)
+        {
+            foreach (var g in groups)
+            {
+                var set = g.BeatmapSet;
+
+                bool hasCurrentMode = set.Beatmaps.Any(bm => bm.Mode == Mode);
+
+                bool match = hasCurrentMode;
+
+                match &= string.IsNullOrEmpty(SearchText)
+                    || (set.Metadata.Artist ?? string.Empty).IndexOf(SearchText, StringComparison.InvariantCultureIgnoreCase) != -1
+                    || (set.Metadata.ArtistUnicode ?? string.Empty).IndexOf(SearchText, StringComparison.InvariantCultureIgnoreCase) != -1
+                    || (set.Metadata.Title ?? string.Empty).IndexOf(SearchText, StringComparison.InvariantCultureIgnoreCase) != -1
+                    || (set.Metadata.TitleUnicode ?? string.Empty).IndexOf(SearchText, StringComparison.InvariantCultureIgnoreCase) != -1;
+
+                switch (g.State)
+                {
+                    case BeatmapGroupState.Hidden:
+                        if (match) g.State = BeatmapGroupState.Collapsed;
+                        break;
+                    default:
+                        if (!match) g.State = BeatmapGroupState.Hidden;
+                        break;
+                }
+            }
+
+            switch (Sort)
+            {
+                default:
+                case SortMode.Artist:
+                    groups.Sort((x, y) => string.Compare(x.BeatmapSet.Metadata.Artist, y.BeatmapSet.Metadata.Artist, StringComparison.InvariantCultureIgnoreCase));
+                    break;
+                case SortMode.Title:
+                    groups.Sort((x, y) => string.Compare(x.BeatmapSet.Metadata.Title, y.BeatmapSet.Metadata.Title, StringComparison.InvariantCultureIgnoreCase));
+                    break;
+                case SortMode.Author:
+                    groups.Sort((x, y) => string.Compare(x.BeatmapSet.Metadata.Author, y.BeatmapSet.Metadata.Author, StringComparison.InvariantCultureIgnoreCase));
+                    break;
+                case SortMode.Difficulty:
+                    groups.Sort((x, y) => x.BeatmapSet.MaxStarDifficulty.CompareTo(y.BeatmapSet.MaxStarDifficulty));
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Select
         private BeatmapDatabase database;
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenBeatmap(Beatmap);
 
-        private CarouselContainer carousel;
+        private BeatmapCarousel carousel;
         private TrackManager trackManager;
         private DialogOverlay dialogOverlay;
 
@@ -82,7 +82,7 @@ namespace osu.Game.Screens.Select
                     }
                 }
             });
-            Add(carousel = new CarouselContainer
+            Add(carousel = new BeatmapCarousel
             {
                 RelativeSizeAxes = Axes.Y,
                 Size = new Vector2(carousel_width, 1),

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Screens\Play\SkipButton.cs" />
     <Compile Include="Modes\UI\StandardComboCounter.cs" />
     <Compile Include="Screens\Select\BeatmapCarousel.cs" />
+    <Compile Include="Screens\Select\FilterCriteria.cs" />
     <Compile Include="Screens\Select\Filter\GroupMode.cs" />
     <Compile Include="Screens\Select\Filter\SortMode.cs" />
     <Compile Include="Screens\Select\MatchSongSelect.cs" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -196,7 +196,7 @@
     <Compile Include="Screens\Play\PlayerLoader.cs" />
     <Compile Include="Screens\Play\SkipButton.cs" />
     <Compile Include="Modes\UI\StandardComboCounter.cs" />
-    <Compile Include="Screens\Select\CarouselContainer.cs" />
+    <Compile Include="Screens\Select\BeatmapCarousel.cs" />
     <Compile Include="Screens\Select\Filter\GroupMode.cs" />
     <Compile Include="Screens\Select\Filter\SortMode.cs" />
     <Compile Include="Screens\Select\MatchSongSelect.cs" />


### PR DESCRIPTION
- Load time for 160 beatmaps is down to <1s from 12.
- Carousel no longer exposes BeatmapGroups.
- FilterCriteria applies sort/group/filter directly.
- SongSelect is preloaded while at main menu.
- Difficulty calculation is no longer post-import.

Still much more work to be done, but this brings us further in line with the expected load pattern for song select.