### PR TITLE
Stopping non-url text from being hyperlinks

### DIFF
--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -433,7 +433,13 @@ namespace osu.Game.Overlays.Profile
             if (string.IsNullOrEmpty(str)) return;
 
             infoTextRight.AddIcon(icon);
-            infoTextRight.AddLink(" " + str, url);
+            if (url != null)
+            {
+                infoTextRight.AddLink(" " + str, url);
+            } else
+            {
+                infoTextRight.AddText(" " + str);
+            }
             infoTextRight.NewLine();
         }
 


### PR DESCRIPTION
Fixed crash when you would attempt to click one