### PR TITLE
Make the osu! logo shared game-wide

### DIFF
--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Game.Screens.Menu;
+using OpenTK;
 
 namespace osu.Game.Screens
 {
@@ -13,6 +15,18 @@ namespace osu.Game.Screens
         public Loader()
         {
             ValidForResume = false;
+        }
+
+        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        {
+            base.LogoSetup(logo, resuming);
+
+            logo.RelativePositionAxes = Axes.Both;
+            logo.Triangles = false;
+            logo.Position = new Vector2(0.9f);
+            logo.Scale = new Vector2(0.2f);
+
+            logo.FadeInFromZero(5000, Easing.OutQuint);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -17,9 +17,9 @@ namespace osu.Game.Screens
             ValidForResume = false;
         }
 
-        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
+        protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
-            base.OnArrivedLogo(logo, resuming);
+            base.LogoArriving(logo, resuming);
 
             logo.RelativePositionAxes = Axes.Both;
             logo.Triangles = false;

--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -17,9 +17,9 @@ namespace osu.Game.Screens
             ValidForResume = false;
         }
 
-        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
         {
-            base.LogoSetup(logo, resuming);
+            base.OnArrivedLogo(logo, resuming);
 
             logo.RelativePositionAxes = Axes.Both;
             logo.Triangles = false;

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Screens.Menu
             switch (args.Key)
             {
                 case Key.Space:
-                    logo.TriggerOnClick(state);
+                    logo?.TriggerOnClick(state);
                     return true;
                 case Key.Escape:
                     switch (State)

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -326,8 +326,6 @@ namespace osu.Game.Screens.Menu
 
         private bool trackingPosition;
 
-        public void SetLogoTracking(bool value) => trackingPosition = value;
-
         protected override void Update()
         {
             //if (OsuGame.IdleTime > 6000 && State != MenuState.Exit)

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -39,12 +39,25 @@ namespace osu.Game.Screens.Menu
 
         //todo: make these non-internal somehow.
         internal const float BUTTON_AREA_HEIGHT = 100;
+
         internal const float BUTTON_WIDTH = 140f;
         internal const float WEDGE_WIDTH = 20;
 
-        public const int EXIT_DELAY = 3000;
+        private OsuLogo logo;
 
-        private readonly OsuLogo osuLogo;
+        public void SetOsuLogo(OsuLogo logo)
+        {
+            this.logo = logo;
+
+            if (this.logo != null)
+            {
+                this.logo.Action = onOsuLogo;
+
+                // osuLogo.SizeForFlow relies on loading to be complete.
+                buttonFlow.Position = new Vector2(WEDGE_WIDTH * 2 - (BUTTON_WIDTH + this.logo.SizeForFlow / 4), 0);
+            }
+        }
+
         private readonly Drawable iconFacade;
         private readonly Container buttonArea;
         private readonly Box buttonAreaBackground;
@@ -99,12 +112,6 @@ namespace osu.Game.Screens.Menu
                         }
                     }
                 },
