### PR TITLE
Initial implementation of osu!mania hit explosions

### DIFF
--- a/osu.Desktop.Tests/Visual/TestCaseManiaPlayfield.cs
+++ b/osu.Desktop.Tests/Visual/TestCaseManiaPlayfield.cs
@@ -16,7 +16,6 @@ using osu.Game.Rulesets.Timing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
-using OpenTK.Graphics;
 
 namespace osu.Desktop.Tests.Visual
 {

--- a/osu.Desktop.Tests/Visual/TestCaseManiaPlayfield.cs
+++ b/osu.Desktop.Tests/Visual/TestCaseManiaPlayfield.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -32,6 +33,8 @@ namespace osu.Desktop.Tests.Visual
 
         public TestCaseManiaPlayfield()
         {
+            var rng = new Random(1337);
+
             AddStep("1 column", () => createPlayfield(1, SpecialColumnPosition.Normal));
             AddStep("4 columns", () => createPlayfield(4, SpecialColumnPosition.Normal));
             AddStep("Left special style", () => createPlayfield(4, SpecialColumnPosition.Left));
@@ -51,10 +54,12 @@ namespace osu.Desktop.Tests.Visual
             {
                 var playfield = createPlayfield(4, SpecialColumnPosition.Normal);
 
-                var note = new DrawableNote(new Note(), ManiaAction.Key1)
+                int col = rng.Next(0, 4);
+
+                var note = new DrawableNote(new Note { Column = col }, ManiaAction.Key1)
                 {
                     Judgement = new ManiaJudgement { Result = HitResult.Hit },
-                    AccentColour = Color4.Green
+                    AccentColour = playfield.Columns.ElementAt(col).AccentColour
                 };
 
                 playfield.OnJudgement(note);

--- a/osu.Desktop.Tests/Visual/TestCaseManiaPlayfield.cs
+++ b/osu.Desktop.Tests/Visual/TestCaseManiaPlayfield.cs
@@ -13,6 +13,9 @@ using osu.Game.Rulesets.Mania.Timing;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Timing;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
+using OpenTK.Graphics;
 
 namespace osu.Desktop.Tests.Visual
 {
@@ -43,6 +46,19 @@ namespace osu.Desktop.Tests.Visual
             AddStep("Notes with input (reversed)", () => createPlayfieldWithNotes(false, true));
             AddStep("Notes with gravity", () => createPlayfieldWithNotes(true));
             AddStep("Notes with gravity (reversed)", () => createPlayfieldWithNotes(true, true));
+
+            AddStep("Hit explosion", () =>
+            {
+                var playfield = createPlayfield(4, SpecialColumnPosition.Normal);
+
+                var note = new DrawableNote(new Note(), ManiaAction.Key1)
+                {
+                    Judgement = new ManiaJudgement { Result = HitResult.Hit },
+                    AccentColour = Color4.Green
+                };
+
+                playfield.OnJudgement(note);
+            });
         }
 
         [BackgroundDependencyLoader]
@@ -56,7 +72,7 @@ namespace osu.Desktop.Tests.Visual
             TimingPoint = { BeatLength = 1000 }
         }, gravity ? ScrollingAlgorithm.Gravity : ScrollingAlgorithm.Basic);
 
-        private void createPlayfield(int cols, SpecialColumnPosition specialPos, bool inverted = false)
+        private ManiaPlayfield createPlayfield(int cols, SpecialColumnPosition specialPos, bool inverted = false)
         {
             Clear();
 
@@ -72,6 +88,8 @@ namespace osu.Desktop.Tests.Visual
             });
 
             playfield.Inverted.Value = inverted;
+
+            return playfield;
         }
 
         private void createPlayfieldWithNotes(bool gravity, bool inverted = false)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -58,9 +58,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     }
                 }
             };
-
-            // Set the default glow
-            AccentColour = Color4.White;
         }
 
         public override Color4 AccentColour

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -71,12 +71,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected override void UpdateState(ArmedState state)
         {
-            switch (State)
-            {
-                case ArmedState.Hit:
-                    Colour = Color4.Green;
-                    break;
-            }
         }
 
         public virtual bool OnPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -37,6 +37,17 @@ namespace osu.Game.Rulesets.Mania.Objects
             }
         }
 
+        public override int Column
+        {
+            get { return base.Column; }
+            set
+            {
+                base.Column = value;
+                Head.Column = value;
+                Tail.Column = value;
+            }
+        }
+
         /// <summary>
         /// The head note of the hold.
         /// </summary>

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -91,7 +91,8 @@ namespace osu.Game.Rulesets.Mania.Objects
             {
                 ret.Add(new HoldNoteTick
                 {
-                    StartTime = t
+                    StartTime = t,
+                    Column = Column
                 });
             }
 

