### PR TITLE
Ensure all parsed "Online" IDs are above zero or null

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -19,12 +19,23 @@ namespace osu.Game.Beatmaps
         //TODO: should be in database
         public int BeatmapVersion;
 
+        private int? onlineBeatmapID;
+        private int? onlineBeatmapSetID;
+
         [JsonProperty("id")]
-        public int? OnlineBeatmapID { get; set; }
+        public int? OnlineBeatmapID
+        {
+            get { return onlineBeatmapID; }
+            set { onlineBeatmapID = value > 0 ? value : null; }
+        }
 
         [JsonProperty("beatmapset_id")]
         [NotMapped]
-        public int? OnlineBeatmapSetID { get; set; }
+        public int? OnlineBeatmapSetID
+        {
+            get { return onlineBeatmapSetID; }
+            set { onlineBeatmapSetID = value > 0 ? value : null; }
+        }
 
         public int BeatmapSetInfoID { get; set; }
 

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -14,8 +14,14 @@ namespace osu.Game.Beatmaps
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int ID { get; set; }
 
+        private int? onlineBeatmapSetID;
+
         [NotMapped]
-        public int? OnlineBeatmapSetID { get; set; }
+        public int? OnlineBeatmapSetID
+        {
+            get { return onlineBeatmapSetID; }
+            set { onlineBeatmapSetID = value > 0 ? value : null; }
+        }
 
         public string Title { get; set; }
         public string TitleUnicode { get; set; }

--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Database
                         Database.ExecuteSqlCommand("DROP TABLE RulesetInfo_Old");
 
                         Database.ExecuteSqlCommand(
-                            "INSERT INTO BeatmapInfo SELECT ID, AudioLeadIn, BaseDifficultyID, BeatDivisor, BeatmapSetInfoID, Countdown, DistanceSpacing, GridSize, Hash, IFNULL(Hidden, 0), LetterboxInBreaks, MD5Hash, NULLIF(BeatmapMetadataID, 0), OnlineBeatmapID, Path, RulesetID, SpecialStyle, StackLeniency, StarDifficulty, StoredBookmarks, TimelineZoom, Version, WidescreenStoryboard FROM BeatmapInfo_Old");
+                            "INSERT INTO BeatmapInfo SELECT ID, AudioLeadIn, BaseDifficultyID, BeatDivisor, BeatmapSetInfoID, Countdown, DistanceSpacing, GridSize, Hash, IFNULL(Hidden, 0), LetterboxInBreaks, MD5Hash, NULLIF(BeatmapMetadataID, 0), NULLIF(OnlineBeatmapID, 0), Path, RulesetID, SpecialStyle, StackLeniency, StarDifficulty, StoredBookmarks, TimelineZoom, Version, WidescreenStoryboard FROM BeatmapInfo_Old");
                         Database.ExecuteSqlCommand("DROP TABLE BeatmapInfo_Old");
 
                         Logger.Log("Migration complete!", LoggingTarget.Database, Framework.Logging.LogLevel.Important);


### PR DESCRIPTION
Some .osu file sources (or database sources) may be in a bad state. We want to get these ones right as they cannot be enforced by the database itself (via FKs or constraints).

Fixes #1425.