-                osuLogo = new OsuLogo
-                {
-                    Action = onOsuLogo,
-                    Origin = Anchor.Centre,
-                    Anchor = Anchor.Centre,
-                }
             };
 
             buttonsPlay.Add(new Button(@"solo", @"select-6", FontAwesome.fa_user, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
@@ -127,14 +134,6 @@ namespace osu.Game.Screens.Menu
             sampleBack = audio.Sample.Get(@"Menu/select-4");
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            // osuLogo.SizeForFlow relies on loading to be complete.
-            buttonFlow.Position = new Vector2(WEDGE_WIDTH * 2 - (BUTTON_WIDTH + osuLogo.SizeForFlow / 4), 0);
-        }
-
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
             if (args.Repeat) return false;
@@ -142,7 +141,7 @@ namespace osu.Game.Screens.Menu
             switch (args.Key)
             {
                 case Key.Space:
-                    osuLogo.TriggerOnClick(state);
+                    logo.TriggerOnClick(state);
                     return true;
                 case Key.Escape:
                     switch (State)
@@ -215,24 +214,31 @@ namespace osu.Game.Screens.Menu
                 backButton.ContractStyle = 0;
                 settingsButton.ContractStyle = 0;
 
-                bool fromInitial = lastState == MenuState.Initial;
-
                 if (state == MenuState.TopLevel)
                     buttonArea.FinishTransforms(true);
 
-                using (buttonArea.BeginDelayedSequence(fromInitial ? 150 : 0, true))
+                using (buttonArea.BeginDelayedSequence(lastState == MenuState.Initial ? 150 : 0, true))
                 {
                     switch (state)
                     {
                         case MenuState.Exit:
                         case MenuState.Initial:
+                            trackingPosition = false;
+
                             buttonAreaBackground.ScaleTo(Vector2.One, 500, Easing.Out);
                             buttonArea.FadeOut(300);
 
-                            osuLogo.Delay(150)
-                                .Schedule(() => toolbar?.Hide())
-                                .ScaleTo(1, 800, Easing.OutExpo)
-                                .MoveTo(Vector2.Zero, 800, Easing.OutExpo);
+                            logo?.Delay(150)
+                                .Schedule(() =>
+                                {
+                                    toolbar?.Hide();
+
+                                    logo.ClearTransforms(targetMember: nameof(Position));
+                                    logo.RelativePositionAxes = Axes.Both;
+
+                                    logo.MoveTo(new Vector2(0.5f), 800, Easing.OutExpo);
+                                    logo.ScaleTo(1, 800, Easing.OutExpo);
+                                });
 
                             foreach (Button b in buttonsTopLevel)
                                 b.State = ButtonState.Contracted;
@@ -240,27 +246,40 @@ namespace osu.Game.Screens.Menu
                             foreach (Button b in buttonsPlay)
                                 b.State = ButtonState.Contracted;
 
-                            if (state == MenuState.Exit)
-                            {
-                                osuLogo.RotateTo(20, EXIT_DELAY * 1.5f);
-                                osuLogo.FadeOut(EXIT_DELAY);
-                            }
-                            else if (lastState == MenuState.TopLevel)
+                            if (state != MenuState.Exit && lastState == MenuState.TopLevel)
                                 sampleBack?.Play();
                             break;
                         case MenuState.TopLevel:
                             buttonAreaBackground.ScaleTo(Vector2.One, 200, Easing.Out);
 
-                            var sequence = osuLogo
-                                .ScaleTo(0.5f, 200, Easing.In)
-                                .MoveTo(buttonFlow.DrawPosition, 200, Easing.In);
+                            logo.ClearTransforms(targetMember: nameof(Position));
+                            logo.RelativePositionAxes = Axes.None;
 
-                            if (fromInitial && osuLogo.Scale.X > 0.5f)
-                                sequence.OnComplete(o =>
-                                {
-                                    o.Impact();
-                                    toolbar?.Show();
-                                });
+                            trackingPosition = true;
+
+                            switch (lastState)
+                            {
+                                case MenuState.Initial:
+                                    logo.ScaleTo(0.5f, 200, Easing.In);
+
+                                    trackingPosition = false;
+                                    logo
+                                        .MoveTo(iconTrackingPosition, lastState == MenuState.EnteringMode ? 0 : 200, Easing.In)
+                                        .OnComplete(o =>
+                                        {
+                                            trackingPosition = true;
+
+                                            if (logo.Scale.X > 0.5f)
+                                            {
+                                                o.Impact();
+                                                toolbar?.Show();
+                                            }
+                                        });
+                                    break;
+                                default:
+                                    logo.ScaleTo(0.5f, 200, Easing.OutQuint);
+                                    break;
+                            }
 
                             buttonArea.FadeIn(300);
 
@@ -279,6 +298,8 @@ namespace osu.Game.Screens.Menu
                             break;
                         case MenuState.EnteringMode:
                             buttonAreaBackground.ScaleTo(new Vector2(2, 0), 300, Easing.InSine);
+
+                            trackingPosition = true;
 
                             buttonsTopLevel.ForEach(b => b.ContractStyle = 1);
                             buttonsPlay.ForEach(b => b.ContractStyle = 1);
@@ -301,15 +322,26 @@ namespace osu.Game.Screens.Menu
             }
         }
 
+        private Vector2 iconTrackingPosition => logo.Parent.ToLocalSpace(iconFacade.ScreenSpaceDrawQuad.Centre);
+
+        private bool trackingPosition;
+
+        public void SetLogoTracking(bool value) => trackingPosition = value;
+
         protected override void Update()
         {
             //if (OsuGame.IdleTime > 6000 && State != MenuState.Exit)
             //    State = MenuState.Initial;
 
-            osuLogo.Interactive = Alpha > 0.2f;
-
-            iconFacade.Width = osuLogo.SizeForFlow * 0.5f;
             base.Update();
+
+            if (logo != null)
+            {
+                if (trackingPosition)
+                    logo.Position = iconTrackingPosition;
+
+                iconFacade.Width = logo.SizeForFlow * 0.5f;
+            }
         }
     }
 

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Screens.Menu
             logo.Colour = Color4.DarkGray;
             logo.Ripple = false;
 
-            const int quick_appear = 150;
+            const int quick_appear = 350;
 
             int initialMovementTime = logo.Alpha > 0.2f ? quick_appear : 0;
 

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -14,14 +14,13 @@ using osu.Game.Beatmaps.IO;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Backgrounds;
+using OpenTK;
 using OpenTK.Graphics;
 
 namespace osu.Game.Screens.Menu
 {
     public class Intro : OsuScreen
     {
-        private readonly OsuLogo logo;
-
         private const string menu_music_beatmap_hash = "3c8b1fcc9434dbb29e2fb613d3b9eada9d7bb6c125ceb32396c3b53437280c83";
 
         /// <summary>
@@ -39,32 +38,10 @@ namespace osu.Game.Screens.Menu
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenEmpty();
 
-        public Intro()
-        {
-            Children = new Drawable[]
-            {
-                new ParallaxContainer
-                {
-                    ParallaxAmount = 0.01f,
-                    Children = new Drawable[]
-                    {
-                        logo = new OsuLogo
-                        {
-                            Alpha = 0,
-                            Triangles = false,
-                            Blending = BlendingMode.Additive,
-                            Interactive = false,
-                            Colour = Color4.DarkGray,
-                            Ripple = false
-                        }
-                    }
-                }
-            };
-        }
-
         private Bindable<bool> menuVoice;
         private Bindable<bool> menuMusic;
         private Track track;
+        private readonly ParallaxContainer parallax;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, OsuConfigManager config, BeatmapManager beatmaps, Framework.Game game)
@@ -121,14 +98,48 @@ namespace osu.Game.Screens.Menu
                 {
                     DidLoadMenu = true;
                     Push(mainMenu);
-                }, 2300);
-            }, 600);
+                }, delay_step_one);
+            }, delay_step_two);
+        }
 
