### PR TITLE
Hide the notification overlay on screens which explicitly hide overlays

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -334,6 +334,7 @@ namespace osu.Game
                 direct.State = Visibility.Hidden;
                 social.State = Visibility.Hidden;
                 userProfile.State = Visibility.Hidden;
+                notificationOverlay.State = Visibility.Hidden;
             }
             else
             {


### PR DESCRIPTION
Notification overlay doesn't hide during playing osu.