### PR TITLE
Make error more verbose when beatmap import fails

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Beatmaps
                 catch (Exception e)
                 {
                     e = e.InnerException ?? e;
-                    Logger.Error(e, @"Could not import beatmap set");
+                    Logger.Error(e, $@"Could not import beatmap set ({Path.GetFileName(path)})");
                 }
             }
 

--- a/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace osu.Game.Beatmaps.Formats
 {
@@ -25,9 +26,10 @@ namespace osu.Game.Beatmaps.Formats
             do { line = stream.ReadLine()?.Trim(); }
             while (line != null && line.Length == 0);
 
-            if (line == null || !decoders.ContainsKey(line))
+            string decoderKey = decoders.Keys.FirstOrDefault(k => line.Contains(k));
+            if (decoderKey == null)
                 throw new IOException(@"Unknown file format");
-            return (BeatmapDecoder)Activator.CreateInstance(decoders[line], line);
+            return (BeatmapDecoder)Activator.CreateInstance(decoders[decoderKey], decoderKey);
         }
 
         protected static void AddDecoder<T>(string magic) where T : BeatmapDecoder

--- a/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Beatmaps.Formats
             do { line = stream.ReadLine()?.Trim(); }
             while (line != null && line.Length == 0);
 
-            string decoderKey = decoders.Keys.FirstOrDefault(k => line.Contains(k));
+            string decoderKey = decoders.Keys.FirstOrDefault(k => line?.Contains(k) ?? false);
             if (decoderKey == null)
                 throw new IOException(@"Unknown file format");
             return (BeatmapDecoder)Activator.CreateInstance(decoders[decoderKey], decoderKey);

--- a/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/BeatmapDecoder.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace osu.Game.Beatmaps.Formats
 {
@@ -26,10 +25,9 @@ namespace osu.Game.Beatmaps.Formats
             do { line = stream.ReadLine()?.Trim(); }
             while (line != null && line.Length == 0);
 
-            string decoderKey = decoders.Keys.FirstOrDefault(k => line?.Contains(k) ?? false);
-            if (decoderKey == null)
+            if (line == null || !decoders.ContainsKey(line))
                 throw new IOException(@"Unknown file format");
-            return (BeatmapDecoder)Activator.CreateInstance(decoders[decoderKey], decoderKey);
+            return (BeatmapDecoder)Activator.CreateInstance(decoders[line], line);
         }
 
         protected static void AddDecoder<T>(string magic) where T : BeatmapDecoder


### PR DESCRIPTION
This should make it easier to find failing beatmap sets when importing.

Additionally it should be able to import beatmaps like [these](https://osu.ppy.sh/b/548058&m=0) that have unwanted characters (`\u007` in this example) in the first line.