### PR TITLE
Add screen selection tabcontrol to the editor

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Graphics.UserInterface
         public class OsuTabItem : TabItem<T>, IHasAccentColour
         {
             protected readonly SpriteText Text;
-            private readonly Box box;
+            protected readonly Box Bar;
 
             private Color4 accentColour;
             public Color4 AccentColour
@@ -77,13 +77,13 @@ namespace osu.Game.Graphics.UserInterface
 
             private void fadeActive()
             {
-                box.FadeIn(transition_length, Easing.OutQuint);
+                Bar.FadeIn(transition_length, Easing.OutQuint);
                 Text.FadeColour(Color4.White, transition_length, Easing.OutQuint);
             }
 
             private void fadeInactive()
             {
-                box.FadeOut(transition_length, Easing.OutQuint);
+                Bar.FadeOut(transition_length, Easing.OutQuint);
                 Text.FadeColour(AccentColour, transition_length, Easing.OutQuint);
             }
 
@@ -123,7 +123,7 @@ namespace osu.Game.Graphics.UserInterface
                         TextSize = 14,
                         Font = @"Exo2.0-Bold", // Font should only turn bold when active?
                     },
-                    box = new Box
+                    Bar = new Box
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = 1,

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -32,16 +32,11 @@ namespace osu.Game.Screens.Edit
                 Height = 40,
                 Children = new Drawable[]
                 {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = OsuColour.FromHex("111")
-                    },
                     new EditorMenuBar
                     {
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
-                        X = 100,
+                        RelativeSizeAxes = Axes.Both,
                         Items = new[]
                         {
                             new EditorMenuBarItem("File")

--- a/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
@@ -44,27 +44,12 @@ namespace osu.Game.Screens.Edit.Menus
             private Color4 openedForegroundColour;
             private Color4 openedBackgroundColour;
 
-            public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => parentSizedBox.ReceiveMouseInputAt(screenSpacePos);
-
-            /// <summary>
-            /// A box with width equal to this <see cref="DrawableEditorBarMenuItem"/>'s width, and height equal to the parent height.
-            /// </summary>
-            private readonly Box parentSizedBox;
 
             public DrawableEditorBarMenuItem(MenuItem item)
                 : base(item)
             {
                 Anchor = Anchor.CentreLeft;
                 Origin = Anchor.CentreLeft;
-
-                AddInternal(parentSizedBox = new Box
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.X,
-                    BypassAutoSizeAxes = Axes.Both,
-                    Alpha = 0,
-                });
             }
 
             public override void SetFlowDirection(Direction direction)
@@ -100,8 +85,6 @@ namespace osu.Game.Screens.Edit.Menus
             protected override void Update()
             {
                 base.Update();
-
-                parentSizedBox.Height = Parent.DrawHeight;
             }
 
             protected override Drawable CreateBackground() => new Container

--- a/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
@@ -41,9 +41,6 @@ namespace osu.Game.Screens.Edit.Menus
 
         private class DrawableEditorBarMenuItem : DrawableOsuMenuItem
         {
-            private Color4 openedForegroundColour;
-            private Color4 openedBackgroundColour;
-
 
             public DrawableEditorBarMenuItem(MenuItem item)
                 : base(item)
@@ -52,24 +49,24 @@ namespace osu.Game.Screens.Edit.Menus
                 Origin = Anchor.CentreLeft;
             }
 
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                ForegroundColour = colours.BlueLight;
+                BackgroundColour = Color4.Transparent;
+                ForegroundColourHover = Color4.White;
+                BackgroundColourHover = colours.Gray3;
+            }
+
             public override void SetFlowDirection(Direction direction)
             {
                 AutoSizeAxes = Axes.Both;
             }
 
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
-            {
-                ForegroundColour = ForegroundColourHover = colours.BlueLight;
-                BackgroundColour = BackgroundColourHover = Color4.Transparent;
-                openedForegroundColour = Color4.White;
-                openedBackgroundColour = colours.Gray3;
-            }
-
             protected override void UpdateBackgroundColour()
             {
                 if (State == MenuItemState.Selected)
-                    Background.FadeColour(openedBackgroundColour);
+                    Background.FadeColour(BackgroundColourHover);
                 else
                     base.UpdateBackgroundColour();
             }
