### PR TITLE
Allow Rulesets to create a non-FontAwesome icon

### DIFF
--- a/osu.Desktop.VisualTests/Tests/TestCaseTextAwesome.cs
+++ b/osu.Desktop.VisualTests/Tests/TestCaseTextAwesome.cs
@@ -31,10 +31,10 @@ namespace osu.Desktop.VisualTests.Tests
             int i = 50;
             foreach (FontAwesome fa in Enum.GetValues(typeof(FontAwesome)))
             {
-                flow.Add(new TextAwesome
+                flow.Add(new SpriteIcon
                 {
                     Icon = fa,
-                    TextSize = 60,
+                    Size = new Vector2(60),
                     Colour = new Color4(
                         Math.Max(0.5f, RNG.NextSingle()),
                         Math.Max(0.5f, RNG.NextSingle()),

--- a/osu.Desktop/Overlays/VersionManager.cs
+++ b/osu.Desktop/Overlays/VersionManager.cs
@@ -209,13 +209,13 @@ namespace osu.Desktop.Overlays
                         RelativeSizeAxes = Axes.Both,
                         Colour = ColourInfo.GradientVertical(colours.YellowDark, colours.Yellow)
                     },
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Icon = FontAwesome.fa_upload,
                         Colour = Color4.White,
-                        TextSize = 20
+                        Size = new Vector2(20),
                     }
                 });
             }

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Scoring;
 using osu.Game.Rulesets.Scoring;
 
@@ -85,7 +86,7 @@ namespace osu.Game.Rulesets.Catch
 
         public override string Description => "osu!catch";
 
-        public override FontAwesome Icon => FontAwesome.fa_osu_fruits_o;
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.fa_osu_fruits_o };
 
         public override IEnumerable<KeyCounter> CreateGameplayKeys() => new KeyCounter[]
         {

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Game.Beatmaps;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Scoring;
 
@@ -106,7 +107,7 @@ namespace osu.Game.Rulesets.Mania
 
         public override string Description => "osu!mania";
 
-        public override FontAwesome Icon => FontAwesome.fa_osu_mania_o;
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.fa_osu_mania_o };
 
         public override IEnumerable<KeyCounter> CreateGameplayKeys() => new KeyCounter[] { /* Todo: Should be keymod specific */ };
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly CirclePiece circle;
         private readonly GlowPiece glow;
 
-        private readonly TextAwesome symbol;
+        private readonly SpriteIcon symbol;
 
         private readonly Color4 baseColour = OsuColour.FromHex(@"002c3c");
         private readonly Color4 fillColour = OsuColour.FromHex(@"005b7c");
@@ -64,12 +64,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                             Anchor = Anchor.Centre,
                         },
                         new RingPiece(),
-                        symbol = new TextAwesome
+                        symbol = new SpriteIcon
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            UseFullGlyphHeight = true,
-                            TextSize = 48,
+                            Size = new Vector2(48),
                             Icon = FontAwesome.fa_asterisk,
                             Shadow = false,
                         },

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBouncer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBouncer.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
+using OpenTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
@@ -11,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
     {
         private readonly Slider slider;
         private readonly bool isEnd;
-        private readonly TextAwesome icon;
+        private readonly SpriteIcon icon;
 
         public SliderBouncer(Slider slider, bool isEnd)
         {
@@ -24,12 +25,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Children = new Drawable[]
             {
-                icon = new TextAwesome
+                icon = new SpriteIcon
                 {
                     Icon = FontAwesome.fa_eercast,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    TextSize = 48,
+                    Size = new Vector2(48),
                 }
             };
         }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Overlays.Settings;
@@ -104,7 +105,7 @@ namespace osu.Game.Rulesets.Osu
             }
         }
 
-        public override FontAwesome Icon => FontAwesome.fa_osu_osu_o;
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.fa_osu_osu_o };
 
         public override DifficultyCalculator CreateDifficultyCalculator(Beatmap beatmap) => new OsuDifficultyCalculator(beatmap);
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/Pieces/SwellSymbolPiece.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/Pieces/SwellSymbolPiece.cs
@@ -3,20 +3,20 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
+using OpenTK;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces
 {
     /// <summary>
     /// The symbol used for swell pieces.
     /// </summary>
-    public class SwellSymbolPiece : TextAwesome
+    public class SwellSymbolPiece : SpriteIcon
     {
         public SwellSymbolPiece()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            UseFullGlyphHeight = true;
-            TextSize = CirclePiece.SYMBOL_INNER_SIZE;
+            Size = new Vector2(CirclePiece.SYMBOL_INNER_SIZE);
             Icon = FontAwesome.fa_asterisk;
             Shadow = false;
         }

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Scoring;
 
@@ -85,7 +86,7 @@ namespace osu.Game.Rulesets.Taiko
 
         public override string Description => "osu!taiko";
 
-        public override FontAwesome Icon => FontAwesome.fa_osu_taiko_o;
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.fa_osu_taiko_o };
 
         public override IEnumerable<KeyCounter> CreateGameplayKeys() => new KeyCounter[]
         {

--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -4,8 +4,8 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using OpenTK;
-using OpenTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
@@ -22,23 +22,20 @@ namespace osu.Game.Beatmaps.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            Children = new[]
+            Children = new Drawable[]
             {
-                new TextAwesome
+                new SpriteIcon
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    TextSize = Size.X,
+                    RelativeSizeAxes = Axes.Both,
                     Colour = AccentColour,
                     Icon = FontAwesome.fa_circle
                 },
-                new TextAwesome
+                new ConstrainedIconContainer
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    TextSize = Size.X,
-                    Colour = Color4.White,
-                    Icon = beatmap.Ruleset.CreateInstance().Icon
+                    RelativeSizeAxes = Axes.Both,
+                    Icon = beatmap.Ruleset.CreateInstance().CreateIcon()
                 }
             };
         }

--- a/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
+++ b/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Graphics.Containers
     /// <summary>
     /// Display an icon that is constrained to a physical region on screen.
     /// </summary>
