### PR TITLE
Fix a few usages of AllJudged possibly not being correct

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             holdStartTime = null;
 
             // If the key has been released too early, the user should not receive full score for the release
-            if (!tail.AllJudged)
+            if (!tail.IsHit)
                 hasBroken = true;
 
             return true;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (timeOffset < 0)
                 return;
 
-            int countHit = NestedHitObjects.Count(o => o.AllJudged);
+            int countHit = NestedHitObjects.Count(o => o.IsHit);
 
             if (countHit > HitObject.RequiredGoodHits)
             {


### PR DESCRIPTION
Fixes #1888.

This isn't going to affect anything in terms of drum rolls, since ticks could only ever have a "hit" judgement, but who knows if this will change in the future.

Hold notes should also be unaffected, but this is more correct anyway.