### PR TITLE
Fix negative beatIndex NewBeat events not being correctly fired

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         /// <param name="time">The time to find the timing control point at.</param>
         /// <returns>The timing control point.</returns>
-        public TimingControlPoint TimingPointAt(double time) => binarySearch(TimingPoints, time, () => TimingPoints[0]);
+        public TimingControlPoint TimingPointAt(double time) => binarySearch(TimingPoints, time, TimingPoints.FirstOrDefault());
 
         /// <summary>
         /// Finds the maximum BPM represented by any timing control point.
@@ -81,16 +81,16 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         /// <param name="list">The list to search.</param>
         /// <param name="time">The time to find the control point at.</param>
-        /// <param name="prePoint">The control point to use when <paramref name="time"/> is before any control points.</param>
+        /// <param name="prePoint">The control point to use when <paramref name="time"/> is before any control points. If null, a new control point will be constructed.</param>
         /// <returns>The active control point at <paramref name="time"/>.</returns>
-        private T binarySearch<T>(SortedList<T> list, double time, Func<T> prePoint = null)
+        private T binarySearch<T>(SortedList<T> list, double time, T prePoint = null)
             where T : ControlPoint, new()
         {
             if (list.Count == 0)
                 return new T();
 
             if (time < list[0].Time)
-                return prePoint?.Invoke() ?? new T();
+                return prePoint ?? new T();
 
             int index = list.BinarySearch(new T() { Time = time });
 

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Lists;

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Beatmaps.ControlPoints
                 return new T();
 
             if (time < list[0].Time)
-                return new T();
+                return list[0];
 
             int index = list.BinarySearch(new T() { Time = time });
 

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -77,12 +77,12 @@ namespace osu.Game.Beatmaps.ControlPoints
             60000 / (TimingPoints.GroupBy(c => c.BeatLength).OrderByDescending(grp => grp.Count()).FirstOrDefault()?.FirstOrDefault() ?? new TimingControlPoint()).BeatLength;
 
         /// <summary>
-        /// Binary searches one of the control point lists to find the active contro point at <paramref name="time"/>.
+        /// Binary searches one of the control point lists to find the active control point at <paramref name="time"/>.
         /// </summary>
         /// <param name="list">The list to search.</param>
         /// <param name="time">The time to find the control point at.</param>
         /// <param name="prePoint">The control point to use when <paramref name="time"/> is before any control points.</param>
-        /// <returns></returns>
+        /// <returns>The active control point at <paramref name="time"/>.</returns>
         private T binarySearch<T>(SortedList<T> list, double time, Func<T> prePoint = null)
             where T : ControlPoint, new()
         {

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -100,6 +100,8 @@ namespace osu.Game.Beatmaps.ControlPoints
 
             index = ~index;
 
+            // BinarySearch will return the index of the first element _greater_ than the search
+            // This is the inactive point - the active point is the one before it (index - 1)
             return list[index - 1];
         }
     }

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -92,8 +92,6 @@ namespace osu.Game.Beatmaps.ControlPoints
 
             index = ~index;
 
-            if (index == list.Count)
-                return list[list.Count - 1];
             return list[index - 1];
         }
     }


### PR DESCRIPTION
At least, fixes OnNewBeat being called with the "same" timing point - because this was constructing a new timing point every time.

I didn't implement .Equals + .GetHashCode on the control points due to their mutability.