-    public class ConstrainedIconContainer : Container
+    public class ConstrainedIconContainer : CompositeDrawable
     {
         public Drawable Icon
         {
@@ -24,6 +24,17 @@ namespace osu.Game.Graphics.Containers
             {
                 InternalChild = value;
             }
+        }
+
+        /// <summary>
+        /// Determines an edge effect of this <see cref="Container"/>.
+        /// Edge effects are e.g. glow or a shadow.
+        /// Only has an effect when <see cref="CompositeDrawable.Masking"/> is true.
+        /// </summary>
+        public new EdgeEffectParameters EdgeEffect
+        {
+            get { return base.EdgeEffect; }
+            set { base.EdgeEffect = value; }
         }
 
         protected override void Update()

--- a/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
+++ b/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
@@ -42,6 +42,11 @@ namespace osu.Game.Graphics.Containers
             base.Update();
             if (InternalChildren.Count > 0 && InternalChild.DrawSize.X > 0)
             {
+                // We're modifying scale here for a few reasons
+                // - Guarantees correctness if BorderWidth is being used
+                // - If we were to use RelativeSize/FillMode, we'd need to set the Icon's RelativeSizeAxes directly.
+                //   We can't do this because we would need access to AutoSizeAxes to set it to none.
+                //   Other issues come up along the way too, so it's not a good solution.
                 var fitScale = Math.Min(DrawSize.X / InternalChild.DrawSize.X, DrawSize.Y / InternalChild.DrawSize.Y);
                 InternalChild.Scale = new Vector2(fitScale);
                 InternalChild.Anchor = Anchor.Centre;

--- a/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
+++ b/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
@@ -9,7 +9,7 @@ using OpenTK;
 namespace osu.Game.Graphics.Containers
 {
     /// <summary>
-    /// Display an icon that is constrained to a physical region on screen.
+    /// Display an icon that is forced to scale to the size of this container.
     /// </summary>
     public class ConstrainedIconContainer : CompositeDrawable
     {

--- a/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
+++ b/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using OpenTK;
+
+namespace osu.Game.Graphics.Containers
+{
+    /// <summary>
+    /// Display an icon that is constrained to a physical region on screen.
+    /// </summary>
+    public class ConstrainedIconContainer : Container
+    {
+        public Drawable Icon
+        {
+            get
+            {
+                return InternalChild;
+            }
+
+            set
+            {
+                InternalChild = value;
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            if (InternalChildren.Count > 0 && InternalChild.DrawSize.X > 0)
+            {
+                var fitScale = Math.Min(DrawSize.X / InternalChild.DrawSize.X, DrawSize.Y / InternalChild.DrawSize.Y);
+                InternalChild.Scale = new Vector2(fitScale);
+                InternalChild.Anchor = Anchor.Centre;
+                InternalChild.Origin = Anchor.Centre;
+            }
+        }
+
+        public ConstrainedIconContainer()
+        {
+            Masking = true;
+        }
+    }
+}

--- a/osu.Game/Graphics/SpriteIcon.cs
+++ b/osu.Game/Graphics/SpriteIcon.cs
@@ -49,12 +49,6 @@ namespace osu.Game.Graphics
             updateTexture();
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-            if (Size.X == 0) throw new System.Exception("size required");
-        }
-
         private void updateTexture()
         {
             var texture = store?.Get(((char)icon).ToString());

--- a/osu.Game/Graphics/SpriteIcon.cs
+++ b/osu.Game/Graphics/SpriteIcon.cs
@@ -1,13 +1,76 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Game.Graphics.Sprites;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics;
+using osu.Framework.IO.Stores;
+using OpenTK;
+using OpenTK.Graphics;
 
 namespace osu.Game.Graphics
 {
-    public class TextAwesome : OsuSpriteText
+    public class SpriteIcon : CompositeDrawable
     {
-        //public override FontFace FontFace => (int)Icon < 0xf000 ? FontFace.OsuFont : FontFace.FontAwesome;
+        private readonly Sprite spriteShadow;
+        private readonly Sprite spriteMain;
+
+        public SpriteIcon()
+        {
+            InternalChildren = new[]
+            {
+                spriteShadow = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = FillMode.Fit,
+                    Position = new Vector2(0, 0.06f),
+                    Colour = new Color4(0f, 0f, 0f, 0.2f),
+                    Alpha = 0
+                },
+                spriteMain = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = FillMode.Fit
+                },
+            };
+        }
+
+        private FontStore store;
+
+        [BackgroundDependencyLoader]
+        private void load(FontStore store)
+        {
+            this.store = store;
+            updateTexture();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            if (Size.X == 0) throw new System.Exception("size required");
+        }
+
+        private void updateTexture()
+        {
+            var texture = store?.Get(((char)icon).ToString());
+
+            spriteMain.Texture = texture;
+            spriteShadow.Texture = texture;
+
+            if (Size == Vector2.Zero)
+                Size = new Vector2(texture?.DisplayWidth ?? 0, texture?.DisplayHeight ?? 0);
+        }
+
+        public bool Shadow
+        {
+            get { return spriteShadow.IsPresent; }
+            set { spriteShadow.Alpha = value ? 1 : 0; }
+        }
 
         private FontAwesome icon;
 
@@ -23,7 +86,8 @@ namespace osu.Game.Graphics
                 if (icon == value) return;
 
                 icon = value;
-                Text = ((char)icon).ToString();
+                if (IsLoaded)
+                    updateTexture();
             }
         }
     }

--- a/osu.Game/Graphics/UserInterface/BreadcrumbControl.cs
+++ b/osu.Game/Graphics/UserInterface/BreadcrumbControl.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private class BreadcrumbTabItem : OsuTabItem, IStateful<Visibility>
         {
-            public readonly TextAwesome Chevron;
+            public readonly SpriteIcon Chevron;
 
             //don't allow clicking between transitions and don't make the chevron clickable
             public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => Alpha == 1f && Text.ReceiveMouseInputAt(screenSpacePos);
@@ -69,11 +69,11 @@ namespace osu.Game.Graphics.UserInterface
             {
                 Text.TextSize = 16;
                 Padding = new MarginPadding { Right = padding + 8 }; //padding + chevron width
-                Add(Chevron = new TextAwesome
+                Add(Chevron = new SpriteIcon
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreLeft,
-                    TextSize = 12,
+                    Size = new Vector2(12),
                     Icon = FontAwesome.fa_chevron_right,
                     Margin = new MarginPadding { Left = padding },
                     Alpha = 0f,

--- a/osu.Game/Graphics/UserInterface/IconButton.cs
+++ b/osu.Game/Graphics/UserInterface/IconButton.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class IconButton : OsuClickableContainer
     {
-        private readonly TextAwesome icon;
+        private readonly SpriteIcon icon;
         private readonly Box hover;
         private readonly Container content;
 
@@ -47,7 +47,7 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    Size = new Vector2 (button_size),
+                    Size = new Vector2(button_size),
 
                     CornerRadius = 5,
                     Masking = true,
@@ -64,11 +64,11 @@ namespace osu.Game.Graphics.UserInterface
                             RelativeSizeAxes = Axes.Both,
                             Alpha = 0,
                         },
-                        icon = new TextAwesome
+                        icon = new SpriteIcon
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                            TextSize = 18,
+                            Size = new Vector2(18),
                         }
                     }
                 }

--- a/osu.Game/Graphics/UserInterface/LoadingAnimation.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingAnimation.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class LoadingAnimation : VisibilityContainer
     {
-        private readonly TextAwesome spinner;
+        private readonly SpriteIcon spinner;
 
         public LoadingAnimation()
         {
@@ -20,9 +20,9 @@ namespace osu.Game.Graphics.UserInterface
 
             Children = new Drawable[]
             {
-                spinner = new TextAwesome
+                spinner = new SpriteIcon
                 {
-                    TextSize = 20,
+                    Size = new Vector2(20),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Icon = FontAwesome.fa_spinner

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
+using OpenTK;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -60,14 +61,13 @@ namespace osu.Game.Graphics.UserInterface
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        Chevron = new TextAwesome
+                        Chevron = new SpriteIcon
                         {
                             AlwaysPresent = true,
                             Icon = FontAwesome.fa_chevron_right,
-                            UseFullGlyphHeight = false,
                             Colour = Color4.Black,
                             Alpha = 0.5f,
-                            TextSize = 8,
+                            Size = new Vector2(8),
                             Margin = new MarginPadding { Left = 3, Right = 3 },
                             Origin = Anchor.CentreLeft,
                             Anchor = Anchor.CentreLeft,
@@ -84,7 +84,7 @@ namespace osu.Game.Graphics.UserInterface
 
             private Color4? accentColour;
 
-            protected readonly TextAwesome Chevron;
+            protected readonly SpriteIcon Chevron;
             protected readonly OsuSpriteText Label;
 
             protected override void FormatForeground(bool hover = false)
@@ -123,7 +123,7 @@ namespace osu.Game.Graphics.UserInterface
                 set { Text.Text = value; }
             }
 
-            protected readonly TextAwesome Icon;
+            protected readonly SpriteIcon Icon;
 
             private Color4? accentColour;
             public virtual Color4 AccentColour
@@ -152,13 +152,13 @@ namespace osu.Game.Graphics.UserInterface
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                     },
-                    Icon = new TextAwesome
+                    Icon = new SpriteIcon
                     {
                         Icon = FontAwesome.fa_chevron_down,
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
                         Margin = new MarginPadding { Right = 4 },
-                        TextSize = 20
+                        Size = new Vector2(20),
                     }
                 };
             }

--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -209,10 +209,10 @@ namespace osu.Game.Graphics.UserInterface
 
                     Foreground.Children = new Drawable[]
                     {
-                        new TextAwesome
+                        new SpriteIcon
                         {
                             Icon = FontAwesome.fa_ellipsis_h,
-                            TextSize = 14,
+                            Size = new Vector2(14),
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
                         }

--- a/osu.Game/Graphics/UserInterface/OsuTabControlCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControlCheckbox.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Graphics.UserInterface
     {
         private readonly Box box;
         private readonly SpriteText text;
-        private readonly TextAwesome icon;
+        private readonly SpriteIcon icon;
 
         private Color4? accentColour;
         public Color4 AccentColour
@@ -99,9 +99,9 @@ namespace osu.Game.Graphics.UserInterface
                             TextSize = 14,
                             Font = @"Exo2.0-Bold",
                         },
-                        icon = new TextAwesome
+                        icon = new SpriteIcon
                         {
-                            TextSize = 14,
+                            Size = new Vector2(14),
                             Icon = FontAwesome.fa_circle_o,
                             Shadow = true,
                         },

--- a/osu.Game/Graphics/UserInterface/SearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/SearchTextBox.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Input;
+using OpenTK;
 using OpenTK.Input;
 
 namespace osu.Game.Graphics.UserInterface
@@ -19,13 +20,13 @@ namespace osu.Game.Graphics.UserInterface
             Height = 35;
             AddRange(new Drawable[]
             {
-                new TextAwesome
+                new SpriteIcon
                 {
                     Icon = FontAwesome.fa_search,
                     Origin = Anchor.CentreRight,
                     Anchor = Anchor.CentreRight,
                     Margin = new MarginPadding { Right = 10 },
-                    TextSize = 20
+                    Size = new Vector2(20),
                 }
             });
 

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -142,16 +142,16 @@ namespace osu.Game.Graphics.UserInterface
 
         private class Star : Container
         {
-            public readonly TextAwesome Icon;
+            public readonly SpriteIcon Icon;
             public Star()
             {
                 Size = new Vector2(star_size);
 
                 Children = new[]
                 {
-                    Icon = new TextAwesome
+                    Icon = new SpriteIcon
                     {
-                        TextSize = star_size,
+                        Size = new Vector2(star_size),
                         Icon = FontAwesome.fa_star,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -215,7 +215,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             private const double beat_in_time = 60;
 
-            private readonly TextAwesome icon;
+            private readonly SpriteIcon icon;
 
             public FontAwesome Icon { set { icon.Icon = value; } }
 
@@ -226,11 +226,11 @@ namespace osu.Game.Graphics.UserInterface
 
                 Children = new Drawable[]
                 {
-                    icon = new TextAwesome
+                    icon = new SpriteIcon
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        TextSize = 25
+                        Size = new Vector2(25),
                     }
                 };
             }

--- a/osu.Game/Online/Multiplayer/GameType.cs
+++ b/osu.Game/Online/Multiplayer/GameType.cs
@@ -21,15 +21,14 @@ namespace osu.Game.Online.Multiplayer
         public override string Name => "Tag";
         public override Drawable GetIcon(OsuColour colours, float size)
         {
-            return new TextAwesome
+            return new SpriteIcon
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Icon = FontAwesome.fa_refresh,
-                TextSize = size,
+                Size = new Vector2(size),
                 Colour = colours.Blue,
                 Shadow = false,
-                UseFullGlyphHeight = false,
             };
         }
     }
@@ -61,21 +60,19 @@ namespace osu.Game.Online.Multiplayer
                 Spacing = new Vector2(2f),
                 Children = new[]
                 {
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Icon = FontAwesome.fa_refresh,
-                        TextSize = size * 0.75f,
+                        Size = new Vector2(size * 0.75f),
                         Colour = colours.Blue,
                         Shadow = false,
-                        UseFullGlyphHeight = false,
                     },
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Icon = FontAwesome.fa_refresh,
-                        TextSize = size * 0.75f,
+                        Size = new Vector2(size * 0.75f),
                         Colour = colours.Pink,
                         Shadow = false,
-                        UseFullGlyphHeight = false,
                     },
                 },
             };

--- a/osu.Game/Overlays/Chat/ChannelListItem.cs
+++ b/osu.Game/Overlays/Chat/ChannelListItem.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.Chat
         private readonly Bindable<bool> joinedBind = new Bindable<bool>();
         private readonly OsuSpriteText name;
         private readonly OsuSpriteText topic;
-        private readonly TextAwesome joinedCheckmark;
+        private readonly SpriteIcon joinedCheckmark;
 
         private Color4 joinedColour;
         private Color4 topicColour;
@@ -68,12 +68,12 @@ namespace osu.Game.Overlays.Chat
                         {
                             Children = new[]
                             {
-                                joinedCheckmark = new TextAwesome
+                                joinedCheckmark = new SpriteIcon
                                 {
                                     Anchor = Anchor.TopRight,
                                     Origin = Anchor.TopRight,
                                     Icon = FontAwesome.fa_check_circle,
-                                    TextSize = text_size,
+                                    Size = new Vector2(text_size),
                                     Shadow = false,
                                     Margin = new MarginPadding { Right = 10f },
                                     Alpha = 0f,
@@ -121,10 +121,10 @@ namespace osu.Game.Overlays.Chat
                             Spacing = new Vector2(3f, 0f),
                             Children = new Drawable[]
                             {
-                                new TextAwesome
+                                new SpriteIcon
                                 {
                                     Icon = FontAwesome.fa_user,
-                                    TextSize = text_size - 2,
+                                    Size = new Vector2(text_size - 2),
                                     Shadow = false,
                                     Margin = new MarginPadding { Top = 1 },
                                 },

--- a/osu.Game/Overlays/Chat/ChatTabControl.cs
+++ b/osu.Game/Overlays/Chat/ChatTabControl.cs
@@ -35,13 +35,13 @@ namespace osu.Game.Overlays.Chat
             TabContainer.Spacing = new Vector2(-shear_width, 0);
             TabContainer.Masking = false;
 
-            AddInternal(new TextAwesome
+            AddInternal(new SpriteIcon
             {
                 Icon = FontAwesome.fa_comments,
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
-                TextSize = 20,
-                Padding = new MarginPadding(10),
+                Size = new Vector2(20),
+                Margin = new MarginPadding(10),
             });
 
             AddTabItem(selectorTab = new ChannelTabItem.ChannelSelectorTabItem(new Channel { Name = "+" }));
@@ -72,7 +72,7 @@ namespace osu.Game.Overlays.Chat
             private readonly SpriteText textBold;
             private readonly Box box;
             private readonly Box highlightBox;
-            private readonly TextAwesome icon;
+            private readonly SpriteIcon icon;
 
             private void updateState()
             {
@@ -176,7 +176,7 @@ namespace osu.Game.Overlays.Chat
                         RelativeSizeAxes = Axes.Both,
                         Children = new Drawable[]
                         {
-                            icon = new TextAwesome
+                            icon = new SpriteIcon
                             {
                                 Icon = FontAwesome.fa_hashtag,
                                 Anchor = Anchor.CentreLeft,
@@ -184,7 +184,7 @@ namespace osu.Game.Overlays.Chat
                                 Colour = Color4.Black,
                                 X = -10,
                                 Alpha = 0.2f,
-                                TextSize = ChatOverlay.TAB_AREA_HEIGHT,
+                                Size = new Vector2(ChatOverlay.TAB_AREA_HEIGHT),
                             },
                             text = new OsuSpriteText
                             {

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -30,14 +30,14 @@ namespace osu.Game.Overlays.Dialog
         private readonly Container content;
         private readonly Container ring;
         private readonly FillFlowContainer<PopupDialogButton> buttonsContainer;
-        private readonly TextAwesome iconText;
+        private readonly SpriteIcon icon;
         private readonly SpriteText header;
         private readonly SpriteText body;
 
         public FontAwesome Icon
         {
-            get { return iconText.Icon; }
-            set { iconText.Icon = value; }
+            get { return icon.Icon; }
+            set { icon.Icon = value; }
         }
 
         public string HeaderText
@@ -205,12 +205,12 @@ namespace osu.Game.Overlays.Dialog
                                                     RelativeSizeAxes = Axes.Both,
                                                     Colour = Color4.Black.Opacity(0),
                                                 },
-                                                iconText = new TextAwesome
+                                                icon = new SpriteIcon
                                                 {
                                                     Origin = Anchor.Centre,
                                                     Anchor = Anchor.Centre,
                                                     Icon = FontAwesome.fa_close,
-                                                    TextSize = 50,
+                                                    Size = new Vector2(50),
                                                 },
                                             },
                                         },

--- a/osu.Game/Overlays/Direct/DirectListPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectListPanel.cs
@@ -152,18 +152,17 @@ namespace osu.Game.Overlays.Direct
 
         private class DownloadButton : OsuClickableContainer
         {
-            private readonly TextAwesome icon;
+            private readonly SpriteIcon icon;
 
             public DownloadButton()
             {
                 Children = new Drawable[]
                 {
-                    icon = new TextAwesome
+                    icon = new SpriteIcon
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        UseFullGlyphHeight = false,
-                        TextSize = 30,
+                        Size = new Vector2(30),
                         Icon = FontAwesome.fa_osu_chevron_down_o,
                     },
                 };

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -75,11 +75,11 @@ namespace osu.Game.Overlays.Direct
                     {
                         Font = @"Exo2.0-SemiBoldItalic",
                     },
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Icon = icon,
                         Shadow = true,
-                        TextSize = 14,
+                        Size = new Vector2(14),
                         Margin = new MarginPadding { Top = 1 },
                     },
                 };

--- a/osu.Game/Overlays/Direct/FilterControl.cs
+++ b/osu.Game/Overlays/Direct/FilterControl.cs
@@ -47,7 +47,11 @@ namespace osu.Game.Overlays.Direct
 
         private class RulesetToggleButton : OsuClickableContainer
         {
-            private readonly TextAwesome icon;
+            private Drawable icon
+            {
+                get { return iconContainer.Icon; }
+                set { iconContainer.Icon = value; }
+            }
 
             private RulesetInfo ruleset;
             public RulesetInfo Ruleset
@@ -56,15 +60,17 @@ namespace osu.Game.Overlays.Direct
                 set
                 {
                     ruleset = value;
-                    icon.Icon = Ruleset.CreateInstance().Icon;
+                    icon = Ruleset.CreateInstance().CreateIcon();
                 }
             }
 
             private readonly Bindable<RulesetInfo> bindable;
 
+            private readonly ConstrainedIconContainer iconContainer;
+
             private void Bindable_ValueChanged(RulesetInfo obj)
             {
-                icon.FadeTo(Ruleset.ID == obj?.ID ? 1f : 0.5f, 100);
+                iconContainer.FadeTo(Ruleset.ID == obj?.ID ? 1f : 0.5f, 100);
             }
 
             public RulesetToggleButton(Bindable<RulesetInfo> bindable, RulesetInfo ruleset)
@@ -74,11 +80,11 @@ namespace osu.Game.Overlays.Direct
 
                 Children = new[]
                 {
-                    icon = new TextAwesome
+                    iconContainer = new ConstrainedIconContainer
                     {
                         Origin = Anchor.TopLeft,
                         Anchor = Anchor.TopLeft,
-                        TextSize = 32,
+                        Size = new Vector2(32),
                     }
                 };
 

--- a/osu.Game/Overlays/Music/CollectionsDropdown.cs
+++ b/osu.Game/Overlays/Music/CollectionsDropdown.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays.Music
             {
                 CornerRadius = 5;
                 Height = 30;
-                Icon.TextSize = 14;
+                Icon.Size = new Vector2(14);
                 Icon.Margin = new MarginPadding(0);
                 Foreground.Padding = new MarginPadding { Top = 4, Bottom = 4, Left = 10, Right = 10 };
                 EdgeEffect = new EdgeEffectParameters

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -12,6 +12,7 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using OpenTK;
 
 namespace osu.Game.Overlays.Music
 {
@@ -22,7 +23,7 @@ namespace osu.Game.Overlays.Music
         private Color4 hoverColour;
         private Color4 artistColour;
 
-        private TextAwesome handle;
+        private SpriteIcon handle;
         private TextFlowContainer text;
         private IEnumerable<SpriteText> titleSprites;
         private UnicodeBindableString titleBind;
@@ -67,16 +68,15 @@ namespace osu.Game.Overlays.Music
 
             Children = new Drawable[]
             {
-                handle = new TextAwesome
+                handle = new SpriteIcon
                 {
                     Anchor = Anchor.TopLeft,
                     Origin = Anchor.TopLeft,
-                    TextSize = 12,
+                    Size = new Vector2(12),
                     Colour = colours.Gray5,
                     Icon = FontAwesome.fa_bars,
                     Alpha = 0f,
-                    Margin = new MarginPadding { Left = 5 },
-                    Padding = new MarginPadding { Top = 2 },
+                    Margin = new MarginPadding { Left = 5, Top = 2 },
                 },
                 text = new OsuTextFlowContainer
                 {

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -165,12 +165,12 @@ namespace osu.Game.Overlays.Notifications
 
                 Children = new[]
                 {
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Icon = FontAwesome.fa_times_circle,
-                        TextSize = 20
+                        Size = new Vector2(20),
                     }
                 };
             }

--- a/osu.Game/Overlays/Notifications/SimpleNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleNotification.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using OpenTK;
 
 namespace osu.Game.Overlays.Notifications
 {
@@ -36,7 +37,7 @@ namespace osu.Game.Overlays.Notifications
         }
 
         private readonly SpriteText textDrawable;
-        private readonly TextAwesome iconDrawable;
+        private readonly SpriteIcon iconDrawable;
 
         protected Box IconBackgound;
 
@@ -49,12 +50,12 @@ namespace osu.Game.Overlays.Notifications
                     RelativeSizeAxes = Axes.Both,
                     Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.6f))
                 },
-                iconDrawable = new TextAwesome
+                iconDrawable = new SpriteIcon
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Icon = icon,
-                    TextSize = 20
+                    Size = new Vector2(20),
                 }
             });
 

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -110,12 +110,12 @@ namespace osu.Game.Overlays.Profile
                                                     Alpha = 0,
                                                     AlwaysPresent = true
                                                 },
-                                                new TextAwesome
+                                                new SpriteIcon
                                                 {
                                                     Icon = FontAwesome.fa_heart,
                                                     Anchor = Anchor.Centre,
                                                     Origin = Anchor.Centre,
-                                                    TextSize = 12
+                                                    Size = new Vector2(12),
                                                 }
                                             }
                                         },

