### PR TITLE
Retrieve online metrics

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Configuration;
 using osu.Framework.Platform;
+using osu.Game.Screens.Select;
 
 namespace osu.Game.Configuration
 {
@@ -33,6 +34,8 @@ namespace osu.Game.Configuration
             Set(OsuConfig.SnakingOutSliders, true);
 
             Set(OsuConfig.MenuParallax, true);
+
+            Set(OsuConfig.BeatmapDetailTab, BeatmapDetailTab.Details);
 
             Set(OsuConfig.ShowInterface, true);
             Set(OsuConfig.KeyOverlay, false);
@@ -316,6 +319,7 @@ namespace osu.Game.Configuration
         MenuMusic,
         MenuVoice,
         MenuParallax,
+        BeatmapDetailTab,
         RawInput,
         AbsoluteToOsuWindow,
         ConfineMouse,

--- a/osu.Game/Database/BeatmapMetrics.cs
+++ b/osu.Game/Database/BeatmapMetrics.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace osu.Game.Database
 {
@@ -18,11 +19,13 @@ namespace osu.Game.Database
         /// <summary>
         /// Points of failure on a relative time scale (usually 0..100).
         /// </summary>
+        [JsonProperty(@"fail")]
         public IEnumerable<int> Fails { get; set; }
 
         /// <summary>
         /// Points of retry on a relative time scale (usually 0..100).
         /// </summary>
+        [JsonProperty(@"exit")]
         public IEnumerable<int> Retries { get; set; }
     }
 }

--- a/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using Newtonsoft.Json;
-using osu.Framework.IO.Network;
 using osu.Game.Database;
 
 namespace osu.Game.Online.API.Requests

--- a/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Framework.IO.Network;
 using osu.Game.Database;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Online.API.Requests
 {
@@ -13,23 +11,11 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly BeatmapInfo beatmap;
 
-        private string lookupString;
+        private string lookupString => beatmap.OnlineBeatmapID > 0 ? beatmap.OnlineBeatmapID.ToString() : $@"lookup?checksum={beatmap.Hash}&filename={beatmap.Path}";
 
         public GetBeatmapDetailsRequest(BeatmapInfo beatmap)
         {
             this.beatmap = beatmap;
-        }
-
-        protected override WebRequest CreateWebRequest()
-        {
-            if (beatmap.OnlineBeatmapID > 0)
-                lookupString = beatmap.OnlineBeatmapID.ToString();
-            else
-                lookupString = $@"lookup?checksum={beatmap.Hash}&filename={beatmap.Path}";
-
-            var req = base.CreateWebRequest();
-
-            return req;
         }
 
         protected override string Target => $@"beatmaps/{lookupString}";
@@ -43,8 +29,8 @@ namespace osu.Game.Online.API.Requests
         {
             set
             {
-                this.Fails = value.Fails;
-                this.Retries = value.Retries;
+                Fails = value.Fails;
+                Retries = value.Retries;
             }
         }
 
@@ -54,7 +40,7 @@ namespace osu.Game.Online.API.Requests
         {
             set
             {
-                this.Ratings = value.Ratings;
+                Ratings = value.Ratings;
             }
         }
     }

