### PR TITLE
Pause current track on song preview

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapSetOverlay.cs
@@ -14,15 +14,25 @@ namespace osu.Game.Tests.Visual
 {
     public class TestCaseBeatmapSetOverlay : OsuTestCase
     {
-        private readonly BeatmapSetOverlay overlay;
+        private RulesetStore rulesets;
+        private readonly BeatmapSetOverlay overlay = new BeatmapSetOverlay();
+        private readonly MusicController musicController = new MusicController();
 
-        public TestCaseBeatmapSetOverlay()
-        {
-            Add(overlay = new BeatmapSetOverlay());
-        }
+        private DependencyContainer dependencies;
+
+        protected override IReadOnlyDependencyContainer CreateLocalDependencies(IReadOnlyDependencyContainer parent) => dependencies = new DependencyContainer(parent);
 
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
+        {
+            this.rulesets = rulesets;
+            dependencies.Cache(musicController);
+
+            Add(overlay);
+            Add(musicController);
+        }
+
+        protected override void LoadComplete()
         {
             var mania = rulesets.GetRuleset(3);
             var taiko = rulesets.GetRuleset(1);

--- a/osu.Game/Overlays/BeatmapSet/PreviewButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/PreviewButton.cs
@@ -15,6 +15,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Game.Overlays.Direct;
 using osu.Framework.Configuration;
+using System;
 
 namespace osu.Game.Overlays.BeatmapSet
 {
@@ -82,7 +83,8 @@ namespace osu.Game.Overlays.BeatmapSet
 
             if (Playing.Value && preview != null)
             {
-                progress.Width = (float)(preview.CurrentTime / preview.Length);
+                // prevent negative (potential infinite) width if a track without length was loaded
+                progress.Width = (float)Math.Max(preview.CurrentTime / preview.Length, 0);
             }
         }
 

--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Overlays.Direct
         private readonly SpriteIcon icon;
         private readonly LoadingAnimation loadingAnimation;
 
+        private MusicController musicController;
+
         private const float transition_duration = 500;
 
         private bool loading
@@ -83,9 +85,12 @@ namespace osu.Game.Overlays.Direct
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour)
+        private void load(OsuColour colour, MusicController musicController)
         {
             hoverColour = colour.Yellow;
+            this.musicController = musicController;
+
+            musicController.StartedPlaying += () => Playing.Value = false;
         }
 
         protected override bool OnClick(InputState state)
@@ -128,13 +133,14 @@ namespace osu.Game.Overlays.Direct
                     return;
                 }
 
-                Preview.Seek(0);
-                Preview.Start();
+                Preview.Restart();
+                musicController.Pause();
             }
             else
             {
                 Preview?.Stop();
                 loading = false;
+                musicController.Resume();
             }
         }
 
@@ -142,7 +148,12 @@ namespace osu.Game.Overlays.Direct
 
         private void beginAudioLoad()
         {
-            if (trackLoader != null) return;
+            if (trackLoader != null)
+            {
+                Preview = trackLoader.Preview;
+                Playing.TriggerChange();
+                return;
+            }
 
             loading = true;
 

--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -13,6 +13,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using OpenTK;
 using OpenTK.Graphics;
+using System;
 
 namespace osu.Game.Overlays.Music
 {
@@ -30,6 +31,8 @@ namespace osu.Game.Overlays.Music
         private readonly Bindable<WorkingBeatmap> beatmapBacking = new Bindable<WorkingBeatmap>();
 
         public IEnumerable<BeatmapSetInfo> BeatmapSets => list.BeatmapSets;
+
+        public event Action StartedPlaying;
 
         [BackgroundDependencyLoader]
         private void load(OsuGameBase game, BeatmapManager beatmaps, OsuColour colours)
@@ -152,6 +155,7 @@ namespace osu.Game.Overlays.Music
             var track = beatmapBacking.Value.Track;
 
             track.Restart();
+            StartedPlaying?.Invoke();
         }
     }
 


### PR DESCRIPTION
This allows pausing and resuming the current track if you start a song preview.
Also if the user previously paused the track manually it will not restart by itself.

Closes #1585