### PR TITLE
Fix Leaderboard loading multiple times

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseLeaderboard.cs
+++ b/osu.Game.Tests/Visual/TestCaseLeaderboard.cs
@@ -38,6 +38,11 @@ namespace osu.Game.Tests.Visual
             AddStep(@"Not logged in", () => leaderboard.SetRetrievalState(PlaceholderState.NotLoggedIn));
             AddStep(@"Unavailable", () => leaderboard.SetRetrievalState(PlaceholderState.Unavailable));
             AddStep(@"Real beatmap", realBeatmap);
+            AddStep("New Scores + Empty Scores", () =>
+            {
+                newScores();
+                leaderboard.SetRetrievalState(PlaceholderState.NoScores);
+            });
         }
 
         [BackgroundDependencyLoader]
@@ -271,6 +276,7 @@ namespace osu.Game.Tests.Visual
         {
             public void SetRetrievalState(PlaceholderState state)
             {
+                Scores = null; // emulate updateScores which would delete them
                 PlaceholderState = state;
             }
         }

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -108,13 +108,6 @@ namespace osu.Game.Screens.Select.Leaderboards
             get { return placeholderState; }
             set
             {
-                if (value != PlaceholderState.Successful)
-                {
-                    getScoresRequest?.Cancel();
-                    getScoresRequest = null;
-                    Scores = null;
-                }
-
                 if (value == placeholderState)
                     return;
 
@@ -177,7 +170,6 @@ namespace osu.Game.Screens.Select.Leaderboards
                     return;
 
                 beatmap = value;
-                Scores = null;
 
                 pendingBeatmapSwitch?.Cancel();
                 pendingBeatmapSwitch = Schedule(updateScores);
@@ -221,6 +213,10 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         private void updateScores()
         {
+            getScoresRequest?.Cancel();
+            getScoresRequest = null;
+            Scores = null;
+
             if (Scope == LeaderboardScope.Local)
             {
                 // TODO: get local scores from wherever here.
@@ -280,8 +276,6 @@ namespace osu.Game.Screens.Select.Leaderboards
 
             if (placeholder == null)
                 return;
-
-            Scores = null;
 
             placeholderContainer.Add(placeholder);
 

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -107,14 +107,15 @@ namespace osu.Game.Screens.Select.Leaderboards
             get { return placeholderState; }
             set
             {
-                if (value == placeholderState) return;
-
                 if (value != PlaceholderState.Successful)
                 {
                     getScoresRequest?.Cancel();
                     getScoresRequest = null;
                     Scores = null;
                 }
+
+                if (value == placeholderState)
+                    return;
 
                 switch (placeholderState = value)
                 {

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -93,7 +93,8 @@ namespace osu.Game.Screens.Select.Leaderboards
             get { return scope; }
             set
             {
-                if (value == scope) return;
+                if (value == scope)
+                    return;
 
                 scope = value;
                 updateScores();
@@ -172,7 +173,8 @@ namespace osu.Game.Screens.Select.Leaderboards
             get { return beatmap; }
             set
             {
-                if (beatmap == value) return;
+                if (beatmap == value)
+                    return;
 
                 beatmap = value;
                 Scores = null;
@@ -260,7 +262,8 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         private void onUpdateFailed(Exception e)
         {
-            if (e is OperationCanceledException) return;
+            if (e is OperationCanceledException)
+                return;
 
             PlaceholderState = PlaceholderState.NetworkFailure;
             Logger.Error(e, @"Couldn't fetch beatmap scores!");
@@ -295,7 +298,8 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (!scrollContainer.IsScrolledToEnd())
                 fadeStart -= LeaderboardScore.HEIGHT;
 
-            if (scrollFlow == null) return;
+            if (scrollFlow == null)
+                return;
 
             foreach (var c in scrollFlow.Children)
             {


### PR DESCRIPTION
This also moves some logic out of the `PlaceHolderState` setter. It was kind of confusing how much was happening in there.
Scores are now only reset in `updateScores` which should only happen when you change your selection to cause a new update.

Closes #1841.