### PR TITLE
Use separate database context per transaction

### DIFF
--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -39,10 +39,8 @@ namespace osu.Game.Tests.Visual
             {
                 var storage = new TestStorage(@"TestCasePlaySongSelect");
 
-                // this is by no means clean. should be replacing inside of OsuGameBase somehow.
-                var context = new OsuDbContext();
-
-                Func<OsuDbContext> contextFactory = () => context;
+                // TODO replace with something more sane
+                var contextFactory = new DatabaseContextFactory(null);
 
                 dependencies.Cache(rulesets = new RulesetStore(contextFactory));
                 dependencies.Cache(manager = new BeatmapManager(storage, contextFactory, rulesets, null));

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -59,9 +59,9 @@ namespace osu.Game.Beatmaps
 
         private readonly Storage storage;
 
-        private BeatmapStore createBeatmapStore(Func<OsuDbContext> context)
+        private BeatmapStore createBeatmapStore(DatabaseContextFactory contextFactory)
         {
-            var store = new BeatmapStore(context);
+            var store = new BeatmapStore(contextFactory);
             store.BeatmapSetAdded += s => BeatmapSetAdded?.Invoke(s);
             store.BeatmapSetRemoved += s => BeatmapSetRemoved?.Invoke(s);
             store.BeatmapHidden += b => BeatmapHidden?.Invoke(b);
@@ -69,7 +69,7 @@ namespace osu.Game.Beatmaps
             return store;
         }
 
-        private readonly Func<OsuDbContext> createContext;
+        private readonly DatabaseContextFactory dataContextFactory;
 
         private readonly FileStore files;
 
@@ -94,18 +94,19 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public Func<Storage> GetStableStorage { private get; set; }
 
-        public BeatmapManager(Storage storage, Func<OsuDbContext> context, RulesetStore rulesets, APIAccess api, IIpcHost importHost = null)
+        public BeatmapManager(Storage storage, DatabaseContextFactory contextFactory, RulesetStore rulesets, APIAccess api, IIpcHost importHost = null)
         {
-            createContext = context;
-            importContext = new Lazy<OsuDbContext>(() =>
+            dataContextFactory = contextFactory;
+            importLock = new object();
+            getImportContext = () =>
             {
-                var c = createContext();
+                var c = dataContextFactory.GetContext();
                 c.Database.AutoTransactionsEnabled = false;
                 return c;
-            });
+            };
 
-            beatmaps = createBeatmapStore(context);
-            files = new FileStore(context, storage);
+            beatmaps = createBeatmapStore(contextFactory);
+            files = new FileStore(contextFactory, storage);
 
             this.storage = files.Storage;
             this.rulesets = rulesets;
@@ -172,7 +173,8 @@ namespace osu.Game.Beatmaps
             notification.State = ProgressNotificationState.Completed;
         }
 
-        private readonly Lazy<OsuDbContext> importContext;
+        private readonly Func<OsuDbContext> getImportContext;
+        private readonly object importLock;
 
         /// <summary>
         /// Import a beatmap from an <see cref="ArchiveReader"/>.
@@ -181,26 +183,23 @@ namespace osu.Game.Beatmaps
         public BeatmapSetInfo Import(ArchiveReader archiveReader)
         {
             // let's only allow one concurrent import at a time for now.
-            lock (importContext)
+            lock (importLock)
             {
-                var context = importContext.Value;
-
-                using (var transaction = context.BeginTransaction())
+                using (var context = getImportContext())
                 {
-                    // create local stores so we can isolate and thread safely, and share a context/transaction.
-                    var iFiles = new FileStore(() => context, storage);
-                    var iBeatmaps = createBeatmapStore(() => context);
-
-                    BeatmapSetInfo set = importToStorage(iFiles, iBeatmaps, archiveReader);
-
-                    if (set.ID == 0)
+                    using (var transaction = context.BeginTransaction())
                     {
-                        iBeatmaps.Add(set);
-                        context.SaveChanges();
-                    }
+                        BeatmapSetInfo set = importToStorage(files, beatmaps, archiveReader);
 
-                    context.SaveChanges(transaction);
-                    return set;
+                        if (set.ID == 0)
+                        {
+                            beatmaps.Add(set);
+                            context.SaveChanges();
+                        }
+
+                        context.SaveChanges(transaction);
+                        return set;
+                    }
                 }
             }
         }
@@ -214,7 +213,7 @@ namespace osu.Game.Beatmaps
             // If we have an ID then we already exist in the database.
             if (beatmapSetInfo.ID != 0) return;
 
-            createBeatmapStore(createContext).Add(beatmapSetInfo);
+            createBeatmapStore(dataContextFactory).Add(beatmapSetInfo);
         }
 
         /// <summary>
