### PR TITLE
Fix a potential hard crash when exiting song select

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Screens.Select
                     requestedBeatmap.Metrics = res;
                     Schedule(() => updateMetrics(res));
                 };
-                lookup.Failure += e => updateMetrics(null);
+                lookup.Failure += e => Schedule(() => updateMetrics(null));
 
                 api.Queue(lookup);
                 loading.Show();


### PR DESCRIPTION
Fixes race condition when API returns a failure after exiting song select. Note that the API does also schedule to the correct thread, but this schedule ensures the callback is never run, which is what we want in this case.