### PR TITLE
Remove assert which is not always true on some operating systems

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,15 +9,9 @@
     "showOutput": "silent",
     "args": [
         "/property:GenerateFullPaths=true",
-        "/property:DebugType=portable"
+        "/property:DebugType=portable",
+        "/m" //parallel compiling support.
     ],
-    "windows": {
-        "args": [
-            "/property:GenerateFullPaths=true",
-            "/property:DebugType=portable",
-            "/m" //parallel compiling support. doesn't work well with mono atm
-        ]
-    },
     "tasks": [
         {
             "taskName": "Build (Debug)",

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                 File.Delete(temp);
 
-                Assert.IsFalse(File.Exists(temp), "We likely help a read lock not he file when we shouldn't");
+                Assert.IsFalse(File.Exists(temp), "We likely held a read lock on the file when we shouldn't");
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -75,18 +75,16 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                 var temp = prepareTempCopy(osz_path);
 
-                Assert.IsTrue(File.Exists(temp));
+                Assert.IsTrue(File.Exists(temp), "Temporary file copy never substantiated");
 
                 using (File.OpenRead(temp))
                     host.Dependencies.Get<BeatmapDatabase>().Import(temp);
 
                 ensureLoaded(host);
 
-                Assert.IsTrue(File.Exists(temp));
-
                 File.Delete(temp);
 
-                Assert.IsFalse(File.Exists(temp));
+                Assert.IsFalse(File.Exists(temp), "We likely help a read lock not he file when we shouldn't");
             }
         }
 


### PR DESCRIPTION
On unix-based systems a file can be removed from disk while handles are still open. So let's not assert otherwise.