### PR TITLE
Allow files missing on disk to be restored on beatmap import

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -429,6 +429,15 @@ namespace osu.Game.Beatmaps
             if (beatmapSet != null)
             {
                 Undelete(beatmapSet);
+
+                // ensure all files are present and accessible
+                foreach (var f in beatmapSet.Files)
+                {
+                    if (!storage.Exists(f.FileInfo.StoragePath))
+                        using (Stream s = reader.GetStream(f.Filename))
+                            files.Add(s, false);
+                }
+
                 return beatmapSet;
             }
 


### PR DESCRIPTION
Previously, in the rare case the database became out of sync with the disk store, it was impossible to feasibly repair a beatmap. Now reimporting checks each file exists on disk and adds it back if it doesn't.