### PR TITLE
Allow player to change initial spinner spin

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -165,7 +165,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             glow.Colour = colours.BlueDark;
 
             rotationMultiplier = config.GetBindable<bool>(OsuSetting.InitialSpinnerRotationCW) ? -1 : 1;
-            
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -14,6 +14,7 @@ using osu.Framework.Allocation;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Screens.Ranking;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -39,6 +40,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private Color4 normalColour;
         private Color4 completeColour;
+        private int rotationMultiplier;
 
         public DrawableSpinner(Spinner s) : base(s)
         {
@@ -150,7 +152,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuConfigManager config, OsuColour colours)
         {
             normalColour = baseColour;
 
@@ -161,6 +163,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Disc.AccentColour = fillColour;
             circle.Colour = colours.BlueDark;
             glow.Colour = colours.BlueDark;
+
+            rotationMultiplier = config.GetBindable<bool>(OsuSetting.InitialSpinnerRotationCW) ? -1 : 1;
+            
         }
 
         protected override void Update()
@@ -193,8 +198,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             circleContainer.ScaleTo(spinner.Scale * 0.3f);
             circleContainer.ScaleTo(spinner.Scale, TIME_PREEMPT / 1.4f, Easing.OutQuint);
 
-            Disc.RotateTo(-720);
-            symbol.RotateTo(-720);
+            Disc.RotateTo(rotationMultiplier * 720);
+            symbol.RotateTo(rotationMultiplier * 720);
 
             mainContainer
                 .ScaleTo(0)

--- a/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
@@ -27,6 +27,11 @@ namespace osu.Game.Rulesets.Osu.UI
                     LabelText = "Snaking out sliders",
                     Bindable = config.GetBindable<bool>(OsuSetting.SnakingOutSliders)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Spinners initially spin clockwise",
+                    Bindable = config.GetBindable<bool>(OsuSetting.InitialSpinnerRotationCW)
+                },
             };
         }
     }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -60,9 +60,6 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.MenuParallax, true);
 
-            Set(OsuSetting.SnakingInSliders, true);
-            Set(OsuSetting.SnakingOutSliders, true);
-
             // Gameplay
             Set(OsuSetting.DimLevel, 0.3, 0, 1, 0.01);
 
@@ -70,6 +67,10 @@ namespace osu.Game.Configuration
             Set(OsuSetting.KeyOverlay, false);
 
             Set(OsuSetting.FloatingComments, false);
+
+            Set(OsuSetting.SnakingInSliders, true);
+            Set(OsuSetting.SnakingOutSliders, true);
+            Set(OsuSetting.InitialSpinnerRotationCW, true);
 
             // Update
             Set(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
@@ -111,6 +112,7 @@ namespace osu.Game.Configuration
         RandomSelectAlgorithm,
         SnakingInSliders,
         SnakingOutSliders,
+        InitialSpinnerRotationCW,
         ShowFpsDisplay,
         ChatDisplayHeight,
         Version,


### PR DESCRIPTION
I spin CCW and find it really annoying that the spinner initially spins CW.