### PR TITLE
Fix UserProfile crash if displayed User has rank 0 (unranked) in their 30-day history.

### DIFF
--- a/osu.Game/Overlays/Profile/RankChart.cs
+++ b/osu.Game/Overlays/Profile/RankChart.cs
@@ -81,12 +81,12 @@ namespace osu.Game.Overlays.Profile
         {
             rankText.Text = user.Statistics.Rank > 0 ? $"#{user.Statistics.Rank:#,0}" : "no rank";
             performanceText.Text = user.Statistics.PP != null ? $"{user.Statistics.PP:#,0}pp" : string.Empty;
-            relativeText.Text = $"{user.Country?.FullName} #{user.CountryRank:#,0}";
+            relativeText.Text = user.CountryRank > 0 ? $"{user.Country?.FullName} #{user.CountryRank:#,0}" : $"{user.Country?.FullName}";
         }
 
         private void showHistoryRankTexts(int dayIndex)
         {
-            rankText.Text = $"#{ranks[dayIndex]:#,0}";
+            rankText.Text = ranks[dayIndex] > 0 ? $"#{ranks[dayIndex]:#,0}" : "no rank";
             dayIndex++;
             relativeText.Text = dayIndex == ranks.Length ? "Now" : $"{ranks.Length - dayIndex} days ago";
             //plural should be handled in a general way
@@ -99,7 +99,7 @@ namespace osu.Game.Overlays.Profile
             {
                 graph.Colour = colours.Yellow;
                 // use logarithmic coordinates
-                graph.Values = ranks.Select(x => -(float)Math.Log(x));
+                graph.Values = ranks.Select(x => x == 0 ? float.MinValue : -(float)Math.Log(x));
                 graph.SetStaticBallPosition();
             }
 


### PR DESCRIPTION
Closes #1644 as it was caused by this.

`Math.Log(x)` returns `-Infinity` for x == 0, so when the graph tries to draw, it crashes (since some of its values are `Infinity`).
I fixed this by adding a special case where rank == 0 will be added to the rank graph as `float.MinValue` (i think this was intended, graph falls down and out of sight). I also changed it so "#0" would not be displayed in the graph.