### PR TITLE
A lot of fixes to replay playback

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseAutoplay.cs
+++ b/osu.Game.Tests/Visual/TestCaseAutoplay.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System.ComponentModel;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Tests.Visual
+{
+    [Description("Player instantiated with an autoplay mod.")]
+    public class TestCaseAutoplay : TestCasePlayer
+    {
+        protected override Player CreatePlayer(WorkingBeatmap beatmap, Ruleset ruleset)
+        {
+            beatmap.Mods.Value = beatmap.Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            return base.CreatePlayer(beatmap, ruleset);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/TestCaseReplay.cs
+++ b/osu.Game.Tests/Visual/TestCaseReplay.cs
@@ -1,19 +1,35 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.ComponentModel;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual
 {
+    [Description("Player instantiated with a replay.")]
     public class TestCaseReplay : TestCasePlayer
     {
         protected override Player CreatePlayer(WorkingBeatmap beatmap, Ruleset ruleset)
         {
+            // We create a dummy RulesetContainer just to get the replay - we don't want to use mods here
+            // to simulate setting a replay rather than having the replay already set for us
             beatmap.Mods.Value = beatmap.Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
-            return base.CreatePlayer(beatmap, ruleset);
+            var dummyRulesetContainer = ruleset.CreateRulesetContainerWith(beatmap, false);
+
+            // We have the replay
+            var replay = dummyRulesetContainer.Replay;
+
+            // Reset the mods
+            beatmap.Mods.Value = beatmap.Mods.Value.Where(m => !(m is ModAutoplay));
+
+            return new ReplayPlayer(replay)
+            {
+                InitialBeatmap = beatmap
+            };
         }
     }
 }

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Visual\TestCasePlaySongSelect.cs" />
     <Compile Include="Visual\TestCasePopupDialog.cs" />
     <Compile Include="Visual\TestCaseRankGraph.cs" />
+    <Compile Include="Visual\TestCaseAutoplay.cs" />
     <Compile Include="Visual\TestCaseReplay.cs" />
     <Compile Include="Visual\TestCaseReplaySettingsOverlay.cs" />
     <Compile Include="Visual\TestCaseResults.cs" />

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -156,6 +156,7 @@ namespace osu.Game.Beatmaps
 
         public IQueryable<BeatmapInfo> Beatmaps => GetContext().BeatmapInfo
                                                                .Include(b => b.BeatmapSet).ThenInclude(s => s.Metadata)
+                                                               .Include(b => b.BeatmapSet).ThenInclude(s => s.Files).ThenInclude(f => f.FileInfo)
                                                                .Include(b => b.Metadata)
                                                                .Include(b => b.Ruleset)
                                                                .Include(b => b.BaseDifficulty);

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -143,7 +142,11 @@ namespace osu.Game.Rulesets.Scoring
                     continue;
                 }
 
-                lastTime += float.Parse(split[0]);
+                var diff = float.Parse(split[0]);
+                lastTime += diff;
+
+                if (diff < 0)
+                    continue;
 
                 frames.Add(new ReplayFrame(
                     lastTime,
@@ -153,7 +156,7 @@ namespace osu.Game.Rulesets.Scoring
                 ));
             }
 
-            return new Replay { Frames = frames.OrderBy(f => f.Time).ToList() };
+            return new Replay { Frames = frames };
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -145,6 +145,8 @@ namespace osu.Game.Rulesets.Scoring
                 var diff = float.Parse(split[0]);
                 lastTime += diff;
 
+                // Todo: At some point we probably want to rewind and play back the negative-time frames
+                // but for now we'll achieve equal playback to stable by skipping negative frames
                 if (diff < 0)
                     continue;
 

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -11,6 +11,7 @@ using osu.Game.Database;
 using osu.Game.IO.Legacy;
 using osu.Game.IPC;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Users;
 using SharpCompress.Compressors.LZMA;
 
 namespace osu.Game.Rulesets.Scoring
@@ -55,7 +56,7 @@ namespace osu.Game.Rulesets.Scoring
                 var beatmapHash = sr.ReadString();
                 score.Beatmap = beatmaps.QueryBeatmap(b => b.MD5Hash == beatmapHash);
                 /* score.PlayerName = */
-                sr.ReadString();
+                score.User = new User { Username = sr.ReadString() };
                 /* var localScoreChecksum = */
                 sr.ReadString();
                 /* score.Count300 = */
@@ -108,7 +109,10 @@ namespace osu.Game.Rulesets.Scoring
 
                     using (var lzma = new LzmaStream(properties, replayInStream, compressedSize, outSize))
                     using (var reader = new StreamReader(lzma))
+                    {
                         score.Replay = createLegacyReplay(reader);
+                        score.Replay.User = score.User;
+                    }
                 }
             }
 

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -129,7 +130,14 @@ namespace osu.Game.Rulesets.Scoring
             {
                 var split = l.Split('|');
 
-                if (split.Length < 4 || float.Parse(split[0]) < 0) continue;
+                if (split.Length < 4)
+                    continue;
+
+                if (split[0] == "-12345")
+                {
+                    // Todo: The seed is provided in split[3], which we'll need to use at some point
+                    continue;
+                }
 
                 lastTime += float.Parse(split[0]);
 
@@ -141,7 +149,7 @@ namespace osu.Game.Rulesets.Scoring
                 ));
             }
 
