### PR TITLE
Fix hitting down and enter at song select causing a hard-crash

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Screens.Select
     {
         public BeatmapInfo SelectedBeatmap => selectedPanel?.Beatmap;
 
+        public override bool HandleInput => AllowSelection;
+
         public Action BeatmapsChanged;
 
         public IEnumerable<BeatmapSetInfo> Beatmaps
@@ -227,6 +229,8 @@ namespace osu.Game.Screens.Select
         private FilterCriteria criteria = new FilterCriteria();
 
         private ScheduledDelegate filterTask;
+
+        public bool AllowSelection = true;
 
         public void Filter(FilterCriteria newCriteria = null, bool debounce = true)
         {

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -105,6 +105,7 @@ namespace osu.Game.Screens.Select
             if (player != null) return;
 
             Beatmap.Value.Track.Looping = false;
+            Beatmap.Disabled = true;
 
             LoadComponentAsync(player = new PlayerLoader(new Player()), l => Push(player));
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.Select
                 Origin = Anchor.CentreRight,
                 SelectionChanged = carouselSelectionChanged,
                 BeatmapsChanged = carouselBeatmapsLoaded,
-                StartRequested = carouselRaisedStart
+                StartRequested = carouselRaisedStart,
             });
             Add(FilterControl = new FilterControl
             {
@@ -185,6 +185,9 @@ namespace osu.Game.Screens.Select
             carousel.Beatmaps = database.GetAllWithChildren<BeatmapSetInfo>(b => !b.DeletePending);
 
             Beatmap.ValueChanged += beatmap_ValueChanged;
+
+            Beatmap.DisabledChanged += disabled => carousel.AllowSelection = !disabled;
+            carousel.AllowSelection = !Beatmap.Disabled;
         }
 
         private void carouselBeatmapsLoaded()


### PR DESCRIPTION
Carousel was not aware of the disabled beatmap change state. Also it was being set too late (in an async load) so wasn't useful. It's now pre-emptively set in PlaySongSelect before loading Player.