### PR TITLE
Fix ModSelectOverlay accepting escape when it shouldn't

### DIFF
--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -71,8 +71,7 @@ namespace osu.Game.Screens.Select
 
         protected override void OnSuspending(Screen next)
         {
-            if (modSelect.State == Visibility.Visible)
-                modSelect.Hide();
+            modSelect.Hide();
 
             base.OnSuspending(next);
         }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -69,6 +69,14 @@ namespace osu.Game.Screens.Select
             base.OnResuming(last);
         }
 
+        protected override void OnSuspending(Screen next)
+        {
+            if (modSelect.State == Visibility.Visible)
+                modSelect.Hide();
+
+            base.OnSuspending(next);
+        }
+
         protected override bool OnExiting(Screen next)
         {
             if (modSelect.State == Visibility.Visible)


### PR DESCRIPTION
Because `PlaySongSelect` is suspending when selecting a song, we don't actually hide `ModSelectOverlay`.

Fixes #721 