### PR TITLE
Correctly make fullscreen overlays block keyboard input from drawables behind them

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Overlays.Mods
         protected readonly OsuSpriteText MultiplierLabel;
         private readonly FillFlowContainer footerContainer;
 
+        protected override bool BlockPassThroughKeyboard => false;
+
         protected readonly FillFlowContainer<ModSection> ModSectionsContainer;
 
         public readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>();

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Overlays
 
         private readonly Container contentContainer;
 
+        protected override bool BlockPassThroughKeyboard => true;
+
         protected override Container<Drawable> Content => contentContainer;
 
         protected Color4 FirstWaveColour


### PR DESCRIPTION
- [x] Depends on #1711 to get correct global binding handling.