### PR TITLE
Remove FullyLoaded logic

### DIFF
--- a/osu.Desktop.VisualTests/Beatmaps/TestWorkingBeatmap.cs
+++ b/osu.Desktop.VisualTests/Beatmaps/TestWorkingBeatmap.cs
@@ -10,7 +10,7 @@ namespace osu.Desktop.VisualTests.Beatmaps
     public class TestWorkingBeatmap : WorkingBeatmap
     {
         public TestWorkingBeatmap(Beatmap beatmap)
-            : base(beatmap.BeatmapInfo, true)
+            : base(beatmap.BeatmapInfo)
         {
             this.beatmap = beatmap;
         }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -22,17 +22,11 @@ namespace osu.Game.Beatmaps
 
         public readonly Bindable<IEnumerable<Mod>> Mods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
 
-        /// <summary>
-        /// Denotes whether extras like storyboards have been loaded for this <see cref="WorkingBeatmap"/>.
-        /// </summary>
-        public bool FullyLoaded { get; protected set; }
-
-        protected WorkingBeatmap(BeatmapInfo beatmapInfo, bool fullyLoaded = false)
+        protected WorkingBeatmap(BeatmapInfo beatmapInfo)
         {
             BeatmapInfo = beatmapInfo;
             BeatmapSetInfo = beatmapInfo.BeatmapSet;
             Metadata = beatmapInfo.Metadata ?? BeatmapSetInfo.Metadata;
-            FullyLoaded = fullyLoaded;
 
             Mods.ValueChanged += mods => applyRateAdjustments();
         }

--- a/osu.Game/Database/BeatmapDatabase.cs
+++ b/osu.Game/Database/BeatmapDatabase.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Database
             if (beatmapInfo.Metadata == null)
                 beatmapInfo.Metadata = beatmapInfo.BeatmapSet.Metadata;
 
-            WorkingBeatmap working = new DatabaseWorkingBeatmap(this, beatmapInfo, withStoryboard);
+            WorkingBeatmap working = new DatabaseWorkingBeatmap(this, beatmapInfo);
 
             previous?.TransferTo(working);
 

--- a/osu.Game/Database/DatabaseWorkingBeatmap.cs
+++ b/osu.Game/Database/DatabaseWorkingBeatmap.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Database
     {
         private readonly BeatmapDatabase database;
 
-        public DatabaseWorkingBeatmap(BeatmapDatabase database, BeatmapInfo beatmapInfo, bool fullyLoaded = false)
-            : base(beatmapInfo, fullyLoaded)
+        public DatabaseWorkingBeatmap(BeatmapDatabase database, BeatmapInfo beatmapInfo)
+            : base(beatmapInfo)
         {
             this.database = database;
         }
@@ -37,7 +37,7 @@ namespace osu.Game.Database
                         beatmap = decoder.Decode(stream);
                     }
 
-                    if (beatmap == null || !FullyLoaded || BeatmapSetInfo.StoryboardFile == null)
+                    if (beatmap == null || BeatmapSetInfo.StoryboardFile == null)
                         return beatmap;
 
                     using (var stream = new StreamReader(reader.GetStream(BeatmapSetInfo.StoryboardFile)))

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Play
         private bool loadedSuccessfully => HitRenderer?.Objects.Any() == true;
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(AudioManager audio, BeatmapDatabase beatmaps, OsuConfigManager config, OsuGame osu)
+        private void load(AudioManager audio, OsuConfigManager config, OsuGame osu)
         {
             dimLevel = config.GetBindable<double>(OsuSetting.DimLevel);
             mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
@@ -81,10 +81,6 @@ namespace osu.Game.Screens.Play
 
             try
             {
-                if (!Beatmap.Value.FullyLoaded)
-                    // we need to ensure extras like storyboards are loaded.
-                    Beatmap.Value = beatmaps.GetWorkingBeatmap(Beatmap.Value.BeatmapInfo, withStoryboard: true);
-
                 if (Beatmap.Value.Beatmap == null)
                     throw new InvalidOperationException("Beatmap was not loaded");
 


### PR DESCRIPTION
Always parse storyboards for now.

Let's not optimise this until it is necessary. It was leading to weird threading problems due to the load call in Player's async load method.