### PR TITLE
Key shortcut for enabling/disabling mouse buttons (F10)

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -35,6 +35,8 @@ namespace osu.Game
 
         private ChatOverlay chat;
 
+        private OnScreenDisplay onScreenDisplay;
+
         private MusicController musicController;
 
         private NotificationManager notificationManager;
@@ -225,6 +227,7 @@ namespace osu.Game
             Cursor.State = Visibility.Hidden;
         }
 
+
         private bool globalHotkeyPressed(InputState state, KeyDownEventArgs args)
         {
             if (args.Repeat || intro == null) return false;
@@ -233,6 +236,9 @@ namespace osu.Game
             {
                 case Key.F8:
                     chat.ToggleVisibility();
+                    return true;
+                case Key.F10:
+                    LocalConfig.Set(OsuSetting.MouseDisableButtons, !LocalConfig.Get<bool>(OsuSetting.MouseDisableButtons));
                     return true;
                 case Key.PageUp:
                 case Key.PageDown:

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -35,8 +35,6 @@ namespace osu.Game
 
         private ChatOverlay chat;
 
-        private OnScreenDisplay onScreenDisplay;
-
         private MusicController musicController;
 
         private NotificationManager notificationManager;
@@ -226,7 +224,6 @@ namespace osu.Game
 
             Cursor.State = Visibility.Hidden;
         }
-
 
         private bool globalHotkeyPressed(InputState state, KeyDownEventArgs args)
         {

--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -120,16 +120,7 @@ namespace osu.Game.Overlays
             trackSetting(frameworkConfig.GetBindable<FrameSync>(FrameworkSetting.FrameSync), v => display(v, "Frame Limiter", v.GetDescription(), "Ctrl+F7"));
             trackSetting(frameworkConfig.GetBindable<string>(FrameworkSetting.AudioDevice), v => display(v, "Audio Device", string.IsNullOrEmpty(v) ? "Default" : v, v));
             trackSetting(frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay), v => display(v, "Debug Logs", v ? "visible" : "hidden", "Ctrl+F10"));
-            trackSetting(osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons), v => 
-            {
-                string currentMouseState = "";
-                if (osuConfig.Get<bool>(OsuSetting.MouseDisableButtons))
-                    currentMouseState = "Disabled";
-                else
-                    currentMouseState = "Enabled";
-                display(0, "Mouse Buttons", currentMouseState, "F10");
-            });
-
+            trackSetting(osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons), v => display(0, "Mouse Buttons", osuConfig.Get<bool>(OsuSetting.MouseDisableButtons) ? "Disabled" : "Enabled", "F10"));
 
             Action displayResolution = delegate { display(null, "Screen Resolution", frameworkConfig.Get<int>(FrameworkSetting.Width) + "x" + frameworkConfig.Get<int>(FrameworkSetting.Height)); };
 

--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Overlays
             trackSetting(frameworkConfig.GetBindable<FrameSync>(FrameworkSetting.FrameSync), v => display(v, "Frame Limiter", v.GetDescription(), "Ctrl+F7"));
             trackSetting(frameworkConfig.GetBindable<string>(FrameworkSetting.AudioDevice), v => display(v, "Audio Device", string.IsNullOrEmpty(v) ? "Default" : v, v));
             trackSetting(frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay), v => display(v, "Debug Logs", v ? "visible" : "hidden", "Ctrl+F10"));
-            trackSetting(osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons), v => display(0, "Mouse Buttons", osuConfig.Get<bool>(OsuSetting.MouseDisableButtons) ? "Disabled" : "Enabled", "F10"));
+            trackSetting(osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons), v => display(!v, "Mouse Buttons", v ? "Disabled" : "Enabled", "F10"));
 
             Action displayResolution = delegate { display(null, "Screen Resolution", frameworkConfig.Get<int>(FrameworkSetting.Width) + "x" + frameworkConfig.Get<int>(FrameworkSetting.Height)); };
 

--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Game.Configuration;
 
 namespace osu.Game.Overlays
 {
@@ -114,11 +115,21 @@ namespace osu.Game.Overlays
         }
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager frameworkConfig)
+        private void load(FrameworkConfigManager frameworkConfig, OsuConfigManager osuConfig)
         {
             trackSetting(frameworkConfig.GetBindable<FrameSync>(FrameworkSetting.FrameSync), v => display(v, "Frame Limiter", v.GetDescription(), "Ctrl+F7"));
             trackSetting(frameworkConfig.GetBindable<string>(FrameworkSetting.AudioDevice), v => display(v, "Audio Device", string.IsNullOrEmpty(v) ? "Default" : v, v));
             trackSetting(frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay), v => display(v, "Debug Logs", v ? "visible" : "hidden", "Ctrl+F10"));
+            trackSetting(osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons), v => 
+            {
+                string currentMouseState = "";
+                if (osuConfig.Get<bool>(OsuSetting.MouseDisableButtons))
+                    currentMouseState = "Disabled";
+                else
+                    currentMouseState = "Enabled";
+                display(0, "Mouse Buttons", currentMouseState, "F10");
+            });
+
 
             Action displayResolution = delegate { display(null, "Screen Resolution", frameworkConfig.Get<int>(FrameworkSetting.Width) + "x" + frameworkConfig.Get<int>(FrameworkSetting.Height)); };
 


### PR DESCRIPTION
Adds a F10 shortcut to toggle mouse buttons, I tried to make it act and look like it does on the live version. Also displays a message showing the current state of the mouse buttons (whether they're enabled or not).