### PR TITLE
Update framework in line with the new Menu changes

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -33,19 +33,16 @@ namespace osu.Game.Beatmaps.Drawables
 
         public BeatmapSetHeader Header;
 
-        private BeatmapGroupState state;
-
         public List<BeatmapPanel> BeatmapPanels;
 
         public BeatmapSetInfo BeatmapSet;
 
+        private BeatmapGroupState state;
         public BeatmapGroupState State
         {
             get { return state; }
             set
             {
-                if (state == value)
-                    return;
                 state = value;
 
                 switch (value)
@@ -96,6 +93,7 @@ namespace osu.Game.Beatmaps.Drawables
 
             Header.AddDifficultyIcons(BeatmapPanels);
         }
+
 
         private void headerGainedSelection(BeatmapSetHeader panel)
         {

--- a/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapGroup.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Beatmaps.Drawables
 {
     public class BeatmapGroup : IStateful<BeatmapGroupState>
     {
+        public event Action<BeatmapGroupState> StateChanged;
+
         public BeatmapPanel SelectedPanel;
 
         /// <summary>
@@ -42,6 +44,10 @@ namespace osu.Game.Beatmaps.Drawables
             get { return state; }
             set
             {
+                if (state == value)
+                    return;
+                state = value;
+
                 switch (value)
                 {
                     case BeatmapGroupState.Expanded:
@@ -60,7 +66,8 @@ namespace osu.Game.Beatmaps.Drawables
                             panel.State = PanelSelectedState.Hidden;
                         break;
                 }
-                state = value;
+
+                StateChanged?.Invoke(state);
             }
         }
 

--- a/osu.Game/Beatmaps/Drawables/Panel.cs
+++ b/osu.Game/Beatmaps/Drawables/Panel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using osu.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,6 +15,8 @@ namespace osu.Game.Beatmaps.Drawables
     public class Panel : Container, IStateful<PanelSelectedState>
     {
         public const float MAX_HEIGHT = 80;
+
+        public event Action<PanelSelectedState> StateChanged;
 
         public override bool RemoveWhenNotAlive => false;
 
@@ -77,11 +80,15 @@ namespace osu.Game.Beatmaps.Drawables
 
             set
             {
-                if (state == value) return;
+                if (state == value)
+                    return;
 
                 var last = state;
                 state = value;
+
                 ApplyState(last);
+
+                StateChanged?.Invoke(State);
             }
         }
 

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -19,12 +19,12 @@ namespace osu.Game.Graphics.Containers
             samplePopIn = audio.Sample.Get(@"UI/melodic-5");
             samplePopOut = audio.Sample.Get(@"UI/melodic-4");
 
-            StateChanged += OsuFocusedOverlayContainer_StateChanged;
+            StateChanged += onStateChanged;
         }
 
-        private void OsuFocusedOverlayContainer_StateChanged(VisibilityContainer arg1, Visibility arg2)
+        private void onStateChanged(Visibility visibility)
         {
-            switch (arg2)
+            switch (visibility)
             {
                 case Visibility.Visible:
                     samplePopIn?.Play();

--- a/osu.Game/Graphics/UserInterface/BreadcrumbControl.cs
+++ b/osu.Game/Graphics/UserInterface/BreadcrumbControl.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using OpenTK;
 using osu.Framework;
 using osu.Framework.Graphics;
@@ -35,6 +36,8 @@ namespace osu.Game.Graphics.UserInterface
 
         private class BreadcrumbTabItem : OsuTabItem, IStateful<Visibility>
         {
+            public event Action<Visibility> StateChanged;
+
             public readonly SpriteIcon Chevron;
 
             //don't allow clicking between transitions and don't make the chevron clickable
@@ -42,6 +45,7 @@ namespace osu.Game.Graphics.UserInterface
             public override bool HandleInput => State == Visibility.Visible;
 
             private Visibility state;
+
             public Visibility State
             {
                 get { return state; }
@@ -62,6 +66,8 @@ namespace osu.Game.Graphics.UserInterface
                         this.FadeOut(transition_duration, Easing.OutQuint);
                         this.ScaleTo(new Vector2(0.8f, 1f), transition_duration, Easing.OutQuint);
                     }
+
+                    StateChanged?.Invoke(State);
                 }
             }
 

--- a/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuContextMenu.cs
@@ -14,14 +14,17 @@ namespace osu.Game.Graphics.UserInterface
         private const int fade_duration = 250;
 
         public OsuContextMenu()
+            : base(Direction.Vertical)
         {
-            CornerRadius = 5;
-            EdgeEffect = new EdgeEffectParameters
+            MaskingContainer.CornerRadius = 5;
+            MaskingContainer.EdgeEffect = new EdgeEffectParameters
             {
                 Type = EdgeEffectType.Shadow,
                 Colour = Color4.Black.Opacity(0.1f),
                 Radius = 4,
             };
+
+            ItemsContainer.Padding = new MarginPadding { Vertical = DrawableOsuMenuItem.MARGIN_VERTICAL };
         }
 
         [BackgroundDependencyLoader]
@@ -32,7 +35,5 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void AnimateOpen() => this.FadeIn(fade_duration, Easing.OutQuint);
         protected override void AnimateClose() => this.FadeOut(fade_duration, Easing.OutQuint);
-
-        protected override MarginPadding ItemFlowContainerPadding => new MarginPadding { Vertical = DrawableOsuMenuItem.MARGIN_VERTICAL };
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -57,6 +57,9 @@ namespace osu.Game.Graphics.UserInterface
             {
                 CornerRadius = 4;
                 BackgroundColour = Color4.Black.Opacity(0.5f);
+
+                // todo: this uses the same styling as OsuMenu. hopefully we can just use OsuMenu in the future with some refactoring
+                ItemsContainer.Padding = new MarginPadding(5);
             }
 
             // todo: this uses the same styling as OsuMenu. hopefully we can just use OsuMenu in the future with some refactoring
@@ -64,14 +67,7 @@ namespace osu.Game.Graphics.UserInterface
             protected override void AnimateClose() => this.FadeOut(300, Easing.OutQuint);
 
             // todo: this uses the same styling as OsuMenu. hopefully we can just use OsuMenu in the future with some refactoring
-            protected override MarginPadding ItemFlowContainerPadding => new MarginPadding(5);
-
-            // todo: this uses the same styling as OsuMenu. hopefully we can just use OsuMenu in the future with some refactoring
-            protected override void UpdateMenuHeight()
-            {
-                var actualHeight = (RelativeSizeAxes & Axes.Y) > 0 ? 1 : ContentHeight;
-                this.ResizeHeightTo(State == MenuState.Opened ? actualHeight : 0, 300, Easing.OutQuint);
-            }
+            protected override void UpdateSize(Vector2 newSize) => this.ResizeTo(newSize, 300, Easing.OutQuint);
 
             private Color4 accentColour;
             public Color4 AccentColour
@@ -141,7 +137,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 protected override Drawable CreateContent() => new Content();
 
-                protected class Content : FillFlowContainer, IHasText
+                protected new class Content : FillFlowContainer, IHasText
                 {
                     public string Text
                     {

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -67,7 +67,19 @@ namespace osu.Game.Graphics.UserInterface
             protected override void AnimateClose() => this.FadeOut(300, Easing.OutQuint);
 
             // todo: this uses the same styling as OsuMenu. hopefully we can just use OsuMenu in the future with some refactoring
-            protected override void UpdateSize(Vector2 newSize) => this.ResizeTo(newSize, 300, Easing.OutQuint);
+            protected override void UpdateSize(Vector2 newSize)
+            {
+                if (Direction == Direction.Vertical)
+                {
+                    Width = newSize.X;
+                    this.ResizeHeightTo(newSize.Y, 300, Easing.OutQuint);
+                }
+                else
+                {
+                    Height = newSize.Y;
+                    this.ResizeWidthTo(newSize.X, 300, Easing.OutQuint);
+                }
+            }
 
             private Color4 accentColour;
             public Color4 AccentColour

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -12,27 +12,25 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Game.Graphics.Sprites;
+using OpenTK;
 
 namespace osu.Game.Graphics.UserInterface
 {
     public class OsuMenu : Menu
     {
-        public OsuMenu()
+        public OsuMenu(Direction direction)
+            : base(direction)
         {
-            CornerRadius = 4;
             BackgroundColour = Color4.Black.Opacity(0.5f);
+
+            MaskingContainer.CornerRadius = 4;
+            ItemsContainer.Padding = new MarginPadding(5);
         }
 
         protected override void AnimateOpen() => this.FadeIn(300, Easing.OutQuint);
         protected override void AnimateClose() => this.FadeOut(300, Easing.OutQuint);
 
-        protected override void UpdateMenuHeight()
-        {
-            var actualHeight = (RelativeSizeAxes & Axes.Y) > 0 ? 1 : ContentHeight;
-            this.ResizeHeightTo(State == MenuState.Opened ? actualHeight : 0, 300, Easing.OutQuint);
-        }
-
-        protected override MarginPadding ItemFlowContainerPadding => new MarginPadding(5);
+        protected override void UpdateSize(Vector2 newSize) => this.ResizeTo(newSize, 300, Easing.OutQuint);
 
         protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableOsuMenuItem(item);
 

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -30,7 +30,19 @@ namespace osu.Game.Graphics.UserInterface
         protected override void AnimateOpen() => this.FadeIn(300, Easing.OutQuint);
         protected override void AnimateClose() => this.FadeOut(300, Easing.OutQuint);
 
-        protected override void UpdateSize(Vector2 newSize) => this.ResizeTo(newSize, 300, Easing.OutQuint);
+        protected override void UpdateSize(Vector2 newSize)
+        {
+            if (Direction == Direction.Vertical)
+            {
+                Width = newSize.X;
+                this.ResizeHeightTo(newSize.Y, 300, Easing.OutQuint);
+            }
+            else
+            {
+                Height = newSize.Y;
+                this.ResizeWidthTo(newSize.X, 300, Easing.OutQuint);
+            }
+        }
 
         protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableOsuMenuItem(item);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -230,13 +230,13 @@ namespace osu.Game
             var singleDisplayOverlays = new OverlayContainer[] { chat, social, direct };
             foreach (var overlay in singleDisplayOverlays)
             {
-                overlay.StateChanged += (container, state) =>
+                overlay.StateChanged += state =>
                 {
                     if (state == Visibility.Hidden) return;
 
                     foreach (var c in singleDisplayOverlays)
                     {
-                        if (c == container) continue;
+                        if (c == overlay) continue;
                         c.State = Visibility.Hidden;
                     }
                 };

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays
 
             channelTabs.Current.ValueChanged += newChannel => CurrentChannel = newChannel;
             channelTabs.ChannelSelectorActive.ValueChanged += value => channelSelection.State = value ? Visibility.Visible : Visibility.Hidden;
-            channelSelection.StateChanged += (overlay, state) =>
+            channelSelection.StateChanged += state =>
             {
                 channelTabs.ChannelSelectorActive.Value = state == Visibility.Visible;
 

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays
             dialogContainer.Add(currentDialog);
 
             currentDialog.Show();
-            currentDialog.StateChanged += onDialogOnStateChanged;
+            currentDialog.StateChanged += state => onDialogOnStateChanged(dialog, state);
             State = Visibility.Visible;
         }
 

--- a/osu.Game/Overlays/MainSettings.cs
+++ b/osu.Game/Overlays/MainSettings.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays
 
         private const float hidden_width = 120;
 
-        private void keyBindingOverlay_StateChanged(VisibilityContainer container, Visibility visibility)
+        private void keyBindingOverlay_StateChanged(Visibility visibility)
         {
             switch (visibility)
             {

--- a/osu.Game/Overlays/MedalSplash/DrawableMedal.cs
+++ b/osu.Game/Overlays/MedalSplash/DrawableMedal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using osu.Framework;
 using OpenTK;
 using osu.Framework.Allocation;
@@ -18,6 +19,8 @@ namespace osu.Game.Overlays.MedalSplash
     {
         private const float scale_when_unlocked = 0.76f;
         private const float scale_when_full = 0.6f;
+
+        public event Action<DisplayState> StateChanged;
 
         private readonly Medal medal;
         private readonly Container medalContainer;
@@ -132,6 +135,8 @@ namespace osu.Game.Overlays.MedalSplash
 
                 state = value;
                 updateState();
+
+                StateChanged?.Invoke(State);
             }
         }
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Overlays
 
             beatmapBacking.BindTo(game.Beatmap);
 
-            playlist.StateChanged += (c, s) => playlistButton.FadeColour(s == Visibility.Visible ? colours.Yellow : Color4.White, 200, Easing.OutQuint);
+            playlist.StateChanged += s => playlistButton.FadeColour(s == Visibility.Visible ? colours.Yellow : Color4.White, 200, Easing.OutQuint);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -292,6 +292,8 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         Colour = Color4.Black.Opacity(0.25f),
                         Radius = 4,
                     };
+
+                    ItemsContainer.Padding = new MarginPadding();
                 }
 
                 [BackgroundDependencyLoader]
@@ -299,8 +301,6 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 {
                     BackgroundColour = colours.Gray3;
                 }
-
-                protected override MarginPadding ItemFlowContainerPadding => new MarginPadding();
 
                 protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableUserDropdownMenuItem(item);
 

--- a/osu.Game/Overlays/Settings/Sidebar.cs
+++ b/osu.Game/Overlays/Settings/Sidebar.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using System.Linq;
 using osu.Framework;
 using OpenTK;
@@ -19,6 +20,9 @@ namespace osu.Game.Overlays.Settings
         private readonly FillFlowContainer<SidebarButton> content;
         internal const float DEFAULT_WIDTH = ToolbarButton.WIDTH;
         internal const int EXPANDED_WIDTH = 200;
+
+        public event Action<ExpandedState> StateChanged;
+
         protected override Container<SidebarButton> Content => content;
 
         public Sidebar()
@@ -102,6 +106,8 @@ namespace osu.Game.Overlays.Settings
                         this.ResizeTo(new Vector2(EXPANDED_WIDTH, Height), 500, Easing.OutQuint);
                         break;
                 }
+
+                StateChanged?.Invoke(State);
             }
         }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Overlays.Toolbar
                 stateContainer.StateChanged -= stateChanged;
         }
 
-        private void stateChanged(VisibilityContainer c, Visibility state)
+        private void stateChanged(Visibility state)
         {
             switch (state)
             {

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -167,6 +167,8 @@ namespace osu.Game.Overlays
 
         private class Wave : Container, IStateful<Visibility>
         {
+            public event Action<Visibility> StateChanged;
+
             public float FinalPosition;
 
             public Wave()
@@ -200,6 +202,7 @@ namespace osu.Game.Overlays
             }
 
             private Visibility state;
+
             public Visibility State
             {
                 get { return state; }
@@ -216,6 +219,8 @@ namespace osu.Game.Overlays
                             this.MoveToY(FinalPosition, APPEAR_DURATION, easing_show);
                             break;
                     }
+
+                    StateChanged?.Invoke(State);
                 }
             }
         }

--- a/osu.Game/Screens/Menu/Button.cs
+++ b/osu.Game/Screens/Menu/Button.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Screens.Menu
     /// </summary>
     public class Button : BeatSyncedContainer, IStateful<ButtonState>
     {
+        public event Action<ButtonState> StateChanged;
+
         private readonly Container iconText;
         private readonly Container box;
         private readonly Box boxHoverLayer;
@@ -266,6 +268,8 @@ namespace osu.Game.Screens.Menu
                         this.FadeOut(explode_duration / 4f * 3);
                         break;
                 }
+
+                StateChanged?.Invoke(State);
             }
         }
     }

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Screens.Menu
 {
     public class ButtonSystem : Container, IStateful<MenuState>
     {
+        public event Action<MenuState> StateChanged;
+
         public Action OnEdit;
         public Action OnExit;
         public Action OnDirect;
@@ -294,6 +296,8 @@ namespace osu.Game.Screens.Menu
                     backButton.State = state == MenuState.Play ? ButtonState.Expanded : ButtonState.Contracted;
                     settingsButton.State = state == MenuState.TopLevel ? ButtonState.Expanded : ButtonState.Contracted;
                 }
+
+                StateChanged?.Invoke(State);
             }
         }
 

