### PR TITLE
Keep downloads active until their associated import operation finishes

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -287,9 +287,8 @@ namespace osu.Game.Beatmaps
                         Import(archive);
 
                     downloadNotification.State = ProgressNotificationState.Completed;
+                    currentDownloads.Remove(request);
                 }, TaskCreationOptions.LongRunning);
-
-                currentDownloads.Remove(request);
             };
 
             request.Failure += data =>


### PR DESCRIPTION
This avoids race conditions where a second download can potentially be started while the first is still active.