### PR TITLE
Taiko scoreprocessing

### DIFF
--- a/osu.Desktop.VisualTests/Tests/TestCaseLeaderboard.cs
+++ b/osu.Desktop.VisualTests/Tests/TestCaseLeaderboard.cs
@@ -4,9 +4,9 @@
 using OpenTK;
 using osu.Framework.Graphics;
 using osu.Framework.Screens.Testing;
-using osu.Game.Modes;
 using osu.Game.Modes.Mods;
 using osu.Game.Modes.Osu.Mods;
+using osu.Game.Modes.Scoring;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
 

--- a/osu.Game.Modes.Catch/CatchRuleset.cs
+++ b/osu.Game.Modes.Catch/CatchRuleset.cs
@@ -10,6 +10,8 @@ using osu.Game.Modes.Mods;
 using osu.Game.Modes.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using osu.Game.Modes.Catch.Scoring;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes.Catch
 {

--- a/osu.Game.Modes.Catch/Judgements/CatchJudgement.cs
+++ b/osu.Game.Modes.Catch/Judgements/CatchJudgement.cs
@@ -7,8 +7,8 @@ namespace osu.Game.Modes.Catch.Judgements
 {
     public class CatchJudgement : Judgement
     {
-        public override string ScoreString => string.Empty;
+        public override string ResultString => string.Empty;
 
-        public override string MaxScoreString => string.Empty;
+        public override string MaxResultString => string.Empty;
     }
 }

--- a/osu.Game.Modes.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Modes.Catch/Scoring/CatchScoreProcessor.cs
@@ -3,9 +3,10 @@
 
 using osu.Game.Modes.Catch.Judgements;
 using osu.Game.Modes.Catch.Objects;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.UI;
 
-namespace osu.Game.Modes.Catch
+namespace osu.Game.Modes.Catch.Scoring
 {
     internal class CatchScoreProcessor : ScoreProcessor<CatchBaseHit, CatchJudgement>
     {

--- a/osu.Game.Modes.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Modes.Catch/Scoring/CatchScoreProcessor.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Modes.Catch.Scoring
         {
         }
 
-        protected override void UpdateCalculations(CatchJudgement newJudgement)
+        protected override void OnNewJugement(CatchJudgement judgement)
         {
         }
     }

--- a/osu.Game.Modes.Catch/UI/CatchHitRenderer.cs
+++ b/osu.Game.Modes.Catch/UI/CatchHitRenderer.cs
@@ -5,7 +5,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Modes.Catch.Beatmaps;
 using osu.Game.Modes.Catch.Judgements;
 using osu.Game.Modes.Catch.Objects;
+using osu.Game.Modes.Catch.Scoring;
 using osu.Game.Modes.Objects.Drawables;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.UI;
 
 namespace osu.Game.Modes.Catch.UI

--- a/osu.Game.Modes.Catch/osu.Game.Modes.Catch.csproj
+++ b/osu.Game.Modes.Catch/osu.Game.Modes.Catch.csproj
@@ -50,7 +50,7 @@
     <Compile Include="Beatmaps\CatchBeatmapConverter.cs" />
     <Compile Include="Beatmaps\CatchBeatmapProcessor.cs" />
     <Compile Include="CatchDifficultyCalculator.cs" />
-    <Compile Include="CatchScoreProcessor.cs" />
+    <Compile Include="Scoring\CatchScoreProcessor.cs" />
     <Compile Include="Judgements\CatchJudgement.cs" />
     <Compile Include="Objects\CatchBaseHit.cs" />
     <Compile Include="Objects\Drawable\DrawableFruit.cs" />

--- a/osu.Game.Modes.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Modes.Mania/Judgements/ManiaJudgement.cs
@@ -7,8 +7,8 @@ namespace osu.Game.Modes.Mania.Judgements
 {
     public class ManiaJudgement : Judgement
     {
-        public override string ScoreString => string.Empty;
+        public override string ResultString => string.Empty;
 
-        public override string MaxScoreString => string.Empty;
+        public override string MaxResultString => string.Empty;
     }
 }

--- a/osu.Game.Modes.Mania/ManiaRuleset.cs
+++ b/osu.Game.Modes.Mania/ManiaRuleset.cs
@@ -9,6 +9,8 @@ using osu.Game.Modes.Mods;
 using osu.Game.Modes.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using osu.Game.Modes.Mania.Scoring;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes.Mania
 {

--- a/osu.Game.Modes.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Modes.Mania/Scoring/ManiaScoreProcessor.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Modes.Mania.Scoring
         {
         }
 
-        protected override void UpdateCalculations(ManiaJudgement newJudgement)
+        protected override void OnNewJugement(ManiaJudgement judgement)
         {
         }
     }

--- a/osu.Game.Modes.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Modes.Mania/Scoring/ManiaScoreProcessor.cs
@@ -3,9 +3,10 @@
 
 using osu.Game.Modes.Mania.Judgements;
 using osu.Game.Modes.Mania.Objects;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.UI;
 
-namespace osu.Game.Modes.Mania
+namespace osu.Game.Modes.Mania.Scoring
 {
     internal class ManiaScoreProcessor : ScoreProcessor<ManiaBaseHit, ManiaJudgement>
     {

--- a/osu.Game.Modes.Mania/UI/ManiaHitRenderer.cs
+++ b/osu.Game.Modes.Mania/UI/ManiaHitRenderer.cs
@@ -5,7 +5,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Modes.Mania.Beatmaps;
 using osu.Game.Modes.Mania.Judgements;
 using osu.Game.Modes.Mania.Objects;
+using osu.Game.Modes.Mania.Scoring;
 using osu.Game.Modes.Objects.Drawables;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.UI;
 
 namespace osu.Game.Modes.Mania.UI

--- a/osu.Game.Modes.Mania/osu.Game.Modes.Mania.csproj
+++ b/osu.Game.Modes.Mania/osu.Game.Modes.Mania.csproj
@@ -51,7 +51,7 @@
     <Compile Include="Beatmaps\ManiaBeatmapProcessor.cs" />
     <Compile Include="Judgements\ManiaJudgement.cs" />
     <Compile Include="ManiaDifficultyCalculator.cs" />
-    <Compile Include="ManiaScoreProcessor.cs" />
+    <Compile Include="Scoring\ManiaScoreProcessor.cs" />
     <Compile Include="Objects\Drawable\DrawableNote.cs" />
     <Compile Include="Objects\HoldNote.cs" />
     <Compile Include="Objects\ManiaBaseHit.cs" />

--- a/osu.Game.Modes.Osu/Judgements/OsuJudgement.cs
+++ b/osu.Game.Modes.Osu/Judgements/OsuJudgement.cs
@@ -25,9 +25,9 @@ namespace osu.Game.Modes.Osu.Judgements
         /// </summary>
         public OsuScoreResult MaxScore = OsuScoreResult.Hit300;
 
-        public override string ScoreString => Score.GetDescription();
+        public override string ResultString => Score.GetDescription();
 
-        public override string MaxScoreString => MaxScore.GetDescription();
+        public override string MaxResultString => MaxScore.GetDescription();
 
         public int ScoreValue => scoreToInt(Score);
 

--- a/osu.Game.Modes.Osu/Mods/OsuMod.cs
+++ b/osu.Game.Modes.Osu/Mods/OsuMod.cs
@@ -7,6 +7,7 @@ using osu.Game.Modes.Mods;
 using osu.Game.Modes.Osu.Objects;
 using System;
 using System.Linq;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes.Osu.Mods
 {

--- a/osu.Game.Modes.Osu/OsuRuleset.cs
+++ b/osu.Game.Modes.Osu/OsuRuleset.cs
@@ -12,6 +12,8 @@ using osu.Game.Modes.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Modes.Osu.Scoring;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes.Osu
 {

--- a/osu.Game.Modes.Osu/Scoring/OsuScore.cs
+++ b/osu.Game.Modes.Osu/Scoring/OsuScore.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-namespace osu.Game.Modes.Osu
+using osu.Game.Modes.Scoring;
+
+namespace osu.Game.Modes.Osu.Scoring
 {
     internal class OsuScore : Score
     {

--- a/osu.Game.Modes.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Modes.Osu/Scoring/OsuScoreProcessor.cs
@@ -4,9 +4,10 @@
 using osu.Game.Modes.Objects.Drawables;
 using osu.Game.Modes.Osu.Judgements;
 using osu.Game.Modes.Osu.Objects;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.UI;
 
-namespace osu.Game.Modes.Osu
+namespace osu.Game.Modes.Osu.Scoring
 {
     internal class OsuScoreProcessor : ScoreProcessor<OsuHitObject, OsuJudgement>
     {

--- a/osu.Game.Modes.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Modes.Osu/Scoring/OsuScoreProcessor.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Modes.Osu.Scoring
             Accuracy.Value = 1;
         }
 
-        protected override void UpdateCalculations(OsuJudgement judgement)
+        protected override void OnNewJugement(OsuJudgement judgement)
         {
             if (judgement != null)
             {

--- a/osu.Game.Modes.Osu/UI/OsuHitRenderer.cs
+++ b/osu.Game.Modes.Osu/UI/OsuHitRenderer.cs
@@ -7,6 +7,8 @@ using osu.Game.Modes.Osu.Beatmaps;
 using osu.Game.Modes.Osu.Judgements;
 using osu.Game.Modes.Osu.Objects;
 using osu.Game.Modes.Osu.Objects.Drawables;
+using osu.Game.Modes.Osu.Scoring;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.UI;
 using osu.Game.Screens.Play;
 

--- a/osu.Game.Modes.Osu/osu.Game.Modes.Osu.csproj
+++ b/osu.Game.Modes.Osu/osu.Game.Modes.Osu.csproj
@@ -72,8 +72,8 @@
     <Compile Include="OsuAutoReplay.cs" />
     <Compile Include="OsuDifficultyCalculator.cs" />
     <Compile Include="OsuKeyConversionInputManager.cs" />
-    <Compile Include="OsuScore.cs" />
-    <Compile Include="OsuScoreProcessor.cs" />
+    <Compile Include="Scoring\OsuScore.cs" />
+    <Compile Include="Scoring\OsuScoreProcessor.cs" />
     <Compile Include="UI\OsuHitRenderer.cs" />
     <Compile Include="UI\OsuPlayfield.cs" />
     <Compile Include="OsuRuleset.cs" />

--- a/osu.Game.Modes.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Modes.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Modes.Taiko.Beatmaps
             IHasRepeats repeatsData = original as IHasRepeats;
             IHasEndTime endTimeData = original as IHasEndTime;
 
-            bool isFinisher = (original.Sample.Type & SampleType.Finish) > 0;
+            bool isFinisher = ((original.Sample?.Type ?? SampleType.None) & SampleType.Finish) > 0;
 
             if (distanceData != null)
             {

--- a/osu.Game.Modes.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Modes.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -3,6 +3,7 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
+using osu.Game.Beatmaps.Samples;
 using osu.Game.Modes.Objects;
 using osu.Game.Modes.Objects.Types;
 using osu.Game.Modes.Taiko.Objects;
@@ -43,12 +44,15 @@ namespace osu.Game.Modes.Taiko.Beatmaps
             IHasRepeats repeatsData = original as IHasRepeats;
             IHasEndTime endTimeData = original as IHasEndTime;
 
+            bool isFinisher = (original.Sample.Type & SampleType.Finish) > 0;
+
             if (distanceData != null)
             {
                 return new DrumRoll
                 {
                     StartTime = original.StartTime,
                     Sample = original.Sample,
+                    IsFinisher = isFinisher,
 
                     Distance = distanceData.Distance * (repeatsData?.RepeatCount ?? 1)
                 };
@@ -61,6 +65,7 @@ namespace osu.Game.Modes.Taiko.Beatmaps
                 {
                     StartTime = original.StartTime,
                     Sample = original.Sample,
+                    IsFinisher = isFinisher,
 
                     EndTime = original.StartTime + endTimeData.Duration * bash_convert_factor 
                 };
@@ -70,6 +75,7 @@ namespace osu.Game.Modes.Taiko.Beatmaps
             {
                 StartTime = original.StartTime,
                 Sample = original.Sample,
+                IsFinisher = isFinisher
             };
         }
     }

--- a/osu.Game.Modes.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Modes.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Modes.Taiko.Beatmaps
             IHasRepeats repeatsData = original as IHasRepeats;
             IHasEndTime endTimeData = original as IHasEndTime;
 
-            bool isFinisher = ((original.Sample?.Type ?? SampleType.None) & SampleType.Finish) > 0;
+            bool accented = ((original.Sample?.Type ?? SampleType.None) & SampleType.Finish) > 0;
 
             if (distanceData != null)
             {
@@ -52,7 +52,7 @@ namespace osu.Game.Modes.Taiko.Beatmaps
                 {
                     StartTime = original.StartTime,
                     Sample = original.Sample,
-                    IsFinisher = isFinisher,
+                    Accented = accented,
 
                     Distance = distanceData.Distance * (repeatsData?.RepeatCount ?? 1)
                 };
@@ -65,7 +65,7 @@ namespace osu.Game.Modes.Taiko.Beatmaps
                 {
                     StartTime = original.StartTime,
                     Sample = original.Sample,
-                    IsFinisher = isFinisher,
+                    Accented = accented,
 
                     EndTime = original.StartTime + endTimeData.Duration * bash_convert_factor 
                 };
@@ -75,7 +75,7 @@ namespace osu.Game.Modes.Taiko.Beatmaps
             {
                 StartTime = original.StartTime,
                 Sample = original.Sample,
-                IsFinisher = isFinisher
+                Accented = accented
             };
         }
     }

--- a/osu.Game.Modes.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
+++ b/osu.Game.Modes.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
@@ -8,12 +8,12 @@ namespace osu.Game.Modes.Taiko.Judgements
         /// <summary>
         /// Drum roll ticks don't display judgement text.
         /// </summary>
-        public override string ScoreString => string.Empty;
+        public override string ResultString => string.Empty;
 
         /// <summary>
         /// Drum roll ticks don't display judgement text.
         /// </summary>
-        public override string MaxScoreString => string.Empty;
+        public override string MaxResultString => string.Empty;
 
         protected override int NumericResultForScore(TaikoHitResult result)
         {

--- a/osu.Game.Modes.Taiko/Judgements/TaikoJudgement.cs
+++ b/osu.Game.Modes.Taiko/Judgements/TaikoJudgement.cs
@@ -9,38 +9,38 @@ namespace osu.Game.Modes.Taiko.Judgements
     public class TaikoJudgement : Judgement
     {
         /// <summary>
-        /// The maximum score value.
+        /// The maximum result.
         /// </summary>
         public const TaikoHitResult MAX_HIT_RESULT = TaikoHitResult.Great;
 
         /// <summary>
-        /// The score value.
+        /// The result.
         /// </summary>
         public TaikoHitResult TaikoResult;
 
         /// <summary>
-        /// The score value for the combo portion of the score.
+        /// The result value for the combo portion of the score.
         /// </summary>
-        public int ScoreValue => NumericResultForScore(TaikoResult);
+        public int ResultValueForScore => NumericResultForScore(TaikoResult);
         
         /// <summary>
-        /// The score value for the accuracy portion of the score.
+        /// The result value for the accuracy portion of the score.
         /// </summary>
-        public int AccuracyScoreValue => NumericResultForAccuracy(TaikoResult);
+        public int ResultValueForAccuracy => NumericResultForAccuracy(TaikoResult);
 
         /// <summary>
-        /// The maximum score value for the combo portion of the score.
+        /// The maximum result value for the combo portion of the score.
         /// </summary>
-        public int MaxScoreValue => NumericResultForScore(MAX_HIT_RESULT);
+        public int MaxResultValueForScore => NumericResultForScore(MAX_HIT_RESULT);
         
         /// <summary>
-        /// The maximum score value for the accuracy portion of the score.
+        /// The maximum result value for the accuracy portion of the score.
         /// </summary>
-        public int MaxAccuracyScoreValue => NumericResultForAccuracy(MAX_HIT_RESULT);
+        public int MaxResultValueForAccuracy => NumericResultForAccuracy(MAX_HIT_RESULT);
 
-        public override string ScoreString => TaikoResult.GetDescription();
+        public override string ResultString => TaikoResult.GetDescription();
 
-        public override string MaxScoreString => MAX_HIT_RESULT.GetDescription();
+        public override string MaxResultString => MAX_HIT_RESULT.GetDescription();
 
         /// <summary>
         /// Whether this Judgement has a secondary hit in the case of finishers.
@@ -48,11 +48,11 @@ namespace osu.Game.Modes.Taiko.Judgements
         public bool SecondHit;
 
         /// <summary>
-        /// Computes the numeric score value for the combo portion of the score.
+        /// Computes the numeric result value for the combo portion of the score.
         /// For the accuracy portion of the score (including accuracy percentage), see <see cref="NumericResultForAccuracy(TaikoHitResult)"/>.
         /// </summary>
-        /// <param name="result">The result to compute the score value for.</param>
-        /// <returns>The numeric score value.</returns>
+        /// <param name="result">The result to compute the value for.</param>
+        /// <returns>The numeric result value.</returns>
         protected virtual int NumericResultForScore(TaikoHitResult result)
         {
             switch (result)
@@ -67,11 +67,11 @@ namespace osu.Game.Modes.Taiko.Judgements
         }
 
         /// <summary>
-        /// Computes the numeric score value for the accuracy portion of the score.
+        /// Computes the numeric result value for the accuracy portion of the score.
         /// For the combo portion of the score, see <see cref="NumericResultForScore(TaikoHitResult)"/>.
         /// </summary>
-        /// <param name="result">The result to compute the score value for.</param>
-        /// <returns>The numeric score value.</returns>
+        /// <param name="result">The result to compute the value for.</param>
+        /// <returns>The numeric result value.</returns>
         protected virtual int NumericResultForAccuracy(TaikoHitResult result)
         {
             switch (result)

--- a/osu.Game.Modes.Taiko/Objects/TaikoHitObject.cs
+++ b/osu.Game.Modes.Taiko/Objects/TaikoHitObject.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Modes.Taiko.Objects
         public double PreEmpt;
 
         /// <summary>
+        /// Whether this HitObject is a finisher.
+        /// </summary>
+        public bool IsFinisher;
+
+        /// <summary>
         /// Whether this HitObject is in Kiai time.
         /// </summary>
         public bool Kiai { get; protected set; }

--- a/osu.Game.Modes.Taiko/Objects/TaikoHitObject.cs
+++ b/osu.Game.Modes.Taiko/Objects/TaikoHitObject.cs
@@ -20,9 +20,10 @@ namespace osu.Game.Modes.Taiko.Objects
         public double PreEmpt;
 
         /// <summary>
-        /// Whether this HitObject is a finisher.
+        /// Whether this HitObject is accented.
+        /// Accented hit objects give more points for hitting the hit object with both keys.
         /// </summary>
-        public bool IsFinisher;
+        public bool Accented;
 
         /// <summary>
         /// Whether this HitObject is in Kiai time.

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -196,7 +196,7 @@ namespace osu.Game.Modes.Taiko.Scoring
             // Apply score changes
             if (newJudgement.Result == HitResult.Hit)
             {
-                double baseValue = newJudgement.ScoreValue;
+                double baseValue = newJudgement.ResultValueForScore;
 
                 // Add bonus points for hitting a finisher with the second key
                 if (newJudgement.SecondHit)
@@ -243,16 +243,16 @@ namespace osu.Game.Modes.Taiko.Scoring
             }
 
             // Compute the new score + accuracy
-            int score = 0;
-            int maxScore = 0;
+            int scoreForAccuracy = 0;
+            int maxScoreForAccuracy = 0;
 
             foreach (var j in Judgements)
             {
-                score += j.AccuracyScoreValue;
-                maxScore = j.MaxAccuracyScoreValue;
+                scoreForAccuracy += j.ResultValueForAccuracy;
+                maxScoreForAccuracy = j.MaxResultValueForAccuracy;
             }
 
-            Accuracy.Value = (double)score / maxScore;
+            Accuracy.Value = (double)scoreForAccuracy / maxScoreForAccuracy;
             TotalScore.Value = comboScore + accuracyScore + bonusScore;
         }
 

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -85,17 +85,17 @@ namespace osu.Game.Modes.Taiko.Scoring
         public override bool HasFailed => totalHits == maxTotalHits && Health.Value <= 0.5;
 
         /// <summary>
-        /// The final combo portion of the score.
+        /// The cumulative combo portion of the score.
         /// </summary>
         private double comboScore => combo_portion_max * comboPortion / maxComboPortion;
 
         /// <summary>
-        /// The final accuracy portion of the score.
+        /// The cumulative accuracy portion of the score.
         /// </summary>
         private double accuracyScore => accuracy_portion_max * Math.Pow(Accuracy, 3.6) * totalHits / maxTotalHits;
 
         /// <summary>
-        /// The final bonus score.
+        /// The cumulative bonus score.
         /// This is added on top of <see cref="max_score"/>, thus the total score can exceed <see cref="max_score"/>.
         /// </summary>
         private double bonusScore;

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Modes.Taiko.Scoring
             hpIncreaseGood = hpMultiplierNormal * BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_hit_good_max, hp_hit_good, hp_hit_good);
             hpIncreaseMiss = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_miss_min, hp_miss_mid, hp_miss_max);
 
-            var finishers = beatmap.HitObjects.FindAll(o => o is Hit && o.IsFinisher);
+            var finishers = beatmap.HitObjects.FindAll(o => o is Hit && o.Accented);
 
             // This is a linear function that awards:
             // 10 times bonus points for hitting a finisher with both keys with 30 finishers in the map
@@ -149,7 +149,7 @@ namespace osu.Game.Modes.Taiko.Scoring
                     {
                         Result = HitResult.Hit,
                         TaikoResult = TaikoHitResult.Great,
-                        SecondHit = obj.IsFinisher
+                        SecondHit = obj.Accented
                     });
                 }
                 else if (obj is DrumRoll)
@@ -160,7 +160,7 @@ namespace osu.Game.Modes.Taiko.Scoring
                         {
                             Result = HitResult.Hit,
                             TaikoResult = TaikoHitResult.Great,
-                            SecondHit = obj.IsFinisher
+                            SecondHit = obj.Accented
                         });
                     }
 
@@ -168,7 +168,7 @@ namespace osu.Game.Modes.Taiko.Scoring
                     {
                         Result = HitResult.Hit,
                         TaikoResult = TaikoHitResult.Great,
-                        SecondHit = obj.IsFinisher
+                        SecondHit = obj.Accented
                     });
                 }
                 else if (obj is Bash)

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -1,16 +1,17 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using OpenTK;
+using System;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Modes.Objects.Drawables;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.Taiko.Judgements;
 using osu.Game.Modes.Taiko.Objects;
 using osu.Game.Modes.UI;
-using System;
+using OpenTK;
 
-namespace osu.Game.Modes.Taiko
+namespace osu.Game.Modes.Taiko.Scoring
 {
     internal class TaikoScoreProcessor : ScoreProcessor<TaikoHitObject, TaikoJudgement>
     {

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -179,21 +179,21 @@ namespace osu.Game.Modes.Taiko.Scoring
             maxComboPortion = comboPortion;
         }
 
-        protected override void UpdateCalculations(TaikoJudgement newJudgement)
+        protected override void OnNewJugement(TaikoJudgement judgement)
         {
-            bool isTick = newJudgement is TaikoDrumRollTickJudgement;
+            bool isTick = judgement is TaikoDrumRollTickJudgement;
 
             // Don't consider ticks as a type of hit that counts towards map completion
             if (!isTick)
                 totalHits++;
 
             // Apply score changes
-            if (newJudgement.Result == HitResult.Hit)
+            if (judgement.Result == HitResult.Hit)
             {
-                double baseValue = newJudgement.ResultValueForScore;
+                double baseValue = judgement.ResultValueForScore;
 
                 // Add bonus points for hitting an accented hit object with the second key
-                if (newJudgement.SecondHit)
+                if (judgement.SecondHit)
                     baseValue += baseValue * accentedHitScale;
 
                 // Add score to portions
@@ -212,7 +212,7 @@ namespace osu.Game.Modes.Taiko.Scoring
             }
 
             // Apply HP changes
-            switch (newJudgement.Result)
+            switch (judgement.Result)
             {
                 case HitResult.Miss:
                     // Missing ticks shouldn't drop HP
@@ -220,7 +220,7 @@ namespace osu.Game.Modes.Taiko.Scoring
                         Health.Value += hpIncreaseMiss;
                     break;
                 case HitResult.Hit:
-                    switch (newJudgement.TaikoResult)
+                    switch (judgement.TaikoResult)
                     {
                         case TaikoHitResult.Good:
                             Health.Value += hpIncreaseGood;

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -187,10 +187,10 @@ namespace osu.Game.Modes.Taiko.Scoring
 
         protected override void UpdateCalculations(TaikoJudgement newJudgement)
         {
-            var tickJudgement = newJudgement as TaikoDrumRollTickJudgement;
+            bool isTick = newJudgement is TaikoDrumRollTickJudgement;
 
             // Don't consider ticks as a type of hit that counts towards map completion
-            if (tickJudgement == null)
+            if (!isTick)
                 totalHits++;
 
             // Apply score changes
@@ -203,7 +203,7 @@ namespace osu.Game.Modes.Taiko.Scoring
                     baseValue += baseValue * finisherScoreScale;
 
                 // Add score to portions
-                if (tickJudgement != null)
+                if (isTick)
                     bonusScore += baseValue;
                 else
                 {
@@ -222,7 +222,7 @@ namespace osu.Game.Modes.Taiko.Scoring
             {
                 case HitResult.Miss:
                     // Missing ticks shouldn't drop HP
-                    if (tickJudgement == null)
+                    if (!isTick)
                         Health.Value += hpIncreaseMiss;
                     break;
                 case HitResult.Hit:
@@ -232,8 +232,7 @@ namespace osu.Game.Modes.Taiko.Scoring
                             Health.Value += hpIncreaseGood;
                             break;
                         case TaikoHitResult.Great:
-                            // Ticks only give out a different portion of HP because they're more spammable
-                            if (tickJudgement != null)
+                            if (isTick)
                                 Health.Value += hpIncreaseTick;
                             else
                                 Health.Value += hpIncreaseGreat;

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -42,20 +42,9 @@ namespace osu.Game.Modes.Taiko.Scoring
         private const double hp_hit_great = 0.03;
 
         /// <summary>
-        /// The minimum HP awarded for a <see cref="TaikoHitResult.Good"/> hit.
-        /// This occurs when HP Drain >= 5.
+        /// The HP awarded for a <see cref="TaikoHitResult.Good"/> hit.
         /// </summary>
-        private const double hp_hit_good_min = 0.011;
-
-        /// <summary>
-        /// The maximum HP awarded for a <see cref="TaikoHitResult.Good"/> hit.
-        /// This occurs when HP Drain = 0.
-        /// <para>
-        /// Yes, this is incorrect, and goods at HP = 0 will award more HP than greats.
-        /// This is legacy and should be fixed, but is kept as is for now for compatibility.
-        /// </para>
-        /// </summary>
-        private const double hp_hit_good_max = hp_hit_good_min * 8;
+        private const double hp_hit_good = 0.011;
 
         /// <summary>
         /// The minimum HP deducted for a <see cref="HitResult.Miss"/>.
@@ -136,7 +125,7 @@ namespace osu.Game.Modes.Taiko.Scoring
 
             hpIncreaseTick = hp_hit_tick;
             hpIncreaseGreat = hpMultiplierNormal * hp_hit_great;
-            hpIncreaseGood = hpMultiplierNormal * BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_hit_good_max, hp_hit_good_min, hp_hit_good_min);
+            hpIncreaseGood = hpMultiplierNormal * hp_hit_good;
             hpIncreaseMiss = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_miss_min, hp_miss_mid, hp_miss_max);
 
             var accentedHits = beatmap.HitObjects.FindAll(o => o is Hit && o.Accented);

--- a/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -42,31 +42,36 @@ namespace osu.Game.Modes.Taiko.Scoring
         private const double hp_hit_great = 0.03;
 
         /// <summary>
-        /// The HP awarded for a <see cref="TaikoHitResult.Good"/> hit at HP >= 5.
+        /// The minimum HP awarded for a <see cref="TaikoHitResult.Good"/> hit.
+        /// This occurs when HP Drain >= 5.
         /// </summary>
-        private const double hp_hit_good = 0.011;
+        private const double hp_hit_good_min = 0.011;
 
         /// <summary>
-        /// The HP awarded for a <see cref="TaikoHitResult.Good"/> hit at HP = 0.
+        /// The maximum HP awarded for a <see cref="TaikoHitResult.Good"/> hit.
+        /// This occurs when HP Drain = 0.
         /// <para>
         /// Yes, this is incorrect, and goods at HP = 0 will award more HP than greats.
         /// This is legacy and should be fixed, but is kept as is for now for compatibility.
         /// </para>
         /// </summary>
-        private const double hp_hit_good_max = hp_hit_good * 8;
+        private const double hp_hit_good_max = hp_hit_good_min * 8;
 
         /// <summary>
-        /// The HP deducted for a <see cref="HitResult.Miss"/> at HP = 0.
+        /// The minimum HP deducted for a <see cref="HitResult.Miss"/>.
+        /// This occurs when HP Drain = 0.
         /// </summary>
         private const double hp_miss_min = -0.0018;
 
         /// <summary>
-        /// The HP deducted for a <see cref="HitResult.Miss"/> at HP = 5.
+        /// The median HP deducted for a <see cref="HitResult.Miss"/>.
+        /// This occurs when HP Drain = 5.
         /// </summary>
         private const double hp_miss_mid = -0.0075;
 
         /// <summary>
-        /// The HP deducted for a <see cref="HitResult.Miss"/> at HP = 10.
+        /// The maximum HP deducted for a <see cref="HitResult.Miss"/>.
+        /// This occurs when HP Drain = 10.
         /// </summary>
         private const double hp_miss_max = -0.12;
 
@@ -102,9 +107,9 @@ namespace osu.Game.Modes.Taiko.Scoring
 
         /// <summary>
         /// The multiple of the original score added to the combo portion of the score
-        /// for correctly hitting a finisher with both keys.
+        /// for correctly hitting an accented hit object with both keys.
         /// </summary>
-        private double finisherScoreScale;
+        private double accentedHitScale;
 
         private double hpIncreaseTick;
         private double hpIncreaseGreat;
@@ -131,15 +136,15 @@ namespace osu.Game.Modes.Taiko.Scoring
 
             hpIncreaseTick = hp_hit_tick;
             hpIncreaseGreat = hpMultiplierNormal * hp_hit_great;
-            hpIncreaseGood = hpMultiplierNormal * BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_hit_good_max, hp_hit_good, hp_hit_good);
+            hpIncreaseGood = hpMultiplierNormal * BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_hit_good_max, hp_hit_good_min, hp_hit_good_min);
             hpIncreaseMiss = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_miss_min, hp_miss_mid, hp_miss_max);
 
-            var finishers = beatmap.HitObjects.FindAll(o => o is Hit && o.Accented);
+            var accentedHits = beatmap.HitObjects.FindAll(o => o is Hit && o.Accented);
 
             // This is a linear function that awards:
-            // 10 times bonus points for hitting a finisher with both keys with 30 finishers in the map
-            // 3 times bonus points for hitting a finisher with both keys with 120 finishers in the map
-            finisherScoreScale = -7d / 90d * MathHelper.Clamp(finishers.Count, 30, 120) + 111d / 9d;
+            // 10 times bonus points for hitting an accented hit object with both keys with 30 accented hit objects in the map
+            // 3 times bonus points for hitting an accented hit object with both keys with 120 accented hit objects in the map
+            accentedHitScale = -7d / 90d * MathHelper.Clamp(accentedHits.Count, 30, 120) + 111d / 9d;
 
             foreach (var obj in beatmap.HitObjects)
             {
@@ -198,9 +203,9 @@ namespace osu.Game.Modes.Taiko.Scoring
             {
                 double baseValue = newJudgement.ResultValueForScore;
 
-                // Add bonus points for hitting a finisher with the second key
+                // Add bonus points for hitting an accented hit object with the second key
                 if (newJudgement.SecondHit)
-                    baseValue += baseValue * finisherScoreScale;
+                    baseValue += baseValue * accentedHitScale;
 
                 // Add score to portions
                 if (isTick)

--- a/osu.Game.Modes.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Modes.Taiko/TaikoRuleset.cs
@@ -10,6 +10,8 @@ using osu.Game.Modes.Taiko.UI;
 using osu.Game.Modes.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using osu.Game.Modes.Scoring;
+using osu.Game.Modes.Taiko.Scoring;
 
 namespace osu.Game.Modes.Taiko
 {

--- a/osu.Game.Modes.Taiko/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/TaikoScoreProcessor.cs
@@ -140,11 +140,11 @@ namespace osu.Game.Modes.Taiko
             // 3 times bonus points for hitting a finisher with both keys with 120 finishers in the map
             finisherScoreScale = -7d / 90d * MathHelper.Clamp(finishers.Count, 30, 120) + 111d / 9d;
 
-            foreach (TaikoHitObject obj in beatmap.HitObjects)
+            foreach (var obj in beatmap.HitObjects)
             {
                 if (obj is Hit)
                 {
-                    AddJudgement(new TaikoJudgementInfo
+                    AddJudgement(new TaikoJudgement
                     {
                         Result = HitResult.Hit,
                         TaikoResult = TaikoHitResult.Great,
@@ -155,7 +155,7 @@ namespace osu.Game.Modes.Taiko
                 {
                     for (int i = 0; i < ((DrumRoll)obj).TotalTicks; i++)
                     {
-                        AddJudgement(new TaikoDrumRollTickJudgementInfo
+                        AddJudgement(new TaikoDrumRollTickJudgement
                         {
                             Result = HitResult.Hit,
                             TaikoResult = TaikoHitResult.Great,
@@ -163,7 +163,7 @@ namespace osu.Game.Modes.Taiko
                         });
                     }
 
-                    AddJudgement(new TaikoJudgementInfo
+                    AddJudgement(new TaikoJudgement
                     {
                         Result = HitResult.Hit,
                         TaikoResult = TaikoHitResult.Great,
@@ -172,7 +172,7 @@ namespace osu.Game.Modes.Taiko
                 }
                 else if (obj is Bash)
                 {
-                    AddJudgement(new TaikoJudgementInfo
+                    AddJudgement(new TaikoJudgement
                     {
                         Result = HitResult.Hit,
                         TaikoResult = TaikoHitResult.Great
@@ -184,9 +184,9 @@ namespace osu.Game.Modes.Taiko
             maxComboPortion = comboPortion;
         }
 
-        protected override void UpdateCalculations(TaikoJudgementInfo newJudgement)
+        protected override void UpdateCalculations(TaikoJudgement newJudgement)
         {
-            TaikoDrumRollTickJudgementInfo tickJudgement = newJudgement as TaikoDrumRollTickJudgementInfo;
+            var tickJudgement = newJudgement as TaikoDrumRollTickJudgement;
 
             // Don't consider ticks as a type of hit that counts towards map completion
             if (tickJudgement == null)

--- a/osu.Game.Modes.Taiko/TaikoScoreProcessor.cs
+++ b/osu.Game.Modes.Taiko/TaikoScoreProcessor.cs
@@ -1,14 +1,120 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using OpenTK;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Modes.Objects.Drawables;
 using osu.Game.Modes.Taiko.Judgements;
 using osu.Game.Modes.Taiko.Objects;
 using osu.Game.Modes.UI;
+using System;
 
 namespace osu.Game.Modes.Taiko
 {
     internal class TaikoScoreProcessor : ScoreProcessor<TaikoHitObject, TaikoJudgementInfo>
     {
+        /// <summary>
+        /// The maximum score achievable.
+        /// Does _not_ include bonus score - for bonus score see <see cref="bonusScore"/>.
+        /// </summary>
+        private const int max_score = 1000000;
+
+        /// <summary>
+        /// The amount of the score attributed to combo.
+        /// </summary>
+        private const double combo_portion_max = max_score * 0.2;
+
+        /// <summary>
+        /// The amount of the score attributed to accuracy.
+        /// </summary>
+        private const double accuracy_portion_max = max_score * 0.8;
+
+        /// <summary>
+        /// The factor used to determine relevance of combos.
+        /// </summary>
+        private const double combo_base = 4;
+
+        /// <summary>
+        /// The HP awarded by a <see cref="TaikoHitResult.Great"/> hit.
+        /// </summary>
+        private const double hp_hit_great = 0.03;
+
+        /// <summary>
+        /// The HP awarded for a <see cref="TaikoHitResult.Good"/> hit at HP >= 5.
+        /// </summary>
+        private const double hp_hit_good = 0.011;
+
+        /// <summary>
+        /// The HP awarded for a <see cref="TaikoHitResult.Good"/> hit at HP = 0.
+        /// <para>
+        /// Yes, this is incorrect, and goods at HP = 0 will award more HP than greats.
+        /// This is legacy and should be fixed, but is kept as is for now for compatibility.
+        /// </para>
+        /// </summary>
+        private const double hp_hit_good_max = hp_hit_good * 8;
+
+        /// <summary>
+        /// The HP deducted for a <see cref="HitResult.Miss"/> at HP = 0.
+        /// </summary>
+        private const double hp_miss_min = -0.0018;
+
+        /// <summary>
+        /// The HP deducted for a <see cref="HitResult.Miss"/> at HP = 5.
+        /// </summary>
+        private const double hp_miss_mid = -0.0075;
+
+        /// <summary>
+        /// The HP deducted for a <see cref="HitResult.Miss"/> at HP = 10.
+        /// </summary>
+        private const double hp_miss_max = -0.12;
+
+        /// <summary>
+        /// The HP awarded for a <see cref="DrumRollTick"/> hit.
+        /// <para>
+        /// <see cref="DrumRollTick"/> hits award less HP as they're more spammable, although in hindsight
+        /// this probably awards too little HP and is kept at this value for now for compatibility.
+        /// </para>
+        /// </summary>
+        private const double hp_hit_tick = 0.00000003;
+
+        /// <summary>
+        /// Taiko fails at the end of the map if the player has not half-filled their HP bar.
+        /// </summary>
+        public override bool HasFailed => totalHits == maxTotalHits && Health.Value <= 0.5;
+
+        /// <summary>
+        /// The final combo portion of the score.
+        /// </summary>
+        private double comboScore => combo_portion_max * comboPortion / maxComboPortion;
+
+        /// <summary>
+        /// The final accuracy portion of the score.
+        /// </summary>
+        private double accuracyScore => accuracy_portion_max * Math.Pow(Accuracy, 3.6) * totalHits / maxTotalHits;
+
+        /// <summary>
+        /// The final bonus score.
+        /// This is added on top of <see cref="max_score"/>, thus the total score can exceed <see cref="max_score"/>.
+        /// </summary>
+        private double bonusScore;
+
+        /// <summary>
+        /// The multiple of the original score added to the combo portion of the score
+        /// for correctly hitting a finisher with both keys.
+        /// </summary>
+        private double finisherScoreScale;
+
+        private double hpIncreaseTick;
+        private double hpIncreaseGreat;
+        private double hpIncreaseGood;
+        private double hpIncreaseMiss;
+
+        private double maxComboPortion;
+        private double comboPortion;
+        private int maxTotalHits;
+        private int totalHits;
+
         public TaikoScoreProcessor()
         {
         }
@@ -18,8 +124,146 @@ namespace osu.Game.Modes.Taiko
         {
         }
 
+        protected override void ComputeTargets(Beatmap<TaikoHitObject> beatmap)
+        {
+            double hpMultiplierNormal = 1 / (hp_hit_great * beatmap.HitObjects.FindAll(o => o is Hit).Count * BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, 0.5, 0.75, 0.98));
+
+            hpIncreaseTick = hp_hit_tick;
+            hpIncreaseGreat = hpMultiplierNormal * hp_hit_great;
+            hpIncreaseGood = hpMultiplierNormal * BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_hit_good_max, hp_hit_good, hp_hit_good);
+            hpIncreaseMiss = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.Difficulty.DrainRate, hp_miss_min, hp_miss_mid, hp_miss_max);
+
+            var finishers = beatmap.HitObjects.FindAll(o => o is Hit && o.IsFinisher);
+
+            // This is a linear function that awards:
+            // 10 times bonus points for hitting a finisher with both keys with 30 finishers in the map
+            // 3 times bonus points for hitting a finisher with both keys with 120 finishers in the map
+            finisherScoreScale = -7d / 90d * MathHelper.Clamp(finishers.Count, 30, 120) + 111d / 9d;
+
+            foreach (TaikoHitObject obj in beatmap.HitObjects)
+            {
+                if (obj is Hit)
+                {
+                    AddJudgement(new TaikoJudgementInfo
+                    {
+                        Result = HitResult.Hit,
+                        TaikoResult = TaikoHitResult.Great,
+                        SecondHit = obj.IsFinisher
+                    });
+                }
+                else if (obj is DrumRoll)
+                {
+                    for (int i = 0; i < ((DrumRoll)obj).TotalTicks; i++)
+                    {
+                        AddJudgement(new TaikoDrumRollTickJudgementInfo
+                        {
+                            Result = HitResult.Hit,
+                            TaikoResult = TaikoHitResult.Great,
+                            SecondHit = obj.IsFinisher
+                        });
+                    }
+
+                    AddJudgement(new TaikoJudgementInfo
+                    {
+                        Result = HitResult.Hit,
+                        TaikoResult = TaikoHitResult.Great,
+                        SecondHit = obj.IsFinisher
+                    });
+                }
+                else if (obj is Bash)
+                {
+                    AddJudgement(new TaikoJudgementInfo
+                    {
+                        Result = HitResult.Hit,
+                        TaikoResult = TaikoHitResult.Great
+                    });
+                }
+            }
+
+            maxTotalHits = totalHits;
+            maxComboPortion = comboPortion;
+        }
+
         protected override void UpdateCalculations(TaikoJudgementInfo newJudgement)
         {
+            TaikoDrumRollTickJudgementInfo tickJudgement = newJudgement as TaikoDrumRollTickJudgementInfo;
+
+            // Don't consider ticks as a type of hit that counts towards map completion
+            if (tickJudgement == null)
+                totalHits++;
+
+            // Apply score changes
+            if (newJudgement.Result == HitResult.Hit)
+            {
+                double baseValue = newJudgement.ScoreValue;
+
+                // Add bonus points for hitting a finisher with the second key
+                if (newJudgement.SecondHit)
+                    baseValue += baseValue * finisherScoreScale;
+
+                // Add score to portions
+                if (tickJudgement != null)
+                    bonusScore += baseValue;
+                else
+                {
+                    Combo.Value++;
+
+                    // A relevance factor that needs to be applied to make higher combos more relevant
+                    // Value is capped at 400 combo
+                    double comboRelevance = Math.Min(Math.Log(400, combo_base), Math.Max(0.5, Math.Log(Combo.Value, combo_base)));
+
+                    comboPortion += baseValue * comboRelevance;
+                }
+            }
+
+            // Apply HP changes
+            switch (newJudgement.Result)
+            {
+                case HitResult.Miss:
+                    // Missing ticks shouldn't drop HP
+                    if (tickJudgement == null)
+                        Health.Value += hpIncreaseMiss;
+                    break;
+                case HitResult.Hit:
+                    switch (newJudgement.TaikoResult)
+                    {
+                        case TaikoHitResult.Good:
+                            Health.Value += hpIncreaseGood;
+                            break;
+                        case TaikoHitResult.Great:
+                            // Ticks only give out a different portion of HP because they're more spammable
+                            if (tickJudgement != null)
+                                Health.Value += hpIncreaseTick;
+                            else
+                                Health.Value += hpIncreaseGreat;
+                            break;
+                    }
+                    break;
+            }
+
+            // Compute the new score + accuracy
+            int score = 0;
+            int maxScore = 0;
+
+            foreach (var j in Judgements)
+            {
+                score += j.AccuracyScoreValue;
+                maxScore = j.MaxAccuracyScoreValue;
+            }
+
+            Accuracy.Value = (double)score / maxScore;
+            TotalScore.Value = comboScore + accuracyScore + bonusScore;
+        }
+
+        protected override void Reset()
+        {
+            base.Reset();
+
+            Health.Value = 0;
+
+            bonusScore = 0;
+            comboPortion = 0;
+            totalHits = 0;
         }
     }
 }

--- a/osu.Game.Modes.Taiko/UI/TaikoHitRenderer.cs
+++ b/osu.Game.Modes.Taiko/UI/TaikoHitRenderer.cs
@@ -3,9 +3,11 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Modes.Objects.Drawables;
+using osu.Game.Modes.Scoring;
 using osu.Game.Modes.Taiko.Beatmaps;
 using osu.Game.Modes.Taiko.Judgements;
 using osu.Game.Modes.Taiko.Objects;
+using osu.Game.Modes.Taiko.Scoring;
 using osu.Game.Modes.UI;
 
 namespace osu.Game.Modes.Taiko.UI

--- a/osu.Game.Modes.Taiko/osu.Game.Modes.Taiko.csproj
+++ b/osu.Game.Modes.Taiko/osu.Game.Modes.Taiko.csproj
@@ -60,7 +60,7 @@
     <Compile Include="TaikoDifficultyCalculator.cs" />
     <Compile Include="Objects\TaikoHitObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TaikoScoreProcessor.cs" />
+    <Compile Include="Scoring\TaikoScoreProcessor.cs" />
     <Compile Include="UI\HitTarget.cs" />
     <Compile Include="UI\InputDrum.cs" />
     <Compile Include="UI\DrawableTaikoJudgement.cs" />

--- a/osu.Game/Database/ScoreDatabase.cs
+++ b/osu.Game/Database/ScoreDatabase.cs
@@ -8,6 +8,7 @@ using osu.Framework.Platform;
 using osu.Game.IO.Legacy;
 using osu.Game.IPC;
 using osu.Game.Modes;
+using osu.Game.Modes.Scoring;
 using SharpCompress.Compressors.LZMA;
 
 namespace osu.Game.Database

--- a/osu.Game/Modes/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Modes/Judgements/DrawableJudgement.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Modes.Judgements
 
             AutoSizeAxes = Axes.Both;
 
-            string scoreString = judgement.Result == HitResult.Hit ? judgement.ScoreString : judgement.Result.GetDescription();
+            string resultString = judgement.Result == HitResult.Hit ? judgement.ResultString : judgement.Result.GetDescription();
 
             Children = new[]
             {
@@ -43,7 +43,7 @@ namespace osu.Game.Modes.Judgements
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    Text = scoreString.ToUpper(),
+                    Text = resultString.ToUpper(),
                     Font = @"Venera",
                     TextSize = 16
                 }

--- a/osu.Game/Modes/Judgements/Judgement.cs
+++ b/osu.Game/Modes/Judgements/Judgement.cs
@@ -23,13 +23,13 @@ namespace osu.Game.Modes.Judgements
         public ulong? ComboAtHit;
 
         /// <summary>
-        /// The string representation for the score achieved.
+        /// The string representation for the result achieved.
         /// </summary>
-        public abstract string ScoreString { get; }
+        public abstract string ResultString { get; }
 
         /// <summary>
-        /// The string representation for the max score achievable.
+        /// The string representation for the max result achievable.
         /// </summary>
-        public abstract string MaxScoreString { get; }
+        public abstract string MaxResultString { get; }
     }
 }

--- a/osu.Game/Modes/Mods/Mod.cs
+++ b/osu.Game/Modes/Mods/Mod.cs
@@ -6,6 +6,7 @@ using osu.Game.Graphics;
 using osu.Game.Modes.Objects;
 using osu.Game.Modes.UI;
 using System;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes.Mods
 {

--- a/osu.Game/Modes/Ruleset.cs
+++ b/osu.Game/Modes/Ruleset.cs
@@ -9,6 +9,7 @@ using osu.Game.Screens.Play;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes
 {

--- a/osu.Game/Modes/ScoreProcessor.cs
+++ b/osu.Game/Modes/ScoreProcessor.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Modes
         {
             Judgements.Capacity = hitRenderer.Beatmap.HitObjects.Count;
 
-            hitRenderer.OnJudgement += addJudgement;
+            hitRenderer.OnJudgement += AddJudgement;
 
             ComputeTargets(hitRenderer.Beatmap);
 
@@ -139,7 +139,7 @@ namespace osu.Game.Modes
         /// Adds a judgement to this ScoreProcessor.
         /// </summary>
         /// <param name="judgement">The judgement to add.</param>
-        private void addJudgement(TJudgement judgement)
+        protected void AddJudgement(TJudgement judgement)
         {
             Judgements.Add(judgement);
 

--- a/osu.Game/Modes/Scoring/Score.cs
+++ b/osu.Game/Modes/Scoring/Score.cs
@@ -3,11 +3,11 @@
 
 using System;
 using Newtonsoft.Json;
-using osu.Game.Users;
 using osu.Game.Database;
 using osu.Game.Modes.Mods;
+using osu.Game.Users;
 
-namespace osu.Game.Modes
+namespace osu.Game.Modes.Scoring
 {
     public class Score
     {

--- a/osu.Game/Modes/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Modes/Scoring/ScoreProcessor.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Framework.Configuration;
 using System;
 using System.Collections.Generic;
-using osu.Game.Modes.Judgements;
-using osu.Game.Modes.UI;
-using osu.Game.Modes.Objects;
+using osu.Framework.Configuration;
 using osu.Game.Beatmaps;
+using osu.Game.Modes.Judgements;
+using osu.Game.Modes.Objects;
+using osu.Game.Modes.UI;
 
-namespace osu.Game.Modes
+namespace osu.Game.Modes.Scoring
 {
     public abstract class ScoreProcessor
     {

--- a/osu.Game/Modes/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Modes/Scoring/ScoreProcessor.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Modes.Scoring
         {
             Judgements.Add(judgement);
 
-            UpdateCalculations(judgement);
+            OnNewJugement(judgement);
 
             judgement.ComboAtHit = (ulong)Combo.Value;
 
@@ -158,7 +158,7 @@ namespace osu.Game.Modes.Scoring
         /// <summary>
         /// Update any values that potentially need post-processing on a judgement change.
         /// </summary>
-        /// <param name="newJudgement">A new Judgement that triggered this calculation. May be null.</param>
-        protected abstract void UpdateCalculations(TJudgement newJudgement);
+        /// <param name="judgement">The judgement that triggered this calculation.</param>
+        protected abstract void OnNewJugement(TJudgement judgement);
     }
 }

--- a/osu.Game/Modes/Scoring/ScoreRank.cs
+++ b/osu.Game/Modes/Scoring/ScoreRank.cs
@@ -3,7 +3,7 @@
 
 using System.ComponentModel;
 
-namespace osu.Game.Modes
+namespace osu.Game.Modes.Scoring
 {
     public enum ScoreRank
     {

--- a/osu.Game/Modes/UI/HitRenderer.cs
+++ b/osu.Game/Modes/UI/HitRenderer.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes.UI
 {

--- a/osu.Game/Modes/UI/HudOverlay.cs
+++ b/osu.Game/Modes/UI/HudOverlay.cs
@@ -9,6 +9,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Play;
 using System;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Modes.UI
 {

--- a/osu.Game/Online/API/Requests/GetScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetScoresRequest.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Framework.IO.Network;
 using osu.Game.Database;
-using osu.Game.Modes;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Online.API.Requests
 {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -26,6 +26,7 @@ using osu.Framework.Graphics.Primitives;
 using System.Threading.Tasks;
 using osu.Framework.Threading;
 using osu.Game.Graphics;
+using osu.Game.Modes.Scoring;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Play;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -23,6 +23,7 @@ using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Ranking;
 using System;
 using System.Linq;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Screens.Play
 {

--- a/osu.Game/Screens/Ranking/Results.cs
+++ b/osu.Game/Screens/Ranking/Results.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Modes;
+using osu.Game.Modes.Scoring;
 using osu.Game.Screens.Backgrounds;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Game/Screens/Select/Leaderboards/DrawableRank.cs
+++ b/osu.Game/Screens/Select/Leaderboards/DrawableRank.cs
@@ -6,8 +6,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Modes;
 using osu.Framework.Extensions;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Screens.Select.Leaderboards
 {

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -9,8 +9,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
-using osu.Game.Modes;
 using System;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Screens.Select.Leaderboards
 {

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -10,11 +10,11 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Modes;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Modes.Mods;
 using osu.Game.Users;
 using osu.Framework;
+using osu.Game.Modes.Scoring;
 
 namespace osu.Game.Screens.Select.Leaderboards
 {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -124,8 +124,8 @@
     <Compile Include="Modes\Objects\Types\IHasHold.cs" />
     <Compile Include="Modes\Objects\Legacy\LegacyHitObjectType.cs" />
     <Compile Include="Modes\Replay.cs" />
-    <Compile Include="Modes\Score.cs" />
-    <Compile Include="Modes\ScoreProcessor.cs" />
+    <Compile Include="Modes\Scoring\Score.cs" />
+    <Compile Include="Modes\Scoring\ScoreProcessor.cs" />
     <Compile Include="Modes\UI\HealthDisplay.cs" />
     <Compile Include="Modes\UI\HudOverlay.cs" />
     <Compile Include="Modes\UI\StandardHealthDisplay.cs" />
@@ -359,7 +359,7 @@
     <Compile Include="Screens\Select\Leaderboards\LeaderboardScore.cs" />
     <Compile Include="Users\Country.cs" />
     <Compile Include="Users\Team.cs" />
-    <Compile Include="Modes\ScoreRank.cs" />
+    <Compile Include="Modes\Scoring\ScoreRank.cs" />
     <Compile Include="Users\Avatar.cs" />
     <Compile Include="Screens\Select\Leaderboards\DrawableRank.cs" />
     <Compile Include="Graphics\UserInterface\OsuTabControl.cs" />


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/542

I didn't really want to derive `Hit` once more for `HitFinisher` (which would add no additional properties), and realized it could be used in the future for other hit objects as well, so I added a property to TaikoHitObject.
This'll also be eventually used for actually getting the visual representation of these base hitobjects.

The calculations right now should be equivalent to osu!stable for the purpose of TWC, although we should look at simplifying it uniformly in the future.