### PR TITLE
Fix migrating in back and forth between database engines breaking startup

### DIFF
--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -180,13 +180,15 @@ namespace osu.Game.Database
         {
             try
             {
-                // will fail if EF hasn't touched the database yet.
-                Database.ExecuteSqlCommand("SELECT * FROM __EFMigrationsHistory LIMIT 1");
+                // will fail if the database isn't in a sane EF-migradted state.
+                Database.ExecuteSqlCommand("SELECT MetadataID FROM BeatmapSetInfo LIMIT 1");
             }
             catch
             {
                 try
                 {
+                    Database.ExecuteSqlCommand("DROP TABLE IF EXISTS __EFMigrationsHistory");
+
                     // will fail (intentionally) if we don't have sqlite-net data present.
                     Database.ExecuteSqlCommand("SELECT OnlineBeatmapSetId FROM BeatmapMetadata LIMIT 1");
 

--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Database
         {
             try
             {
-                // will fail if the database isn't in a sane EF-migradted state.
+                // will fail if the database isn't in a sane EF-migrated state.
                 Database.ExecuteSqlCommand("SELECT MetadataID FROM BeatmapSetInfo LIMIT 1");
             }
             catch


### PR DESCRIPTION
This method allows switching between sqlite-net and EF builds without completely breaking. Note that DB migration still only happens in a forward direction, but this will allow switching back and forth without eventually being unable to start the game.