### PR TITLE
Fix SpriteIcon potentially not updating texture during a load race condition

### DIFF
--- a/osu.Game/Graphics/SpriteIcon.cs
+++ b/osu.Game/Graphics/SpriteIcon.cs
@@ -57,19 +57,31 @@ namespace osu.Game.Graphics
         private void load(FontStore store)
         {
             this.store = store;
-
             updateTexture();
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateTexture();
+        }
+
+        private FontAwesome loadedIcon;
         private void updateTexture()
         {
-            var texture = store?.Get(((char)icon).ToString());
+            var loadableIcon = icon;
+
+            if (loadableIcon == loadedIcon) return;
+
+            var texture = store?.Get(((char)loadableIcon).ToString());
 
             spriteMain.Texture = texture;
             spriteShadow.Texture = texture;
 
             if (Size == Vector2.Zero)
                 Size = new Vector2(texture?.DisplayWidth ?? 0, texture?.DisplayHeight ?? 0);
+
+            loadedIcon = loadableIcon;
         }
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)


### PR DESCRIPTION
Better fix for #1577.