### PR TITLE
Check for supporter before displaying leaderboard loading animation 

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -234,15 +234,14 @@ namespace osu.Game.Screens.Select.Leaderboards
                 return;
             }
 
-            PlaceholderState = PlaceholderState.Retrieving;
-            loading.Show();
-
             if (Scope != LeaderboardScope.Global && !api.LocalUser.Value.IsSupporter)
             {
-                loading.Hide();
                 PlaceholderState = PlaceholderState.NotSupporter;
                 return;
             }
+
+            PlaceholderState = PlaceholderState.Retrieving;
+            loading.Show();
 
             getScoresRequest = new GetScoresRequest(Beatmap, osuGame?.Ruleset.Value ?? Beatmap.Ruleset, Scope);
             getScoresRequest.Success += r =>

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -109,6 +109,13 @@ namespace osu.Game.Screens.Select.Leaderboards
             {
                 if (value == placeholderState) return;
 
+                if (value != PlaceholderState.Successful)
+                {
+                    getScoresRequest?.Cancel();
+                    getScoresRequest = null;
+                    Scores = null;
+                }
+
                 switch (placeholderState = value)
                 {
                     case PlaceholderState.NetworkFailure:
@@ -211,10 +218,6 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         private void updateScores()
         {
-            getScoresRequest?.Cancel();
-            getScoresRequest = null;
-            Scores = null;
-
             if (Scope == LeaderboardScope.Local)
             {
                 // TODO: get local scores from wherever here.


### PR DESCRIPTION
Trying to load one of the supporter leaderboards without supporter and then clicking the other caused the message to disappear. https://streamable.com/guisc
Instead of displaying the loading spinner and aborting if the user has no supporter, it instead displays the message immediately and returns.