### PR TITLE
Fixed various exceptions when no beatmaps are imported

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -177,6 +177,9 @@ namespace osu.Game.Screens.Select
 
         public void SelectNextRandom()
         {
+            if (groups.Count == 0)
+                return;
+
             randomSelectedBeatmaps.Push(new KeyValuePair<BeatmapGroup, BeatmapPanel>(selectedGroup, selectedGroup.SelectedPanel));
 
             var visibleGroups = getVisibleGroups();

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -313,6 +313,9 @@ namespace osu.Game.Screens.Select
 
         private void removeGroup(BeatmapGroup group)
         {
+            if (group == null)
+                return;
+
             groups.Remove(group);
             panels.Remove(group.Header);
             foreach (var p in group.BeatmapPanels)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -384,7 +384,7 @@ namespace osu.Game.Screens.Select
 
         private void promptDelete()
         {
-            if (Beatmap != null)
+            if (Beatmap != null && !Beatmap.IsDefault)
                 dialogOverlay?.Push(new BeatmapDeleteDialog(Beatmap));
         }
 


### PR DESCRIPTION
Fixes Crash when clicking Random (or F2) in SongSelect when no beatmaps are present, do not delete Beatmap.Default and prevent removing null Group from Carousel