--- a/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
+++ b/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Overlays.SearchableList
 
         private class DisplayStyleToggleButton : OsuClickableContainer
         {
-            private readonly TextAwesome icon;
+            private readonly SpriteIcon icon;
             private readonly PanelDisplayStyle style;
             private readonly Bindable<PanelDisplayStyle> bindable;
 
@@ -67,13 +67,12 @@ namespace osu.Game.Overlays.SearchableList
 
                 Children = new Drawable[]
                 {
-                    this.icon = new TextAwesome
+                    this.icon = new SpriteIcon
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Icon = icon,
-                        TextSize = 18,
-                        UseFullGlyphHeight = false,
+                        Size = new Vector2(18),
                         Alpha = 0.5f,
                     },
                 };

--- a/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Overlays.SearchableList
                             Spacing = new Vector2(10f, 0f),
                             Children = new[]
                             {
-                                new TextAwesome
+                                new SpriteIcon
                                 {
-                                    TextSize = 25,
+                                    Size = new Vector2(25),
                                     Icon = Icon,
                                 },
                                 CreateHeaderText(),

--- a/osu.Game/Overlays/SearchableList/SlimEnumDropdown.cs
+++ b/osu.Game/Overlays/SearchableList/SlimEnumDropdown.cs
@@ -6,6 +6,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
+using OpenTK;
 
 namespace osu.Game.Overlays.SearchableList
 {
@@ -19,7 +20,7 @@ namespace osu.Game.Overlays.SearchableList
             public SlimDropdownHeader()
             {
                 Height = 25;
-                Icon.TextSize = 16;
+                Icon.Size = new Vector2(16);
                 Foreground.Padding = new MarginPadding { Top = 4, Bottom = 4, Left = 8, Right = 4 };
             }
 

--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -286,7 +286,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
             {
                 public const float LABEL_LEFT_MARGIN = 20;
 
-                private readonly TextAwesome statusIcon;
+                private readonly SpriteIcon statusIcon;
                 public Color4 StatusColour
                 {
                     set
@@ -308,15 +308,15 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         Radius = 4,
                     };
 
-                    Icon.TextSize = 14;
+                    Icon.Size = new Vector2(14);
                     Icon.Margin = new MarginPadding(0);
 
-                    Foreground.Add(statusIcon = new TextAwesome
+                    Foreground.Add(statusIcon = new SpriteIcon
                     {
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                         Icon = FontAwesome.fa_circle_o,
-                        TextSize = 14,
+                        Size = new Vector2(14),
                     });
 
                     Text.Margin = new MarginPadding { Left = LABEL_LEFT_MARGIN };

--- a/osu.Game/Overlays/Settings/SettingsFooter.cs
+++ b/osu.Game/Overlays/Settings/SettingsFooter.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets;
 using OpenTK;
@@ -27,12 +28,14 @@ namespace osu.Game.Overlays.Settings
 
             foreach (var ruleset in rulesets.AllRulesets)
             {
-                modes.Add(new TextAwesome
+                var icon = new ConstrainedIconContainer
                 {
-                    Icon = ruleset.CreateInstance().Icon,
+                    Icon = ruleset.CreateInstance().CreateIcon(),
                     Colour = Color4.Gray,
-                    TextSize = 20
-                });
+                    Size = new Vector2(20),
+                };
+
+                modes.Add(icon);
             }
 
             Children = new Drawable[]

--- a/osu.Game/Overlays/Settings/SidebarButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarButton.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Overlays.Settings
 {
     public class SidebarButton : Container
     {
-        private readonly TextAwesome drawableIcon;
+        private readonly SpriteIcon drawableIcon;
         private readonly SpriteText headerText;
         private readonly Box backgroundBox;
         private readonly Box selectionIndicator;
@@ -77,7 +77,7 @@ namespace osu.Game.Overlays.Settings
                     Width = Sidebar.DEFAULT_WIDTH,
                     RelativeSizeAxes = Axes.Y,
                     Colour = OsuColour.Gray(0.6f),
-                    Children = new[]
+                    Children = new Drawable[]
                     {
                         headerText = new OsuSpriteText
                         {
@@ -85,11 +85,11 @@ namespace osu.Game.Overlays.Settings
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                         },
-                        drawableIcon = new TextAwesome
+                        drawableIcon = new SpriteIcon
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            TextSize = 20
+                            Size = new Vector2(20),
                         },
                     }
                 },

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -20,10 +20,21 @@ namespace osu.Game.Overlays.Toolbar
     {
         public const float WIDTH = Toolbar.HEIGHT * 1.4f;
 
+        public void SetIcon(Drawable icon)
+        {
+            IconContainer.Icon = icon;
+            IconContainer.Show();
+        }
+
+        public void SetIcon(FontAwesome icon) => SetIcon(new SpriteIcon
+        {
+            Size = new Vector2(20),
+            Icon = icon
+        });
+
         public FontAwesome Icon
         {
-            get { return DrawableIcon.Icon; }
-            set { DrawableIcon.Icon = value; }
+            set { SetIcon(value); }
         }
 
         public string Text
@@ -55,7 +66,7 @@ namespace osu.Game.Overlays.Toolbar
 
         protected virtual Anchor TooltipAnchor => Anchor.TopLeft;
 
-        protected TextAwesome DrawableIcon;
+        protected ConstrainedIconContainer IconContainer;
         protected SpriteText DrawableText;
         protected Box HoverBackground;
         private readonly FillFlowContainer tooltipContainer;
@@ -88,11 +99,12 @@ namespace osu.Game.Overlays.Toolbar
                     AutoSizeAxes = Axes.X,
                     Children = new Drawable[]
                     {
-                        DrawableIcon = new TextAwesome
+                        IconContainer = new ConstrainedIconContainer
                         {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            TextSize = 20
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Size = new Vector2(20),
+                            Alpha = 0,
                         },
                         DrawableText = new OsuSpriteText
                         {

--- a/osu.Game/Overlays/Toolbar/ToolbarChatButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarChatButton.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Overlays.Toolbar
     {
         public ToolbarChatButton()
         {
-            Icon = FontAwesome.fa_comments;
+            SetIcon(FontAwesome.fa_comments);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Toolbar/ToolbarModeButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarModeButton.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Overlays.Toolbar
 
                 TooltipMain = rInstance.Description;
                 TooltipSub = $"Play some {rInstance.Description}";
-                Icon = rInstance.Icon;
+                SetIcon(rInstance.CreateIcon());
             }
         }
 
@@ -31,9 +31,8 @@ namespace osu.Game.Overlays.Toolbar
             {
                 if (value)
                 {
-                    DrawableIcon.Colour = Color4.White;
-                    DrawableIcon.Masking = true;
-                    DrawableIcon.EdgeEffect = new EdgeEffectParameters
+                    IconContainer.Colour = Color4.White;
+                    IconContainer.EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
                         Colour = new Color4(255, 194, 224, 100),
@@ -43,8 +42,8 @@ namespace osu.Game.Overlays.Toolbar
                 }
                 else
                 {
-                    DrawableIcon.Masking = false;
-                    DrawableIcon.Colour = new Color4(255, 194, 224, 255);
+                    IconContainer.Colour = new Color4(255, 194, 224, 255);
+                    IconContainer.EdgeEffect = new EdgeEffectParameters();
                 }
             }
         }
@@ -52,7 +51,7 @@ namespace osu.Game.Overlays.Toolbar
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            DrawableIcon.TextSize *= 1.4f;
+            IconContainer.Scale *= 1.4f;
         }
     }
 }

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using System.Collections.Generic;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Overlays.Settings;
 
@@ -31,7 +32,7 @@ namespace osu.Game.Rulesets
 
         public abstract ScoreProcessor CreateScoreProcessor();
 
-        public virtual FontAwesome Icon => FontAwesome.fa_question_circle;
+        public virtual Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.fa_question_circle };
 
         public abstract string Description { get; }
 

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -8,13 +8,14 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
+using OpenTK;
 
 namespace osu.Game.Rulesets.UI
 {
     public class ModIcon : Container
     {
-        private readonly TextAwesome modIcon;
-        private readonly TextAwesome background;
+        private readonly SpriteIcon modIcon;
+        private readonly SpriteIcon background;
 
         private const float icon_size = 80;
 
@@ -34,20 +35,20 @@ namespace osu.Game.Rulesets.UI
 
             Children = new Drawable[]
             {
-                background = new TextAwesome
+                background = new SpriteIcon
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    TextSize = icon_size,
+                    Size = new Vector2(icon_size),
                     Icon = FontAwesome.fa_osu_mod_bg,
                     Shadow = true,
                 },
-                modIcon = new TextAwesome
+                modIcon = new SpriteIcon
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
                     Colour = OsuColour.Gray(84),
-                    TextSize = icon_size - 35,
+                    Size = new Vector2(icon_size - 35),
                     Icon = mod.Icon
                 },
             };

--- a/osu.Game/Screens/Menu/Button.cs
+++ b/osu.Game/Screens/Menu/Button.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Menu
         private readonly Container iconText;
         private readonly Container box;
         private readonly Box boxHoverLayer;
-        private readonly TextAwesome icon;
+        private readonly SpriteIcon icon;
         private readonly string sampleName;
         private readonly Action clickAction;
         private readonly Key triggerKey;
@@ -95,12 +95,12 @@ namespace osu.Game.Screens.Menu
                     Origin = Anchor.Centre,
                     Children = new Drawable[]
                     {
-                        icon = new TextAwesome
+                        icon = new SpriteIcon
                         {
                             Shadow = true,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            TextSize = 30,
+                            Size = new Vector2(30),
                             Position = new Vector2(0, 0),
                             Icon = symbol
                         },

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Menu
     internal class Disclaimer : OsuScreen
     {
         private Intro intro;
-        private readonly TextAwesome icon;
+        private readonly SpriteIcon icon;
         private Color4 iconColour;
 
         internal override bool ShowOverlays => false;
@@ -37,12 +37,12 @@ namespace osu.Game.Screens.Menu
                     Spacing = new Vector2(0, 2),
                     Children = new Drawable[]
                     {
-                        icon = new TextAwesome
+                        icon = new SpriteIcon
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Icon = FontAwesome.fa_warning,
-                            TextSize = 30,
+                            Size = new Vector2(30),
                         },
                         new OsuSpriteText
                         {

--- a/osu.Game/Screens/Play/SkipButton.cs
+++ b/osu.Game/Screens/Play/SkipButton.cs
@@ -227,9 +227,9 @@ namespace osu.Game.Screens.Play
                                 Direction = FillDirection.Horizontal,
                                 Children = new[]
                                 {
-                                    new TextAwesome { Icon = FontAwesome.fa_chevron_right },
-                                    new TextAwesome { Icon = FontAwesome.fa_chevron_right },
-                                    new TextAwesome { Icon = FontAwesome.fa_chevron_right },
+                                    new SpriteIcon { Icon = FontAwesome.fa_chevron_right },
+                                    new SpriteIcon { Icon = FontAwesome.fa_chevron_right },
+                                    new SpriteIcon { Icon = FontAwesome.fa_chevron_right },
                                 }
                             },
                             new OsuSpriteText

--- a/osu.Game/Screens/Ranking/ResultModeButton.cs
+++ b/osu.Game/Screens/Ranking/ResultModeButton.cs
@@ -78,14 +78,14 @@ namespace osu.Game.Screens.Ranking
                             RelativeSizeAxes = Axes.Both,
                             Colour = Color4.Transparent,
                         },
-                        new TextAwesome
+                        new SpriteIcon
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Shadow = false,
                             Colour = OsuColour.Gray(0.95f),
                             Icon = icon,
-                            TextSize = 20,
+                            Size = new Vector2(20),
                         }
                     }
                 }

