### PR TITLE
Fix now unnecessary flowingchildren reversal

### DIFF
--- a/osu.Game/Graphics/Containers/ReverseChildIDFillFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/ReverseChildIDFillFlowContainer.cs
@@ -11,7 +11,5 @@ namespace osu.Game.Graphics.Containers
     public class ReverseChildIDFillFlowContainer<T> : FillFlowContainer<T> where T : Drawable
     {
         protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
-
-        protected override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
     }
 }

--- a/osu.Game/Screens/Menu/FlowContainerWithOrigin.cs
+++ b/osu.Game/Screens/Menu/FlowContainerWithOrigin.cs
@@ -22,8 +22,6 @@ namespace osu.Game.Screens.Menu
 
         protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
 
-        protected override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
-
         public override Anchor Origin => Anchor.Custom;
 
         public override Vector2 OriginPosition


### PR DESCRIPTION
In-line with framework changes, since fillflow now explicitly orders by ChildId in cases where previously the result from Compare was used.

In these cases, the Compare override still affects the depth, so we want to keep that.