### PR TITLE
Fix global audio not resuming on completed direct download

### DIFF
--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -191,7 +191,13 @@ namespace osu.Game.Overlays
         private void setAdded(BeatmapSetInfo set)
         {
             // if a new map was imported, we should remove it from search results (download completed etc.)
-            panels?.FirstOrDefault(p => p.SetInfo.OnlineBeatmapSetID == set.OnlineBeatmapSetID)?.FadeOut(400).Expire();
+            var existingPanel = panels?.FirstOrDefault(p => p.SetInfo.OnlineBeatmapSetID == set.OnlineBeatmapSetID);
+            if (existingPanel != null)
+            {
+                existingPanel.PreviewPlaying.Value = false;
+                existingPanel.FadeOut(400).Expire();
+            }
+
             BeatmapSets = BeatmapSets?.Where(b => b.OnlineBeatmapSetID != set.OnlineBeatmapSetID);
         }
 


### PR DESCRIPTION
This would fix the issue of finished downloads removing the panel which prevents the preview resuming global audio.

I honstly feel this is awkward.
I played with making the `DirectPanel` a `VisibilityContainer` and let `PopOut()` do the audio thing but then you have to change the VisibilityState in one way or another anyways.
This resulted in the same awkwardness just with different shiny text (instead of setting the playing value you call `Hide()` or `Toggle()` or similar).

I feel like the panel should stop its preview by itself if it gets inactive though. I'm just not sure how to do that... or if it should do that.