### PR TITLE
Fix result page from leaderboards not sorting hitcounts correctly

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using OpenTK;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 

--- a/osu.Game.Rulesets.Mania/Judgements/HitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HitWindows.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Judgements
 {

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTailJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTailJudgement.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Judgements
 {

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Judgements
 {

--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Judgements
 {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Input.Bindings;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -8,6 +8,7 @@ using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -6,7 +6,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 

--- a/osu.Game.Rulesets.Mania/Tests/TestCaseManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/Tests/TestCaseManiaPlayfield.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Timing;
 using osu.Game.Rulesets.Mania.UI;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Timing;
 using osu.Game.Tests.Visual;
 

--- a/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
@@ -4,7 +4,7 @@
 using OpenTK;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Judgements
 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
 using OpenTK;
 using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Judgements;
 using OpenTK;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using OpenTK;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -8,6 +8,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -13,6 +13,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Screens.Ranking;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -7,7 +7,7 @@ using OpenTK;
 using osu.Game.Rulesets.Objects.Types;
 using OpenTK.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -9,9 +9,9 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 using System;
 using System.Diagnostics;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Replays
 {

--- a/osu.Game.Rulesets.Osu/Scoring/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuPerformanceCalculator.cs
@@ -10,7 +10,6 @@ using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
-using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Rulesets.Osu.Scoring
 {
@@ -42,10 +41,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
             mods = Score.Mods;
             accuracy = Score.Accuracy;
             scoreMaxCombo = Score.MaxCombo;
-            count300 = Convert.ToInt32(Score.Statistics[HitCount.Great]);
-            count100 = Convert.ToInt32(Score.Statistics[HitCount.Good]);
-            count50 = Convert.ToInt32(Score.Statistics[HitCount.Meh]);
-            countMiss = Convert.ToInt32(Score.Statistics[HitCount.Miss]);
+            count300 = Convert.ToInt32(Score.Statistics[HitResult.Great]);
+            count100 = Convert.ToInt32(Score.Statistics[HitResult.Good]);
+            count50 = Convert.ToInt32(Score.Statistics[HitResult.Meh]);
+            countMiss = Convert.ToInt32(Score.Statistics[HitResult.Miss]);
 
             // Don't count scores made with supposedly unranked mods
             if (mods.Any(m => !m.Ranked))

--- a/osu.Game.Rulesets.Osu/Scoring/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuPerformanceCalculator.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
+using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Rulesets.Osu.Scoring
 {
@@ -41,10 +42,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
             mods = Score.Mods;
             accuracy = Score.Accuracy;
             scoreMaxCombo = Score.MaxCombo;
-            count300 = Convert.ToInt32(Score.Statistics["300"]);
-            count100 = Convert.ToInt32(Score.Statistics["100"]);
-            count50 = Convert.ToInt32(Score.Statistics["50"]);
-            countMiss = Convert.ToInt32(Score.Statistics["x"]);
+            count300 = Convert.ToInt32(Score.Statistics[HitCount.Great]);
+            count100 = Convert.ToInt32(Score.Statistics[HitCount.Good]);
+            count50 = Convert.ToInt32(Score.Statistics[HitCount.Meh]);
+            countMiss = Convert.ToInt32(Score.Statistics[HitCount.Miss]);
 
             // Don't count scores made with supposedly unranked mods
             if (mods.Any(m => !m.Ranked))

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
+using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Rulesets.Osu.Scoring
 {
@@ -33,8 +34,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
             foreach (var obj in beatmap.HitObjects)
             {
-                var slider = obj as Slider;
-                if (slider != null)
+                if (obj is Slider slider)
                 {
                     // Head
                     AddJudgement(new OsuJudgement { Result = HitResult.Great });
@@ -64,10 +64,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
             base.PopulateScore(score);
 
-            score.Statistics[@"300"] = scoreResultCounts.GetOrDefault(HitResult.Great);
-            score.Statistics[@"100"] = scoreResultCounts.GetOrDefault(HitResult.Good);
-            score.Statistics[@"50"] = scoreResultCounts.GetOrDefault(HitResult.Meh);
-            score.Statistics[@"x"] = scoreResultCounts.GetOrDefault(HitResult.Miss);
+            score.Statistics[HitCount.Great] = scoreResultCounts.GetOrDefault(HitResult.Great);
+            score.Statistics[HitCount.Good] = scoreResultCounts.GetOrDefault(HitResult.Good);
+            score.Statistics[HitCount.Meh] = scoreResultCounts.GetOrDefault(HitResult.Meh);
+            score.Statistics[HitCount.Miss] = scoreResultCounts.GetOrDefault(HitResult.Miss);
         }
 
         protected override void OnNewJudgement(Judgement judgement)

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -6,13 +6,11 @@ using System.Linq;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
-using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Rulesets.Osu.Scoring
 {
@@ -64,10 +62,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
             base.PopulateScore(score);
 
-            score.Statistics[HitCount.Great] = scoreResultCounts.GetOrDefault(HitResult.Great);
-            score.Statistics[HitCount.Good] = scoreResultCounts.GetOrDefault(HitResult.Good);
-            score.Statistics[HitCount.Meh] = scoreResultCounts.GetOrDefault(HitResult.Meh);
-            score.Statistics[HitCount.Miss] = scoreResultCounts.GetOrDefault(HitResult.Miss);
+            score.Statistics[HitResult.Great] = scoreResultCounts.GetOrDefault(HitResult.Great);
+            score.Statistics[HitResult.Good] = scoreResultCounts.GetOrDefault(HitResult.Good);
+            score.Statistics[HitResult.Meh] = scoreResultCounts.GetOrDefault(HitResult.Meh);
+            score.Statistics[HitResult.Miss] = scoreResultCounts.GetOrDefault(HitResult.Miss);
         }
 
         protected override void OnNewJudgement(Judgement judgement)

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Judgements
 {

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoJudgement.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Judgements
 {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHitStrong.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHitStrong.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Judgements;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -14,6 +14,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Taiko.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Rulesets.Taiko.Objects;

--- a/osu.Game.Rulesets.Taiko/Tests/TestCaseTaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/Tests/TestCaseTaikoPlayfield.cs
@@ -20,6 +20,7 @@ using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Visual;
 using OpenTK;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {

--- a/osu.Game.Tests/Visual/TestCaseBeatmapScoresContainer.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapScoresContainer.cs
@@ -14,7 +14,6 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Users;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Containers;
-using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Tests.Visual
 {
@@ -161,9 +160,9 @@ namespace osu.Game.Tests.Visual
             };
             foreach(var s in scores)
             {
-                s.Statistics.Add(HitCount.Great, RNG.Next(2000));
-                s.Statistics.Add(HitCount.Good, RNG.Next(2000));
-                s.Statistics.Add(HitCount.Meh, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Great, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Good, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Meh, RNG.Next(2000));
             }
 
             anotherScores = new[]
@@ -273,9 +272,9 @@ namespace osu.Game.Tests.Visual
             };
             foreach (var s in anotherScores)
             {
-                s.Statistics.Add(HitCount.Great, RNG.Next(2000));
-                s.Statistics.Add(HitCount.Good, RNG.Next(2000));
-                s.Statistics.Add(HitCount.Meh, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Great, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Good, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Meh, RNG.Next(2000));
             }
 
             topScore = new OnlineScore
@@ -300,9 +299,9 @@ namespace osu.Game.Tests.Visual
                 TotalScore = 987654321,
                 Accuracy = 0.8487,
             };
-            topScore.Statistics.Add(HitCount.Great, RNG.Next(2000));
-            topScore.Statistics.Add(HitCount.Good, RNG.Next(2000));
-            topScore.Statistics.Add(HitCount.Meh, RNG.Next(2000));
+            topScore.Statistics.Add(HitResult.Great, RNG.Next(2000));
+            topScore.Statistics.Add(HitResult.Good, RNG.Next(2000));
+            topScore.Statistics.Add(HitResult.Meh, RNG.Next(2000));
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Tests/Visual/TestCaseBeatmapScoresContainer.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapScoresContainer.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Users;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Containers;
+using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Tests.Visual
 {
@@ -160,9 +161,9 @@ namespace osu.Game.Tests.Visual
             };
             foreach(var s in scores)
             {
-                s.Statistics.Add("300", RNG.Next(2000));
-                s.Statistics.Add("100", RNG.Next(2000));
-                s.Statistics.Add("50", RNG.Next(2000));
+                s.Statistics.Add(HitCount.Great, RNG.Next(2000));
+                s.Statistics.Add(HitCount.Good, RNG.Next(2000));
+                s.Statistics.Add(HitCount.Meh, RNG.Next(2000));
             }
 
             anotherScores = new[]
@@ -272,9 +273,9 @@ namespace osu.Game.Tests.Visual
             };
             foreach (var s in anotherScores)
             {
-                s.Statistics.Add("300", RNG.Next(2000));
-                s.Statistics.Add("100", RNG.Next(2000));
-                s.Statistics.Add("50", RNG.Next(2000));
+                s.Statistics.Add(HitCount.Great, RNG.Next(2000));
+                s.Statistics.Add(HitCount.Good, RNG.Next(2000));
+                s.Statistics.Add(HitCount.Meh, RNG.Next(2000));
             }
 
             topScore = new OnlineScore
@@ -299,9 +300,9 @@ namespace osu.Game.Tests.Visual
                 TotalScore = 987654321,
                 Accuracy = 0.8487,
             };
-            topScore.Statistics.Add("300", RNG.Next(2000));
-            topScore.Statistics.Add("100", RNG.Next(2000));
-            topScore.Statistics.Add("50", RNG.Next(2000));
+            topScore.Statistics.Add(HitCount.Great, RNG.Next(2000));
+            topScore.Statistics.Add(HitCount.Good, RNG.Next(2000));
+            topScore.Statistics.Add(HitCount.Meh, RNG.Next(2000));
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Tests/Visual/TestCaseResults.cs
+++ b/osu.Game.Tests/Visual/TestCaseResults.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Users;
-using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Tests.Visual
 {
@@ -42,12 +41,12 @@ namespace osu.Game.Tests.Visual
                 MaxCombo = 123,
                 Rank = ScoreRank.A,
                 Date = DateTimeOffset.Now,
-                Statistics = new Dictionary<HitCount, dynamic>
+                Statistics = new Dictionary<HitResult, dynamic>
                 {
-                    { HitCount.Great, 50 },
-                    { HitCount.Good, 20 },
-                    { HitCount.Meh, 50 },
-                    { HitCount.Miss, 1 }
+                    { HitResult.Great, 50 },
+                    { HitResult.Good, 20 },
+                    { HitResult.Meh, 50 },
+                    { HitResult.Miss, 1 }
                 },
                 User = new User
                 {

--- a/osu.Game.Tests/Visual/TestCaseResults.cs
+++ b/osu.Game.Tests/Visual/TestCaseResults.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Users;
+using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Tests.Visual
 {
@@ -41,12 +42,12 @@ namespace osu.Game.Tests.Visual
                 MaxCombo = 123,
                 Rank = ScoreRank.A,
                 Date = DateTimeOffset.Now,
-                Statistics = new Dictionary<string, dynamic>
+                Statistics = new Dictionary<HitCount, dynamic>
                 {
-                    { "300", 50 },
-                    { "100", 20 },
-                    { "50", 50 },
-                    { "x", 1 }
+                    { HitCount.Great, 50 },
+                    { HitCount.Good, 20 },
+                    { HitCount.Meh, 50 },
+                    { HitCount.Miss, 1 }
                 },
                 User = new User
                 {

--- a/osu.Game/Online/API/Requests/GetScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetScoresRequest.cs
@@ -122,26 +122,26 @@ namespace osu.Game.Online.API.Requests
             {
                 foreach (var kvp in value)
                 {
-                    string key = kvp.Key;
-                    switch (key)
+                    HitCount newKey;
+                    switch (kvp.Key)
                     {
                         case @"count_300":
-                            key = @"300";
+                            newKey = HitCount.Great;
                             break;
                         case @"count_100":
-                            key = @"100";
+                            newKey = HitCount.Good;
                             break;
                         case @"count_50":
-                            key = @"50";
+                            newKey = HitCount.Meh;
                             break;
                         case @"count_miss":
-                            key = @"x";
+                            newKey = HitCount.Miss;
                             break;
                         default:
                             continue;
                     }
 
-                    Statistics.Add(key, kvp.Value);
+                    Statistics.Add(newKey, kvp.Value);
                 }
             }
         }

--- a/osu.Game/Online/API/Requests/GetScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetScoresRequest.cs
@@ -122,20 +122,20 @@ namespace osu.Game.Online.API.Requests
             {
                 foreach (var kvp in value)
                 {
-                    HitCount newKey;
+                    HitResult newKey;
                     switch (kvp.Key)
                     {
                         case @"count_300":
-                            newKey = HitCount.Great;
+                            newKey = HitResult.Great;
                             break;
                         case @"count_100":
-                            newKey = HitCount.Good;
+                            newKey = HitResult.Good;
                             break;
                         case @"count_50":
-                            newKey = HitCount.Meh;
+                            newKey = HitResult.Meh;
                             break;
                         case @"count_miss":
-                            newKey = HitCount.Miss;
+                            newKey = HitResult.Miss;
                             break;
                         default:
                             continue;

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableScore.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
+using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -104,7 +105,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Text = $"{score.Statistics["300"]}/{score.Statistics["100"]}/{score.Statistics["50"]}",
+                    Text = $"{score.Statistics[HitCount.Great]}/{score.Statistics[HitCount.Good]}/{score.Statistics[HitCount.Meh]}",
                     Font = @"Exo2.0-RegularItalic",
                     Margin = new MarginPadding { Right = side_margin }
                 },

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableScore.cs
@@ -12,10 +12,10 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Profile.Sections.Ranks;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
-using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -105,7 +105,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Text = $"{score.Statistics[HitCount.Great]}/{score.Statistics[HitCount.Good]}/{score.Statistics[HitCount.Meh]}",
+                    Text = $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Meh]}",
                     Font = @"Exo2.0-RegularItalic",
                     Margin = new MarginPadding { Right = side_margin }
                 },

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
+using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -58,7 +59,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
 
                 totalScore.Value = $@"{score.TotalScore:N0}";
                 accuracy.Value = $@"{score.Accuracy:P2}";
-                statistics.Value = $"{score.Statistics["300"]}/{score.Statistics["100"]}/{score.Statistics["50"]}";
+                statistics.Value = $"{score.Statistics[HitCount.Great]}/{score.Statistics[HitCount.Good]}/{score.Statistics[HitCount.Meh]}";
 
                 modsContainer.Clear();
                 foreach (Mod mod in score.Mods)

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
@@ -18,7 +18,6 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
-using static osu.Game.Rulesets.Scoring.Score;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
 {
@@ -59,7 +58,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
 
                 totalScore.Value = $@"{score.TotalScore:N0}";
                 accuracy.Value = $@"{score.Accuracy:P2}";
-                statistics.Value = $"{score.Statistics[HitCount.Great]}/{score.Statistics[HitCount.Good]}/{score.Statistics[HitCount.Meh]}";
+                statistics.Value = $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Meh]}";
 
                 modsContainer.Clear();
                 foreach (Mod mod in score.Mods)

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Judgements
 {

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Judgements
 {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -16,6 +16,7 @@ using osu.Game.Graphics;
 using osu.Framework.Configuration;
 using OpenTK;
 using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Objects.Drawables
 {

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -3,7 +3,7 @@
 
 using System.ComponentModel;
 
-namespace osu.Game.Rulesets.Objects.Drawables
+namespace osu.Game.Rulesets.Scoring
 {
     public enum HitResult
     {

--- a/osu.Game/Rulesets/Scoring/Score.cs
+++ b/osu.Game/Rulesets/Scoring/Score.cs
@@ -7,7 +7,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Users;
 using osu.Game.Rulesets.Replays;
-using System.ComponentModel;
 
 namespace osu.Game.Rulesets.Scoring
 {
@@ -41,21 +40,6 @@ namespace osu.Game.Rulesets.Scoring
 
         public DateTimeOffset Date;
 
-        public Dictionary<HitCount, object> Statistics = new Dictionary<HitCount, object>();
-
-        public enum HitCount
-        {
-            [Description("300")]
-            Great,
-
-            [Description("100")]
-            Good,
-
-            [Description("50")]
-            Meh,
-
-            [Description("x")]
-            Miss
-        }
+        public Dictionary<HitResult, object> Statistics = new Dictionary<HitResult, object>();
     }
 }

--- a/osu.Game/Rulesets/Scoring/Score.cs
+++ b/osu.Game/Rulesets/Scoring/Score.cs
@@ -7,6 +7,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Users;
 using osu.Game.Rulesets.Replays;
+using System.ComponentModel;
 
 namespace osu.Game.Rulesets.Scoring
 {
@@ -40,6 +41,21 @@ namespace osu.Game.Rulesets.Scoring
 
         public DateTimeOffset Date;
 
-        public Dictionary<string, object> Statistics = new Dictionary<string, object>();
+        public Dictionary<HitCount, object> Statistics = new Dictionary<HitCount, object>();
+
+        public enum HitCount
+        {
+            [Description("300")]
+            Great,
+
+            [Description("100")]
+            Good,
+
+            [Description("50")]
+            Meh,
+
+            [Description("x")]
+            Miss
+        }
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.UI;
-using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Scoring
 {

--- a/osu.Game/Screens/Play/HUD/StandardHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/StandardHealthDisplay.cs
@@ -7,10 +7,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Screens.Play.HUD
 {

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.Ranking
                 }
             };
 
-            statisticsContainer.ChildrenEnumerable = Score.Statistics.Select(s => new DrawableScoreStatistic(s));
+            statisticsContainer.ChildrenEnumerable = Score.Statistics.OrderBy(p => p.Key).Select(s => new DrawableScoreStatistic(s));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Screens.Ranking
                 }
             };
 
-            statisticsContainer.ChildrenEnumerable = Score.Statistics.OrderBy(p => p.Key).Select(s => new DrawableScoreStatistic(s));
+            statisticsContainer.ChildrenEnumerable = Score.Statistics.OrderByDescending(p => p.Key).Select(s => new DrawableScoreStatistic(s));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -23,6 +23,8 @@ using osu.Game.Screens.Play;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
 using osu.Framework.Graphics.Shapes;
+using static osu.Game.Rulesets.Scoring.Score;
+using osu.Framework.Extensions;
 
 namespace osu.Game.Screens.Ranking
 {
@@ -186,9 +188,9 @@ namespace osu.Game.Screens.Ranking
 
         private class DrawableScoreStatistic : Container
         {
-            private readonly KeyValuePair<string, object> statistic;
+            private readonly KeyValuePair<HitCount, object> statistic;
 
-            public DrawableScoreStatistic(KeyValuePair<string, object> statistic)
+            public DrawableScoreStatistic(KeyValuePair<HitCount, object> statistic)
             {
                 this.statistic = statistic;
 
@@ -209,7 +211,7 @@ namespace osu.Game.Screens.Ranking
                         Origin = Anchor.TopCentre,
                     },
                     new OsuSpriteText {
-                        Text = statistic.Key,
+                        Text = statistic.Key.GetDescription(),
                         Colour = colours.Gray7,
                         Font = @"Exo2.0-Bold",
                         Y = 26,

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -23,7 +23,6 @@ using osu.Game.Screens.Play;
 using osu.Game.Screens.Select.Leaderboards;
 using osu.Game.Users;
 using osu.Framework.Graphics.Shapes;
-using static osu.Game.Rulesets.Scoring.Score;
 using osu.Framework.Extensions;
 
 namespace osu.Game.Screens.Ranking
@@ -188,9 +187,9 @@ namespace osu.Game.Screens.Ranking
 
         private class DrawableScoreStatistic : Container
         {
-            private readonly KeyValuePair<HitCount, object> statistic;
+            private readonly KeyValuePair<HitResult, object> statistic;
 
-            public DrawableScoreStatistic(KeyValuePair<HitCount, object> statistic)
+            public DrawableScoreStatistic(KeyValuePair<HitResult, object> statistic)
             {
                 this.statistic = statistic;
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -612,7 +612,7 @@
     <Compile Include="Rulesets\Objects\Drawables\ArmedState.cs" />
     <Compile Include="Rulesets\Objects\Drawables\DrawableHitObject.cs" />
     <Compile Include="Rulesets\Objects\Drawables\DrawableScrollingHitObject.cs" />
-    <Compile Include="Rulesets\Objects\Drawables\HitResult.cs" />
+    <Compile Include="Rulesets\Scoring\HitResult.cs" />
     <Compile Include="Rulesets\Objects\Drawables\IDrawableHitObjectWithProxiedApproach.cs" />
     <Compile Include="Rulesets\Objects\Drawables\IScrollingHitObject.cs" />
     <Compile Include="Rulesets\Objects\HitObject.cs" />


### PR DESCRIPTION
I took the liberty to replace all the strings with an enum which also made it easier to sort it. It now shouldn't matter in which order the statistics are added.

Closes https://github.com/ppy/osu/issues/1809