### PR TITLE
Update osu!mania notes + hold notes with glows

### DIFF
--- a/osu.Desktop.Tests/Visual/TestCaseManiaHitObjects.cs
+++ b/osu.Desktop.Tests/Visual/TestCaseManiaHitObjects.cs
@@ -41,8 +41,22 @@ namespace osu.Desktop.Tests.Visual
                                 RelativeChildSize = new Vector2(1, 10000),
                                 Children = new[]
                                 {
-                                    new DrawableNote(new Note { StartTime = 5000 }, ManiaAction.Key1) { AccentColour = Color4.Red },
-                                    new DrawableNote(new Note { StartTime = 6000 }, ManiaAction.Key1) { AccentColour = Color4.Red }
+                                    new DrawableNote(new Note(), ManiaAction.Key1)
+                                    {
+                                        RelativePositionAxes = Axes.Y,
+                                        Y = 5000,
+                                        LifetimeStart = double.MinValue,
+                                        LifetimeEnd = double.MaxValue,
+                                        AccentColour = Color4.Red
+                                    },
+                                    new DrawableNote(new Note(), ManiaAction.Key1)
+                                    {
+                                        RelativePositionAxes = Axes.Y,
+                                        Y = 6000,
+                                        LifetimeStart = double.MinValue,
+                                        LifetimeEnd = double.MaxValue,
+                                        AccentColour = Color4.Red
+                                    }
                                 }
                             }
                         }
@@ -63,11 +77,15 @@ namespace osu.Desktop.Tests.Visual
                                 RelativeChildSize = new Vector2(1, 10000),
                                 Children = new[]
                                 {
-                                    new DrawableHoldNote(new HoldNote
+                                    new DrawableHoldNote(new HoldNote(), ManiaAction.Key1)
                                     {
-                                        StartTime = 5000,
-                                        Duration = 1000
-                                    }, ManiaAction.Key1) { AccentColour = Color4.Red }
+                                        RelativePositionAxes = Axes.Y,
+                                        Y = 5000,
+                                        Height = 3000,
+                                        LifetimeStart = double.MinValue,
+                                        LifetimeEnd = double.MaxValue,
+                                        AccentColour = Color4.Red
+                                    }
                                 }
                             }
                         }

