### PR TITLE
Fix mod tooltips not showing in mod selection

### DIFF
--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -204,13 +204,13 @@ namespace osu.Game.Overlays.Mods
             {
                 iconsContainer.AddRange(new[]
                 {
-                    backgroundIcon = new ModIcon(Mods[1])
+                    backgroundIcon = new ModIcon(Mods[1], this)
                     {
                         Origin = Anchor.BottomRight,
                         Anchor = Anchor.BottomRight,
                         Position = new Vector2(1.5f),
                     },
-                    foregroundIcon = new ModIcon(Mods[0])
+                    foregroundIcon = new ModIcon(Mods[0], this)
                     {
                         Origin = Anchor.BottomRight,
                         Anchor = Anchor.BottomRight,
@@ -220,7 +220,7 @@ namespace osu.Game.Overlays.Mods
             }
             else
             {
-                iconsContainer.Add(foregroundIcon = new ModIcon(Mod)
+                iconsContainer.Add(foregroundIcon = new ModIcon(Mod, this)
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -10,13 +10,15 @@ using osu.Framework.Graphics.Cursor;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using OpenTK;
+using osu.Game.Overlays.Mods;
 
 namespace osu.Game.Rulesets.UI
 {
     public class ModIcon : Container, IHasTooltip
     {
-        private readonly SpriteIcon modIcon;
-        private readonly SpriteIcon background;
+        private readonly string modName;
+        private readonly ModButton modButton;
+        private readonly SpriteIcon modIcon, background;
 
         private const float size = 80;
 
@@ -28,15 +30,15 @@ namespace osu.Game.Rulesets.UI
 
         private readonly ModType type;
 
-        public string TooltipText { get; }
+        public string TooltipText => modButton?.TooltipText ?? modName;
 
-        public ModIcon(Mod mod)
+        public ModIcon(Mod mod, ModButton button = null)
         {
             if (mod == null) throw new ArgumentNullException(nameof(mod));
 
             type = mod.Type;
-
-            TooltipText = mod.Name;
+            modName = mod.Name;
+            modButton = button;
 
             Size = new Vector2(size);
 


### PR DESCRIPTION
Fixes mod tooltips not showing the correct text when the `ModIcon` is hovered in mod selection.
Also retains the correct tooltip when hovered in other areas like leaderboards.
Solves #1604.