### PR TITLE
Fix taiko autoplay hitting drumroll ticks with the rims instead of centres

### DIFF
--- a/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
+++ b/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Taiko.Replays
                 {
                     foreach (var tick in drumRoll.NestedHitObjects.OfType<DrumRollTick>())
                     {
-                        Frames.Add(new ReplayFrame(tick.StartTime, null, null, hitButton ? ReplayButtonState.Left1 : ReplayButtonState.Left2));
+                        Frames.Add(new ReplayFrame(tick.StartTime, null, null, hitButton ? ReplayButtonState.Right1 : ReplayButtonState.Right2));
                         hitButton = !hitButton;
                     }
                 }


### PR DESCRIPTION
Fixes #1772.