### PR TITLE
Improve PlaybackContainer (and rename to PlaybackControl)

### DIFF
--- a/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Tests.Visual
     {
         public TestCasePlaybackControl()
         {
-            var playback = new PlaybackControl()
+            var playback = new PlaybackControl
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,

--- a/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Edit.Components;
+using osu.Game.Tests.Beatmaps;
+using OpenTK;
+
+namespace osu.Game.Tests.Visual
+{
+    public class TestCasePlaybackControl : OsuTestCase
+    {
+        public TestCasePlaybackControl()
+        {
+            var playback = new PlaybackControl()
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(200,100)
+            };
+            playback.Beatmap.Value = new TestWorkingBeatmap(new Beatmap());
+
+            Add(playback);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Visual\TestCaseOnScreenDisplay.cs" />
     <Compile Include="Visual\TestCaseAllPlayers.cs" />
     <Compile Include="Visual\TestCaseOsuGame.cs" />
+    <Compile Include="Visual\TestCasePlaybackControl.cs" />
     <Compile Include="Visual\TestCasePlaySongSelect.cs" />
     <Compile Include="Visual\TestCaseReplay.cs" />
     <Compile Include="Visual\TestCaseReplaySettingsOverlay.cs" />

--- a/osu.Game/Screens/Edit/Components/BottomBarContainer.cs
+++ b/osu.Game/Screens/Edit/Components/BottomBarContainer.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens.Edit.Components
         private const float corner_radius = 5;
         private const float contents_padding = 15;
 
-        public Bindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
+        public readonly Bindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
         protected Track Track => Beatmap.Value.Track;
 
         private readonly Drawable background;

--- a/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
@@ -128,32 +128,25 @@ namespace osu.Game.Screens.Edit.Components
 
                 protected override bool OnHover(InputState state)
                 {
-                    if (!Active)
-                        toBold();
+                    updateState();
                     return true;
                 }
 
                 protected override void OnHoverLost(InputState state)
                 {
-                    if (!Active)
-                        toNormal();
+                    updateState();
                 }
 
-                private void toBold()
+
+                private void updateState()
                 {
-                    text.FadeOut(fade_duration);
-                    textBold.FadeIn(fade_duration);
+                    text.FadeTo(Active || IsHovered ? 0 : 1, fade_duration);
+                    textBold.FadeTo(Active || IsHovered ? 1 : 0, fade_duration);
                 }
 
-                private void toNormal()
-                {
-                    text.FadeIn(fade_duration);
-                    textBold.FadeOut(fade_duration);
-                }
+                protected override void OnActivated() => updateState();
 
-                protected override void OnActivated() => toBold();
-
-                protected override void OnDeactivated() => toNormal();
+                protected override void OnDeactivated() => updateState();
             }
         }
     }

--- a/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.Edit.Components
                     Scale = new Vector2(1.4f),
                     IconScale = new Vector2(1.4f),
                     Icon = FontAwesome.fa_play_circle_o,
-                    Action = playPause,
+                    Action = togglePause,
                     Padding = new MarginPadding { Left = 20 }
                 },
                 new OsuSpriteText
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Edit.Components
             tabs.Current.ValueChanged += newValue => Track.Tempo.Value = newValue;
         }
 
-        private void playPause()
+        private void togglePause()
         {
             if (Track.IsRunning)
                 Track.Stop();

--- a/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
@@ -104,14 +104,14 @@ namespace osu.Game.Screens.Edit.Components
                         {
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
-                            Text = $"{value:P0}",
+                            Text = $"{value:0%}",
                             TextSize = 14,
                         },
                         textBold = new OsuSpriteText
                         {
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
-                            Text = $"{value:P0}",
+                            Text = $"{value:0%}",
                             TextSize = 14,
                             Font = @"Exo2.0-Bold",
                             Alpha = 0,

--- a/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackContainer.cs
@@ -1,12 +1,16 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Globalization;
+using System.Linq;
 using OpenTK;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -52,10 +56,6 @@ namespace osu.Game.Screens.Edit.Components
                 }
             };
 
-            tabs.AddItem(0.25);
-            tabs.AddItem(0.75);
-            tabs.AddItem(1);
-
             tabs.Current.ValueChanged += newValue => Track.Tempo.Value = newValue;
         }
 
@@ -76,6 +76,8 @@ namespace osu.Game.Screens.Edit.Components
 
         private class PlaybackTabControl : OsuTabControl<double>
         {
+            private static double[] tempo_values = new [] { 0.5, 0.75, 1 };
+
             protected override TabItem<double> CreateTabItem(double value) => new PlaybackTabItem(value);
 
             protected override Dropdown<double> CreateDropdown() => null;
@@ -83,7 +85,9 @@ namespace osu.Game.Screens.Edit.Components
             public PlaybackTabControl()
             {
                 RelativeSizeAxes = Axes.Both;
-                TabContainer.Spacing = new Vector2(20, 0);
+                TabContainer.Spacing = Vector2.Zero;
+
+                tempo_values.ForEach(AddItem);
             }
 
             public class PlaybackTabItem : TabItem<double>
@@ -95,8 +99,9 @@ namespace osu.Game.Screens.Edit.Components
 
                 public PlaybackTabItem(double value) : base(value)
                 {
-                    AutoSizeAxes = Axes.X;
-                    RelativeSizeAxes = Axes.Y;
+                    RelativeSizeAxes = Axes.Both;
+
+                    Width = 1f / tempo_values.Length;
 
                     Children = new Drawable[]
                     {
@@ -115,7 +120,6 @@ namespace osu.Game.Screens.Edit.Components
                             TextSize = 14,
                             Font = @"Exo2.0-Bold",
                             Alpha = 0,
-                            AlwaysPresent = true,
                         },
                     };
                 }

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Linq;
 using OpenTK;
