### PR TITLE
Fix startup crash on mono.

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Graphics.UserInterface
             protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableOsuDropdownMenuItem(item) { AccentColour = accentColour };
 
             #region DrawableOsuDropdownMenuItem
-            protected class DrawableOsuDropdownMenuItem : DrawableDropdownMenuItem, IHasAccentColour
+            public class DrawableOsuDropdownMenuItem : DrawableDropdownMenuItem, IHasAccentColour
             {
                 private Color4? accentColour;
                 public Color4 AccentColour


### PR DESCRIPTION
Fixes `MethodAccessException` thrown in constructor of `DrawableOsuTabDropdownMenuItem` on Mono 5.2.0.215, as reported in #1204 

- [x] Depends on ppy/osu-framework#1022