### PR TITLE
Fix some backgrounds filenames not being parsed correctly

### DIFF
--- a/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps.Timing;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Beatmaps.ControlPoints;
+using System.Linq;
 
 namespace osu.Game.Beatmaps.Formats
 {
@@ -220,14 +221,20 @@ namespace osu.Game.Beatmaps.Formats
         /// <param name="line">The line which may contains variables.</param>
         private void decodeVariables(ref string line)
         {
-            while (line.IndexOf('$') >= 0)
+            bool needsRecheck = true;
+            while (line.IndexOf('$') >= 0 && needsRecheck)
             {
+                needsRecheck = false;
                 string[] split = line.Split(',');
+                handleFilenames(ref split);
                 for (int i = 0; i < split.Length; i++)
                 {
                     var item = split[i];
                     if (item.StartsWith("$") && variables.ContainsKey(item))
+                    {
+                        needsRecheck = true;
                         split[i] = variables[item];
+                    }
                 }
 
                 line = string.Join(",", split);
@@ -239,6 +246,8 @@ namespace osu.Game.Beatmaps.Formats
             decodeVariables(ref line);
 
             string[] split = line.Split(',');
+
+            handleFilenames(ref split);
 
             EventType type;
             if (!Enum.TryParse(split[0], out type))
@@ -267,6 +276,24 @@ namespace osu.Game.Beatmaps.Formats
 
                     beatmap.Breaks.Add(breakEvent);
                     break;
+            }
+        }
+
+        private void handleFilenames(ref string[] split)
+        {
+            for (int i = 0; i < split.Length; i++)
+            {
+                if (split[i].IndexOf('"') >= 0 && split[i].LastIndexOf('"') == split[i].IndexOf('"'))
+                {
+                    List<string> splitRemake = new List<string>(split);
+                    int lastIndex = splitRemake.IndexOf(split.Last(s => s.IndexOf('"') >= 0));
+                    while (lastIndex-- > i)
+                    {
+                        splitRemake[i] = string.Join(",", splitRemake[i], splitRemake[i + 1]);
+                        splitRemake.Remove(splitRemake[i + 1]);
+                    }
+                    split = splitRemake.ToArray();
+                }
             }
         }
 


### PR DESCRIPTION
This fixes these two scenarios (and combinations of them):
- Background files which had a `$` on their filename would freeze the game.
- Background files which had a `,` on their filename won't load. (even osu!stable has problems loading these!).

Here's an example beatmapset with a combination of the mentioned fixes: 
[Deorro - Yee.zip](https://github.com/ppy/osu/files/1161478/Deorro.-.Yee.zip)


