### PR TITLE
Add setting to disable gameplay cursor expanding on click

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursor.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         }
 
         private int downCount;
+        private Bindable<bool> cursorExpand;
 
         public class OsuCursor : Container
         {
@@ -132,31 +133,41 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             }
         }
 
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            cursorExpand = config.GetBindable<bool>(OsuSetting.CursorExpand);
+        }
+
         public bool OnPressed(OsuAction action)
         {
-            switch (action)
+            if (cursorExpand)
             {
-                case OsuAction.LeftButton:
-                case OsuAction.RightButton:
-                    downCount++;
-                    ActiveCursor.ScaleTo(1).ScaleTo(1.2f, 100, Easing.OutQuad);
-                    break;
+                switch (action)
+                {
+                    case OsuAction.LeftButton:
+                    case OsuAction.RightButton:
+                        downCount++;
+                        ActiveCursor.ScaleTo(1).ScaleTo(1.2f, 100, Easing.OutQuad);
+                        break;
+                }
             }
-
             return false;
         }
 
         public bool OnReleased(OsuAction action)
         {
-            switch (action)
+            if (cursorExpand)
             {
-                case OsuAction.LeftButton:
-                case OsuAction.RightButton:
-                    if (--downCount == 0)
-                        ActiveCursor.ScaleTo(1, 200, Easing.OutQuad);
-                    break;
+                switch (action)
+                {
+                    case OsuAction.LeftButton:
+                    case OsuAction.RightButton:
+                        if (--downCount == 0)
+                            ActiveCursor.ScaleTo(1, 200, Easing.OutQuad);
+                        break;
+                }
             }
-
             return false;
         }
     }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Configuration
             Set(OsuSetting.MenuCursorSize, 1.0, 0.5f, 2, 0.01);
             Set(OsuSetting.GameplayCursorSize, 1.0, 0.5f, 2, 0.01);
             Set(OsuSetting.AutoCursorSize, false);
+            Set(OsuSetting.CursorExpand, true);
 
             Set(OsuSetting.MouseDisableButtons, false);
             Set(OsuSetting.MouseDisableWheel, false);
@@ -89,6 +90,7 @@ namespace osu.Game.Configuration
         MenuCursorSize,
         GameplayCursorSize,
         AutoCursorSize,
+        CursorExpand,
         DimLevel,
         ShowStoryboard,
         KeyOverlay,

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -38,6 +38,11 @@ namespace osu.Game.Overlays.Settings.Sections
                     LabelText = "Adjust gameplay cursor size based on current beatmap",
                     Bindable = config.GetBindable<bool>(OsuSetting.AutoCursorSize)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Expand cursor on click",
+                    Bindable = config.GetBindable<bool>(OsuSetting.CursorExpand)
+                },
             };
         }
 


### PR DESCRIPTION
Adds a checkbox in settings to allow disabling the cursor expanding animation on click during gameplay, similar to stable's CursorExpand option in skin.ini.
