### PR TITLE
Small fix to the chat overlay to prevent crashing on the test

### DIFF
--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Overlays
         {
             var postText = sender.Text;
 
-            if (!string.IsNullOrEmpty(postText))
+            if (!string.IsNullOrEmpty(postText) && api.LocalUser.Value != null)
             {
                 //todo: actually send to server
                 careChannels.FirstOrDefault()?.AddNewMessages(new[]


### PR DESCRIPTION
Sorry if this isn't the best way to do it.

Previously, if you attempted to send a message on the chat overlay test, the game would crash. This fixes it.