### PR TITLE
Fix osu star rating calculation

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double EndTime => StartTime + this.SpanCount() * Curve.Distance / Velocity;
         public double Duration => EndTime - StartTime;
 
+        public Vector2 StackedPositionAt(double t) => this.PositionAt(t) + this.StackOffset;
         public override Vector2 EndPosition => this.PositionAt(1);
 
         public SliderCurve Curve { get; } = new SliderCurve();

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double EndTime => StartTime + this.SpanCount() * Curve.Distance / Velocity;
         public double Duration => EndTime - StartTime;
 
-        public Vector2 StackedPositionAt(double t) => this.PositionAt(t) + this.StackOffset;
+        public Vector2 StackedPositionAt(double t) => this.PositionAt(t) + StackOffset;
         public override Vector2 EndPosition => this.PositionAt(1);
 
         public SliderCurve Curve { get; } = new SliderCurve();

--- a/osu.Game.Rulesets.Osu/OsuDifficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/OsuDifficulty/OsuDifficultyCalculator.cs
@@ -29,8 +29,7 @@ namespace osu.Game.Rulesets.Osu.OsuDifficulty
 
         protected override void PreprocessHitObjects()
         {
-            foreach (OsuHitObject h in Beatmap.HitObjects)
-                (h as Slider)?.Curve?.Calculate();
+            new OsuBeatmapProcessor().PostProcess(Beatmap);
         }
 
         public override double Calculate(Dictionary<string, double> categoryDifficulty = null)

--- a/osu.Game.Rulesets.Osu/OsuDifficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/OsuDifficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Osu.OsuDifficulty.Preprocessing
             var computeVertex = new Action<double>(t =>
             {
                 // ReSharper disable once PossibleInvalidOperationException (bugged in current r# version)
-                var diff = slider.PositionAt(t) + slider.StackOffset - slider.LazyEndPosition.Value;
+                var diff = slider.StackedPositionAt(t) - slider.LazyEndPosition.Value;
                 float dist = diff.Length;
 
                 if (dist > approxFollowCircleRadius)

--- a/osu.Game.Rulesets.Osu/OsuDifficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/OsuDifficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using osu.Game.Rulesets.Objects.Types;
 using OpenTK;
 using osu.Game.Rulesets.Osu.Objects;
 

--- a/osu.Game.Rulesets.Osu/OsuDifficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/OsuDifficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Osu.OsuDifficulty.Preprocessing
             var computeVertex = new Action<double>(t =>
             {
                 // ReSharper disable once PossibleInvalidOperationException (bugged in current r# version)
-                var diff = slider.PositionAt(t) - slider.LazyEndPosition.Value;
+                var diff = slider.PositionAt(t) + slider.StackOffset - slider.LazyEndPosition.Value;
                 float dist = diff.Length;
 
                 if (dist > approxFollowCircleRadius)

--- a/osu.Game/Beatmaps/DifficultyCalculator.cs
+++ b/osu.Game/Beatmaps/DifficultyCalculator.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Beatmaps
 
     public abstract class DifficultyCalculator<T> : DifficultyCalculator where T : HitObject
     {
-        protected readonly Beatmap<T> Beatmap;
+        protected Beatmap<T> Beatmap;
         protected readonly Mod[] Mods;
 
         protected DifficultyCalculator(Beatmap beatmap, Mod[] mods = null)

--- a/osu.Game/Beatmaps/DifficultyCalculator.cs
+++ b/osu.Game/Beatmaps/DifficultyCalculator.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Beatmaps
 
     public abstract class DifficultyCalculator<T> : DifficultyCalculator where T : HitObject
     {
-        protected Beatmap<T> Beatmap;
+        protected readonly Beatmap<T> Beatmap;
         protected readonly Mod[] Mods;
 
         protected DifficultyCalculator(Beatmap beatmap, Mod[] mods = null)


### PR DESCRIPTION
The main bug was that the beatmap was not being processed prior to
having its Skill values calculated, causing stacking to be ignored in
difficulty calculation. The fix involves processing the beatmap with
OsuBeatmapProcessor.

Another minor bug was that sliders were not taking into account the
stacked position midway through the slider (PositionAt does not return
stacked position.), so I corrected by adding StackOffset.

This fixes difficulty calculation on this map: https://osu.ppy.sh/b/1531041
osu!stable suffers from the same bug, rating this map at 7* when in reality it is a 5* map. This was verified by VINXIS by creating an equivalent map with fully manual stacking.

This is the .osu file. https://pastebin.com/raw/XChF5emy

The section causing intense difficulty spike if stacking is not accounted is

```
281,266,47907,5,12,1:2:0:0:
141,175,47996,1,0,0:0:0:0:
281,266,48086,1,0,0:0:0:0:
144,178,48175,1,0,0:0:0:0:
281,266,48266,1,8,1:2:0:0:
...
281,266,53116,1,0,0:0:0:0:
244,282,53205,1,0,0:0:0:0:
281,266,53295,1,8,1:2:0:0:
248,286,53385,1,0,0:0:0:0:
281,266,53475,5,8,1:2:0:0:
```