### PR TITLE
Fix MusicController ignoring Looping property of Track

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Overlays
 
                 playButton.Icon = track.IsRunning ? FontAwesome.fa_pause_circle_o : FontAwesome.fa_play_circle_o;
 
-                if (track.HasCompleted && !beatmapBacking.Disabled && playlist.BeatmapSets.Any())
+                if (track.HasCompleted && !track.Looping && !beatmapBacking.Disabled && playlist.BeatmapSets.Any())
                     next();
             }
             else


### PR DESCRIPTION
My pull request #1649 accidentally removed checking the `Looping` property. It's back now.

Fixes #1608