### PR TITLE
Don't block input in BeatmapInfoWedge.

### DIFF
--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -47,6 +47,8 @@ namespace osu.Game.Screens.Select
 
         protected override bool HideOnEscape => false;
 
+        protected override bool BlockPassThroughInput => false;
+
         protected override void PopIn()
         {
             MoveToX(0, 800, EasingTypes.OutQuint);


### PR DESCRIPTION
It becomes doubtful now whether it should be an `OverlayContainer`, as we discussed to have a placeholder for beatmap, and it will never pop out alone.