@@ -77,7 +74,7 @@ namespace osu.Game.Screens.Edit.Menus
             protected override void UpdateForegroundColour()
             {
                 if (State == MenuItemState.Selected)
-                    Foreground.FadeColour(openedForegroundColour);
+                    Foreground.FadeColour(ForegroundColourHover);
                 else
                     base.UpdateForegroundColour();
             }

--- a/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
@@ -41,12 +41,15 @@ namespace osu.Game.Screens.Edit.Menus
 
         private class DrawableEditorBarMenuItem : DrawableOsuMenuItem
         {
+            private BackgroundBox background;
 
             public DrawableEditorBarMenuItem(MenuItem item)
                 : base(item)
             {
                 Anchor = Anchor.CentreLeft;
                 Origin = Anchor.CentreLeft;
+
+                StateChanged += stateChanged;
             }
 
             [BackgroundDependencyLoader]
@@ -79,25 +82,15 @@ namespace osu.Game.Screens.Edit.Menus
                     base.UpdateForegroundColour();
             }
 
-            protected override void Update()
+            private void stateChanged(MenuItemState newState)
             {
-                base.Update();
+                if (newState == MenuItemState.Selected)
+                    background.Expand();
+                else
+                    background.Contract();
             }
 
-            protected override Drawable CreateBackground() => new Container
-            {
-                RelativeSizeAxes = Axes.Both,
-                Masking = true,
-                Child = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Height = 2,
-                    Masking = true,
-                    CornerRadius = 4,
-                    Child = new Box { RelativeSizeAxes = Axes.Both }
-                }
-            };
-
+            protected override Drawable CreateBackground() => background = new BackgroundBox();
             protected override DrawableOsuMenuItem.TextContainer CreateTextContainer() => new TextContainer();
 
             private new class TextContainer : DrawableOsuMenuItem.TextContainer
@@ -107,6 +100,34 @@ namespace osu.Game.Screens.Edit.Menus
                     NormalText.TextSize = BoldText.TextSize = 14;
                     NormalText.Margin = BoldText.Margin = new MarginPadding { Horizontal = 10, Vertical = MARGIN_VERTICAL };
                 }
+            }
+
+            private class BackgroundBox : CompositeDrawable
+            {
+                private readonly Container innerBackground;
+
+                public BackgroundBox()
+                {
+                    RelativeSizeAxes = Axes.Both;
+                    Masking = true;
+                    InternalChild = innerBackground = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        CornerRadius = 4,
+                        Child = new Box { RelativeSizeAxes = Axes.Both }
+                    };
+                }
+
+                /// <summary>
+                /// Expands the background such that it doesn't show the bottom corners.
+                /// </summary>
+                public void Expand() => innerBackground.Height = 2;
+
+                /// <summary>
+                /// Contracts the background such that it shows the bottom corners.
+                /// </summary>
+                public void Contract() => innerBackground.Height = 1;
             }
         }
 

--- a/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
@@ -22,16 +22,10 @@ namespace osu.Game.Screens.Edit.Menus
             RelativeSizeAxes = Axes.X;
 
             ItemsContainer.Padding = new MarginPadding { Left = 100 };
-            BackgroundColour = Color4.Transparent;
+            BackgroundColour = OsuColour.FromHex("111");
 
             AddRangeInternal(new Drawable[]
             {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = OsuColour.FromHex("111"),
-                    Depth = float.MaxValue
-                },
                 new ScreenSelectionTabControl
                 {
                     Anchor = Anchor.BottomRight,

--- a/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
@@ -19,8 +19,20 @@ namespace osu.Game.Screens.Edit.Menus
         public EditorMenuBar()
             : base(Direction.Horizontal, true)
         {
-            ItemsContainer.Padding = new MarginPadding(0);
+            RelativeSizeAxes = Axes.X;
+
+            ItemsContainer.Padding = new MarginPadding { Left = 100 };
             BackgroundColour = Color4.Transparent;
+
+            AddRangeInternal(new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = OsuColour.FromHex("111"),
+                    Depth = float.MaxValue
+                },
+            });
         }
 
         protected override Framework.Graphics.UserInterface.Menu CreateSubMenu() => new SubMenu();
