### PR TITLE
Fix retry count not displaying on pause overlay

### DIFF
--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -122,44 +122,20 @@ namespace osu.Game.Screens.Play
                 },
             };
 
-            Retries = 0;
+            updateRetryCount();
         }
 
+        private int retries;
         public int Retries
         {
             set
             {
-                if (retryCounterContainer != null)
-                {
-                    // "You've retried 1,065 times in this session"
-                    // "You've retried 1 time in this session"
+                if (value == retries)
+                    return;
 
-                    retryCounterContainer.Children = new Drawable[]
-                    {
-                        new OsuSpriteText
-                        {
-                            Text = "You've retried ",
-                            Shadow = true,
-                            ShadowColour = new Color4(0, 0, 0, 0.25f),
-                            TextSize = 18
-                        },
-                        new OsuSpriteText
-                        {
-                            Text = $"{value:n0}",
-                            Font = @"Exo2.0-Bold",
-                            Shadow = true,
-                            ShadowColour = new Color4(0, 0, 0, 0.25f),
-                            TextSize = 18
-                        },
-                        new OsuSpriteText
-                        {
-                            Text = $" time{(value == 1 ? "" : "s")} in this session",
-                            Shadow = true,
-                            ShadowColour = new Color4(0, 0, 0, 0.25f),
-                            TextSize = 18
-                        }
-                    };
-                }
+                retries = value;
+                if (retryCounterContainer != null)
+                    updateRetryCount();
             }
         }
 
@@ -247,6 +223,38 @@ namespace osu.Game.Screens.Play
                 selectionIndex = -1;
             else
                 selectionIndex = InternalButtons.IndexOf(button);
+        }
+
+        private void updateRetryCount()
+        {
+            // "You've retried 1,065 times in this session"
+            // "You've retried 1 time in this session"
+
+            retryCounterContainer.Children = new Drawable[]
+            {
+                        new OsuSpriteText
+                        {
+                            Text = "You've retried ",
+                            Shadow = true,
+                            ShadowColour = new Color4(0, 0, 0, 0.25f),
+                            TextSize = 18
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = $"{retries:n0}",
+                            Font = @"Exo2.0-Bold",
+                            Shadow = true,
+                            ShadowColour = new Color4(0, 0, 0, 0.25f),
+                            TextSize = 18
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = $" time{(retries == 1 ? "" : "s")} in this session",
+                            Shadow = true,
+                            ShadowColour = new Color4(0, 0, 0, 0.25f),
+                            TextSize = 18
+                        }
+            };
         }
 
         private class Button : DialogButton

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -128,6 +128,7 @@ namespace osu.Game.Screens.Play
         }
 
         private int retries;
+
         public int Retries
         {
             set
@@ -235,28 +236,28 @@ namespace osu.Game.Screens.Play
 
             retryCounterContainer.Children = new Drawable[]
             {
-                        new OsuSpriteText
-                        {
-                            Text = "You've retried ",
-                            Shadow = true,
-                            ShadowColour = new Color4(0, 0, 0, 0.25f),
-                            TextSize = 18
-                        },
-                        new OsuSpriteText
-                        {
-                            Text = $"{retries:n0}",
-                            Font = @"Exo2.0-Bold",
-                            Shadow = true,
-                            ShadowColour = new Color4(0, 0, 0, 0.25f),
-                            TextSize = 18
-                        },
-                        new OsuSpriteText
-                        {
-                            Text = $" time{(retries == 1 ? "" : "s")} in this session",
-                            Shadow = true,
-                            ShadowColour = new Color4(0, 0, 0, 0.25f),
-                            TextSize = 18
-                        }
+                new OsuSpriteText
+                {
+                    Text = "You've retried ",
+                    Shadow = true,
+                    ShadowColour = new Color4(0, 0, 0, 0.25f),
+                    TextSize = 18
+                },
+                new OsuSpriteText
+                {
+                    Text = $"{retries:n0}",
+                    Font = @"Exo2.0-Bold",
+                    Shadow = true,
+                    ShadowColour = new Color4(0, 0, 0, 0.25f),
+                    TextSize = 18
+                },
+                new OsuSpriteText
+                {
+                    Text = $" time{(retries == 1 ? "" : "s")} in this session",
+                    Shadow = true,
+                    ShadowColour = new Color4(0, 0, 0, 0.25f),
+                    TextSize = 18
+                }
             };
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -161,8 +161,8 @@ namespace osu.Game.Screens.Play
                     OnRetry = Restart,
                     OnQuit = Exit,
                     CheckCanPause = () => AllowPause && ValidForResume && !HasFailed && !RulesetContainer.HasReplayLoaded,
-                    Retries = RestartCount,
                     OnPause = () => {
+                        pauseContainer.Retries = RestartCount;
                         hudOverlay.KeyCounter.IsCounting = pauseContainer.IsPaused;
                     },
                     OnResume = () => {


### PR DESCRIPTION
I've find "You've retried xx time(s)" message that something weird.
That is not displayed pause overlay and only see count on FailOverlay
I change that code that PauseContainer.Retries property can be set call-back function.
