### PR TITLE
Make slider tails count towards the slider's judgement

### DIFF
--- a/osu.Game.Rulesets.Osu/Judgements/OsuSliderTailJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuSliderTailJudgement.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Judgements
+{
+    public class OsuSliderTailJudgement : OsuJudgement
+    {
+        public override bool AffectsCombo => false;
+        protected override int NumericResultFor(HitResult result) => 0;
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     {
         private readonly Slider slider;
 
-        public readonly DrawableHitCircle InitialCircle;
+        public readonly DrawableHitCircle HeadCircle;
 
         private readonly List<Drawable> components = new List<Drawable>();
 
@@ -51,27 +51,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     AlwaysPresent = true,
                     Alpha = 0
                 },
-                InitialCircle = new DrawableHitCircle(new HitCircle
-                {
-                    StartTime = s.StartTime,
-                    Position = s.StackedPosition,
-                    IndexInCurrentCombo = s.IndexInCurrentCombo,
-                    Scale = s.Scale,
-                    ComboColour = s.ComboColour,
-                    Samples = s.Samples,
-                    SampleControlPoint = s.SampleControlPoint,
-                    TimePreempt = s.TimePreempt,
-                    TimeFadein = s.TimeFadein,
-                    HitWindow300 = s.HitWindow300,
-                    HitWindow100 = s.HitWindow100,
-                    HitWindow50 = s.HitWindow50
-                })
+                HeadCircle = new DrawableHitCircle(s.HeadCircle)
             };
 
             components.Add(Body);
             components.Add(Ball);
 
-            AddNested(InitialCircle);
+            AddNested(HeadCircle);
 
             foreach (var tick in s.NestedHitObjects.OfType<SliderTick>())
             {
@@ -121,8 +107,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 currentSpan = span;
 
             //todo: we probably want to reconsider this before adding scoring, but it looks and feels nice.
-            if (!InitialCircle.Judgements.Any(j => j.IsHit))
-                InitialCircle.Position = slider.Curve.PositionAt(progress);
+            if (!HeadCircle.Judgements.Any(j => j.IsHit))
+                HeadCircle.Position = slider.Curve.PositionAt(progress);
 
             foreach (var c in components.OfType<ISliderProgress>()) c.UpdateProgress(progress, span);
             foreach (var c in components.OfType<ITrackSnaking>()) c.UpdateSnakingPosition(slider.Curve.PositionAt(Body.SnakedStart ?? 0), slider.Curve.PositionAt(Body.SnakedEnd ?? 0));
@@ -135,13 +121,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 var judgementsCount = ticks.Children.Count + repeatPoints.Children.Count + 1;
                 var judgementsHit = ticks.Children.Count(t => t.Judgements.Any(j => j.IsHit)) + repeatPoints.Children.Count(t => t.Judgements.Any(j => j.IsHit));
-                if (InitialCircle.Judgements.Any(j => j.IsHit))
+                if (HeadCircle.Judgements.Any(j => j.IsHit))
                     judgementsHit++;
 
                 var hitFraction = (double)judgementsHit / judgementsCount;
-                if (hitFraction == 1 && InitialCircle.Judgements.Any(j => j.Result == HitResult.Great))
+                if (hitFraction == 1 && HeadCircle.Judgements.Any(j => j.Result == HitResult.Great))
                     AddJudgement(new OsuJudgement { Result = HitResult.Great });
-                else if (hitFraction >= 0.5 && InitialCircle.Judgements.Any(j => j.Result >= HitResult.Good))
+                else if (hitFraction >= 0.5 && HeadCircle.Judgements.Any(j => j.Result >= HitResult.Good))
                     AddJudgement(new OsuJudgement { Result = HitResult.Good });
                 else if (hitFraction > 0)
                     AddJudgement(new OsuJudgement { Result = HitResult.Meh });
@@ -173,7 +159,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        public Drawable ProxiedLayer => InitialCircle.ApproachCircle;
+        public Drawable ProxiedLayer => HeadCircle.ApproachCircle;
 
         public override Vector2 SelectionPoint => ToScreenSpace(Body.Position);
         public override Quad SelectionQuad => Body.PathDrawQuad;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 currentSpan = span;
 
             //todo: we probably want to reconsider this before adding scoring, but it looks and feels nice.
-            if (!HeadCircle.Judgements.Any(j => j.IsHit))
+            if (!HeadCircle.IsHit)
                 HeadCircle.Position = slider.Curve.PositionAt(progress);
 
             foreach (var c in components.OfType<ISliderProgress>()) c.UpdateProgress(progress, span);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Objects.Drawables
+{
+    public class DrawableSliderTail : DrawableOsuHitObject, IRequireTracking
+    {
+        /// <summary>
+        /// The judgement text is provided by the <see cref="DrawableSlider"/>.
+        /// </summary>
+        public override bool DisplayJudgement => false;
+
+        public bool Tracking { get; set; }
+
+        public DrawableSliderTail(HitCircle hitCircle)
+            : base(hitCircle)
+        {
+            AlwaysPresent = true;
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        protected override void CheckForJudgements(bool userTriggered, double timeOffset)
+        {
+            if (!userTriggered && timeOffset >= 0)
+                AddJudgement(new OsuSliderTailJudgement { Result = Tracking ? HitResult.Great : HitResult.Miss });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -12,14 +12,14 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
-    public class DrawableSliderTick : DrawableOsuHitObject
+    public class DrawableSliderTick : DrawableOsuHitObject, IRequireTracking
     {
         private readonly SliderTick sliderTick;
 
         public double FadeInTime;
         public double FadeOutTime;
 
-        public bool Tracking;
+        public bool Tracking { get; set; }
 
         public override bool DisplayJudgement => false;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/IRequireTracking.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/IRequireTracking.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Game.Rulesets.Osu.Objects.Drawables
+{
+    public interface IRequireTracking
+    {
+        /// <summary>
+        /// Whether the <see cref="DrawableSlider"/> is currently being tracked by the user.
+        /// </summary>
+        bool Tracking { get; set; }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -81,6 +81,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double TickDistance;
 
         public HitCircle HeadCircle;
+        public HitCircle TailCircle;
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
         {
@@ -104,7 +105,18 @@ namespace osu.Game.Rulesets.Osu.Objects
                 SampleControlPoint = SampleControlPoint
             };
 
+            TailCircle = new HitCircle
+            {
+                StartTime = EndTime,
+                Position = StackedEndPosition,
+                IndexInCurrentCombo = IndexInCurrentCombo,
+                ComboColour = ComboColour,
+                Samples = Samples,
+                SampleControlPoint = SampleControlPoint
+            };
+
             HeadCircle.ApplyDefaults(controlPointInfo, difficulty);
+            TailCircle.ApplyDefaults(controlPointInfo, difficulty);
         }
 
         protected override void CreateNestedHitObjects()

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -94,7 +94,19 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             Velocity = scoringDistance / timingPoint.BeatLength;
             TickDistance = scoringDistance / difficulty.SliderTickRate;
+        }
 
+        protected override void CreateNestedHitObjects()
+        {
+            base.CreateNestedHitObjects();
+
+            createSliderEnds();
+            createTicks();
+            createRepeatPoints();
+        }
+
+        private void createSliderEnds()
+        {
             HeadCircle = new HitCircle
             {
                 StartTime = StartTime,
@@ -115,16 +127,8 @@ namespace osu.Game.Rulesets.Osu.Objects
                 SampleControlPoint = SampleControlPoint
             };
 
-            HeadCircle.ApplyDefaults(controlPointInfo, difficulty);
-            TailCircle.ApplyDefaults(controlPointInfo, difficulty);
-        }
-
-        protected override void CreateNestedHitObjects()
-        {
-            base.CreateNestedHitObjects();
-
-            createTicks();
-            createRepeatPoints();
+            AddNested(HeadCircle);
+            AddNested(TailCircle);
         }
 
         private void createTicks()

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -80,6 +80,8 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double Velocity;
         public double TickDistance;
 
+        public HitCircle HeadCircle;
+
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
         {
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
@@ -91,6 +93,18 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             Velocity = scoringDistance / timingPoint.BeatLength;
             TickDistance = scoringDistance / difficulty.SliderTickRate;
+
+            HeadCircle = new HitCircle
+            {
+                StartTime = StartTime,
+                Position = StackedPosition,
+                IndexInCurrentCombo = IndexInCurrentCombo,
+                ComboColour = ComboColour,
+                Samples = Samples,
+                SampleControlPoint = SampleControlPoint
+            };
+
+            HeadCircle.ApplyDefaults(controlPointInfo, difficulty);
         }
 
         protected override void CreateNestedHitObjects()

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
@@ -150,6 +150,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             Add(drawable);
         }
 
+        private float judgementOffsetDirection = 1;
         private void onJudgement(DrawableHitObject judgedObject, Judgement judgement)
         {
             var osuObject = judgedObject as DrawableOsuHitObject;
@@ -164,12 +165,14 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Text = judgement.IsHit ? "Hit!" : "Miss!",
                 Colour = judgement.IsHit ? Color4.Green : Color4.Red,
                 TextSize = 30,
-                Position = osuObject.HitObject.StackedEndPosition - new Vector2(0, 45)
+                Position = osuObject.HitObject.StackedEndPosition + judgementOffsetDirection * new Vector2(0, 45)
             });
 
             text.Delay(150)
                 .Then().FadeOut(200)
                 .Then().Expire();
+
+            judgementOffsetDirection *= -1;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
@@ -16,6 +16,9 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Game.Rulesets.Mods;
 using System.Linq;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
 
 namespace osu.Game.Rulesets.Osu.Tests
@@ -142,7 +145,31 @@ namespace osu.Game.Rulesets.Osu.Tests
             foreach (var mod in Mods.OfType<IApplicableToDrawableHitObjects>())
                 mod.ApplyToDrawableHitObjects(new[] { drawable });
 
+            drawable.OnJudgement += onJudgement;
+
             Add(drawable);
+        }
+
+        private void onJudgement(DrawableHitObject judgedObject, Judgement judgement)
+        {
+            var osuObject = judgedObject as DrawableOsuHitObject;
+            if (osuObject == null)
+                return;
+
+            OsuSpriteText text;
+            Add(text = new OsuSpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Text = judgement.IsHit ? "Hit!" : "Miss!",
+                Colour = judgement.IsHit ? Color4.Green : Color4.Red,
+                TextSize = 30,
+                Position = osuObject.HitObject.StackedEndPosition - new Vector2(0, 45)
+            });
+
+            text.Delay(150)
+                .Then().FadeOut(200)
+                .Then().Expire();
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+++ b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Edit\OsuEditPlayfield.cs" />
     <Compile Include="Edit\OsuEditRulesetContainer.cs" />
     <Compile Include="Edit\OsuHitObjectComposer.cs" />
+    <Compile Include="Judgements\OsuSliderTailJudgement.cs" />
     <Compile Include="Mods\OsuModAutopilot.cs" />
     <Compile Include="Mods\OsuModAutoplay.cs" />
     <Compile Include="Mods\OsuModDaycore.cs" />
@@ -75,6 +76,8 @@
     <Compile Include="Objects\Drawables\Connections\FollowPointRenderer.cs" />
     <Compile Include="Judgements\OsuJudgement.cs" />
     <Compile Include="Objects\Drawables\DrawableRepeatPoint.cs" />
+    <Compile Include="Objects\Drawables\DrawableSliderTail.cs" />
+    <Compile Include="Objects\Drawables\IRequireTracking.cs" />
     <Compile Include="Objects\Drawables\ITrackSnaking.cs" />
     <Compile Include="Objects\Drawables\Pieces\ApproachCircle.cs" />
     <Compile Include="Objects\Drawables\Pieces\SpinnerBackground.cs" />

--- a/osu.Game.Tests/Visual/TestCaseEditorSelectionLayer.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditorSelectionLayer.cs
@@ -8,6 +8,8 @@ using OpenTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Edit.Layers.Selection;
 using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Objects;
@@ -35,9 +37,9 @@ namespace osu.Game.Tests.Visual
                 new SelectionLayer(playfield)
             };
 
-            playfield.Add(new DrawableHitCircle(new HitCircle { Position = new Vector2(256, 192), Scale = 0.5f }));
-            playfield.Add(new DrawableHitCircle(new HitCircle { Position = new Vector2(344, 148), Scale = 0.5f }));
-            playfield.Add(new DrawableSlider(new Slider
+            var hitCircle1 = new HitCircle { Position = new Vector2(256, 192), Scale = 0.5f };
+            var hitCircle2 = new HitCircle { Position = new Vector2(344, 148), Scale = 0.5f };
+            var slider = new Slider
             {
                 ControlPoints = new List<Vector2>
                 {
@@ -48,8 +50,16 @@ namespace osu.Game.Tests.Visual
                 Position = new Vector2(128, 256),
                 Velocity = 1,
                 TickDistance = 100,
-                Scale = 0.5f
-            }));
+                Scale = 0.5f,
+            };
+
+            hitCircle1.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            hitCircle2.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            playfield.Add(new DrawableHitCircle(hitCircle1));
+            playfield.Add(new DrawableHitCircle(hitCircle2));
+            playfield.Add(new DrawableSlider(slider));
         }
     }
 }

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -240,12 +240,12 @@ namespace osu.Game.Rulesets.UI
             foreach (var mod in Mods.OfType<IApplicableToDifficulty>())
                 mod.ApplyToDifficulty(Beatmap.BeatmapInfo.BaseDifficulty);
 
+            // Post-process the beatmap
+            processor.PostProcess(Beatmap);
+
             // Apply defaults
             foreach (var h in Beatmap.HitObjects)
                 h.ApplyDefaults(Beatmap.ControlPointInfo, Beatmap.BeatmapInfo.BaseDifficulty);
-
-            // Post-process the beatmap
-            processor.PostProcess(Beatmap);
 
             KeyBindingInputManager = CreateInputManager();
             KeyBindingInputManager.RelativeSizeAxes = Axes.Both;


### PR DESCRIPTION
Alternative to https://github.com/ppy/osu/pull/1954.

Adds an invisible nested hitobject for the slider tail which provides a dummy judgement in a similar way to slider ticks.

Also moves the head circle to a nested hitobject.