### PR TITLE
Fix fullScreen combined key not working

### DIFF
--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -274,6 +274,9 @@ namespace osu.Game.Screens.Play
                 if (args.Repeat || args.Key != Key.Enter || !Selected)
                     return false;
 
+                if (state != null && state.Keyboard.AltPressed)
+                    return false;
+
                 OnClick(state);
                 return true;
             }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -475,8 +475,13 @@ namespace osu.Game.Screens.Select
             {
                 case Key.KeypadEnter:
                 case Key.Enter:
-                    FinaliseSelection();
-                    return true;
+                    if (!state.Keyboard.AltPressed)
+                    {
+                        FinaliseSelection();
+                        return true;
+                    }
+
+                    break;
                 case Key.Delete:
                     if (state.Keyboard.ShiftPressed)
                     {


### PR DESCRIPTION
Fullscreen key ( ALT + ENTER ) key has been not work on songselect screen and
wrong work on overlay screen.

I fixed that issue.

Signed-off-by: Seokho Song <0xdevssh@gmail.com>