### PR TITLE
Fix visual settings checkboxes playing sounds in bindable binding

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -76,17 +76,22 @@ namespace osu.Game.Graphics.UserInterface
 
             Nub.Current.BindTo(Current);
 
+            Current.DisabledChanged += disabled =>
+            {
+                Alpha = disabled ? 0.3f : 1;
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
             Current.ValueChanged += newValue =>
             {
                 if (newValue)
                     sampleChecked?.Play();
                 else
                     sampleUnchecked?.Play();
-            };
-
-            Current.DisabledChanged += disabled =>
-            {
-                Alpha = disabled ? 0.3f : 1;
             };
         }
 


### PR DESCRIPTION
Move sound binding to much later in the process to avoid programmatic checkbox changes triggering interaction sounds