### PR TITLE
Fix crash on rapid selection at song select

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -194,7 +194,11 @@ namespace osu.Game.Screens.Select
             if (!Items.Any())
                 return;
 
-            int originalIndex = Items.IndexOf(selectedBeatmap?.Drawables.First());
+            var d = selectedBeatmap?.Drawables.FirstOrDefault();
+            if (d == null)
+                return;
+
+            int originalIndex = Items.IndexOf(d);
             int currentIndex = originalIndex;
 
             // local function to increment the index in the required direction, wrapping over extremities.

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -194,11 +194,14 @@ namespace osu.Game.Screens.Select
             if (!Items.Any())
                 return;
 
-            var d = selectedBeatmap?.Drawables.FirstOrDefault();
-            if (d == null)
+            DrawableCarouselItem drawable = null;
+
+            if (selectedBeatmap != null && (drawable = selectedBeatmap.Drawables.FirstOrDefault()) == null)
+                // if the selected beatmap isn't present yet, we can't correctly change selection.
+                // we can fix this by changing this method to not reference drawables / Items in the first place.
                 return;
 
-            int originalIndex = Items.IndexOf(d);
+            int originalIndex = Items.IndexOf(drawable);
             int currentIndex = originalIndex;
 
             // local function to increment the index in the required direction, wrapping over extremities.


### PR DESCRIPTION
This caused a crash when changing beatmap while the SongSelect screen was just being opened.

Steps to reproduce:
1. Go to main menu
2. Open SongSelect
3. Mash up/down/both

This will _most of the time_ crash with a "sequence does not contain any elements" exception being thrown from `selectedBeatmap?.Drawables.First()`.

This change just `return`s which leads to this being called again for a few times until `Drawables` is not empty and the next map can be selected.
According to ppy this is a temporary fix until the logic gets changed to not rely on drawables anymore.