### PR TITLE
Add support for hiding individual beatmap difficulties

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -52,6 +52,8 @@ namespace osu.Game.Beatmaps
         [JsonProperty("file_sha2")]
         public string Hash { get; set; }
 
+        public bool Hidden { get; set; }
+
         /// <summary>
         /// MD5 is kept for legacy support (matching against replays, osu-web-10 etc.).
         /// </summary>

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Beatmaps
         /// Delete a beatmap from the manager.
         /// Is a no-op for already deleted beatmaps.
         /// </summary>
-        /// <param name="beatmapSet">The beatmap to delete.</param>
+        /// <param name="beatmapSet">The beatmap set to delete.</param>
         public void Delete(BeatmapSetInfo beatmapSet)
         {
             lock (beatmaps)
@@ -178,6 +178,16 @@ namespace osu.Game.Beatmaps
 
             if (!beatmapSet.Protected)
                 files.Dereference(beatmapSet.Files.Select(f => f.FileInfo).ToArray());
+        }
+
+        /// <summary>
+        /// Delete a beatmap from the manager.
+        /// Is a no-op for already deleted beatmaps.
+        /// </summary>
+        /// <param name="beatmap">The beatmap difficulty to delete.</param>
+        public void Delete(BeatmapInfo beatmap)
+        {
+            //todo: implement
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -34,9 +34,19 @@ namespace osu.Game.Beatmaps
         public event Action<BeatmapSetInfo> BeatmapSetAdded;
 
         /// <summary>
+        /// Fired when a single difficulty has been hidden.
+        /// </summary>
+        public event Action<BeatmapInfo> BeatmapHidden;
+
+        /// <summary>
         /// Fired when a <see cref="BeatmapSetInfo"/> is removed from the database.
         /// </summary>
         public event Action<BeatmapSetInfo> BeatmapSetRemoved;
+
+        /// <summary>
+        /// Fired when a single difficulty has been restored.
+        /// </summary>
+        public event Action<BeatmapInfo> BeatmapRestored;
 
         /// <summary>
         /// A default representation of a WorkingBeatmap to use when no beatmap is available.
@@ -71,6 +81,8 @@ namespace osu.Game.Beatmaps
             beatmaps = new BeatmapStore(connection);
             beatmaps.BeatmapSetAdded += s => BeatmapSetAdded?.Invoke(s);
             beatmaps.BeatmapSetRemoved += s => BeatmapSetRemoved?.Invoke(s);
+            beatmaps.BeatmapHidden += b => BeatmapHidden?.Invoke(b);
+            beatmaps.BeatmapRestored += b => BeatmapRestored?.Invoke(b);
 
             this.storage = storage;
             this.files = files;
@@ -162,8 +174,7 @@ namespace osu.Game.Beatmaps
             // If we have an ID then we already exist in the database.
             if (beatmapSetInfo.ID != 0) return;
 
-            lock (beatmaps)
-                beatmaps.Add(beatmapSetInfo);
+            beatmaps.Add(beatmapSetInfo);
         }
 
         /// <summary>
@@ -173,22 +184,23 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapSet">The beatmap set to delete.</param>
         public void Delete(BeatmapSetInfo beatmapSet)
         {
-            lock (beatmaps)
-                if (!beatmaps.Delete(beatmapSet)) return;
+            if (!beatmaps.Delete(beatmapSet)) return;
 
             if (!beatmapSet.Protected)
                 files.Dereference(beatmapSet.Files.Select(f => f.FileInfo).ToArray());
         }
 
         /// <summary>
-        /// Delete a beatmap from the manager.
-        /// Is a no-op for already deleted beatmaps.
+        /// Delete a beatmap difficulty.
         /// </summary>
