### PR TITLE
Allow rulesets to create their own instantiation info

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Catch
 
         public override int LegacyID => 2;
 
-        public CatchRuleset(RulesetInfo rulesetInfo)
+        public CatchRuleset(RulesetInfo rulesetInfo = null)
             : base(rulesetInfo)
         {
         }

--- a/osu.Game.Rulesets.Catch/Tests/TestCaseCatchPlayer.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCaseCatchPlayer.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Tests
     [Ignore("getting CI working")]
     public class TestCaseCatchPlayer : Game.Tests.Visual.TestCasePlayer
     {
-        public TestCaseCatchPlayer() : base(typeof(CatchRuleset))
+        public TestCaseCatchPlayer() : base(new CatchRuleset())
         {
         }
     }

--- a/osu.Game.Rulesets.Catch/Tests/TestCaseCatchStacker.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCaseCatchStacker.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Catch.Tests
     public class TestCaseCatchStacker : Game.Tests.Visual.TestCasePlayer
     {
         public TestCaseCatchStacker()
-            : base(typeof(CatchRuleset))
+            : base(new CatchRuleset())
         {
         }
 

--- a/osu.Game.Rulesets.Catch/Tests/TestCaseHyperdash.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCaseHyperdash.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Catch.Tests
     public class TestCaseHyperdash : Game.Tests.Visual.TestCasePlayer
     {
         public TestCaseHyperdash()
-            : base(typeof(CatchRuleset))
+            : base(new CatchRuleset())
         {
         }
 

--- a/osu.Game.Rulesets.Catch/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCasePerformancePoints.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Tests
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()
-            : base(new CatchRuleset(new RulesetInfo()))
+            : base(new CatchRuleset())
         {
         }
     }

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Mania
 
         public override int LegacyID => 3;
 
-        public ManiaRuleset(RulesetInfo rulesetInfo)
+        public ManiaRuleset(RulesetInfo rulesetInfo = null)
             : base(rulesetInfo)
         {
         }

--- a/osu.Game.Rulesets.Mania/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Mania/Tests/TestCasePerformancePoints.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Mania.Tests
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()
-            : base(new ManiaRuleset(new RulesetInfo()))
+            : base(new ManiaRuleset())
         {
         }
     }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Osu
 
         public override int LegacyID => 0;
 
-        public OsuRuleset(RulesetInfo rulesetInfo)
+        public OsuRuleset(RulesetInfo rulesetInfo = null)
             : base(rulesetInfo)
         {
         }

--- a/osu.Game.Rulesets.Osu/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCasePerformancePoints.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Osu.Tests
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()
-            : base(new OsuRuleset(new RulesetInfo()))
+            : base(new OsuRuleset())
         {
         }
     }

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Taiko
 
         public override int LegacyID => 1;
 
-        public TaikoRuleset(RulesetInfo rulesetInfo)
+        public TaikoRuleset(RulesetInfo rulesetInfo = null)
             : base(rulesetInfo)
         {
         }

--- a/osu.Game.Rulesets.Taiko/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Taiko/Tests/TestCasePerformancePoints.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()
-            : base(new TaikoRuleset(new RulesetInfo()))
+            : base(new TaikoRuleset())
         {
         }
     }

--- a/osu.Game.Tests/Visual/TestCaseGamefield.cs
+++ b/osu.Game.Tests/Visual/TestCaseGamefield.cs
@@ -56,25 +56,25 @@ namespace osu.Game.Tests.Visual
                     Clock = new FramedClock(),
                     Children = new Drawable[]
                     {
-                        new OsuRulesetContainer(new OsuRuleset(new RulesetInfo()), beatmap, false)
+                        new OsuRulesetContainer(new OsuRuleset(), beatmap, false)
                         {
                             Scale = new Vector2(0.5f),
                             Anchor = Anchor.TopLeft,
                             Origin = Anchor.TopLeft
                         },
-                        new TaikoRulesetContainer(new TaikoRuleset(new RulesetInfo()),beatmap, false)
+                        new TaikoRulesetContainer(new TaikoRuleset(),beatmap, false)
                         {
                             Scale = new Vector2(0.5f),
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight
                         },
-                        new CatchRulesetContainer(new CatchRuleset(new RulesetInfo()),beatmap, false)
+                        new CatchRulesetContainer(new CatchRuleset(),beatmap, false)
                         {
                             Scale = new Vector2(0.5f),
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft
                         },
-                        new ManiaRulesetContainer(new ManiaRuleset(new RulesetInfo()),beatmap, false)
+                        new ManiaRulesetContainer(new ManiaRuleset(),beatmap, false)
                         {
                             Scale = new Vector2(0.5f),
                             Anchor = Anchor.BottomRight,

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Beatmaps
 
                 public override string ShortName => "dummy";
 
-                public DummyRuleset(RulesetInfo rulesetInfo)
+                public DummyRuleset(RulesetInfo rulesetInfo = null)
                     : base(rulesetInfo)
                 {
                 }

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Rulesets
 
         public Mod GetAutoplayMod() => GetAllMods().First(mod => mod is ModAutoplay);
 
-        protected Ruleset(RulesetInfo rulesetInfo)
+        protected Ruleset(RulesetInfo rulesetInfo = null)
         {
-            RulesetInfo = rulesetInfo;
+            RulesetInfo = rulesetInfo ?? createRulesetInfo();
         }
 
         /// <summary>
@@ -88,5 +88,17 @@ namespace osu.Game.Rulesets
         /// <param name="variant">The variant.</param>
         /// <returns>A descriptive name of the variant.</returns>
         public virtual string GetVariantName(int variant) => string.Empty;
+
+        /// <summary>
+        /// Create a ruleset info based on this ruleset.
+        /// </summary>
+        /// <returns>A filled <see cref="RulesetInfo"/>.</returns>
+        private RulesetInfo createRulesetInfo() => new RulesetInfo
+        {
+            Name = Description,
+            ShortName = ShortName,
+            InstantiationInfo = GetType().AssemblyQualifiedName,
+            ID = LegacyID
+        };
     }
 }


### PR DESCRIPTION
- Allow rulesets to be created without RulesetInfo (a lot of the time an arbitrary empty `RulesetInfo` was being passed in).
- Allow for dynamic compilation to work with lower level ruleset components (previously not possible due to the way `Ruleset` was instantiated directly form the `RulesetStore`).