--- a/osu.Game/Screens/ScreenWhiteBox.cs
+++ b/osu.Game/Screens/ScreenWhiteBox.cs
@@ -108,14 +108,14 @@ namespace osu.Game.Screens
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Direction = FillDirection.Vertical,
-                            Children = new[]
+                            Children = new Drawable[]
                             {
-                                new TextAwesome
+                                new SpriteIcon
                                 {
                                     Icon = FontAwesome.fa_universal_access,
                                     Anchor = Anchor.TopCentre,
                                     Origin = Anchor.TopCentre,
-                                    TextSize = 50,
+                                    Size = new Vector2(50),
                                 },
                                 new OsuSpriteText
                                 {

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -247,21 +247,21 @@ namespace osu.Game.Screens.Select
                     AutoSizeAxes = Axes.Both;
                     Children = new Drawable[]
                     {
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Icon = FontAwesome.fa_square,
                         Origin = Anchor.Centre,
                         Colour = new Color4(68, 17, 136, 255),
                         Rotation = 45,
-                        TextSize = 20
+                        Size = new Vector2(20),
                     },
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Icon = statistic.Icon,
                         Origin = Anchor.Centre,
                         Colour = new Color4(255, 221, 85, 255),
                         Scale = new Vector2(0.8f),
-                        TextSize = 20
+                        Size = new Vector2(20),
                     },
                     new OsuSpriteText
                     {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Screens.Select
                                 //{
                                 //    Font = @"Exo2.0-Bold",
                                 //    Text = "Sort results by",
-                                //    TextSize = 14,
+                                //    Size = 14,
                                 //    Margin = new MarginPadding
                                 //    {
                                 //        Top = 5,

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -334,25 +334,23 @@ namespace osu.Game.Screens.Select.Leaderboards
 
                 Children = new[]
                 {
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
                         Icon = FontAwesome.fa_osu_mod_bg,
                         Colour = colour,
                         Shadow = true,
-                        TextSize = 30,
-                        UseFullGlyphHeight = false,
+                        Size = new Vector2(30),
                     },
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
                         Icon = icon,
                         Colour = OsuColour.Gray(84),
-                        TextSize = 18,
+                        Size = new Vector2(18),
                         Position = new Vector2(0f, 2f),
-                        UseFullGlyphHeight = false,
                     },
                 };
             }
