### PR TITLE
Store filenames against BeatmapSetFileInfo for correctness

### DIFF
--- a/osu.Game/Beatmaps/BeatmapSetFileInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetFileInfo.cs
@@ -2,16 +2,26 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Game.IO;
+using SQLite.Net.Attributes;
 using SQLiteNetExtensions.Attributes;
 
 namespace osu.Game.Beatmaps
 {
     public class BeatmapSetFileInfo
     {
-        [ForeignKey(typeof(BeatmapSetInfo))]
+        [PrimaryKey, AutoIncrement]
+        public int ID { get; set; }
+
+        [ForeignKey(typeof(BeatmapSetInfo)), NotNull]
         public int BeatmapSetInfoID { get; set; }
 
-        [ForeignKey(typeof(FileInfo))]
+        [ForeignKey(typeof(FileInfo)), NotNull]
         public int FileInfoID { get; set; }
+
+        [OneToOne(CascadeOperations = CascadeOperation.CascadeRead)]
+        public FileInfo FileInfo { get; set; }
+
+        [NotNull]
+        public string Filename { get; set; }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.IO;
 using SQLite.Net.Attributes;
 using SQLiteNetExtensions.Attributes;
 
@@ -37,8 +36,8 @@ namespace osu.Game.Beatmaps
 
         public string StoryboardFile => Files.FirstOrDefault(f => f.Filename.EndsWith(".osb"))?.Filename;
 
-        [ManyToMany(typeof(BeatmapSetFileInfo), CascadeOperations = CascadeOperation.CascadeRead)]
-        public List<FileInfo> Files { get; set; }
+        [OneToMany(CascadeOperations = CascadeOperation.All)]
+        public List<BeatmapSetFileInfo> Files { get; set; }
 
         public bool Protected { get; set; }
     }

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Beatmaps
         /// The current version of this store. Used for migrations (see <see cref="PerformMigration(int, int)"/>).
         /// The initial version is 1.
         /// </summary>
-        protected override int StoreVersion => 1;
+        protected override int StoreVersion => 2;
 
         public BeatmapStore(SQLiteConnection connection)
             : base(connection)
@@ -74,14 +74,9 @@ namespace osu.Game.Beatmaps
                 switch (currentVersion)
                 {
                     case 1:
-                        // initialising from a version before we had versioning (or a fresh install).
-
-                        // force adding of Protected column (not automatically migrated).
-                        Connection.MigrateTable<BeatmapSetInfo>();
-
-                        // remove all existing beatmaps.
-                        foreach (var b in Connection.GetAllWithChildren<BeatmapSetInfo>(null, true))
-                            Connection.Delete(b, true);
+                    case 2:
+                        // cannot migrate; breaking underlying changes.
+                        Reset();
                         break;
                 }
             }

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -52,7 +52,11 @@ namespace osu.Game.Beatmaps
             Connection.CreateTable<BeatmapSetInfo>();
             Connection.CreateTable<BeatmapSetFileInfo>();
             Connection.CreateTable<BeatmapInfo>();
+        }
 
+        protected override void StartupTasks()
+        {
+            base.StartupTasks();
             cleanupPendingDeletions();
         }
 
@@ -60,12 +64,12 @@ namespace osu.Game.Beatmaps
         /// Perform migrations between two store versions.
         /// </summary>
         /// <param name="currentVersion">The current store version. This will be zero on a fresh database initialisation.</param>
