### PR TITLE
Fix null reference in release builds

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -272,7 +272,7 @@ namespace osu.Game
                 };
             }
 
-            Action<Visibility> stateChanged = delegate
+            void updateScreenOffset()
             {
                 float offset = 0;
 
@@ -281,11 +281,11 @@ namespace osu.Game
                 if (notifications.State == Visibility.Visible)
                     offset -= ToolbarButton.WIDTH / 2;
 
-                intro.MoveToX(offset, SettingsOverlay.TRANSITION_LENGTH, Easing.OutQuint);
-            };
+                screenStack.MoveToX(offset, SettingsOverlay.TRANSITION_LENGTH, Easing.OutQuint);
+            }
 
-            settings.StateChanged += stateChanged;
-            notifications.StateChanged += stateChanged;
+            settings.StateChanged += _ => updateScreenOffset();
+            notifications.StateChanged += _ => updateScreenOffset();
 
             Cursor.State = Visibility.Hidden;
         }


### PR DESCRIPTION
Intro may not be initialised yet

Also fixes regression (caused by https://github.com/ppy/osu-framework/commit/7f6cda35ae1ef6736085cb00cbb97ce68b263b43#diff-e19eebe9adf50de8f9383e1460e2b4cd) where only background is offset by settings/notifications becoming visible.