### PR TITLE
Fix ratio container being added to a level too high

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -146,7 +146,7 @@ namespace osu.Game
         {
             base.LoadComplete();
 
-            AddInternal(ratioContainer = new RatioAdjust
+            base.Content.Add(ratioContainer = new RatioAdjust
             {
                 Children = new Drawable[]
                 {


### PR DESCRIPTION
That's a bad ratio container! How did we not notice this until now?