@@ -298,29 +297,26 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapSet">The beatmap set to delete.</param>
         public void Delete(BeatmapSetInfo beatmapSet)
         {
-            lock (importContext)
+            lock (importLock)
             {
-                var context = importContext.Value;
-
-                using (var transaction = context.BeginTransaction())
+                using (var context = getImportContext())
                 {
-                    context.ChangeTracker.AutoDetectChangesEnabled = false;
-
-                    // re-fetch the beatmap set on the import context.
-                    beatmapSet = context.BeatmapSetInfo.Include(s => s.Files).ThenInclude(f => f.FileInfo).First(s => s.ID == beatmapSet.ID);
-
-                    // create local stores so we can isolate and thread safely, and share a context/transaction.
-                    var iFiles = new FileStore(() => context, storage);
-                    var iBeatmaps = createBeatmapStore(() => context);
-
-                    if (iBeatmaps.Delete(beatmapSet))
+                    using (var transaction = context.BeginTransaction())
                     {
-                        if (!beatmapSet.Protected)
-                            iFiles.Dereference(beatmapSet.Files.Select(f => f.FileInfo).ToArray());
-                    }
+                        context.ChangeTracker.AutoDetectChangesEnabled = false;
 
-                    context.ChangeTracker.AutoDetectChangesEnabled = true;
-                    context.SaveChanges(transaction);
+                        // re-fetch the beatmap set on the import context.
+                        beatmapSet = context.BeatmapSetInfo.Include(s => s.Files).ThenInclude(f => f.FileInfo).First(s => s.ID == beatmapSet.ID);
+
+                        if (beatmaps.Delete(beatmapSet))
+                        {
+                            if (!beatmapSet.Protected)
+                                files.Dereference(context, beatmapSet.Files.Select(f => f.FileInfo).ToArray());
+                        }
+
+                        context.ChangeTracker.AutoDetectChangesEnabled = true;
+                        context.SaveChanges(transaction);
+                    }
                 }
             }
         }
@@ -346,8 +342,10 @@ namespace osu.Game.Beatmaps
         {
             if (!beatmaps.Undelete(beatmapSet)) return;
 
-            if (!beatmapSet.Protected)
-                files.Reference(beatmapSet.Files.Select(f => f.FileInfo).ToArray());
+            // TODO this does not look like "database context per transaction" and should be changed
+            using (var context = dataContextFactory.GetContext())
+                if (!beatmapSet.Protected)
+                    files.Reference(context, beatmapSet.Files.Select(f => f.FileInfo).ToArray());
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -365,6 +365,8 @@ namespace osu.Game.Beatmaps
             if (beatmapInfo.Metadata == null)
                 beatmapInfo.Metadata = beatmapInfo.BeatmapSet.Metadata;
 
+            // TODO Other "files" field usages are locked using importLock. This usage should be locked too or importLock should be removed.
+            // ReSharper disable once InconsistentlySynchronizedField
             WorkingBeatmap working = new BeatmapManagerWorkingBeatmap(files.Store, beatmapInfo);
 
             previous?.TransferTo(working);

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -16,7 +16,11 @@ namespace osu.Game.Database
             this.host = host;
         }
 
