### PR TITLE
Ensure previews stop playing when they are removed from the draw hierarchy

### DIFF
--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -106,6 +106,8 @@ namespace osu.Game.Overlays.Direct
             beatmaps.BeatmapDownloadBegan += attachDownload;
         }
 
+        public override bool DisposeOnDeathRemoval => true;
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);

--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -145,6 +145,12 @@ namespace osu.Game.Overlays.Direct
             }
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            Playing.Value = false;
+        }
+
         private TrackLoader trackLoader;
         private AudioManager audio;
 


### PR DESCRIPTION
Alternative implementation to #1936.

- [x] Depends on https://github.com/ppy/osu-framework/pull/1340