### PR TITLE
Remove precision limitation on chat height to allow pixel-perfect dragging

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.SelectionRandomType, SelectionRandomType.RandomPermutation);
 
-            Set(OsuSetting.ChatDisplayHeight, ChatOverlay.DEFAULT_HEIGHT, 0.2, 1, 0.01);
+            Set(OsuSetting.ChatDisplayHeight, ChatOverlay.DEFAULT_HEIGHT, 0.2, 1);
 
             // Online settings
             Set(OsuSetting.Username, string.Empty);


### PR DESCRIPTION
Regression from adding precision to config settings.

Before:

![kapture 2017-11-28 at 12 56 36](https://user-images.githubusercontent.com/191335/33301886-b105fe1a-d43b-11e7-94a8-52a995b87b1c.gif)

After:

![kapture 2017-11-28 at 12 55 50](https://user-images.githubusercontent.com/191335/33301881-ade64c08-d43b-11e7-8d6f-1b86e731353a.gif)