### PR TITLE
Individually bind OnJudgement from hitobjects in each Playfield

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -58,6 +58,7 @@ namespace osu.Game.Rulesets.Catch.UI
         public override void Add(DrawableHitObject h)
         {
             h.Depth = (float)h.HitObject.StartTime;
+            h.OnJudgement += OnJudgement;
 
             base.Add(h);
 
@@ -65,6 +66,6 @@ namespace osu.Game.Rulesets.Catch.UI
             fruit.CheckPosition = CheckIfWeCanCatch;
         }
 
-        public override void OnJudgement(DrawableHitObject judgedObject, Judgement judgement) => catcherArea.OnJudgement((DrawableCatchHitObject)judgedObject, judgement);
+        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement) => catcherArea.OnJudgement((DrawableCatchHitObject)judgedObject, judgement);
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Catch.UI
         public override void Add(DrawableHitObject h)
         {
             h.Depth = (float)h.HitObject.StartTime;
-            h.OnJudgement += OnJudgement;
+            h.OnJudgement += onJudgement;
 
             base.Add(h);
 
@@ -66,6 +66,6 @@ namespace osu.Game.Rulesets.Catch.UI
             fruit.CheckPosition = CheckIfWeCanCatch;
         }
 
-        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement) => catcherArea.OnJudgement((DrawableCatchHitObject)judgedObject, judgement);
+        private void onJudgement(DrawableHitObject judgedObject, Judgement judgement) => catcherArea.OnJudgement((DrawableCatchHitObject)judgedObject, judgement);
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -204,12 +204,13 @@ namespace osu.Game.Rulesets.Mania.UI
         public override void Add(DrawableHitObject hitObject)
         {
             hitObject.Depth = (float)hitObject.HitObject.StartTime;
-
             hitObject.AccentColour = AccentColour;
+            hitObject.OnJudgement += OnJudgement;
+
             HitObjects.Add(hitObject);
         }
 
-        public override void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             if (!judgement.IsHit)
                 return;

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -205,12 +205,12 @@ namespace osu.Game.Rulesets.Mania.UI
         {
             hitObject.Depth = (float)hitObject.HitObject.StartTime;
             hitObject.AccentColour = AccentColour;
-            hitObject.OnJudgement += OnJudgement;
+            hitObject.OnJudgement += onJudgement;
 
             HitObjects.Add(hitObject);
         }
 
-        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        private void onJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             if (!judgement.IsHit)
                 return;

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -192,11 +192,8 @@ namespace osu.Game.Rulesets.Mania.UI
             }
         }
 
-        public override void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
-            var maniaObject = (ManiaHitObject)judgedObject.HitObject;
-            columns[maniaObject.Column].OnJudgement(judgedObject, judgement);
-
             judgements.Clear();
             judgements.Add(new DrawableManiaJudgement(judgement)
             {
@@ -224,7 +221,11 @@ namespace osu.Game.Rulesets.Mania.UI
             }
         }
 
-        public override void Add(DrawableHitObject h) => Columns.ElementAt(((ManiaHitObject)h.HitObject).Column).Add(h);
+        public override void Add(DrawableHitObject h)
+        {
+            h.OnJudgement += OnJudgement;
+            Columns.ElementAt(((ManiaHitObject)h.HitObject).Column).Add(h);
+        }
 
         public void Add(DrawableBarLine barline) => HitObjects.Add(barline);
 

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -192,7 +192,7 @@ namespace osu.Game.Rulesets.Mania.UI
             }
         }
 
-        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        internal void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             judgements.Clear();
             judgements.Add(new DrawableManiaJudgement(judgement)

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             h.Depth = (float)h.HitObject.StartTime;
 
-            h.OnJudgement += OnJudgement;
+            h.OnJudgement += onJudgement;
 
             var c = h as IDrawableHitObjectWithProxiedApproach;
             if (c != null && ProxyApproachCircles)
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Osu.UI
                 .OrderBy(h => h.StartTime).OfType<OsuHitObject>();
         }
 
-        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        private void onJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             var osuJudgement = (OsuJudgement)judgement;
             var osuObject = (OsuHitObject)judgedObject.HitObject;

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -70,6 +70,8 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             h.Depth = (float)h.HitObject.StartTime;
 
+            h.OnJudgement += OnJudgement;
+
             var c = h as IDrawableHitObjectWithProxiedApproach;
             if (c != null && ProxyApproachCircles)
                 approachCircles.Add(c.ProxiedLayer.CreateProxy());
