### PR TITLE
Account for all files instead of just the main directory ones

### DIFF
--- a/osu.Game/Beatmaps/IO/LegacyFilesystemReader.cs
+++ b/osu.Game/Beatmaps/IO/LegacyFilesystemReader.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Beatmaps.IO
             // no-op
         }
 
-        public override IEnumerable<string> Filenames => Directory.GetDirectories(path).Select(Path.GetFileName).ToArray();
+        public override IEnumerable<string> Filenames => Directory.GetFiles(path, "*", SearchOption.AllDirectories).Select(Path.GetFileName).ToArray();
 
         public override Stream GetUnderlyingStream() => null;
     }

--- a/osu.Game/Beatmaps/IO/LegacyFilesystemReader.cs
+++ b/osu.Game/Beatmaps/IO/LegacyFilesystemReader.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Beatmaps.IO
             // no-op
         }
 
-        public override IEnumerable<string> Filenames => Directory.GetFiles(path).Select(Path.GetFileName).ToArray();
+        public override IEnumerable<string> Filenames => Directory.GetDirectories(path).Select(Path.GetFileName).ToArray();
 
         public override Stream GetUnderlyingStream() => null;
     }


### PR DESCRIPTION
Previously the files that where in a subdirectory would not be loaded, meaning some storyboards would be missing some if not all of their assets.
This also means beatmaps which have this problem need to be reimported though...