-            logo.ScaleTo(0.4f);
-            logo.FadeOut();
+        private const double delay_step_one = 2300;
+        private const double delay_step_two = 600;
 
-            logo.ScaleTo(1, 4400, Easing.OutQuint);
-            logo.FadeIn(20000, Easing.OutQuint);
+        public const int EXIT_DELAY = 3000;
+
+        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        {
+            base.LogoSetup(logo, resuming);
+
+            logo.RelativePositionAxes = Axes.Both;
+
+            logo.Triangles = false;
+            logo.Colour = Color4.DarkGray;
+            logo.Ripple = false;
+
+            const int quick_appear = 150;
+
+            int initialMovementTime = logo.Alpha > 0.2f ? quick_appear : 0;
+
+            logo.MoveTo(new Vector2(0.5f), initialMovementTime, Easing.OutQuint);
+
+            if (!resuming)
+            {
+                logo.ScaleTo(0.4f);
+                logo.FadeOut();
+
+                logo.ScaleTo(1, delay_step_one + delay_step_two, Easing.OutQuint);
+                logo.FadeIn(delay_step_one + delay_step_two, Easing.OutQuint);
+            }
+            else
+            {
+                logo
+                    .ScaleTo(1, initialMovementTime, Easing.OutQuint)
+                    .FadeIn(quick_appear, Easing.OutQuint)
+                    .Then()
+                    .RotateTo(20, EXIT_DELAY * 1.5f)
+                    .FadeOut(EXIT_DELAY);
+            }
         }
 
         protected override void OnSuspending(Screen next)
@@ -148,7 +159,7 @@ namespace osu.Game.Screens.Menu
             if (!(last is MainMenu))
                 Content.FadeIn(300);
 
-            double fadeOutTime = 2000;
+            double fadeOutTime = EXIT_DELAY;
             //we also handle the exit transition.
             if (menuVoice)
                 seeya.Play();

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -109,9 +109,9 @@ namespace osu.Game.Screens.Menu
 
         public const int EXIT_DELAY = 3000;
 
