### PR TITLE
Fix black screens on startup

### DIFF
--- a/osu.Game/Graphics/Processing/RatioAdjust.cs
+++ b/osu.Game/Graphics/Processing/RatioAdjust.cs
@@ -18,7 +18,12 @@ namespace osu.Game.Graphics.Processing
         protected override void Update()
         {
             base.Update();
+
             Vector2 parent = Parent.DrawSize;
+
+            // return if parent doesn't have a size yet.
+            // this was happening at the top-level and causing nothing to be displayed as a result.
+            if (parent.X == 0 || parent.Y == 0) return;
 
             Scale = new Vector2(Math.Min(parent.Y / 768f, parent.X / 1024f));
             Size = new Vector2(1 / Scale.X);


### PR DESCRIPTION
RatioAdjust was calculating in its update method without a valid parent size.