### PR TITLE
Fixes to catching fruit

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Catch.Objects
     {
         public override FruitVisualRepresentation VisualRepresentation => FruitVisualRepresentation.Banana;
 
+        public override bool LastInCombo => true;
+
         protected override void CreateNestedHitObjects()
         {
             base.CreateNestedHitObjects();

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
     {
         private readonly Container bananaContainer;
 
-        public DrawableBananaShower(BananaShower s)
+        public DrawableBananaShower(BananaShower s, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> getVisualRepresentation = null)
             : base(s)
         {
             RelativeSizeAxes = Axes.X;
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             Child = bananaContainer = new Container { RelativeSizeAxes = Axes.Both };
 
             foreach (var b in s.NestedHitObjects.Cast<BananaShower.Banana>())
-                AddNested(new DrawableFruit(b));
+                AddNested(getVisualRepresentation?.Invoke(b));
         }
 
         protected override void AddNested(DrawableHitObject h)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
@@ -5,7 +5,9 @@ using System;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
@@ -24,6 +26,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 
             foreach (var b in s.NestedHitObjects.Cast<BananaShower.Banana>())
                 AddNested(getVisualRepresentation?.Invoke(b));
+        }
+
+        protected override void CheckForJudgements(bool userTriggered, double timeOffset)
+        {
+            if (timeOffset >= 0)
+                AddJudgement(new Judgement { Result = NestedHitObjects.Cast<DrawableCatchHitObject>().Any(n => n.Judgements.Any(j => j.IsHit)) ? HitResult.Perfect : HitResult.Miss });
         }
 
         protected override void AddNested(DrawableHitObject h)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Types;
 using OpenTK;
 using osu.Game.Rulesets.Scoring;
 
@@ -13,6 +14,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
     public abstract class PalpableCatchHitObject<TObject> : DrawableCatchHitObject<TObject>
         where TObject : CatchHitObject
     {
+        public override bool CanBePlated => true;
+
         protected PalpableCatchHitObject(TObject hitObject)
             : base(hitObject)
         {
@@ -36,6 +39,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 
     public abstract class DrawableCatchHitObject : DrawableHitObject<CatchHitObject>
     {
+        public virtual bool CanBePlated => false;
+
         protected DrawableCatchHitObject(CatchHitObject hitObject)
             : base(hitObject)
         {
@@ -47,8 +52,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 
         protected override void CheckForJudgements(bool userTriggered, double timeOffset)
         {
+            if (CheckPosition == null) return;
+
             if (timeOffset > 0)
-                AddJudgement(new Judgement { Result = CheckPosition?.Invoke(HitObject) ?? false ? HitResult.Perfect : HitResult.Miss });
+                AddJudgement(new Judgement { Result = (bool)CheckPosition?.Invoke(HitObject) ? HitResult.Perfect : HitResult.Miss });
         }
 
         private const float preempt = 1000;
@@ -61,12 +68,19 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
                 this.FadeIn(200);
             }
 
-            switch (state)
+            var endTime = (HitObject as IHasEndTime)?.EndTime ?? HitObject.StartTime;
+
+            using (BeginAbsoluteSequence(endTime, true))
             {
-                case ArmedState.Miss:
-                    using (BeginAbsoluteSequence(HitObject.StartTime, true))
-                        this.FadeOut(250).RotateTo(Rotation * 2, 250, Easing.Out);
-                    break;
+                switch (state)
+                {
+                    case ArmedState.Miss:
+                        this.FadeOut(250).RotateTo(Rotation * 2, 250, Easing.Out).Expire();
+                        break;
+                    case ArmedState.Hit:
+                        this.FadeOut().Expire();
+                        break;
+                }
             }
         }
     }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             if (CheckPosition == null) return;
 
             if (timeOffset > 0)
-                AddJudgement(new Judgement { Result = (bool)CheckPosition?.Invoke(HitObject) ? HitResult.Perfect : HitResult.Miss });
+                AddJudgement(new Judgement { Result = CheckPosition.Invoke(HitObject) ? HitResult.Perfect : HitResult.Miss });
         }
 
         private const float preempt = 1000;

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableCatchHitObject.cs
@@ -63,10 +63,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         protected override void UpdateState(ArmedState state)
         {
             using (BeginAbsoluteSequence(HitObject.StartTime - preempt))
-            {
-                // animation
                 this.FadeIn(200);
-            }
 
             var endTime = (HitObject as IHasEndTime)?.EndTime ?? HitObject.StartTime;
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using OpenTK;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawable
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
     {
         private readonly Container dropletContainer;
 
-        public DrawableJuiceStream(JuiceStream s)
+        public DrawableJuiceStream(JuiceStream s, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> getVisualRepresentation = null)
             : base(s)
         {
             RelativeSizeAxes = Axes.Both;
@@ -21,21 +22,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 
             Child = dropletContainer = new Container { RelativeSizeAxes = Axes.Both, };
 
-            foreach (var tick in s.NestedHitObjects)
-            {
-                switch (tick)
-                {
-                    case TinyDroplet tiny:
-                        AddNested(new DrawableDroplet(tiny) { Scale = new Vector2(0.5f) });
-                        break;
-                    case Droplet droplet:
-                        AddNested(new DrawableDroplet(droplet));
-                        break;
-                    case Fruit fruit:
-                        AddNested(new DrawableFruit(fruit));
-                        break;
-                }
-            }
+            foreach (var o in s.NestedHitObjects.Cast<CatchHitObject>())
+                AddNested(getVisualRepresentation?.Invoke(o));
         }
 
         protected override void AddNested(DrawableHitObject h)

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -125,9 +125,7 @@ namespace osu.Game.Rulesets.Catch.Objects
                     X = Curve.PositionAt(reversed ? 0 : 1).X / CatchPlayfield.BASE_WIDTH
                 });
             }
-
         }
