### PR TITLE
Fix selection not being reset correct when changing between rulesets

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Select
 
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
-            if (groups.Count == 0)
+            if (groups.Count == 0 || groups.All(g => g.State == BeatmapGroupState.Hidden))
             {
                 selectedGroup = null;
                 selectedPanel = null;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Select
 
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
-            if (groups.Count == 0 || groups.All(g => g.State == BeatmapGroupState.Hidden))
+            if (groups.All(g => g.State == BeatmapGroupState.Hidden))
             {
                 selectedGroup = null;
                 selectedPanel = null;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -229,6 +229,13 @@ namespace osu.Game.Screens.Select
                 changeBackground(Beatmap.Value);
             };
 
+            selectionChangedDebounce?.Cancel();
+
+            if (beatmap?.Equals(beatmapNoDebounce) == true)
+                return;
+
+            beatmapNoDebounce = beatmap;
+
             if (beatmap == null)
             {
                 if (!Beatmap.IsDefault)
@@ -236,17 +243,10 @@ namespace osu.Game.Screens.Select
             }
             else
             {
-                selectionChangedDebounce?.Cancel();
-
-                if (beatmap.Equals(beatmapNoDebounce))
-                    return;
-
                 if (beatmap.BeatmapSetInfoID == beatmapNoDebounce?.BeatmapSetInfoID)
                     sampleChangeDifficulty.Play();
                 else
                     sampleChangeBeatmap.Play();
-
-                beatmapNoDebounce = beatmap;
 
                 if (beatmap == Beatmap.Value.BeatmapInfo)
                     performLoad();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -243,6 +243,8 @@ namespace osu.Game.Screens.Select
             }
             else
             {
+                ruleset.Value = beatmap.Ruleset;
+
                 if (beatmap.BeatmapSetInfoID == beatmapNoDebounce?.BeatmapSetInfoID)
                     sampleChangeDifficulty.Play();
                 else


### PR DESCRIPTION
Carousels filtered to results with no maps visible were not being handled correctly in a few different ways. This covers all those scenarios.