-        /// <param name="beatmap">The beatmap difficulty to delete.</param>
-        public void Delete(BeatmapInfo beatmap)
-        {
-            //todo: implement
-        }
+        /// <param name="beatmap">The beatmap difficulty to hide.</param>
+        public void Hide(BeatmapInfo beatmap) => beatmaps.Hide(beatmap);
+
+        /// <summary>
+        /// Restore a beatmap difficulty.
+        /// </summary>
+        /// <param name="beatmap">The beatmap difficulty to restore.</param>
+        public void Restore(BeatmapInfo beatmap) => beatmaps.Restore(beatmap);
 
         /// <summary>
         /// Returns a <see cref="BeatmapSetInfo"/> to a usable state if it has previously been deleted but not yet purged.
@@ -197,8 +209,7 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapSet">The beatmap to restore.</param>
         public void Undelete(BeatmapSetInfo beatmapSet)
         {
-            lock (beatmaps)
-                if (!beatmaps.Undelete(beatmapSet)) return;
+            if (!beatmaps.Undelete(beatmapSet)) return;
 
             if (!beatmapSet.Protected)
                 files.Reference(beatmapSet.Files.Select(f => f.FileInfo).ToArray());
@@ -259,13 +270,20 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
+        /// Refresh an existing instance of a <see cref="BeatmapSetInfo"/> from the store.
+        /// </summary>
+        /// <param name="beatmapSet">A stale instance.</param>
+        /// <returns>A fresh instance.</returns>
+        public BeatmapSetInfo Refresh(BeatmapSetInfo beatmapSet) => QueryBeatmapSet(s => s.ID == beatmapSet.ID);
+
+        /// <summary>
         /// Perform a lookup query on available <see cref="BeatmapSetInfo"/>s.
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>Results from the provided query.</returns>
         public List<BeatmapSetInfo> QueryBeatmapSets(Expression<Func<BeatmapSetInfo, bool>> query)
         {
-            lock (beatmaps) return beatmaps.QueryAndPopulate(query);
+            return beatmaps.QueryAndPopulate(query);
         }
 
         /// <summary>
@@ -275,15 +293,12 @@ namespace osu.Game.Beatmaps
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
         public BeatmapInfo QueryBeatmap(Func<BeatmapInfo, bool> query)
         {
-            lock (beatmaps)
-            {
-                BeatmapInfo set = beatmaps.Query<BeatmapInfo>().FirstOrDefault(query);
+            BeatmapInfo set = beatmaps.Query<BeatmapInfo>().FirstOrDefault(query);
 
-                if (set != null)
-                    beatmaps.Populate(set);
+            if (set != null)
+                beatmaps.Populate(set);
 
-                return set;
-            }
+            return set;
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Beatmaps.Drawables
         /// </summary>
         public Action<BeatmapInfo> StartRequested;
 
+        public Action<WorkingBeatmap> DeleteRequested;
+
         public BeatmapSetHeader Header;
 
         private BeatmapGroupState state;
@@ -66,6 +68,7 @@ namespace osu.Game.Beatmaps.Drawables
             Header = new BeatmapSetHeader(beatmap)
             {
                 GainedSelection = headerGainedSelection,
+                DeleteRequested = b => DeleteRequested(b),
                 RelativeSizeAxes = Axes.X,
             };
 

--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Beatmaps.Drawables
 
         public Action<BeatmapSetInfo> DeleteRequested;
 
+        public Action<BeatmapInfo> DeleteDifficultyRequested;
+
         public BeatmapSetHeader Header;
 
         private BeatmapGroupState state;
@@ -77,6 +79,7 @@ namespace osu.Game.Beatmaps.Drawables
             {
                 Alpha = 0,
                 GainedSelection = panelGainedSelection,
+                DeleteRequested = p => DeleteDifficultyRequested?.Invoke(p),
                 StartRequested = p => { StartRequested?.Invoke(p.Beatmap); },
                 RelativeSizeAxes = Axes.X,
             }).ToList();

--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Beatmaps.Drawables
 
         public Action<BeatmapSetInfo> DeleteRequested;
 
+        public Action<BeatmapSetInfo> RestoreHiddenRequested;
+
         public Action<BeatmapInfo> DeleteDifficultyRequested;
 
         public BeatmapSetHeader Header;
@@ -71,10 +73,11 @@ namespace osu.Game.Beatmaps.Drawables
             {
                 GainedSelection = headerGainedSelection,
                 DeleteRequested = b => DeleteRequested(b),
+                RestoreHiddenRequested = b => RestoreHiddenRequested(b),
                 RelativeSizeAxes = Axes.X,
             };
 
-            BeatmapSet.Beatmaps = BeatmapSet.Beatmaps.OrderBy(b => b.StarDifficulty).ToList();
+            BeatmapSet.Beatmaps = BeatmapSet.Beatmaps.Where(b => !b.Hidden).OrderBy(b => b.StarDifficulty).ToList();
             BeatmapPanels = BeatmapSet.Beatmaps.Select(b => new BeatmapPanel(b)
             {
                 Alpha = 0,

--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Beatmaps.Drawables
         /// </summary>
         public Action<BeatmapInfo> StartRequested;
 
-        public Action<WorkingBeatmap> DeleteRequested;
+        public Action<BeatmapSetInfo> DeleteRequested;
 
         public BeatmapSetHeader Header;
 

--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Beatmaps.Drawables
 
         public Action<BeatmapSetInfo> RestoreHiddenRequested;
 
-        public Action<BeatmapInfo> DeleteDifficultyRequested;
+        public Action<BeatmapInfo> HideDifficultyRequested;
 
         public BeatmapSetHeader Header;
 
@@ -82,7 +82,7 @@ namespace osu.Game.Beatmaps.Drawables
             {
                 Alpha = 0,
                 GainedSelection = panelGainedSelection,
-                DeleteRequested = p => DeleteDifficultyRequested?.Invoke(p),
+                HideRequested = p => HideDifficultyRequested?.Invoke(p),
                 StartRequested = p => { StartRequested?.Invoke(p.Beatmap); },
                 RelativeSizeAxes = Axes.X,
             }).ToList();

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
@@ -14,16 +15,19 @@ using OpenTK.Graphics;
 using osu.Framework.Input;
 using osu.Game.Graphics.Sprites;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    public class BeatmapPanel : Panel
+    public class BeatmapPanel : Panel, IHasContextMenu
     {
         public BeatmapInfo Beatmap;
         private readonly Sprite background;
 
         public Action<BeatmapPanel> GainedSelection;
         public Action<BeatmapPanel> StartRequested;
+        public Action<BeatmapInfo> DeleteRequested;
+
         private readonly Triangles triangles;
         private readonly StarCounter starCounter;
 
@@ -148,5 +152,12 @@ namespace osu.Game.Beatmaps.Drawables
                 }
             };
         }
