### PR TITLE
Cap ApproachRate in HardRock mod at 10

### DIFF
--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         {
             const float ratio = 1.4f;
             difficulty.CircleSize *= 1.3f; // CS uses a custom 1.3 ratio.
-            difficulty.ApproachRate *= ratio;
+            difficulty.ApproachRate = Math.Min(difficulty.ApproachRate * ratio, 10.0f);
             difficulty.DrainRate *= ratio;
             difficulty.OverallDifficulty *= ratio;
         }


### PR DESCRIPTION
This is a fix for the issue #1904. As I said in the comments, the game crashes when the AR is > 10, because then it calculates negative `FadeIn` and `FadePreempt` values (in `OsuHitObject.ApplyDefaultsToSelf`). So, I capped the AR at 10.