### PR TITLE
SelectNextRandom(): Check if selectedGroup is null

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -178,6 +178,9 @@ namespace osu.Game.Screens.Select
 
         public void SelectNextRandom()
         {
+            if (selectedGroup == null)
+                return;
+
             randomSelectedBeatmaps.Push(new KeyValuePair<BeatmapGroup, BeatmapPanel>(selectedGroup, selectedGroup.SelectedPanel));
 
             var visibleGroups = getVisibleGroups();


### PR DESCRIPTION
In case user haven't added any beatmaps, selectedGroup is null, which crashes osu!lazer when SelectNextRandom() is called (aka when user requests random beatmap).