### PR TITLE
Create a LargeTextureStore for cached (but not atlased) global textures

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -19,6 +19,7 @@ using osu.Game.Beatmaps.Formats;
 using osu.Game.Beatmaps.IO;
 using osu.Game.Database;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Textures;
 using osu.Game.IO;
 using osu.Game.IPC;
 using osu.Game.Online.API;
@@ -651,7 +652,7 @@ namespace osu.Game.Beatmaps
 
                 try
                 {
-                    return new TextureStore(new RawTextureLoaderStore(store), false).Get(getPathForFile(Metadata.BackgroundFile));
+                    return new LargeTextureStore(new RawTextureLoaderStore(store)).Get(getPathForFile(Metadata.BackgroundFile));
                 }
                 catch
                 {

--- a/osu.Game/Graphics/Backgrounds/Background.cs
+++ b/osu.Game/Graphics/Backgrounds/Background.cs
@@ -5,8 +5,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using OpenTK.Graphics;
+using osu.Game.Graphics.Textures;
 
 namespace osu.Game.Graphics.Backgrounds
 {
@@ -22,7 +22,6 @@ namespace osu.Game.Graphics.Backgrounds
 
             this.textureName = textureName;
             RelativeSizeAxes = Axes.Both;
-            Depth = float.MaxValue;
 
             Add(Sprite = new Sprite
             {
@@ -35,7 +34,7 @@ namespace osu.Game.Graphics.Backgrounds
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(LargeTextureStore textures)
         {
             if (!string.IsNullOrEmpty(textureName))
                 Sprite.Texture = textures.Get(textureName);

--- a/osu.Game/Graphics/Textures/LargeTextureStore.cs
+++ b/osu.Game/Graphics/Textures/LargeTextureStore.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+
+namespace osu.Game.Graphics.Textures
+{
+    /// <summary>
+    /// A texture store that bypasses atlasing.
+    /// </summary>
+    public class LargeTextureStore : TextureStore
+    {
+        public LargeTextureStore(IResourceStore<RawTexture> store = null) : base(store, false)
+        {
+        }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -86,14 +86,12 @@ namespace osu.Game
 
         private DatabaseContextFactory contextFactory;
 
-        private LargeTextureStore largeTextureStore;
-
         [BackgroundDependencyLoader]
         private void load()
         {
             dependencies.Cache(contextFactory = new DatabaseContextFactory(Host));
 
-            dependencies.Cache(largeTextureStore = new LargeTextureStore(new RawTextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures"))));
+            dependencies.Cache(new LargeTextureStore(new RawTextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures"))));
 
             dependencies.Cache(this);
             dependencies.Cache(LocalConfig);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -18,8 +18,10 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
 using osu.Framework.Graphics.Performance;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
 using osu.Game.Database;
+using osu.Game.Graphics.Textures;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.IO;
@@ -84,10 +86,14 @@ namespace osu.Game
 
         private DatabaseContextFactory contextFactory;
 
+        private LargeTextureStore largeTextureStore;
+
         [BackgroundDependencyLoader]
         private void load()
         {
             dependencies.Cache(contextFactory = new DatabaseContextFactory(Host));
+
+            dependencies.Cache(largeTextureStore = new LargeTextureStore(new RawTextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures"))));
 
             dependencies.Cache(this);
             dependencies.Cache(LocalConfig);

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Threading;
 using osu.Game.Graphics.Backgrounds;
 
 namespace osu.Game.Screens.Backgrounds
@@ -24,16 +25,22 @@ namespace osu.Game.Screens.Backgrounds
 
         private void display(Background newBackground)
         {
-            current?.FadeOut(800, Easing.OutQuint);
+            current?.FadeOut(800, Easing.InOutSine);
             current?.Expire();
 
             Add(current = newBackground);
+            currentDisplay++;
         }
+
+        private ScheduledDelegate nextTask;
 
         public void Next()
         {
-            currentDisplay++;
-            LoadComponentAsync(new Background(backgroundName) { Depth = currentDisplay }, display);
+            nextTask?.Cancel();
+            nextTask = Scheduler.AddDelayed(() =>
+            {
+                LoadComponentAsync(new Background(backgroundName) { Depth = currentDisplay }, display);
+            }, 100);
         }
     }
 }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Beatmaps\Formats\LegacyStoryboardDecoder.cs" />
     <Compile Include="Database\DatabaseContextFactory.cs" />
     <Compile Include="Database\IHasPrimaryKey.cs" />
+    <Compile Include="Graphics\Textures\LargeTextureStore.cs" />
     <Compile Include="Overlays\Profile\SupporterIcon.cs" />
     <Compile Include="Overlays\Settings\DangerousSettingsButton.cs" />
     <Compile Include="Graphics\UserInterface\HoverClickSounds.cs" />


### PR DESCRIPTION
Fixes frame drops when returning to the main menu (or switching beatmaps) the first time. Was caused by atlas exhaustion, so let's not use atlases for such large textures (we should never be).

Also
- Fixes first transition depth being incorrect.
- Improves smoothness of transitions (and adds a slight delay to offset from screen switches).