### PR TITLE
Fix DrawableHitObject not binding nested hitobject events

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -167,6 +167,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             if (nestedHitObjects == null)
                 nestedHitObjects = new List<DrawableHitObject>();
+
+            h.OnJudgement += (d, j) => OnJudgement?.Invoke(d, j);
+            h.OnJudgementRemoved += (d, j) => OnJudgementRemoved?.Invoke(d, j);
+            h.ApplyCustomUpdateState += (d, j) => ApplyCustomUpdateState?.Invoke(d, j);
+
             nestedHitObjects.Add(h);
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/1903 + a lot of other stuff relating to judgements.