### PR TITLE
Fix settings button

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarSettingsButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarSettingsButton.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Overlays.Toolbar
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(SettingsOverlay settings)
+        private void load(MainSettings settings)
         {
             StateContainer = settings;
         }


### PR DESCRIPTION
Right now the settings button is non-functional if you try to click it. Only keyboard shortcuts work.

This may be a side effect caused by the recent changes to how types are cached.

`SettingsOverlay settings = new MainSettings();`
Above is not able to be injected as `SettingsOverlay` anymore.

Feel free to disregard this if it needs to be fixed in the framework (which I won't touch).