### PR TITLE
Trigger null-selection in SongSelect when the last beatmap is hidden

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
@@ -70,6 +70,7 @@ namespace osu.Game.Tests.Visual
 
             testRemoveAll();
             testEmptyTraversal();
+            testHiding();
         }
 
         private void ensureRandomFetchSuccess() =>
@@ -293,6 +294,40 @@ namespace osu.Game.Tests.Visual
 
             advanceSelection(direction: -1, diff: true);
             checkNoSelection();
+        }
+
+        private void testHiding()
+        {
+            var hidingSet = createTestBeatmapSet(1);
+            hidingSet.Beatmaps[1].Hidden = true;
+            AddStep("Add set with diff 2 hidden", () => carousel.UpdateBeatmapSet(hidingSet));
+            setSelected(1, 1);
+
+            checkVisibleItemCount(true, 2);
+            advanceSelection(true);
+            checkSelected(1, 3);
+
+            setHidden(3);
+            checkSelected(1, 1);
+
+            setHidden(2, false);
+            advanceSelection(true);
+            checkSelected(1, 2);
+
+            setHidden(1);
+            checkSelected(1, 2);
+
+            setHidden(2);
+            checkNoSelection();
+
+            void setHidden(int diff, bool hidden = true)
+            {
+                AddStep((hidden ? "" : "un") + $"hide diff {diff}", () =>
+                {
+                    hidingSet.Beatmaps[diff - 1].Hidden = hidden;
+                    carousel.UpdateBeatmapSet(hidingSet);
+                });
+            }
         }
 
         private BeatmapSetInfo createTestBeatmapSet(int i)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -511,7 +511,7 @@ namespace osu.Game.Screens.Select
             currentY += DrawHeight / 2;
             scrollableContent.Height = currentY;
 
-            if (!Items.Any() || selectedBeatmapSet != null && selectedBeatmapSet.State.Value != CarouselItemState.Selected)
+            if (selectedBeatmapSet != null && (selectedBeatmap == null || selectedBeatmapSet.State.Value != CarouselItemState.Selected))
             {
                 selectedBeatmapSet = null;
                 SelectionChanged?.Invoke(null);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -142,7 +142,6 @@ namespace osu.Game.Screens.Select
                 if (newSet == null)
                 {
                     itemsCache.Invalidate();
-                    SelectNext();
                     return;
                 }
 
@@ -512,7 +511,7 @@ namespace osu.Game.Screens.Select
             currentY += DrawHeight / 2;
             scrollableContent.Height = currentY;
 
-            if (selectedBeatmapSet != null && selectedBeatmapSet.State.Value != CarouselItemState.Selected)
+            if (!Items.Any() || selectedBeatmapSet != null && selectedBeatmapSet.State.Value != CarouselItemState.Selected)
             {
                 selectedBeatmapSet = null;
                 SelectionChanged?.Invoke(null);


### PR DESCRIPTION
I also removed the `SelectNext()` call since it's not needed for removing maps, so it shouldn't be necessary for hiding the last map of a set either (the set disappears for both actions, and it works without that method call in my testing).

Closes #1723 .