@@ -32,9 +44,32 @@ namespace osu.Game.Screens.Edit.Menus
             private Color4 openedForegroundColour;
             private Color4 openedBackgroundColour;
 
+            public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => parentSizedBox.ReceiveMouseInputAt(screenSpacePos);
+
+            /// <summary>
+            /// A box with width equal to this <see cref="DrawableEditorBarMenuItem"/>'s width, and height equal to the parent height.
+            /// </summary>
+            private readonly Box parentSizedBox;
+
             public DrawableEditorBarMenuItem(MenuItem item)
                 : base(item)
             {
+                Anchor = Anchor.CentreLeft;
+                Origin = Anchor.CentreLeft;
+
+                AddInternal(parentSizedBox = new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.X,
+                    BypassAutoSizeAxes = Axes.Both,
+                    Alpha = 0,
+                });
+            }
+
+            public override void SetFlowDirection(Direction direction)
+            {
+                AutoSizeAxes = Axes.Both;
             }
 
             [BackgroundDependencyLoader]
@@ -62,6 +97,13 @@ namespace osu.Game.Screens.Edit.Menus
                     base.UpdateForegroundColour();
             }
 
+            protected override void Update()
+            {
+                base.Update();
+
+                parentSizedBox.Height = Parent.DrawHeight;
+            }
+
             protected override Drawable CreateBackground() => new Container
             {
                 RelativeSizeAxes = Axes.Both,
@@ -75,6 +117,17 @@ namespace osu.Game.Screens.Edit.Menus
                     Child = new Box { RelativeSizeAxes = Axes.Both }
                 }
             };
+
+            protected override DrawableOsuMenuItem.TextContainer CreateTextContainer() => new TextContainer();
+
+            private new class TextContainer : DrawableOsuMenuItem.TextContainer
+            {
+                public TextContainer()
+                {
+                    NormalText.TextSize = BoldText.TextSize = 14;
+                    NormalText.Margin = BoldText.Margin = new MarginPadding { Horizontal = 10, Vertical = MARGIN_VERTICAL };
+                }
+            }
         }
 
         private class SubMenu : OsuMenu

--- a/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Menus/EditorMenuBar.cs
@@ -32,6 +32,12 @@ namespace osu.Game.Screens.Edit.Menus
                     Colour = OsuColour.FromHex("111"),
                     Depth = float.MaxValue
                 },
+                new ScreenSelectionTabControl
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    X = -15
+                }
             });
         }
 