-        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
         {
-            base.LogoSetup(logo, resuming);
+            base.OnArrivedLogo(logo, resuming);
 
             logo.RelativePositionAxes = Axes.Both;
 

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -109,9 +109,9 @@ namespace osu.Game.Screens.Menu
 
         public const int EXIT_DELAY = 3000;
 
-        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
+        protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
-            base.OnArrivedLogo(logo, resuming);
+            base.LogoArriving(logo, resuming);
 
             logo.RelativePositionAxes = Axes.Both;
 

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -103,9 +103,9 @@ namespace osu.Game.Screens.Menu
             Beatmap.ValueChanged += beatmap_ValueChanged;
         }
 
-        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
+        protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
-            base.OnArrivedLogo(logo, resuming);
+            base.LogoArriving(logo, resuming);
 
             buttons.SetOsuLogo(logo);
 
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.Menu
                 buttons.State = MenuState.TopLevel;
         }
 
-        protected override void OnSuspendingLogo(OsuLogo logo)
+        protected override void LogoSuspending(OsuLogo logo)
         {
             logo.FadeOut(300, Easing.InSine)
                 .ScaleTo(0.2f, 300, Easing.InSine)

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -103,9 +103,9 @@ namespace osu.Game.Screens.Menu
             Beatmap.ValueChanged += beatmap_ValueChanged;
         }
 
-        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
         {
-            base.LogoSetup(logo, resuming);
+            base.OnArrivedLogo(logo, resuming);
 
             buttons.SetOsuLogo(logo);
 
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.Menu
                 buttons.State = MenuState.TopLevel;
         }
 
-        protected override void LogoOnSuspending(OsuLogo logo)
+        protected override void OnSuspendingLogo(OsuLogo logo)
         {
             logo.FadeOut(300, Easing.InSine)
                 .ScaleTo(0.2f, 300, Easing.InSine)

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using OpenTK;
+using OpenTK.Graphics;
 using OpenTK.Input;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -102,6 +103,29 @@ namespace osu.Game.Screens.Menu
             Beatmap.ValueChanged += beatmap_ValueChanged;
         }
 
+        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        {
+            base.LogoSetup(logo, resuming);
+
+            buttons.SetOsuLogo(logo);
+
+            logo.Triangles = true;
+            logo.Ripple = false;
+
+            logo.FadeColour(Color4.White, 100, Easing.OutQuint);
+            logo.FadeIn(100, Easing.OutQuint);
+
+            if (resuming)
+                buttons.State = MenuState.TopLevel;
+        }
+
+        protected override void LogoOnSuspending(OsuLogo logo)
+        {
+            logo.FadeOut(300, Easing.InSine)
+                .ScaleTo(0.2f, 300, Easing.InSine)
+                .OnComplete(l => buttons.SetOsuLogo(null));
+        }
+
         private void beatmap_ValueChanged(WorkingBeatmap newValue)
         {
             if (!IsCurrentScreen)
@@ -134,8 +158,6 @@ namespace osu.Game.Screens.Menu
             preloadSongSelect();
 
             const float length = 300;
-
-            buttons.State = MenuState.TopLevel;
 
             Content.FadeIn(length, Easing.OutQuint);
             Content.MoveTo(new Vector2(0, 0), length, Easing.OutQuint);

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -224,27 +224,6 @@ namespace osu.Game.Screens.Menu
             ripple.Texture = textures.Get(@"Menu/logo");
         }
 
-        private double? reservationEndTime;
-        private Action<OsuLogo> reservationCallback;
-
-        private bool canFulfillReservation => !reservationEndTime.HasValue || reservationEndTime <= Time.Current;
-
-        public void RequestUsage(Action<OsuLogo> callback)
-        {
-            reservationCallback = callback;
-        }
-
-        private void fulfillReservation()
-        {
-            reservationCallback(this);
-            reservationCallback = null;
-        }
-
-        public void ReserveFor(float duration)
-        {
-            reservationEndTime = Time.Current + duration;
-        }
-
         private int lastBeatIndex;
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
@@ -311,9 +290,6 @@ namespace osu.Game.Screens.Menu
             {
                 triangles.Velocity = paused_velocity;
             }