-            return new Replay { Frames = frames };
+            return new Replay { Frames = frames.OrderBy(f => f.Time).ToList() };
         }
     }
 }

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
 using osu.Game.Rulesets.Replays;
@@ -45,9 +46,9 @@ namespace osu.Game.Rulesets.UI
         public PassThroughInputManager KeyBindingInputManager;
 
         /// <summary>
-        /// Whether we have a replay loaded currently.
+        /// Whether a replay is currently loaded.
         /// </summary>
-        public bool HasReplayLoaded => ReplayInputManager?.ReplayInputHandler != null;
+        public readonly BindableBool HasReplayLoaded = new BindableBool();
 
         public abstract IEnumerable<HitObject> Objects { get; }
 
@@ -99,6 +100,8 @@ namespace osu.Game.Rulesets.UI
 
             Replay = replay;
             ReplayInputManager.ReplayInputHandler = replay != null ? CreateReplayInputHandler(replay) : null;
+
+            HasReplayLoaded.Value = ReplayInputManager.ReplayInputHandler != null;
         }
 
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -60,23 +60,6 @@ namespace osu.Game.Screens.Play
                 }
             });
 
-            replayLoaded.ValueChanged += replayLoadedValueChanged;
-        }
-
-        private void replayLoadedValueChanged(bool loaded)
-        {
-            ReplaySettingsOverlay.ReplayLoaded = loaded;
-
-            if (loaded)
-            {
-                ReplaySettingsOverlay.Show();
-                ModDisplay.FadeIn(200);
-            }
-            else
-            {
-                ReplaySettingsOverlay.Hide();
-                ModDisplay.Delay(2000).FadeOut(200);
-            }
         }
 
         [BackgroundDependencyLoader(true)]
@@ -109,12 +92,35 @@ namespace osu.Game.Screens.Play
             }
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            replayLoaded.ValueChanged += replayLoadedValueChanged;
+            replayLoaded.TriggerChange();
+        }
+
+        private void replayLoadedValueChanged(bool loaded)
+        {
+            ReplaySettingsOverlay.ReplayLoaded = loaded;
+
+            if (loaded)
+            {
+                ReplaySettingsOverlay.Show();
+                ModDisplay.FadeIn(200);
+            }
+            else
+            {
+                ReplaySettingsOverlay.Hide();
+                ModDisplay.Delay(2000).FadeOut(200);
+            }
+        }
+
         public virtual void BindRulesetContainer(RulesetContainer rulesetContainer)
         {
             (rulesetContainer.KeyBindingInputManager as ICanAttachKeyCounter)?.Attach(KeyCounter);
 
             replayLoaded.BindTo(rulesetContainer.HasReplayLoaded);
-            replayLoaded.TriggerChange();
 
             Progress.BindRulestContainer(rulesetContainer);
         }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Play
         public readonly ReplaySettingsOverlay ReplaySettingsOverlay;
 
         private Bindable<bool> showHud;
-        private bool replayLoaded;
+        private readonly BindableBool replayLoaded = new BindableBool();
 
         private static bool hasShownNotificationOnce;
 
@@ -59,6 +59,24 @@ namespace osu.Game.Screens.Play
                     ReplaySettingsOverlay = CreateReplaySettingsOverlay(),
                 }
             });
+
+            replayLoaded.ValueChanged += replayLoadedValueChanged;
+        }
+
+        private void replayLoadedValueChanged(bool loaded)
+        {
+            ReplaySettingsOverlay.ReplayLoaded = loaded;
+
+            if (loaded)
+            {
+                ReplaySettingsOverlay.Show();
+                ModDisplay.FadeIn(200);
+            }
+            else
+            {
+                ReplaySettingsOverlay.Hide();
+                ModDisplay.Delay(2000).FadeOut(200);
+            }
         }
 
         [BackgroundDependencyLoader(true)]
