### PR TITLE
Fix results screen displaying after failing on the last hitobject

### DIFF
--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -224,8 +224,8 @@ namespace osu.Game.Rulesets.Scoring
             OnNewJudgement(judgement);
             updateScore();
 
-            NotifyNewJudgement(judgement);
             UpdateFailed();
+            NotifyNewJudgement(judgement);
         }
 
         protected void RemoveJudgement(Judgement judgement)


### PR DESCRIPTION
**Abstract**
Failing a map because of the last hitobject (either by losing your last bit of health, or missing the last note with Sudden Death enabled) causes the fail overlay to display, but then be replaced by the results screen after 1 second.

**Steps to Reproduce**
*Method 1*
Miss the last note of a map with Sudden Death enabled.

*Method 2*
Lose the last bit of health by missing the last note. This can be easily achieved by missing the last six notes of https://osu.ppy.sh/b/1059389&m=0 while at full health.

**Fix**
Update the ScoreProcessor's failed state before notifying subscribers that all hitobjects have been judged. I'm not aware of any issues with deferring the notification until after the fail state has been updated.