### PR TITLE
Add support for local chat echo

### DIFF
--- a/osu.Game/Online/Chat/Channel.cs
+++ b/osu.Game/Online/Chat/Channel.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Online.Chat
 
             foreach (Message message in messages)
             {
-                // Add non echo messages to its calculated index and local echo messages to the end
+                // Add non echo messages in front of the local echo messages and local echo messages to the end
                 if (!(message is LocalEchoMessage))
                     Messages.Insert(Messages.Count - (SentMessages.Count - handledSentMessages.Count), message);
                 else
@@ -96,10 +96,15 @@ namespace osu.Game.Online.Chat
 
         public void ReplaceLocalEchoMessage(LocalEchoMessage oldMessage, Message newMessage)
         {
-            // Replace the old message's tuple with a new one containing the received message.
             int oldTupleIndex = SentMessages.FindIndex(tuple => tuple.Item1.Equals(oldMessage));
-            SentMessages.RemoveAt(oldTupleIndex);
-            SentMessages.Insert(oldTupleIndex, new Tuple<LocalEchoMessage, Message>(oldMessage, newMessage));
+
+            // Check if the local echo message exists. It may not if it has already been pushed out of both lists.
+            if (oldTupleIndex != -1)
+            {
+                // Replace the old message's tuple with a new one containing the received message.
+                SentMessages.RemoveAt(oldTupleIndex);
+                SentMessages.Insert(oldTupleIndex, new Tuple<LocalEchoMessage, Message>(oldMessage, newMessage));
+            }
         }
 
         public override string ToString() => Name;

--- a/osu.Game/Online/Chat/Channel.cs
+++ b/osu.Game/Online/Chat/Channel.cs
@@ -52,17 +52,18 @@ namespace osu.Game.Online.Chat
             foreach (Tuple<LocalEchoMessage, Message> handledTuple in handledConfirmedSentMessages)
                 Messages.Remove(handledTuple.Item1);
 
-            // Add local echo messages and error messages to the end of the list and received messages right in front of the first local echo message.
+            // Calculate the insertion index for all non echo messages. They are inserted in front of the first local echo message
+            int nonEchoInsertionIndex = -1;
+            if (messages.Any(message => !(message is LocalEchoMessage)))
+                nonEchoInsertionIndex = Messages.FindIndex(element => element is LocalEchoMessage);
+
             foreach (Message message in messages)
             {
-                int insertionIndex = -1;
-
-                // Calculate the index of the first local echo message if the message is a received message
-                if (!(message is LocalEchoMessage) && !(message is ErrorMessage))
-                    insertionIndex = Messages.FindIndex(element => element is LocalEchoMessage);
-
-                // If there is no local echo message or if the message isn't a received message, insert the message at the list's very end
-                Messages.Insert(insertionIndex != -1 ? insertionIndex : Messages.Count, message);
+                // Add non echo messages to its calculated index and local echo messages to the end
+                if (!(message is LocalEchoMessage) && nonEchoInsertionIndex != -1)
+                    Messages.Insert(nonEchoInsertionIndex++, message);
+                else
+                    Messages.Add(message);
             }
 
             purgeOldMessages();

--- a/osu.Game/Online/Chat/LocalEchoMessage.cs
+++ b/osu.Game/Online/Chat/LocalEchoMessage.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Game.Online.Chat
+{
+    public class LocalEchoMessage : Message
+    {
+        public override bool Equals(Message other) => other is LocalEchoMessage ? this == other : base.Equals(other);
+    }
+}

--- a/osu.Game/Online/Chat/Message.cs
+++ b/osu.Game/Online/Chat/Message.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Online.Chat
 
         public int CompareTo(Message other) => Id.CompareTo(other.Id);
 
-        public bool Equals(Message other) => Id == other?.Id;
+        public virtual bool Equals(Message other) => Id == other?.Id;
 
         public override int GetHashCode() => Id.GetHashCode();
     }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -27,12 +27,21 @@ namespace osu.Game.Overlays.Chat
             {
                 if (message.Equals(value)) return;
 
+                if (!IsLoaded)
+                {
+                    message = value;
+                    return;
+                }
+
                 // Check if the children have to be redone
                 bool childrenOutdated = message.Sender != value.Sender || message.Timestamp != value.Timestamp || !string.Equals(message.Content, value.Content);
 
                 // Fade if the message type changed from local echo message to non local echo message
                 if (message is LocalEchoMessage && !(value is LocalEchoMessage))
+                {
                     this.FadeIn(echo_to_non_echo_fade_duration);
+                    timestamp.FadeTo(timestamp_alpha, echo_to_non_echo_fade_duration);
+                }
 
                 message = value;
 
@@ -88,6 +97,8 @@ namespace osu.Game.Overlays.Chat
         private const float message_padding = 200;
         private const float text_size = 20;
 
+        private const float timestamp_alpha = 0.4f;
+
         private const float echo_alpha = 0.5f;
         private const double echo_to_non_echo_fade_duration = 400;
 
@@ -95,14 +106,14 @@ namespace osu.Game.Overlays.Chat
 
         private Color4 customUsernameColour;
 
+        private OsuSpriteText timestamp;
+
         public ChatLine(Message message)
         {
             this.message = message;
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
-
-            Alpha = message is LocalEchoMessage ? echo_alpha : 1.0f;
 
             Padding = new MarginPadding { Left = padding, Right = padding };
         }
@@ -118,6 +129,7 @@ namespace osu.Game.Overlays.Chat
         {
             base.LoadComplete();
 
+            Alpha = message is LocalEchoMessage ? echo_alpha : 1.0f;
             addChildren();
         }
 
@@ -171,7 +183,7 @@ namespace osu.Game.Overlays.Chat
                     Size = new Vector2(message_padding, text_size),
                     Children = new Drawable[]
                     {
-                        new OsuSpriteText
+                        timestamp = new OsuSpriteText
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
@@ -179,7 +191,7 @@ namespace osu.Game.Overlays.Chat
                             Text = $@"{message.Timestamp.LocalDateTime:HH:mm:ss}",
                             FixedWidth = true,
                             TextSize = text_size * 0.75f,
-                            Alpha = 0.4f,
+                            Alpha = message is LocalEchoMessage ? 0.0f : timestamp_alpha,
                         },
                         new ClickableContainer
                         {

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -106,9 +106,9 @@ namespace osu.Game.Overlays.Chat
             ensureOrder();
         }
 
-        private void localEchoMessagesRemoved(IEnumerable<Message> RemovedLocalEchoMessages)
+        private void localEchoMessagesRemoved(IEnumerable<Message> removedLocalEchoMessages)
         {
-            foreach (ChatLine chatLine in flow.Children.Where(child => RemovedLocalEchoMessages.Contains(child.Message)))
+            foreach (ChatLine chatLine in flow.Children.Where(child => removedLocalEchoMessages.Contains(child.Message)))
                 chatLine.FadeColour(Color4.Red, 400).FadeOut(600).Expire();
         }
 

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -476,7 +476,7 @@ namespace osu.Game.Overlays
 
             req.Failure += e =>
             {
-                currentChannel.RemoveMessages(message);
+                currentChannel.RemoveLocalEchoMessage(message);
 
                 inputTextBox.FlashColour(Color4.Red, 1000);
             };

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -6,23 +6,23 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using OpenTK;
+using OpenTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Threading;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.Chat;
-using osu.Game.Graphics.UserInterface;
-using osu.Framework.Graphics.UserInterface;
-using OpenTK.Graphics;
-using osu.Framework.Input;
-using osu.Game.Configuration;
-using osu.Game.Graphics;
 using osu.Game.Overlays.Chat;
-using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays
 {
@@ -136,7 +136,7 @@ namespace osu.Game.Overlays
                                             Height = 1,
                                             PlaceholderText = "type your message",
                                             Exit = () => State = Visibility.Hidden,
-                                            OnCommit = postMessage,
+                                            OnCommit = commitInputTextBox,
                                             ReleaseFocusOnCommit = false,
                                             HoldFocus = true,
                                         }
@@ -433,9 +433,16 @@ namespace osu.Game.Overlays
             api.Queue(fetchReq);
         }
 
