### PR TITLE
Fix startup crash caused by MenuMusic binding

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -76,10 +76,10 @@ namespace osu.Game.Screens.Menu
             if (!menuMusic)
             {
                 trackManager = game.Audio.Track;
-                List<BeatmapSetInfo> choosableBeatmapsets = beatmaps.Query<BeatmapSetInfo>().ToList();
-                if (choosableBeatmapsets.Count > 0)
+                List<BeatmapSetInfo> choosableBeatmapSets = beatmaps.Query<BeatmapSetInfo>().ToList();
+                if (choosableBeatmapSets.Count > 0)
                 {
-                    song = beatmaps.GetWorkingBeatmap(beatmaps.GetWithChildren<BeatmapSetInfo>(choosableBeatmapsets[RNG.Next(0, choosableBeatmapsets.Count - 1)].ID).Beatmaps[0]);
+                    song = beatmaps.GetWorkingBeatmap(beatmaps.GetWithChildren<BeatmapSetInfo>(choosableBeatmapSets[RNG.Next(0, choosableBeatmapSets.Count - 1)].ID).Beatmaps[0]);
                     Beatmap = song;
                 }
             }

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -22,6 +22,8 @@ using osu.Game.Screens.Tournament;
 using osu.Framework.Input;
 using OpenTK.Input;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.Game.Screens.Menu
 {
@@ -74,10 +76,10 @@ namespace osu.Game.Screens.Menu
             if (!menuMusic)
             {
                 trackManager = game.Audio.Track;
-                int choosableBeatmapsetAmmount = beatmaps.Query<BeatmapSetInfo>().Count();
-                if (choosableBeatmapsetAmmount > 0)
+                List<BeatmapSetInfo> choosableBeatmapsets = beatmaps.Query<BeatmapSetInfo>().ToList();
+                if (choosableBeatmapsets.Count > 0)
                 {
-                    song = beatmaps.GetWorkingBeatmap(beatmaps.GetWithChildren<BeatmapSetInfo>(RNG.Next(1, choosableBeatmapsetAmmount)).Beatmaps[0]);
+                    song = beatmaps.GetWorkingBeatmap(beatmaps.GetWithChildren<BeatmapSetInfo>(choosableBeatmapsets[RNG.Next(0, choosableBeatmapsets.Count - 1)].ID).Beatmaps[0]);
                     Beatmap = song;
                 }
             }


### PR DESCRIPTION
This happened because the IDs stored in the beatmap do not correspond to their position on it, causing an exeption when trying to lookup for the non-existent ID.

Reproducible if some beatmaps where deleted.