### PR TITLE
Don't allow auto to fail

### DIFF
--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -29,5 +29,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Description => "Watch a perfect automated play through the song";
         public override double ScoreMultiplier => 0;
         public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModSuddenDeath), typeof(ModNoFail) };
+        public override bool AllowFail => false;	
     }
 }

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -29,6 +29,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Description => "Watch a perfect automated play through the song";
         public override double ScoreMultiplier => 0;
         public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModSuddenDeath), typeof(ModNoFail) };
-        public override bool AllowFail => false;	
+        public override bool AllowFail => false;
     }
 }


### PR DESCRIPTION
Currently, auto can fail a map, while it doesn't in stable. 