### PR TITLE
Make mania play the next note's sounds if no note is hit

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -136,7 +136,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </summary>
         public event Action<DrawableHitObject, ArmedState> ApplyCustomUpdateState;
 
-        protected void PlaySamples() => Samples.ForEach(s => s?.Play());
+        /// <summary>
+        /// Plays all the hitsounds for this <see cref="DrawableHitObject"/>.
+        /// </summary>
+        public void PlaySamples() => Samples.ForEach(s => s?.Play());
 
         protected override void Update()
         {


### PR DESCRIPTION
Fixes #1911.

This follows what osu!stable does, which is rather unfortunate, since it just plays every sound for the _note_, unlike taiko :|.