### PR TITLE
Reduced usage of AsyncLoadWrapper and merging both load wrappers into a new class LoadWrapper

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Beatmaps.Drawables
 
             Children = new Drawable[]
             {
-                new DelayedLoadWrapper(
+                new LoadWrapper(
                     new PanelBackground(beatmap)
                     {
                         RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -43,16 +43,14 @@ namespace osu.Game.Beatmaps.Drawables
 
             Children = new Drawable[]
             {
-                new LoadWrapper(
+                new DelayedLoadWrapper(
                     new PanelBackground(beatmap)
                     {
                         RelativeSizeAxes = Axes.Both,
                         OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    }
-                )
-                {
-                    TimeBeforeLoad = 300,
-                },
+                    },
+                    300
+                ),
                 new FillFlowContainer
                 {
                     Direction = FillDirection.Vertical,

--- a/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetHeader.cs
@@ -48,9 +48,7 @@ namespace osu.Game.Beatmaps.Drawables
                     {
                         RelativeSizeAxes = Axes.Both,
                         OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    },
-                    300
-                ),
+                    }, 300),
                 new FillFlowContainer
                 {
                     Direction = FillDirection.Vertical,

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private readonly AuthorInfo author;
         public Details Details;
 
-        private DelayedLoadWrapper cover;
+        private LoadWrapper cover;
 
         public readonly BeatmapPicker Picker;
 
@@ -52,7 +52,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 videoButtons.FadeTo(BeatmapSet.OnlineInfo.HasVideo ? 1 : 0, transition_duration);
 
                 cover?.FadeOut(400, Easing.Out);
-                coverContainer.Add(cover = new DelayedLoadWrapper(new BeatmapSetCover(BeatmapSet)
+                coverContainer.Add(cover = new LoadWrapper(new BeatmapSetCover(BeatmapSet)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -52,17 +52,18 @@ namespace osu.Game.Overlays.BeatmapSet
                 videoButtons.FadeTo(BeatmapSet.OnlineInfo.HasVideo ? 1 : 0, transition_duration);
 
                 cover?.FadeOut(400, Easing.Out);
-                coverContainer.Add(cover = new LoadWrapper(new BeatmapSetCover(BeatmapSet)
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    FillMode = FillMode.Fill,
-                    OnLoadComplete = d =>
+                coverContainer.Add(cover = new LoadWrapper(
+                    new BeatmapSetCover(BeatmapSet)
                     {
-                        d.FadeInFromZero(400, Easing.Out);
-                    },
-                })
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        FillMode = FillMode.Fill,
+                        OnLoadComplete = d =>
+                        {
+                            d.FadeInFromZero(400, Easing.Out);
+                        },
+                    })
                 {
                     RelativeSizeAxes = Axes.Both,
                     TimeBeforeLoad = 300

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -59,10 +59,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.Both,
                         FillMode = FillMode.Fill,
-                        OnLoadComplete = d =>
-                        {
-                            d.FadeInFromZero(400, Easing.Out);
-                        },
+                        OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
                     })
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private readonly AuthorInfo author;
         public Details Details;
 
-        private LoadWrapper cover;
+        private DelayedLoadWrapper cover;
 
         public readonly BeatmapPicker Picker;
 
@@ -52,7 +52,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 videoButtons.FadeTo(BeatmapSet.OnlineInfo.HasVideo ? 1 : 0, transition_duration);
 
                 cover?.FadeOut(400, Easing.Out);
-                coverContainer.Add(cover = new LoadWrapper(
+                coverContainer.Add(cover = new DelayedLoadWrapper(
                     new BeatmapSetCover(BeatmapSet)
                     {
                         Anchor = Anchor.Centre,
@@ -60,10 +60,10 @@ namespace osu.Game.Overlays.BeatmapSet
                         RelativeSizeAxes = Axes.Both,
                         FillMode = FillMode.Fill,
                         OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    })
+                    },
+                    300)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    TimeBeforeLoad = 300
                 });
             }
         }

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -60,8 +60,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         RelativeSizeAxes = Axes.Both,
                         FillMode = FillMode.Fill,
                         OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    },
-                    300)
+                    }, 300)
                 {
                     RelativeSizeAxes = Axes.Both,
                 });

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Overlays.Direct
             return icons;
         }
 
