### PR TITLE
Always ApplyDefaults after parsing beatmaps to make sure hit objects …

### DIFF
--- a/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
@@ -428,6 +428,9 @@ namespace osu.Game.Beatmaps.Formats
                         break;
                 }
             }
+
+            foreach (var hitObject in beatmap.HitObjects)
+                hitObject.ApplyDefaults(beatmap.ControlPointInfo, beatmap.BeatmapInfo.Difficulty);
         }
 
         internal enum LegacySampleBank

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
         public double EndTime => StartTime + RepeatCount * Distance / Velocity;
         public double Duration => EndTime - StartTime;
 
-        public double Velocity;
+        public double Velocity = 1;
 
         public Vector2 PositionAt(double progress)
         {

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -18,21 +18,15 @@ namespace osu.Game.Rulesets.Objects.Legacy
         /// </summary>
         private const float base_scoring_distance = 100;
 
-        public readonly SliderCurve Curve = new SliderCurve();
-
         public List<Vector2> ControlPoints { get; set; }
         public CurveType CurveType { get; set; }
 
-        public double Distance
-        {
-            get { return Curve.Distance; }
-            set { Curve.Distance = value; }
-        }
+        public double Distance { get; set; }
 
         public List<SampleInfoList> RepeatSamples { get; set; }
         public int RepeatCount { get; set; } = 1;
 
-        public double EndTime => StartTime + RepeatCount * Curve.Distance / Velocity;
+        public double EndTime => StartTime + RepeatCount * Distance / Velocity;
         public double Duration => EndTime - StartTime;
 
         public double Velocity;


### PR DESCRIPTION
Superseeds https://github.com/ppy/osu/pull/872.

ConvertSlider durations were not calculated, and duration was only calculated when they were converted to osu! ruleset sliders. This caused the issue where if the map ends in a slider the end time will be 0, thus the beatmap duration was calculated incorrectly.

Issue was visible on https://osu.ppy.sh/s/138235