### PR TITLE
Fix WaveOverlayContainer appearing incorrectly on first PopIn

### DIFF
--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -168,6 +168,8 @@ namespace osu.Game.Overlays
         {
             public float FinalPosition;
 
+            protected override bool StartHidden => true;
+
             public Wave()
             {
                 RelativeSizeAxes = Axes.X;


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/1114

Closes https://github.com/ppy/osu/issues/1419.