### PR TITLE
Fix double null check in GetWorkingBeatmap

### DIFF
--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -268,10 +268,14 @@ namespace osu.Game.Database
         public WorkingBeatmap GetWorkingBeatmap(BeatmapInfo beatmapInfo, WorkingBeatmap previous = null, bool withStoryboard = false)
         {
             if (beatmapInfo.BeatmapSet == null)
+            {
                 beatmapInfo = GetChildren(beatmapInfo, true);
+                
+                if (beatmapInfo.BeatmapSet == null)
+                    throw new InvalidOperationException($@"Beatmap set {beatmapInfo.BeatmapSetInfoID} is not in the local database.");
+            }
 
-            if (beatmapInfo.BeatmapSet == null)
-                throw new InvalidOperationException($@"Beatmap set {beatmapInfo.BeatmapSetInfoID} is not in the local database.");
+
 
             if (beatmapInfo.Metadata == null)
                 beatmapInfo.Metadata = beatmapInfo.BeatmapSet.Metadata;

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -270,7 +270,7 @@ namespace osu.Game.Database
             if (beatmapInfo.BeatmapSet == null)
             {
                 beatmapInfo = GetChildren(beatmapInfo, true);
-                
+
                 if (beatmapInfo.BeatmapSet == null)
                     throw new InvalidOperationException($@"Beatmap set {beatmapInfo.BeatmapSetInfoID} is not in the local database.");
             }


### PR DESCRIPTION
No idea if this makes any difference performance-wise, but behaviour should be the same.