+using OpenTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
@@ -92,7 +93,7 @@ namespace osu.Game.Screens.Edit.Components
 
             public class PlaybackTabItem : TabItem<double>
             {
-                private const float fade_duration = 100;
+                private const float fade_duration = 200;
 
                 private readonly OsuSpriteText text;
                 private readonly OsuSpriteText textBold;
@@ -124,10 +125,14 @@ namespace osu.Game.Screens.Edit.Components
                     };
                 }
 
+                private Color4 hoveredColour;
+                private Color4 normalColour;
+
                 [BackgroundDependencyLoader]
                 private void load(OsuColour colours)
                 {
-                    text.Colour = colours.Gray5;
+                    text.Colour = normalColour = colours.YellowDarker;
+                    textBold.Colour = hoveredColour = colours.Yellow;
                 }
 
                 protected override bool OnHover(InputState state)
@@ -144,8 +149,9 @@ namespace osu.Game.Screens.Edit.Components
 
                 private void updateState()
                 {
-                    text.FadeTo(Active || IsHovered ? 0 : 1, fade_duration);
-                    textBold.FadeTo(Active || IsHovered ? 1 : 0, fade_duration);
+                    text.FadeColour(Active || IsHovered ? hoveredColour : normalColour, fade_duration, Easing.OutQuint);
+                    text.FadeTo(Active ? 0 : 1, fade_duration, Easing.OutQuint);
+                    textBold.FadeTo(Active ? 1 : 0, fade_duration, Easing.OutQuint);
                 }
 
                 protected override void OnActivated() => updateState();

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -17,11 +17,11 @@ using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Screens.Edit.Components
 {
-    public class PlaybackContainer : BottomBarContainer
+    public class PlaybackControl : BottomBarContainer
     {
         private readonly IconButton playButton;
 
-        public PlaybackContainer()
+        public PlaybackControl()
         {
             PlaybackTabControl tabs;
 

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Globalization;
-using System.Linq;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
@@ -11,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -77,7 +74,7 @@ namespace osu.Game.Screens.Edit.Components
 
         private class PlaybackTabControl : OsuTabControl<double>
         {
-            private static double[] tempo_values = new [] { 0.5, 0.75, 1 };
+            private static readonly double[] tempo_values = { 0.5, 0.75, 1 };
 
             protected override TabItem<double> CreateTabItem(double value) => new PlaybackTabItem(value);
 

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -138,11 +138,9 @@ namespace osu.Game.Screens.Edit.Components
                     return true;
                 }
 
-                protected override void OnHoverLost(InputState state)
-                {
-                    updateState();
-                }
-
+                protected override void OnHoverLost(InputState state) => updateState();
+                protected override void OnActivated() => updateState();
+                protected override void OnDeactivated() => updateState();
 
                 private void updateState()
                 {
@@ -150,10 +148,6 @@ namespace osu.Game.Screens.Edit.Components
                     text.FadeTo(Active ? 0 : 1, fade_duration, Easing.OutQuint);
                     textBold.FadeTo(Active ? 1 : 0, fade_duration, Easing.OutQuint);
                 }
-
-                protected override void OnActivated() => updateState();
-
-                protected override void OnDeactivated() => updateState();
             }
         }
     }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Edit
             EditorMenuBar menuBar;
             TimeInfoContainer timeInfo;
             SummaryTimeline timeline;
-            PlaybackContainer playback;
+            PlaybackControl playback;
 
             Children = new[]
             {
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Edit
                                         {
                                             RelativeSizeAxes = Axes.Both,
                                             Padding = new MarginPadding { Left = 10 },
-                                            Child = playback = new PlaybackContainer { RelativeSizeAxes = Axes.Both },
+                                            Child = playback = new PlaybackControl { RelativeSizeAxes = Axes.Both },
                                         }
                                     },
                                 }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -299,7 +299,7 @@
     <Compile Include="Overlays\Profile\Sections\Ranks\ScoreModsContainer.cs" />
     <Compile Include="Overlays\Settings\SettingsButton.cs" />
     <Compile Include="Screens\Edit\Components\BottomBarContainer.cs" />
-    <Compile Include="Screens\Edit\Components\PlaybackContainer.cs" />
+    <Compile Include="Screens\Edit\Components\PlaybackControl.cs" />
     <Compile Include="Screens\Edit\Components\TimeInfoContainer.cs" />
     <Compile Include="Rulesets\Mods\IApplicableToScoreProcessor.cs" />
     <Compile Include="Screens\Edit\Screens\Compose\Timeline\BeatmapWaveformGraph.cs" />


### PR DESCRIPTION
Unsure how it got merged in the previous state.

- Adds TestCase.
- Brings design up-to-date.
- Fixes leading spaces before % symbol on some cultures.
- Removes usage of AlwaysPresent.
- Removes 25% tempo option. Sounds bad with current implementation and should not be used for timing anyway.