@@ -95,16 +113,10 @@ namespace osu.Game.Screens.Play
         {
             (rulesetContainer.KeyBindingInputManager as ICanAttachKeyCounter)?.Attach(KeyCounter);
 
-            replayLoaded = rulesetContainer.HasReplayLoaded;
+            replayLoaded.BindTo(rulesetContainer.HasReplayLoaded);
+            replayLoaded.TriggerChange();
 
-            ReplaySettingsOverlay.ReplayLoaded = replayLoaded;
-
-            // in the case a replay isn't loaded, we want some elements to only appear briefly.
-            if (!replayLoaded)
-            {
-                ReplaySettingsOverlay.Hide();
-                ModDisplay.Delay(2000).FadeOut(200);
-            }
+            Progress.BindRulestContainer(rulesetContainer);
         }
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -59,7 +59,6 @@ namespace osu.Game.Screens.Play
                     ReplaySettingsOverlay = CreateReplaySettingsOverlay(),
                 }
             });
-
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Play
         public int RestartCount;
 
         public CursorContainer Cursor => RulesetContainer.Cursor;
-        public bool ProvidingUserCursor => RulesetContainer?.Cursor != null && !RulesetContainer.HasReplayLoaded;
+        public bool ProvidingUserCursor => RulesetContainer?.Cursor != null && !RulesetContainer.HasReplayLoaded.Value;
 
         private IAdjustableClock adjustableSourceClock;
         private FramedOffsetClock offsetClock;
@@ -226,7 +226,6 @@ namespace osu.Game.Screens.Play
 
             hudOverlay.Progress.Objects = RulesetContainer.Objects;
             hudOverlay.Progress.AudioClock = decoupledClock;
-            hudOverlay.Progress.AllowSeeking = RulesetContainer.HasReplayLoaded;
             hudOverlay.Progress.OnSeek = pos => decoupledClock.Seek(pos);
 
             hudOverlay.ModDisplay.Current.BindTo(working.Mods);

--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -9,9 +9,12 @@ using System.Collections.Generic;
 using osu.Game.Graphics;
 using osu.Framework.Allocation;
 using System.Linq;
+using osu.Framework.Configuration;
 using osu.Framework.Timing;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.UI;
+
 namespace osu.Game.Screens.Play
 {
     public class SongProgress : OverlayContainer
@@ -53,6 +56,8 @@ namespace osu.Game.Screens.Play
             }
         }
 
+        private readonly BindableBool replayLoaded = new BindableBool();
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
@@ -92,11 +97,19 @@ namespace osu.Game.Screens.Play
                     OnSeek = position => OnSeek?.Invoke(position),
                 },
             };
+
+            replayLoaded.ValueChanged += v => AllowSeeking = v;
         }
 
         protected override void LoadComplete()
         {
             State = Visibility.Visible;
+        }
+
+        public void BindRulestContainer(RulesetContainer rulesetContainer)
+        {
+            replayLoaded.BindTo(rulesetContainer.HasReplayLoaded);
+            replayLoaded.TriggerChange();
         }
 
         private bool allowSeeking;

--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -105,12 +105,14 @@ namespace osu.Game.Screens.Play
         protected override void LoadComplete()
         {
             State = Visibility.Visible;
+
+            replayLoaded.ValueChanged += v => AllowSeeking = v;
+            replayLoaded.TriggerChange();
         }
 
         public void BindRulestContainer(RulesetContainer rulesetContainer)
         {
             replayLoaded.BindTo(rulesetContainer.HasReplayLoaded);
-            replayLoaded.TriggerChange();
         }
 
         private bool allowSeeking;

--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -98,8 +98,6 @@ namespace osu.Game.Screens.Play
                     OnSeek = position => OnSeek?.Invoke(position),
                 },
             };
-
-            replayLoaded.ValueChanged += v => AllowSeeking = v;
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Fixes:
* Replays not getting loaded when dragged in.
  * The BeatmapSet Files weren't populated through BeatmapManager.QueryBeatmap.
  * I don't know whether this is the _best_ fix for this, but this (and similar) functions are only used here and in a testcase, so it's not going to cause any performance issues.
* Replays being offset.
  * Negative-time frame offsets weren't considered.
  * Although I don't know how this is possible, I do remember it being a thing for a very long time and still continues to be a thing with recent replays.
* ReplayPlayer not giving us the replay UI and not allowing timeline scrolling.
  * Wasn't being treated as actually having a replay due to it setting the replay in LoadComplete().
* ResultsScreen displaying the wrong user for replays loaded through the ScoreStore.