### PR TITLE
Initialise BeatmapMetadata by default

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Beatmaps
         public int BeatmapMetadataID { get; set; }
 
         [OneToOne(CascadeOperations = CascadeOperation.All)]
-        public BeatmapMetadata Metadata { get; set; }
+        public BeatmapMetadata Metadata { get; set; } = new BeatmapMetadata();
 
         [ForeignKey(typeof(BeatmapDifficulty)), NotNull]
         public int BaseDifficultyID { get; set; }


### PR DESCRIPTION
Fixes a crash in TestCasePlayer. Not sure if we should be worried about performance overhead of initialising like this (when it's going to get replaced in the majority of situations).