### PR TITLE
Fix TestCaseManiaHitObjects exception on load

### DIFF
--- a/osu.Game.Rulesets.Mania/Tests/TestCaseManiaHitObjects.cs
+++ b/osu.Game.Rulesets.Mania/Tests/TestCaseManiaHitObjects.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                                 RelativeChildSize = new Vector2(1, 10000),
                                 Children = new[]
                                 {
-                                    new DrawableHoldNote(new HoldNote(), ManiaAction.Key1)
+                                    new DrawableHoldNote(new HoldNote { Duration = 1 }, ManiaAction.Key1)
                                     {
                                         Y = 5000,
                                         Height = 1000,


### PR DESCRIPTION
Closes #1755 .

The problem was just that the DrawableHoldNote usually sets its height according to the underlying note's duration, which is 0 by default. Then [this](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs#L67) triggers an exception since the `RelativeChildSize` can't contain a zero value.

The actual duration is not important in this case since the height is overridden anyways.