--- a/osu.Desktop.Tests/Visual/TestCaseManiaHitObjects.cs
+++ b/osu.Desktop.Tests/Visual/TestCaseManiaHitObjects.cs
@@ -43,7 +43,6 @@ namespace osu.Desktop.Tests.Visual
                                 {
                                     new DrawableNote(new Note(), ManiaAction.Key1)
                                     {
-                                        RelativePositionAxes = Axes.Y,
                                         Y = 5000,
                                         LifetimeStart = double.MinValue,
                                         LifetimeEnd = double.MaxValue,
@@ -51,7 +50,6 @@ namespace osu.Desktop.Tests.Visual
                                     },
                                     new DrawableNote(new Note(), ManiaAction.Key1)
                                     {
-                                        RelativePositionAxes = Axes.Y,
                                         Y = 6000,
                                         LifetimeStart = double.MinValue,
                                         LifetimeEnd = double.MaxValue,
@@ -79,9 +77,8 @@ namespace osu.Desktop.Tests.Visual
                                 {
                                     new DrawableHoldNote(new HoldNote(), ManiaAction.Key1)
                                     {
-                                        RelativePositionAxes = Axes.Y,
                                         Y = 5000,
-                                        Height = 3000,
+                                        Height = 1000,
                                         LifetimeStart = double.MinValue,
                                         LifetimeEnd = double.MaxValue,
                                         AccentColour = Color4.Red

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -207,6 +207,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 RelativePositionAxes = Axes.None;
                 Y = 0;
 
+                // Life time managed by the parent DrawableHoldNote
+                LifetimeStart = double.MinValue;
+                LifetimeEnd = double.MaxValue;
+
                 HasOwnGlow = false;
             }
 
@@ -245,6 +249,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
                 RelativePositionAxes = Axes.None;
                 Y = 0;
+
+                // Life time managed by the parent DrawableHoldNote
+                LifetimeStart = double.MinValue;
+                LifetimeEnd = double.MaxValue;
 
                 HasOwnGlow = false;
             }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -45,9 +45,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
             AddRange(new Drawable[]
             {
-                // For now the body piece covers the entire height of the container
-                // whereas possibly in the future we don't want to extend under the head/tail.
-                // This will be fixed when new designs are given or the current design is finalized.
                 bodyPiece = new BodyPiece
                 {
                     Anchor = Anchor.TopCentre,

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 LifetimeStart = double.MinValue;
                 LifetimeEnd = double.MaxValue;
 
-                HasOwnGlow = false;
+                ApplyGlow = false;
             }
 
             public override bool OnPressed(ManiaAction action)
@@ -251,7 +251,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 LifetimeStart = double.MinValue;
                 LifetimeEnd = double.MaxValue;
 
-                HasOwnGlow = false;
+                ApplyGlow = false;
             }
 
             protected override ManiaJudgement CreateJudgement() => new HoldNoteTailJudgement();

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
+                    RelativeSizeAxes = Axes.X,
                 },
                 tickContainer = new Container<DrawableHoldNoteTick>
                 {
@@ -102,6 +103,14 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected override void UpdateState(ArmedState state)
         {
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            bodyPiece.Y = head.Height;
+            bodyPiece.Height = DrawHeight - head.Height;
         }
 
         public bool OnPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -70,6 +70,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.TopCentre
                 },
+                // The hit object itself cannot be used for the glow because the tail overshoots it
+                // So a specialized container that is updated to contain the tail height is used
                 glowContainer = new Container
                 {
                     RelativeSizeAxes = Axes.X,
@@ -98,6 +100,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             AddNested(tail);
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            updateGlow();
+        }
+
         public override Color4 AccentColour
         {
             get { return base.AccentColour; }
@@ -112,7 +121,23 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 bodyPiece.AccentColour = value;
                 head.AccentColour = value;
                 tail.AccentColour = value;
+
+                updateGlow();
             }
+        }
+
+        private void updateGlow()
+        {
+            if (!IsLoaded)
+                return;
+
+            glowContainer.EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Colour = AccentColour.Opacity(0.5f),
+                Radius = 10,
+                Hollow = true
+            };
         }
 
         protected override void UpdateState(ArmedState state)
@@ -123,17 +148,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             base.Update();
 
+            // Make the body piece not lie under the head note
             bodyPiece.Y = head.Height;
             bodyPiece.Height = DrawHeight - head.Height;
 
+            // Make the glowContainer "contain" the height of the tail note, keeping in mind
+            // that the tail note overshoots the height of this hit object
             glowContainer.Height = DrawHeight + tail.Height;
-            glowContainer.EdgeEffect = new EdgeEffectParameters
-            {
-                Type = EdgeEffectType.Glow,
-                Colour = AccentColour.Opacity(0.5f),
-                Radius = 10,
-                Hollow = true,
-            };
         }
 
         public bool OnPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
@@ -9,6 +10,7 @@ using OpenTK;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
@@ -23,6 +25,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         private readonly BodyPiece bodyPiece;
         private readonly Container<DrawableHoldNoteTick> tickContainer;
+        private readonly Container glowContainer;
 
         /// <summary>
         /// Time at which the user started holding this hold note. Null if the user is not holding this hold note.
@@ -66,6 +69,17 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 {
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.TopCentre
+                },
+                glowContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Masking = true,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0,
+                        AlwaysPresent = true
+                    }
                 }
             });
 
@@ -111,6 +125,15 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
             bodyPiece.Y = head.Height;
             bodyPiece.Height = DrawHeight - head.Height;
+
+            glowContainer.Height = DrawHeight + tail.Height;
+            glowContainer.EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Colour = AccentColour.Opacity(0.5f),
+                Radius = 10,
+                Hollow = true,
+            };
         }
 
         public bool OnPressed(ManiaAction action)
@@ -162,6 +185,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
                 RelativePositionAxes = Axes.None;
                 Y = 0;
+
+                HasOwnGlow = false;
             }
 
             public override bool OnPressed(ManiaAction action)
@@ -199,6 +224,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
                 RelativePositionAxes = Axes.None;
                 Y = 0;
