### PR TITLE
ParallaxContainer should always know the mouse position.

### DIFF
--- a/osu.Game/Graphics/Containers/ParallaxContainer.cs
+++ b/osu.Game/Graphics/Containers/ParallaxContainer.cs
@@ -12,7 +12,7 @@ using osu.Framework.Configuration;
 
 namespace osu.Game.Graphics.Containers
 {
-    internal class ParallaxContainer : Container
+    internal class ParallaxContainer : Container, IRequireHighFrequencyMousePosition
     {
         public float ParallaxAmount = 0.02f;
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/595.