-        protected Drawable CreateBackground() => new DelayedLoadWrapper(new BeatmapSetCover(SetInfo)
+        protected Drawable CreateBackground() => new LoadWrapper(new BeatmapSetCover(SetInfo)
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -219,18 +219,19 @@ namespace osu.Game.Overlays.Direct
             return icons;
         }
 
-        protected Drawable CreateBackground() => new LoadWrapper(new BeatmapSetCover(SetInfo)
-        {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            RelativeSizeAxes = Axes.Both,
-            FillMode = FillMode.Fill,
-            OnLoadComplete = d =>
+        protected Drawable CreateBackground() => new LoadWrapper(
+            new BeatmapSetCover(SetInfo)
             {
-                d.FadeInFromZero(400, Easing.Out);
-                BlackBackground.Delay(400).FadeOut();
-            },
-        })
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                FillMode = FillMode.Fill,
+                OnLoadComplete = d =>
+                {
+                    d.FadeInFromZero(400, Easing.Out);
+                    BlackBackground.Delay(400).FadeOut();
+                },
+            })
         {
             RelativeSizeAxes = Axes.Both,
             TimeBeforeLoad = 300

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Overlays.Direct
             return icons;
         }
 
-        protected Drawable CreateBackground() => new LoadWrapper(
+        protected Drawable CreateBackground() => new DelayedLoadWrapper(
             new BeatmapSetCover(SetInfo)
             {
                 Anchor = Anchor.Centre,
@@ -231,10 +231,10 @@ namespace osu.Game.Overlays.Direct
                     d.FadeInFromZero(400, Easing.Out);
                     BlackBackground.Delay(400).FadeOut();
                 },
-            })
+            },
+            300)
         {
             RelativeSizeAxes = Axes.Both,
-            TimeBeforeLoad = 300
         };
 
         public class Statistic : FillFlowContainer

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -231,8 +231,7 @@ namespace osu.Game.Overlays.Direct
                     d.FadeInFromZero(400, Easing.Out);
                     BlackBackground.Delay(400).FadeOut();
                 },
-            },
-            300)
+            }, 300)
         {
             RelativeSizeAxes = Axes.Both,
         };

--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -146,18 +146,17 @@ namespace osu.Game.Overlays.Direct
 
             loading = true;
 
-            Add(new AsyncLoadWrapper(trackLoader = new TrackLoader($"https://b.ppy.sh/preview/{BeatmapSet.OnlineBeatmapSetID}.mp3")
-            {
-                OnLoadComplete = d =>
+            LoadComponentAsync(trackLoader = new TrackLoader($"https://b.ppy.sh/preview/{BeatmapSet.OnlineBeatmapSetID}.mp3"),
+                d =>
                 {
-                    // we may have been replaced by another loader
+                    // We may have been replaced by another loader
                     if (trackLoader != d) return;
 
                     Preview = (d as TrackLoader)?.Preview;
                     Playing.TriggerChange();
                     loading = false;
-                },
-            }));
+                    Add(trackLoader);
+                });
         }
 
         private class TrackLoader : Drawable

--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Overlays.Direct
                     // We may have been replaced by another loader
                     if (trackLoader != d) return;
 
-                    Preview = (d as TrackLoader)?.Preview;
+                    Preview = d?.Preview;
                     Playing.TriggerChange();
                     loading = false;
                     Add(trackLoader);

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -316,18 +316,18 @@ namespace osu.Game.Overlays.Profile
 
         private void loadUser()
         {
-            coverContainer.Add(new AsyncLoadWrapper(new UserCoverBackground(user)
+            LoadComponentAsync(new UserCoverBackground(user)
             {
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 FillMode = FillMode.Fill,
                 OnLoadComplete = d => d.FadeInFromZero(200)
-            })
+            },
+            ucb =>
             {
-                Masking = true,
-                RelativeSizeAxes = Axes.Both,
-                Depth = float.MaxValue
+                ucb.Depth = float.MaxValue;
+                coverContainer.Add(ucb);
             });
 
             if (user.IsSupporter) supporterTag.Show();

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -322,13 +322,10 @@ namespace osu.Game.Overlays.Profile
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 FillMode = FillMode.Fill,
-                OnLoadComplete = d => d.FadeInFromZero(200)
+                OnLoadComplete = d => d.FadeInFromZero(200),
+                Depth = float.MaxValue,
             },
-            ucb =>
-            {
-                ucb.Depth = float.MaxValue;
-                coverContainer.Add(ucb);
-            });
+            coverContainer.Add);
 
             if (user.IsSupporter) supporterTag.Show();
 

