### PR TITLE
Fix osu! logo triangles going super fast when the track is paused

### DIFF
--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -272,14 +272,22 @@ namespace osu.Game.Screens.Menu
 
             const float scale_adjust_cutoff = 0.4f;
             const float velocity_adjust_cutoff = 0.98f;
+            const float paused_velocity = 0.5f;
 
-            var maxAmplitude = lastBeatIndex >= 0 ? Beatmap.Value.Track?.CurrentAmplitudes.Maximum ?? 0 : 0;
-            logoAmplitudeContainer.ScaleTo(1 - Math.Max(0, maxAmplitude - scale_adjust_cutoff) * 0.04f, 75, Easing.OutQuint);
+            if (Beatmap.Value.Track.IsRunning)
+            {
+                var maxAmplitude = lastBeatIndex >= 0 ? Beatmap.Value.Track.CurrentAmplitudes.Maximum : 0;
+                logoAmplitudeContainer.ScaleTo(1 - Math.Max(0, maxAmplitude - scale_adjust_cutoff) * 0.04f, 75, Easing.OutQuint);
 
-            if (maxAmplitude > velocity_adjust_cutoff)
-                triangles.Velocity = 1 + Math.Max(0, maxAmplitude - velocity_adjust_cutoff) * 50;
+                if (maxAmplitude > velocity_adjust_cutoff)
+                    triangles.Velocity = 1 + Math.Max(0, maxAmplitude - velocity_adjust_cutoff) * 50;
+                else
+                    triangles.Velocity = (float)Interpolation.Damp(triangles.Velocity, 1, 0.995f, Time.Elapsed);
+            }
             else
-                triangles.Velocity = (float)Interpolation.Damp(triangles.Velocity, 1, 0.995f, Time.Elapsed);
+            {
+                triangles.Velocity = paused_velocity;
+            }
         }
 
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)


### PR DESCRIPTION
Seems to be Bass returning odd values for channel amplitudes, and possibly only on macOS.
Arbitrarily chose 0.5f as a paused velocity because it felt nice.
Also removed the optional chaining on `Beatmap.Value.Track` as it is guaranteed to return a value now.