### PR TITLE
Choose random beatmap when entering song select for the first time

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -563,14 +563,14 @@ namespace osu.Game.Beatmaps
         {
             var beatmapSetList = GetAllUsableBeatmapSets();
 
-            if (beatmapSetList.Count() == 0) return null;
+            if (beatmapSetList.Any()) return null;
 
-            var beatmapSet = beatmapSetList.ElementAt(RNG.Next(beatmapSetList.Count()));
+            var beatmapSet = beatmapSetList.ElementAt(RNG.Next(beatmapSetList.Count));
             var beatmapList = beatmapSet.Beatmaps.Where(b => !b.Hidden).ToList();
 
-            if (beatmapList.Count() == 0) return null;
+            if (beatmapList.Any()) return null;
 
-            return beatmapList.ElementAt(RNG.Next(beatmapList.Count()));
+            return beatmapList.ElementAt(RNG.Next(beatmapList.Count));
         }
 
         protected class BeatmapManagerWorkingBeatmap : WorkingBeatmap

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -14,6 +14,7 @@ using osu.Framework.Extensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
+using osu.Framework.MathUtils;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Beatmaps.IO;
@@ -552,6 +553,24 @@ namespace osu.Game.Beatmaps
         public List<BeatmapSetInfo> GetAllUsableBeatmapSets()
         {
             return beatmaps.BeatmapSets.Where(s => !s.DeletePending).ToList();
+        }
+
+        /// <summary>
+        /// Returns a random usable and visible <see cref="BeatmapInfo"/>.
+        /// </summary>
+        /// <returns>A random <see cref="BeatmapInfo"/> or null if none are available.</returns>
+        public BeatmapInfo GetRandomUsableBeatmap()
+        {
+            var beatmapSetList = GetAllUsableBeatmapSets();
+
+            if (beatmapSetList.Count() == 0) return null;
+
+            var beatmapSet = beatmapSetList.ElementAt(RNG.Next(beatmapSetList.Count()));
+            var beatmapList = beatmapSet.Beatmaps.Where(b => !b.Hidden).ToList();
+
+            if (beatmapList.Count() == 0) return null;
+
+            return beatmapList.ElementAt(RNG.Next(beatmapList.Count()));
         }
 
         protected class BeatmapManagerWorkingBeatmap : WorkingBeatmap

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.Menu
 {
     public class Intro : OsuScreen
     {
-        private const string menu_music_beatmap_hash = "3c8b1fcc9434dbb29e2fb613d3b9eada9d7bb6c125ceb32396c3b53437280c83";
+        public const string MENU_MUSIC_BEATMAP_HASH = "3c8b1fcc9434dbb29e2fb613d3b9eada9d7bb6c125ceb32396c3b53437280c83";
 
         /// <summary>
         /// Whether we have loaded the menu previously.
@@ -58,7 +58,7 @@ namespace osu.Game.Screens.Menu
 
             if (setInfo == null)
             {
-                setInfo = beatmaps.QueryBeatmapSet(b => b.Hash == menu_music_beatmap_hash);
+                setInfo = beatmaps.QueryBeatmapSet(b => b.Hash == MENU_MUSIC_BEATMAP_HASH);
 
                 if (setInfo == null)
                 {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -307,6 +307,19 @@ namespace osu.Game.Screens.Select
             Content.FadeInFromZero(250);
 
             FilterControl.Activate();
+
+            // select and preview a random beatmap if we come from MainMenu the first time
+            if (last is MainMenu)
+            {
+                var beatmapInfo = Beatmap.Value.BeatmapInfo;
+                if (beatmapInfo?.Hash == Intro.MENU_MUSIC_BEATMAP_HASH)
+                {
+                    var rndBeatmap = beatmaps.GetRandomUsableBeatmap();
+                    Beatmap.Value = beatmaps.GetWorkingBeatmap(rndBeatmap, Beatmap);
+                    UpdateBeatmap(Beatmap);
+                    ensurePlayingSelected();
+                }
+            }
         }
 
         private const double logo_transition = 250;


### PR DESCRIPTION
Looking at stable I wanted to have something that is easily adaptible for the case you go into Multi first instead of Solo.

I wanted to use `beatmapCarousel.SelectNextRandom()` but I noticed that it wouldn't work in Multi because the actual song select comes way later and stable selects a random song on entering Multi right away.

So I hope this way of getting a random beatmap helps when adding random beatmap selection for Multi in the future.