### PR TITLE
Mute global track volume when a beatmap preview is playing

### DIFF
--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -132,8 +132,7 @@ namespace osu.Game.Overlays.Direct
                     return;
                 }
 
-                Preview.Seek(0);
-                Preview.Start();
+                Preview.Restart();
 
                 audio.Track.AddAdjustment(AdjustableProperty.Volume, muteBindable);
             }

--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -9,6 +9,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
+using osu.Framework.IO.Stores;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -38,6 +39,8 @@ namespace osu.Game.Overlays.Direct
         private Color4 hoverColour;
         private readonly SpriteIcon icon;
         private readonly LoadingAnimation loadingAnimation;
+
+        private readonly BindableDouble muteBindable = new BindableDouble();
 
         private const float transition_duration = 500;
 
@@ -83,9 +86,10 @@ namespace osu.Game.Overlays.Direct
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour)
+        private void load(OsuColour colour, AudioManager audio)
         {
             hoverColour = colour.Yellow;
+            this.audio = audio;
         }
 
         protected override bool OnClick(InputState state)
@@ -130,15 +134,20 @@ namespace osu.Game.Overlays.Direct
 
                 Preview.Seek(0);
                 Preview.Start();
+
+                audio.Track.AddAdjustment(AdjustableProperty.Volume, muteBindable);
             }
             else
             {
+                audio.Track.RemoveAdjustment(AdjustableProperty.Volume, muteBindable);
+
                 Preview?.Stop();
                 loading = false;
             }
         }
 
         private TrackLoader trackLoader;
+        private AudioManager audio;
 
         private void beginAudioLoad()
         {
@@ -164,6 +173,7 @@ namespace osu.Game.Overlays.Direct
             private readonly string preview;
 
             public Track Preview;
+            private TrackManager trackManager;
 
             public TrackLoader(string preview)
             {
@@ -171,10 +181,22 @@ namespace osu.Game.Overlays.Direct
             }
 
             [BackgroundDependencyLoader]
-            private void load(AudioManager audio)
+            private void load(AudioManager audio, FrameworkConfigManager config)
             {
+                // create a local trackManager to bypass the mute we are applying above.
+                audio.AddItem(trackManager = new TrackManager(new OnlineStore()));
+
+                // add back the user's music volume setting (since we are no longer in the global TrackManager's hierarchy).
+                config.BindWith(FrameworkSetting.VolumeMusic, trackManager.Volume);
+
                 if (!string.IsNullOrEmpty(preview))
-                    Preview = audio.Track.Get(preview);
+                    Preview = trackManager.Get(preview);
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+                trackManager?.Dispose();
             }
         }
     }


### PR DESCRIPTION
Alternative to #1892.
Closes #1585.

Reasoning for muting instead of pausing is that it has 100% less change of conflicting with other components. Examples of potential conflicts caused by the other approach:

- Beatmap could be switched; new beatmap plays sound.
- Player could be paused, causing countless sync issues.