### PR TITLE
Fix osu!direct download reloading all panels

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private void handleBeatmapAdd(BeatmapSetInfo beatmap)
         {
-            if (beatmap.OnlineBeatmapSetID == BeatmapSet.OnlineBeatmapSetID)
+            if (beatmap.OnlineBeatmapSetID == BeatmapSet?.OnlineBeatmapSetID)
                 downloadButtonsContainer.FadeOut(transition_duration);
         }
 

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -65,8 +65,6 @@ namespace osu.Game.Overlays
                 }
 
                 ResultAmounts = new ResultCounts(distinctCount(artists), distinctCount(songs), distinctCount(tags));
-
-                recreatePanels(Filter.DisplayStyleControl.DisplayStyle.Value);
             }
         }
 
@@ -282,7 +280,11 @@ namespace osu.Game.Overlays
                     var sets = response.Select(r => r.ToBeatmapSet(rulesets)).Where(b => !presentOnlineIds.Contains(b.OnlineBeatmapSetID)).ToList();
 
                     // may not need scheduling; loads async internally.
-                    Schedule(() => BeatmapSets = sets);
+                    Schedule(() =>
+                    {
+                        BeatmapSets = sets;
+                        recreatePanels(Filter.DisplayStyleControl.DisplayStyle.Value);
+                    });
                 });
             };
 

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays
             {
                 if (beatmapSets?.Equals(value) ?? false) return;
 
-                beatmapSets = value;
+                beatmapSets = value?.ToList();
 
                 if (beatmapSets == null) return;
 


### PR DESCRIPTION
This fixes the recreation of all panels when a download completes.
Also fixes NullReference when you download without ever opening the details of one Set.
Closes #1570