-
-            if (reservationCallback != null && canFulfillReservation)
-                fulfillReservation();
         }
 
         private bool interactive => Action != null && Alpha > 0.2f;

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -77,6 +77,7 @@ namespace osu.Game.Screens.Menu
 
         public OsuLogo()
         {
+            // Required to make Schedule calls run in OsuScreen even when we are not visible.
             AlwaysPresent = true;
 
             EarlyActivationMilliseconds = early_activation;

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens
         protected override void OnResuming(Screen last)
         {
             base.OnResuming(last);
-            logo.DelayUntilTransformsFinished().Schedule(() => logoSetup(true));
+            logo.DelayUntilTransformsFinished().Schedule(() => LogoSetup(logo, true));
             sampleExit?.Play();
         }
 
@@ -122,7 +122,7 @@ namespace osu.Game.Screens
 
             base.OnEntering(last);
 
-            logo.DelayUntilTransformsFinished().Schedule(() => logoSetup(false));
+            logo.DelayUntilTransformsFinished().Schedule(() => LogoSetup(logo, false));
         }
 
         protected override bool OnExiting(Screen next)
@@ -147,8 +147,6 @@ namespace osu.Game.Screens
             Beatmap.UnbindAll();
             return false;
         }
-
-        private void logoSetup(bool resuming) => LogoSetup(logo, resuming);
 
         protected virtual void LogoSetup(OsuLogo logo, bool resuming)
         {

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -76,14 +76,14 @@ namespace osu.Game.Screens
         protected override void OnResuming(Screen last)
         {
             base.OnResuming(last);
-            logo.DelayUntilTransformsFinished().Schedule(() => LogoSetup(logo, true));
+            logo.DelayUntilTransformsFinished().Schedule(() => OnArrivedLogo(logo, true));
             sampleExit?.Play();
         }
 
         protected override void OnSuspending(Screen next)
         {
             base.OnSuspending(next);
-            logoOnSuspending();
+            onSuspendingLogo();
         }
 
         protected override void OnEntering(Screen last)
@@ -122,13 +122,13 @@ namespace osu.Game.Screens
 
             base.OnEntering(last);
 
-            logo.DelayUntilTransformsFinished().Schedule(() => LogoSetup(logo, false));
+            logo.DelayUntilTransformsFinished().Schedule(() => OnArrivedLogo(logo, false));
         }
 
         protected override bool OnExiting(Screen next)
         {
             if (ValidForResume && logo != null)
-                logoOnExiting();
+                onExitingLogo();
 
             OsuScreen nextOsu = next as OsuScreen;
 
@@ -148,29 +148,38 @@ namespace osu.Game.Screens
             return false;
         }
 
-        protected virtual void LogoSetup(OsuLogo logo, bool resuming)
+        /// <summary>
+        /// Fired when this screen was entered or resumed and the logo state is required to be adjusted.
+        /// </summary>
+        protected virtual void OnArrivedLogo(OsuLogo logo, bool resuming)
         {
             logo.Action = null;
             logo.FadeOut(300, Easing.OutQuint);
         }
 
-        private void logoOnExiting()
+        private void onExitingLogo()
         {
             logo.ClearTransforms();
-            LogoOnExiting(logo);
+            OnExitingLogo(logo);
         }
 
-        protected virtual void LogoOnExiting(OsuLogo logo)
+        /// <summary>
+        /// Fired when this screen was exited to add any outwards transition to the logo.
+        /// </summary>
+        protected virtual void OnExitingLogo(OsuLogo logo)
         {
         }
 
-        private void logoOnSuspending()
+        private void onSuspendingLogo()
         {
             logo.ClearTransforms();
-            LogoOnSuspending(logo);
+            OnSuspendingLogo(logo);
         }
 
-        protected virtual void LogoOnSuspending(OsuLogo logo)
+        /// <summary>
+        /// Fired when this screen was suspended to add any outwards transition to the logo.
+        /// </summary>
+        protected virtual void OnSuspendingLogo(OsuLogo logo)
         {
         }
     }

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens
         protected override void OnResuming(Screen last)
         {
             base.OnResuming(last);
-            logo.DelayUntilTransformsFinished().Schedule(() => OnArrivedLogo(logo, true));
+            logo.DelayUntilTransformsFinished().Schedule(() => LogoArriving(logo, true));
             sampleExit?.Play();
         }
 
@@ -122,7 +122,7 @@ namespace osu.Game.Screens
 
             base.OnEntering(last);
 
