### PR TITLE
Fix carousel filter debounce causing a race condition

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -232,7 +232,11 @@ namespace osu.Game.Screens.Select
 
         public bool AllowSelection = true;
 
-        public bool PendingFilter => filterTask?.Completed == false;
+        public void FlushPendingFilters()
+        {
+            if (filterTask?.Completed == false)
+                Filter(null, false);
+        }
 
         public void Filter(FilterCriteria newCriteria = null, bool debounce = true)
         {

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -232,6 +232,8 @@ namespace osu.Game.Screens.Select
 
         public bool AllowSelection = true;
 
+        public bool PendingFilter => filterTask?.Completed == false;
+
         public void Filter(FilterCriteria newCriteria = null, bool debounce = true)
         {
             if (newCriteria != null)
@@ -263,6 +265,8 @@ namespace osu.Game.Screens.Select
             };
 
             filterTask?.Cancel();
+            filterTask = null;
+
             if (debounce)
                 filterTask = Scheduler.AddDelayed(perform, 250);
             else

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -198,10 +198,9 @@ namespace osu.Game.Screens.Select
 
         private void carouselRaisedStart()
         {
-            if (carousel.PendingFilter)
-                // if we have a pending filter operation, we want to run it now.
-                // it could change selection (ie. if the ruleset has been changed).
-                carousel.Filter(null, false);
+            // if we have a pending filter operation, we want to run it now.
+            // it could change selection (ie. if the ruleset has been changed).
+            carousel.FlushPendingFilters();
 
             if (selectionChangedDebounce?.Completed == false)
             {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -198,13 +198,16 @@ namespace osu.Game.Screens.Select
 
         private void carouselRaisedStart()
         {
-            var pendingSelection = selectionChangedDebounce;
-            selectionChangedDebounce = null;
+            if (carousel.PendingFilter)
+                // if we have a pending filter operation, we want to run it now.
+                // it could change selection (ie. if the ruleset has been changed).
+                carousel.Filter(null, false);
 
-            if (pendingSelection?.Completed == false)
+            if (selectionChangedDebounce?.Completed == false)
             {
-                pendingSelection.RunTask();
-                pendingSelection.Cancel(); // cancel the already scheduled task.
+                selectionChangedDebounce.RunTask();
+                selectionChangedDebounce.Cancel(); // cancel the already scheduled task.
+                selectionChangedDebounce = null;
             }
 
             OnSelected();


### PR DESCRIPTION
Clicking a ruleset button on toolbar would schedule a delayed filter of carousel, which could in turn trigger a beatmap change after pushing a Player. This resolves that by forcing any pending operations to complete.