@@ -369,7 +367,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
                 Children = new Drawable[]
                 {
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Origin = Anchor.Centre,
                         Icon = FontAwesome.fa_square,
@@ -377,7 +375,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                         Rotation = 45,
                         Shadow = true,
                     },
-                    new TextAwesome
+                    new SpriteIcon
                     {
                         Origin = Anchor.Centre,
                         Icon = icon,

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Select.Options
 
         private readonly Box background;
         private readonly Box flash;
-        private readonly TextAwesome iconText;
+        private readonly SpriteIcon iconText;
         private readonly OsuSpriteText firstLine;
         private readonly OsuSpriteText secondLine;
         private readonly Container box;
@@ -134,11 +134,11 @@ namespace osu.Game.Screens.Select.Options
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        iconText = new TextAwesome
+                        iconText = new SpriteIcon
                         {
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
-                            TextSize = 30,
+                            Size = new Vector2(30),
                             Shadow = true,
                             Icon = FontAwesome.fa_close,
                             Margin = new MarginPadding

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -142,15 +142,15 @@ namespace osu.Game.Users
                             Origin = Anchor.Centre,
                             AutoSizeAxes = Axes.Both,
                             Spacing = new Vector2(5f, 0f),
-                            Children = new[]
+                            Children = new Drawable[]
                             {
-                                new TextAwesome
+                                new SpriteIcon
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
                                     Icon = FontAwesome.fa_circle_o,
                                     Shadow = true,
-                                    TextSize = 14,
+                                    Size = new Vector2(14),
                                 },
                                 statusMessage = new OsuSpriteText
                                 {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Overlays\Profile\RankChart.cs" />
     <Compile Include="Overlays\Profile\Sections\RanksSection.cs" />
     <Compile Include="Overlays\Profile\Sections\RecentSection.cs" />
+    <Compile Include="Graphics\Containers\ConstrainedIconContainer.cs" />
     <Compile Include="Users\UserCoverBackground.cs" />
     <Compile Include="Overlays\UserProfileOverlay.cs" />
     <Compile Include="Overlays\Profile\ProfileHeader.cs" />
@@ -349,7 +350,7 @@
     <Compile Include="Graphics\Containers\ParallaxContainer.cs" />
     <Compile Include="Graphics\Cursor\MenuCursor.cs" />
     <Compile Include="Graphics\Processing\RatioAdjust.cs" />
-    <Compile Include="Graphics\TextAwesome.cs" />
+    <Compile Include="Graphics\SpriteIcon.cs" />
     <Compile Include="Screens\Play\KeyCounter.cs" />
     <Compile Include="Screens\Play\KeyCounterKeyboard.cs" />
     <Compile Include="Screens\Play\KeyCounterCollection.cs" />


### PR DESCRIPTION
This also
- Renames TextAwesome to SpriteIcon.
- Removes the default size of "20" from SpriteIcon (now defaults to the underlying texture size).