-            logo.DelayUntilTransformsFinished().Schedule(() => OnArrivedLogo(logo, false));
+            logo.DelayUntilTransformsFinished().Schedule(() => LogoArriving(logo, false));
         }
 
         protected override bool OnExiting(Screen next)
@@ -151,7 +151,7 @@ namespace osu.Game.Screens
         /// <summary>
         /// Fired when this screen was entered or resumed and the logo state is required to be adjusted.
         /// </summary>
-        protected virtual void OnArrivedLogo(OsuLogo logo, bool resuming)
+        protected virtual void LogoArriving(OsuLogo logo, bool resuming)
         {
             logo.Action = null;
             logo.FadeOut(300, Easing.OutQuint);
@@ -160,26 +160,26 @@ namespace osu.Game.Screens
         private void onExitingLogo()
         {
             logo.ClearTransforms();
-            OnExitingLogo(logo);
+            LogoExiting(logo);
         }
 
         /// <summary>
         /// Fired when this screen was exited to add any outwards transition to the logo.
         /// </summary>
-        protected virtual void OnExitingLogo(OsuLogo logo)
+        protected virtual void LogoExiting(OsuLogo logo)
         {
         }
 
         private void onSuspendingLogo()
         {
             logo.ClearTransforms();
-            OnSuspendingLogo(logo);
+            LogoSuspending(logo);
         }
 
         /// <summary>
         /// Fired when this screen was suspended to add any outwards transition to the logo.
         /// </summary>
-        protected virtual void OnSuspendingLogo(OsuLogo logo)
+        protected virtual void LogoSuspending(OsuLogo logo)
         {
         }
     }

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -10,7 +10,9 @@ using osu.Game.Graphics.Containers;
 using OpenTK;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets;
+using osu.Game.Screens.Menu;
 
 namespace osu.Game.Screens
 {
@@ -29,6 +31,8 @@ namespace osu.Game.Screens
         protected new OsuGameBase Game => base.Game as OsuGameBase;
 
         public virtual bool HasLocalCursorDisplayed => false;
+
+        private OsuLogo logo;
 
         /// <summary>
         /// Whether the beatmap or ruleset should be allowed to be changed by the user or game.
@@ -72,7 +76,14 @@ namespace osu.Game.Screens
         protected override void OnResuming(Screen last)
         {
             base.OnResuming(last);
+            logo.WaitForTransforms().Schedule(() => logoSetup(true));
             sampleExit?.Play();
+        }
+
+        protected override void OnSuspending(Screen next)
+        {
+            base.OnSuspending(next);
+            logoOnSuspending();
         }
 
         protected override void OnEntering(Screen last)
@@ -106,11 +117,19 @@ namespace osu.Game.Screens
                 });
             }
 
+            if ((logo = lastOsu?.logo) == null)
+                AddInternal(logo = new OsuLogo());
+
             base.OnEntering(last);
+
+            logo.WaitForTransforms().Schedule(() => logoSetup(false));
         }
 
         protected override bool OnExiting(Screen next)
         {
+            if (ValidForResume && logo != null)
+                logoOnExiting();
+
             OsuScreen nextOsu = next as OsuScreen;
 
             if (Background != null && !Background.Equals(nextOsu?.Background))
@@ -127,6 +146,34 @@ namespace osu.Game.Screens
 
             Beatmap.UnbindAll();
             return false;
+        }
+
+        private void logoSetup(bool resuming) => LogoSetup(logo, resuming);
+
+        protected virtual void LogoSetup(OsuLogo logo, bool resuming)
+        {
+            logo.Action = null;
+            logo.FadeOut(300, Easing.OutQuint);
+        }
+
+        private void logoOnExiting()
+        {
+            logo.ClearTransforms();
+            LogoOnExiting(logo);
+        }
+
+        protected virtual void LogoOnExiting(OsuLogo logo)
+        {
+        }
+
+        private void logoOnSuspending()
+        {
+            logo.ClearTransforms();
+            LogoOnSuspending(logo);
+        }
+
+        protected virtual void LogoOnSuspending(OsuLogo logo)
+        {
         }
     }
 }

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens
         protected override void OnResuming(Screen last)
         {
             base.OnResuming(last);
-            logo.WaitForTransforms().Schedule(() => logoSetup(true));
+            logo.DelayUntilTransformsFinished().Schedule(() => logoSetup(true));
             sampleExit?.Play();
         }
 
