### PR TITLE
Make many internal classes and methods public

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapBackgroundSprite.cs
@@ -7,7 +7,7 @@ using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    internal class BeatmapBackgroundSprite : Sprite
+    public class BeatmapBackgroundSprite : Sprite
     {
         private readonly WorkingBeatmap working;
 

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Beatmaps
 {
-    internal class DummyWorkingBeatmap : WorkingBeatmap
+    public class DummyWorkingBeatmap : WorkingBeatmap
     {
         private readonly OsuGameBase game;
 

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         private float textSize = 28;
-        internal float TextSize
+        public float TextSize
         {
             get
             {

--- a/osu.Game/Graphics/UserInterface/Volume/VolumeControl.cs
+++ b/osu.Game/Graphics/UserInterface/Volume/VolumeControl.cs
@@ -11,7 +11,7 @@ using osu.Game.Input.Bindings;
 
 namespace osu.Game.Graphics.UserInterface.Volume
 {
-    internal class VolumeControl : OverlayContainer
+    public class VolumeControl : OverlayContainer
     {
         private readonly VolumeMeter volumeMeterMaster;
 

--- a/osu.Game/Graphics/UserInterface/Volume/VolumeControlReceptor.cs
+++ b/osu.Game/Graphics/UserInterface/Volume/VolumeControlReceptor.cs
@@ -8,7 +8,7 @@ using osu.Game.Input.Bindings;
 
 namespace osu.Game.Graphics.UserInterface.Volume
 {
-    internal class VolumeControlReceptor : Container, IKeyBindingHandler<GlobalAction>
+    public class VolumeControlReceptor : Container, IKeyBindingHandler<GlobalAction>
     {
         public Func<GlobalAction, bool> ActionRequested;
 

--- a/osu.Game/Graphics/UserInterface/Volume/VolumeMeter.cs
+++ b/osu.Game/Graphics/UserInterface/Volume/VolumeMeter.cs
@@ -13,7 +13,7 @@ using osu.Game.Input.Bindings;
 
 namespace osu.Game.Graphics.UserInterface.Volume
 {
-    internal class VolumeMeter : Container, IKeyBindingHandler<GlobalAction>
+    public class VolumeMeter : Container, IKeyBindingHandler<GlobalAction>
     {
         private readonly Box meterFill;
         public BindableDouble Bindable { get; } = new BindableDouble();

--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -6,7 +6,7 @@ using osu.Framework.IO.Network;
 
 namespace osu.Game.Online.API
 {
-    internal class OAuth
+    public class OAuth
     {
         private readonly string clientId;
         private readonly string clientSecret;

--- a/osu.Game/Online/API/OAuthToken.cs
+++ b/osu.Game/Online/API/OAuthToken.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace osu.Game.Online.API
 {
     [Serializable]
-    internal class OAuthToken
+    public class OAuthToken
     {
         /// <summary>
         /// OAuth 2.0 access token.

--- a/osu.Game/Online/Multiplayer/GameType.cs
+++ b/osu.Game/Online/Multiplayer/GameType.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Online.Multiplayer
         }
     }
 
-    internal class VersusRow : FillFlowContainer
+    public class VersusRow : FillFlowContainer
     {
         public VersusRow(Color4 first, Color4 second, float size)
         {

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Overlays
         private readonly Box chatBackground;
         private readonly Box tabBackground;
 
-        public Bindable<double> ChatHeight { get; public set; }
+        public Bindable<double> ChatHeight { get; set; }
 
         private readonly Container channelSelectionContainer;
         private readonly ChannelSelectionOverlay channelSelection;

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Overlays
         private readonly Box chatBackground;
         private readonly Box tabBackground;
 
-        public Bindable<double> ChatHeight { get; internal set; }
+        public Bindable<double> ChatHeight { get; public set; }
 
         private readonly Container channelSelectionContainer;
         private readonly ChannelSelectionOverlay channelSelection;

--- a/osu.Game/Overlays/KeyBinding/KeyBindingRow.cs
+++ b/osu.Game/Overlays/KeyBinding/KeyBindingRow.cs
@@ -19,7 +19,7 @@ using OpenTK.Input;
 
 namespace osu.Game.Overlays.KeyBinding
 {
-    internal class KeyBindingRow : Container, IFilterable
+    public class KeyBindingRow : Container, IFilterable
     {
         private readonly object action;
         private readonly IEnumerable<Framework.Input.Bindings.KeyBinding> bindings;

--- a/osu.Game/Overlays/KeyBinding/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/KeyBinding/KeyBindingsSubsection.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Overlays.KeyBinding
         }
     }
 
-    internal class ResetButton : OsuButton
+    public class ResetButton : OsuButton
     {
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)

--- a/osu.Game/Overlays/LoginOverlay.cs
+++ b/osu.Game/Overlays/LoginOverlay.cs
@@ -13,7 +13,7 @@ using osu.Game.Graphics.Cursor;
 
 namespace osu.Game.Overlays
 {
-    internal class LoginOverlay : OsuFocusedOverlayContainer
+    public class LoginOverlay : OsuFocusedOverlayContainer
     {
         private LoginSettings settingsSection;
 

--- a/osu.Game/Overlays/Music/FilterControl.cs
+++ b/osu.Game/Overlays/Music/FilterControl.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace osu.Game.Overlays.Music
 {
-    internal class FilterControl : Container
+    public class FilterControl : Container
     {
         public readonly FilterTextBox Search;
 

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -17,7 +17,7 @@ using OpenTK;
 
 namespace osu.Game.Overlays.Music
 {
-    internal class PlaylistItem : Container, IFilterable, IDraggable
+    public class PlaylistItem : Container, IFilterable, IDraggable
     {
         private const float fade_duration = 100;
 

--- a/osu.Game/Overlays/Music/PlaylistList.cs
+++ b/osu.Game/Overlays/Music/PlaylistList.cs
@@ -14,7 +14,7 @@ using OpenTK;
 
 namespace osu.Game.Overlays.Music
 {
-    internal class PlaylistList : CompositeDrawable
+    public class PlaylistList : CompositeDrawable
     {
         public Action<BeatmapSetInfo> OnSelect;
 

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays.Settings
         private class RestoreDefaultValueButton : Box, IHasTooltip
         {
             private Bindable<T> bindable;
-            internal Bindable<T> Bindable
+            public Bindable<T> Bindable
             {
                 get { return bindable; }
                 set
@@ -185,13 +185,13 @@ namespace osu.Game.Overlays.Settings
                 UpdateState();
             }
 
-            internal void SetButtonColour(Color4 buttonColour)
+            public void SetButtonColour(Color4 buttonColour)
             {
                 this.buttonColour = buttonColour;
                 UpdateState();
             }
 
-            internal void UpdateState()
+            public void UpdateState()
             {
                 if (bindable == null)
                     return;

--- a/osu.Game/Overlays/Settings/SettingsLabel.cs
+++ b/osu.Game/Overlays/Settings/SettingsLabel.cs
@@ -7,7 +7,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Settings
 {
-    internal class SettingsLabel : SettingsItem<string>
+    public class SettingsLabel : SettingsItem<string>
     {
         protected override Drawable CreateControl() => null;
 

--- a/osu.Game/Overlays/Settings/Sidebar.cs
+++ b/osu.Game/Overlays/Settings/Sidebar.cs
@@ -18,8 +18,8 @@ namespace osu.Game.Overlays.Settings
     public class Sidebar : Container<SidebarButton>, IStateful<ExpandedState>
     {
         private readonly FillFlowContainer<SidebarButton> content;
-        internal const float DEFAULT_WIDTH = ToolbarButton.WIDTH;
-        internal const int EXPANDED_WIDTH = 200;
+        public const float DEFAULT_WIDTH = ToolbarButton.WIDTH;
+        public const int EXPANDED_WIDTH = 200;
 
         public event Action<ExpandedState> StateChanged;
 

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays
 {
     public abstract class SettingsOverlay : OsuFocusedOverlayContainer
     {
-        internal const float CONTENT_MARGINS = 10;
+        public const float CONTENT_MARGINS = 10;
 
         public const float TRANSITION_LENGTH = 600;
 

--- a/osu.Game/Overlays/Toolbar/ToolbarChatButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarChatButton.cs
@@ -6,7 +6,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarChatButton : ToolbarOverlayToggleButton
+    public class ToolbarChatButton : ToolbarOverlayToggleButton
     {
         public ToolbarChatButton()
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarDirectButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarDirectButton.cs
@@ -6,7 +6,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarDirectButton : ToolbarOverlayToggleButton
+    public class ToolbarDirectButton : ToolbarOverlayToggleButton
     {
         public ToolbarDirectButton()
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
@@ -5,7 +5,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarHomeButton : ToolbarButton
+    public class ToolbarHomeButton : ToolbarButton
     {
         public ToolbarHomeButton()
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarModeSelector.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarModeSelector.cs
@@ -14,7 +14,7 @@ using osu.Game.Rulesets;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarModeSelector : Container
+    public class ToolbarModeSelector : Container
     {
         private const float padding = 10;
 

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -6,7 +6,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarMusicButton : ToolbarOverlayToggleButton
+    public class ToolbarMusicButton : ToolbarOverlayToggleButton
     {
         public ToolbarMusicButton()
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarNotificationButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarNotificationButton.cs
@@ -7,7 +7,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarNotificationButton : ToolbarOverlayToggleButton
+    public class ToolbarNotificationButton : ToolbarOverlayToggleButton
     {
         protected override Anchor TooltipAnchor => Anchor.TopRight;
 

--- a/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
@@ -9,7 +9,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarOverlayToggleButton : ToolbarButton
+    public class ToolbarOverlayToggleButton : ToolbarButton
     {
         private readonly Box stateBackground;
 

--- a/osu.Game/Overlays/Toolbar/ToolbarSettingsButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarSettingsButton.cs
@@ -6,7 +6,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarSettingsButton : ToolbarOverlayToggleButton
+    public class ToolbarSettingsButton : ToolbarOverlayToggleButton
     {
         public ToolbarSettingsButton()
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarSocialButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarSocialButton.cs
@@ -6,7 +6,7 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarSocialButton : ToolbarOverlayToggleButton
+    public class ToolbarSocialButton : ToolbarOverlayToggleButton
     {
         public ToolbarSocialButton()
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarUserArea.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserArea.cs
@@ -9,7 +9,7 @@ using OpenTK;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarUserArea : Container
+    public class ToolbarUserArea : Container
     {
         public LoginOverlay LoginOverlay;
         private ToolbarUserButton button;

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -12,7 +12,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    internal class ToolbarUserButton : ToolbarButton, IOnlineComponent
+    public class ToolbarUserButton : ToolbarButton, IOnlineComponent
     {
         private readonly UpdateableAvatar avatar;
 

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -20,12 +20,12 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// The combo prior to this judgement occurring.
         /// </summary>
-        internal int ComboAtJudgement;
+        public int ComboAtJudgement;
 
         /// <summary>
         /// The highest combo achieved prior to this judgement occurring.
         /// </summary>
-        internal int HighestComboAtJudgement;
+        public int HighestComboAtJudgement;
 
         /// <summary>
         /// Whether a successful hit occurred.
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Judgements
         /// The offset from a perfect hit at which this judgement occurred.
         /// Populated when added via <see cref="DrawableHitObject{TObject}.AddJudgement"/>.
         /// </summary>
-        public double TimeOffset { get; internal set; }
+        public double TimeOffset { get; public set; }
 
         /// <summary>
         /// Whether the <see cref="Result"/> should affect the combo portion of the score.

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Judgements
         /// The offset from a perfect hit at which this judgement occurred.
         /// Populated when added via <see cref="DrawableHitObject{TObject}.AddJudgement"/>.
         /// </summary>
-        public double TimeOffset { get; public set; }
+        public double TimeOffset { get; set; }
 
         /// <summary>
         /// Whether the <see cref="Result"/> should affect the combo portion of the score.

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
     /// <summary>
     /// A HitObjectParser to parse legacy osu!catch Beatmaps.
     /// </summary>
-    internal class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
+    public class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
     {
         protected override HitObject CreateHit(Vector2 position, bool newCombo)
         {

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
     /// <summary>
     /// A HitObjectParser to parse legacy Beatmaps.
     /// </summary>
-    internal abstract class ConvertHitObjectParser : HitObjectParser
+    public abstract class ConvertHitObjectParser : HitObjectParser
     {
         public override HitObject Parse(string text)
         {

--- a/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHitObjectParser.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
     /// <summary>
     /// A HitObjectParser to parse legacy osu!mania Beatmaps.
     /// </summary>
-    internal class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
+    public class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
     {
         protected override HitObject CreateHit(Vector2 position, bool newCombo)
         {

--- a/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Osu
     /// <summary>
     /// A HitObjectParser to parse legacy osu! Beatmaps.
     /// </summary>
-    internal class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
+    public class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
     {
         protected override HitObject CreateHit(Vector2 position, bool newCombo)
         {

--- a/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHitObjectParser.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Taiko
     /// <summary>
     /// A HitObjectParser to parse legacy osu!taiko Beatmaps.
     /// </summary>
-    internal class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
+    public class ConvertHitObjectParser : Legacy.ConvertHitObjectParser
     {
         protected override HitObject CreateHit(Vector2 position, bool newCombo)
         {

--- a/osu.Game/Rulesets/Timing/LinearScrollingContainer.cs
+++ b/osu.Game/Rulesets/Timing/LinearScrollingContainer.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Timing
     /// <summary>
     /// A <see cref="ScrollingContainer"/> which scrolls linearly relative to the <see cref="MultiplierControlPoint"/> start time.
     /// </summary>
-    internal class LinearScrollingContainer : ScrollingContainer
+    public class LinearScrollingContainer : ScrollingContainer
     {
         private readonly MultiplierControlPoint controlPoint;
 

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         public HitObjectContainer HitObjects { get; protected set; }
 
-        internal Container<Drawable> ScaledContent;
+        public Container<Drawable> ScaledContent;
 
         /// <summary>
         /// Whether we are currently providing the local user a gameplay cursor.

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.UI
         /// A visual representation of a <see cref="Rulesets.Ruleset"/>.
         /// </summary>
         /// <param name="ruleset">The ruleset being repesented.</param>
-        internal RulesetContainer(Ruleset ruleset)
+        public RulesetContainer(Ruleset ruleset)
         {
             Ruleset = ruleset;
         }

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.UI
         /// A visual representation of a <see cref="Rulesets.Ruleset"/>.
         /// </summary>
         /// <param name="ruleset">The ruleset being repesented.</param>
-        public RulesetContainer(Ruleset ruleset)
+        protected RulesetContainer(Ruleset ruleset)
         {
             Ruleset = ruleset;
         }

--- a/osu.Game/Screens/Charts/ChartInfo.cs
+++ b/osu.Game/Screens/Charts/ChartInfo.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Screens.Charts
 {
-    internal class ChartInfo : ScreenWhiteBox
+    public class ChartInfo : ScreenWhiteBox
     {
     }
 }

--- a/osu.Game/Screens/Charts/ChartListing.cs
+++ b/osu.Game/Screens/Charts/ChartListing.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace osu.Game.Screens.Charts
 {
-    internal class ChartListing : ScreenWhiteBox
+    public class ChartListing : ScreenWhiteBox
     {
         protected override IEnumerable<Type> PossibleChildren => new[] {
                 typeof(ChartInfo)

--- a/osu.Game/Screens/Direct/OnlineListing.cs
+++ b/osu.Game/Screens/Direct/OnlineListing.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Game.Screens.Direct
 {
-    internal class OnlineListing : ScreenWhiteBox
+    public class OnlineListing : ScreenWhiteBox
     {
     }
 }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BookmarkPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BookmarkPart.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// <summary>
     /// The part of the timeline that displays bookmarks.
     /// </summary>
-    internal class BookmarkPart : TimelinePart
+    public class BookmarkPart : TimelinePart
     {
         protected override void LoadBeatmap(WorkingBeatmap beatmap)
         {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// <summary>
     /// The part of the timeline that displays breaks in the song.
     /// </summary>
-    internal class BreakPart : TimelinePart
+    public class BreakPart : TimelinePart
     {
         protected override void LoadBeatmap(WorkingBeatmap beatmap)
         {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointPart.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// <summary>
     /// The part of the timeline that displays the control points.
     /// </summary>
-    internal class ControlPointPart : TimelinePart
+    public class ControlPointPart : TimelinePart
     {
         protected override void LoadBeatmap(WorkingBeatmap beatmap)
         {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// <summary>
     /// The part of the timeline that displays the current position of the song.
     /// </summary>
-    internal class MarkerPart : TimelinePart
+    public class MarkerPart : TimelinePart
     {
         private readonly Drawable marker;
 

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// <summary>
     /// Represents a part of the summary timeline..
     /// </summary>
-    internal abstract class TimelinePart : CompositeDrawable
+    public abstract class TimelinePart : CompositeDrawable
     {
         public Bindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
 

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/DurationVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/DurationVisualisation.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
     /// <summary>
     /// Represents a spanning point on a timeline part.
     /// </summary>
-    internal class DurationVisualisation : Container
+    public class DurationVisualisation : Container
     {
         protected DurationVisualisation(double startTime, double endTime)
         {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
     /// <summary>
     /// Represents a singular point on a timeline part.
     /// </summary>
-    internal class PointVisualisation : Box
+    public class PointVisualisation : Box
     {
         protected PointVisualisation(double startTime)
         {

--- a/osu.Game/Screens/Edit/Screens/Design/Design.cs
+++ b/osu.Game/Screens/Edit/Screens/Design/Design.cs
@@ -9,7 +9,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Screens.Design
 {
-    internal class Design : EditorScreen
+    public class Design : EditorScreen
     {
         public Design()
         {

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -39,10 +39,10 @@ namespace osu.Game.Screens.Menu
         private readonly FlowContainerWithOrigin buttonFlow;
 
         //todo: make these non-internal somehow.
-        internal const float BUTTON_AREA_HEIGHT = 100;
+        public const float BUTTON_AREA_HEIGHT = 100;
 
-        internal const float BUTTON_WIDTH = 140f;
-        internal const float WEDGE_WIDTH = 20;
+        public const float BUTTON_WIDTH = 140f;
+        public const float WEDGE_WIDTH = 20;
 
         private OsuLogo logo;
 

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// Whether we have loaded the menu previously.
         /// </summary>
-        internal bool DidLoadMenu;
+        public bool DidLoadMenu;
 
         private MainMenu mainMenu;
         private SampleChannel welcome;

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -226,7 +226,7 @@ namespace osu.Game.Screens.Menu
         /// </summary>
         /// <param name="action">The animation to be performed</param>
         /// <param name="waitForPrevious">If true, the new animation is delayed until all previous transforms finish. If false, existing transformed are cleared.</param>
-        internal void AppendAnimatingAction(Action action, bool waitForPrevious)
+        public void AppendAnimatingAction(Action action, bool waitForPrevious)
         {
             Action runnableAction = () =>
             {

--- a/osu.Game/Screens/Multiplayer/Lobby.cs
+++ b/osu.Game/Screens/Multiplayer/Lobby.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace osu.Game.Screens.Multiplayer
 {
-    internal class Lobby : ScreenWhiteBox
+    public class Lobby : ScreenWhiteBox
     {
         protected override IEnumerable<Type> PossibleChildren => new[] {
                 typeof(MatchCreate),

--- a/osu.Game/Screens/Multiplayer/Match.cs
+++ b/osu.Game/Screens/Multiplayer/Match.cs
@@ -12,7 +12,7 @@ using osu.Framework.Graphics;
 
 namespace osu.Game.Screens.Multiplayer
 {
-    internal class Match : ScreenWhiteBox
+    public class Match : ScreenWhiteBox
     {
         protected override IEnumerable<Type> PossibleChildren => new[] {
             typeof(MatchSongSelect),

--- a/osu.Game/Screens/Multiplayer/MatchCreate.cs
+++ b/osu.Game/Screens/Multiplayer/MatchCreate.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace osu.Game.Screens.Multiplayer
 {
-    internal class MatchCreate : ScreenWhiteBox
+    public class MatchCreate : ScreenWhiteBox
     {
         protected override IEnumerable<Type> PossibleChildren => new[] {
                 typeof(Match)

--- a/osu.Game/Screens/Ranking/ResultsPage.cs
+++ b/osu.Game/Screens/Ranking/ResultsPage.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Screens.Ranking
 {
-    internal class ResultsPage : Container
+    public class ResultsPage : Container
     {
         protected readonly Score Score;
         protected readonly WorkingBeatmap Beatmap;

--- a/osu.Game/Screens/Ranking/ResultsPageRanking.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageRanking.cs
@@ -12,7 +12,7 @@ using osu.Framework.Graphics.Shapes;
 
 namespace osu.Game.Screens.Ranking
 {
-    internal class ResultsPageRanking : ResultsPage
+    public class ResultsPageRanking : ResultsPage
     {
         public ResultsPageRanking(Score score, WorkingBeatmap beatmap = null) : base(score, beatmap)
         {

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -26,7 +26,7 @@ using osu.Framework.Graphics.Shapes;
 
 namespace osu.Game.Screens.Ranking
 {
-    internal class ResultsPageScore : ResultsPage
+    public class ResultsPageScore : ResultsPage
     {
         private ScoreCounter scoreCounter;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -23,7 +23,7 @@ using osu.Game.Graphics.Cursor;
 
 namespace osu.Game.Screens.Select
 {
-    internal class BeatmapCarousel : OsuScrollContainer
+    public class BeatmapCarousel : OsuScrollContainer
     {
         public BeatmapInfo SelectedBeatmap => selectedPanel?.Beatmap;
 
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.Select
             Schedule(() => removeGroup(groups.Find(b => b.BeatmapSet.ID == beatmapSet.ID)));
         }
 
-        internal void UpdateBeatmap(BeatmapInfo beatmap)
+        public void UpdateBeatmap(BeatmapInfo beatmap)
         {
             // todo: this method should not run more than once for the same BeatmapSetInfo.
             var set = manager.QueryBeatmapSet(s => s.ID == beatmap.BeatmapSetInfoID);

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -22,7 +22,7 @@ using osu.Framework.Graphics.Shapes;
 
 namespace osu.Game.Screens.Select
 {
-    internal class BeatmapInfoWedge : OverlayContainer
+    public class BeatmapInfoWedge : OverlayContainer
     {
         private static readonly Vector2 wedged_container_shear = new Vector2(0.15f, 0);
 

--- a/osu.Game/Screens/Tournament/Components/VisualiserContainer.cs
+++ b/osu.Game/Screens/Tournament/Components/VisualiserContainer.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace osu.Game.Screens.Tournament.Components
 {
-    internal class VisualiserContainer : Container
+    public class VisualiserContainer : Container
     {
         /// <summary>
         /// Number of lines in the visualiser.


### PR DESCRIPTION
This is important when using dynamic compiling to rapidly iterate. Until we actually split projects out into pieces (like the abstract ruleset project we have talked about) there is no advantage to using internal in the osu! game code.