### PR TITLE
Always update the music controller

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Overlays
         {
             this.localisation = localisation;
 
+            AlwaysPresent = true;
+
             Children = new Drawable[]
             {
                 dragContainer = new Container


### PR DESCRIPTION
If the music controller was never visible, the current track is not updated to skip to the next one when completed. Also fixes delayed transformation movements.

- [ ] Depends on https://github.com/ppy/osu/pull/955