### PR TITLE
Move validKeys to DrawableTaikoHitObject. Cleanup + reword comments.

### DIFF
--- a/osu.Game.Modes.Taiko/Objects/Drawable/DrawableAccentedHit.cs
+++ b/osu.Game.Modes.Taiko/Objects/Drawable/DrawableAccentedHit.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Modes.Taiko.Objects.Drawable
         private const double second_hit_window = 30;
 
         private double firstHitTime;
+        private bool firstKeyHeld;
         private Key firstHitKey;
 
         protected DrawableAccentedHit(Hit hit)
@@ -41,40 +42,44 @@ namespace osu.Game.Modes.Taiko.Objects.Drawable
                 Judgement.SecondHit = true;
         }
 
-        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        protected override bool HandleKeyPress(Key key)
         {
-            // Check if we've handled the initial key
+            // Check if we've handled the first key
             if (!Judgement.Result.HasValue)
             {
-                bool result = base.OnKeyDown(state, args);
+                // First key hasn't been handled yet, attempt to handle it
+                bool handled = base.HandleKeyPress(key);
 
-                if (result)
+                if (handled)
                 {
                     firstHitTime = Time.Current;
-                    firstHitKey = args.Key;
+                    firstHitKey = key;
                 }
 
-                return result;
+                return handled;
             }
 
             // If we've already hit the second key, don't handle this object any further
             if (Judgement.SecondHit)
                 return false;
 
-            // Don't handle represses of the same key
-            if (firstHitKey == args.Key)
+            // Don't handle represses of the first key
+            if (firstHitKey == key)
                 return false;
 
             // Don't handle invalid hit key presses
-            if (!HitKeys.Contains(args.Key))
+            if (!HitKeys.Contains(key))
                 return false;
 
-            // If we're not holding the first key down still, assume the intention
-            // was not to hit the accented hit with both keys simultaneously
-            if (!state.Keyboard.Keys.Contains(firstHitKey))
-                return false;
+            // Assume the intention was to hit the accented hit with both keys only if the first key is still being held down
+            return firstKeyHeld && UpdateJudgement(true);
+        }
 
-            return UpdateJudgement(true);
+        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        {
+            firstKeyHeld = state.Keyboard.Keys.Contains(firstHitKey);
+
+            return base.OnKeyDown(state, args);
         }
     }
 }

--- a/osu.Game.Modes.Taiko/Objects/Drawable/DrawableHit.cs
+++ b/osu.Game.Modes.Taiko/Objects/Drawable/DrawableHit.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using OpenTK.Input;
-using osu.Framework.Input;
 using osu.Game.Modes.Objects.Drawables;
 using osu.Game.Modes.Taiko.Judgements;
 using System;
@@ -16,12 +15,6 @@ namespace osu.Game.Modes.Taiko.Objects.Drawable
         /// A list of keys which can result in hits for this HitObject.
         /// </summary>
         protected abstract List<Key> HitKeys { get; }
-
-        /// <summary>
-        /// A list of keys which this hit object will accept. These are the standard Taiko keys for now.
-        /// These should be moved to bindings later.
-        /// </summary>
-        private readonly List<Key> validKeys = new List<Key>(new[] { Key.D, Key.F, Key.J, Key.K });
 
         private readonly Hit hit;
 
@@ -61,7 +54,7 @@ namespace osu.Game.Modes.Taiko.Objects.Drawable
                 Judgement.Result = HitResult.Miss;
         }
 
-        protected virtual bool HandleKeyPress(Key key)
+        protected override bool HandleKeyPress(Key key)
         {
             if (Judgement.Result.HasValue)
                 return false;
@@ -69,20 +62,6 @@ namespace osu.Game.Modes.Taiko.Objects.Drawable
             validKeyPressed = HitKeys.Contains(key);
 
             return UpdateJudgement(true);
-        }
-
-        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
-        {
-            // Make sure we don't handle held-down keys
-            if (args.Repeat)
-                return false;
-
-            // Check if we've pressed a valid taiko key
-            if (!validKeys.Contains(args.Key))
-                return false;
-
-            // Handle it!
-            return HandleKeyPress(args.Key);
         }
     }
 }

--- a/osu.Game.Modes.Taiko/Objects/Drawable/DrawableTaikoHitObject.cs
+++ b/osu.Game.Modes.Taiko/Objects/Drawable/DrawableTaikoHitObject.cs
@@ -1,15 +1,24 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using OpenTK.Input;
 using osu.Framework.Graphics;
 using osu.Game.Modes.Objects.Drawables;
 using osu.Game.Modes.Taiko.Judgements;
 using osu.Game.Modes.Taiko.Objects.Drawable.Pieces;
+using System.Collections.Generic;
+using osu.Framework.Input;
 
 namespace osu.Game.Modes.Taiko.Objects.Drawable
 {
     public abstract class DrawableTaikoHitObject : DrawableHitObject<TaikoHitObject, TaikoJudgement>
     {
+        /// <summary>
+        /// A list of keys which this hit object will accept. These are the standard Taiko keys for now.
+        /// These should be moved to bindings later.
+        /// </summary>
+        private readonly List<Key> validKeys = new List<Key>(new[] { Key.D, Key.F, Key.J, Key.K });
+
         protected DrawableTaikoHitObject(TaikoHitObject hitObject)
             : base(hitObject)
         {
@@ -47,6 +56,22 @@ namespace osu.Game.Modes.Taiko.Objects.Drawable
         protected override void Update()
         {
             UpdateScrollPosition(Time.Current);
+        }
+
+        protected virtual bool HandleKeyPress(Key key) { return false; }
+
+        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        {
+            // Make sure we don't handle held-down keys
+            if (args.Repeat)
+                return false;
+
+            // Check if we've pressed a valid taiko key
+            if (!validKeys.Contains(args.Key))
+                return false;
+
+            // Handle it!
+            return HandleKeyPress(args.Key);
         }
 
         protected abstract CirclePiece CreateCircle();

--- a/osu.Game.Modes.Taiko/Objects/Drawable/DrawableTaikoHitObject.cs
+++ b/osu.Game.Modes.Taiko/Objects/Drawable/DrawableTaikoHitObject.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Modes.Taiko.Objects.Drawable
             UpdateScrollPosition(Time.Current);
         }
 
-        protected virtual bool HandleKeyPress(Key key) { return false; }
+        protected virtual bool HandleKeyPress(Key key) => false;
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {


### PR DESCRIPTION
validKeys is meant to just limit the input for HitObjects to DFJK. Likewise, no taiko hit objects will ever handle repeats of the same key.
Both of these can be put into the base DrawableTaikoHitObject. Keeping mostly the same structure at the derived hit object level.

Beyond that, just rewording comments.