### PR TITLE
Implement Taiko difficulty calculation.

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/TaikoHitObjectDifficulty.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoHitObjectDifficulty.cs
@@ -1,0 +1,127 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+
+namespace osu.Game.Rulesets.Taiko.Objects
+{
+    internal class TaikoHitObjectDifficulty
+    {
+        /// <summary>
+        /// Factor by how much individual / overall strain decays per second.
+        /// </summary>
+        /// <remarks>
+        /// These values are results of tweaking a lot and taking into account general feedback.
+        /// </remarks>
+        internal const double DECAY_BASE = 0.30;
+
+        private const double type_change_bonus = 0.75;
+        private const double rhythm_change_bonus = 1.0;
+        private const double rhythm_change_base_threshold = 0.2;
+        private const double rhythm_change_base = 2.0;
+
+        internal TaikoHitObject BaseHitObject;
+
+        /// <summary>
+        /// Measures note density in a way
+        /// </summary>
+        internal double Strain = 1;
+
+        private double timeElapsed = 0;
+        private int sameTypeSince = 1;
+
+        private bool isRim => BaseHitObject is RimHit;
+
+        public TaikoHitObjectDifficulty(TaikoHitObject baseHitObject)
+        {
+            this.BaseHitObject = baseHitObject;
+        }
+
+        internal void CalculateStrains(TaikoHitObjectDifficulty previousHitObject, double timeRate)
+        {
+            // Rather simple, but more specialized things are inherently inaccurate due to the big difference playstyles and opinions make.
+            // See Taiko feedback thread.
+            timeElapsed = (BaseHitObject.StartTime - previousHitObject.BaseHitObject.StartTime) / timeRate;
+            double decay = Math.Pow(DECAY_BASE, timeElapsed / 1000);
+
+            double addition = 1;
+
+            // Only if we are no slider or spinner we get an extra addition
+            if (previousHitObject.BaseHitObject is Hit && BaseHitObject is Hit
+                && BaseHitObject.StartTime - previousHitObject.BaseHitObject.StartTime < 1000) // And we only want to check out hitobjects which aren't so far in the past
+            {
+                addition += typeChangeAddition(previousHitObject);
+                addition += rhythmChangeAddition(previousHitObject);
+            }
+
+            double additionFactor = 1.0;
+            // Scale AdditionFactor linearly from 0.4 to 1 for TimeElapsed from 0 to 50
+            if (timeElapsed < 50.0)
+                additionFactor = 0.4 + 0.6 * timeElapsed / 50.0;
+
+            Strain = previousHitObject.Strain * decay + addition * additionFactor;
+        }
+
+        private TypeSwitch lastTypeSwitchEven = TypeSwitch.None;
+        private double typeChangeAddition(TaikoHitObjectDifficulty previousHitObject)
+        {
+            // If we don't have the same hit type, trigger a type change!
+            if (previousHitObject.isRim != isRim)
+            {
+                lastTypeSwitchEven = previousHitObject.sameTypeSince % 2 == 0 ? TypeSwitch.Even : TypeSwitch.Odd;
+
+                // We only want a bonus if the parity of the type switch changes!
+                switch (previousHitObject.lastTypeSwitchEven)
+                {
+                    case TypeSwitch.Even:
+                        if (lastTypeSwitchEven == TypeSwitch.Odd)
+                            return type_change_bonus;
+                        break;
+                    case TypeSwitch.Odd:
+                        if (lastTypeSwitchEven == TypeSwitch.Even)
+                            return type_change_bonus;
+                        break;
+                }
+            }
+            // No type change? Increment counter and keep track of last type switch
+            else
+            {
+                lastTypeSwitchEven = previousHitObject.lastTypeSwitchEven;
+                sameTypeSince = previousHitObject.sameTypeSince + 1;
+            }
+
+            return 0;
+        }
+
+        private double rhythmChangeAddition(TaikoHitObjectDifficulty previousHitObject)
+        {
+            // We don't want a division by zero if some random mapper decides to put 2 HitObjects at the same time.
+            if (timeElapsed == 0 || previousHitObject.timeElapsed == 0)
+                return 0;
+
+            double timeElapsedRatio = Math.Max(previousHitObject.timeElapsed / timeElapsed, timeElapsed / previousHitObject.timeElapsed);
+
+            if (timeElapsedRatio >= 8)
+                return 0;
+
+            double difference = Math.Log(timeElapsedRatio, rhythm_change_base) % 1.0;
+
+            if (isWithinChangeThreshold(difference))
+                return rhythm_change_bonus;
+
+            return 0;
+        }
+
+        private bool isWithinChangeThreshold(double value)
+        {
+            return value > rhythm_change_base_threshold && value < 1 - rhythm_change_base_threshold;
+        }
+
+        private enum TypeSwitch
+        {
+            None,
+            Even,
+            Odd
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoHitObjectDifficulty.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoHitObjectDifficulty.cs
@@ -27,14 +27,14 @@ namespace osu.Game.Rulesets.Taiko.Objects
         /// </summary>
         internal double Strain = 1;
 
-        private double timeElapsed = 0;
+        private double timeElapsed;
         private int sameTypeSince = 1;
 
         private bool isRim => BaseHitObject is RimHit;
 
         public TaikoHitObjectDifficulty(TaikoHitObject baseHitObject)
         {
-            this.BaseHitObject = baseHitObject;
+            BaseHitObject = baseHitObject;
         }
 
         internal void CalculateStrains(TaikoHitObjectDifficulty previousHitObject, double timeRate)

--- a/osu.Game.Rulesets.Taiko/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoDifficultyCalculator.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko
         /// <summary>
         /// HitObjects are stored as a member variable.
         /// </summary>
-        private List<TaikoHitObjectDifficulty> difficultyHitObjects = new List<TaikoHitObjectDifficulty>();
+        private readonly List<TaikoHitObjectDifficulty> difficultyHitObjects = new List<TaikoHitObjectDifficulty>();
 
         public TaikoDifficultyCalculator(Beatmap beatmap)
             : base(beatmap)
@@ -64,22 +64,22 @@ namespace osu.Game.Rulesets.Taiko
         private bool calculateStrainValues()
         {
             // Traverse hitObjects in pairs to calculate the strain value of NextHitObject from the strain value of CurrentHitObject and environment.
-            List<TaikoHitObjectDifficulty>.Enumerator hitObjectsEnumerator = difficultyHitObjects.GetEnumerator();
-
-            if (!hitObjectsEnumerator.MoveNext()) return false;
-
-            TaikoHitObjectDifficulty currentHitObject = hitObjectsEnumerator.Current;
-            TaikoHitObjectDifficulty nextHitObject;
-
-            // First hitObject starts at strain 1. 1 is the default for strain values, so we don't need to set it here. See DifficultyHitObject.
-            while (hitObjectsEnumerator.MoveNext())
+            using (List<TaikoHitObjectDifficulty>.Enumerator hitObjectsEnumerator = difficultyHitObjects.GetEnumerator())
             {
-                nextHitObject = hitObjectsEnumerator.Current;
-                nextHitObject.CalculateStrains(currentHitObject, TimeRate);
-                currentHitObject = nextHitObject;
-            }
+                if (!hitObjectsEnumerator.MoveNext()) return false;
 
-            return true;
+                TaikoHitObjectDifficulty current = hitObjectsEnumerator.Current;
+
+                // First hitObject starts at strain 1. 1 is the default for strain values, so we don't need to set it here. See DifficultyHitObject.
+                while (hitObjectsEnumerator.MoveNext())
+                {
+                    var next = hitObjectsEnumerator.Current;
+                    next?.CalculateStrains(current, TimeRate);
+                    current = next;
+                }
+
+                return true;
+            }
         }
 
         private double calculateDifficulty()

--- a/osu.Game.Rulesets.Taiko/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoDifficultyCalculator.cs
@@ -6,18 +6,133 @@ using osu.Game.Rulesets.Beatmaps;
 using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.Taiko.Objects;
 using System.Collections.Generic;
+using System.Globalization;
+using System;
 
 namespace osu.Game.Rulesets.Taiko
 {
-    public class TaikoDifficultyCalculator : DifficultyCalculator<TaikoHitObject>
+    internal class TaikoDifficultyCalculator : DifficultyCalculator<TaikoHitObject>
     {
-        public TaikoDifficultyCalculator(Beatmap beatmap) : base(beatmap)
+        private const double star_scaling_factor = 0.04125;
+
+        /// <summary>
+        /// In milliseconds. For difficulty calculation we will only look at the highest strain value in each time interval of size STRAIN_STEP.
+        /// This is to eliminate higher influence of stream over aim by simply having more HitObjects with high strain.
+        /// The higher this value, the less strains there will be, indirectly giving long beatmaps an advantage.
+        /// </summary>
+        private const double strain_step = 400;
+
+        /// <summary>
+        /// The weighting of each strain value decays to this number * it's previous value
+        /// </summary>
+        private const double decay_weight = 0.9;
+
+        /// <summary>
+        /// HitObjects are stored as a member variable.
+        /// </summary>
+        private List<TaikoHitObjectDifficulty> difficultyHitObjects = new List<TaikoHitObjectDifficulty>();
+
+        public TaikoDifficultyCalculator(Beatmap beatmap)
+            : base(beatmap)
         {
         }
 
         protected override double CalculateInternal(Dictionary<string, string> categoryDifficulty)
         {
-            return 0;
+            // Fill our custom DifficultyHitObject class, that carries additional information
+            difficultyHitObjects.Clear();
+
+            foreach (var hitObject in Objects)
+                difficultyHitObjects.Add(new TaikoHitObjectDifficulty(hitObject));
+
+            // Sort DifficultyHitObjects by StartTime of the HitObjects - just to make sure.
+            difficultyHitObjects.Sort((a, b) => a.BaseHitObject.StartTime.CompareTo(b.BaseHitObject.StartTime));
+
+            if (!calculateStrainValues()) return 0;
+
+            double starRating = calculateDifficulty() * star_scaling_factor;
+
+            if (categoryDifficulty != null)
+            {
+                categoryDifficulty.Add("Strain", starRating.ToString("0.00", CultureInfo.InvariantCulture));
+                categoryDifficulty.Add("Hit window 300", (35 /*HitObjectManager.HitWindow300*/ / TimeRate).ToString("0.00", CultureInfo.InvariantCulture));
+            }
+
+            return starRating;
+        }
+
+        private bool calculateStrainValues()
+        {
+            // Traverse hitObjects in pairs to calculate the strain value of NextHitObject from the strain value of CurrentHitObject and environment.
+            List<TaikoHitObjectDifficulty>.Enumerator hitObjectsEnumerator = difficultyHitObjects.GetEnumerator();
+
+            if (!hitObjectsEnumerator.MoveNext()) return false;
+
+            TaikoHitObjectDifficulty currentHitObject = hitObjectsEnumerator.Current;
+            TaikoHitObjectDifficulty nextHitObject;
+
+            // First hitObject starts at strain 1. 1 is the default for strain values, so we don't need to set it here. See DifficultyHitObject.
+            while (hitObjectsEnumerator.MoveNext())
+            {
+                nextHitObject = hitObjectsEnumerator.Current;
+                nextHitObject.CalculateStrains(currentHitObject, TimeRate);
+                currentHitObject = nextHitObject;
+            }
+
+            return true;
+        }
+
+        private double calculateDifficulty()
+        {
+            double actualStrainStep = strain_step * TimeRate;
+
+            // Find the highest strain value within each strain step
+            List<double> highestStrains = new List<double>();
+            double intervalEndTime = actualStrainStep;
+            double maximumStrain = 0; // We need to keep track of the maximum strain in the current interval
+
+            TaikoHitObjectDifficulty previousHitObject = null;
+            foreach (var hitObject in difficultyHitObjects)
+            {
+                // While we are beyond the current interval push the currently available maximum to our strain list
+                while (hitObject.BaseHitObject.StartTime > intervalEndTime)
+                {
+                    highestStrains.Add(maximumStrain);
+
+                    // The maximum strain of the next interval is not zero by default! We need to take the last hitObject we encountered, take its strain and apply the decay
+                    // until the beginning of the next interval.
+                    if (previousHitObject == null)
+                    {
+                        maximumStrain = 0;
+                    }
+                    else
+                    {
+                        double decay = Math.Pow(TaikoHitObjectDifficulty.DECAY_BASE, (intervalEndTime - previousHitObject.BaseHitObject.StartTime) / 1000);
+                        maximumStrain = previousHitObject.Strain * decay;
+                    }
+
+                    // Go to the next time interval
+                    intervalEndTime += actualStrainStep;
+                }
+
+                // Obtain maximum strain
+                maximumStrain = Math.Max(hitObject.Strain, maximumStrain);
+
+                previousHitObject = hitObject;
+            }
+
+            // Build the weighted sum over the highest strains for each interval
+            double difficulty = 0;
+            double weight = 1;
+            highestStrains.Sort((a, b) => b.CompareTo(a)); // Sort from highest to lowest strain.
+
+            foreach (double strain in highestStrains)
+            {
+                difficulty += weight * strain;
+                weight *= decay_weight;
+            }
+
+            return difficulty;
         }
 
         protected override BeatmapConverter<TaikoHitObject> CreateBeatmapConverter() => new TaikoBeatmapConverter();

--- a/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
+++ b/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Replays\TaikoFramedReplayInputHandler.cs" />
     <Compile Include="Replays\TaikoAutoReplay.cs" />
     <Compile Include="Objects\TaikoHitObject.cs" />
+    <Compile Include="Objects\TaikoHitObjectDifficulty.cs" />
     <Compile Include="TaikoDifficultyCalculator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scoring\TaikoScoreProcessor.cs" />

--- a/osu.Game/Beatmaps/DifficultyCalculator.cs
+++ b/osu.Game/Beatmaps/DifficultyCalculator.cs
@@ -35,6 +35,10 @@ namespace osu.Game.Beatmaps
         protected DifficultyCalculator(Beatmap beatmap)
         {
             Objects = CreateBeatmapConverter().Convert(beatmap).HitObjects;
+
+            foreach (var h in Objects)
+                h.ApplyDefaults(beatmap.TimingInfo, beatmap.BeatmapInfo.Difficulty);
+
             PreprocessHitObjects();
         }
 


### PR DESCRIPTION
Completes worklist item #9 from https://github.com/ppy/osu/issues/597.

Implemented almost identical to stable, minus a few renamings.

Note that diff calc in general is going to need quite a bit of work. Until then I have kept `categoryDifficulty` to be used when that happens.