--- a/osu.Game.Rulesets.Mania/Objects/ManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/ManiaHitObject.cs
@@ -8,6 +8,6 @@ namespace osu.Game.Rulesets.Mania.Objects
 {
     public abstract class ManiaHitObject : HitObject, IHasColumn
     {
-        public int Column { get; set; }
+        public virtual int Column { get; set; }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -36,6 +36,9 @@ namespace osu.Game.Rulesets.Mania.UI
         private readonly Container hitTargetBar;
         private readonly Container keyIcon;
 
+        internal readonly Container TopLevelContainer;
+        private readonly Container explosionContainer;
+
         protected override Container<Drawable> Content => content;
         private readonly Container<Drawable> content;
 
@@ -98,6 +101,11 @@ namespace osu.Game.Rulesets.Mania.UI
                         {
                             Pressed = onPressed,
                             Released = onReleased
+                        },
+                        explosionContainer = new Container
+                        {
+                            Name = "Hit explosions",
+                            RelativeSizeAxes = Axes.Both
                         }
                     }
                 },
@@ -136,8 +144,11 @@ namespace osu.Game.Rulesets.Mania.UI
                             }
                         }
                     }
-                }
+                },
+                TopLevelContainer = new Container { RelativeSizeAxes = Axes.Both }
             };
+
+            TopLevelContainer.Add(explosionContainer.CreateProxy());
         }
 
         public override Axes RelativeSizeAxes => Axes.Y;
@@ -192,6 +203,14 @@ namespace osu.Game.Rulesets.Mania.UI
         {
             hitObject.AccentColour = AccentColour;
             HitObjects.Add(hitObject);
+        }
+
+        public override void OnJudgement(DrawableHitObject<ManiaHitObject, ManiaJudgement> judgedObject)
+        {
+            if (judgedObject.Judgement.Result != HitResult.Hit)
+                return;
+
+            explosionContainer.Add(new HitExplosion(judgedObject));
         }
 
         private bool onPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
@@ -1,4 +1,7 @@
-﻿using OpenTK;
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
@@ -1,0 +1,55 @@
+﻿using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Mania.Judgements;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Mania.UI
+{
+    internal class HitExplosion : CompositeDrawable
+    {
+        private readonly Box inner;
+
+        public HitExplosion(DrawableHitObject<ManiaHitObject, ManiaJudgement> judgedObject)
+        {
+            Anchor = Anchor.TopCentre;
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+            FillMode = FillMode.Fit;
+
+            BlendingMode = BlendingMode.Additive;
+
+            InternalChild = new CircularContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Masking = true,
+                BorderThickness = 1,
+                BorderColour = judgedObject.AccentColour,
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Glow,
+                    Colour = judgedObject.AccentColour,
+                    Radius = 10,
+                    Hollow = true
+                },
+                Child = inner = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = judgedObject.AccentColour,
+                    Alpha = 1,
+                    AlwaysPresent = true,
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            this.ScaleTo(2f, 600, Easing.OutQuint).FadeOut(500);
+            inner.FadeOut(250);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mania.UI
             Size = new Vector2(isTick ? 0.5f : 1);
             FillMode = FillMode.Fit;
 
-            BlendingMode = BlendingMode.Additive;
+            Blending = BlendingMode.Additive;
 
             Color4 accent = isTick ? Color4.White : judgedObject.AccentColour;
 

--- a/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/HitExplosion.cs
@@ -1,8 +1,11 @@
-﻿using osu.Framework.Graphics;
+﻿using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Mania.UI
@@ -13,31 +16,36 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public HitExplosion(DrawableHitObject<ManiaHitObject, ManiaJudgement> judgedObject)
         {
+            bool isTick = judgedObject is DrawableHoldNoteTick;
+
             Anchor = Anchor.TopCentre;
             Origin = Anchor.Centre;
 
             RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(isTick ? 0.5f : 1);
             FillMode = FillMode.Fit;
 
             BlendingMode = BlendingMode.Additive;
+
+            Color4 accent = isTick ? Color4.White : judgedObject.AccentColour;
 
             InternalChild = new CircularContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Masking = true,
                 BorderThickness = 1,
-                BorderColour = judgedObject.AccentColour,
+                BorderColour = accent,
                 EdgeEffect = new EdgeEffectParameters
                 {
                     Type = EdgeEffectType.Glow,
-                    Colour = judgedObject.AccentColour,
+                    Colour = accent,
                     Radius = 10,
                     Hollow = true
                 },
                 Child = inner = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = judgedObject.AccentColour,
+                    Colour = accent,
                     Alpha = 1,
                     AlwaysPresent = true,
                 }

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -180,6 +180,8 @@ namespace osu.Game.Rulesets.Mania.UI
             }
         }
 