@@ -122,7 +122,7 @@ namespace osu.Game.Screens
 
             base.OnEntering(last);
 
-            logo.WaitForTransforms().Schedule(() => logoSetup(false));
+            logo.DelayUntilTransformsFinished().Schedule(() => logoSetup(false));
         }
 
         protected override bool OnExiting(Screen next)

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -104,9 +104,9 @@ namespace osu.Game.Screens.Play
 
             logo.ScaleTo(new Vector2(0.15f), 300, Easing.In);
             logo.MoveTo(new Vector2(0.5f), 300, Easing.In);
-            logo.FadeIn();
+            logo.FadeIn(350);
 
-            logo.Delay(500).MoveToOffset(new Vector2(0, -0.24f), 500, Easing.InOutExpo);
+            logo.Delay(resuming ? 0 : 500).MoveToOffset(new Vector2(0, -0.24f), 500, Easing.InOutExpo);
         }
 
         private void pushWhenLoaded()

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -95,9 +95,9 @@ namespace osu.Game.Screens.Play
             this.Delay(2150).Schedule(pushWhenLoaded);
         }
 
-        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
+        protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
-            base.OnArrivedLogo(logo, resuming);
+            base.LogoArriving(logo, resuming);
 
             logo.ClearTransforms(targetMember: nameof(Position));
             logo.RelativePositionAxes = Axes.Both;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -95,9 +95,9 @@ namespace osu.Game.Screens.Play
             this.Delay(2150).Schedule(pushWhenLoaded);
         }
 
