### PR TITLE
Add Keyboard Control in PauseOverlay and FailOverlay

### DIFF
--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -78,6 +78,31 @@ namespace osu.Game.Graphics.UserInterface
                 spriteText.TextSize = value;
             }
         }
+        private bool isSelected = false;
+        public bool IsSelected
+        {
+            get
+            {
+                return isSelected;
+            }
+            set
+            {
+                isSelected = value;
+                if(value)
+                {
+                    spriteText.TransformSpacingTo(hoverSpacing, hover_duration, Easing.OutElastic);
+                    colourContainer.ResizeTo(new Vector2(hover_width, 1f), hover_duration, Easing.OutElastic);
+                    glowContainer.FadeIn(glow_fade_duration, Easing.Out);
+                }
+                else
+                {
+                    colourContainer.ResizeTo(new Vector2(0.8f, 1f), hover_duration, Easing.OutElastic);
+                    spriteText.TransformSpacingTo(Vector2.Zero, hover_duration, Easing.OutElastic);
+                    glowContainer.FadeOut(glow_fade_duration, Easing.Out);
+                }
+
+            }
+        }
 
         private readonly Container backgroundContainer;
         private readonly Container colourContainer;
@@ -111,10 +136,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnHover(Framework.Input.InputState state)
         {
-            spriteText.TransformSpacingTo(hoverSpacing, hover_duration, Easing.OutElastic);
-
-            colourContainer.ResizeTo(new Vector2(hover_width, 1f), hover_duration, Easing.OutElastic);
-            glowContainer.FadeIn(glow_fade_duration, Easing.Out);
+            IsSelected = true;
             base.OnHover(state);
             return true;
         }
@@ -123,9 +145,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             if (!didClick)
             {
-                colourContainer.ResizeTo(new Vector2(0.8f, 1f), hover_duration, Easing.OutElastic);
-                spriteText.TransformSpacingTo(Vector2.Zero, hover_duration, Easing.OutElastic);
-                glowContainer.FadeOut(glow_fade_duration, Easing.Out);
+                IsSelected = false;
             }
 
             didClick = false;

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -78,17 +78,18 @@ namespace osu.Game.Graphics.UserInterface
                 spriteText.TextSize = value;
             }
         }
-        private bool isSelected = false;
-        public bool IsSelected
+
+        private bool isSelectedMouse;
+        public bool IsSelectedMouse
         {
             get
             {
-                return isSelected;
+                return isSelectedMouse;
             }
             set
             {
-                isSelected = value;
-                if(value)
+                isSelectedMouse = value;
+                if (value)
                 {
                     spriteText.TransformSpacingTo(hoverSpacing, hover_duration, Easing.OutElastic);
                     colourContainer.ResizeTo(new Vector2(hover_width, 1f), hover_duration, Easing.OutElastic);
@@ -100,9 +101,24 @@ namespace osu.Game.Graphics.UserInterface
                     spriteText.TransformSpacingTo(Vector2.Zero, hover_duration, Easing.OutElastic);
                     glowContainer.FadeOut(glow_fade_duration, Easing.Out);
                 }
-
             }
         }
+
+        private bool isSelectedKeyboard;
+        public bool IsSelectedKeyboard
+        {
+            get
+            {
+                return isSelectedKeyboard;
+            }
+            set
+            {
+                isSelectedKeyboard = value;
+                spriteText.Scale = value ? new Vector2(1.3f, 1.3f) : Vector2.One;
+            }
+        }
+
+        public bool IsSelected => isSelectedMouse || isSelectedKeyboard;
 
         private readonly Container backgroundContainer;
         private readonly Container colourContainer;
@@ -136,7 +152,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnHover(Framework.Input.InputState state)
         {
-            IsSelected = true;
+            IsSelectedMouse = true;
             base.OnHover(state);
             return true;
         }
@@ -145,7 +161,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             if (!didClick)
             {
-                IsSelected = false;
+                IsSelectedMouse = false;
             }
 
             didClick = false;

--- a/osu.Game/Screens/Play/FailOverlay.cs
+++ b/osu.Game/Screens/Play/FailOverlay.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Screens.Play
     {
         public override string Header => "failed";
         public override string Description => "you're dead, try again?";
+        private int selectedButton;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -29,7 +30,6 @@ namespace osu.Game.Screens.Play
                 Buttons.Children.Last().TriggerOnClick();
                 return true;
             }
-
             return base.OnKeyDown(state, args);
         }
     }

--- a/osu.Game/Screens/Play/MenuOverlay.cs
+++ b/osu.Game/Screens/Play/MenuOverlay.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics;
 using osu.Framework.Allocation;
 using osu.Game.Graphics.UserInterface;
 using osu.Framework.Graphics.Shapes;
+using OpenTK.Input;
 
 namespace osu.Game.Screens.Play
 {
@@ -31,6 +32,7 @@ namespace osu.Game.Screens.Play
         public abstract string Description { get; }
 
         protected FillFlowContainer<DialogButton> Buttons;
+        private int selectedButton = -1;
 
         public int Retries
         {
@@ -181,6 +183,56 @@ namespace osu.Game.Screens.Play
 
             Retries = 0;
         }
+
+        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        {
+            if (!args.Repeat && args.Key == Key.Up)
+            {
+                if(selectedButton == -1)
+                {
+                    selectedButton = Buttons.Count - 1;
+                    Buttons[selectedButton].IsSelectedKeyboard = true;
+                }
+                else
+                {
+                    Buttons[selectedButton].IsSelectedKeyboard = false;
+                    selectedButton--;
+                    if (selectedButton < 0)
+                        selectedButton = Buttons.Count - 1;
+                    Buttons[selectedButton].IsSelectedKeyboard = true;
+                    return true;
+                }
+            }
+
+            if (!args.Repeat && args.Key == Key.Down)
+            {
+                if (selectedButton == -1)
+                {
+                    selectedButton = 0;
+                    Buttons[selectedButton].IsSelectedKeyboard = true;
+                }
+                else
+                {
+                    Buttons[selectedButton].IsSelectedKeyboard = false;
+                    selectedButton++;
+                    if (selectedButton > Buttons.Count - 1)
+                        selectedButton = 0;
+                    Buttons[selectedButton].IsSelectedKeyboard = true;
+                    return true;
+                }
+                return true;
+            }
+
+            if (!args.Repeat && args.Key == Key.Enter)
+            {
+                if (Buttons[selectedButton].IsSelectedKeyboard)
+                    Buttons[selectedButton].Action();
+            }
+
+            return base.OnKeyDown(state, args);
+        }
+
+
 
         protected MenuOverlay()
         {

--- a/osu.Game/Screens/Play/PauseContainer.cs
+++ b/osu.Game/Screens/Play/PauseContainer.cs
@@ -126,6 +126,8 @@ namespace osu.Game.Screens.Play
             public override string Header => "paused";
             public override string Description => "you're not going to do what i think you're going to do, are ya?";
 
+            private int selectedButton;
+
             protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
             {
                 if (!args.Repeat && args.Key == Key.Escape)
@@ -133,7 +135,6 @@ namespace osu.Game.Screens.Play
                     Buttons.Children.First().TriggerOnClick();
                     return true;
                 }
-
                 return base.OnKeyDown(state, args);
             }
 


### PR DESCRIPTION
Before, PauseOverlay and FailOverlay buttons cannot be selected using keyboard.
So I insert SelectedButton member in these classes
and add conditional clauses in onKeyDown Callbacks.
And I change DialogButton class for that work.