+        public override void OnJudgement(DrawableHitObject<ManiaHitObject, ManiaJudgement> judgedObject) => columns[judgedObject.HitObject.Column].OnJudgement(judgedObject);
+
         /// <summary>
         /// Whether the column index is a special column for this playfield.
         /// </summary>

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Rulesets.Mania.UI
         protected override Container<Drawable> Content => content;
         private readonly Container<Drawable> content;
 
+        private readonly Container topLevelContainer;
+
         private List<Color4> normalColumnColours = new List<Color4>();
         private Color4 specialColumnColour;
 
@@ -69,17 +71,16 @@ namespace osu.Game.Rulesets.Mania.UI
             {
                 new Container
                 {
+                    Name = "Playfield elements",
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    RelativeSizeAxes = Axes.Both,
-                    Masking = true,
+                    RelativeSizeAxes = Axes.Y,
+                    AutoSizeAxes = Axes.X,
                     Children = new Drawable[]
                     {
                         new Container
                         {
-                            Name = "Masked elements",
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
+                            Name = "Columns mask",
                             RelativeSizeAxes = Axes.Y,
                             AutoSizeAxes = Axes.X,
                             Masking = true,
@@ -87,6 +88,7 @@ namespace osu.Game.Rulesets.Mania.UI
                             {
                                 new Box
                                 {
+                                    Name = "Background",
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = Color4.Black
                                 },
@@ -98,27 +100,28 @@ namespace osu.Game.Rulesets.Mania.UI
                                     Direction = FillDirection.Horizontal,
                                     Padding = new MarginPadding { Left = 1, Right = 1 },
                                     Spacing = new Vector2(1, 0)
-                                }
+                                },
                             }
                         },
                         new Container
                         {
+                            Name = "Barlines mask",
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
-                            RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Top = HIT_TARGET_POSITION },
-                            Children = new[]
+                            RelativeSizeAxes = Axes.Y,
+                            Width = 1366, // Bar lines should only be masked on the vertical axis
+                            BypassAutoSizeAxes = Axes.Both,
+                            Masking = true,
+                            Child = content = new Container
                             {
-                                content = new Container
-                                {
-                                    Name = "Bar lines",
-                                    Anchor = Anchor.TopCentre,
-                                    Origin = Anchor.TopCentre,
-                                    RelativeSizeAxes = Axes.Y,
-                                    // Width is set in the Update method
-                                }
+                                Name = "Bar lines",
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                RelativeSizeAxes = Axes.Y,
+                                Padding = new MarginPadding { Top = HIT_TARGET_POSITION }
                             }
-                        }
+                        },
+                        topLevelContainer = new Container { RelativeSizeAxes = Axes.Both }
                     }
                 }
             };

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -14,6 +14,7 @@ using osu.Framework.Allocation;
 using System.Linq;
 using System.Collections.Generic;
 using osu.Framework.Configuration;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Framework.Graphics.Shapes;
@@ -50,8 +51,6 @@ namespace osu.Game.Rulesets.Mania.UI
         protected override Container<Drawable> Content => content;
         private readonly Container<Drawable> content;
 
-        private readonly Container topLevelContainer;
-
         private List<Color4> normalColumnColours = new List<Color4>();
         private Color4 specialColumnColour;
 
@@ -67,6 +66,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             Inverted.Value = true;
 
+            Container topLevelContainer;
             InternalChildren = new Drawable[]
             {
                 new Container
@@ -134,6 +134,8 @@ namespace osu.Game.Rulesets.Mania.UI
 
                 c.IsSpecial = isSpecialColumn(i);
                 c.Action = c.IsSpecial ? ManiaAction.Special : currentAction++;
+
+                topLevelContainer.Add(c.TopLevelContainer.CreateProxy());
 
                 columns.Add(c);
                 AddNested(c);

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -14,7 +14,6 @@ using osu.Framework.Allocation;
 using System.Linq;
 using System.Collections.Generic;
 using osu.Framework.Configuration;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+++ b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Timing\GravityScrollingContainer.cs" />
     <Compile Include="Timing\ScrollingAlgorithm.cs" />
     <Compile Include="UI\Column.cs" />
+    <Compile Include="UI\HitExplosion.cs" />
     <Compile Include="UI\ManiaRulesetContainer.cs" />
     <Compile Include="UI\ManiaPlayfield.cs" />
     <Compile Include="ManiaRuleset.cs" />

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <summary>
         /// The colour used for various elements of this DrawableHitObject.
         /// </summary>
-        public virtual Color4 AccentColour { get; set; }
+        public virtual Color4 AccentColour { get; set; } = Color4.Gray;
 
         protected DrawableHitObject(HitObject hitObject)
         {


### PR DESCRIPTION
Matches the column colour, except in the case of ticks which will be white and 50% the size. Ticks won't be visible/won't work without https://github.com/ppy/osu/pull/1233