### PR TITLE
Tidy up

### DIFF
--- a/osu.Desktop.VisualTests/Tests/TestCaseResults.cs
+++ b/osu.Desktop.VisualTests/Tests/TestCaseResults.cs
@@ -47,7 +47,7 @@ namespace osu.Desktop.VisualTests.Tests
                 Accuracy = 0.98,
                 MaxCombo = 123,
                 Rank = ScoreRank.A,
-                Date = DateTime.Now,
+                Date = DateTimeOffset.Now,
                 Statistics = new Dictionary<string, dynamic>()
                 {
                     { "300", 50 },

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using OpenTK;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -13,7 +14,8 @@ using osu.Framework.Input;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class OsuSliderBar<T> : SliderBar<T>, IHasTooltip where T : struct
+    public class OsuSliderBar<T> : SliderBar<T>, IHasTooltip
+        where T : struct, IEquatable<T>
     {
         private SampleChannel sample;
         private double lastSampleTime;

--- a/osu.Game/Graphics/UserInterface/RollingCounter.cs
+++ b/osu.Game/Graphics/UserInterface/RollingCounter.cs
@@ -181,7 +181,7 @@ namespace osu.Game.Graphics.UserInterface
         protected virtual void TransformCount(T currentValue, T newValue)
         {
             Debug.Assert(
-                TransformType.IsSubclassOf(typeof(Transform<T>)) || TransformType == typeof(Transform<T>),
+                typeof(Transform<T>).IsAssignableFrom(TransformType),
                 @"transformType should be a subclass of Transform<T>."
             );
 

--- a/osu.Game/IO/Legacy/SerializationReader.cs
+++ b/osu.Game/IO/Legacy/SerializationReader.cs
@@ -66,7 +66,7 @@ namespace osu.Game.IO.Legacy
         public DateTime ReadDateTime()
         {
             long ticks = ReadInt64();
-            if (ticks < 0) throw new AbandonedMutexException("oops");
+            if (ticks < 0) throw new IOException("Bad ticks count read!");
             return new DateTime(ticks, DateTimeKind.Utc);
         }
 

--- a/osu.Game/IO/Legacy/SerializationReader.cs
+++ b/osu.Game/IO/Legacy/SerializationReader.cs
@@ -10,7 +10,6 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
-using System.Threading;
 
 namespace osu.Game.IO.Legacy
 {

--- a/osu.Game/Online/Chat/Channel.cs
+++ b/osu.Game/Online/Chat/Channel.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Online.Chat
         [JsonProperty(@"channel_id")]
         public int Id;
 
-        public readonly SortedList<Message> Messages = new SortedList<Message>((m1, m2) => m1.Id.CompareTo(m2.Id));
+        public readonly SortedList<Message> Messages = new SortedList<Message>(Comparer<Message>.Default);
 
         //internal bool Joined;
 

--- a/osu.Game/Online/Chat/ErrorMessage.cs
+++ b/osu.Game/Online/Chat/ErrorMessage.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Online.Chat
 
         public ErrorMessage(string message) : base(errorId--)
         {
-            Timestamp = DateTime.Now;
+            Timestamp = DateTimeOffset.Now;
             Content = message;
 
             Sender = new User

--- a/osu.Game/Online/Chat/Message.cs
+++ b/osu.Game/Online/Chat/Message.cs
@@ -8,7 +8,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Online.Chat
 {
-    public class Message
+    public class Message : IComparable<Message>
     {
         [JsonProperty(@"message_id")]
         public readonly long Id;
@@ -42,17 +42,7 @@ namespace osu.Game.Online.Chat
             Id = id;
         }
 
-        public override bool Equals(object obj)
-        {
-            var objMessage = obj as Message;
-
-            return Id == objMessage?.Id;
-        }
-
-        public override int GetHashCode()
-        {
-            return Id.GetHashCode();
-        }
+        public int CompareTo(Message other) => Id.CompareTo(other.Id);
     }
 
     public enum TargetType

--- a/osu.Game/Overlays/NotificationManager.cs
+++ b/osu.Game/Overlays/NotificationManager.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Overlays
                 hasCompletionTarget.CompletionTarget = Post;
 
             var ourType = notification.GetType();
-            sections.Children.FirstOrDefault(s => s.AcceptTypes.Any(accept => ourType == accept || ourType.IsSubclassOf(accept)))?.Add(notification);
+            sections.Children.FirstOrDefault(s => s.AcceptTypes.Any(accept => accept.IsAssignableFrom(ourType)))?.Add(notification);
         }
 
         protected override void PopIn()

--- a/osu.Game/Overlays/Settings/SettingsSlider.cs
+++ b/osu.Game/Overlays/Settings/SettingsSlider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
@@ -8,12 +9,12 @@ using osu.Game.Graphics.UserInterface;
 namespace osu.Game.Overlays.Settings
 {
     public class SettingsSlider<T> : SettingsSlider<T, OsuSliderBar<T>>
-        where T : struct
+        where T : struct, IEquatable<T>
     {
     }
 
     public class SettingsSlider<T, U> : SettingsItem<T>
-        where T : struct
+        where T : struct, IEquatable<T>
         where U : SliderBar<T>, new()
     {
         protected override Drawable CreateControl() => new U()

--- a/osu.Game/Rulesets/Scoring/Score.cs
+++ b/osu.Game/Rulesets/Scoring/Score.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Scoring
         public long OnlineScoreID;
 
         [JsonProperty(@"created_at")]
-        public DateTime Date;
+        public DateTimeOffset Date;
 
         [JsonProperty(@"statistics")]
         private Dictionary<string, dynamic> jsonStats

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Scoring
             score.MaxCombo = HighestCombo;
             score.Accuracy = Accuracy;
             score.Rank = rankFrom(Accuracy);
-            score.Date = DateTime.Now;
+            score.Date = DateTimeOffset.Now;
             score.Health = Health;
         }
     }

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.Ranking
                             Origin = Anchor.TopCentre,
                             Margin = new MarginPadding { Bottom = 10 },
                         },
-                        new DateDisplay(Score.Date.LocalDateTime)
+                        new DateTimeDisplay(Score.Date.LocalDateTime)
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
@@ -220,13 +220,13 @@ namespace osu.Game.Screens.Ranking
             }
         }
 
-        private class DateDisplay : Container
+        private class DateTimeDisplay : Container
         {
-            private DateTime date;
+            private DateTime datetime;
 
-            public DateDisplay(DateTime date)
+            public DateTimeDisplay(DateTime datetime)
             {
-                this.date = date;
+                this.datetime = datetime;
 
                 AutoSizeAxes = Axes.Y;
 
@@ -250,7 +250,7 @@ namespace osu.Game.Screens.Ranking
                     {
                         Origin = Anchor.CentreLeft,
                         Anchor = Anchor.CentreLeft,
-                        Text = date.ToString("HH:mm"),
+                        Text = datetime.ToString("HH:mm"),
                         Padding = new MarginPadding { Left = 10, Right = 10, Top = 5, Bottom = 5 },
                         Colour = Color4.White,
                     },
@@ -258,7 +258,7 @@ namespace osu.Game.Screens.Ranking
                     {
                         Origin = Anchor.CentreRight,
                         Anchor = Anchor.CentreRight,
-                        Text = date.ToString("yyyy/MM/dd"),
+                        Text = datetime.ToString("yyyy/MM/dd"),
                         Padding = new MarginPadding { Left = 10, Right = 10, Top = 5, Bottom = 5 },
                         Colour = Color4.White,
                     }

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.Ranking
                             Origin = Anchor.TopCentre,
                             Margin = new MarginPadding { Bottom = 10 },
                         },
-                        new DateDisplay(Score.Date)
+                        new DateDisplay(Score.Date.LocalDateTime)
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,


### PR DESCRIPTION
Use more `DateTimeOffset` please 😃 .
Local `DateTime` should only be created for display, because time zone can be changed during game running. UTC `DateTime` is sure, but remember to create it with specified UTC kind.
JSON.Net handles `DateTimeOffset` well, so use it for online components.

(In my own project, I ban the `DateTime` type almost totally, and only use it for a bridge between `DateTimeOffset` and string)