### PR TITLE
Increase timeout in TestImportOverIPC

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 Assert.IsTrue(File.Exists(temp));
 
                 var importer = new BeatmapIPCChannel(client);
-                if (!importer.ImportAsync(temp).Wait(5000))
+                if (!importer.ImportAsync(temp).Wait(10000))
                     Assert.Fail(@"IPC took too long to send");
 
                 ensureLoaded(host);


### PR DESCRIPTION
Has been failing CI randomly, so let's increase the timeout a bit.