### PR TITLE
Fix sliders not checking the correct cursor position

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -98,17 +98,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             return base.OnMouseMove(state);
         }
 
-        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos)
-        {
-            // If the current time is between the start and end of the slider, we should track mouse input regardless of the cursor position.
-            return canCurrentlyTrack || base.ReceiveMouseInputAt(screenSpacePos);
-        }
+        // If the current time is between the start and end of the slider, we should track mouse input regardless of the cursor position.
+        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => canCurrentlyTrack || base.ReceiveMouseInputAt(screenSpacePos);
 
         private bool tracking;
         public bool Tracking
         {
             get { return tracking; }
-            set
+            private set
             {
                 if (value == tracking) return;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
+using OpenTK;
 using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
@@ -97,6 +98,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             return base.OnMouseMove(state);
         }
 
+        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos)
+        {
+            // If the current time is between the start and end of the slider, we should track mouse input regardless of the cursor position.
+            return canCurrentlyTrack || base.ReceiveMouseInputAt(screenSpacePos);
+        }
+
         private bool tracking;
         public bool Tracking
         {
@@ -118,8 +125,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         {
             base.Update();
 
+            // Make sure to use the base version of ReceiveMouseInputAt so that we correctly check the position.
             if (Time.Current < slider.EndTime)
-                Tracking = canCurrentlyTrack && lastState != null && ReceiveMouseInputAt(lastState.Mouse.NativeState.Position) && ((Parent as DrawableSlider)?.OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
+                Tracking = canCurrentlyTrack && lastState != null && base.ReceiveMouseInputAt(lastState.Mouse.NativeState.Position) && ((Parent as DrawableSlider)?.OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
         }
 
         public void UpdateProgress(double progress, int repeat)


### PR DESCRIPTION
Previously, the slider ball would stop receiving mouse events once the cursor moved out of the follow circle.  This meant that as long as the last received position was inside the circle, it would count as correctly tracking, regardless of the actual cursor position.

The fix is to force the slider to always receive mouse events if the current time is between its start and end.  This way it is not receiving unnecessary events if it does not yet need to update the tracking position, but it will not miss any events when the mouse moves outside the circle.