+
+        public MenuItem[] ContextMenuItems => new MenuItem[]
+        {
+            new OsuMenuItem("Play", MenuItemType.Highlighted),
+            new OsuMenuItem("Edit"),
+            new OsuMenuItem("Delete", MenuItemType.Destructive),
+        };
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Beatmaps.Drawables
 
         public Action<BeatmapPanel> GainedSelection;
         public Action<BeatmapPanel> StartRequested;
+        public Action<BeatmapPanel> EditRequested;
         public Action<BeatmapInfo> DeleteRequested;
 
         private readonly Triangles triangles;
@@ -155,8 +156,8 @@ namespace osu.Game.Beatmaps.Drawables
 
         public MenuItem[] ContextMenuItems => new MenuItem[]
         {
-            new OsuMenuItem("Play", MenuItemType.Highlighted),
-            new OsuMenuItem("Edit"),
+            new OsuMenuItem("Play", MenuItemType.Highlighted, () => StartRequested?.Invoke(this)),
+            new OsuMenuItem("Edit", MenuItemType.Standard, () => EditRequested?.Invoke(this)),
             new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke(Beatmap)),
         };
     }

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Beatmaps.Drawables
         {
             new OsuMenuItem("Play", MenuItemType.Highlighted),
             new OsuMenuItem("Edit"),
-            new OsuMenuItem("Delete", MenuItemType.Destructive),
+            new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke(Beatmap)),
         };
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Beatmaps.Drawables
         public Action<BeatmapPanel> GainedSelection;
         public Action<BeatmapPanel> StartRequested;
         public Action<BeatmapPanel> EditRequested;
