### PR TITLE
Fix profile rank graph being hidden (and improve visually)

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseRankGraph.cs
+++ b/osu.Game.Tests/Visual/TestCaseRankGraph.cs
@@ -9,23 +9,28 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using System.Collections.Generic;
 using System;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
     public class TestCaseRankGraph : OsuTestCase
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(RankChart) };
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(RankGraph),
+            typeof(LineGraph)
+        };
 
         public TestCaseRankGraph()
         {
-            RankChart graph;
+            RankGraph graph;
 
             var data = new int[89];
             var dataWithZeros = new int[89];
             var smallData = new int[89];
 
-            for(int i = 0; i < 89; i++)
+            for (int i = 0; i < 89; i++)
                 data[i] = dataWithZeros[i] = (i + 1) * 1000;
 
             for (int i = 20; i < 60; i++)
@@ -46,7 +51,7 @@ namespace osu.Game.Tests.Visual
                         RelativeSizeAxes = Axes.Both,
                         Colour = OsuColour.Gray(0.2f)
                     },
-                    graph = new RankChart
+                    graph = new RankGraph
                     {
                         RelativeSizeAxes = Axes.Both,
                     }

--- a/osu.Game.Tests/Visual/TestCaseRankGraph.cs
+++ b/osu.Game.Tests/Visual/TestCaseRankGraph.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Game.Overlays.Profile;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using OpenTK;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using System.Collections.Generic;
+using System;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.Visual
+{
+    public class TestCaseRankGraph : OsuTestCase
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(RankChart) };
+
+        public TestCaseRankGraph()
+        {
+            RankChart graph;
+
+            var data = new int[89];
+            var dataWithZeros = new int[89];
+            var smallData = new int[89];
+
+            for(int i = 0; i < 89; i++)
+                data[i] = dataWithZeros[i] = (i + 1) * 1000;
+
+            for (int i = 20; i < 60; i++)
+                dataWithZeros[i] = 0;
+
+            for (int i = 79; i < 89; i++)
+                smallData[i] = 100000 - i * 1000;
+
+            Add(new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(300, 150),
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = OsuColour.Gray(0.2f)
+                    },
+                    graph = new RankChart
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    }
+                }
+            });
+
+            AddStep("null user", () => graph.User.Value = null);
+            AddStep("rank only", () =>
+            {
+                graph.User.Value = new User
+                {
+                    Statistics = new UserStatistics
+                    {
+                        Rank = 123456,
+                        PP = 12345,
+                    }
+                };
+            });
+
+            AddStep("with rank history", () =>
+            {
+                graph.User.Value = new User
+                {
+                    Statistics = new UserStatistics
+                    {
+                        Rank = 89000,
+                        PP = 12345,
+                    },
+                    RankHistory = new User.RankHistoryData
+                    {
+                        Data = data,
+                    }
+                };
+            });
+
+            AddStep("with zero values", () =>
+            {
+                graph.User.Value = new User
+                {
+                    Statistics = new UserStatistics
+                    {
+                        Rank = 89000,
+                        PP = 12345,
+                    },
+                    RankHistory = new User.RankHistoryData
+                    {
+                        Data = dataWithZeros,
+                    }
+                };
+            });
+
+            AddStep("small amount of data", () =>
+            {
+                graph.User.Value = new User
+                {
+                    Statistics = new UserStatistics
+                    {
+                        Rank = 12000,
+                        PP = 12345,
+                    },
+                    RankHistory = new User.RankHistoryData
+                    {
+                        Data = smallData,
+                    }
+                };
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/TestCaseUserProfile.cs
+++ b/osu.Game.Tests/Visual/TestCaseUserProfile.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.Visual
         {
             typeof(ProfileHeader),
             typeof(UserProfileOverlay),
-            typeof(RankChart),
+            typeof(RankGraph),
             typeof(LineGraph),
         };
 

--- a/osu.Game.Tests/Visual/TestCaseUserProfile.cs
+++ b/osu.Game.Tests/Visual/TestCaseUserProfile.cs
@@ -2,14 +2,25 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Profile;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
     public class TestCaseUserProfile : OsuTestCase
     {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(ProfileHeader),
+            typeof(UserProfileOverlay),
+            typeof(RankChart),
+            typeof(LineGraph),
+        };
+
         public TestCaseUserProfile()
         {
             var profile = new UserProfileOverlay();

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Visual\TestCaseOsuGame.cs" />
     <Compile Include="Visual\TestCasePlaybackControl.cs" />
     <Compile Include="Visual\TestCasePlaySongSelect.cs" />
+    <Compile Include="Visual\TestCaseRankGraph.cs" />
     <Compile Include="Visual\TestCaseReplay.cs" />
     <Compile Include="Visual\TestCaseReplaySettingsOverlay.cs" />
     <Compile Include="Visual\TestCaseResults.cs" />

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -421,7 +421,7 @@ namespace osu.Game.Overlays.Profile
                 gradeSPlus.DisplayCount = 0;
                 gradeSSPlus.DisplayCount = 0;
 
-                rankGraph.Redraw(user);
+                rankGraph.User.Value = user;
             }
         }
 

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays.Profile
         private readonly OsuTextFlowContainer infoTextLeft;
         private readonly LinkFlowContainer infoTextRight;
         private readonly FillFlowContainer<SpriteText> scoreText, scoreNumberText;
-        private readonly RankChart rankGraph;
+        private readonly RankGraph rankGraph;
 
         private readonly Container coverContainer, supporterTag;
         private readonly Sprite levelBadge;
@@ -287,7 +287,7 @@ namespace osu.Game.Overlays.Profile
                                     Colour = Color4.Black.Opacity(0.25f),
                                     RelativeSizeAxes = Axes.Both
                                 },