-
 
         public double EndTime => StartTime + RepeatCount * Curve.Distance / Velocity;
 

--- a/osu.Game.Rulesets.Catch/Tests/TestCaseBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCaseBananaShower.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 }
             };
 
-            beatmap.HitObjects.Add(new BananaShower { StartTime = 200, Duration = 500, NewCombo = true });
+            beatmap.HitObjects.Add(new BananaShower { StartTime = 200, Duration = 5000, NewCombo = true });
 
             return beatmap;
         }

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private readonly CatcherArea catcherArea;
 
-        public CatchPlayfield(BeatmapDifficulty difficulty)
+        public CatchPlayfield(BeatmapDifficulty difficulty, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> getVisualRepresentation)
             : base(ScrollingDirection.Down, BASE_WIDTH)
         {
             Container explodingFruitContainer;
@@ -44,6 +45,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 },
                 catcherArea = new CatcherArea(difficulty)
                 {
+                    GetVisualRepresentation = getVisualRepresentation,
                     ExplodingFruitTarget = explodingFruitContainer,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.TopLeft,

--- a/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
+using OpenTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
@@ -31,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         protected override BeatmapConverter<CatchHitObject> CreateBeatmapConverter() => new CatchBeatmapConverter();
 
-        protected override Playfield CreatePlayfield() => new CatchPlayfield(Beatmap.BeatmapInfo.BaseDifficulty);
+        protected override Playfield CreatePlayfield() => new CatchPlayfield(Beatmap.BeatmapInfo.BaseDifficulty, GetVisualRepresentation);
 
         public override PassThroughInputManager CreateInputManager() => new CatchInputManager(Ruleset.RulesetInfo);
 
@@ -42,9 +43,13 @@ namespace osu.Game.Rulesets.Catch.UI
                 case Fruit fruit:
                     return new DrawableFruit(fruit);
                 case JuiceStream stream:
-                    return new DrawableJuiceStream(stream);
+                    return new DrawableJuiceStream(stream, GetVisualRepresentation);
                 case BananaShower banana:
-                    return new DrawableBananaShower(banana);
+                    return new DrawableBananaShower(banana, GetVisualRepresentation);
+                case TinyDroplet tiny:
+                    return new DrawableDroplet(tiny) { Scale = new Vector2(0.5f) };
+                case Droplet droplet:
+                    return new DrawableDroplet(droplet);
             }
 
             return null;

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -69,18 +69,20 @@ namespace osu.Game.Rulesets.Catch.UI
                 lastPlateableFruit = caughtFruit;
             }
 
-            // this is required to make this run after the last caught fruit runs UpdateState at least once.
-            // TODO: find a better alternative
-            lastPlateableFruit.OnLoadComplete = _ =>
+            if (fruit.HitObject.LastInCombo)
             {
-                if (fruit.HitObject.LastInCombo)
+                if (judgement.IsHit)
                 {
-                    if (judgement.IsHit)
+                    // this is required to make this run after the last caught fruit runs UpdateState at least once.
+                    // TODO: find a better alternative
+                    if (lastPlateableFruit.IsLoaded)
                         MovableCatcher.Explode();
                     else
-                        MovableCatcher.Drop();
+                        lastPlateableFruit.OnLoadComplete = _ => { MovableCatcher.Explode(); };
                 }
-            };
+                else
+                    MovableCatcher.Drop();
+            }
         }
 
         public bool OnPressed(CatchAction action)

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -54,7 +54,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 if (caughtFruit == null) return;
 
-                caughtFruit.State.Value = ArmedState.Idle;
                 caughtFruit.AccentColour = fruit.AccentColour;
                 caughtFruit.RelativePositionAxes = Axes.None;
                 caughtFruit.Position = new Vector2(MovableCatcher.ToLocalSpace(fruit.ScreenSpaceDrawQuad.Centre).X - MovableCatcher.DrawSize.X / 2, 0);


### PR DESCRIPTION
- Make banana showers always last in combo (explode plate).
- Fix fruit not correctly landing on plate (removes Remove logic).
- More