### PR TITLE
Make ScrollingPlayfield.Reversed protected and make ManiaPlayfield invertible

### DIFF
--- a/osu.Desktop.Tests/Visual/TestCaseScrollingPlayfield.cs
+++ b/osu.Desktop.Tests/Visual/TestCaseScrollingPlayfield.cs
@@ -64,8 +64,8 @@ namespace osu.Desktop.Tests.Visual
 
             AddStep("Reverse direction", () =>
             {
-                horizontalRulesetContainer.Playfield.Reversed.Toggle();
-                verticalRulesetContainer.Playfield.Reversed.Toggle();
+                horizontalRulesetContainer.Playfield.Reverse();
+                verticalRulesetContainer.Playfield.Reverse();
             });
         }
 
@@ -210,6 +210,8 @@ namespace osu.Desktop.Tests.Visual
                     content = new Container { RelativeSizeAxes = Axes.Both }
                 };
             }
+
+            public void Reverse() => Reversed.Toggle();
         }
 
 

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -14,6 +14,7 @@ using osu.Framework.Allocation;
 using OpenTK.Input;
 using System.Linq;
 using System.Collections.Generic;
+using osu.Framework.Configuration;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Framework.Graphics.Shapes;
@@ -45,6 +46,11 @@ namespace osu.Game.Rulesets.Mania.UI
             }
         }
 
+        /// <summary>
+        /// Whether this playfield should be inverted. This flips everything inside the playfield.
+        /// </summary>
+        public readonly Bindable<bool> Inverted = new Bindable<bool>(true);
+
         private readonly FlowContainer<Column> columns;
         public IEnumerable<Column> Columns => columns.Children;
 
@@ -63,6 +69,8 @@ namespace osu.Game.Rulesets.Mania.UI
 
             if (columnCount <= 0)
                 throw new ArgumentException("Can't have zero or fewer columns.");
+
+            Inverted.Value = true;
 
             InternalChildren = new Drawable[]
             {
@@ -126,7 +134,6 @@ namespace osu.Game.Rulesets.Mania.UI
             for (int i = 0; i < columnCount; i++)
             {
                 var c = new Column();
-                c.Reversed.BindTo(Reversed);
                 c.VisibleTimeRange.BindTo(VisibleTimeRange);
 
                 c.IsSpecial = isSpecialColumn(i);
@@ -135,6 +142,14 @@ namespace osu.Game.Rulesets.Mania.UI
                 columns.Add(c);
                 AddNested(c);
             }
+
+            Inverted.ValueChanged += invertedChanged;
+            Inverted.TriggerChange();
+        }
+
+        private void invertedChanged(bool newValue)
+        {
+            Scale = new Vector2(1, newValue ? -1 : 1);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Rulesets/UI/ScrollingPlayfield.cs
+++ b/osu.Game/Rulesets/UI/ScrollingPlayfield.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Rulesets.UI
         };
 
         /// <summary>
-        /// Whether to reverse the scrolling direction is reversed.
+        /// Whether to reverse the scrolling direction is reversed. Note that this does _not_ invert the hit objects.
         /// </summary>
-        public readonly BindableBool Reversed = new BindableBool();
+        protected readonly BindableBool Reversed = new BindableBool();
 
         /// <summary>
         /// The container that contains the <see cref="SpeedAdjustmentContainer"/>s and <see cref="DrawableHitObject"/>s.


### PR DESCRIPTION
Fixes #1160.

Basically, mania playfields can't use the "reversed" property of ScrollingPlayfield due to the nature of mania hit objects - they are top-centre aligned (imagine them scrolling upwards to understand that), which brings a judgement offset if movement is then simply reversed.
Because of this I've chosen to go down another direction and create a property specific to ManiaPlayfield - "Inverted", which basically flips the whole playfield. Note that with this all drawables are flipped, which is a functionality we may not want in the future, however we'll deal with that when we get to skinning.