+
+                HasOwnGlow = false;
             }
 
             protected override ManiaJudgement CreateJudgement() => new HoldNoteTailJudgement();

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {
@@ -22,11 +23,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         /// References the time at which the user started holding the hold note.
         /// </summary>
         public Func<double?> HoldStartTime;
-
-        /// <summary>
-        /// References whether the user is currently holding the hold note.
-        /// </summary>
-        public Func<bool> IsHolding;
 
         private readonly Container glowContainer;
 
@@ -118,7 +114,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (Judgement.Result != HitResult.None)
                 return;
 
-            if (IsHolding?.Invoke() != true)
+            if (HoldStartTime?.Invoke() == null)
                 return;
 
             UpdateJudgement(true);

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -36,8 +36,14 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;
 
+            Y = (float)HitObject.StartTime;
+
             RelativeSizeAxes = Axes.X;
             Size = new Vector2(1);
+
+            // Life time managed by the parent DrawableHoldNote
+            LifetimeStart = double.MinValue;
+            LifetimeEnd = double.MaxValue;
 
             Children = new[]
             {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using osu.Framework.Graphics;
 using OpenTK.Graphics;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -20,6 +21,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         protected DrawableManiaHitObject(TObject hitObject, ManiaAction? action = null)
             : base(hitObject)
         {
+            RelativePositionAxes = Axes.Y;
             HitObject = hitObject;
 
             if (action != null)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using osu.Framework.Extensions.Color4Extensions;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
@@ -16,6 +18,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public class DrawableNote : DrawableManiaHitObject<Note>, IKeyBindingHandler<ManiaAction>
     {
+        /// <summary>
+        /// Whether the glow for this <see cref="DrawableNote"/> is handled by a <see cref="DrawableHitObject"/> containing it.
+        /// </summary>
+        protected bool HasOwnGlow = true;
+
         private readonly NotePiece headPiece;
 
         public DrawableNote(Note hitObject, ManiaAction action)
@@ -23,12 +30,20 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
+            Masking = true;
 
             Add(headPiece = new NotePiece
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre
             });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            UpdateGlow();
         }
 
         public override Color4 AccentColour
@@ -41,6 +56,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 base.AccentColour = value;
 
                 headPiece.AccentColour = value;
+
+                UpdateGlow();
             }
         }
 
@@ -77,6 +94,23 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     Colour = Color4.Green;
                     break;
             }
+        }
+
+        protected virtual void UpdateGlow()
+        {
+            if (!IsLoaded)
+                return;
+
+            if (!HasOwnGlow)
+                return;
+
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Colour = AccentColour.Opacity(0.5f),
+                Radius = 10,
+                Hollow = true
+            };
         }
 
         public virtual bool OnPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -19,9 +19,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     public class DrawableNote : DrawableManiaHitObject<Note>, IKeyBindingHandler<ManiaAction>
     {
         /// <summary>
-        /// Whether the glow for this <see cref="DrawableNote"/> is handled by a <see cref="DrawableHitObject"/> containing it.
+        /// Gets or sets whether this <see cref="DrawableNote"/> should apply glow to itself.
         /// </summary>
-        protected bool HasOwnGlow = true;
+        protected bool ApplyGlow = true;
 
         private readonly NotePiece headPiece;
 
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (!IsLoaded)
                 return;
 
-            if (!HasOwnGlow)
+            if (!ApplyGlow)
                 return;
 
             EdgeEffect = new EdgeEffectParameters

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             : base(hitObject, action)
         {
             RelativeSizeAxes = Axes.X;
-            Height = 100;
+            AutoSizeAxes = Axes.Y;
 
             Add(headPiece = new NotePiece
             {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             base.LoadComplete();
 
-            UpdateGlow();
+            updateGlow();
         }
 
         public override Color4 AccentColour
@@ -57,8 +57,25 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
                 headPiece.AccentColour = value;
 
-                UpdateGlow();
+                updateGlow();
             }
+        }
+
+        private void updateGlow()
+        {
+            if (!IsLoaded)
+                return;
+
+            if (!HasOwnGlow)
+                return;
+
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Colour = AccentColour.Opacity(0.5f),
+                Radius = 10,
+                Hollow = true
+            };
         }
 
         protected override void CheckJudgement(bool userTriggered)
@@ -94,23 +111,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     Colour = Color4.Green;
                     break;
             }
