### PR TITLE
Direct results maintain download status between switching views

### DIFF
--- a/osu.Desktop.Tests/Visual/TestCaseDirect.cs
+++ b/osu.Desktop.Tests/Visual/TestCaseDirect.cs
@@ -41,12 +41,14 @@ namespace osu.Desktop.Tests.Visual
             {
                 new BeatmapSetInfo
                 {
+                    OnlineBeatmapSetID = 578332,
                     Metadata = new BeatmapMetadata
                     {
                         Title = @"OrVid",
                         Artist = @"An",
                         Author = @"RLC",
                         Source = @"",
+                        Tags = @"acuticnotes an-fillnote revid tear tearvid encrpted encryption axi axivid quad her hervid recoll",
                     },
                     OnlineInfo = new BeatmapSetOnlineInfo
                     {
@@ -71,12 +73,14 @@ namespace osu.Desktop.Tests.Visual
                 },
                 new BeatmapSetInfo
                 {
+                    OnlineBeatmapSetID = 599627,
                     Metadata = new BeatmapMetadata
                     {
                         Title = @"tiny lamp",
                         Artist = @"fhana",
                         Author = @"Sotarks",
                         Source = @"ぎんぎつね",
+                        Tags = @"lantis junichi sato yuxuki waga kevin mitsunaga towana gingitsune opening op full ver version kalibe collab collaboration",
                     },
                     OnlineInfo = new BeatmapSetOnlineInfo
                     {
@@ -101,12 +105,14 @@ namespace osu.Desktop.Tests.Visual
                 },
                 new BeatmapSetInfo
                 {
+                    OnlineBeatmapSetID = 513268,
                     Metadata = new BeatmapMetadata
                     {
                         Title = @"At Gwanghwamun",
                         Artist = @"KYUHYUN",
                         Author = @"Cerulean Veyron",
                         Source = @"",
+                        Tags = @"soul ballad kh super junior sj suju 슈퍼주니어 kt뮤직 sm엔터테인먼트 s.m.entertainment kt music 1st mini album ep",
                     },
                     OnlineInfo = new BeatmapSetOnlineInfo
                     {
@@ -146,12 +152,14 @@ namespace osu.Desktop.Tests.Visual
                 },
                 new BeatmapSetInfo
                 {
+                    OnlineBeatmapSetID = 586841,
                     Metadata = new BeatmapMetadata
                     {
                         Title = @"RHAPSODY OF BLUE SKY",
                         Artist = @"fhana",
                         Author = @"[Kamiya]",
                         Source = @"小林さんちのメイドラゴン",
+                        Tags = @"kobayashi san chi no maidragon aozora no opening anime maid dragon oblivion karen dynamix imoutosan pata-mon gxytcgxytc",
                     },
                     OnlineInfo = new BeatmapSetOnlineInfo
                     {

--- a/osu.Desktop.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Desktop.Tests/Visual/TestCasePlaySongSelect.cs
@@ -32,7 +32,7 @@ namespace osu.Desktop.Tests.Visual
                 backingDatabase.CreateTable<StoreVersion>();
 
                 rulesets = new RulesetStore(backingDatabase);
-                manager = new BeatmapManager(storage, null, backingDatabase, rulesets);
+                manager = new BeatmapManager(storage, null, backingDatabase, rulesets, null);
 
                 for (int i = 0; i < 100; i += 10)
                     manager.Import(createTestBeatmapSet(i));

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -188,9 +188,9 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Download a beatmap
+        /// Downloads a beatmap.
         /// </summary>
-        /// <param name="beatmapSetInfo">The beatmap to be downloaded</param>
+        /// <param name="beatmapSetInfo">The <see cref="BeatmapSetInfo"/> to be downloaded.</param>
         /// <returns>The new <see cref="DownloadBeatmapSetRequest"/>, or null if a download already exists for the same beatmap.</returns>
         public DownloadBeatmapSetRequest Download(BeatmapSetInfo beatmapSetInfo)
         {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Beatmaps
 
         private readonly APIAccess api;
 
-        private readonly List<DownloadBeatmapSetRequest> currentDownloads;
+        private readonly List<DownloadBeatmapSetRequest> currentDownloads = new List<DownloadBeatmapSetRequest>();
 
         // ReSharper disable once NotAccessedField.Local (we should keep a reference to this so it is not finalised)
         private BeatmapIPCChannel ipc;
@@ -99,8 +99,6 @@ namespace osu.Game.Beatmaps
 
             if (importHost != null)
                 ipc = new BeatmapIPCChannel(importHost, this);
-
-            currentDownloads = new List<DownloadBeatmapSetRequest>();
         }
 
         /// <summary>
@@ -194,7 +192,7 @@ namespace osu.Game.Beatmaps
         /// <returns>A new <see cref="DownloadBeatmapSetRequest"/>, or an existing one if a download is already in progress.</returns>
         public DownloadBeatmapSetRequest Download(BeatmapSetInfo beatmapSetInfo)
         {
-            var existing = currentDownloads.Find(d => d.BeatmapSet.OnlineBeatmapSetID == beatmapSetInfo.OnlineBeatmapSetID);
+            var existing = GetExistingDownload(beatmapSetInfo);
 
             if (existing != null) return existing;
 
@@ -243,7 +241,6 @@ namespace osu.Game.Beatmaps
             PostNotification?.Invoke(downloadNotification);
 
             // don't run in the main api queue as this is a long-running task.
-            // TODO: ensure the Success/Failure callbacks are being scheduled to the main thread for thread safety.
             Task.Run(() => request.Perform(api));
 
             return request;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -191,11 +191,14 @@ namespace osu.Game.Beatmaps
         /// Downloads a beatmap.
         /// </summary>
         /// <param name="beatmapSetInfo">The <see cref="BeatmapSetInfo"/> to be downloaded.</param>
-        /// <returns>The new <see cref="DownloadBeatmapSetRequest"/>, or null if a download already exists for the same beatmap.</returns>
+        /// <returns>A new <see cref="DownloadBeatmapSetRequest"/>, or an existing one if a download is already in progress.</returns>
         public DownloadBeatmapSetRequest Download(BeatmapSetInfo beatmapSetInfo)
         {
-            if (api == null || downloadsList.Find(d => d.BeatmapSet.OnlineBeatmapSetID == beatmapSetInfo.OnlineBeatmapSetID) != null)
-                return null;
+            var existing = downloadsList.Find(d => d.BeatmapSet.OnlineBeatmapSetID == beatmapSetInfo.OnlineBeatmapSetID);
+
+            if (existing != null) return existing;
+
+            if (api == null) return null;
 
             ProgressNotification downloadNotification = new ProgressNotification
             {

--- a/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
@@ -1,4 +1,7 @@
-﻿using osu.Game.Beatmaps;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Game.Beatmaps;
 using System;
 
 namespace osu.Game.Online.API.Requests

--- a/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
@@ -8,17 +8,17 @@ namespace osu.Game.Online.API.Requests
 {
     public class DownloadBeatmapSetRequest : APIDownloadRequest
     {
-        private readonly BeatmapSetInfo beatmapSet;
+        public readonly BeatmapSetInfo BeatmapSet;
 
         public Action<float> DownloadProgressed;
 
-        public DownloadBeatmapSetRequest(BeatmapSetInfo beatmapSet)
+        public DownloadBeatmapSetRequest(BeatmapSetInfo set)
         {
-            this.beatmapSet = beatmapSet;
+            BeatmapSet = set;
 
             Progress += (current, total) => DownloadProgressed?.Invoke((float) current / total);
         }
 
-        protected override string Target => $@"beatmapsets/{beatmapSet.OnlineBeatmapSetID}/download";
+        protected override string Target => $@"beatmapsets/{BeatmapSet.OnlineBeatmapSetID}/download";
     }
 }

--- a/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
@@ -1,0 +1,21 @@
+﻿using osu.Game.Beatmaps;
+using System;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class DownloadBeatmapSetRequest : APIDownloadRequest
+    {
+        private readonly BeatmapSetInfo beatmapSet;
+
+        public Action<float> DownloadProgressed;
+
+        public DownloadBeatmapSetRequest(BeatmapSetInfo beatmapSet)
+        {
+            this.beatmapSet = beatmapSet;
+
+            Progress += (current, total) => DownloadProgressed?.Invoke((float) current / total);
+        }
+
+        protected override string Target => $@"beatmapsets/{beatmapSet.OnlineBeatmapSetID}/download";
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -106,9 +106,15 @@ namespace osu.Game
 
             connection.CreateTable<StoreVersion>();
 
+            dependencies.Cache(API = new APIAccess
+            {
+                Username = LocalConfig.Get<string>(OsuSetting.Username),
+                Token = LocalConfig.Get<string>(OsuSetting.Token)
+            });
+
             dependencies.Cache(RulesetStore = new RulesetStore(connection));
             dependencies.Cache(FileStore = new FileStore(connection, Host.Storage));
-            dependencies.Cache(BeatmapManager = new BeatmapManager(Host.Storage, FileStore, connection, RulesetStore, Host));
+            dependencies.Cache(BeatmapManager = new BeatmapManager(Host.Storage, FileStore, connection, RulesetStore, API, Host));
             dependencies.Cache(ScoreStore = new ScoreStore(Host.Storage, connection, Host, BeatmapManager, RulesetStore));
             dependencies.Cache(KeyBindingStore = new KeyBindingStore(connection, RulesetStore));
             dependencies.Cache(new OsuColour());
@@ -143,12 +149,6 @@ namespace osu.Game
             var defaultBeatmap = new DummyWorkingBeatmap(this);
             Beatmap = new NonNullableBindable<WorkingBeatmap>(defaultBeatmap);
             BeatmapManager.DefaultBeatmap = defaultBeatmap;
-
-            dependencies.Cache(API = new APIAccess
-            {
-                Username = LocalConfig.Get<string>(OsuSetting.Username),
-                Token = LocalConfig.Get<string>(OsuSetting.Token)
-            });
 
             Beatmap.ValueChanged += b =>
             {

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -60,13 +60,7 @@ namespace osu.Game.Overlays.Direct
                     Logger.Error(e, "Failed to get beatmap download information");
                 };
 
-                downloadRequest.Progress += (current, total) =>
-                {
-                    float progress = (float)current / total;
-
-                    progressBar.Current.Value = progress;
-
-                };
+                downloadRequest.DownloadProgressed += progress => progressBar.Current.Value = progress;
 
                 downloadRequest.Success += data =>
                 {

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Overlays.Direct
             get { return downloadRequest; }
             set
             {
-                if (value == null) return;
+                if (value == null || downloadRequest == value) return;
 
                 downloadRequest = value;
 

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
-using System.IO;
-using System.Threading.Tasks;
 using OpenTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,7 +18,6 @@ using osu.Framework.Input;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Framework.Logging;
-using osu.Game.Beatmaps.IO;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Online.API.Requests;
 
@@ -175,7 +172,6 @@ namespace osu.Game.Overlays.Direct
                        .MoveToX(5, 100, Easing.InOutSine).Then()
                        .MoveToX(-5, 100, Easing.InOutSine).Then()
                        .MoveToX(0, 50, Easing.InSine).Then();
-                return;
             }
         }
 

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -160,13 +160,17 @@ namespace osu.Game.Overlays.Direct
             }
 
             // we already have an active download running.
-            if ((DownloadRequest = beatmaps.Download(SetInfo)) == null)
+            if (beatmaps.GetExistingDownload(SetInfo) != null)
             {
                 content.MoveToX(-5, 50, Easing.OutSine).Then()
                        .MoveToX(5, 100, Easing.InOutSine).Then()
                        .MoveToX(-5, 100, Easing.InOutSine).Then()
                        .MoveToX(0, 50, Easing.InSine).Then();
+
+                return;
             }
+
+            DownloadRequest = beatmaps.Download(SetInfo);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Overlays
         {
             // if a new map was imported, we should remove it from search results (download completed etc.)
             panels?.FirstOrDefault(p => p.SetInfo.OnlineBeatmapSetID == set.OnlineBeatmapSetID)?.FadeOut(400).Expire();
-            BeatmapSets = BeatmapSets.Where(b => b.OnlineBeatmapSetID != set.OnlineBeatmapSetID);
+            BeatmapSets = BeatmapSets?.Where(b => b.OnlineBeatmapSetID != set.OnlineBeatmapSetID);
         }
 
         private void updateResultCounts()

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -63,6 +63,10 @@ namespace osu.Game.Overlays
                 }
 
                 ResultAmounts = new ResultCounts(distinctCount(artists), distinctCount(songs), distinctCount(tags));
+
+                if (beatmapSets.Any() && panels == null)
+                    // real use case? currently only seems to be for test case
+                    recreatePanels(Filter.DisplayStyleControl.DisplayStyle.Value);
             }
         }
 
@@ -256,7 +260,7 @@ namespace osu.Game.Overlays
             {
                 BeatmapSets = r?.
                                 Select(response => response.ToBeatmapSet(rulesets)).
-                                Where(b => (beatmaps.QueryBeatmapSet(q => q.OnlineBeatmapSetID == b.OnlineBeatmapSetID) == null));
+                                Where(b => beatmaps.QueryBeatmapSet(q => q.OnlineBeatmapSetID == b.OnlineBeatmapSetID) == null);
 
                 recreatePanels(Filter.DisplayStyleControl.DisplayStyle.Value);
             };

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Overlays
 
         private APIAccess api;
         private RulesetStore rulesets;
+        private BeatmapManager beatmaps;
 
         private readonly FillFlowContainer resultCountsContainer;
         private readonly OsuSpriteText resultCountsText;
@@ -147,6 +148,8 @@ namespace osu.Game.Overlays
         {
             this.api = api;
             this.rulesets = rulesets;
+            this.beatmaps = beatmaps;
+
             resultCountsContainer.Colour = colours.Yellow;
 
             beatmaps.BeatmapSetAdded += setAdded;
@@ -237,7 +240,10 @@ namespace osu.Game.Overlays
 
             getSetsRequest.Success += r =>
             {
-                BeatmapSets = r?.Select(response => response.ToBeatmapSet(rulesets));
+                BeatmapSets = r?.
+                                Select(response => response.ToBeatmapSet(rulesets)).
+                                Where(b => (beatmaps.QueryBeatmapSet(q => q.OnlineBeatmapSetID == b.OnlineBeatmapSetID) == null));
+
                 if (BeatmapSets == null) return;
 
                 var artists = new List<string>();

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -47,9 +47,22 @@ namespace osu.Game.Overlays
             set
             {
                 if (beatmapSets?.Equals(value) ?? false) return;
+
                 beatmapSets = value;
 
-                recreatePanels(Filter.DisplayStyleControl.DisplayStyle.Value);
+                if (beatmapSets == null) return;
+
+                var artists = new List<string>();
+                var songs = new List<string>();
+                var tags = new List<string>();
+                foreach (var s in beatmapSets)
+                {
+                    artists.Add(s.Metadata.Artist);
+                    songs.Add(s.Metadata.Title);
+                    tags.AddRange(s.Metadata.Tags.Split(' '));
+                }
+
+                ResultAmounts = new ResultCounts(distinctCount(artists), distinctCount(songs), distinctCount(tags));
             }
         }
 
@@ -159,6 +172,7 @@ namespace osu.Game.Overlays
         {
             // if a new map was imported, we should remove it from search results (download completed etc.)
             panels?.FirstOrDefault(p => p.SetInfo.OnlineBeatmapSetID == set.OnlineBeatmapSetID)?.FadeOut(400).Expire();
+            BeatmapSets = BeatmapSets.Where(b => b.OnlineBeatmapSetID != set.OnlineBeatmapSetID);
         }
 
         private void updateResultCounts()
@@ -244,19 +258,7 @@ namespace osu.Game.Overlays
                                 Select(response => response.ToBeatmapSet(rulesets)).
                                 Where(b => (beatmaps.QueryBeatmapSet(q => q.OnlineBeatmapSetID == b.OnlineBeatmapSetID) == null));
 
-                if (BeatmapSets == null) return;
-
-                var artists = new List<string>();
-                var songs = new List<string>();
-                var tags = new List<string>();
-                foreach (var s in BeatmapSets)
-                {
-                    artists.Add(s.Metadata.Artist);
-                    songs.Add(s.Metadata.Title);
-                    tags.AddRange(s.Metadata.Tags.Split(' '));
-                }
-
-                ResultAmounts = new ResultCounts(distinctCount(artists), distinctCount(songs), distinctCount(tags));
+                recreatePanels(Filter.DisplayStyleControl.DisplayStyle.Value);
             };
 
             api.Queue(getSetsRequest);

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Input\Bindings\GlobalKeyBindingInputManager.cs" />
     <Compile Include="IO\FileStore.cs" />
     <Compile Include="IO\FileInfo.cs" />
+    <Compile Include="Online\API\Requests\DownloadBeatmapSetRequest.cs" />
     <Compile Include="Online\API\Requests\GetUsersRequest.cs" />
     <Compile Include="Online\API\Requests\PostMessageRequest.cs" />
     <Compile Include="Online\Chat\ErrorMessage.cs" />


### PR DESCRIPTION
Also:
- Moves the download logic to `BeatmapManager` (there was a TODO for this somewhere (?))
- Updates result counts when a downloaded beatmap is removed from results
- Filters results to not show beatmaps that are already added