### PR TITLE
Only convert chords into strong hits for mania -> taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -55,14 +55,17 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
 
             Beatmap<TaikoHitObject> converted = base.ConvertBeatmap(original);
 
-            // Post processing step to transform hit objects with the same start time into strong hits
-            converted.HitObjects = converted.HitObjects.GroupBy(t => t.StartTime).Select(x =>
+            if (original.BeatmapInfo.RulesetID == 3)
             {
-                TaikoHitObject first = x.First();
-                if (x.Skip(1).Any())
-                    first.IsStrong = true;
-                return first;
-            }).ToList();
+                // Post processing step to transform mania hit objects with the same start time into strong hits
+                converted.HitObjects = converted.HitObjects.GroupBy(t => t.StartTime).Select(x =>
+                {
+                    TaikoHitObject first = x.First();
+                    if (x.Skip(1).Any())
+                        first.IsStrong = true;
+                    return first;
+                }).ToList();
+            }
 
             return converted;
         }


### PR DESCRIPTION
this taiko map: https://osu.ppy.sh/b/1206929 has incorrect star rating in lazer (6.85 stars instead of 10.13).

I noticed that the difficulty hitobject count was much lower than it was supposed to be (~1.4k objects instead of ~1.9k).

after digging through the commit history i saw this: https://github.com/ppy/osu/commit/3b9067e55e4f06015754e9f6fd165d5c947e8efb#diff-529d0026e81a8fd590c2e43bdbee72f3

I'm not really familiar with beatmap conversion quirks, but I suppose this is meant only for mania -> taiko conversion, so I made the post-processing step check for the beatmap's gamemode and that fixed the issue.