### PR TITLE
Fix a possible horrendous endless auth loop

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -118,6 +118,7 @@ namespace osu.Game.Online.API
                             //NotificationOverlay.ShowMessage("Login failed!");
                             log.Add(@"Login failed!");
                             Password = null;
+                            authentication.Clear();
                             continue;
                         }
 

--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Online.API
 
         internal bool AuthenticateWithLogin(string username, string password)
         {
+            if (string.IsNullOrEmpty(username)) return false;
+            if (string.IsNullOrEmpty(password)) return false;
+
             using (var req = new AccessTokenRequestPassword(username, password)
             {
                 Url = $@"{endpoint}/oauth/token",


### PR DESCRIPTION
Token wasn't being cleared on a failed login. Also checks empty string rather than just null.