-        public Action<BeatmapInfo> DeleteRequested;
+        public Action<BeatmapInfo> HideRequested;
 
         private readonly Triangles triangles;
         private readonly StarCounter starCounter;
@@ -158,7 +158,7 @@ namespace osu.Game.Beatmaps.Drawables
         {
             new OsuMenuItem("Play", MenuItemType.Highlighted, () => StartRequested?.Invoke(this)),
             new OsuMenuItem("Edit", MenuItemType.Standard, () => EditRequested?.Invoke(this)),
-            new OsuMenuItem("Hide", MenuItemType.Destructive, () => DeleteRequested?.Invoke(Beatmap)),
+            new OsuMenuItem("Hide", MenuItemType.Destructive, () => HideRequested?.Invoke(Beatmap)),
         };
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapPanel.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Beatmaps.Drawables
         {
             new OsuMenuItem("Play", MenuItemType.Highlighted, () => StartRequested?.Invoke(this)),
             new OsuMenuItem("Edit", MenuItemType.Standard, () => EditRequested?.Invoke(this)),
-            new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke(Beatmap)),
+            new OsuMenuItem("Hide", MenuItemType.Destructive, () => DeleteRequested?.Invoke(Beatmap)),
         };
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
@@ -24,6 +25,8 @@ namespace osu.Game.Beatmaps.Drawables
         public Action<BeatmapSetHeader> GainedSelection;
 
         public Action<BeatmapSetInfo> DeleteRequested;
+
+        public Action<BeatmapSetInfo> RestoreHiddenRequested;
 
         private readonly SpriteText title;
         private readonly SpriteText artist;
@@ -163,6 +166,9 @@ namespace osu.Game.Beatmaps.Drawables
 
                 if (State == PanelSelectedState.NotSelected)
                     items.Add(new OsuMenuItem("Expand", MenuItemType.Highlighted, () => State = PanelSelectedState.Selected));
+
+                if (beatmap.BeatmapSetInfo.Beatmaps.Any(b => b.Hidden))
+                    items.Add(new OsuMenuItem("Restore all hidden", MenuItemType.Standard, () => RestoreHiddenRequested?.Invoke(beatmap.BeatmapSetInfo)));
 
                 items.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke(beatmap.BeatmapSetInfo)));
 

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -9,16 +9,22 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    public class BeatmapSetHeader : Panel
+    public class BeatmapSetHeader : Panel, IHasContextMenu
     {
         public Action<BeatmapSetHeader> GainedSelection;
+
+        public Action<WorkingBeatmap> DeleteRequested;
+
         private readonly SpriteText title;
         private readonly SpriteText artist;
 
@@ -147,6 +153,21 @@ namespace osu.Game.Beatmaps.Drawables
         {
             foreach (var p in panels)
                 difficultyIcons.Add(new DifficultyIcon(p.Beatmap));
+        }
+
+        public MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                List<MenuItem> items = new List<MenuItem>();
+
+                if (State == PanelSelectedState.NotSelected)
+                    items.Add(new OsuMenuItem("Expand", MenuItemType.Highlighted, () => State = PanelSelectedState.Selected));
+
+                items.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke(beatmap)));
+
+                return items.ToArray();
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Beatmaps.Drawables
     {
         public Action<BeatmapSetHeader> GainedSelection;
 
-        public Action<WorkingBeatmap> DeleteRequested;
+        public Action<BeatmapSetInfo> DeleteRequested;
 
         private readonly SpriteText title;
         private readonly SpriteText artist;
@@ -164,7 +164,7 @@ namespace osu.Game.Beatmaps.Drawables
                 if (State == PanelSelectedState.NotSelected)
                     items.Add(new OsuMenuItem("Expand", MenuItemType.Highlighted, () => State = PanelSelectedState.Selected));
 
-                items.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke(beatmap)));
+                items.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, () => DeleteRequested?.Invoke(beatmap.BeatmapSetInfo)));
 
                 return items.ToArray();
             }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         private OsuButton importButton;
         private OsuButton deleteButton;
