### PR TITLE
Fix taiko accuracy starting at 0% instead of 100%

### DIFF
--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -268,6 +268,7 @@ namespace osu.Game.Rulesets.Taiko.Scoring
             base.Reset();
 
             Health.Value = 0;
+            Accuracy.Value = 1;
 
             bonusScore = 0;
             comboPortion = 0;


### PR DESCRIPTION
Accuracy is stuck at 0% until a GOOD or a MISS happens.