@@ -84,7 +86,7 @@ namespace osu.Game.Rulesets.Osu.UI
                 .OrderBy(h => h.StartTime).OfType<OsuHitObject>();
         }
 
-        public override void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             var osuJudgement = (OsuJudgement)judgement;
             var osuObject = (OsuHitObject)judgedObject.HitObject;

--- a/osu.Game.Rulesets.Taiko/Tests/TestCaseTaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/Tests/TestCaseTaikoPlayfield.cs
@@ -143,18 +143,18 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
             var h = new DrawableTestHit(hit) { X = RNG.NextSingle(hitResult == HitResult.Good ? -0.1f : -0.05f, hitResult == HitResult.Good ? 0.1f : 0.05f) };
 
-            rulesetContainer.Playfield.OnJudgement(h, new TaikoJudgement { Result = hitResult });
+            ((TaikoPlayfield)rulesetContainer.Playfield).OnJudgement(h, new TaikoJudgement { Result = hitResult });
 
             if (RNG.Next(10) == 0)
             {
-                rulesetContainer.Playfield.OnJudgement(h, new TaikoJudgement { Result = hitResult });
-                rulesetContainer.Playfield.OnJudgement(h, new TaikoStrongHitJudgement());
+                ((TaikoPlayfield)rulesetContainer.Playfield).OnJudgement(h, new TaikoJudgement { Result = hitResult });
+                ((TaikoPlayfield)rulesetContainer.Playfield).OnJudgement(h, new TaikoStrongHitJudgement());
             }
         }
 
         private void addMissJudgement()
         {
-            rulesetContainer.Playfield.OnJudgement(new DrawableTestHit(new Hit()), new TaikoJudgement { Result = HitResult.Miss });
+            ((TaikoPlayfield)rulesetContainer.Playfield).OnJudgement(new DrawableTestHit(new Hit()), new TaikoJudgement { Result = HitResult.Miss });
         }
 
         private void addBarLine(bool major, double delay = scroll_time)

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                 swell.OnStart += () => topLevelHitContainer.Add(swell.CreateProxy());
         }
 
-        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        internal void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             if (judgedObject.DisplayJudgement && judgementContainer.FirstOrDefault(j => j.JudgedObject == judgedObject) == null)
             {

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -209,6 +209,8 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             h.Depth = (float)h.HitObject.StartTime;
 
+            h.OnJudgement += OnJudgement;
+
             base.Add(h);
 
             var barline = h as DrawableBarLine;
@@ -221,7 +223,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                 swell.OnStart += () => topLevelHitContainer.Add(swell.CreateProxy());
         }
 
-        public override void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        public void OnJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             if (judgedObject.DisplayJudgement && judgementContainer.FirstOrDefault(j => j.JudgedObject == judgedObject) == null)
             {

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
 using OpenTK;
-using osu.Game.Rulesets.Judgements;
 using osu.Framework.Allocation;
 
 namespace osu.Game.Rulesets.UI
@@ -85,13 +84,6 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         /// <param name="h">The DrawableHitObject to remove.</param>
         public virtual void Remove(DrawableHitObject h) => HitObjects.Remove(h);
-
-        /// <summary>
-        /// Triggered when a new <see cref="Judgement"/> occurs on a <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <param name="judgedObject">The object that <paramref name="judgement"/> occured for.</param>
-        /// <param name="judgement">The <see cref="Judgement"/> that occurred.</param>
-        public virtual void OnJudgement(DrawableHitObject judgedObject, Judgement judgement) { }
 
         /// <summary>
         /// Registers a <see cref="Playfield"/> as a nested <see cref="Playfield"/>.

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -262,12 +262,7 @@ namespace osu.Game.Rulesets.UI
                 if (drawableObject == null)
                     continue;
 
-                drawableObject.OnJudgement += (d, j) =>
-                {
-                    Playfield.OnJudgement(d, j);
-                    OnJudgement?.Invoke(j);
-                };
-
+                drawableObject.OnJudgement += (d, j) => OnJudgement?.Invoke(j);
                 drawableObject.OnJudgementRemoved += (d, j) => OnJudgementRemoved?.Invoke(j);
 
                 Playfield.Add(drawableObject);


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/1914

In the case of nested playfields:

1. The RulesetContainer can't pass OnJudgement to the correct Playfield (the hitobject may be proxied to another nested Playfield).
2. Even if RulesetContainer could pass OnJudgement all the way down, there's no way to know that the hitobject was judged in that playfield (e.g. mania stages).

Beyond that, considering that hitobjects may have different events such as OnStart (DrawableSwell), OnJudgementRemoved (DrawableHitObject), etc, I think manually binding where required makes sense.