### PR TITLE
Fix hard-crash on missing metrics

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -226,16 +226,9 @@ namespace osu.Game.Screens.Select
                 ratings.FadeIn(transition_duration);
             }
             else if (failOnMissing)
-            {
-                ratings.Metrics = new BeatmapMetrics
-                {
-                    Ratings = new int[10],
-                };
-            }
+                ratings.Metrics = new BeatmapMetrics { Ratings = new int[11] };
             else
-            {
                 ratings.FadeTo(0.25f, transition_duration);
-            }
 
             if (hasRetriesFails)
             {


### PR DESCRIPTION
Default data was no longer matching expected API return.