### PR TITLE
Use IQueryable wherever possible

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -379,7 +379,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
-        public BeatmapSetInfo QueryBeatmapSet(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.BeatmapSets.FirstOrDefault(query);
+        public BeatmapSetInfo QueryBeatmapSet(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.BeatmapSets.AsNoTracking().FirstOrDefault(query);
 
         /// <summary>
         /// Refresh an existing instance of a <see cref="BeatmapSetInfo"/> from the store.
@@ -400,7 +400,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
-        public BeatmapInfo QueryBeatmap(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.FirstOrDefault(query);
+        public BeatmapInfo QueryBeatmap(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.AsNoTracking().FirstOrDefault(query);
 
         /// <summary>
         /// Perform a lookup query on available <see cref="BeatmapInfo"/>s.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Ionic.Zip;
 using Microsoft.EntityFrameworkCore;
@@ -378,7 +379,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
-        public BeatmapSetInfo QueryBeatmapSet(Func<BeatmapSetInfo, bool> query) => beatmaps.BeatmapSets.FirstOrDefault(query);
+        public BeatmapSetInfo QueryBeatmapSet(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.BeatmapSets.FirstOrDefault(query);
 
         /// <summary>
         /// Refresh an existing instance of a <see cref="BeatmapSetInfo"/> from the store.
@@ -392,21 +393,21 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>Results from the provided query.</returns>
-        public List<BeatmapSetInfo> QueryBeatmapSets(Func<BeatmapSetInfo, bool> query) => beatmaps.BeatmapSets.Where(query).ToList();
+        public List<BeatmapSetInfo> QueryBeatmapSets(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.BeatmapSets.Where(query).ToList();
 
         /// <summary>
         /// Perform a lookup query on available <see cref="BeatmapInfo"/>s.
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
-        public BeatmapInfo QueryBeatmap(Func<BeatmapInfo, bool> query) => beatmaps.Beatmaps.FirstOrDefault(query);
+        public BeatmapInfo QueryBeatmap(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.FirstOrDefault(query);
 
         /// <summary>
         /// Perform a lookup query on available <see cref="BeatmapInfo"/>s.
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>Results from the provided query.</returns>
-        public List<BeatmapInfo> QueryBeatmaps(Func<BeatmapInfo, bool> query) => beatmaps.Beatmaps.Where(query).ToList();
+        public List<BeatmapInfo> QueryBeatmaps(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.Where(query).ToList();
 
         /// <summary>
         /// Creates an <see cref="ArchiveReader"/> from a valid storage path.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -393,7 +393,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>Results from the provided query.</returns>
-        public List<BeatmapSetInfo> QueryBeatmapSets(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.BeatmapSets.Where(query).ToList();
+        public IEnumerable<BeatmapSetInfo> QueryBeatmapSets(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.BeatmapSets.AsNoTracking().Where(query);
 
         /// <summary>
         /// Perform a lookup query on available <see cref="BeatmapInfo"/>s.
@@ -407,7 +407,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="query">The query.</param>
         /// <returns>Results from the provided query.</returns>
-        public List<BeatmapInfo> QueryBeatmaps(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.Where(query).ToList();
+        public IEnumerable<BeatmapInfo> QueryBeatmaps(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.AsNoTracking().Where(query);
 
         /// <summary>
         /// Creates an <see cref="ArchiveReader"/> from a valid storage path.

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using osu.Game.Database;
@@ -136,14 +135,14 @@ namespace osu.Game.Beatmaps
             context.SaveChanges();
         }
 
-        public IEnumerable<BeatmapSetInfo> BeatmapSets => GetContext().BeatmapSetInfo
+        public IQueryable<BeatmapSetInfo> BeatmapSets => GetContext().BeatmapSetInfo
                                                                       .Include(s => s.Metadata)
                                                                       .Include(s => s.Beatmaps).ThenInclude(s => s.Ruleset)
                                                                       .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
                                                                       .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
                                                                       .Include(s => s.Files).ThenInclude(f => f.FileInfo);
 
-        public IEnumerable<BeatmapInfo> Beatmaps => GetContext().BeatmapInfo
+        public IQueryable<BeatmapInfo> Beatmaps => GetContext().BeatmapInfo
                                                                 .Include(b => b.BeatmapSet).ThenInclude(s => s.Metadata)
                                                                 .Include(b => b.Metadata)
                                                                 .Include(b => b.Ruleset)

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -136,16 +136,16 @@ namespace osu.Game.Beatmaps
         }
 
         public IQueryable<BeatmapSetInfo> BeatmapSets => GetContext().BeatmapSetInfo
-                                                                      .Include(s => s.Metadata)
-                                                                      .Include(s => s.Beatmaps).ThenInclude(s => s.Ruleset)
-                                                                      .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
-                                                                      .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
-                                                                      .Include(s => s.Files).ThenInclude(f => f.FileInfo);
+                                                                     .Include(s => s.Metadata)
+                                                                     .Include(s => s.Beatmaps).ThenInclude(s => s.Ruleset)
+                                                                     .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
+                                                                     .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
+                                                                     .Include(s => s.Files).ThenInclude(f => f.FileInfo);
 
         public IQueryable<BeatmapInfo> Beatmaps => GetContext().BeatmapInfo
-                                                                .Include(b => b.BeatmapSet).ThenInclude(s => s.Metadata)
-                                                                .Include(b => b.Metadata)
-                                                                .Include(b => b.Ruleset)
-                                                                .Include(b => b.BaseDifficulty);
+                                                               .Include(b => b.BeatmapSet).ThenInclude(s => s.Metadata)
+                                                               .Include(b => b.Metadata)
+                                                               .Include(b => b.Ruleset)
+                                                               .Include(b => b.BaseDifficulty);
     }
 }

--- a/osu.Game/Input/KeyBindingStore.cs
+++ b/osu.Game/Input/KeyBindingStore.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Input
         }
 
         /// <summary>
-        /// Retrieve <see cref="KeyBinding"/>s for a specified ruleset/variant content.
+        /// Retrieve <see cref="DatabasedKeyBinding"/>s for a specified ruleset/variant content.
         /// </summary>
         /// <param name="rulesetId">The ruleset's internal ID.</param>
         /// <param name="variant">An optional variant.</param>

--- a/osu.Game/Input/KeyBindingStore.cs
+++ b/osu.Game/Input/KeyBindingStore.cs
@@ -60,12 +60,12 @@ namespace osu.Game.Input
         }
 
         /// <summary>
-        /// Retrieve <see cref="DatabasedKeyBinding"/>s for a specified ruleset/variant content.
+        /// Retrieve <see cref="KeyBinding"/>s for a specified ruleset/variant content.
         /// </summary>
         /// <param name="rulesetId">The ruleset's internal ID.</param>
         /// <param name="variant">An optional variant.</param>
         /// <returns></returns>
-        public IEnumerable<DatabasedKeyBinding> Query(int? rulesetId = null, int? variant = null) =>
+        public List<DatabasedKeyBinding> Query(int? rulesetId = null, int? variant = null) =>
             GetContext().DatabasedKeyBinding.Where(b => b.RulesetID == rulesetId && b.Variant == variant).ToList();
 
         public void Update(KeyBinding keyBinding)

--- a/osu.Game/Input/KeyBindingStore.cs
+++ b/osu.Game/Input/KeyBindingStore.cs
@@ -65,8 +65,8 @@ namespace osu.Game.Input
         /// <param name="rulesetId">The ruleset's internal ID.</param>
         /// <param name="variant">An optional variant.</param>
         /// <returns></returns>
-        public IEnumerable<KeyBinding> Query(int? rulesetId = null, int? variant = null) =>
-            GetContext().DatabasedKeyBinding.Where(b => b.RulesetID == rulesetId && b.Variant == variant);
+        public IEnumerable<DatabasedKeyBinding> Query(int? rulesetId = null, int? variant = null) =>
+            GetContext().DatabasedKeyBinding.Where(b => b.RulesetID == rulesetId && b.Variant == variant).ToList();
 
         public void Update(KeyBinding keyBinding)
         {

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets
         /// <summary>
         /// All available rulesets.
         /// </summary>
-        public IEnumerable<RulesetInfo> AvailableRulesets => GetContext().RulesetInfo.Where(r => r.Available);
+        public IQueryable<RulesetInfo> AvailableRulesets => GetContext().RulesetInfo.Where(r => r.Available);
 
         private static Assembly currentDomain_AssemblyResolve(object sender, ResolveEventArgs args) => loaded_assemblies.Keys.FirstOrDefault(a => a.FullName == args.Name);
 


### PR DESCRIPTION
Until now we were returning and querying against IEnumerable, and therefore never hitting the database for constraints. This resolves that.

Also adds NoTracking to common read lookups (this may not be permanent based on how we move forward with threadedness, but works well for now).

- [x] Depends on https://github.com/ppy/osu/pull/1435 (Refresh's `IEnumerable` should be changed to `IQueryable` after it is merged).
- [x] Depends on https://github.com/ppy/osu/pull/1436 (All IEnumerables should be changes to `IQueryable` where necessary).