--- a/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
@@ -9,13 +9,13 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Online.API.Requests
 {
-    public class GetBeatmapDeatilsRequest : APIRequest<GetBeatmapDeatilsResponse>
+    public class GetBeatmapDetailsRequest : APIRequest<GetBeatmapDeatilsResponse>
     {
         private readonly BeatmapInfo beatmap;
 
         private string lookupString;
 
-        public GetBeatmapDeatilsRequest(BeatmapInfo beatmap)
+        public GetBeatmapDetailsRequest(BeatmapInfo beatmap)
         {
             this.beatmap = beatmap;
         }

--- a/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using osu.Framework.IO.Network;
+using osu.Game.Database;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetBeatmapDeatilsRequest : APIRequest<GetBeatmapDeatilsResponse>
+    {
+        private readonly BeatmapInfo beatmap;
+
+        private string lookupString;
+
+        public GetBeatmapDeatilsRequest(BeatmapInfo beatmap)
+        {
+            this.beatmap = beatmap;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            if (beatmap.OnlineBeatmapID > 0)
+                lookupString = beatmap.OnlineBeatmapID.ToString();
+            else
+                lookupString = $@"lookup?checksum={beatmap.Hash}&filename={beatmap.Path}";
+
+            var req = base.CreateWebRequest();
+
+            return req;
+        }
+
+        protected override string Target => $@"beatmaps/{lookupString}";
+    }
+
+    public class GetBeatmapDeatilsResponse : BeatmapMetrics
+    {
+        //the online API returns some metrics as a nested object.
+        [JsonProperty(@"failtimes")]
+        private BeatmapMetrics failTimes
+        {
+            set
+            {
+                this.Fails = value.Fails;
+                this.Retries = value.Retries;
+            }
+        }
+
+        //and other metrics in the beatmap set.
+        [JsonProperty(@"beatmapset")]
+        private BeatmapMetrics beatmapSet
+        {
+            set
+            {
+                this.Ratings = value.Ratings;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Select/BeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailArea.cs
@@ -66,14 +66,14 @@ namespace osu.Game.Screens.Select
             {
                 Details = new BeatmapDetails
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding(5),
+                    RelativeSizeAxes = Axes.X,
+                    Masking = true,
+                    Height = 352,
                     Alpha = 0,
                 },
                 Leaderboard = new Leaderboard
                 {
                     RelativeSizeAxes = Axes.Both,
-
                 }
             });
         }

--- a/osu.Game/Screens/Select/BeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailArea.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Select
             {
                 beatmap = value;
                 Leaderboard.Beatmap = beatmap?.BeatmapInfo;
-                Details.Beatmap = beatmap?.Beatmap.BeatmapInfo;
+                Details.Beatmap = beatmap?.BeatmapInfo;
             }
         }
 

--- a/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
@@ -4,10 +4,12 @@
 using System;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 
@@ -21,15 +23,22 @@ namespace osu.Game.Screens.Select
 
         public Action<BeatmapDetailTab, bool> OnFilter; //passed the selected tab and if mods is checked
 
+        private Bindable<BeatmapDetailTab> selectedTab;
+
         private void invokeOnFilter()
         {
             OnFilter?.Invoke(tabs.Current, modsCheckbox.Current);
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour)
+        private void load(OsuColour colour, OsuConfigManager config)
         {
             modsCheckbox.AccentColour = tabs.AccentColour = colour.YellowLight;
+
+            selectedTab = config.GetBindable<BeatmapDetailTab>(OsuConfig.BeatmapDetailTab);
+
+            tabs.Current.BindTo(selectedTab);
+            tabs.Current.TriggerChange();
         }
 
         public BeatmapDetailAreaTabControl()
@@ -62,8 +71,6 @@ namespace osu.Game.Screens.Select
 
             tabs.Current.ValueChanged += item => invokeOnFilter();
             modsCheckbox.Current.ValueChanged += item => invokeOnFilter();
-
-            tabs.Current.Value = BeatmapDetailTab.Global;
         }
     }
 

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Select
             var requestedBeatmap = beatmap;
             if (requestedBeatmap.Metrics == null)
             {
-                var lookup = new GetBeatmapDeatilsRequest(requestedBeatmap);
+                var lookup = new GetBeatmapDetailsRequest(requestedBeatmap);
                 lookup.Success += res =>
                 {
                     if (beatmap != requestedBeatmap)

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -14,6 +14,10 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using System.Globalization;
 using System.Linq;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Framework.Threading;
+using System;
 
 namespace osu.Game.Screens.Select
 {
@@ -39,59 +43,99 @@ namespace osu.Game.Screens.Select
         private readonly BarGraph retryGraph;
         private readonly BarGraph failGraph;
 
+        private ScheduledDelegate pendingBeatmapSwitch;
         private BeatmapInfo beatmap;
+
         public BeatmapInfo Beatmap
         {
-            get
-            {
-                return beatmap;
-            }
+            get { return beatmap; }
             set
             {
                 beatmap = value;
 
-                if (beatmap == null) return;
-
-                description.Text = beatmap.Version;
-                source.Text = beatmap.Metadata.Source;
-                tags.Text = beatmap.Metadata.Tags;
-
-                circleSize.Value = beatmap.Difficulty.CircleSize;
-                drainRate.Value = beatmap.Difficulty.DrainRate;
-                overallDifficulty.Value = beatmap.Difficulty.OverallDifficulty;
-                approachRate.Value = beatmap.Difficulty.ApproachRate;
-                stars.Value = (float)beatmap.StarDifficulty;
-
-                if (beatmap.Metrics?.Ratings.Any() ?? false)
-                {
-                    var ratings = beatmap.Metrics.Ratings.ToList();
-                    ratingsContainer.Show();
-
-                    negativeRatings.Text = ratings.GetRange(0, ratings.Count / 2).Sum().ToString();
-                    positiveRatings.Text = ratings.GetRange(ratings.Count / 2, ratings.Count / 2).Sum().ToString();
-                    ratingsBar.Length = (float)ratings.GetRange(0, ratings.Count / 2).Sum() / ratings.Sum();
-
-                    ratingsGraph.Values = ratings.Select(rating => (float)rating);
-                }
-                else
-                    ratingsContainer.Hide();
-
-                if ((beatmap.Metrics?.Retries.Any() ?? false) && beatmap.Metrics.Fails.Any())
-                {
-                    var retries = beatmap.Metrics.Retries;
-                    var fails = beatmap.Metrics.Fails;
-                    retryFailContainer.Show();
-
-                    float maxValue = fails.Zip(retries, (fail, retry) => fail + retry).Max();
-                    failGraph.MaxValue = maxValue;
-                    retryGraph.MaxValue = maxValue;
-
-                    failGraph.Values = fails.Select(fail => (float)fail);
-                    retryGraph.Values = retries.Zip(fails, (retry, fail) => retry + MathHelper.Clamp(fail, 0, maxValue));
-                }
-                else
-                    retryFailContainer.Hide();
+                pendingBeatmapSwitch?.Cancel();
+                pendingBeatmapSwitch = Schedule(updateStats);
             }
+        }
+
+        private void updateStats()
+        {
+            description.Text = beatmap.Version;
+            source.Text = beatmap.Metadata.Source;
+            tags.Text = beatmap.Metadata.Tags;
+
+            circleSize.Value = beatmap.Difficulty.CircleSize;
+            drainRate.Value = beatmap.Difficulty.DrainRate;
+            overallDifficulty.Value = beatmap.Difficulty.OverallDifficulty;
+            approachRate.Value = beatmap.Difficulty.ApproachRate;
+            stars.Value = (float)beatmap.StarDifficulty;
+
+            var requestedBeatmap = beatmap;
+            if (requestedBeatmap.Metrics == null)
+            {
+                var lookup = new GetBeatmapDeatilsRequest(requestedBeatmap);
+                lookup.Success += res =>
+                {
+                    if (beatmap != requestedBeatmap)
+                            //the beatmap has been changed since we started the lookup.
+                            return;
+
+                    requestedBeatmap.Metrics = res;
+                    Schedule(() => updateMetrics(res, true));
+                };
+                lookup.Failure += e => updateMetrics(null, true);
+
+                api.Queue(lookup);
+            }
+
+            updateMetrics(requestedBeatmap.Metrics, false);
+        }
+
+        private void updateMetrics(BeatmapMetrics metrics, bool failOnMissing = true)
+        {
+            var hasRatings = metrics?.Ratings.Any() ?? false;
+            var hasRetriesFails = (metrics?.Retries.Any() ?? false) && metrics.Fails.Any();
+
+            if (hasRatings)
+            {
+                var ratings = metrics.Ratings.ToList();
+                ratingsContainer.Show();
+
+                negativeRatings.Text = ratings.GetRange(0, ratings.Count / 2).Sum().ToString();
+                positiveRatings.Text = ratings.GetRange(ratings.Count / 2, ratings.Count / 2).Sum().ToString();
+                ratingsBar.Length = (float)ratings.GetRange(0, ratings.Count / 2).Sum() / ratings.Sum();
+
+                ratingsGraph.Values = ratings.Select(rating => (float)rating);
+
+                ratingsContainer.FadeColour(Color4.White, 500, EasingTypes.Out);
+            }
+            else if (failOnMissing)
+                ratingsGraph.Values = new float[10];
+            else
+                ratingsContainer.FadeColour(Color4.Gray, 500, EasingTypes.Out);
+
+            if (hasRetriesFails)
+            {
+                var retries = metrics.Retries;
+                var fails = metrics.Fails;
+                retryFailContainer.Show();
+
+                float maxValue = fails.Zip(retries, (fail, retry) => fail + retry).Max();
+                failGraph.MaxValue = maxValue;
+                retryGraph.MaxValue = maxValue;
+
+                failGraph.Values = fails.Select(fail => (float)fail);
+                retryGraph.Values = retries.Zip(fails, (retry, fail) => retry + MathHelper.Clamp(fail, 0, maxValue));
+
+                retryFailContainer.FadeColour(Color4.White, 500, EasingTypes.Out);
+            }
+            else if (failOnMissing)
+            {
+                failGraph.Values = new float[100];
+                retryGraph.Values = new float[100];
+            }
+            else
+                retryFailContainer.FadeColour(Color4.Gray, 500, EasingTypes.Out);
         }
 
         public BeatmapDetails()
@@ -272,9 +316,13 @@ namespace osu.Game.Screens.Select
             };
         }
 
+        private APIAccess api;
+
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour)
+        private void load(OsuColour colour, APIAccess api)
         {
+            this.api = api;
+
             description.AccentColour = colour.GrayB;
             source.AccentColour = colour.GrayB;
             tags.AccentColour = colour.YellowLight;

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -92,6 +92,11 @@ namespace osu.Game.Screens.Select
             updateMetrics(requestedBeatmap.Metrics, false);
         }
 
