### PR TITLE
Fix PlayerSettingsOverlay not able to reappear after being hidden

### DIFF
--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -49,6 +49,9 @@ namespace osu.Game.Screens.Play.HUD
         protected override void PopIn() => this.FadeIn(fade_duration);
         protected override void PopOut() => this.FadeOut(fade_duration);
 
+        //We want to handle keyboard inputs all the time in order to trigger ToggleVisibility() when not visible
+        public override bool HandleKeyboardInput => true;
+
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
             if (args.Repeat) return false;


### PR DESCRIPTION
Pressing Ctrl-H when the PlayerSettingsOverlay was Hidden did not trigger ToggleVisibility()
Fixed by always handling inputs