### PR TITLE
Fix lead in time.

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         {
             base.LoadComplete();
 
+            Delay(-TransformStartTime); // So our follow points start their transforms from t=0 (the start of the map), rather from the lead in time (where the clock is right now).
             Delay(StartTime);
             FadeIn(DrawableOsuHitObject.TIME_FADEIN);
             ScaleTo(1.5f);

--- a/osu.Game/Screens/Play/PlayerInputManager.cs
+++ b/osu.Game/Screens/Play/PlayerInputManager.cs
@@ -48,7 +48,9 @@ namespace osu.Game.Screens.Play
             base.LoadComplete();
 
             parentClock = Clock;
+            clock.CurrentTime = parentClock.CurrentTime;
             Clock = new FramedClock(clock);
+            Clock.ProcessFrame();
         }
 
         /// <summary>


### PR DESCRIPTION
The issue was that hitobjects are very sensitive to the exact clock
time when their loadComplete is called. Before, PlayerInputManager
would override the clock with its own framed ManualClock, but it did
not set the time and ProcessFrame immediately after init (it only does
this in Update), thus when it came to the HitObject being loaded, it
had a Clock.Current of 0. The end result was sliders that look bad

https://streamable.com/d9e0i

Hit objects should probably not be so sensitive to their start time,
but it's probably a good idea to init them with the correct start time regardless.