### PR TITLE
Allow osu.Desktop.Deploy to work without a github token

### DIFF
--- a/osu.Desktop.Deploy/App.config
+++ b/osu.Desktop.Deploy/App.config
@@ -13,7 +13,7 @@ Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/maste
     <add key="ProjectName" value="osu.Desktop" />
     <add key="NuSpecName" value="osu.Desktop\osu.nuspec" />
     <add key="SolutionName" value="osu" />
-    <add key="TargetName" value="Client\osu.Desktop" />
+    <add key="TargetName" value="osu.Desktop" />
     <add key="PackageName" value="osulazer" />
     <add key="IconName" value="lazer.ico" />
     <add key="CodeSigningCertificate" value="" />

--- a/osu.Desktop.Deploy/Program.cs
+++ b/osu.Desktop.Deploy/Program.cs
@@ -145,6 +145,8 @@ namespace osu.Desktop.Deploy
         /// </summary>
         private static void checkReleaseFiles()
         {
+            if (!canGitHub) return;
+
             var releaseLines = getReleaseLines();
 
             //ensure we have all files necessary
@@ -157,6 +159,8 @@ namespace osu.Desktop.Deploy
 
         private static void pruneReleases()
         {
+            if (!canGitHub) return;
+
             write("Pruning RELEASES...");
 
             var releaseLines = getReleaseLines().ToList();
@@ -190,7 +194,7 @@ namespace osu.Desktop.Deploy
 
         private static void uploadBuild(string version)
         {
-            if (string.IsNullOrEmpty(GitHubAccessToken) || string.IsNullOrEmpty(codeSigningCertPath))
+            if (!canGitHub || string.IsNullOrEmpty(CodeSigningCertificate))
                 return;
 
             write("Publishing to GitHub...");
@@ -228,8 +232,12 @@ namespace osu.Desktop.Deploy
 
         private static void openGitHubReleasePage() => Process.Start(GitHubReleasePage);
 
+        private static bool canGitHub => !string.IsNullOrEmpty(GitHubAccessToken);
+
         private static void checkGitHubReleases()
         {
+            if (!canGitHub) return;
+
             write("Checking GitHub releases...");
             var req = new JsonWebRequest<List<GitHubRelease>>($"{GitHubApiEndpoint}");
             req.AuthenticatedBlockingPerform();


### PR DESCRIPTION
Fixes some broken defaults and avoids hard-crashing when missing configuration.