### PR TITLE
Reduce synchronous access to WorkingBeatmap properties

### DIFF
--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu
         };
 
         public override IEnumerable<BeatmapStatistic> GetBeatmapStatistics(WorkingBeatmap beatmap) => new[]
-            {
+        {
             new BeatmapStatistic
             {
                 Name = @"Circle count",

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Graphics.Containers
 
             double currentTrackTime = track.Length > 0 ? track.CurrentTime + EarlyActivationMilliseconds : Clock.CurrentTime;
 
-            TimingControlPoint timingPoint = Beatmap.Value.Beatmap.ControlPointInfo.TimingPointAt(currentTrackTime);
-            EffectControlPoint effectPoint = Beatmap.Value.Beatmap.ControlPointInfo.EffectPointAt(currentTrackTime);
+            TimingControlPoint timingPoint = beatmap.ControlPointInfo.TimingPointAt(currentTrackTime);
+            EffectControlPoint effectPoint = beatmap.ControlPointInfo.EffectPointAt(currentTrackTime);
 
             if (timingPoint.BeatLength == 0)
                 return;
@@ -67,7 +67,7 @@ namespace osu.Game.Graphics.Containers
                 return;
 
             using (BeginDelayedSequence(-TimeSinceLastBeat, true))
-                OnNewBeat(beatIndex, timingPoint, effectPoint, Beatmap.Value.Track.CurrentAmplitudes);
+                OnNewBeat(beatIndex, timingPoint, effectPoint, track.CurrentAmplitudes);
 
             lastBeat = beatIndex;
             lastTimingPoint = timingPoint;

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays
 
         private const float bottom_black_area_height = 55;
 
-        private Drawable currentBackground;
+        private Drawable background;
         private ProgressBar progressBar;
 
         private IconButton prevButton;
@@ -120,7 +120,7 @@ namespace osu.Game.Overlays
                             },
                             Children = new[]
                             {
-                                currentBackground = new Background(),
+                                background = new Background(),
                                 title = new OsuSpriteText
                                 {
                                     Origin = Anchor.BottomCentre,
@@ -334,6 +334,7 @@ namespace osu.Game.Overlays
 
             pendingBeatmapSwitch = Schedule(delegate
             {
+                // todo: this can likely be replaced with WorkingBeatmap.GetBeatmapAsync()
                 Task.Run(() =>
                 {
                     if (beatmap?.Beatmap == null) //this is not needed if a placeholder exists
@@ -352,29 +353,26 @@ namespace osu.Game.Overlays
                     }
                 });
 
-                playerContainer.Add(new AsyncLoadWrapper(new Background(beatmap)
+                LoadComponentAsync(new Background(beatmap) { Depth = float.MaxValue }, newBackground =>
                 {
-                    OnLoadComplete = newBackground =>
+                    switch (direction)
                     {
-                        switch (direction)
-                        {
-                            case TransformDirection.Next:
-                                newBackground.Position = new Vector2(400, 0);
-                                newBackground.MoveToX(0, 500, Easing.OutCubic);
-                                currentBackground.MoveToX(-400, 500, Easing.OutCubic);
-                                break;
-                            case TransformDirection.Prev:
-                                newBackground.Position = new Vector2(-400, 0);
-                                newBackground.MoveToX(0, 500, Easing.OutCubic);
-                                currentBackground.MoveToX(400, 500, Easing.OutCubic);
-                                break;
-                        }
-                        currentBackground.Expire();
-                        currentBackground = newBackground;
+                        case TransformDirection.Next:
+                            newBackground.Position = new Vector2(400, 0);
+                            newBackground.MoveToX(0, 500, Easing.OutCubic);
+                            background.MoveToX(-400, 500, Easing.OutCubic);
+                            break;
+                        case TransformDirection.Prev:
+                            newBackground.Position = new Vector2(-400, 0);
+                            newBackground.MoveToX(0, 500, Easing.OutCubic);
+                            background.MoveToX(400, 500, Easing.OutCubic);
+                            break;
                     }
-                })
-                {
-                    Depth = float.MaxValue,
+
+                    background.Expire();
+                    background = newBackground;
+
+                    playerContainer.Add(newBackground);
                 });
             });
         }

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -32,9 +32,7 @@ namespace osu.Game.Screens.Backgrounds
 
                 Schedule(() =>
                 {
-                    var newBackground = new BeatmapBackground(beatmap);
-
-                    LoadComponentAsync(newBackground, delegate
+                    LoadComponentAsync(new BeatmapBackground(beatmap), b =>
                     {
                         float newDepth = 0;
                         if (background != null)
@@ -45,8 +43,8 @@ namespace osu.Game.Screens.Backgrounds
                             background.Expire();
                         }
 
-                        newBackground.Depth = newDepth;
-                        Add(background = newBackground);
+                        b.Depth = newDepth;
+                        Add(background = b);
                         background.BlurSigma = blurTarget;
                     });
                 });

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Menu
 
         private void updateAmplitudes()
         {
-            var track = beatmap.Value.Track;
+            var track = beatmap.Value.TrackLoaded ? beatmap.Value.Track : null;
 
             float[] temporalAmplitudes = track?.CurrentAmplitudes.FrequencyAmplitudes ?? new float[256];
 

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Select
     {
         private static readonly Vector2 wedged_container_shear = new Vector2(0.15f, 0);
 
-        private Drawable beatmapInfoContainer;
+        private Drawable info;
 
         public BeatmapInfoWedge()
         {
@@ -65,29 +65,34 @@ namespace osu.Game.Screens.Select
 
         public void UpdateBeatmap(WorkingBeatmap beatmap)
         {
-            var lastContainer = beatmapInfoContainer;
-            float newDepth = lastContainer?.Depth + 1 ?? 0;
-
-            Add(beatmapInfoContainer = new AsyncLoadWrapper(
-                new BufferedWedgeInfo(beatmap)
-                {
-                    Shear = -Shear,
-                    OnLoadComplete = d =>
-                    {
-                        this.FadeIn(250);
-
-                        lastContainer?.FadeOut(250);
-                        lastContainer?.Expire();
-                    }
-                })
+            LoadComponentAsync(new BufferedWedgeInfo(beatmap)
             {
-                Depth = newDepth,
+                Shear = -Shear,
+                Depth = info?.Depth + 1 ?? 0,
+            }, newInfo =>
+            {
+                // ensure we ourselves are visible if not already.
+                if (!IsPresent)
+                    this.FadeIn(250);
+
+                info?.FadeOut(250);
+                info?.Expire();
+
+                Add(info = newInfo);
             });
         }
 
         public class BufferedWedgeInfo : BufferedContainer
         {
+            private readonly WorkingBeatmap beatmap;
+
             public BufferedWedgeInfo(WorkingBeatmap beatmap)
+            {
+                this.beatmap = beatmap;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
             {
                 BeatmapInfo beatmapInfo = beatmap.BeatmapInfo;
                 BeatmapMetadata metadata = beatmapInfo.Metadata ?? beatmap.BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
@@ -206,13 +211,13 @@ namespace osu.Game.Screens.Select
                                         Font = @"Exo2.0-Medium",
                                         Text = "mapped by ",
                                         TextSize = 15,
-                                        },
+                                    },
                                     new OsuSpriteText
                                     {
                                         Font = @"Exo2.0-Bold",
                                         Text = metadata.Author.Username,
                                         TextSize = 15,
-                                        },
+                                    },
                                 }
                             },
                             new FillFlowContainer
@@ -244,38 +249,39 @@ namespace osu.Game.Screens.Select
                     AutoSizeAxes = Axes.Both;
                     Children = new Drawable[]
                     {
-                    new SpriteIcon
-                    {
-                        Icon = FontAwesome.fa_square,
-                        Origin = Anchor.Centre,
-                        Colour = new Color4(68, 17, 136, 255),
-                        Rotation = 45,
-                        Size = new Vector2(20),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = statistic.Icon,
-                        Origin = Anchor.Centre,
-                        Colour = new Color4(255, 221, 85, 255),
-                        Scale = new Vector2(0.8f),
-                        Size = new Vector2(20),
-                    },
-                    new OsuSpriteText
-                    {
-                        Margin = new MarginPadding { Left = 13 },
-                        Font = @"Exo2.0-Bold",
-                        Colour = new Color4(255, 221, 85, 255),
-                        Text = statistic.Content,
-                        TextSize = 17,
-                        Origin = Anchor.CentreLeft
-                    },
+                        new SpriteIcon
+                        {
+                            Icon = FontAwesome.fa_square,
+                            Origin = Anchor.Centre,
+                            Colour = new Color4(68, 17, 136, 255),
+                            Rotation = 45,
+                            Size = new Vector2(20),
+                        },
+                        new SpriteIcon
+                        {
+                            Icon = statistic.Icon,
+                            Origin = Anchor.Centre,
+                            Colour = new Color4(255, 221, 85, 255),
+                            Scale = new Vector2(0.8f),
+                            Size = new Vector2(20),
+                        },
+                        new OsuSpriteText
+                        {
+                            Margin = new MarginPadding { Left = 13 },
+                            Font = @"Exo2.0-Bold",
+                            Colour = new Color4(255, 221, 85, 255),
+                            Text = statistic.Content,
+                            TextSize = 17,
+                            Origin = Anchor.CentreLeft
+                        },
                     };
                 }
             }
 
             private class DifficultyColourBar : DifficultyColouredContainer
             {
-                public DifficultyColourBar(BeatmapInfo beatmap) : base(beatmap)
+                public DifficultyColourBar(BeatmapInfo beatmap)
+                    : base(beatmap)
                 {
                 }
 
@@ -286,21 +292,21 @@ namespace osu.Game.Screens.Select
 
                     Children = new Drawable[]
                     {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = AccentColour,
-                        Width = full_opacity_ratio,
-                    },
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        RelativePositionAxes = Axes.Both,
-                        Colour = AccentColour,
-                        Alpha = 0.5f,
-                        X = full_opacity_ratio,
-                        Width = 1 - full_opacity_ratio,
-                    }
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = AccentColour,
+                            Width = full_opacity_ratio,
+                        },
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            RelativePositionAxes = Axes.Both,
+                            Colour = AccentColour,
+                            Alpha = 0.5f,
+                            X = full_opacity_ratio,
+                            Width = 1 - full_opacity_ratio,
+                        }
                     };
                 }
             }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -84,42 +84,43 @@ namespace osu.Game.Screens.Select
 
         public class BufferedWedgeInfo : BufferedContainer
         {
-            private readonly WorkingBeatmap beatmap;
+            private readonly WorkingBeatmap working;
 
-            public BufferedWedgeInfo(WorkingBeatmap beatmap)
+            public BufferedWedgeInfo(WorkingBeatmap working)
             {
-                this.beatmap = beatmap;
+                this.working = working;
             }
 
             [BackgroundDependencyLoader]
             private void load()
             {
-                BeatmapInfo beatmapInfo = beatmap.BeatmapInfo;
-                BeatmapMetadata metadata = beatmapInfo.Metadata ?? beatmap.BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
+                BeatmapInfo beatmapInfo = working.BeatmapInfo;
+                BeatmapMetadata metadata = beatmapInfo.Metadata ?? working.BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
+                Beatmap beatmap = working.Beatmap;
 
                 List<InfoLabel> labels = new List<InfoLabel>();
 
-                if (beatmap.Beatmap != null)
+                if (beatmap != null)
                 {
-                    HitObject lastObject = beatmap.Beatmap.HitObjects.LastOrDefault();
+                    HitObject lastObject = beatmap.HitObjects.LastOrDefault();
                     double endTime = (lastObject as IHasEndTime)?.EndTime ?? lastObject?.StartTime ?? 0;
 
                     labels.Add(new InfoLabel(new BeatmapStatistic
                     {
                         Name = "Length",
                         Icon = FontAwesome.fa_clock_o,
-                        Content = beatmap.Beatmap.HitObjects.Count == 0 ? "-" : TimeSpan.FromMilliseconds(endTime - beatmap.Beatmap.HitObjects.First().StartTime).ToString(@"m\:ss"),
+                        Content = beatmap.HitObjects.Count == 0 ? "-" : TimeSpan.FromMilliseconds(endTime - beatmap.HitObjects.First().StartTime).ToString(@"m\:ss"),
                     }));
 
                     labels.Add(new InfoLabel(new BeatmapStatistic
                     {
                         Name = "BPM",
                         Icon = FontAwesome.fa_circle,
-                        Content = getBPMRange(beatmap.Beatmap),
+                        Content = getBPMRange(beatmap),
                     }));
 
                     //get statistics from the current ruleset.
-                    labels.AddRange(beatmapInfo.Ruleset.CreateInstance().GetBeatmapStatistics(beatmap).Select(s => new InfoLabel(s)));
+                    labels.AddRange(beatmapInfo.Ruleset.CreateInstance().GetBeatmapStatistics(working).Select(s => new InfoLabel(s)));
                 }
 
                 PixelSnapping = true;
@@ -145,7 +146,7 @@ namespace osu.Game.Screens.Select
                         Children = new[]
                         {
                             // Zoomed-in and cropped beatmap background
-                            new BeatmapBackgroundSprite(beatmap)
+                            new BeatmapBackgroundSprite(working)
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Anchor = Anchor.Centre,
@@ -154,7 +155,7 @@ namespace osu.Game.Screens.Select
                             },
                         },
                     },
-                    new DifficultyColourBar(beatmap.BeatmapInfo)
+                    new DifficultyColourBar(beatmapInfo)
                     {
                         RelativeSizeAxes = Axes.Y,
                         Width = 20,

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using System.Linq;
 using OpenTK;
 using OpenTK.Graphics;
@@ -23,8 +22,6 @@ namespace osu.Game.Screens.Select.Leaderboards
     public class LeaderboardScore : OsuClickableContainer
     {
         public static readonly float HEIGHT = 60;
-
-        public event Action<Visibility> StateChanged;
 
         public readonly int RankPosition;
         public readonly Score Score;


### PR DESCRIPTION
I've added `Get*Async()` methods in a separate branch, but before resorting to using these, let's try and move as much access to the properties to conditional (using `*Loaded` as a precondition) or the `BackgroundDependencyLoader`/`LoadComponentAsync` pattern.

Note that editor components (`TimelinePart` derivatives) are not fixed yet. It will require a bit of restructuring to fix these components.