### PR TITLE
Adjust HP penalties/bonuses based on beatmap specification

### DIFF
--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
             base.Reset();
 
-            Health.Value = 1;
+            Health.Value = 0.5;
             Accuracy.Value = 1;
 
             scoreResultCounts.Clear();
@@ -56,13 +56,21 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     scoreResultCounts[judgement.Score] = scoreResultCounts.GetOrDefault(judgement.Score) + 1;
                     comboResultCounts[judgement.Combo] = comboResultCounts.GetOrDefault(judgement.Combo) + 1;
                 }
-
-                switch (judgement.Result)
+                switch (judgement.Score)
                 {
-                    case HitResult.Hit:
-                        Health.Value += 0.1f;
+                    case OsuScoreResult.Hit300:
+                        Health.Value += 0.01f;
                         break;
-                    case HitResult.Miss:
+
+                    case OsuScoreResult.Hit100:
+                        Health.Value -= 0.01f;
+                        break;
+
+                    case OsuScoreResult.Hit50:
+                        Health.Value -= 0.05f;
+                        break;
+
+                    case OsuScoreResult.Miss:
                         Health.Value -= 0.2f;
                         break;
                 }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
         }
 
-        
         float beatmapHp;
 
         protected override void ComputeTargets(Game.Beatmaps.Beatmap<OsuHitObject> beatmap)

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -23,6 +23,14 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
         }
 
+        
+        float beatmapHp = 0;
+
+        protected override void ComputeTargets(Game.Beatmaps.Beatmap<OsuHitObject> beatmap)
+        {
+            beatmapHp = beatmap.BeatmapInfo.Difficulty.DrainRate;
+        }
+
         protected override void Reset()
         {
             base.Reset();
@@ -59,19 +67,19 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 switch (judgement.Score)
                 {
                     case OsuScoreResult.Hit300:
-                        Health.Value += 0.01f;
+                        Health.Value += (10.2 - beatmapHp) * 0.02;
                         break;
 
                     case OsuScoreResult.Hit100:
-                        Health.Value -= 0.01f;
+                        Health.Value += (8 - beatmapHp) * 0.02;
                         break;
 
                     case OsuScoreResult.Hit50:
-                        Health.Value -= 0.05f;
+                        Health.Value += (4 - beatmapHp) * 0.02;
                         break;
 
                     case OsuScoreResult.Miss:
-                        Health.Value -= 0.2f;
+                        Health.Value -= beatmapHp * 0.04;
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
             base.Reset();
 
-            Health.Value = 0.5;
+            Health.Value = 1;
             Accuracy.Value = 1;
 
             scoreResultCounts.Clear();

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
         }
 
-        float beatmapHp;
+        private float beatmapHp;
 
         protected override void ComputeTargets(Game.Beatmaps.Beatmap<OsuHitObject> beatmap)
         {

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -23,11 +23,11 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
         }
 
-        private float beatmapHp;
+        private float hpDrainRate;
 
         protected override void ComputeTargets(Game.Beatmaps.Beatmap<OsuHitObject> beatmap)
         {
-            beatmapHp = beatmap.BeatmapInfo.Difficulty.DrainRate;
+            hpDrainRate = beatmap.BeatmapInfo.Difficulty.DrainRate;
         }
 
         protected override void Reset()
@@ -66,23 +66,23 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 switch (judgement.Score)
                 {
                     case OsuScoreResult.Hit300:
-                        Health.Value += (10.2 - beatmapHp) * 0.02;
+                        Health.Value += (10.2 - hpDrainRate) * 0.02;
                         break;
 
                     case OsuScoreResult.Hit100:
-                        Health.Value += (8 - beatmapHp) * 0.02;
+                        Health.Value += (8 - hpDrainRate) * 0.02;
                         break;
 
                     case OsuScoreResult.Hit50:
-                        Health.Value += (4 - beatmapHp) * 0.02;
+                        Health.Value += (4 - hpDrainRate) * 0.02;
                         break;
 
                     case OsuScoreResult.SliderTick:
-                        Health.Value += System.Math.Max(7 - beatmapHp, 0) * 0.01;
+                        Health.Value += System.Math.Max(7 - hpDrainRate, 0) * 0.01;
                         break;
 
                     case OsuScoreResult.Miss:
-                        Health.Value -= beatmapHp * 0.04;
+                        Health.Value -= hpDrainRate * 0.04;
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
         }
 
         
-        float beatmapHp = 0;
+        float beatmapHp;
 
         protected override void ComputeTargets(Game.Beatmaps.Beatmap<OsuHitObject> beatmap)
         {
@@ -76,6 +76,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
                     case OsuScoreResult.Hit50:
                         Health.Value += (4 - beatmapHp) * 0.02;
+                        break;
+
+                    case OsuScoreResult.SliderTick:
+                        Health.Value += System.Math.Max(7 - beatmapHp, 0) * 0.01;
                         break;
 
                     case OsuScoreResult.Miss:


### PR DESCRIPTION
I think the formula is fine (gives hp 9-10 the same feeling of 99% 300s or die, hp0 of pretty much never die) but can be changed whenever.