--- a/osu.Game/Screens/Multiplayer/DrawableRoom.cs
+++ b/osu.Game/Screens/Multiplayer/DrawableRoom.cs
@@ -229,6 +229,7 @@ namespace osu.Game.Screens.Multiplayer
             {
                 coverContainer.FadeIn(transition_duration);
 
+                
                 LoadComponentAsync(new BeatmapSetCover(value.BeatmapSet)
                 {
                     Anchor = Anchor.Centre,
@@ -236,11 +237,7 @@ namespace osu.Game.Screens.Multiplayer
                     FillMode = FillMode.Fill,
                     OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
                 },
-                bsc =>
-                {
-                    bsc.RelativeSizeAxes = Axes.Both;
-                    coverContainer.Add(bsc);
-                });
+                bsc => coverContainer.Add(bsc));
 
                 beatmapTitle.Current = localisation.GetUnicodePreference(value.Metadata.TitleUnicode, value.Metadata.Title);
                 beatmapDash.Text = @" - ";

--- a/osu.Game/Screens/Multiplayer/DrawableRoom.cs
+++ b/osu.Game/Screens/Multiplayer/DrawableRoom.cs
@@ -228,16 +228,19 @@ namespace osu.Game.Screens.Multiplayer
             if (value != null)
             {
                 coverContainer.FadeIn(transition_duration);
-                coverContainer.Children = new[]
+
+                LoadComponentAsync(new BeatmapSetCover(value.BeatmapSet)
                 {
-                    new AsyncLoadWrapper(new BeatmapSetCover(value.BeatmapSet)
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        FillMode = FillMode.Fill,
-                        OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    }) { RelativeSizeAxes = Axes.Both },
-                };
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    FillMode = FillMode.Fill,
+                    OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
+                },
+                bsc =>
+                {
+                    bsc.RelativeSizeAxes = Axes.Both;
+                    coverContainer.Add(bsc);
+                });
 
                 beatmapTitle.Current = localisation.GetUnicodePreference(value.Metadata.TitleUnicode, value.Metadata.Title);
                 beatmapDash.Text = @" - ";

--- a/osu.Game/Screens/Multiplayer/DrawableRoom.cs
+++ b/osu.Game/Screens/Multiplayer/DrawableRoom.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Screens.Multiplayer
             {
                 coverContainer.FadeIn(transition_duration);
 
-                
+
                 LoadComponentAsync(new BeatmapSetCover(value.BeatmapSet)
                 {
                     Anchor = Anchor.Centre,

--- a/osu.Game/Screens/Multiplayer/DrawableRoom.cs
+++ b/osu.Game/Screens/Multiplayer/DrawableRoom.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Screens.Multiplayer
                     FillMode = FillMode.Fill,
                     OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
                 },
-                bsc => coverContainer.Add(bsc));
+                coverContainer.Add);
 
                 beatmapTitle.Current = localisation.GetUnicodePreference(value.Metadata.TitleUnicode, value.Metadata.Title);
                 beatmapDash.Text = @" - ";

--- a/osu.Game/Screens/Multiplayer/RoomInspector.cs
+++ b/osu.Game/Screens/Multiplayer/RoomInspector.cs
@@ -329,17 +329,20 @@ namespace osu.Game.Screens.Multiplayer
             if (value != null)
             {
                 coverContainer.FadeIn(transition_duration);
-                coverContainer.Children = new[]
+
+                LoadComponentAsync(new BeatmapSetCover(value.BeatmapSet)
                 {
-                    new AsyncLoadWrapper(new BeatmapSetCover(value.BeatmapSet)
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        FillMode = FillMode.Fill,
-                        OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    }) { RelativeSizeAxes = Axes.Both },
-                };
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    FillMode = FillMode.Fill,
+                    OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
+                },
+                bsc =>
+                {
+                    bsc.RelativeSizeAxes = Axes.Both;
+                    coverContainer.Add(bsc);
+                });
 
                 beatmapTitle.Current = localisation.GetUnicodePreference(value.Metadata.TitleUnicode, value.Metadata.Title);
                 beatmapDash.Text = @" - ";

--- a/osu.Game/Screens/Multiplayer/RoomInspector.cs
+++ b/osu.Game/Screens/Multiplayer/RoomInspector.cs
@@ -338,11 +338,7 @@ namespace osu.Game.Screens.Multiplayer
                     FillMode = FillMode.Fill,
                     OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
                 },
