### PR TITLE
Fix main menu flashy sides moving too much

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Menu
         private readonly BackgroundScreenDefault background;
         private Screen songSelect;
 
-        private MenuSideFlashes sideFlashes;
+        private readonly MenuSideFlashes sideFlashes;
 
         protected override BackgroundScreen CreateBackground() => background;
 

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Screens.Menu
         private readonly BackgroundScreenDefault background;
         private Screen songSelect;
 
+        private MenuSideFlashes sideFlashes;
+
         protected override BackgroundScreen CreateBackground() => background;
 
         public MainMenu()
@@ -52,7 +54,7 @@ namespace osu.Game.Screens.Menu
                         }
                     }
                 },
-                new MenuSideFlashes(),
+                sideFlashes = new MenuSideFlashes(),
             };
         }
 
@@ -112,6 +114,8 @@ namespace osu.Game.Screens.Menu
 
             Content.FadeOut(length, EasingTypes.InSine);
             Content.MoveTo(new Vector2(-800, 0), length, EasingTypes.InSine);
+
+            sideFlashes.FadeOut(length / 4, EasingTypes.OutQuint);
         }
 
         protected override void OnResuming(Screen last)
@@ -129,6 +133,8 @@ namespace osu.Game.Screens.Menu
 
             Content.FadeIn(length, EasingTypes.OutQuint);
             Content.MoveTo(new Vector2(0, 0), length, EasingTypes.OutQuint);
+
+            sideFlashes.FadeIn(length / 4, EasingTypes.InQuint);
         }
 
         protected override bool OnExiting(Screen next)

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -49,10 +49,10 @@ namespace osu.Game.Screens.Menu
                             OnSolo = delegate { Push(consumeSongSelect()); },
                             OnMulti = delegate { Push(new Lobby()); },
                             OnExit = delegate { Exit(); },
-                        },
-                        new MenuSideFlashes(),
+                        }
                     }
-                }
+                },
+                new MenuSideFlashes(),
             };
         }
 


### PR DESCRIPTION
They were being affected by moving transitions and also parallax. They shouldn't be affected by either.