### PR TITLE
Fix issues related to hiding beatmaps

### DIFF
--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -102,6 +102,7 @@ namespace osu.Game.Beatmaps
             if (beatmap.Hidden) return false;
 
             beatmap.Hidden = true;
+            context.Update(beatmap);
             context.SaveChanges();
 
             BeatmapHidden?.Invoke(beatmap);
@@ -120,6 +121,7 @@ namespace osu.Game.Beatmaps
             if (!beatmap.Hidden) return false;
 
             beatmap.Hidden = false;
+            context.Update(beatmap);
             context.SaveChanges();
 
             BeatmapRestored?.Invoke(beatmap);


### PR DESCRIPTION
- Always update the beatmap on the context.
- Don't crash when all difficulties of a set are hidden.