### PR TITLE
Fix crash when all beatmaps in a set are hidden

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Select
 
                 Task.Run(() =>
                 {
-                    newGroups = value.Select(createGroup).ToList();
+                    newGroups = value.Select(createGroup).Where(g => g != null).ToList();
                     criteria.Filter(newGroups);
                 }).ContinueWith(t =>
                 {
@@ -124,16 +124,24 @@ namespace osu.Game.Screens.Select
             // todo: this method should be smarter as to not recreate panels that haven't changed, etc.
             var group = groups.Find(b => b.BeatmapSet.ID == set.ID);
 
+            BeatmapGroup newGroup;
             if (group == null)
-                return;
+            {
+                newGroup = createGroup(set);
 
-            int i = groups.IndexOf(group);
-            groups.RemoveAt(i);
+                if (newGroup != null)
+                    groups.Add(newGroup);
+            }
+            else
+            {
+                int i = groups.IndexOf(group);
+                groups.RemoveAt(i);
 
-            var newGroup = createGroup(set);
+                newGroup = createGroup(set);
 
-            if (newGroup != null)
-                groups.Insert(i, newGroup);
+                if (newGroup != null)
+                    groups.Insert(i, newGroup);
+            }
 
             bool hadSelection = selectedGroup == group;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -124,23 +124,18 @@ namespace osu.Game.Screens.Select
             // todo: this method should be smarter as to not recreate panels that haven't changed, etc.
             var group = groups.Find(b => b.BeatmapSet.ID == set.ID);
 
-            BeatmapGroup newGroup;
-            if (group == null)
-            {
-                newGroup = createGroup(set);
-
-                if (newGroup != null)
-                    groups.Add(newGroup);
-            }
-            else
-            {
-                int i = groups.IndexOf(group);
+            int i = groups.IndexOf(group);
+            if (i >= 0)
                 groups.RemoveAt(i);
 
-                newGroup = createGroup(set);
+            var newGroup = createGroup(set);
 
-                if (newGroup != null)
+            if (newGroup != null)
+            {
+                if (i >= 0)
                     groups.Insert(i, newGroup);
+                else
+                    groups.Add(newGroup);
             }
 
             bool hadSelection = selectedGroup == group;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -263,10 +263,7 @@ namespace osu.Game.Screens.Select
             beatmapNoDebounce = beatmap;
 
             if (beatmap == null)
-            {
-                if (!Beatmap.IsDefault)
-                    performLoad();
-            }
+                performLoad();
             else
             {
                 if (beatmap.BeatmapSetInfoID == beatmapNoDebounce?.BeatmapSetInfoID)


### PR DESCRIPTION
Closes #1620.

What happened so far?
1) If you hide all beatmaps in a set the game crashes once you leave the SongSelect and won't start up afterwards.
The reason is a list of `BeatmapGroup`s which has null entries for each set where all beatmaps are hidden (created in `BeatmapCarousel.createGroup`). Preventing those will stop the crash but now the carousel doesn't update when you try to restore them (which leads to point 2).
2) Now the `BeatmapCarousel.UpdateBeatmap` returns early because it can't find a group associated to the beatmap to restore difficulties for (thus not updating at all).
I tried a solution that will prevent an error and also cause to update the carousel again but now I got two different issues.

What issues appear now?
1) If you hide all beatmaps in a set and this set is the only one currently imported an exception appears once you leave the SongSelect and come back (`AdjustableAudioComponent`).
![qq](https://user-images.githubusercontent.com/27222621/33381530-9357f4c0-d51e-11e7-9951-037672fed7f7.png)
This does not happen when you start the game and enter. This only happens after hiding, leaving SS and coming back. I didn't had time to get into this too much yet, but so far I have barely a clue what happens.
2) The other one is that the BeatmapInfoWedge disappears entirely.
![qq](https://user-images.githubusercontent.com/27222621/33381852-737883a8-d51f-11e7-83f9-a6247f36cad0.png)

- [x] Depends on https://github.com/ppy/osu/pull/1633.
