### PR TITLE
Remove volume reduction on song preview

### DIFF
--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -174,10 +174,7 @@ namespace osu.Game.Overlays.Direct
             private void load(AudioManager audio)
             {
                 if (!string.IsNullOrEmpty(preview))
-                {
                     Preview = audio.Track.Get(preview);
-                    Preview.Volume.Value = 0.5;
-                }
             }
         }
     }


### PR DESCRIPTION
It doubles with global reduction causing it to be too low.