### PR TITLE
Fix osu! slider initial circles being placed at the wrong depth.

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -45,6 +45,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public override void Add(DrawableHitObject h)
         {
+            h.Depth = (float)h.HitObject.StartTime;
+
             base.Add(h);
 
             var fruit = (DrawableFruit)h;

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -49,10 +49,9 @@ namespace osu.Game.Rulesets.Catch.UI
 
             var fruit = (DrawableFruit)h;
             fruit.CheckPosition = catcherArea.CheckIfWeCanCatch;
-            fruit.OnJudgement += Fruit_OnJudgement;
         }
 
-        private void Fruit_OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        public override void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             if (judgement.IsHit)
             {

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -203,6 +203,8 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <param name="hitObject">The DrawableHitObject to add.</param>
         public override void Add(DrawableHitObject hitObject)
         {
+            hitObject.Depth = (float)hitObject.HitObject.StartTime;
+
             hitObject.AccentColour = AccentColour;
             HitObjects.Add(hitObject);
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     Scale = s.Scale,
                     ComboColour = s.ComboColour,
                     Samples = s.Samples,
-                }),
+                }) { Depth = 0 },
             };
 
             components.Add(body);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     Scale = s.Scale,
                     ComboColour = s.ComboColour,
                     Samples = s.Samples,
-                }) { Depth = 0 },
+                })
             };
 
             components.Add(body);

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -70,6 +70,8 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public override void Add(DrawableHitObject h)
         {
+            h.Depth = (float)h.HitObject.StartTime;
+
             var c = h as IDrawableHitObjectWithProxiedApproach;
             if (c != null)
                 approachCircles.Add(c.ProxiedLayer.CreateProxy());

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -205,6 +205,8 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public override void Add(DrawableHitObject h)
         {
+            h.Depth = (float)h.HitObject.StartTime;
+
             base.Add(h);
 
             var barline = h as DrawableBarLine;

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -55,8 +55,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
             : base(hitObject)
         {
             HitObject = hitObject;
-
-            Depth = (float)hitObject.StartTime;
         }
 
         private ArmedState state;


### PR DESCRIPTION
Because DrawableHitObjects now set their depth in the ctor. I still believe this is correct functionality since it affects input ordering, so I deemed this as being the appropriate fix.