-        }
-
-        protected virtual void UpdateGlow()
-        {
-            if (!IsLoaded)
-                return;
-
-            if (!HasOwnGlow)
-                return;
-
-            EdgeEffect = new EdgeEffectParameters
-            {
-                Type = EdgeEffectType.Glow,
-                Colour = AccentColour.Opacity(0.5f),
-                Radius = 10,
-                Hollow = true
-            };
         }
 
         public virtual bool OnPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/BodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/BodyPiece.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables.Pieces
                             BackgroundColour = Color4.White.Opacity(0),
                             CacheDrawnFrameBuffer = true,
                             // The 'hole' is achieved by subtracting the result of this container with the parent
-                            Blending = new BlendingModeParameters { AlphaEquation = BlendingEquation.ReverseSubtract },
+                            Blending = new BlendingParameters { AlphaEquation = BlendingEquation.ReverseSubtract },
                             Child = subtractionLayer = new CircularContainer
                             {
                                 Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/BodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/BodyPiece.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
+using osu.Framework.Caching;
 using OpenTK.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -14,20 +17,59 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables.Pieces
     /// </summary>
     internal class BodyPiece : Container, IHasAccentColour
     {
-        private readonly Box box;
+        private readonly Container subtractionLayer;
+
+        private readonly Drawable background;
+        private readonly BufferedContainer foreground;
+        private readonly BufferedContainer subtractionContainer;
 
         public BodyPiece()
         {
-            RelativeSizeAxes = Axes.Both;
+            Blending = BlendingMode.Additive;
 
             Children = new[]
             {
-                box = new Box
+                background = new Box { RelativeSizeAxes = Axes.Both },
+                foreground = new BufferedContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Alpha = 0.3f
+                    CacheDrawnFrameBuffer = true,
+                    Children = new Drawable[]
+                    {
+                        new Box { RelativeSizeAxes = Axes.Both },
+                        subtractionContainer = new BufferedContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            // This is needed because we're blending with another object
+                            BackgroundColour = Color4.White.Opacity(0),
+                            CacheDrawnFrameBuffer = true,
+                            // The 'hole' is achieved by subtracting the result of this container with the parent
+                            Blending = new BlendingModeParameters { AlphaEquation = BlendingEquation.ReverseSubtract },
+                            Child = subtractionLayer = new CircularContainer
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                // Height computed in Update
+                                Width = 1,
+                                Masking = true,
+                                Child = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    AlwaysPresent = true
+                                }
+                            }
+                        }
+                    }
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            updateAccentColour();
         }
 
         private Color4 accentColour;
@@ -40,8 +82,51 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables.Pieces
                     return;
                 accentColour = value;
 
-                box.Colour = accentColour;
+                updateAccentColour();
             }
+        }
+
+        private Cached subtractionCache = new Cached();
+
+        public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
+        {
+            if ((invalidation & Invalidation.DrawSize) > 0)
+                subtractionCache.Invalidate();
+
+            return base.Invalidate(invalidation, source, shallPropagate);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!subtractionCache.IsValid)
+            {
+                subtractionLayer.Width = 5;
+                subtractionLayer.Height = Math.Max(0, DrawHeight - DrawWidth);
+                subtractionLayer.EdgeEffect = new EdgeEffectParameters
+                {
+                    Colour = Color4.White,
+                    Type = EdgeEffectType.Glow,
+                    Radius = DrawWidth
+                };
+
+                foreground.ForceRedraw();
+                subtractionContainer.ForceRedraw();
+
+                subtractionCache.Validate();
+            }
+        }
+
+        private void updateAccentColour()
+        {
+            if (!IsLoaded)
+                return;
+
+            foreground.Colour = AccentColour.Opacity(0.4f);
+            background.Colour = AccentColour.Opacity(0.2f);
+
+            subtractionCache.Invalidate();
         }
     }
 }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -12,10 +12,11 @@ using osu.Game.Rulesets.Objects.Types;
 using OpenTK.Graphics;
 using osu.Game.Audio;
 using System.Linq;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Objects.Drawables
 {
-    public abstract class DrawableHitObject : Container
+    public abstract class DrawableHitObject : Container, IHasAccentColour
     {
         public readonly HitObject HitObject;
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/1231

Might not be the final design, but at least it's a bit more readable now (especially hold notes). Also includes glow for normal notes.