### PR TITLE
Swap the order of the social and chat toolbar buttons

### DIFF
--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -60,8 +60,8 @@ namespace osu.Game.Overlays.Toolbar
                     AutoSizeAxes = Axes.X,
                     Children = new Drawable[]
                     {
-                        new ToolbarSocialButton(),
                         new ToolbarChatButton(),
+                        new ToolbarSocialButton(),
                         new ToolbarMusicButton(),
                         new ToolbarButton
                         {


### PR DESCRIPTION
Currently, the F8 and F9 hotkeys are swapped in comparison to their associated buttons. I think either the order of the buttons or the order of the hotkeys should be swapped. This PR swaps the order of the button to keep the hotkeys consistent with the osu!stable version.