--- a/osu.Game/Screens/Play/SkipButton.cs
+++ b/osu.Game/Screens/Play/SkipButton.cs
@@ -133,6 +133,8 @@ namespace osu.Game.Screens.Play
 
         private class FadeContainer : Container, IStateful<Visibility>
         {
+            public event Action<Visibility> StateChanged;
+
             private Visibility state;
             private ScheduledDelegate scheduledHide;
 
@@ -144,8 +146,10 @@ namespace osu.Game.Screens.Play
                 }
                 set
                 {
-                    var lastState = state;
+                    if (state == value)
+                        return;
 
+                    var lastState = state;
                     state = value;
 
                     scheduledHide?.Cancel();
@@ -164,6 +168,8 @@ namespace osu.Game.Screens.Play
                             this.FadeOut(1000, Easing.OutExpo);
                             break;
                     }
+
+                    StateChanged?.Invoke(State);
                 }
             }
 

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework;
@@ -170,6 +171,8 @@ namespace osu.Game.Screens.Play
             private const float padding = 2;
             public const float WIDTH = cube_size + padding;
 
+            public event Action<ColumnState> StateChanged;
+
             private readonly List<Box> drawableRows = new List<Box>();
 
             private float filled;
@@ -186,6 +189,7 @@ namespace osu.Game.Screens.Play
             }
 
             private ColumnState state;
