### PR TITLE
Clr vscode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,9 @@
     "configurations": [
         {
             "name": "Launch VisualTests",
+            "windows": {
+                "type": "clr"
+            },
             "type": "mono",
             "request": "launch",
             "program": "${workspaceRoot}/osu.Desktop.VisualTests/bin/Debug/osu!.exe",
@@ -15,6 +18,9 @@
         },
         {
             "name": "Launch Desktop",
+            "windows": {
+                "type": "clr"
+            },
             "type": "mono",
             "request": "launch",
             "program": "${workspaceRoot}/osu.Desktop/bin/Debug/osu!.exe",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,11 @@
         },
         {
             "name": "Attach",
+            "windows": {
+                "type": "clr",
+                "request": "attach",
+                "processName": "osu!"
+            },
             "type": "mono",
             "request": "attach",
             "address": "localhost",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,23 @@
             "command": "msbuild",
             "args": [
                 // Ask msbuild to generate full paths for file names.
-                "/property:GenerateFullPaths=true"
+                "/property:GenerateFullPaths=true",
+                "/property:DebugType=portable"
+            ],
+            // Use the standard MS compiler pattern to detect errors, warnings and infos
+            "problemMatcher": "$msCompile",
+            "isBuildCommand": true
+        },
+        {
+            "taskName": "rebuild",
+            "isShellCommand": true,
+            "showOutput": "silent",
+            "command": "msbuild",
+            "args": [
+                // Ask msbuild to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                "/property:DebugType=portable",
+                "/target:Clean,Build"
             ],
             // Use the standard MS compiler pattern to detect errors, warnings and infos
             "problemMatcher": "$msCompile",

--- a/osu.Game/Overlays/Options/Sections/Graphics/LayoutOptions.cs
+++ b/osu.Game/Overlays/Options/Sections/Graphics/LayoutOptions.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Overlays.Options.Sections.Graphics
     {
         protected override string Header => "Layout";
 
-        private OptionSlider<int> letterboxPositionX;
-        private OptionSlider<int> letterboxPositionY;
+        private OptionSlider<double> letterboxPositionX;
+        private OptionSlider<double> letterboxPositionY;
 
         private Bindable<bool> letterboxing;
 
@@ -35,15 +35,15 @@ namespace osu.Game.Overlays.Options.Sections.Graphics
                     LabelText = "Letterboxing",
                     Bindable = letterboxing,
                 },
-                letterboxPositionX = new OptionSlider<int>
+                letterboxPositionX = new OptionSlider<double>
                 {
                     LabelText = "Horizontal position",
-                    Bindable = (BindableInt)config.GetBindable<int>(FrameworkConfig.LetterboxPositionX)
+                    Bindable = config.GetBindable<double>(FrameworkConfig.LetterboxPositionX)
                 },
-                letterboxPositionY = new OptionSlider<int>
+                letterboxPositionY = new OptionSlider<double>
                 {
                     LabelText = "Vertical position",
-                    Bindable = (BindableInt)config.GetBindable<int>(FrameworkConfig.LetterboxPositionY)
+                    Bindable = config.GetBindable<double>(FrameworkConfig.LetterboxPositionY)
                 },
             };
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/655 (for the slider bar fix)

Allows debugging of the projects through the clr. Does _not_ require .NET Core to work (should just work out of the box).

This has no effect on Visual Studio (tested 2015 and 2017).

The rebuild task is necessary because MSBuild doesn't check if the PDBs are portable or not.
