### PR TITLE
Move spinner colours to local definition for now

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private readonly TextAwesome symbol;
 
+        private readonly Color4 baseColour = OsuColour.FromHex(@"002c3c");
+        private readonly Color4 fillColour = OsuColour.FromHex(@"005b7c");
+
         private Color4 normalColour;
         private Color4 completeColour;
 
@@ -154,13 +157,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            normalColour = colours.SpinnerBase;
+            normalColour = baseColour;
 
             background.AccentColour = normalColour;
 
             completeColour = colours.YellowLight.Opacity(0.75f);
 
-            disc.AccentColour = colours.SpinnerFill;
+            disc.AccentColour = fillColour;
             circle.Colour = colours.BlueDark;
             glow.Colour = colours.BlueDark;
         }

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -87,8 +87,5 @@ namespace osu.Game.Graphics
         public readonly Color4 RedDarker = FromHex(@"870000");
 
         public readonly Color4 ChatBlue = FromHex(@"17292e");
-
-        public readonly Color4 SpinnerBase = FromHex(@"002c3c");
-        public readonly Color4 SpinnerFill = FromHex(@"005b7c");
     }
 }


### PR DESCRIPTION
We don't want to start polluting the OsuColours namespace with non-UI colours.