+
             public ColumnState State
             {
                 get { return state; }
@@ -196,6 +200,8 @@ namespace osu.Game.Screens.Play
 
                     if (IsLoaded)
                         fillActive();
+
+                    StateChanged?.Invoke(State);
                 }
             }
 

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
@@ -20,6 +21,8 @@ namespace osu.Game.Screens.Select.Leaderboards
     public class LeaderboardScore : OsuClickableContainer, IStateful<Visibility>
     {
         public static readonly float HEIGHT = 60;
+
+        public event Action<Visibility> StateChanged;
 
         public readonly int RankPosition;
         public readonly Score Score;
@@ -41,11 +44,14 @@ namespace osu.Game.Screens.Select.Leaderboards
         private readonly FillFlowContainer<ScoreModIcon> modsContainer;
 
         private Visibility state;
+
         public Visibility State
         {
             get { return state; }
             set
             {
+                if (state == value)
+                    return;
                 state = value;
 
                 switch (state)
@@ -88,6 +94,8 @@ namespace osu.Game.Screens.Select.Leaderboards
 
                         break;
                 }
+
+                StateChanged?.Invoke(State);
             }
         }
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/1013

Accomplishes two things:
1. Implements the new `StateChanged` event on all `IStateful` implementations.
2. Updates OsuMenu/OsuDropdownMenu in-line with osu-framework Menu changes.