### PR TITLE
Fix being stuck in gameplay if exit is pressed too fast

### DIFF
--- a/osu.Game/Screens/Play/PauseContainer.cs
+++ b/osu.Game/Screens/Play/PauseContainer.cs
@@ -22,8 +22,6 @@ namespace osu.Game.Screens.Play
     {
         public bool IsPaused { get; private set; }
 
-        public bool AllowExit => IsPaused && pauseOverlay.Alpha == 1;
-
         public Func<bool> CheckCanPause;
 
         private const double pause_cooldown = 1000;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -357,7 +357,7 @@ namespace osu.Game.Screens.Play
 
         protected override bool OnExiting(Screen next)
         {
-            if (!AllowPause || HasFailed || !ValidForResume || pauseContainer?.AllowExit != false || RulesetContainer?.HasReplayLoaded != false)
+            if (!AllowPause || HasFailed || !ValidForResume || pauseContainer?.IsPaused != false || RulesetContainer?.HasReplayLoaded != false)
             {
                 // In the case of replays, we may have changed the playback rate.
                 applyRateFromMods();


### PR DESCRIPTION
The reliance on `pauseOverlay.Alpha == 1` created a race condition that, when you pressed Exit while the PauseOverlay is still fading in, could get you stuck in gameplay.
The game wants to show the PauseOverlay but also thinks it's already paused and returns early.