-        /// <param name="newVersion">The target version which we are migrating to (equal to the current <see cref="StoreVersion"/>).</param>
-        protected override void PerformMigration(int currentVersion, int newVersion)
+        /// <param name="targetVersion">The target version which we are migrating to (equal to the current <see cref="StoreVersion"/>).</param>
+        protected override void PerformMigration(int currentVersion, int targetVersion)
         {
-            base.PerformMigration(currentVersion, newVersion);
+            base.PerformMigration(currentVersion, targetVersion);
 
-            while (currentVersion++ < newVersion)
+            while (currentVersion++ < targetVersion)
             {
                 switch (currentVersion)
                 {

--- a/osu.Game/Database/DatabaseBackedStore.cs
+++ b/osu.Game/Database/DatabaseBackedStore.cs
@@ -51,14 +51,30 @@ namespace osu.Game.Database
                 PerformMigration(reportedVersion.Version, reportedVersion.Version = StoreVersion);
 
             Connection.InsertOrReplace(reportedVersion);
+
+            StartupTasks();
         }
 
-        protected virtual void PerformMigration(int currentVersion, int newVersion)
+        /// <summary>
+        /// Called when the database version of this store doesn't match the local version.
+        /// Any manual migration operations should be performed in this.
+        /// </summary>
+        /// <param name="currentVersion">The current store version. This will be zero on a fresh database initialisation.</param>
+        /// <param name="targetVersion">The target version which we are migrating to (equal to the current <see cref="StoreVersion"/>).</param>
+        protected virtual void PerformMigration(int currentVersion, int targetVersion)
         {
         }
 
         /// <summary>
-        /// Prepare this database for use.
+        /// Perform any common startup tasks. Runs after <see cref="Prepare(bool)"/> and <see cref="PerformMigration(int, int)"/>.
+        /// </summary>
+        protected virtual void StartupTasks()
+        {
+
+        }
+
+        /// <summary>
+        /// Prepare this database for use. Tables should be created here.
         /// </summary>
         protected abstract void Prepare(bool reset = false);
 

--- a/osu.Game/Database/DatabaseBackedStore.cs
+++ b/osu.Game/Database/DatabaseBackedStore.cs
@@ -101,7 +101,6 @@ namespace osu.Game.Database
         public void Populate<T>(T item, bool recursive = true)
         {
             checkType(item.GetType());
-
             Connection.GetChildren(item, recursive);
         }
 

--- a/osu.Game/IO/FileInfo.cs
+++ b/osu.Game/IO/FileInfo.cs
@@ -11,8 +11,6 @@ namespace osu.Game.IO
         [PrimaryKey, AutoIncrement]
         public int ID { get; set; }
 
-        public string Filename { get; set; }
-
         [Indexed(Unique = true)]
         public string Hash { get; set; }
 

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -41,7 +41,7 @@ namespace osu.Game.IO
                 try
                 {
                     foreach (var f in Query<FileInfo>())
-                        Storage.Delete(Path.Combine(prefix, f.Hash));
+                        Storage.Delete(Path.Combine(prefix, f.StoragePath));
                 }
                 catch
                 {
@@ -150,7 +150,7 @@ namespace osu.Game.IO
                 try
                 {
                     Connection.Delete(f);
-                    Storage.Delete(Path.Combine(prefix, f.Hash));
+                    Storage.Delete(Path.Combine(prefix, f.StoragePath));
                 }
                 catch (Exception e)
                 {

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -38,7 +38,11 @@ namespace osu.Game.IO
                 Connection.DropTable<FileInfo>();
 
             Connection.CreateTable<FileInfo>();
+        }
 
+        protected override void StartupTasks()
+        {
+            base.StartupTasks();
             deletePending();
         }
 

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -38,15 +38,12 @@ namespace osu.Game.IO
         {
             if (reset)
             {
-                try
-                {
-                    foreach (var f in Query<FileInfo>())
-                        Storage.Delete(Path.Combine(prefix, f.StoragePath));
-                }
-                catch
-                {
-                    // we don't want to ever crash as a result of a reset operation.
-                }
+                // in earlier versions we stored beatmaps as solid archives, but not any more.
+                if (Storage.ExistsDirectory("beatmaps"))
+                    Storage.DeleteDirectory("beatmaps");
+
+                if (Storage.ExistsDirectory(prefix))
+                    Storage.DeleteDirectory(prefix);
 
                 Connection.DropTable<FileInfo>();
             }


### PR DESCRIPTION
This fixes incorrect reference counts causing database desync. Fixes the issue I mention in #1067.

Consider two scenarios:

- A single `BeatmapSet` references the same file with two different filenames.
- Multiple distinct `BeatmapSet`s all referenced the same file with different filenames.

Both cases would break with previous logic. The resolution is to store the filename against `BeatmapSetFileInfo` instead.

- [x] Depends on https://github.com/ppy/osu-framework/pull/932.