### PR TITLE
Add special logic to song select to avoid obvious clipping when notifications are displayed

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Select
         {
             Children = new Drawable[]
             {
-                new Box
+                Background = new Box
                 {
                     Colour = Color4.Black,
                     Alpha = 0.8f,
@@ -166,6 +166,8 @@ namespace osu.Game.Screens.Select
         private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
 
         private Bindable<bool> showConverted;
+
+        public readonly Box Background;
 
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(OsuColour colours, OsuGame osu, OsuConfigManager config)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -103,21 +103,41 @@ namespace osu.Game.Screens.Select
                         Right = left_area_padding * 2,
                     }
                 },
-                carousel = new BeatmapCarousel
+                new Container
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    Size = new Vector2(carousel_width, 1),
-                    Anchor = Anchor.CentreRight,
-                    Origin = Anchor.CentreRight,
-                    SelectionChanged = carouselSelectionChanged,
-                    BeatmapSetsChanged = carouselBeatmapsLoaded,
-                },
-                FilterControl = new FilterControl
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = filter_height,
-                    FilterChanged = c => carousel.Filter(c),
-                    Exit = Exit,
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 2, //avoid horizontal masking so the panels don't clip when screen stack is pushed.
+                    Child = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Width = 0.5f,
+                        Children = new Drawable[]
+                        {
+                            carousel = new BeatmapCarousel
+                            {
+                                Masking = false,
+                                RelativeSizeAxes = Axes.Y,
+                                Size = new Vector2(carousel_width, 1),
+                                Anchor = Anchor.CentreRight,
+                                Origin = Anchor.CentreRight,
+                                SelectionChanged = carouselSelectionChanged,
+                                BeatmapSetsChanged = carouselBeatmapsLoaded,
+                            },
+                            FilterControl = new FilterControl
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = filter_height,
+                                FilterChanged = c => carousel.Filter(c),
+                                Background = { Width = 2 },
+                                Exit = Exit,
+                            },
+                        }
+                    },
                 },
                 beatmapInfoWedge = new BeatmapInfoWedge
                 {


### PR DESCRIPTION
Not sure if we will keep this going forward (there will likely be an opaque tab control on the notifications overlay similar to options) but let's go with this for now.