### PR TITLE
Fix yellow line in login overlay not following size correctly

### DIFF
--- a/osu.Game/Overlays/LoginOverlay.cs
+++ b/osu.Game/Overlays/LoginOverlay.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Overlays.Settings.Sections.General;
 using OpenTK.Graphics;
@@ -28,35 +29,43 @@ namespace osu.Game.Overlays
         {
             Children = new Drawable[]
             {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Black,
-                    Alpha = 0.6f,
-                },
                 new OsuContextMenuContainer
                 {
                     Width = 360,
                     AutoSizeAxes = Axes.Y,
-                    Masking = true,
-                    AutoSizeDuration = transition_time,
-                    AutoSizeEasing = Easing.OutQuint,
                     Children = new Drawable[]
                     {
-                        settingsSection = new LoginSettings
-                        {
-                            Padding = new MarginPadding(10),
-                            RequestHide = Hide,
-                        },
                         new Box
                         {
-                            RelativeSizeAxes = Axes.X,
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
-                            Height = 3,
-                            Colour = colours.Yellow,
-                            Alpha = 1,
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Black,
+                            Alpha = 0.6f,
                         },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Masking = true,
+                            AutoSizeDuration = transition_time,
+                            AutoSizeEasing = Easing.OutQuint,
+                            Children = new Drawable[]
+                            {
+                                settingsSection = new LoginSettings
+                                {
+                                    Padding = new MarginPadding(10),
+                                    RequestHide = Hide,
+                                },
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Height = 3,
+                                    Colour = colours.Yellow,
+                                    Alpha = 1,
+                                },
+                            }
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Also allows right click context menu to correctly extrude beyond the local masking.