-                bsc =>
-                {
-                    bsc.RelativeSizeAxes = Axes.Both;
-                    coverContainer.Add(bsc);
-                });
+                bsc => coverContainer.Add(bsc));
 
                 beatmapTitle.Current = localisation.GetUnicodePreference(value.Metadata.TitleUnicode, value.Metadata.Title);
                 beatmapDash.Text = @" - ";

--- a/osu.Game/Screens/Multiplayer/RoomInspector.cs
+++ b/osu.Game/Screens/Multiplayer/RoomInspector.cs
@@ -338,7 +338,7 @@ namespace osu.Game.Screens.Multiplayer
                     FillMode = FillMode.Fill,
                     OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
                 },
-                bsc => coverContainer.Add(bsc));
+                coverContainer.Add);
 
                 beatmapTitle.Current = localisation.GetUnicodePreference(value.Metadata.TitleUnicode, value.Metadata.Title);
                 beatmapDash.Text = @" - ";

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -248,7 +248,8 @@ namespace osu.Game.Screens.Play
             storyboard = beatmap.Storyboard.CreateDrawable(Beatmap.Value);
             storyboard.Masking = true;
 
-            storyboardContainer.Add(asyncLoad ? new AsyncLoadWrapper(storyboard) { RelativeSizeAxes = Axes.Both } : (Drawable)storyboard);
+            if (asyncLoad) LoadComponentAsync(storyboard, s => storyboardContainer.Add(s));
+            else storyboardContainer.Add((Drawable)storyboard);
         }
 
         public void Restart()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -248,8 +248,10 @@ namespace osu.Game.Screens.Play
             storyboard = beatmap.Storyboard.CreateDrawable(Beatmap.Value);
             storyboard.Masking = true;
 
-            if (asyncLoad) LoadComponentAsync(storyboard, s => storyboardContainer.Add(s));
-            else storyboardContainer.Add((Drawable)storyboard);
+            if (asyncLoad)
+                LoadComponentAsync(storyboard, storyboardContainer.Add);
+            else
+                storyboardContainer.Add(storyboard);
         }
 
         public void Restart()

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                             Padding = new MarginPadding(edge_margin),
                             Children = new Drawable[]
                             {
-                                avatar = new DelayedLoadWrapper(
+                                avatar = new LoadWrapper(
                                     new Avatar(Score.User)
                                     {
                                         RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -112,8 +112,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                                             Radius = 1,
                                             Colour = Color4.Black.Opacity(0.2f),
                                         },
-                                    },
-                                    500)
+                                    }, 500)
                                 {
                                     RelativeSizeAxes = Axes.None,
                                     Size = new Vector2(HEIGHT - edge_margin * 2, HEIGHT - edge_margin * 2),

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                             Padding = new MarginPadding(edge_margin),
                             Children = new Drawable[]
                             {
-                                avatar = new LoadWrapper(
+                                avatar = new DelayedLoadWrapper(
                                     new Avatar(Score.User)
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -112,9 +112,9 @@ namespace osu.Game.Screens.Select.Leaderboards
                                             Radius = 1,
                                             Colour = Color4.Black.Opacity(0.2f),
                                         },
-                                    })
+                                    },
+                                    500)
                                 {
-                                    TimeBeforeLoad = 500,
                                     RelativeSizeAxes = Axes.None,
                                     Size = new Vector2(HEIGHT - edge_margin * 2, HEIGHT - edge_margin * 2),
                                 },

--- a/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Screens/Select/Leaderboards/LeaderboardScore.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         private Box background;
         private Container content;
