### PR TITLE
Improve transition when exiting song select

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -119,7 +119,16 @@ namespace osu.Game.Screens.Menu
             logo.FadeIn(100, Easing.OutQuint);
 
             if (resuming)
+            {
                 buttons.State = MenuState.TopLevel;
+
+                const float length = 300;
+
+                Content.FadeIn(length, Easing.OutQuint);
+                Content.MoveTo(new Vector2(0, 0), length, Easing.OutQuint);
+
+                sideFlashes.Delay(length).FadeIn(64, Easing.InQuint);
+            }
         }
 
         protected override void LogoSuspending(OsuLogo logo)
@@ -148,7 +157,7 @@ namespace osu.Game.Screens.Menu
             Content.FadeOut(length, Easing.InSine);
             Content.MoveTo(new Vector2(-800, 0), length, Easing.InSine);
 
-            sideFlashes.FadeOut(length / 4, Easing.OutQuint);
+            sideFlashes.FadeOut(64, Easing.OutQuint);
         }
 
         protected override void OnResuming(Screen last)
@@ -159,13 +168,6 @@ namespace osu.Game.Screens.Menu
 
             //we may have consumed our preloaded instance, so let's make another.
             preloadSongSelect();
-
-            const float length = 300;
-
-            Content.FadeIn(length, Easing.OutQuint);
-            Content.MoveTo(new Vector2(0, 0), length, Easing.OutQuint);
-
-            sideFlashes.FadeIn(length / 4, Easing.InQuint);
         }
 
         protected override bool OnExiting(Screen next)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -340,8 +340,8 @@ namespace osu.Game.Screens.Select
         protected override void LogoExiting(OsuLogo logo)
         {
             base.LogoExiting(logo);
-            logo.ScaleTo(0.2f, logo_transition, Easing.OutQuint);
-            logo.FadeOut(logo_transition, Easing.OutQuint);
+            logo.ScaleTo(0.2f, logo_transition / 2, Easing.Out);
+            logo.FadeOut(logo_transition / 2, Easing.Out);
         }
 
         private void beatmap_ValueChanged(WorkingBeatmap beatmap)


### PR DESCRIPTION
Reduces the delay before the main menu appears, but also synchronises the full main menu appearance animation with the logo's apperance.