### PR TITLE
Don't play sliderbar samples more than once when value has not changed.

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -12,10 +12,11 @@ using osu.Framework.Input;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class OsuSliderBar<U> : SliderBar<U> where U : struct
+    public class OsuSliderBar<T> : SliderBar<T> where T : struct
     {
         private SampleChannel sample;
         private double lastSampleTime;
+        private T lastSampleValue;
 
         private readonly Nub nub;
         private readonly Box leftBox;
@@ -84,6 +85,12 @@ namespace osu.Game.Graphics.UserInterface
         {
             if (Clock == null || Clock.CurrentTime - lastSampleTime <= 50)
                 return;
+
+            if (Current.Value.Equals(lastSampleValue))
+                return;
+
+            lastSampleValue = Current.Value;
+
             lastSampleTime = Clock.CurrentTime;
             sample.Frequency.Value = 1 + NormalizedValue * 0.2f;
 

--- a/osu.Game/Online/Chat/Drawables/ChatLine.cs
+++ b/osu.Game/Online/Chat/Drawables/ChatLine.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Online.Chat.Drawables
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                             Font = @"Exo2.0-SemiBold",
-                            Text = $@"{Message.Timestamp.LocalDateTime:hh:mm:ss}",
+                            Text = $@"{Message.Timestamp.LocalDateTime:HH:mm:ss}",
                             FixedWidth = true,
                             TextSize = text_size * 0.75f,
                             Alpha = 0.4f,


### PR DESCRIPTION
I know I was previously against this, but after seeing how it behaves with int-based sliderbars, I think I prefer limiting it.