### PR TITLE
Continue showing progress bar on direct panels when importing

### DIFF
--- a/osu.Game/Graphics/UserInterface/ProgressBar.cs
+++ b/osu.Game/Graphics/UserInterface/ProgressBar.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Graphics.UserInterface
 
         public Color4 FillColour
         {
-            set { fill.Colour = value; }
+            set { fill.FadeColour(value, 150, Easing.OutQuint); }
         }
 
         public Color4 BackgroundColour

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -65,11 +65,14 @@ namespace osu.Game.Overlays.Direct
             Colour = Color4.Black.Opacity(0.3f),
         };
 
+        private OsuColour colours;
+
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(BeatmapManager beatmaps, OsuColour colours, BeatmapSetOverlay beatmapSetOverlay)
         {
             this.beatmaps = beatmaps;
             this.beatmapSetOverlay = beatmapSetOverlay;
+            this.colours = colours;
 
             AddInternal(content = new Container
             {
@@ -188,7 +191,7 @@ namespace osu.Game.Overlays.Direct
             request.Success += data =>
             {
                 progressBar.Current.Value = 1;
-                progressBar.FadeOut(500);
+                progressBar.FillColour = colours.Yellow;
             };
         }
 


### PR DESCRIPTION
Previously the progrress bar would fade out once downloads completed, which felt unintuitive.