### PR TITLE
Fix loader pushing children screens before it is displayed itself

### DIFF
--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -5,11 +5,14 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Menu;
 using OpenTK;
+using osu.Framework.Screens;
 
 namespace osu.Game.Screens
 {
     public class Loader : OsuScreen
     {
+        private bool showDisclaimer;
+
         public override bool ShowOverlays => false;
 
         public Loader()
@@ -21,21 +24,40 @@ namespace osu.Game.Screens
         {
             base.LogoArriving(logo, resuming);
 
-            logo.RelativePositionAxes = Axes.Both;
+            logo.RelativePositionAxes = Axes.None;
             logo.Triangles = false;
-            logo.Position = new Vector2(0.9f);
+            logo.Origin = Anchor.BottomRight;
+            logo.Anchor = Anchor.BottomRight;
+            logo.Position = new Vector2(-40);
             logo.Scale = new Vector2(0.2f);
 
             logo.FadeInFromZero(5000, Easing.OutQuint);
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuGameBase game)
+        protected override void OnEntering(Screen last)
         {
-            if (game.IsDeployedBuild)
+            base.OnEntering(last);
+
+            if (showDisclaimer)
                 LoadComponentAsync(new Disclaimer(), d => Push(d));
             else
                 LoadComponentAsync(new Intro(), d => Push(d));
+        }
+
+        protected override void LogoSuspending(OsuLogo logo)
+        {
+            base.LogoSuspending(logo);
+            logo.FadeOut(100).OnComplete(l =>
+            {
+                l.Anchor = Anchor.TopLeft;
+                l.Origin = Anchor.Centre;
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGameBase game)
+        {
+            showDisclaimer = game.IsDeployedBuild;
         }
     }
 }


### PR DESCRIPTION
- Realign the loader's osu! logo to have proper margins.
- Ensure pushing children modes is only done post-entering. It could previously have been scheduled before enter.