-                                rankGraph = new RankChart
+                                rankGraph = new RankGraph
                                 {
                                     RelativeSizeAxes = Axes.Both
                                 }

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Overlays.Profile
         private readonly OsuTextFlowContainer infoTextLeft;
         private readonly LinkFlowContainer infoTextRight;
         private readonly FillFlowContainer<SpriteText> scoreText, scoreNumberText;
+        protected readonly RankChart rankGraph;
 
         private readonly Container coverContainer, chartContainer, supporterTag;
         private readonly Sprite levelBadge;
@@ -285,6 +286,10 @@ namespace osu.Game.Overlays.Profile
                                 {
                                     Colour = Color4.Black.Opacity(0.25f),
                                     RelativeSizeAxes = Axes.Both
+                                },
+                                rankGraph = new RankChart
+                                {
+                                    RelativeSizeAxes = Axes.Both
                                 }
                             }
                         }
@@ -303,11 +308,7 @@ namespace osu.Game.Overlays.Profile
 
         public User User
         {
-            get
-            {
-                return user;
-            }
-
+            get { return user; }
             set
             {
                 user = value;
@@ -420,7 +421,7 @@ namespace osu.Game.Overlays.Profile
                 gradeSPlus.DisplayCount = 0;
                 gradeSSPlus.DisplayCount = 0;
 
-                chartContainer.Add(new RankChart(user) { RelativeSizeAxes = Axes.Both });
+                rankGraph.Redraw(user);
             }
         }
 

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Overlays.Profile
         private readonly OsuTextFlowContainer infoTextLeft;
         private readonly LinkFlowContainer infoTextRight;
         private readonly FillFlowContainer<SpriteText> scoreText, scoreNumberText;
-        protected readonly RankChart rankGraph;
+        private readonly RankChart rankGraph;
 
-        private readonly Container coverContainer, chartContainer, supporterTag;
+        private readonly Container coverContainer, supporterTag;
         private readonly Sprite levelBadge;
         private readonly SpriteText levelText;
         private readonly GradeBadge gradeSSPlus, gradeSS, gradeSPlus, gradeS, gradeA;
@@ -274,7 +274,7 @@ namespace osu.Game.Overlays.Profile
                                 }
                             }
                         },