-        private void postMessage(TextBox textbox, bool newText)
+        private void commitInputTextBox(TextBox textbox, bool newText)
         {
-            var postText = textbox.Text;
+            postMessage();
+
+            textbox.Text = string.Empty;
+        }
+
+        private void postMessage()
+        {
+            var postText = inputTextBox.Text;
 
             if (string.IsNullOrEmpty(postText))
                 return;
@@ -443,7 +450,6 @@ namespace osu.Game.Overlays
             if (!api.IsLoggedIn)
             {
                 currentChannel?.AddNewMessages(new ErrorMessage("Please login to participate in chat!"));
-                textbox.Text = string.Empty;
                 return;
             }
 
@@ -453,11 +459,10 @@ namespace osu.Game.Overlays
             {
                 // TODO: handle commands
                 currentChannel.AddNewMessages(new ErrorMessage("Chat commands are not supported yet!"));
-                textbox.Text = string.Empty;
                 return;
             }
 
-            var message = new Message
+            var message = new LocalEchoMessage
             {
                 Sender = api.LocalUser.Value,
                 Timestamp = DateTimeOffset.Now,
@@ -466,22 +471,17 @@ namespace osu.Game.Overlays
                 Content = postText
             };
 
-            textbox.ReadOnly = true;
             var req = new PostMessageRequest(message);
+            currentChannel.AddNewMessages(message);
 
             req.Failure += e =>
             {
-                textbox.FlashColour(Color4.Red, 1000);
-                textbox.ReadOnly = false;
+                currentChannel.RemoveMessages(message);
+
+                inputTextBox.FlashColour(Color4.Red, 1000);
             };
 
-            req.Success += m =>
-            {
-                currentChannel.AddNewMessages(m);
-
-                textbox.ReadOnly = false;
-                textbox.Text = string.Empty;
-            };
+            req.Success += m => currentChannel.ReplaceLocalEchoMessage(message, m);
 
             api.Queue(req);
         }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Online\API\Requests\GetUsersRequest.cs" />
     <Compile Include="Online\API\Requests\PostMessageRequest.cs" />
     <Compile Include="Online\Chat\ErrorMessage.cs" />
+    <Compile Include="Online\Chat\LocalEchoMessage.cs" />
     <Compile Include="Overlays\Chat\ChatTabControl.cs" />
     <Compile Include="Overlays\KeyBinding\GlobalKeyBindingsSection.cs" />
     <Compile Include="Overlays\KeyBinding\KeyBindingRow.cs" />


### PR DESCRIPTION
The local message echo is pinned to a channel's bottom. It is then either transformed to a received message or removed depending on whether the message sending process succeeded.