### PR TITLE
Fix SelectionChanged being invoked twice when changing selection with keyboard.

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -343,6 +343,8 @@ namespace osu.Game.Screens.Select
                 group.State = BeatmapGroupState.Expanded;
                 panel.State = PanelSelectedState.Selected;
 
+                if (selectedPanel == panel) return;
+
                 selectedPanel = panel;
                 selectedGroup = group;
 


### PR DESCRIPTION
This was causing PreviewTime to be ignored completely if it was the second time we selected a beatmapset group and we did it with keyboard.

As the comments in 4e65da0 says an issue was caused by panels not presented at least once, in this case the issue is caused by panels presented at least once.

[Before](https://streamable.com/u7cpd) - [After](https://streamable.com/qlmen)