-                        chartContainer = new Container
+                        new Container
                         {
                             RelativeSizeAxes = Axes.X,
                             Anchor = Anchor.BottomCentre,

--- a/osu.Game/Overlays/Profile/RankChart.cs
+++ b/osu.Game/Overlays/Profile/RankChart.cs
@@ -14,30 +14,40 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Users;
+using System.Collections.Generic;
 
 namespace osu.Game.Overlays.Profile
 {
     public class RankChart : Container
     {
+        private const float primary_textsize = 25;
+        private const float secondary_textsize = 13;
+        private const float padding = 10;
+        private const float fade_duration = 150;
+        private const int rankedDays = 88;
+
         private readonly SpriteText rankText, performanceText, relativeText;
         private readonly RankChartLineGraph graph;
+        private readonly OsuSpriteText placeholder;
 
-        private readonly int[] ranks;
+        private KeyValuePair<int, int>[] ranks;
+        private User user;
 
-        private const float primary_textsize = 25, secondary_textsize = 13, padding = 10;
-
-        private readonly User user;
-
-        public RankChart(User user)
+        public RankChart()
         {
-            this.user = user;
-
-            int[] userRanks = user.RankHistory?.Data ?? new[] { user.Statistics.Rank };
-            ranks = userRanks.SkipWhile(x => x == 0).ToArray();
-
             Padding = new MarginPadding { Vertical = padding };
             Children = new Drawable[]
             {
+                placeholder = new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Text = "No recent plays",
+                    TextSize = 14,
+                    Font = @"Exo2.0-RegularItalic",
+                    Alpha = 0,
+                    Padding = new MarginPadding { Bottom = padding }
+                },
                 rankText = new OsuSpriteText
                 {
                     Anchor = Anchor.TopCentre,
@@ -60,50 +70,73 @@ namespace osu.Game.Overlays.Profile
                     Font = @"Exo2.0-RegularItalic",
                     TextSize = secondary_textsize
                 },
-            };
-
-            if (ranks.Length > 0)
-            {
-                Add(graph = new RankChartLineGraph
+                graph = new RankChartLineGraph
                 {
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.BottomCentre,
                     RelativeSizeAxes = Axes.X,
                     Y = -secondary_textsize,
-                    DefaultValueCount = ranks.Length,
-                });
+                    Alpha = 0,
+                }
+            };
 
-                graph.OnBallMove += showHistoryRankTexts;
+            graph.OnBallMove += showHistoryRankTexts;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            graph.Colour = colours.Yellow;
+        }
+
+        public void Redraw(User user)
+        {
+            if (this.user == null && user != null)
+                placeholder.FadeOut(fade_duration, Easing.Out);
+
+            this.user = user;
+
+            if (user == null)
+            {
+                rankText.Text = string.Empty;
+                performanceText.Text = string.Empty;
+                relativeText.Text = string.Empty;
+                graph.FadeOut(fade_duration, Easing.Out);
+                placeholder.FadeIn(fade_duration, Easing.Out);
+                ranks = null;
+                return;
             }
+
+            int[] userRanks = user.RankHistory?.Data ?? new[] { user.Statistics.Rank };
+            var tempRanks = userRanks.Select((x, index) => new KeyValuePair<int, int>(index, x)).SkipWhile(x => x.Value == 0).ToArray();
+            ranks = tempRanks.Where(x => x.Value != 0).ToArray();
+
+            if (ranks.Length > 1)
+            {
+                graph.DefaultValueCount = ranks.Length;
+                graph.Values = ranks.Select(x => -(float)Math.Log(x.Value));
+                graph.SetStaticBallPosition();
+                graph.FadeIn(fade_duration, Easing.Out);
+            }
+            else
+            {
+                graph.FadeOut(fade_duration, Easing.Out);
+            }
+
+            updateRankTexts();
         }
 
         private void updateRankTexts()
         {
             rankText.Text = user.Statistics.Rank > 0 ? $"#{user.Statistics.Rank:#,0}" : "no rank";
             performanceText.Text = user.Statistics.PP != null ? $"{user.Statistics.PP:#,0}pp" : string.Empty;
-            relativeText.Text = user.CountryRank > 0 ? $"{user.Country?.FullName} #{user.CountryRank:#,0}" : $"{user.Country?.FullName}";
+            relativeText.Text = $"{user.Country?.FullName} #{user.CountryRank:#,0}";
         }
 
         private void showHistoryRankTexts(int dayIndex)
         {
-            rankText.Text = ranks[dayIndex] > 0 ? $"#{ranks[dayIndex]:#,0}" : "no rank";
-            dayIndex++;
-            relativeText.Text = dayIndex == ranks.Length ? "Now" : $"{ranks.Length - dayIndex} days ago";
-            //plural should be handled in a general way
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            if (graph != null)
-            {
-                graph.Colour = colours.Yellow;
-                // use logarithmic coordinates
-                graph.Values = ranks.Select(x => x == 0 ? float.MinValue : -(float)Math.Log(x));
-                graph.SetStaticBallPosition();
-            }
-
-            updateRankTexts();
+            rankText.Text = $"#{ranks[dayIndex].Value:#,0}";
+            relativeText.Text = dayIndex + 1 == ranks.Length ? "Now" : $"{rankedDays - ranks[dayIndex].Key} days ago";
         }
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
@@ -118,31 +151,35 @@ namespace osu.Game.Overlays.Profile
 
         protected override bool OnHover(InputState state)
         {
-            graph?.UpdateBallPosition(state.Mouse.Position.X);
-            graph?.ShowBall();
+            if (ranks != null && ranks.Length > 1)
+            {
+                graph.UpdateBallPosition(state.Mouse.Position.X);
+                graph.ShowBall();
+            }
             return base.OnHover(state);
         }
 
         protected override bool OnMouseMove(InputState state)
         {
-            graph?.UpdateBallPosition(state.Mouse.Position.X);
+            if (ranks != null && ranks.Length > 1)
+                graph.UpdateBallPosition(state.Mouse.Position.X);
+
             return base.OnMouseMove(state);
         }
 
         protected override void OnHoverLost(InputState state)
         {
-            if (graph != null)
+            if (ranks != null && ranks.Length > 1)
             {
                 graph.HideBall();
                 updateRankTexts();
             }
+
             base.OnHoverLost(state);
         }
 
         private class RankChartLineGraph : LineGraph
         {
-            private const double fade_duration = 200;
-
             private readonly CircularContainer staticBall;
             private readonly CircularContainer movingBall;
 

--- a/osu.Game/Overlays/Profile/RankChart.cs
+++ b/osu.Game/Overlays/Profile/RankChart.cs
@@ -108,8 +108,7 @@ namespace osu.Game.Overlays.Profile
             }
 
             int[] userRanks = user.RankHistory?.Data ?? new[] { user.Statistics.Rank };
-            var tempRanks = userRanks.Select((x, index) => new KeyValuePair<int, int>(index, x)).SkipWhile(x => x.Value == 0).ToArray();
-            ranks = tempRanks.Where(x => x.Value != 0).ToArray();
+            ranks = userRanks.Select((x, index) => new KeyValuePair<int, int>(index, x)).Where(x => x.Value != 0).ToArray();
 
             if (ranks.Length > 1)
             {

--- a/osu.Game/Overlays/Profile/RankChart.cs
+++ b/osu.Game/Overlays/Profile/RankChart.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Overlays.Profile
 
         protected override bool OnHover(InputState state)
         {
-            if (ranks != null && ranks.Length > 1)
+            if (ranks?.Length > 1)
             {
                 graph.UpdateBallPosition(state.Mouse.Position.X);
                 graph.ShowBall();
@@ -156,7 +156,7 @@ namespace osu.Game.Overlays.Profile
 
         protected override bool OnMouseMove(InputState state)
         {
-            if (ranks != null && ranks.Length > 1)
+            if (ranks?.Length > 1)
                 graph.UpdateBallPosition(state.Mouse.Position.X);
 
             return base.OnMouseMove(state);
@@ -164,7 +164,7 @@ namespace osu.Game.Overlays.Profile
 
         protected override void OnHoverLost(InputState state)
         {
-            if (ranks != null && ranks.Length > 1)
+            if (ranks?.Length > 1)
             {
                 graph.HideBall();
                 updateRankTexts();

--- a/osu.Game/Overlays/Profile/RankChart.cs
+++ b/osu.Game/Overlays/Profile/RankChart.cs
@@ -46,7 +46,6 @@ namespace osu.Game.Overlays.Profile
                     Text = "No recent plays",
                     TextSize = 14,
                     Font = @"Exo2.0-RegularItalic",
-                    Alpha = 0,
                     Padding = new MarginPadding { Bottom = padding }
                 },
                 rankText = new OsuSpriteText

--- a/osu.Game/Overlays/Profile/RankChart.cs
+++ b/osu.Game/Overlays/Profile/RankChart.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays.Profile
         private const float secondary_textsize = 13;
         private const float padding = 10;
         private const float fade_duration = 150;
-        private const int rankedDays = 88;
+        private const int ranked_days = 88;
 
         private readonly SpriteText rankText, performanceText, relativeText;
         private readonly RankChartLineGraph graph;
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays.Profile
         private void showHistoryRankTexts(int dayIndex)
         {
             rankText.Text = $"#{ranks[dayIndex].Value:#,0}";
-            relativeText.Text = dayIndex + 1 == ranks.Length ? "Now" : $"{rankedDays - ranks[dayIndex].Key} days ago";
+            relativeText.Text = dayIndex + 1 == ranks.Length ? "Now" : $"{ranked_days - ranks[dayIndex].Key} days ago";
         }
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)

--- a/osu.Game/Overlays/Profile/RankGraph.cs
+++ b/osu.Game/Overlays/Profile/RankGraph.cs
@@ -91,11 +91,11 @@ namespace osu.Game.Overlays.Profile
             graph.Colour = colours.Yellow;
         }
 
-        private void userChanged(User newUser)
+        private void userChanged(User user)
         {
             placeholder.FadeIn(fade_duration, Easing.Out);
 
-            if (newUser == null)
+            if (user == null)
             {
                 rankText.Text = string.Empty;
                 performanceText.Text = string.Empty;
@@ -105,7 +105,7 @@ namespace osu.Game.Overlays.Profile
                 return;
             }
 
-            int[] userRanks = newUser.RankHistory?.Data ?? new[] { newUser.Statistics.Rank };
+            int[] userRanks = user.RankHistory?.Data ?? new[] { user.Statistics.Rank };
             ranks = userRanks.Select((x, index) => new KeyValuePair<int, int>(index, x)).Where(x => x.Value != 0).ToArray();
 
             if (ranks.Length > 1)

--- a/osu.Game/Overlays/Profile/RankGraph.cs
+++ b/osu.Game/Overlays/Profile/RankGraph.cs
@@ -19,7 +19,7 @@ using osu.Framework.Configuration;
 
 namespace osu.Game.Overlays.Profile
 {
-    public class RankChart : Container
+    public class RankGraph : Container
     {
         private const float primary_textsize = 25;
         private const float secondary_textsize = 13;
@@ -34,19 +34,18 @@ namespace osu.Game.Overlays.Profile
         private KeyValuePair<int, int>[] ranks;
         public Bindable<User> User = new Bindable<User>();
 
-        public RankChart()
+        public RankGraph()
         {
             Padding = new MarginPadding { Vertical = padding };
             Children = new Drawable[]
             {
                 placeholder = new OsuSpriteText
                 {
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
                     Text = "No recent plays",
                     TextSize = 14,
                     Font = @"Exo2.0-RegularItalic",
-                    Padding = new MarginPadding { Bottom = padding }
                 },
                 rankText = new OsuSpriteText
                 {
@@ -75,6 +74,7 @@ namespace osu.Game.Overlays.Profile
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.BottomCentre,
                     RelativeSizeAxes = Axes.X,
+                    Height = 75,
                     Y = -secondary_textsize,
                     Alpha = 0,
                 }
@@ -93,7 +93,7 @@ namespace osu.Game.Overlays.Profile
 
         private void userChanged(User newUser)
         {
-            placeholder.FadeTo(newUser == null ? 1 : 0, fade_duration, Easing.Out);
+            placeholder.FadeIn(fade_duration, Easing.Out);
 
             if (newUser == null)
             {
@@ -110,6 +110,8 @@ namespace osu.Game.Overlays.Profile
 
             if (ranks.Length > 1)
             {
+                placeholder.FadeOut(fade_duration, Easing.Out);
+
                 graph.DefaultValueCount = ranks.Length;
                 graph.Values = ranks.Select(x => -(float)Math.Log(x.Value));
                 graph.SetStaticBallPosition();
@@ -131,16 +133,6 @@ namespace osu.Game.Overlays.Profile
         {
             rankText.Text = $"#{ranks[dayIndex].Value:#,0}";
             relativeText.Text = dayIndex + 1 == ranks.Length ? "Now" : $"{ranked_days - ranks[dayIndex].Key} days ago";
-        }
-
-        public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
-        {
-            if ((invalidation & Invalidation.DrawSize) != 0)
-            {
-                graph.Height = DrawHeight - padding * 2 - primary_textsize - secondary_textsize * 2;
-            }
-
-            return base.Invalidate(invalidation, source, shallPropagate);
         }
 
         protected override bool OnHover(InputState state)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -499,7 +499,7 @@
     <Compile Include="Overlays\Profile\Sections\Ranks\DrawableProfileScore.cs" />
     <Compile Include="Overlays\Profile\ProfileHeader.cs" />
     <Compile Include="Overlays\Profile\ProfileSection.cs" />
-    <Compile Include="Overlays\Profile\RankChart.cs" />
+    <Compile Include="Overlays\Profile\RankGraph.cs" />
     <Compile Include="Overlays\Profile\Sections\AboutSection.cs" />
     <Compile Include="Overlays\Profile\Sections\BeatmapsSection.cs" />
     <Compile Include="Overlays\Profile\Sections\HistoricalSection.cs" />


### PR DESCRIPTION
- Uses `User` bindable instead of drawing itself in the ctor
- Supports null user
- Can handle the edge case when we can get zero values in rank history
- Hides graph if we have no rank history but have the rank itself