### PR TITLE
Don't change Beatmap while bindable is disabled

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -21,6 +21,7 @@ using osu.Game.Overlays;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Menu;
+using osu.Game.Screens.Play;
 using osu.Game.Screens.Select.Options;
 
 namespace osu.Game.Screens.Select
@@ -250,7 +251,7 @@ namespace osu.Game.Screens.Select
                     bool preview = beatmap?.BeatmapSetInfoID != Beatmap.Value?.BeatmapInfo.BeatmapSetInfoID;
 
                     // Ensure we only change the Beatmap if no map is starting/-ed
-                    if (!Beatmap.Disabled)
+                    if (!(ChildScreen is PlayerLoader))
                         Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap, Beatmap);
                     ensurePlayingSelected(preview);
                 }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -249,7 +249,9 @@ namespace osu.Game.Screens.Select
                 {
                     bool preview = beatmap?.BeatmapSetInfoID != Beatmap.Value?.BeatmapInfo.BeatmapSetInfoID;
 
-                    Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap, Beatmap);
+                    // Ensure we only change the Beatmap if no map is starting/-ed
+                    if (!Beatmap.Disabled)
+                        Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap, Beatmap);
                     ensurePlayingSelected(preview);
                 }
 


### PR DESCRIPTION
I found a better fix than just checking for the `Disabled` flag on the `Bindable`.
This definitely fixes #1719 and possibly #1757 (I wasn't able to reproduce it with this in place, but then again, it was difficult for me to even get that one to throw without it).