### PR TITLE
Fix sliders ignoring actions past the initial hitcircle

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -118,7 +119,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             base.Update();
 
             if (Time.Current < slider.EndTime)
-                Tracking = canCurrentlyTrack && lastState != null && ReceiveMouseInputAt(lastState.Mouse.NativeState.Position) && lastState.Mouse.HasMainButtonPressed;
+                Tracking = canCurrentlyTrack && lastState != null && ReceiveMouseInputAt(lastState.Mouse.NativeState.Position) && ((Parent as DrawableSlider)?.OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
         }
 
         public void UpdateProgress(double progress, int repeat)


### PR DESCRIPTION
Previously, actions would correctly trigger the initial hit circle, but were ignored when tracking the ball.  This meant that the tracking ring was never displayed, and slider ticks were always counted as a miss.
The fix is to make the slider ball keep track of actions (instead of mouse buttons), and to make hit circles not consume the action if their direct parent is a slider (so that the slider ball will correctly accept the initial `OnPressed`).