### PR TITLE
Don't unlimit FPS for visual tests

### DIFF
--- a/osu.Desktop/OsuTestBrowser.cs
+++ b/osu.Desktop/OsuTestBrowser.cs
@@ -24,11 +24,6 @@ namespace osu.Desktop
         public override void SetHost(GameHost host)
         {
             base.SetHost(host);
-
-            host.UpdateThread.InactiveHz = host.UpdateThread.ActiveHz;
-            host.DrawThread.InactiveHz = host.DrawThread.ActiveHz;
-            host.InputThread.InactiveHz = host.InputThread.ActiveHz;
-
             host.Window.CursorState |= CursorState.Hidden;
         }
     }


### PR DESCRIPTION
Not sure why this was being done, but I don't think we need it..