### PR TITLE
Add more glows to osu!mania notes

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
-using osu.Framework.Extensions.Color4Extensions;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
@@ -18,10 +16,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public class DrawableNote : DrawableManiaHitObject<Note>, IKeyBindingHandler<ManiaAction>
     {
-        /// <summary>
-        /// Gets or sets whether this <see cref="DrawableNote"/> should apply glow to itself.
-        /// </summary>
-        protected bool ApplyGlow = true;
+        protected readonly GlowPiece GlowPiece;
 
         private readonly NotePiece headPiece;
 
@@ -31,19 +26,15 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Add(headPiece = new NotePiece
+            Children = new Drawable[]
             {
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.TopCentre,
-                Masking = true
-            });
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            updateGlow();
+                GlowPiece = new GlowPiece(),
+                headPiece = new NotePiece
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre
+                }
+            };
         }
 
         public override Color4 AccentColour
@@ -55,27 +46,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     return;
                 base.AccentColour = value;
 
+                GlowPiece.AccentColour = value;
                 headPiece.AccentColour = value;
-
-                updateGlow();
             }
-        }
-
-        private void updateGlow()
-        {
-            if (!IsLoaded)
-                return;
-
-            if (!ApplyGlow)
-                return;
-
-            headPiece.EdgeEffect = new EdgeEffectParameters
-            {
-                Type = EdgeEffectType.Glow,
-                Colour = AccentColour.Opacity(0.5f),
-                Radius = 10,
-                Hollow = true
-            };
         }
 
         protected override void CheckJudgement(bool userTriggered)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     {
         protected readonly GlowPiece GlowPiece;
 
+        private readonly LaneGlowPiece laneGlowPiece;
         private readonly NotePiece headPiece;
 
         public DrawableNote(Note hitObject, ManiaAction action)
@@ -28,6 +29,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
             Children = new Drawable[]
             {
+                laneGlowPiece = new LaneGlowPiece
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                },
                 GlowPiece = new GlowPiece(),
                 headPiece = new NotePiece
                 {
@@ -46,6 +52,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     return;
                 base.AccentColour = value;
 
+                laneGlowPiece.AccentColour = value;
                 GlowPiece.AccentColour = value;
                 headPiece.AccentColour = value;
             }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/GlowPiece.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/GlowPiece.cs
@@ -1,0 +1,62 @@
+﻿using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using OpenTK.Graphics;
+
+namespace osu.Game.Rulesets.Mania.Objects.Drawables.Pieces
+{
+    public class GlowPiece : CompositeDrawable, IHasAccentColour
+    {
+        private const float glow_alpha = 0.7f;
+        private const float glow_radius = 5;
+
+        public GlowPiece()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Masking = true;
+
+            InternalChild = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Alpha = 0,
+                AlwaysPresent = true
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateGlow();
+        }
+
+        private Color4 accentColour;
+        public Color4 AccentColour
+        {
+            get { return accentColour; }
+            set
+            {
+                if (accentColour == value)
+                    return;
+                accentColour = value;
+
+                updateGlow();
+            }
+        }
+
+        private void updateGlow()
+        {
+            if (!IsLoaded)
+                return;
+
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Colour = AccentColour.Opacity(glow_alpha),
+                Radius = glow_radius,
+                Hollow = true
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/GlowPiece.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/GlowPiece.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Extensions.Color4Extensions;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/LaneGlowPiece.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/LaneGlowPiece.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
 using OpenTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/LaneGlowPiece.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/Pieces/LaneGlowPiece.cs
@@ -1,0 +1,82 @@
+using OpenTK.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+
+namespace osu.Game.Rulesets.Mania.Objects.Drawables.Pieces
+{
+    public class LaneGlowPiece : CompositeDrawable, IHasAccentColour
+    {
+        private const float total_height = 100;
+        private const float glow_height = 50;
+        private const float glow_alpha = 0.4f;
+        private const float edge_alpha = 0.3f;
+
+        public LaneGlowPiece()
+        {
+            BypassAutoSizeAxes = Axes.Both;
+            RelativeSizeAxes = Axes.X;
+            Height = total_height;
+
+            InternalChildren = new[]
+            {
+                new Container
+                {
+                    Name = "Left edge",
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 1,
+                    Children = createGradient(edge_alpha)
+                },
+                new Container
+                {
+                    Name = "Right edge",
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 1,
+                    Children = createGradient(edge_alpha)
+                },
+                new Container
+                {
+                    Name = "Glow",
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.X,
+                    Height = glow_height,
+                    Children = createGradient(glow_alpha)
+                }
+            };
+        }
+
+        private Drawable[] createGradient(float alpha) => new Drawable[]
+        {
+            new Box
+            {
+                Name = "Top",
+                RelativeSizeAxes = Axes.Both,
+                Height = 0.5f,
+                Blending = BlendingMode.Additive,
+                Colour = ColourInfo.GradientVertical(Color4.Transparent, Color4.White.Opacity(alpha))
+            },
+            new Box
+            {
+                Name = "Bottom",
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                RelativeSizeAxes = Axes.Both,
+                Height = 0.5f,
+                Blending = BlendingMode.Additive,
+                Colour = ColourInfo.GradientVertical(Color4.White.Opacity(alpha), Color4.Transparent)
+            }
+        };
+
+        public Color4 AccentColour
+        {
+            get { return Colour; }
+            set { Colour = value; }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+++ b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Objects\Drawables\DrawableNote.cs" />
     <Compile Include="Objects\Drawables\Pieces\BodyPiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\GlowPiece.cs" />
+    <Compile Include="Objects\Drawables\Pieces\LaneGlowPiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\NotePiece.cs" />
     <Compile Include="Objects\Types\IHasColumn.cs" />
     <Compile Include="Scoring\ManiaScoreProcessor.cs" />

--- a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+++ b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Objects\Drawables\DrawableManiaHitObject.cs" />
     <Compile Include="Objects\Drawables\DrawableNote.cs" />
     <Compile Include="Objects\Drawables\Pieces\BodyPiece.cs" />
+    <Compile Include="Objects\Drawables\Pieces\GlowPiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\NotePiece.cs" />
     <Compile Include="Objects\Types\IHasColumn.cs" />
     <Compile Include="Scoring\ManiaScoreProcessor.cs" />

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
@@ -29,19 +29,5 @@ namespace osu.Game.Rulesets.Taiko.Objects
         /// Strong hit objects give more points for hitting the hit object with both keys.
         /// </summary>
         public bool IsStrong;
-
-        /// <summary>
-        /// Whether this HitObject is in Kiai time.
-        /// </summary>
-        public bool Kiai { get; protected set; }
-
-        public override void ApplyDefaults(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
-        {
-            base.ApplyDefaults(controlPointInfo, difficulty);
-
-            EffectControlPoint effectPoint = controlPointInfo.EffectPointAt(StartTime);
-
-            Kiai |= effectPoint.KiaiMode;
-        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Objects

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Rulesets.Objects
         public SampleInfoList Samples = new SampleInfoList();
 
         /// <summary>
+        /// Whether this <see cref="HitObject"/> is in Kiai time.
+        /// </summary>
+        public bool Kiai { get; private set; }
+
+        /// <summary>
         /// Applies default values to this HitObject.
         /// </summary>
         /// <param name="controlPointInfo">The control points.</param>
@@ -38,6 +43,9 @@ namespace osu.Game.Rulesets.Objects
         public virtual void ApplyDefaults(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
         {
             SoundControlPoint soundPoint = controlPointInfo.SoundPointAt(StartTime);
+            EffectControlPoint effectPoint = controlPointInfo.EffectPointAt(StartTime);
+
+            Kiai |= effectPoint.KiaiMode;
 
             // Initialize first sample
             Samples.ForEach(s => initializeSampleInfo(s, soundPoint));


### PR DESCRIPTION
Lane glows - a type of glow that sits behind the notes and lights up in the direction of the lane (i.e. vertically). Follows flytes designs, for now.