+        /// <summary>
+        /// Update displayed metrics.
+        /// </summary>
+        /// <param name="metrics">New metrics to overwrite the existing display. Can be null.</param>
+        /// <param name="failOnMissing">Whether to hide the display on null or empty metrics. If false, we will dim as if waiting for further updates.</param>
         private void updateMetrics(BeatmapMetrics metrics, bool failOnMissing = true)
         {
             var hasRatings = metrics?.Ratings.Any() ?? false;

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -60,6 +60,8 @@ namespace osu.Game.Screens.Select
 
         private void updateStats()
         {
+            if (beatmap == null) return;
+
             description.Text = beatmap.Version;
             source.Text = beatmap.Metadata.Source;
             tags.Text = beatmap.Metadata.Tags;

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -114,7 +114,6 @@ namespace osu.Game.Screens.Select
                     Direction = FillDirection.Vertical,
                     LayoutDuration = 200,
                     LayoutEasing = EasingTypes.OutQuint,
-                    Padding = new MarginPadding(10) { Top = 25 },
                     Children = new []
                     {
                         description = new MetadataSegment("Description"),
@@ -149,8 +148,8 @@ namespace osu.Game.Screens.Select
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                     Direction = FillDirection.Vertical,
-                                    Spacing = new Vector2(0,10),
-                                    Padding = new MarginPadding(15) { Top = 25 },
+                                    Spacing = new Vector2(0,5),
+                                    Padding = new MarginPadding(10),
                                     Children = new []
                                     {
                                         circleSize = new DifficultyRow("Circle Size", 7),

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -17,7 +17,6 @@ using System.Linq;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Framework.Threading;
-using System;
 
 namespace osu.Game.Screens.Select
 {
@@ -83,9 +82,9 @@ namespace osu.Game.Screens.Select
                             return;
 
                     requestedBeatmap.Metrics = res;
-                    Schedule(() => updateMetrics(res, true));
+                    Schedule(() => updateMetrics(res));
                 };
-                lookup.Failure += e => updateMetrics(null, true);
+                lookup.Failure += e => updateMetrics(null);
 
                 api.Queue(lookup);
             }

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Screens.Select
             set
             {
                 beatmap = value;
+
                 if (beatmap == null) return;
 
                 description.Text = beatmap.Version;
@@ -252,7 +253,7 @@ namespace osu.Game.Screens.Select
                                 new Container<BarGraph>
                                 {
                                     RelativeSizeAxes = Axes.X,
-                                    Size = new Vector2(1/0.6f, 50),
+                                    Size = new Vector2(1 / 0.6f, 50),
                                     Children = new[]
                                     {
                                         retryGraph = new BarGraph
@@ -308,7 +309,7 @@ namespace osu.Game.Screens.Select
                 {
                     difficultyValue = value;
                     bar.Length = value / maxValue;
-                    valueText.Text = value.ToString(CultureInfo.InvariantCulture);
+                    valueText.Text = value.ToString("N1", CultureInfo.CurrentCulture);
                 }
             }
 

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Threading;
 using osu.Game.Database;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Online.API;
@@ -93,13 +94,18 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         private BeatmapInfo beatmap;
 
+        private ScheduledDelegate pendingBeatmapSwitch;
+
         public BeatmapInfo Beatmap
         {
             get { return beatmap; }
             set
             {
                 beatmap = value;
-                Schedule(updateScores);
+                Scores = null;
+
+                pendingBeatmapSwitch?.Cancel();
+                pendingBeatmapSwitch = Schedule(updateScores);
             }
         }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Rulesets\UI\StandardHudOverlay.cs" />
     <Compile Include="Online\API\IOnlineComponent.cs" />
     <Compile Include="Online\API\Requests\GetScoresRequest.cs" />
+    <Compile Include="Online\API\Requests\GetBeatmapDetailsRequest.cs" />
     <Compile Include="Online\API\Requests\GetUserRequest.cs" />
     <Compile Include="Overlays\DragBar.cs" />
     <Compile Include="Overlays\LoginOverlay.cs" />


### PR DESCRIPTION
- Completes display of user ratings, fail and retry times at song select.
- Stores the last selected display mode to config.
- Improves lookup reliability of leaderboards.