-        private Container avatar;
+        private Drawable avatar;
         private DrawableRank scoreRank;
         private OsuSpriteText nameLabel;
         private GlowingSpriteText scoreLabel;
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                         {
                             RelativeSizeAxes = Axes.Both,
                             Padding = new MarginPadding(edge_margin),
-                            Children = new Drawable[]
+                            Children = new[]
                             {
                                 avatar = new DelayedLoadWrapper(
                                     new Avatar(Score.User)
@@ -112,7 +112,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                                             Radius = 1,
                                             Colour = Color4.Black.Opacity(0.2f),
                                         },
-                                    }, 500)
+                                    })
                                 {
                                     RelativeSizeAxes = Axes.None,
                                     Size = new Vector2(HEIGHT - edge_margin * 2, HEIGHT - edge_margin * 2),
@@ -210,7 +210,7 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         public override void Show()
         {
-            foreach (var d in new Drawable[] { avatar, nameLabel, scoreLabel, scoreRank, flagBadgeContainer, maxCombo, accuracy, modsContainer })
+            foreach (var d in new[] { avatar, nameLabel, scoreLabel, scoreRank, flagBadgeContainer, maxCombo, accuracy, modsContainer })
                 d.FadeOut();
 
             Alpha = 0;

--- a/osu.Game/Users/UpdateableAvatar.cs
+++ b/osu.Game/Users/UpdateableAvatar.cs
@@ -40,11 +40,13 @@ namespace osu.Game.Users
         {
             displayedAvatar?.FadeOut(300);
             displayedAvatar?.Expire();
-            Add(displayedAvatar = new LoadWrapper(new Avatar(user)
-            {
-                RelativeSizeAxes = Axes.Both,
-                OnLoadComplete = d => d.FadeInFromZero(200),
-            }));
+            Add(displayedAvatar = new LoadWrapper(
+                new Avatar(user)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    OnLoadComplete = d => d.FadeInFromZero(200),
+                })
+            );
         }
     }
 }

--- a/osu.Game/Users/UpdateableAvatar.cs
+++ b/osu.Game/Users/UpdateableAvatar.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Users
         {
             displayedAvatar?.FadeOut(300);
             displayedAvatar?.Expire();
-            Add(displayedAvatar = new DelayedLoadWrapper(new Avatar(user)
+            Add(displayedAvatar = new LoadWrapper(new Avatar(user)
             {
                 RelativeSizeAxes = Axes.Both,
                 OnLoadComplete = d => d.FadeInFromZero(200),

--- a/osu.Game/Users/UpdateableAvatar.cs
+++ b/osu.Game/Users/UpdateableAvatar.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Users
     /// </summary>
     public class UpdateableAvatar : Container
     {
-        private Container displayedAvatar;
+        private Drawable displayedAvatar;
 
         private User user;
 
@@ -45,7 +45,7 @@ namespace osu.Game.Users
                 {
                     RelativeSizeAxes = Axes.Both,
                     OnLoadComplete = d => d.FadeInFromZero(200),
-                }, 500)
+                })
             );
         }
     }

--- a/osu.Game/Users/UpdateableAvatar.cs
+++ b/osu.Game/Users/UpdateableAvatar.cs
@@ -40,12 +40,13 @@ namespace osu.Game.Users
         {
             displayedAvatar?.FadeOut(300);
             displayedAvatar?.Expire();
-            Add(displayedAvatar = new LoadWrapper(
+            Add(displayedAvatar = new DelayedLoadWrapper(
                 new Avatar(user)
                 {
                     RelativeSizeAxes = Axes.Both,
                     OnLoadComplete = d => d.FadeInFromZero(200),
-                })
+                },
+                500)
             );
         }
     }

--- a/osu.Game/Users/UpdateableAvatar.cs
+++ b/osu.Game/Users/UpdateableAvatar.cs
@@ -45,8 +45,7 @@ namespace osu.Game.Users
                 {
                     RelativeSizeAxes = Axes.Both,
                     OnLoadComplete = d => d.FadeInFromZero(200),
-                },
-                500)
+                }, 500)
             );
         }
     }

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Users
 
             Children = new Drawable[]
             {
-                new AsyncLoadWrapper(new UserCoverBackground(user)
+                new LoadWrapper(new UserCoverBackground(user)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Users
                     Origin = Anchor.Centre,
                     FillMode = FillMode.Fill,
                     OnLoadComplete = d => d.FadeInFromZero(200),
-                }) { RelativeSizeAxes = Axes.Both },
+                }, 0) { RelativeSizeAxes = Axes.Both },
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Users
 
             Children = new Drawable[]
             {
-                new LoadWrapper(new UserCoverBackground(user)
+                new DelayedLoadWrapper(new UserCoverBackground(user)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,


### PR DESCRIPTION
What the title says. I have replaced every usage of an AsyncLoadWrapper (except for one) with a LoadComponentAsync call. All remaining usages of AsyncLoadWrapper or DelayedLoadWrapper have been replaced with the new LoadWrapper class. Since this is also a framework change, [this PR](https://github.com/ppy/osu-framework/pull/1181) is necessary for this PR to build/work correctly. (also more info there on the class merge/change)

- [x] Depends on https://github.com/ppy/osu-framework/pull/1181.
- [x] Depends on https://github.com/ppy/osu/pull/1568.

All tests pass on my end. This closes #1541