### PR TITLE
Allow mouse wheel to change volume in pause and fail screen

### DIFF
--- a/osu.Game/Graphics/UserInterface/Volume/VolumeControlReceptor.cs
+++ b/osu.Game/Graphics/UserInterface/Volume/VolumeControlReceptor.cs
@@ -3,12 +3,13 @@
 
 using System;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Game.Input.Bindings;
 
 namespace osu.Game.Graphics.UserInterface.Volume
 {
-    public class VolumeControlReceptor : Container, IKeyBindingHandler<GlobalAction>
+    public class VolumeControlReceptor : Container, IKeyBindingHandler<GlobalAction>, IHandleGlobalInput
     {
         public Func<GlobalAction, bool> ActionRequested;
 

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Framework.Graphics.Shapes;
 using OpenTK.Input;
 using System.Collections.Generic;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Play
 {
@@ -25,6 +26,13 @@ namespace osu.Game.Screens.Play
         private const float background_alpha = 0.75f;
 
         protected override bool BlockPassThroughKeyboard => true;
+
+        private GlobalKeyBindingInputManager globalBinding;
+        protected override bool OnWheel(InputState state)
+        {
+            globalBinding.TriggerOnWheel(state);
+            return true;
+        }
 
         public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => true;
 
@@ -47,8 +55,10 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, GlobalKeyBindingInputManager globalBinding)
         {
+            this.globalBinding = globalBinding;
+
             Children = new Drawable[]
             {
                 new Box

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Play
         protected override bool OnWheel(InputState state)
         {
             globalBinding.TriggerOnWheel(state);
-            return true;
+            return BlockPassThroughMouse;
         }
 
         public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => true;


### PR DESCRIPTION
There are two parts to this:
1. `VolumeControlReceptor` 'implementing' `IHandleGlobalInput` so that it doesn't get removed from the overlays' input queues
2. Triggering the volume change from the actual overlay. Note that we cannot let the wheel pass through normally under any circumstance, since mwheelup and mwheeldown are valid game keys -> you could click circles through the overlay. So I decided to DI the global binding manager and trigger it manually. 

This closes #1800 .