### PR TITLE
Add skip cutscene as "in game" keybinding

### DIFF
--- a/osu.Game/Input/Bindings/GlobalKeyBindingInputManager.cs
+++ b/osu.Game/Input/Bindings/GlobalKeyBindingInputManager.cs
@@ -20,7 +20,9 @@ namespace osu.Game.Input.Bindings
                 handler = game;
         }
 
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+        public override IEnumerable<KeyBinding> DefaultKeyBindings => GlobalKeyBindings.Concat(InGameKeyBindings);
+
+        public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {
             new KeyBinding(InputKey.F8, GlobalAction.ToggleChat),
             new KeyBinding(InputKey.F9, GlobalAction.ToggleSocial),
@@ -31,6 +33,11 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.MouseWheelUp }, GlobalAction.IncreaseVolume),
             new KeyBinding(new[] { InputKey.Down }, GlobalAction.DecreaseVolume),
             new KeyBinding(new[] { InputKey.MouseWheelDown }, GlobalAction.DecreaseVolume),
+        };
+
+        public IEnumerable<KeyBinding> InGameKeyBindings => new[]
+        {
+            new KeyBinding(InputKey.Space, GlobalAction.SkipCutscene)
         };
 
         protected override IEnumerable<Drawable> KeyBindingInputQueue =>
@@ -55,5 +62,9 @@ namespace osu.Game.Input.Bindings
         IncreaseVolume,
         [Description("Decrease Volume")]
         DecreaseVolume,
+
+        // In-Game Keybindings
+        [Description("Skip Cutscene")]
+        SkipCutscene
     }
 }

--- a/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
@@ -1,8 +1,8 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Framework.Input.Bindings;
 using osu.Game.Graphics;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Overlays.KeyBinding
@@ -12,19 +12,31 @@ namespace osu.Game.Overlays.KeyBinding
         public override FontAwesome Icon => FontAwesome.fa_osu_hot;
         public override string Header => "Global";
 
-        public GlobalKeyBindingsSection(KeyBindingContainer manager)
+        public GlobalKeyBindingsSection(GlobalKeyBindingInputManager manager)
         {
             Add(new DefaultBindingsSubsection(manager));
+            Add(new InGameKeyBindingsSubsection(manager));
         }
+
 
         private class DefaultBindingsSubsection : KeyBindingsSubsection
         {
             protected override string Header => string.Empty;
 
-            public DefaultBindingsSubsection(KeyBindingContainer manager)
+            public DefaultBindingsSubsection(GlobalKeyBindingInputManager manager)
                 : base(null)
             {
-                Defaults = manager.DefaultKeyBindings;
+                Defaults = manager.GlobalKeyBindings;
+            }
+        }
+
+        private class InGameKeyBindingsSubsection : KeyBindingsSubsection
+        {
+            protected override string Header => "In Game";
+
+            public InGameKeyBindingsSubsection(GlobalKeyBindingInputManager manager) : base(null)
+            {
+                Defaults = manager.InGameKeyBindings;
             }
         }
     }

--- a/osu.Game/Screens/Play/SkipButton.cs
+++ b/osu.Game/Screens/Play/SkipButton.cs
@@ -14,13 +14,14 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Ranking;
 using OpenTK;
 using OpenTK.Graphics;
-using OpenTK.Input;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.Containers;
+using osu.Framework.Input.Bindings;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Play
 {
-    public class SkipButton : Container
+    public class SkipButton : Container, IKeyBindingHandler<GlobalAction>
     {
         private readonly double startTime;
         public IAdjustableClock AudioClock;
@@ -117,19 +118,19 @@ namespace osu.Game.Screens.Play
             remainingTimeBox.ResizeWidthTo((float)Math.Max(0, 1 - (Time.Current - displayTime) / (beginFadeTime - displayTime)), 120, Easing.OutQuint);
         }
 
-        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        public bool OnPressed(GlobalAction action)
         {
-            if (args.Repeat) return false;
-
-            switch (args.Key)
+            switch (action)
             {
-                case Key.Space:
+                case GlobalAction.SkipCutscene:
                     button.TriggerOnClick();
                     return true;
             }
 
-            return base.OnKeyDown(state, args);
+            return false;
         }
+
+        public bool OnReleased(GlobalAction action) => false;
 
         private class FadeContainer : Container, IStateful<Visibility>
         {


### PR DESCRIPTION
- Allows to skip cutscenes at the beginning of songs by pressing the bound button
- Allows to change said keybind
- Adds "In Game" subsection in keybind settings

Closes #1823