### PR TITLE
Fix OsuTooltipContainer.PopIn not overriding PopOut transforms

### DIFF
--- a/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
+++ b/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
@@ -83,6 +83,8 @@ namespace osu.Game.Graphics.Cursor
             protected override void PopIn()
             {
                 instantMovement |= !IsPresent;
+
+                ClearTransforms();
                 FadeIn(500, EasingTypes.OutQuint);
             }
 


### PR DESCRIPTION
I have some ideas of how this could be fixed on some more fundamental level (mostly by incorporating delay into transforms themselves), but until then let's roll with this solution.