### PR TITLE
Fix mania replays not defining important frames

### DIFF
--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mania.Replays
         public override Replay Generate()
         {
             // Todo: Realistically this shouldn't be needed, but the first frame is skipped with the way replays are currently handled
-            Replay.Frames.Add(new ReplayFrame(-100000, null, null, ReplayButtonState.None));
+            Replay.Frames.Add(new ManiaReplayFrame(-100000, null, null, ReplayButtonState.None));
 
             double[] holdEndTimes = new double[availableColumns];
             for (int i = 0; i < availableColumns; i++)
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Mania.Replays
                     activeColumns |= 1 << obj.Column;
                 }
 
-                Replay.Frames.Add(new ReplayFrame(groupTime, activeColumns, null, ReplayButtonState.None));
+                Replay.Frames.Add(new ManiaReplayFrame(groupTime, activeColumns, null, ReplayButtonState.None));
 
                 // Add the release frames. We can't do this with the loop above because we need activeColumns to be fully populated
                 foreach (var obj in objGroup.GroupBy(h => (h as IHasEndTime)?.EndTime ?? h.StartTime + release_delay).OrderBy(h => h.Key))
@@ -74,14 +74,15 @@ namespace osu.Game.Rulesets.Mania.Replays
                             activeColumnsAtEnd |= 1 << i;
                     }
 
-                    Replay.Frames.Add(new ReplayFrame(groupEndTime, activeColumnsAtEnd, 0, ReplayButtonState.None));
+                    Replay.Frames.Add(new ManiaReplayFrame(groupEndTime, activeColumnsAtEnd, 0, ReplayButtonState.None));
                 }
             }
 
             Replay.Frames = Replay.Frames
                                   // Pick the maximum activeColumns for all frames at the same time
                                   .GroupBy(f => f.Time)
-                                  .Select(g => new ReplayFrame(g.First().Time, maxMouseX(g), 0, ReplayButtonState.None))
+                                  .Select(g => new ManiaReplayFrame(g.First().Time, maxMouseX(g), 0, ReplayButtonState.None))
+                                  .Cast<ReplayFrame>()
                                   // The addition of release frames above maybe result in unordered frames, but we need them ordered
                                   .OrderBy(f => f.Time)
                                   .ToList();

--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mania.Replays
         public override Replay Generate()
         {
             // Todo: Realistically this shouldn't be needed, but the first frame is skipped with the way replays are currently handled
-            Replay.Frames.Add(new ManiaReplayFrame(-100000, null, null, ReplayButtonState.None));
+            Replay.Frames.Add(new ManiaReplayFrame(-100000, 0));
 
             double[] holdEndTimes = new double[availableColumns];
             for (int i = 0; i < availableColumns; i++)
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Mania.Replays
                     activeColumns |= 1 << obj.Column;
                 }
 
-                Replay.Frames.Add(new ManiaReplayFrame(groupTime, activeColumns, null, ReplayButtonState.None));
+                Replay.Frames.Add(new ManiaReplayFrame(groupTime, activeColumns));
 
                 // Add the release frames. We can't do this with the loop above because we need activeColumns to be fully populated
                 foreach (var obj in objGroup.GroupBy(h => (h as IHasEndTime)?.EndTime ?? h.StartTime + release_delay).OrderBy(h => h.Key))
@@ -74,14 +74,14 @@ namespace osu.Game.Rulesets.Mania.Replays
                             activeColumnsAtEnd |= 1 << i;
                     }
 
-                    Replay.Frames.Add(new ManiaReplayFrame(groupEndTime, activeColumnsAtEnd, 0, ReplayButtonState.None));
+                    Replay.Frames.Add(new ManiaReplayFrame(groupEndTime, activeColumnsAtEnd));
                 }
             }
 
             Replay.Frames = Replay.Frames
                                   // Pick the maximum activeColumns for all frames at the same time
                                   .GroupBy(f => f.Time)
-                                  .Select(g => new ManiaReplayFrame(g.First().Time, maxMouseX(g), 0, ReplayButtonState.None))
+                                  .Select(g => new ManiaReplayFrame(g.First().Time, maxMouseX(g)))
                                   .Cast<ReplayFrame>()
                                   // The addition of release frames above maybe result in unordered frames, but we need them ordered
                                   .OrderBy(f => f.Time)
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Mania.Replays
         /// </summary>
         /// <param name="group">The <see cref="ReplayFrame"/> grouping to search.</param>
         /// <returns>The maximum <see cref="ReplayFrame.MouseX"/> by count of bits.</returns>
-        private float maxMouseX(IGrouping<double, ReplayFrame> group)
+        private int maxMouseX(IGrouping<double, ReplayFrame> group)
         {
             int currentCount = -1;
             int currentMax = 0;

--- a/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Game.Rulesets.Replays;
+
+namespace osu.Game.Rulesets.Mania.Replays
+{
+    public class ManiaReplayFrame : ReplayFrame
+    {
+        public override bool IsImportant => MouseX > 0;
+
+        public ManiaReplayFrame(double time, float? mouseX, float? mouseY, ReplayButtonState buttonState)
+            : base(time, mouseX, mouseY, buttonState)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Mania.Replays
         public override bool IsImportant => MouseX > 0;
 
         public ManiaReplayFrame(double time, int activeColumns)
-            : base(time, (float)activeColumns, null, ReplayButtonState.None)
+            : base(time, activeColumns, null, ReplayButtonState.None)
         {
         }
     }

--- a/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
@@ -9,8 +9,8 @@ namespace osu.Game.Rulesets.Mania.Replays
     {
         public override bool IsImportant => MouseX > 0;
 
-        public ManiaReplayFrame(double time, float? mouseX, float? mouseY, ReplayButtonState buttonState)
-            : base(time, mouseX, mouseY, buttonState)
+        public ManiaReplayFrame(double time, int activeColumns)
+            : base(time, (float)activeColumns, null, ReplayButtonState.None)
         {
         }
     }

--- a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+++ b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Objects\Types\IHasColumn.cs" />
     <Compile Include="Replays\ManiaAutoGenerator.cs" />
     <Compile Include="Replays\ManiaFramedReplayInputHandler.cs" />
+    <Compile Include="Replays\ManiaReplayFrame.cs" />
     <Compile Include="Scoring\ManiaScoreProcessor.cs" />
     <Compile Include="Objects\BarLine.cs" />
     <Compile Include="Objects\HoldNote.cs" />

--- a/osu.Game/Rulesets/Replays/ReplayFrame.cs
+++ b/osu.Game/Rulesets/Replays/ReplayFrame.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Replays
     {
         public Vector2 Position => new Vector2(MouseX ?? 0, MouseY ?? 0);
 
-        public bool IsImportant => MouseX.HasValue && MouseY.HasValue && (MouseLeft || MouseRight);
+        public virtual bool IsImportant => MouseX.HasValue && MouseY.HasValue && (MouseLeft || MouseRight);
 
         public float? MouseX;
         public float? MouseY;


### PR DESCRIPTION
Note that this won't fix mania ffoward/rewind in replays, that's a larger issue altogether (will write up an issue thread describing the issue).

Mania uses MouseX to define its keys.