### PR TITLE
Added hitsounds for missed hitobjects in taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -35,6 +35,17 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             MainPiece.KiaiMode = HitObject.Kiai;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            State.ValueChanged += state =>
+            {
+                if (state != ArmedState.Hit)
+                    PlaySamples();
+            };
+        }
+
         protected virtual TaikoPiece CreateMainPiece() => new CirclePiece();
 
         public abstract bool OnPressed(TaikoAction action);


### PR DESCRIPTION
Just added a new Eventhandler for all taiko hitobjects that plays the hitsound as soon the object is missed (unless ofc it's hit normally, in which case it'll play as usual).

This closes #840 