### PR TITLE
Treat inspectcode warnings as errors (CI)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,4 +20,4 @@ build:
   verbosity: minimal
 after_build:
   - cmd: inspectcode /o="inspectcodereport.xml" /caches-home="inspectcode" osu.sln
-  - cmd: NVika parsereport "inspectcodereport.xml"
+  - cmd: NVika parsereport "inspectcodereport.xml" --treatwarningsaserrors


### PR DESCRIPTION
There are many instances we accidentally merge pull requests with outstanding warnings, as the fact warnings exists is not made obvious. This forces all `inspectcode` warnings to an error level.