### PR TITLE
Don't allow randomizer to select invisible maps

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Tests.Visual
             var currentlySelected = carousel.Items.FirstOrDefault(s => s.Item is CarouselBeatmap && s.Item.State == CarouselItemState.Selected);
             if (currentlySelected == null)
                 return true;
-            return !currentlySelected.Item.Filtered;
+            return currentlySelected.Item.Visible;
         }
 
         private void checkInvisibleDifficultiesUnselectable()

--- a/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Tests.Visual
             nextRandom();
             AddAssert("ensure repeat", () => selectedSets.Contains(carousel.SelectedBeatmapSet));
 
-            AddStep("Add set with 100 difficulties", () => carousel.UpdateBeatmapSet(createTestBeatmapSetWith100Difficulties(set_count + 1)));
+            AddStep("Add set with 100 difficulties", () => carousel.UpdateBeatmapSet(createTestBeatmapSetWithManyDifficulties(set_count + 1)));
             AddStep("Filter Extra", () => carousel.Filter(new FilterCriteria { SearchText = "Extra 10" }, false));
             checkInvisibleDifficultiesUnselectable();
             checkInvisibleDifficultiesUnselectable();
@@ -353,26 +353,26 @@ namespace osu.Game.Tests.Visual
             }
         }
 
-        private BeatmapSetInfo createTestBeatmapSet(int i)
+        private BeatmapSetInfo createTestBeatmapSet(int id)
         {
             return new BeatmapSetInfo
             {
-                ID = i,
-                OnlineBeatmapSetID = i,
+                ID = id,
+                OnlineBeatmapSetID = id,
                 Hash = new MemoryStream(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())).ComputeMD5Hash(),
                 Metadata = new BeatmapMetadata
                 {
-                    OnlineBeatmapSetID = i,
+                    OnlineBeatmapSetID = id,
                     // Create random metadata, then we can check if sorting works based on these
-                    Artist = $"peppy{i.ToString().PadLeft(6, '0')}",
-                    Title = $"test set #{i}!",
-                    AuthorString = string.Concat(Enumerable.Repeat((char)('z' - Math.Min(25, i - 1)), 5))
+                    Artist = $"peppy{id.ToString().PadLeft(6, '0')}",
+                    Title = $"test set #{id}!",
+                    AuthorString = string.Concat(Enumerable.Repeat((char)('z' - Math.Min(25, id - 1)), 5))
                 },
                 Beatmaps = new List<BeatmapInfo>(new[]
                 {
                     new BeatmapInfo
                     {
-                        OnlineBeatmapID = i * 10,
+                        OnlineBeatmapID = id * 10,
                         Path = "normal.osu",
                         Version = "Normal",
                         StarDifficulty = 2,
@@ -383,7 +383,7 @@ namespace osu.Game.Tests.Visual
                     },
                     new BeatmapInfo
                     {
-                        OnlineBeatmapID = i * 10 + 1,
+                        OnlineBeatmapID = id * 10 + 1,
                         Path = "hard.osu",
                         Version = "Hard",
                         StarDifficulty = 5,
@@ -394,7 +394,7 @@ namespace osu.Game.Tests.Visual
                     },
                     new BeatmapInfo
                     {
-                        OnlineBeatmapID = i * 10 + 2,
+                        OnlineBeatmapID = id * 10 + 2,
                         Path = "insane.osu",
                         Version = "Insane",
                         StarDifficulty = 6,
@@ -407,20 +407,20 @@ namespace osu.Game.Tests.Visual
             };
         }
 
-        private BeatmapSetInfo createTestBeatmapSetWith100Difficulties(int i)
+        private BeatmapSetInfo createTestBeatmapSetWithManyDifficulties(int id)
         {
             var toReturn = new BeatmapSetInfo
             {
-                ID = i,
-                OnlineBeatmapSetID = i,
+                ID = id,
+                OnlineBeatmapSetID = id,
                 Hash = new MemoryStream(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())).ComputeMD5Hash(),
                 Metadata = new BeatmapMetadata
                 {
-                    OnlineBeatmapSetID = i,
+                    OnlineBeatmapSetID = id,
                     // Create random metadata, then we can check if sorting works based on these
-                    Artist = $"peppy{i.ToString().PadLeft(6, '0')}",
-                    Title = $"test set #{i}!",
-                    AuthorString = string.Concat(Enumerable.Repeat((char)('z' - Math.Min(25, i - 1)), 5))
+                    Artist = $"peppy{id.ToString().PadLeft(6, '0')}",
+                    Title = $"test set #{id}!",
+                    AuthorString = string.Concat(Enumerable.Repeat((char)('z' - Math.Min(25, id - 1)), 5))
                 },
                 Beatmaps = new List<BeatmapInfo>(),
             };

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Screens.Select
                 set = visibleSets.ElementAt(RNG.Next(visibleSets.Count));
 
             var visibleBeatmaps = set.Beatmaps.Where(s => !s.Filtered).ToList();
-            select(visibleBeatmaps.Skip(RNG.Next(visibleBeatmaps.Count)).FirstOrDefault());
+            select(visibleBeatmaps[RNG.Next(visibleBeatmaps.Count)]);
             return true;
         }
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -263,7 +263,7 @@ namespace osu.Game.Screens.Select
                 set = visibleSets.ElementAt(RNG.Next(visibleSets.Count));
 
             var visibleBeatmaps = set.Beatmaps.Where(s => !s.Filtered).ToList();
-            select(visibleBeatmaps.Skip(RNG.Next(visibleBeatmaps.Count())).FirstOrDefault());
+            select(visibleBeatmaps.Skip(RNG.Next(visibleBeatmaps.Count)).FirstOrDefault());
         }
 
         public void SelectPreviousRandom()

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -231,8 +231,8 @@ namespace osu.Game.Screens.Select
 
         public void SelectNextRandom()
         {
-            var visible = beatmapSets.Where(s => !s.Filtered).ToList();
-            if (!visible.Any())
+            var visibleSets = beatmapSets.Where(s => !s.Filtered).ToList();
+            if (!visibleSets.Any())
                 return;
 
             if (selectedBeatmap != null)
@@ -249,20 +249,21 @@ namespace osu.Game.Screens.Select
 
             if (RandomAlgorithm == RandomSelectAlgorithm.RandomPermutation)
             {
-                var notYetVisitedSets = visible.Except(previouslyVisitedRandomSets).ToList();
+                var notYetVisitedSets = visibleSets.Except(previouslyVisitedRandomSets).ToList();
                 if (!notYetVisitedSets.Any())
                 {
                     previouslyVisitedRandomSets.Clear();
-                    notYetVisitedSets = visible;
+                    notYetVisitedSets = visibleSets;
                 }
 
                 set = notYetVisitedSets.ElementAt(RNG.Next(notYetVisitedSets.Count));
                 previouslyVisitedRandomSets.Add(set);
             }
             else
-                set = visible.ElementAt(RNG.Next(visible.Count));
+                set = visibleSets.ElementAt(RNG.Next(visibleSets.Count));
 
-            select(set.Beatmaps.Skip(RNG.Next(set.Beatmaps.Count())).FirstOrDefault());
+            var visibleBeatmaps = set.Beatmaps.Where(s => !s.Filtered).ToList();
+            select(visibleBeatmaps.Skip(RNG.Next(visibleBeatmaps.Count())).FirstOrDefault());
         }
 
         public void SelectPreviousRandom()

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Screens.Select
                 var notYetVisitedSets = visibleSets.Except(previouslyVisitedRandomSets).ToList();
                 if (!notYetVisitedSets.Any())
                 {
-                    previouslyVisitedRandomSets.Clear();
+                    previouslyVisitedRandomSets.RemoveAll(s => visibleSets.Contains(s));
                     notYetVisitedSets = visibleSets;
                 }
 


### PR DESCRIPTION
Before, randomizer might select beatmaps from other rulesets which made the carousel not scroll to anything. This makes it so that randomizer can only select from visible beatmaps of the selected set.