--- a/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
+++ b/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK.Graphics;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using OpenTK;
+
+namespace osu.Game.Screens.Edit.Menus
+{
+    public class ScreenSelectionTabControl : OsuTabControl<EditorScreenMode>
+    {
+        public ScreenSelectionTabControl()
+        {
+            AutoSizeAxes = Axes.X;
+            RelativeSizeAxes = Axes.Y;
+
+            TabContainer.RelativeSizeAxes &= ~Axes.X;
+            TabContainer.AutoSizeAxes = Axes.X;
+            TabContainer.Padding = new MarginPadding();
+
+            Add(new Box
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                RelativeSizeAxes = Axes.X,
+                Height = 1,
+                Colour = Color4.White.Opacity(0.2f),
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            AccentColour = colours.Yellow;
+        }
+
+        protected override Dropdown<EditorScreenMode> CreateDropdown() => null;
+
+        protected override TabItem<EditorScreenMode> CreateTabItem(EditorScreenMode value) => new TabItem(value);
+
+        private new class TabItem : OsuTabItem
+        {
+            private const float transition_length = 250;
+
+            public TabItem(EditorScreenMode value)
+                : base(value)
+            {
+                Text.Margin = new MarginPadding();
+                Text.Anchor = Anchor.CentreLeft;
+                Text.Origin = Anchor.CentreLeft;
+            }
+
+            protected override void OnActivated()
+            {
+                base.OnActivated();
+                Bar.ScaleTo(new Vector2(1, 5), transition_length, Easing.OutQuint);
+            }
+
+            protected override void OnDeactivated()
+            {
+                base.OnDeactivated();
+                Bar.ScaleTo(Vector2.One, transition_length, Easing.OutQuint);
+            }
+        }
+    }
+
+    public enum EditorScreenMode
+    {
+        [System.ComponentModel.Description("compose")]
+        Compose,
+        [System.ComponentModel.Description("design")]
+        Design,
+        [System.ComponentModel.Description("timing")]
+        Timing,
+        [System.ComponentModel.Description("song")]
+        SongSetup
+    }
+}

--- a/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
+++ b/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Edit.Menus
 
         protected override TabItem<EditorScreenMode> CreateTabItem(EditorScreenMode value) => new TabItem(value);
 
-        private new class TabItem : OsuTabItem
+        private class TabItem : OsuTabItem
         {
             private const float transition_length = 250;
 

--- a/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
+++ b/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using OpenTK;
+using System.ComponentModel;
 
 namespace osu.Game.Screens.Edit.Menus
 {
@@ -72,13 +73,13 @@ namespace osu.Game.Screens.Edit.Menus
 
     public enum EditorScreenMode
     {
-        [System.ComponentModel.Description("compose")]
+        [Description("compose")]
         Compose,
-        [System.ComponentModel.Description("design")]
+        [Description("design")]
         Design,
-        [System.ComponentModel.Description("timing")]
+        [Description("timing")]
         Timing,
-        [System.ComponentModel.Description("song")]
+        [Description("song")]
         SongSetup
     }
 }

--- a/osu.Game/Tests/Visual/TestCaseEditorMenuBar.cs
+++ b/osu.Game/Tests/Visual/TestCaseEditorMenuBar.cs
@@ -1,7 +1,10 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Edit.Menus;
 
@@ -9,74 +12,82 @@ namespace osu.Game.Tests.Visual
 {
     public class TestCaseEditorMenuBar : OsuTestCase
     {
+        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(EditorMenuBar), typeof(ScreenSelectionTabControl) };
+
         public TestCaseEditorMenuBar()
         {
-            Add(new EditorMenuBar
+            Add(new Container
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
+                RelativeSizeAxes = Axes.X,
+                Height = 50,
                 Y = 50,
-                Items = new[]
+                Child = new EditorMenuBar
                 {
-                    new EditorMenuBarItem("File")
+                    RelativeSizeAxes = Axes.Both,
+                    Items = new[]
                     {
-                        Items = new[]
+                        new EditorMenuBarItem("File")
                         {
-                            new EditorMenuItem("Clear All Notes"),
-                            new EditorMenuItem("Open Difficulty..."),
-                            new EditorMenuItem("Save"),
-                            new EditorMenuItem("Create a new Difficulty..."),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Revert to Saved"),
-                            new EditorMenuItem("Revert to Saved (Full)"),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Test Beatmap"),
-                            new EditorMenuItem("Open AiMod"),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Upload Beatmap..."),
-                            new EditorMenuItem("Export Package"),
-                            new EditorMenuItem("Export Map Package"),
-                            new EditorMenuItem("Import from..."),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Open Song Folder"),
-                            new EditorMenuItem("Open .osu in Notepad"),
-                            new EditorMenuItem("Open .osb in Notepad"),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Exit"),
-                        }
-                    },
-                    new EditorMenuBarItem("Timing")
-                    {
-                        Items = new[]
+                            Items = new[]
+                            {
+                                new EditorMenuItem("Clear All Notes"),
+                                new EditorMenuItem("Open Difficulty..."),
+                                new EditorMenuItem("Save"),
+                                new EditorMenuItem("Create a new Difficulty..."),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Revert to Saved"),
+                                new EditorMenuItem("Revert to Saved (Full)"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Test Beatmap"),
+                                new EditorMenuItem("Open AiMod"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Upload Beatmap..."),
+                                new EditorMenuItem("Export Package"),
+                                new EditorMenuItem("Export Map Package"),
+                                new EditorMenuItem("Import from..."),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Open Song Folder"),
+                                new EditorMenuItem("Open .osu in Notepad"),
+                                new EditorMenuItem("Open .osb in Notepad"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Exit"),
+                            }
+                        },
+                        new EditorMenuBarItem("Timing")
                         {
-                            new EditorMenuItem("Time Signature"),
-                            new EditorMenuItem("Metronome Clicks"),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Add Timing Section"),
-                            new EditorMenuItem("Add Inheriting Section"),
-                            new EditorMenuItem("Reset Current Section"),
-                            new EditorMenuItem("Delete Timing Section"),
-                            new EditorMenuItem("Resnap Current Section"),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Timing Setup"),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Resnap All Notes", MenuItemType.Destructive),
-                            new EditorMenuItem("Move all notes in time...", MenuItemType.Destructive),
-                            new EditorMenuItem("Recalculate Slider Lengths", MenuItemType.Destructive),
-                            new EditorMenuItem("Delete All Timing Sections", MenuItemType.Destructive),
-                            new EditorMenuItemSpacer(),
-                            new EditorMenuItem("Set Current Position as Preview Point"),
-                        }
-                    },
-                    new EditorMenuBarItem("Testing")
-                    {
-                        Items = new[]
+                            Items = new[]
+                            {
+                                new EditorMenuItem("Time Signature"),
+                                new EditorMenuItem("Metronome Clicks"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Add Timing Section"),
+                                new EditorMenuItem("Add Inheriting Section"),
+                                new EditorMenuItem("Reset Current Section"),
+                                new EditorMenuItem("Delete Timing Section"),
+                                new EditorMenuItem("Resnap Current Section"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Timing Setup"),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Resnap All Notes", MenuItemType.Destructive),
+                                new EditorMenuItem("Move all notes in time...", MenuItemType.Destructive),
+                                new EditorMenuItem("Recalculate Slider Lengths", MenuItemType.Destructive),
+                                new EditorMenuItem("Delete All Timing Sections", MenuItemType.Destructive),
+                                new EditorMenuItemSpacer(),
+                                new EditorMenuItem("Set Current Position as Preview Point"),
+                            }
+                        },
+                        new EditorMenuBarItem("Testing")
                         {
-                            new EditorMenuItem("Item 1"),
-                            new EditorMenuItem("Item 2"),
-                            new EditorMenuItem("Item 3"),
-                        }
-                    },
+                            Items = new[]
+                            {
+                                new EditorMenuItem("Item 1"),
+                                new EditorMenuItem("Item 2"),
+                                new EditorMenuItem("Item 3"),
+                            }
+                        },
+                    }
                 }
             });
         }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -618,6 +618,7 @@
     <Compile Include="Screens\Edit\Menus\EditorMenuBarItem.cs" />
     <Compile Include="Screens\Edit\Menus\EditorMenuItem.cs" />
     <Compile Include="Screens\Edit\Menus\EditorMenuItemSpacer.cs" />
+    <Compile Include="Screens\Edit\Menus\ScreenSelectionTabControl.cs" />
     <Compile Include="Screens\Loader.cs" />
     <Compile Include="Screens\Menu\Button.cs" />
     <Compile Include="Screens\Menu\ButtonSystem.cs" />


### PR DESCRIPTION
Gonna stop this branch right here, without the tabcontrol actually being hooked up, because the changes are already getting pretty lengthy. Just a basic interface implementation for now.

Also adjusts the interface of the EditorMenuBar slightly.