### PR TITLE
Change default play icon in MusicController.cs

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Overlays
                                                     Scale = new Vector2(1.4f),
                                                     IconScale = new Vector2(1.4f),
                                                     Action = play,
-                                                    Icon = FontAwesome.fa_play_circle_o,
+                                                    Icon = FontAwesome.fa_pause_circle_o,   //Jingle song play by default, so we using pause icon instead of play
                                                 },
                                                 nextButton = new IconButton
                                                 {


### PR DESCRIPTION
When open osu, play button in `MusicController` is set to icon play. This is weird because the jingle song is playing. So the icon need to set into pause.

![image](https://user-images.githubusercontent.com/15938103/33181085-888f5adc-d0a1-11e7-8fa1-cf7711a5dcbf.png)


