### PR TITLE
URL encode beatmap filename

### DIFF
--- a/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapDetailsRequest.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly BeatmapInfo beatmap;
 
-        private string lookupString => beatmap.OnlineBeatmapID > 0 ? beatmap.OnlineBeatmapID.ToString() : $@"lookup?checksum={beatmap.Hash}&filename={beatmap.Path}";
+        private string lookupString => beatmap.OnlineBeatmapID > 0 ? beatmap.OnlineBeatmapID.ToString() : $@"lookup?checksum={beatmap.Hash}&filename={System.Uri.EscapeUriString(beatmap.Path)}";
 
         public GetBeatmapDetailsRequest(BeatmapInfo beatmap)
         {


### PR DESCRIPTION
Otherwise if the filename was named something with `&` (possible on linux) it would have added another query argument in that request. + spaces aren't valid characters in a URL component, so some web servers might dislike it (like if bancho would switch to some other server than the C# one)

Changes
```
[network:verbose] Request to https://osu.ppy.sh/api/v2/beatmaps/lookup?checksum=5b71ac39520c7590841547cc4fe30915f72edcbd5864d4c759f9849468bce3a7&filename=Tsukasa - Accelerator (meiikyuu) [Moderate].osu () successfully completed!
```
to
```
[network:verbose] Request to https://osu.ppy.sh/api/v2/beatmaps/lookup?checksum=5b71ac39520c7590841547cc4fe30915f72edcbd5864d4c759f9849468bce3a7&filename=Tsukasa%20-%20Accelerator%20(meiikyuu)%20[Moderate].osu () successfully completed!
```

I checked all `string Target` occurrences and this one seems to be the only one where the user (map creator) can fully control the content of the URL

Just came across this when trying to find the bug that causes the big audio offset on linux that has been in since basically the start of the repo and why the start of a map is so laggy (because changing the audio offset to ~140ms does fix the big async, but the start of a map it's basically unplayable every time and you need to have luck with the clicks unless there is a section to skip). So I would appreciate if you could tell me if you know anything that could help me find said issues in this footer.