### PR TITLE
Fix revert-to-default hiding visual settings at beatmap load

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -181,7 +181,7 @@ namespace osu.Game.Overlays.Settings
             {
                 hovering = true;
                 UpdateState();
-                return true;
+                return false;
             }
 
             protected override void OnHoverLost(InputState state)


### PR DESCRIPTION
Resolves #2024