+        private OsuButton restoreButton;
 
         protected override string Header => "General";
 
@@ -39,6 +40,20 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                     {
                         deleteButton.Enabled.Value = false;
                         Task.Run(() => beatmaps.DeleteAll()).ContinueWith(t => Schedule(() => deleteButton.Enabled.Value = true));
+                    }
+                },
+                restoreButton = new OsuButton
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Text = "Restore all hidden difficulties",
+                    Action = () =>
+                    {
+                        restoreButton.Enabled.Value = false;
+                        Task.Run(() =>
+                        {
+                            foreach (var b in beatmaps.QueryBeatmaps(b => b.Hidden))
+                                beatmaps.Restore(b);
+                        }).ContinueWith(t => Schedule(() => restoreButton.Enabled.Value = true));
                     }
                 },
             };

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -140,7 +140,9 @@ namespace osu.Game.Screens.Select
 
         public Action StartRequested;
 
-        public Action<WorkingBeatmap> DeleteRequested;
+        public Action<BeatmapSetInfo> DeleteRequested;
+
+        public Action<BeatmapInfo> DeleteDifficultyRequested;
 
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
@@ -308,6 +310,7 @@ namespace osu.Game.Screens.Select
                 SelectionChanged = (g, p) => selectGroup(g, p),
                 StartRequested = b => StartRequested?.Invoke(),
                 DeleteRequested = b => DeleteRequested?.Invoke(b),
+                DeleteDifficultyRequested = b => DeleteDifficultyRequested?.Invoke(b),
                 State = BeatmapGroupState.Collapsed
             };
         }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -140,6 +140,8 @@ namespace osu.Game.Screens.Select
 
         public Action StartRequested;
 
+        public Action<WorkingBeatmap> DeleteRequested;
+
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
             if (groups.All(g => g.State == BeatmapGroupState.Hidden))
@@ -305,6 +307,7 @@ namespace osu.Game.Screens.Select
             {
                 SelectionChanged = (g, p) => selectGroup(g, p),
                 StartRequested = b => StartRequested?.Invoke(),
+                DeleteRequested = b => DeleteRequested?.Invoke(b),
                 State = BeatmapGroupState.Collapsed
             };
         }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Screens.Select
 
         public Action<BeatmapSetInfo> RestoreRequested;
 
-        public Action<BeatmapInfo> DeleteDifficultyRequested;
+        public Action<BeatmapInfo> HideDifficultyRequested;
 
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
@@ -341,7 +341,7 @@ namespace osu.Game.Screens.Select
                 StartRequested = b => StartRequested?.Invoke(),
                 DeleteRequested = b => DeleteRequested?.Invoke(b),
                 RestoreHiddenRequested = s => RestoreRequested?.Invoke(s),
