### PR TITLE
Fix duplicate DifficultyControlPoints breaking slider velocities

### DIFF
--- a/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using OpenTK.Graphics;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Beatmaps.Legacy;

--- a/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/OsuLegacyDecoder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using OpenTK.Graphics;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Beatmaps.Legacy;
@@ -331,6 +332,7 @@ namespace osu.Game.Beatmaps.Formats
 
             if (speedMultiplier != difficultyPoint.SpeedMultiplier)
             {
+                beatmap.ControlPointInfo.DifficultyPoints.RemoveAll(x => x.Time == time);
                 beatmap.ControlPointInfo.DifficultyPoints.Add(new DifficultyControlPoint
                 {
                     Time = time,


### PR DESCRIPTION
When importing legacy beatmaps, it was possible to add two `DifficultyControlPoint`s with different multipliers but the same time.  Slider velocity calculation could sometimes take the wrong multiplier, causing the slider ball to move at the wrong speed.

Fix is to first remove any difficulty control points with the same time as the one about to be added, so that the latter lines in the file will take priority.

Fixes issue #1014 