-        public OsuDbContext GetContext() => new OsuDbContext(host.Storage.GetDatabaseConnectionString(database_name));
+        public OsuDbContext GetContext()
+        {
+            var inMemory = host == null;
+            return inMemory ? new OsuDbContext() : new OsuDbContext(host.Storage.GetDatabaseConnectionString(database_name));
+        }
 
         public void ResetDatabase()
         {

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -21,41 +21,42 @@ namespace osu.Game.IO
 
         public Storage Storage => base.Storage;
 
-        public FileStore(Func<OsuDbContext> createContext, Storage storage) : base(createContext, storage.GetStorageForDirectory(@"files"))
+        public FileStore(DatabaseContextFactory dbContextFactory, Storage storage) : base(dbContextFactory, storage.GetStorageForDirectory(@"files"))
         {
             Store = new StorageBackedResourceStore(Storage);
         }
 
         public FileInfo Add(Stream data, bool reference = true)
         {
-            var context = GetContext();
-
-            string hash = data.ComputeSHA2Hash();
-
-            var existing = context.FileInfo.FirstOrDefault(f => f.Hash == hash);
-
-            var info = existing ?? new FileInfo { Hash = hash };
-
-            string path = info.StoragePath;
-
-            // we may be re-adding a file to fix missing store entries.
-            if (!Storage.Exists(path))
+            using (var context = GetContext())
             {
-                data.Seek(0, SeekOrigin.Begin);
+                string hash = data.ComputeSHA2Hash();
 
-                using (var output = Storage.GetStream(path, FileAccess.Write))
-                    data.CopyTo(output);
+                var existing = context.FileInfo.FirstOrDefault(f => f.Hash == hash);
 
-                data.Seek(0, SeekOrigin.Begin);
+                var info = existing ?? new FileInfo { Hash = hash };
+
+                string path = info.StoragePath;
+
+                // we may be re-adding a file to fix missing store entries.
+                if (!Storage.Exists(path))
+                {
+                    data.Seek(0, SeekOrigin.Begin);
+
+                    using (var output = Storage.GetStream(path, FileAccess.Write))
+                        data.CopyTo(output);
+
+                    data.Seek(0, SeekOrigin.Begin);
+                }
+
+                if (reference || existing == null)
+                    Reference(context, info);
+
+                return info;
             }
-
-            if (reference || existing == null)
-                Reference(info);
-
-            return info;
         }
 
-        public void Reference(params FileInfo[] files) => reference(GetContext(), files);
+        public void Reference(OsuDbContext context, params FileInfo[] files) => reference(context, files);
 
         private void reference(OsuDbContext context, FileInfo[] files)
         {
@@ -69,7 +70,7 @@ namespace osu.Game.IO
             context.SaveChanges();
         }
 
-        public void Dereference(params FileInfo[] files) => dereference(GetContext(), files);
+        public void Dereference(OsuDbContext context, params FileInfo[] files) => dereference(context, files);
 
         private void dereference(OsuDbContext context, FileInfo[] files)
         {
@@ -85,22 +86,23 @@ namespace osu.Game.IO
 
         public override void Cleanup()
         {
-            var context = GetContext();
-
-            foreach (var f in context.FileInfo.Where(f => f.ReferenceCount < 1))
+            using (var context = GetContext())
             {
-                try
+                foreach (var f in context.FileInfo.Where(f => f.ReferenceCount < 1))
                 {
-                    Storage.Delete(f.StoragePath);
-                    context.FileInfo.Remove(f);
+                    try
+                    {
+                        Storage.Delete(f.StoragePath);
+                        context.FileInfo.Remove(f);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, $@"Could not delete beatmap {f}");
+                    }
                 }
-                catch (Exception e)
-                {
-                    Logger.Error(e, $@"Could not delete beatmap {f}");
-                }
-            }
 
-            context.SaveChanges();
+                context.SaveChanges();
+            }
         }
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -99,11 +99,11 @@ namespace osu.Game
                 Token = LocalConfig.Get<string>(OsuSetting.Token)
             });
 
-            dependencies.Cache(RulesetStore = new RulesetStore(contextFactory.GetContext));
-            dependencies.Cache(FileStore = new FileStore(contextFactory.GetContext, Host.Storage));
-            dependencies.Cache(BeatmapManager = new BeatmapManager(Host.Storage, contextFactory.GetContext, RulesetStore, API, Host));
-            dependencies.Cache(ScoreStore = new ScoreStore(Host.Storage, contextFactory.GetContext, Host, BeatmapManager, RulesetStore));
-            dependencies.Cache(KeyBindingStore = new KeyBindingStore(contextFactory.GetContext, RulesetStore));
+            dependencies.Cache(RulesetStore = new RulesetStore(contextFactory));
+            dependencies.Cache(FileStore = new FileStore(contextFactory, Host.Storage));
+            dependencies.Cache(BeatmapManager = new BeatmapManager(Host.Storage, contextFactory, RulesetStore, API, Host));
+            dependencies.Cache(ScoreStore = new ScoreStore(Host.Storage, contextFactory, Host, BeatmapManager, RulesetStore));
+            dependencies.Cache(KeyBindingStore = new KeyBindingStore(contextFactory, RulesetStore));
             dependencies.Cache(new OsuColour());
 
             //this completely overrides the framework default. will need to change once we make a proper FontStore.

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using osu.Framework.Platform;

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Scoring
         // ReSharper disable once NotAccessedField.Local (we should keep a reference to this so it is not finalised)
         private ScoreIPCChannel ipc;
 
-        public ScoreStore(Storage storage, Func<OsuDbContext> factory, IIpcHost importHost = null, BeatmapManager beatmaps = null, RulesetStore rulesets = null) : base(factory)
+        public ScoreStore(Storage storage, DatabaseContextFactory factory, IIpcHost importHost = null, BeatmapManager beatmaps = null, RulesetStore rulesets = null) : base(factory)
         {
             this.storage = storage;
             this.beatmaps = beatmaps;


### PR DESCRIPTION
We might want to do this because
1. It will simplify DbContext lifetime management.
2. In my opinion, it is easier to maintain the code(because I do not need to understand how database contexts are shared).

Please note that it is not ready for merge right now. Look at my TODO comments. At least, `BeatmapStore.Beatmaps` and `BeatmapStore.BeatmapSets` properties should be fixed.