-        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
         {
-            base.LogoSetup(logo, resuming);
+            base.OnArrivedLogo(logo, resuming);
 
             logo.ClearTransforms(targetMember: nameof(Position));
             logo.RelativePositionAxes = Axes.Both;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -10,9 +10,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Backgrounds;
-using osu.Game.Screens.Menu;
 using OpenTK;
 using osu.Framework.Localisation;
+using osu.Game.Screens.Menu;
 
 namespace osu.Game.Screens.Play
 {
@@ -20,7 +20,6 @@ namespace osu.Game.Screens.Play
     {
         private Player player;
 
-        private readonly OsuLogo logo;
         private BeatmapMetadataDisplay info;
 
         private bool showOverlays = true;
@@ -38,15 +37,6 @@ namespace osu.Game.Screens.Play
             {
                 showOverlays = false;
                 ValidForResume = true;
-            };
-
-            Children = new Drawable[]
-            {
-                logo = new OsuLogo
-                {
-                    Scale = new Vector2(0.15f),
-                    Interactive = false,
-                },
             };
         }
 
@@ -101,9 +91,22 @@ namespace osu.Game.Screens.Play
 
             contentIn();
 
-            logo.Delay(500).MoveToOffset(new Vector2(0, -180), 500, Easing.InOutExpo);
             info.Delay(750).FadeIn(500);
             this.Delay(2150).Schedule(pushWhenLoaded);
+        }
+
+        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        {
+            base.LogoSetup(logo, resuming);
+
+            logo.ClearTransforms(targetMember: nameof(Position));
+            logo.RelativePositionAxes = Axes.Both;
+
+            logo.ScaleTo(new Vector2(0.15f), 300, Easing.In);
+            logo.MoveTo(new Vector2(0.5f), 300, Easing.In);
+            logo.FadeIn();
+
+            logo.Delay(500).MoveToOffset(new Vector2(0, -0.24f), 500, Easing.InOutExpo);
         }
 
         private void pushWhenLoaded()

--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Screens.Menu;
 
 namespace osu.Game.Screens.Select
 {
@@ -31,11 +30,8 @@ namespace osu.Game.Screens.Select
         private const float padding = 80;
 
         public Action OnBack;
-        public Action OnStart;
 
         private readonly FillFlowContainer<FooterButton> buttons;
-
-        public OsuLogo StartButton;
 
         /// <param name="text">Text on the button.</param>
         /// <param name="colour">Colour of the button.</param>
@@ -106,13 +102,6 @@ namespace osu.Game.Screens.Select
                     Height = 3,
                     Position = new Vector2(0, -3),
                 },
-                StartButton = new OsuLogo
-                {
-                    Anchor = Anchor.BottomRight,
-                    Scale = new Vector2(0.4f),
-                    Position = new Vector2(-70, -25),
-                    Action = () => OnStart?.Invoke()
-                },
                 new BackButton
                 {
                     Anchor = Anchor.BottomLeft,
@@ -142,8 +131,6 @@ namespace osu.Game.Screens.Select
 
             updateModeLight();
         }
-
-        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => base.ReceiveMouseInputAt(screenSpacePos) || StartButton.ReceiveMouseInputAt(screenSpacePos);
 
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => true;
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -311,9 +311,9 @@ namespace osu.Game.Screens.Select
 
         private const double logo_transition = 250;
 
-        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
         {
-            base.LogoSetup(logo, resuming);
+            base.OnArrivedLogo(logo, resuming);
 
             logo.ClearTransforms();
             logo.RelativePositionAxes = Axes.Both;
@@ -337,9 +337,9 @@ namespace osu.Game.Screens.Select
             logo.Action = () => carouselRaisedStart();
         }
 
-        protected override void LogoOnExiting(OsuLogo logo)
+        protected override void OnExitingLogo(OsuLogo logo)
         {
-            base.LogoOnExiting(logo);
+            base.OnExitingLogo(logo);
             logo.ScaleTo(0.2f, logo_transition, Easing.OutQuint);
             logo.FadeOut(logo_transition, Easing.OutQuint);
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -20,6 +20,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
+using osu.Game.Screens.Menu;
 using osu.Game.Screens.Select.Options;
 
 namespace osu.Game.Screens.Select
@@ -153,7 +154,6 @@ namespace osu.Game.Screens.Select
                 Add(Footer = new Footer
                 {
                     OnBack = Exit,
-                    OnStart = () => carouselRaisedStart(),
                 });
 
                 FooterPanels.Add(BeatmapOptions = new BeatmapOptionsOverlay());
@@ -309,6 +309,41 @@ namespace osu.Game.Screens.Select
             FilterControl.Activate();
         }
 
+        private const double logo_transition = 250;
+
+        protected override void LogoSetup(OsuLogo logo, bool resuming)
+        {
+            base.LogoSetup(logo, resuming);
+
+            logo.ClearTransforms();
+            logo.RelativePositionAxes = Axes.Both;
+
+            Vector2 position = new Vector2(0.95f, 0.96f);
+
+            if (logo.Alpha > 0.8f)
+            {
+                logo.MoveTo(position, 500, Easing.OutQuint);
+            }
+            else
+            {
+                logo.Hide();
+                logo.ScaleTo(0.2f);
+                logo.MoveTo(position);
+            }
+
+            logo.FadeIn(logo_transition, Easing.OutQuint);
+            logo.ScaleTo(0.4f, logo_transition, Easing.OutQuint);
+
+            logo.Action = () => carouselRaisedStart();
+        }
+
+        protected override void LogoOnExiting(OsuLogo logo)
+        {
+            base.LogoOnExiting(logo);
+            logo.ScaleTo(0.2f, logo_transition, Easing.OutQuint);
+            logo.FadeOut(logo_transition, Easing.OutQuint);
+        }
+
         private void beatmap_ValueChanged(WorkingBeatmap beatmap)
         {
             if (!IsCurrentScreen) return;
@@ -350,6 +385,7 @@ namespace osu.Game.Screens.Select
             Content.FadeOut(100);
 
             FilterControl.Deactivate();
+
             return base.OnExiting(next);
         }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -311,9 +311,9 @@ namespace osu.Game.Screens.Select
 
         private const double logo_transition = 250;
 
-        protected override void OnArrivedLogo(OsuLogo logo, bool resuming)
+        protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
-            base.OnArrivedLogo(logo, resuming);
+            base.LogoArriving(logo, resuming);
 
             logo.ClearTransforms();
             logo.RelativePositionAxes = Axes.Both;
@@ -337,9 +337,9 @@ namespace osu.Game.Screens.Select
             logo.Action = () => carouselRaisedStart();
         }
 
-        protected override void OnExitingLogo(OsuLogo logo)
+        protected override void LogoExiting(OsuLogo logo)
         {
-            base.OnExitingLogo(logo);
+            base.LogoExiting(logo);
             logo.ScaleTo(0.2f, logo_transition, Easing.OutQuint);
             logo.FadeOut(logo_transition, Easing.OutQuint);
         }


### PR DESCRIPTION
There should only ever be one osu! logo. It is now passed around between screens in a superfluous manner.

- [x] Depends on https://github.com/ppy/osu-framework/pull/1131