-                DeleteDifficultyRequested = b => DeleteDifficultyRequested?.Invoke(b),
+                HideDifficultyRequested = b => HideDifficultyRequested?.Invoke(b),
                 State = BeatmapGroupState.Collapsed
             };
         }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Screens.Select
 
         public void SelectBeatmap(BeatmapInfo beatmap, bool animated = true)
         {
-            if (beatmap == null)
+            if (beatmap == null || beatmap.Hidden)
             {
                 SelectNext();
                 return;

--- a/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -13,28 +12,16 @@ namespace osu.Game.Screens.Select
     {
         private BeatmapManager manager;
 
-        private readonly Action deleteAction;
-
         [BackgroundDependencyLoader]
         private void load(BeatmapManager beatmapManager)
         {
             manager = beatmapManager;
         }
 
-        public BeatmapDeleteDialog(BeatmapSetInfo beatmap) : this()
+        public BeatmapDeleteDialog(BeatmapSetInfo beatmap)
         {
-            BodyText = $@"{beatmap.Metadata?.Artist} - {beatmap.Metadata?.Title} (ALL DIFFICULTIES)";
-            deleteAction = () => manager.Delete(beatmap);
-        }
+            BodyText = $@"{beatmap.Metadata?.Artist} - {beatmap.Metadata?.Title}";
 
-        public BeatmapDeleteDialog(BeatmapInfo beatmap) : this()
-        {
-            BodyText = $@"{beatmap.Metadata?.Artist} - {beatmap.Metadata?.Title} [{beatmap.Version}]";
-            deleteAction = () => manager.Delete(beatmap);
-        }
-
-        public BeatmapDeleteDialog()
-        {
             Icon = FontAwesome.fa_trash_o;
             HeaderText = @"Confirm deletion of";
             Buttons = new PopupDialogButton[]
@@ -42,7 +29,7 @@ namespace osu.Game.Screens.Select
                 new PopupDialogOkButton
                 {
                     Text = @"Yes. Totally. Delete it.",
-                    Action = () => deleteAction(),
+                    Action = () => manager.Delete(beatmap),
                 },
                 new PopupDialogCancelButton
                 {

--- a/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
@@ -13,29 +13,36 @@ namespace osu.Game.Screens.Select
     {
         private BeatmapManager manager;
 
+        private readonly Action deleteAction;
+
         [BackgroundDependencyLoader]
         private void load(BeatmapManager beatmapManager)
         {
             manager = beatmapManager;
         }
 
-        public BeatmapDeleteDialog(WorkingBeatmap beatmap)
+        public BeatmapDeleteDialog(BeatmapSetInfo beatmap) : this()
         {
-            if (beatmap == null) throw new ArgumentNullException(nameof(beatmap));
+            BodyText = $@"{beatmap.Metadata?.Artist} - {beatmap.Metadata?.Title} (ALL DIFFICULTIES)";
+            deleteAction = () => manager.Delete(beatmap);
+        }
 
+        public BeatmapDeleteDialog(BeatmapInfo beatmap) : this()
+        {
+            BodyText = $@"{beatmap.Metadata?.Artist} - {beatmap.Metadata?.Title} [{beatmap.Version}]";
+            deleteAction = () => manager.Delete(beatmap);
+        }
+
+        public BeatmapDeleteDialog()
+        {
             Icon = FontAwesome.fa_trash_o;
             HeaderText = @"Confirm deletion of";
-            BodyText = $@"{beatmap.Metadata?.Artist} - {beatmap.Metadata?.Title}";
             Buttons = new PopupDialogButton[]
             {
                 new PopupDialogOkButton
                 {
                     Text = @"Yes. Totally. Delete it.",
-                    Action = () =>
-                    {
-                        beatmap.Dispose();
-                        manager.Delete(beatmap.BeatmapSetInfo);
-                    },
+                    Action = () => deleteAction(),
                 },
                 new PopupDialogCancelButton
                 {

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -54,13 +54,11 @@ namespace osu.Game.Screens.Select
                 ValidForResume = false;
                 Push(new Editor());
             }, Key.Number3);
-
-            Beatmap.ValueChanged += beatmap_ValueChanged;
         }
 
-        private void beatmap_ValueChanged(WorkingBeatmap beatmap)
+        protected override void UpdateBeatmap(WorkingBeatmap beatmap)
         {
-            if (!IsCurrentScreen) return;
+            base.UpdateBeatmap(beatmap);
 
             beatmap.Mods.BindTo(modSelect.SelectedMods);
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -244,7 +244,7 @@ namespace osu.Game.Screens.Select
                     ensurePlayingSelected(preview);
                 }
 
-                changeBackground(Beatmap.Value);
+                UpdateBeatmap(Beatmap.Value);
             };
 
             selectionChangedDebounce?.Cancel();
@@ -312,7 +312,7 @@ namespace osu.Game.Screens.Select
         {
             if (Beatmap != null && !Beatmap.Value.BeatmapSetInfo.DeletePending)
             {
-                changeBackground(Beatmap);
+                UpdateBeatmap(Beatmap);
                 ensurePlayingSelected();
             }
 
@@ -358,7 +358,12 @@ namespace osu.Game.Screens.Select
             initialAddSetsTask?.Cancel();
         }
 
-        private void changeBackground(WorkingBeatmap beatmap)
+        /// <summary>
+        /// Allow components in SongSelect to update their loaded beatmap details.
+        /// This is a debounced call (unlike directly binding to WorkingBeatmap.ValueChanged).
+        /// </summary>
+        /// <param name="beatmap">The working beatmap.</param>
+        protected virtual void UpdateBeatmap(WorkingBeatmap beatmap)
         {
             var backgroundModeBeatmap = Background as BackgroundScreenBeatmap;
             if (backgroundModeBeatmap != null)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Screens.Select
                 BeatmapsChanged = carouselBeatmapsLoaded,
                 DeleteRequested = b => promptDelete(b),
                 RestoreRequested = s => { foreach (var b in s.Beatmaps) manager.Restore(b); },
-                DeleteDifficultyRequested = b => manager.Hide(b),
+                HideDifficultyRequested = b => manager.Hide(b),
                 StartRequested = () => carouselRaisedStart(),
             });
             Add(FilterControl = new FilterControl

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -107,6 +107,7 @@ namespace osu.Game.Screens.Select
                 SelectionChanged = carouselSelectionChanged,
                 BeatmapsChanged = carouselBeatmapsLoaded,
                 DeleteRequested = b => promptDelete(b),
+                DeleteDifficultyRequested = b => promptDelete(b),
                 StartRequested = () => carouselRaisedStart(),
             });
             Add(FilterControl = new FilterControl
@@ -164,7 +165,7 @@ namespace osu.Game.Screens.Select
                 Footer.AddButton(@"random", colours.Green, triggerRandom, Key.F2);
                 Footer.AddButton(@"options", colours.Blue, BeatmapOptions.ToggleVisibility, Key.F3);
 
-                BeatmapOptions.AddButton(@"Delete", @"Beatmap", FontAwesome.fa_trash, colours.Pink, () => promptDelete(Beatmap), Key.Number4, float.MaxValue);
+                BeatmapOptions.AddButton(@"Delete", @"Beatmap", FontAwesome.fa_trash, colours.Pink, () => promptDelete(Beatmap.Value.BeatmapSetInfo), Key.Number4, float.MaxValue);
             }
 
             if (manager == null)
@@ -392,6 +393,14 @@ namespace osu.Game.Screens.Select
         }
 
         private void promptDelete(BeatmapSetInfo beatmap)
+        {
+            if (beatmap == null)
+                return;
+
+            dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
+        }
+
+        private void promptDelete(BeatmapInfo beatmap)
         {
             if (beatmap == null)
                 return;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -249,7 +249,8 @@ namespace osu.Game.Screens.Select
 
             if (beatmap == null)
             {
-                performLoad();
+                if (!Beatmap.IsDefault)
+                    performLoad();
             }
             else
             {
@@ -390,7 +391,7 @@ namespace osu.Game.Screens.Select
                 Beatmap.SetDefault();
         }
 
-        private void promptDelete(WorkingBeatmap beatmap)
+        private void promptDelete(BeatmapSetInfo beatmap)
         {
             if (beatmap == null)
                 return;
@@ -412,7 +413,7 @@ namespace osu.Game.Screens.Select
                     if (state.Keyboard.ShiftPressed)
                     {
                         if (!Beatmap.IsDefault)
-                            promptDelete(Beatmap);
+                            promptDelete(Beatmap.Value.BeatmapSetInfo);
                         return true;
                     }
                     break;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -107,7 +107,8 @@ namespace osu.Game.Screens.Select
                 SelectionChanged = carouselSelectionChanged,
                 BeatmapsChanged = carouselBeatmapsLoaded,
                 DeleteRequested = b => promptDelete(b),
-                DeleteDifficultyRequested = b => promptDelete(b),
+                RestoreRequested = s => { foreach (var b in s.Beatmaps) manager.Restore(b); },
+                DeleteDifficultyRequested = b => manager.Hide(b),
                 StartRequested = () => carouselRaisedStart(),
             });
             Add(FilterControl = new FilterControl
@@ -176,6 +177,8 @@ namespace osu.Game.Screens.Select
 
             manager.BeatmapSetAdded += onBeatmapSetAdded;
             manager.BeatmapSetRemoved += onBeatmapSetRemoved;
+            manager.BeatmapHidden += onBeatmapHidden;
+            manager.BeatmapRestored += onBeatmapRestored;
 
             dialogOverlay = dialog;
 
@@ -191,6 +194,9 @@ namespace osu.Game.Screens.Select
             Beatmap.DisabledChanged += disabled => carousel.AllowSelection = !disabled;
             carousel.AllowSelection = !Beatmap.Disabled;
         }
+
+        private void onBeatmapRestored(BeatmapInfo b) => carousel.UpdateBeatmap(b);
+        private void onBeatmapHidden(BeatmapInfo b) => carousel.UpdateBeatmap(b);
 
         private void carouselBeatmapsLoaded()
         {
@@ -380,10 +386,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private void addBeatmapSet(BeatmapSetInfo beatmapSet)
-        {
-            carousel.AddBeatmap(beatmapSet);
-        }
+        private void addBeatmapSet(BeatmapSetInfo beatmapSet) => carousel.AddBeatmap(beatmapSet);
 
         private void removeBeatmapSet(BeatmapSetInfo beatmapSet)
         {
@@ -393,14 +396,6 @@ namespace osu.Game.Screens.Select
         }
 
         private void promptDelete(BeatmapSetInfo beatmap)
-        {
-            if (beatmap == null)
-                return;
-
-            dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
-        }
-
-        private void promptDelete(BeatmapInfo beatmap)
         {
             if (beatmap == null)
                 return;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Screens.Select
                 Origin = Anchor.CentreRight,
                 SelectionChanged = carouselSelectionChanged,
                 BeatmapsChanged = carouselBeatmapsLoaded,
+                DeleteRequested = b => promptDelete(b),
                 StartRequested = () => carouselRaisedStart(),
             });
             Add(FilterControl = new FilterControl
@@ -163,7 +164,7 @@ namespace osu.Game.Screens.Select
                 Footer.AddButton(@"random", colours.Green, triggerRandom, Key.F2);
                 Footer.AddButton(@"options", colours.Blue, BeatmapOptions.ToggleVisibility, Key.F3);
 
-                BeatmapOptions.AddButton(@"Delete", @"Beatmap", FontAwesome.fa_trash, colours.Pink, promptDelete, Key.Number4, float.MaxValue);
+                BeatmapOptions.AddButton(@"Delete", @"Beatmap", FontAwesome.fa_trash, colours.Pink, () => promptDelete(Beatmap), Key.Number4, float.MaxValue);
             }
 
             if (manager == null)
@@ -389,10 +390,12 @@ namespace osu.Game.Screens.Select
                 Beatmap.SetDefault();
         }
 
-        private void promptDelete()
+        private void promptDelete(WorkingBeatmap beatmap)
         {
-            if (Beatmap != null && !Beatmap.IsDefault)
-                dialogOverlay?.Push(new BeatmapDeleteDialog(Beatmap));
+            if (beatmap == null)
+                return;
+
+            dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
         }
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
@@ -408,7 +411,8 @@ namespace osu.Game.Screens.Select
                 case Key.Delete:
                     if (state.Keyboard.ShiftPressed)
                     {
-                        promptDelete();
+                        if (!Beatmap.IsDefault)
+                            promptDelete(Beatmap);
                         return true;
                     }
                     break;


### PR DESCRIPTION
This also implements right-click context menus on carousel panels. All features work except edit.

Hidden difficulties can be restored by right-clicking on the header panel or via the maintenance button in settings.

- [x] Depends on https://github.com/ppy/osu-framework/pull/1010
- [x] Depends on https://github.com/ppy/osu-framework/pull/1012