### PR TITLE
Fix nullref on disposing BeatmapSetOverlay before load

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -232,7 +232,7 @@ namespace osu.Game.Overlays.BeatmapSet
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            beatmaps.BeatmapSetAdded -= handleBeatmapAdd;
+            if (beatmaps != null) beatmaps.BeatmapSetAdded -= handleBeatmapAdd;
         }
 
         private void handleBeatmapAdd(BeatmapSetInfo beatmap)


### PR DESCRIPTION
Only affects VisualTests