### PR TITLE
Revert "Use generic IComparable for message."

### DIFF
--- a/osu.Game/Online/Chat/Channel.cs
+++ b/osu.Game/Online/Chat/Channel.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Online.Chat
         [JsonProperty(@"channel_id")]
         public int Id;
 
-        public readonly SortedList<Message> Messages = new SortedList<Message>(Comparer<Message>.Default);
+        public readonly SortedList<Message> Messages = new SortedList<Message>((m1, m2) => m1.Id.CompareTo(m2.Id));
 
         //internal bool Joined;
 

--- a/osu.Game/Online/Chat/Message.cs
+++ b/osu.Game/Online/Chat/Message.cs
@@ -8,7 +8,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Online.Chat
 {
-    public class Message : IComparable<Message>
+    public class Message
     {
         [JsonProperty(@"message_id")]
         public readonly long Id;
@@ -42,7 +42,17 @@ namespace osu.Game.Online.Chat
             Id = id;
         }
 
-        public int CompareTo(Message other) => Id.CompareTo(other.Id);
+        public override bool Equals(object obj)
+        {
+            var objMessage = obj as Message;
+
+            return Id == objMessage?.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
     }
 
     public enum TargetType


### PR DESCRIPTION
Fixes duplicate messages due to equality de-duping failing (Channel.cs line 43).