### PR TITLE
Replay extensibility

### DIFF
--- a/osu.Game.Modes.Osu/OsuAutoReplay.cs
+++ b/osu.Game.Modes.Osu/OsuAutoReplay.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Modes.Osu
             createAutoReplay();
         }
 
-        internal class LegacyReplayFrameComparer : IComparer<LegacyReplayFrame>
+        private class LegacyReplayFrameComparer : IComparer<LegacyReplayFrame>
         {
             public int Compare(LegacyReplayFrame f1, LegacyReplayFrame f2)
             {

--- a/osu.Game/Database/ScoreDatabase.cs
+++ b/osu.Game/Database/ScoreDatabase.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Database
 
                     using (var lzma = new LzmaStream(properties, replayInStream, compressedSize, outSize))
                     using (var reader = new StreamReader(lzma))
-                        score.Replay = new LegacyReplay(reader);
+                        score.Replay = score.CreateLegacyReplayFrom(reader);
                 }
             }
             

--- a/osu.Game/Modes/LegacyReplay.cs
+++ b/osu.Game/Modes/LegacyReplay.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Modes
         /// The ReplayHandler will take a replay and handle the propagation of updates to the input stack.
         /// It handles logic of any frames which *must* be executed.
         /// </summary>
-        public class LegacyReplayInputHandler : ReplayInputHandler
+        protected class LegacyReplayInputHandler : ReplayInputHandler
         {
             private readonly List<LegacyReplayFrame> replayContent;
 
@@ -163,7 +163,7 @@ namespace osu.Game.Modes
                 return currentTime = time;
             }
 
-            private class ReplayMouseState : MouseState
+            protected class ReplayMouseState : MouseState
             {
                 public ReplayMouseState(Vector2 position, IEnumerable<MouseButton> list)
                 {
@@ -172,7 +172,7 @@ namespace osu.Game.Modes
                 }
             }
 
-            private class ReplayKeyboardState : KeyboardState
+            protected class ReplayKeyboardState : KeyboardState
             {
                 public ReplayKeyboardState(List<Key> keys)
                 {
@@ -182,7 +182,7 @@ namespace osu.Game.Modes
         }
 
         [Flags]
-        public enum LegacyButtonState
+        protected enum LegacyButtonState
         {
             None = 0,
             Left1 = 1,
@@ -192,7 +192,7 @@ namespace osu.Game.Modes
             Smoke = 16
         }
 
-        public class LegacyReplayFrame
+        protected class LegacyReplayFrame
         {
             public Vector2 Position => new Vector2(MouseX, MouseY);
 

--- a/osu.Game/Modes/LegacyReplay.cs
+++ b/osu.Game/Modes/LegacyReplay.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Modes
             }
         }
 
-        public override ReplayInputHandler GetInputHandler() => new LegacyReplayInputHandler(Frames);
+        public override ReplayInputHandler CreateInputHandler() => new LegacyReplayInputHandler(Frames);
 
         /// <summary>
         /// The ReplayHandler will take a replay and handle the propagation of updates to the input stack.

--- a/osu.Game/Modes/Mods/Mod.cs
+++ b/osu.Game/Modes/Mods/Mod.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Modes.Mods
 
         public void Apply(HitRenderer<T> hitRenderer)
         {
-            hitRenderer.InputManager.ReplayInputHandler = CreateReplayScore(hitRenderer.Beatmap)?.Replay?.GetInputHandler();
+            hitRenderer.InputManager.ReplayInputHandler = CreateReplayScore(hitRenderer.Beatmap)?.Replay?.CreateInputHandler();
         }
     }
 

--- a/osu.Game/Modes/Replay.cs
+++ b/osu.Game/Modes/Replay.cs
@@ -7,6 +7,6 @@ namespace osu.Game.Modes
 {
     public abstract class Replay
     {
-        public virtual ReplayInputHandler GetInputHandler() => null;
+        public virtual ReplayInputHandler CreateInputHandler() => null;
     }
 }

--- a/osu.Game/Modes/Scoring/Score.cs
+++ b/osu.Game/Modes/Scoring/Score.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using osu.Game.Database;
 using osu.Game.Modes.Mods;
 using osu.Game.Users;
+using System.IO;
 
 namespace osu.Game.Modes.Scoring
 {
@@ -42,6 +43,13 @@ namespace osu.Game.Modes.Scoring
 
         [JsonProperty(@"date")]
         public DateTime Date;
+
+        /// <summary>
+        /// Creates a legacy replay which is read from a stream.
+        /// </summary>
+        /// <param name="reader">The stream reader.</param>
+        /// <returns>The replay.</returns>
+        public virtual Replay CreateLegacyReplayFrom(StreamReader reader) => new LegacyReplay(reader);
 
         //  [JsonProperty(@"count50")] 0,
         //[JsonProperty(@"count100")] 0,

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -126,7 +126,7 @@ namespace osu.Game
 
             Beatmap.Value = BeatmapDatabase.GetWorkingBeatmap(s.Beatmap);
 
-            menu.Push(new PlayerLoader(new Player { ReplayInputHandler = s.Replay.GetInputHandler() }));
+            menu.Push(new PlayerLoader(new Player { ReplayInputHandler = s.Replay.CreateInputHandler() }));
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Changed protection of a few members of LegacyReplay that didn't need to be so open. These members are going to be overridden/derived from within derivations of LegacyReplay (see: https://github.com/smoogipooo/osu/blob/taiko_replays/osu.Game.Modes.Taiko/LegacyTaikoReplay.cs).

Added a way to construct those derived LegacyReplays.