### PR TITLE
Fix selecting unranked beatmaps in song select crashing the game.

### DIFF
--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -44,19 +44,31 @@ namespace osu.Game.Graphics.UserInterface
             {
                 List<Bar> bars = Children.ToList();
                 foreach (var bar in value.Select((length, index) => new { Value = length, Bar = bars.Count > index ? bars[index] : null }))
+                {
+                    float length = MaxValue ?? value.Max();
+                    if (length != 0)
+                        length = bar.Value / length;
+
+                    float size = value.Count();
+                    if (size != 0)
+                        size = 1.0f / size;
+
                     if (bar.Bar != null)
                     {
-                        bar.Bar.Length = bar.Value / (MaxValue ?? value.Max());
-                        bar.Bar.Size = (direction & BarDirection.Horizontal) > 0 ? new Vector2(1, 1.0f / value.Count()) : new Vector2(1.0f / value.Count(), 1);
+                        bar.Bar.Length = length;
+                        bar.Bar.Size = (direction & BarDirection.Horizontal) > 0 ? new Vector2(1, size) : new Vector2(size, 1);
                     }
                     else
+                    {
                         Add(new Bar
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Size = (direction & BarDirection.Horizontal) > 0 ? new Vector2(1, 1.0f / value.Count()) : new Vector2(1.0f / value.Count(), 1),
-                            Length = bar.Value / (MaxValue ?? value.Max()),
+                            Size = (direction & BarDirection.Horizontal) > 0 ? new Vector2(1, size) : new Vector2(size, 1),
+                            Length = length,
                             Direction = Direction,
                         });
+                    }
+                }
                 //I'm using ToList() here because Where() returns an Enumerable which can change it's elements afterwards
                 RemoveRange(Children.Where((bar, index) => index >= value.Count()).ToList());
             }


### PR DESCRIPTION
These calculations lead to NaN values, and directly attached those values to the size properties of the bars, triggering the exceptions.