### PR TITLE
TestCase: Fix SongSelect TestCase

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -240,6 +240,8 @@ namespace osu.Game.Screens.Select
         /// </summary>
         private void carouselSelectionChanged(BeatmapInfo beatmap)
         {
+            if (beatmap == null)
+                return;
             Action performLoad = delegate
             {
                 // We may be arriving here due to another component changing the bindable Beatmap.


### PR DESCRIPTION
VisualTests is died when SongSelectTest Case is selected.

When VisualTests are starting, there are no selected musics. So the parameter 'beatmap' of carouselSelectionChanged function can get NULL.

Because of that reason, It is necessary to add this code.
