### PR TITLE
Improvements to EF context handling and BeatmapManager

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - cmd: git submodule update --init --recursive --depth=5
   - cmd: choco install resharper-clt -y
   - cmd: choco install nvika -y
-  - cmd: appveyor DownloadFile https://github.com/peppy/CodeFileSanity/releases/download/v0.2.3/CodeFileSanity.exe
+  - cmd: appveyor DownloadFile https://github.com/peppy/CodeFileSanity/releases/download/v0.2.4/CodeFileSanity.exe
 before_build:
   - cmd: CodeFileSanity.exe
   - cmd: nuget restore -verbosity quiet

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -107,9 +107,8 @@ namespace osu.Game.Tests.Beatmaps.IO
                     var importedSecondTime = loadOszIntoOsu(osu);
 
                     // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
-                    Assert.IsTrue(imported.ID == importedSecondTime.ID);
-                    Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
-
+                    Assert.IsTrue(imported.ID != importedSecondTime.ID);
+                    Assert.IsTrue(imported.Beatmaps.First().ID < importedSecondTime.Beatmaps.First().ID);
 
                     Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 1);
                     Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -26,19 +26,24 @@ namespace osu.Game.Tests.Beatmaps.IO
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportWhenClosed"))
             {
-                var osu = loadOsu(host);
+                try
+                {
+                    var osu = loadOsu(host);
 
-                var temp = prepareTempCopy(osz_path);
+                    var temp = prepareTempCopy(osz_path);
 
-                Assert.IsTrue(File.Exists(temp));
+                    Assert.IsTrue(File.Exists(temp));
 
-                osu.Dependencies.Get<BeatmapManager>().Import(temp);
+                    osu.Dependencies.Get<BeatmapManager>().Import(temp);
 
-                ensureLoaded(osu);
+                    ensureLoaded(osu);
 
-                waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
-
-                host.Exit();
+                    waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
+                }
+                finally
+                {
+                    host.Exit();
+                }
             }
         }
 
@@ -48,26 +53,31 @@ namespace osu.Game.Tests.Beatmaps.IO
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenDelete"))
             {
-                var osu = loadOsu(host);
+                try
+                {
+                    var osu = loadOsu(host);
 
-                var temp = prepareTempCopy(osz_path);
-                Assert.IsTrue(File.Exists(temp));
+                    var temp = prepareTempCopy(osz_path);
+                    Assert.IsTrue(File.Exists(temp));
 
-                var manager = osu.Dependencies.Get<BeatmapManager>();
+                    var manager = osu.Dependencies.Get<BeatmapManager>();
 
-                var imported = manager.Import(temp);
+                    var imported = manager.Import(temp);
 
-                ensureLoaded(osu);
+                    ensureLoaded(osu);
 
-                manager.Delete(imported.First());
+                    manager.Delete(imported.First());
 
-                Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 0);
-                Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count() == 1);
-                Assert.IsTrue(manager.QueryBeatmapSets(_ => true).First().DeletePending);
+                    Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 0);
+                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
+                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).First().DeletePending);
 
-                waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
-
-                host.Exit();
+                    waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
+                }
+                finally
+                {
+                    host.Exit();
+                }
             }
         }
 
@@ -77,36 +87,41 @@ namespace osu.Game.Tests.Beatmaps.IO
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenDeleteThenImport"))
             {
-                var osu = loadOsu(host);
+                try
+                {
+                    var osu = loadOsu(host);
 
-                var temp = prepareTempCopy(osz_path);
-                Assert.IsTrue(File.Exists(temp));
+                    var temp = prepareTempCopy(osz_path);
+                    Assert.IsTrue(File.Exists(temp));
 
-                var manager = osu.Dependencies.Get<BeatmapManager>();
+                    var manager = osu.Dependencies.Get<BeatmapManager>();
 
-                var imported = manager.Import(temp);
+                    var imported = manager.Import(temp);
 
-                ensureLoaded(osu);
+                    ensureLoaded(osu);
 
-                manager.Delete(imported.First());
+                    manager.Delete(imported.First());
 
-                Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 0);
-                Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count() == 1);
-                Assert.IsTrue(manager.QueryBeatmapSets(_ => true).First().DeletePending);
+                    Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 0);
+                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count() == 1);
+                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).First().DeletePending);
 
-                temp = prepareTempCopy(osz_path);
-                Assert.IsTrue(File.Exists(temp));
-                var importedSecondTime = manager.Import(temp);
+                    temp = prepareTempCopy(osz_path);
+                    Assert.IsTrue(File.Exists(temp));
+                    var importedSecondTime = manager.Import(temp);
 
-                ensureLoaded(osu);
+                    ensureLoaded(osu);
 
-                // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
-                Assert.IsTrue(imported.First().ID == importedSecondTime.First().ID);
-                Assert.IsTrue(imported.First().Beatmaps.First().ID == importedSecondTime.First().Beatmaps.First().ID);
+                    // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
+                    Assert.IsTrue(imported.First().ID == importedSecondTime.First().ID);
+                    Assert.IsTrue(imported.First().Beatmaps.First().ID == importedSecondTime.First().Beatmaps.First().ID);
 
-                waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
-
-                host.Exit();
+                    waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
+                }
+                finally
+                {
+                    host.Exit();
+                }
             }
         }
 
@@ -118,24 +133,29 @@ namespace osu.Game.Tests.Beatmaps.IO
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("host", true))
             using (HeadlessGameHost client = new CleanRunHeadlessGameHost("client", true))
             {
-                Assert.IsTrue(host.IsPrimaryInstance);
-                Assert.IsFalse(client.IsPrimaryInstance);
+                try
+                {
+                    Assert.IsTrue(host.IsPrimaryInstance);
+                    Assert.IsFalse(client.IsPrimaryInstance);
 
-                var osu = loadOsu(host);
+                    var osu = loadOsu(host);
 
-                var temp = prepareTempCopy(osz_path);
+                    var temp = prepareTempCopy(osz_path);
 
-                Assert.IsTrue(File.Exists(temp));
+                    Assert.IsTrue(File.Exists(temp));
 
-                var importer = new BeatmapIPCChannel(client);
-                if (!importer.ImportAsync(temp).Wait(10000))
-                    Assert.Fail(@"IPC took too long to send");
+                    var importer = new BeatmapIPCChannel(client);
+                    if (!importer.ImportAsync(temp).Wait(10000))
+                        Assert.Fail(@"IPC took too long to send");
 
-                ensureLoaded(osu);
+                    ensureLoaded(osu);
 
-                waitForOrAssert(() => !File.Exists(temp), "Temporary still exists after IPC import", 5000);
-
-                host.Exit();
+                    waitForOrAssert(() => !File.Exists(temp), "Temporary still exists after IPC import", 5000);
+                }
+                finally
+                {
+                    host.Exit();
+                }
             }
         }
 
@@ -144,22 +164,21 @@ namespace osu.Game.Tests.Beatmaps.IO
         {
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportWhenFileOpen"))
             {
-                var osu = loadOsu(host);
-
-                var temp = prepareTempCopy(osz_path);
-
-                Assert.IsTrue(File.Exists(temp), "Temporary file copy never substantiated");
-
-                using (File.OpenRead(temp))
-                    osu.Dependencies.Get<BeatmapManager>().Import(temp);
-
-                ensureLoaded(osu);
-
-                File.Delete(temp);
-
-                Assert.IsFalse(File.Exists(temp), "We likely held a read lock on the file when we shouldn't");
-
-                host.Exit();
+                try
+                {
+                    var osu = loadOsu(host);
+                    var temp = prepareTempCopy(osz_path);
+                    Assert.IsTrue(File.Exists(temp), "Temporary file copy never substantiated");
+                    using (File.OpenRead(temp))
+                        osu.Dependencies.Get<BeatmapManager>().Import(temp);
+                    ensureLoaded(osu);
+                    File.Delete(temp);
+                    Assert.IsFalse(File.Exists(temp), "We likely held a read lock on the file when we shouldn't");
+                }
+                finally
+                {
+                    host.Exit();
+                }
             }
         }
 
@@ -173,58 +192,44 @@ namespace osu.Game.Tests.Beatmaps.IO
         {
             var osu = new OsuGameBase();
             Task.Run(() => host.Run(osu));
-
             waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
-
             return osu;
         }
 
         private void ensureLoaded(OsuGameBase osu, int timeout = 60000)
         {
             IEnumerable<BeatmapSetInfo> resultSets = null;
-
             var store = osu.Dependencies.Get<BeatmapManager>();
-
             waitForOrAssert(() => (resultSets = store.QueryBeatmapSets(s => s.OnlineBeatmapSetID == 241526)).Any(),
                 @"BeatmapSet did not import to the database in allocated time.", timeout);
 
             //ensure we were stored to beatmap database backing...
             Assert.IsTrue(resultSets.Count() == 1, $@"Incorrect result count found ({resultSets.Count()} but should be 1).");
-
             IEnumerable<BeatmapInfo> queryBeatmaps() => store.QueryBeatmaps(s => s.BeatmapSet.OnlineBeatmapSetID == 241526 && s.BaseDifficultyID > 0);
             IEnumerable<BeatmapSetInfo> queryBeatmapSets() => store.QueryBeatmapSets(s => s.OnlineBeatmapSetID == 241526);
 
             //if we don't re-check here, the set will be inserted but the beatmaps won't be present yet.
             waitForOrAssert(() => queryBeatmaps().Count() == 12,
                 @"Beatmaps did not import to the database in allocated time", timeout);
-
             waitForOrAssert(() => queryBeatmapSets().Count() == 1,
                 @"BeatmapSet did not import to the database in allocated time", timeout);
-
             int countBeatmapSetBeatmaps = 0;
             int countBeatmaps = 0;
-
             waitForOrAssert(() =>
                     (countBeatmapSetBeatmaps = queryBeatmapSets().First().Beatmaps.Count) ==
                     (countBeatmaps = queryBeatmaps().Count()),
                 $@"Incorrect database beatmap count post-import ({countBeatmaps} but should be {countBeatmapSetBeatmaps}).", timeout);
 
             var set = queryBeatmapSets().First();
-
             foreach (BeatmapInfo b in set.Beatmaps)
                 Assert.IsTrue(set.Beatmaps.Any(c => c.OnlineBeatmapID == b.OnlineBeatmapID));
-
             Assert.IsTrue(set.Beatmaps.Count > 0);
-
             var beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 0))?.Beatmap;
             Assert.IsTrue(beatmap?.HitObjects.Count > 0);
-
             beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 1))?.Beatmap;
             Assert.IsTrue(beatmap?.HitObjects.Count > 0);
-
             beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 2))?.Beatmap;
             Assert.IsTrue(beatmap?.HitObjects.Count > 0);
-
             beatmap = store.GetWorkingBeatmap(set.Beatmaps.First(b => b.RulesetID == 3))?.Beatmap;
             Assert.IsTrue(beatmap?.HitObjects.Count > 0);
         }
@@ -235,6 +240,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 while (!result()) Thread.Sleep(200);
             };
+
             Assert.IsTrue(waitAction.BeginInvoke(null, null).AsyncWaitHandle.WaitOne(timeout), failureMessage);
         }
     }

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -88,6 +88,40 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
+        public void TestImportThenImportDifferentHash()
+        {
+            //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenImportDifferentHash"))
+            {
+                try
+                {
+                    var osu = loadOsu(host);
+                    var manager = osu.Dependencies.Get<BeatmapManager>();
+
+                    var imported = loadOszIntoOsu(osu);
+
+                    //var change = manager.QueryBeatmapSets(_ => true).First();
+                    imported.Hash += "-changed";
+                    manager.Update(imported);
+
+                    var importedSecondTime = loadOszIntoOsu(osu);
+
+                    // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
+                    Assert.IsTrue(imported.ID == importedSecondTime.ID);
+                    Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
+
+
+                    Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 1);
+                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
         public void TestImportThenDeleteThenImport()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     manager.Delete(imported.First());
 
                     Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 0);
-                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count() == 1);
+                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
                     Assert.IsTrue(manager.QueryBeatmapSets(_ => true).First().DeletePending);
 
                     temp = prepareTempCopy(osz_path);

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -59,6 +59,35 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
+        public void TestImportThenImport()
+        {
+            //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenDeleteThenImport"))
+            {
+                try
+                {
+                    var osu = loadOsu(host);
+
+                    var imported = loadOszIntoOsu(osu);
+                    var importedSecondTime = loadOszIntoOsu(osu);
+
+                    // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
+                    Assert.IsTrue(imported.ID == importedSecondTime.ID);
+                    Assert.IsTrue(imported.Beatmaps.First().ID == importedSecondTime.Beatmaps.First().ID);
+
+                    var manager = osu.Dependencies.Get<BeatmapManager>();
+
+                    Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 1);
+                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
         public void TestImportThenDeleteThenImport()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         public void TestImportThenImport()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
-            using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenDeleteThenImport"))
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenImport"))
             {
                 try
                 {

--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -63,12 +63,10 @@ namespace osu.Game.Tests.Visual
             var storage = new TestStorage(@"TestCasePlaySongSelect");
 
             // this is by no means clean. should be replacing inside of OsuGameBase somehow.
-            var context = new OsuDbContext();
+            DatabaseContextFactory factory = new SingletonContextFactory(new OsuDbContext());
 
-            OsuDbContext contextFactory() => context;
-
-            dependencies.Cache(rulesets = new RulesetStore(contextFactory));
-            dependencies.Cache(manager = new BeatmapManager(storage, contextFactory, rulesets, null)
+            dependencies.Cache(rulesets = new RulesetStore(factory));
+            dependencies.Cache(manager = new BeatmapManager(storage, factory, rulesets, null)
             {
                 DefaultBeatmap = defaultBeatmap = game.Beatmap.Default
             });

--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual
             var storage = new TestStorage(@"TestCasePlaySongSelect");
 
             // this is by no means clean. should be replacing inside of OsuGameBase somehow.
-            DatabaseContextFactory factory = new SingletonContextFactory(new OsuDbContext());
+            IDatabaseContextFactory factory = new SingletonContextFactory(new OsuDbContext());
 
             dependencies.Cache(rulesets = new RulesetStore(factory));
             dependencies.Cache(manager = new BeatmapManager(storage, factory, rulesets, null)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public WorkingBeatmap DefaultBeatmap { private get; set; }
 
-        private readonly DatabaseContextFactory contextFactory;
+        private readonly IDatabaseContextFactory contextFactory;
 
         private readonly FileStore files;
 
@@ -85,7 +85,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public Func<Storage> GetStableStorage { private get; set; }
 
-        public BeatmapManager(Storage storage, DatabaseContextFactory contextFactory, RulesetStore rulesets, APIAccess api, IIpcHost importHost = null)
+        public BeatmapManager(Storage storage, IDatabaseContextFactory contextFactory, RulesetStore rulesets, APIAccess api, IIpcHost importHost = null)
         {
             this.contextFactory = contextFactory;
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -503,6 +503,9 @@ namespace osu.Game.Beatmaps
         /// <returns>Results from the provided query.</returns>
         public IEnumerable<BeatmapInfo> QueryBeatmaps(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.AsNoTracking().Where(query);
 
+        /// <summary>
+        /// Import a <see cref="BeatmapSetInfo"/> into the beatmap store.
+        /// </summary>
         private void import(BeatmapSetInfo beatmapSet, OsuDbContext context) => getBeatmapStoreWithContext(context).Add(beatmapSet);
 
         /// <summary>
@@ -530,10 +533,8 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        ///
+        /// Create a <see cref="BeatmapSetInfo"/> from a provided archive.
         /// </summary>
-        /// <param name="reader"></param>
-        /// <returns></returns>
         private BeatmapSetInfo createBeatmapSetInfo(ArchiveReader reader)
         {
             // let's make sure there are actually .osu files to import.
@@ -553,6 +554,9 @@ namespace osu.Game.Beatmaps
             };
         }
 
+        /// <summary>
+        /// Create all required <see cref="FileInfo"/>s for the provided archive, adding them to the global file store.
+        /// </summary>
         private List<BeatmapSetFileInfo> createFileInfos(ArchiveReader reader, FileStore files)
         {
             List<BeatmapSetFileInfo> fileInfos = new List<BeatmapSetFileInfo>();

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -65,20 +65,6 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public WorkingBeatmap DefaultBeatmap { private get; set; }
 
-        private FileStore getFileStoreWithContext(OsuDbContext context) => new FileStore(() => context, files.Storage);
-
-        private BeatmapStore getBeatmapStoreWithContext(OsuDbContext context) => getBeatmapStoreWithContext(() => context);
-
-        private BeatmapStore getBeatmapStoreWithContext(Func<OsuDbContext> context)
-        {
-            var store = new BeatmapStore(context);
-            store.BeatmapSetAdded += s => BeatmapSetAdded?.Invoke(s);
-            store.BeatmapSetRemoved += s => BeatmapSetRemoved?.Invoke(s);
-            store.BeatmapHidden += b => BeatmapHidden?.Invoke(b);
-            store.BeatmapRestored += b => BeatmapRestored?.Invoke(b);
-            return store;
-        }
-
         private readonly Func<OsuDbContext> createContext;
 
         private readonly FileStore files;
@@ -496,6 +482,12 @@ namespace osu.Game.Beatmaps
         public BeatmapSetInfo Refresh(BeatmapSetInfo beatmapSet) => QueryBeatmapSet(s => s.ID == beatmapSet.ID);
 
         /// <summary>
+        /// Returns a list of all usable <see cref="BeatmapSetInfo"/>s.
+        /// </summary>
+        /// <returns>A list of available <see cref="BeatmapSetInfo"/>.</returns>
+        public List<BeatmapSetInfo> GetAllUsableBeatmapSets() => beatmaps.BeatmapSets.Where(s => !s.DeletePending).ToList();
+
+        /// <summary>
         /// Perform a lookup query on available <see cref="BeatmapSetInfo"/>s.
         /// </summary>
         /// <param name="query">The query.</param>
@@ -621,11 +613,19 @@ namespace osu.Game.Beatmaps
             return beatmapInfos;
         }
 
-        /// <summary>
-        /// Returns a list of all usable <see cref="BeatmapSetInfo"/>s.
-        /// </summary>
-        /// <returns>A list of available <see cref="BeatmapSetInfo"/>.</returns>
-        public List<BeatmapSetInfo> GetAllUsableBeatmapSets() => beatmaps.BeatmapSets.Where(s => !s.DeletePending).ToList();
+        private FileStore getFileStoreWithContext(OsuDbContext context) => new FileStore(() => context, files.Storage);
+
+        private BeatmapStore getBeatmapStoreWithContext(OsuDbContext context) => getBeatmapStoreWithContext(() => context);
+
+        private BeatmapStore getBeatmapStoreWithContext(Func<OsuDbContext> context)
+        {
+            var store = new BeatmapStore(context);
+            store.BeatmapSetAdded += s => BeatmapSetAdded?.Invoke(s);
+            store.BeatmapSetRemoved += s => BeatmapSetRemoved?.Invoke(s);
+            store.BeatmapHidden += b => BeatmapHidden?.Invoke(b);
+            store.BeatmapRestored += b => BeatmapRestored?.Invoke(b);
+            return store;
+        }
 
         protected class BeatmapManagerWorkingBeatmap : WorkingBeatmap
         {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Beatmaps
         /// This will post a notification tracking import progress.
         /// </summary>
         /// <param name="paths">One or more beatmap locations on disk.</param>
-        public void Import(params string[] paths)
+        public List<BeatmapSetInfo> Import(params string[] paths)
         {
             var notification = new ProgressNotification
             {
@@ -153,18 +153,20 @@ namespace osu.Game.Beatmaps
 
             PostNotification?.Invoke(notification);
 
+            List<BeatmapSetInfo> imported = new List<BeatmapSetInfo>();
+
             int i = 0;
             foreach (string path in paths)
             {
                 if (notification.State == ProgressNotificationState.Cancelled)
                     // user requested abort
-                    return;
+                    return imported;
 
                 try
                 {
                     notification.Text = $"Importing ({i} of {paths.Length})\n{Path.GetFileName(path)}";
                     using (ArchiveReader reader = getReaderFrom(path))
-                        Import(reader);
+                        imported.Add(Import(reader));
 
                     notification.Progress = (float)++i / paths.Length;
 
@@ -191,6 +193,7 @@ namespace osu.Game.Beatmaps
             }
 
             notification.State = ProgressNotificationState.Completed;
+            return imported;
         }
 
         private readonly object importContextLock = new object();

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// Import one or more <see cref="BeatmapSetInfo"/> from filesystem <paramref name="paths"/>.
-        /// This will post a notification tracking import progress.
+        /// This will post notifications tracking progress.
         /// </summary>
         /// <param name="paths">One or more beatmap locations on disk.</param>
         public List<BeatmapSetInfo> Import(params string[] paths)
@@ -250,6 +250,7 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// Downloads a beatmap.
+        /// This will post notifications tracking progress.
         /// </summary>
         /// <param name="beatmapSetInfo">The <see cref="BeatmapSetInfo"/> to be downloaded.</param>
         /// <param name="noVideo">Whether the beatmap should be downloaded without video. Defaults to false.</param>
@@ -361,6 +362,10 @@ namespace osu.Game.Beatmaps
             }
         }
 
+        /// <summary>
+        /// Restore all beatmaps that were previously deleted.
+        /// This will post notifications tracking progress.
+        /// </summary>
         public void UndeleteAll()
         {
             var deleteMaps = QueryBeatmapSets(bs => bs.DeletePending).ToList();
@@ -392,6 +397,10 @@ namespace osu.Game.Beatmaps
             notification.State = ProgressNotificationState.Completed;
         }
 
+        /// <summary>
+        /// Restore a beatmap that was previously deleted. Is a no-op if the beatmap is not in a deleted state, or has its protected flag set.
+        /// </summary>
+        /// <param name="beatmapSet">The beatmap to restore</param>
         public void Undelete(BeatmapSetInfo beatmapSet)
         {
             if (beatmapSet.Protected)
@@ -502,6 +511,9 @@ namespace osu.Game.Beatmaps
         /// <returns>Results from the provided query.</returns>
         public IEnumerable<BeatmapInfo> QueryBeatmaps(Expression<Func<BeatmapInfo, bool>> query) => beatmaps.Beatmaps.AsNoTracking().Where(query);
 
+        /// <summary>
+        /// Denotes whether an osu-stable installation is present to perform automated imports from.
+        /// </summary>
         public bool StableInstallationAvailable => GetStableStorage?.Invoke() != null;
 
         /// <summary>
@@ -520,6 +532,10 @@ namespace osu.Game.Beatmaps
             await Task.Factory.StartNew(() => Import(stable.GetDirectories("Songs")), TaskCreationOptions.LongRunning);
         }
 
+        /// <summary>
+        /// Delete all beatmaps.
+        /// This will post notifications tracking progress.
+        /// </summary>
         public void DeleteAll()
         {
             var maps = GetAllUsableBeatmapSets();
@@ -569,6 +585,9 @@ namespace osu.Game.Beatmaps
             return new LegacyFilesystemReader(path);
         }
 
+        /// <summary>
+        /// Create a SHA-2 hash from the provided archive based on contained beatmap filenames.
+        /// </summary>
         private string computeBeatmapSetHash(ArchiveReader reader)
         {
             // for now, concatenate all .osu files in the set to create a unique hash.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -191,8 +191,6 @@ namespace osu.Game.Beatmaps
                     var existingOnlineId = beatmaps.BeatmapSets.FirstOrDefault(b => b.OnlineBeatmapSetID == beatmapSet.OnlineBeatmapSetID);
                     if (existingOnlineId != null)
                     {
-                        // {Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException: Database operation expected to affect 1 row(s) but actually affected 0 row(s). Data may have been modified or deleted since entities were loaded. See http://go.microsoft.com/fwlink/?LinkId=527962…}
-
                         Delete(existingOnlineId);
                         beatmaps.Cleanup(s => s.ID == existingOnlineId.ID);
                     }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -588,11 +588,8 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Import a beamap into our local <see cref="FileStore"/> storage.
-        /// If the beatmap is already imported, the existing instance will be returned.
+        /// Create all required <see cref="BeatmapInfo"/>s for the provided archive.
         /// </summary>
-        /// <param name="reader">The beatmap archive to be read.</param>
-        /// <returns>The imported beatmap, or an existing instance if it is already present.</returns>
         private List<BeatmapInfo> createBeatmapDifficulties(ArchiveReader reader)
         {
             var beatmapInfos = new List<BeatmapInfo>();

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -210,7 +210,12 @@ namespace osu.Game.Beatmaps
                     {
                         var existingOnlineId = beatmaps.BeatmapSets.FirstOrDefault(b => b.OnlineBeatmapSetID == beatmapSet.OnlineBeatmapSetID);
                         if (existingOnlineId != null)
+                        {
+                            // {Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException: Database operation expected to affect 1 row(s) but actually affected 0 row(s). Data may have been modified or deleted since entities were loaded. See http://go.microsoft.com/fwlink/?LinkId=527962…}
+
                             Delete(existingOnlineId);
+                            beatmaps.Cleanup(s => s.ID == existingOnlineId.ID);
+                        }
                     }
 
                     beatmapSet.Files = createFileInfos(archive, getFileStoreWithContext(context));
@@ -331,6 +336,12 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmap">The <see cref="BeatmapSetInfo"/> whose download request is wanted.</param>
         /// <returns>The <see cref="DownloadBeatmapSetRequest"/> object if it exists, or null.</returns>
         public DownloadBeatmapSetRequest GetExistingDownload(BeatmapSetInfo beatmap) => currentDownloads.Find(d => d.BeatmapSet.OnlineBeatmapSetID == beatmap.OnlineBeatmapSetID);
+
+        /// <summary>
+        /// Update a BeatmapSetInfo with all changes. TODO: This only supports very basic updates currently.
+        /// </summary>
+        /// <param name="beatmapSet">The beatmap set to update.</param>
+        public void Update(BeatmapSetInfo beatmap) => beatmaps.Update(beatmap);
 
         /// <summary>
         /// Delete a beatmap from the manager.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -535,7 +535,7 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Create a SHA-2 hash from the provided archive based on contained beatmap filenames.
+        /// Create a SHA-2 hash from the provided archive based on contained beatmap (.osu) file content.
         /// </summary>
         private string computeBeatmapSetHash(ArchiveReader reader)
         {

--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
 using System.IO;
 using System.Linq;
 using osu.Framework.Audio.Track;

--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.Graphics.Textures;
+using osu.Game.Storyboards;
+
+namespace osu.Game.Beatmaps
+{
+    public partial class BeatmapManager
+    {
+        protected class BeatmapManagerWorkingBeatmap : WorkingBeatmap
+        {
+            private readonly IResourceStore<byte[]> store;
+
+            public BeatmapManagerWorkingBeatmap(IResourceStore<byte[]> store, BeatmapInfo beatmapInfo)
+                : base(beatmapInfo)
+            {
+                this.store = store;
+            }
+
+            protected override Beatmap GetBeatmap()
+            {
+                try
+                {
+                    using (var stream = new StreamReader(store.GetStream(getPathForFile(BeatmapInfo.Path))))
+                    {
+                        Decoder decoder = Decoder.GetDecoder(stream);
+                        return decoder.DecodeBeatmap(stream);
+                    }
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            private string getPathForFile(string filename) => BeatmapSetInfo.Files.First(f => string.Equals(f.Filename, filename, StringComparison.InvariantCultureIgnoreCase)).FileInfo.StoragePath;
+
+            protected override Texture GetBackground()
+            {
+                if (Metadata?.BackgroundFile == null)
+                    return null;
+
+                try
+                {
+                    return new LargeTextureStore(new RawTextureLoaderStore(store)).Get(getPathForFile(Metadata.BackgroundFile));
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            protected override Track GetTrack()
+            {
+                try
+                {
+                    var trackData = store.GetStream(getPathForFile(Metadata.AudioFile));
+                    return trackData == null ? null : new TrackBass(trackData);
+                }
+                catch
+                {
+                    return new TrackVirtual();
+                }
+            }
+
+            protected override Waveform GetWaveform() => new Waveform(store.GetStream(getPathForFile(Metadata.AudioFile)));
+
+            protected override Storyboard GetStoryboard()
+            {
+                try
+                {
+                    using (var beatmap = new StreamReader(store.GetStream(getPathForFile(BeatmapInfo.Path))))
+                    {
+                        Decoder decoder = Decoder.GetDecoder(beatmap);
+
+                        if (BeatmapSetInfo?.StoryboardFile == null)
+                            return decoder.GetStoryboardDecoder().DecodeStoryboard(beatmap);
+
+                        using (var storyboard = new StreamReader(store.GetStream(getPathForFile(BeatmapSetInfo.StoryboardFile))))
+                            return decoder.GetStoryboardDecoder().DecodeStoryboard(beatmap, storyboard);
+                    }
+                }
+                catch
+                {
+                    return new Storyboard();
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Beatmaps
         public event Action<BeatmapInfo> BeatmapHidden;
         public event Action<BeatmapInfo> BeatmapRestored;
 
-        public BeatmapStore(Func<OsuDbContext> factory)
+        public BeatmapStore(DatabaseContextFactory factory)
             : base(factory)
         {
         }
@@ -31,24 +31,25 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapSet">The beatmap to add.</param>
         public void Add(BeatmapSetInfo beatmapSet)
         {
-            var context = GetContext();
-
-            foreach (var beatmap in beatmapSet.Beatmaps.Where(b => b.Metadata != null))
+            using (var db = ContextFactory.GetForWrite())
             {
-                // If we detect a new metadata object it'll be attached to the current context so it can be reused
-                // to prevent duplicate entries when persisting. To accomplish this we look in the cache (.Local)
-                // of the corresponding table (.Set<BeatmapMetadata>()) for matching entries to our criteria.
-                var contextMetadata = context.Set<BeatmapMetadata>().Local.SingleOrDefault(e => e.Equals(beatmap.Metadata));
-                if (contextMetadata != null)
-                    beatmap.Metadata = contextMetadata;
-                else
-                    context.BeatmapMetadata.Attach(beatmap.Metadata);
+                var context = db.Context;
+
+                foreach (var beatmap in beatmapSet.Beatmaps.Where(b => b.Metadata != null))
+                {
+                    // If we detect a new metadata object it'll be attached to the current context so it can be reused
+                    // to prevent duplicate entries when persisting. To accomplish this we look in the cache (.Local)
+                    // of the corresponding table (.Set<BeatmapMetadata>()) for matching entries to our criteria.
+                    var contextMetadata = context.Set<BeatmapMetadata>().Local.SingleOrDefault(e => e.Equals(beatmap.Metadata));
+                    if (contextMetadata != null)
+                        beatmap.Metadata = contextMetadata;
+                    else
+                        context.BeatmapMetadata.Attach(beatmap.Metadata);
+                }
+
+                context.BeatmapSetInfo.Attach(beatmapSet);
+                BeatmapSetAdded?.Invoke(beatmapSet);
             }
-
-            context.BeatmapSetInfo.Attach(beatmapSet);
-            context.SaveChanges();
-
-            BeatmapSetAdded?.Invoke(beatmapSet);
         }
 
         /// <summary>
@@ -59,10 +60,8 @@ namespace osu.Game.Beatmaps
         {
             BeatmapSetRemoved?.Invoke(beatmapSet);
 
-            var context = GetContext();
-
-            context.BeatmapSetInfo.Update(beatmapSet);
-            context.SaveChanges();
+            using (var usage = ContextFactory.GetForWrite())
+                usage.Context.BeatmapSetInfo.Update(beatmapSet);
 
             BeatmapSetAdded?.Invoke(beatmapSet);
         }
@@ -74,13 +73,13 @@ namespace osu.Game.Beatmaps
         /// <returns>Whether the beatmap's <see cref="BeatmapSetInfo.DeletePending"/> was changed.</returns>
         public bool Delete(BeatmapSetInfo beatmapSet)
         {
-            var context = GetContext();
+            using ( ContextFactory.GetForWrite())
+            {
+                Refresh(ref beatmapSet, BeatmapSets);
 
-            Refresh(ref beatmapSet, BeatmapSets);
-
-            if (beatmapSet.DeletePending) return false;
-            beatmapSet.DeletePending = true;
-            context.SaveChanges();
+                if (beatmapSet.DeletePending) return false;
+                beatmapSet.DeletePending = true;
+            }
 
             BeatmapSetRemoved?.Invoke(beatmapSet);
             return true;
@@ -93,13 +92,13 @@ namespace osu.Game.Beatmaps
         /// <returns>Whether the beatmap's <see cref="BeatmapSetInfo.DeletePending"/> was changed.</returns>
         public bool Undelete(BeatmapSetInfo beatmapSet)
         {
-            var context = GetContext();
+            using ( ContextFactory.GetForWrite())
+            {
+                Refresh(ref beatmapSet, BeatmapSets);
 
-            Refresh(ref beatmapSet, BeatmapSets);
-
-            if (!beatmapSet.DeletePending) return false;
-            beatmapSet.DeletePending = false;
-            context.SaveChanges();
+                if (!beatmapSet.DeletePending) return false;
+                beatmapSet.DeletePending = false;
+            }
 
             BeatmapSetAdded?.Invoke(beatmapSet);
             return true;
@@ -112,15 +111,16 @@ namespace osu.Game.Beatmaps
         /// <returns>Whether the beatmap's <see cref="BeatmapInfo.Hidden"/> was changed.</returns>
         public bool Hide(BeatmapInfo beatmap)
         {
-            var context = GetContext();
+            using (ContextFactory.GetForWrite())
+            {
+                Refresh(ref beatmap, Beatmaps);
 
-            Refresh(ref beatmap, Beatmaps);
+                if (beatmap.Hidden) return false;
+                beatmap.Hidden = true;
 
-            if (beatmap.Hidden) return false;
-            beatmap.Hidden = true;
-            context.SaveChanges();
+                BeatmapHidden?.Invoke(beatmap);
+            }
 
-            BeatmapHidden?.Invoke(beatmap);
             return true;
         }
 
@@ -131,13 +131,13 @@ namespace osu.Game.Beatmaps
         /// <returns>Whether the beatmap's <see cref="BeatmapInfo.Hidden"/> was changed.</returns>
         public bool Restore(BeatmapInfo beatmap)
         {
-            var context = GetContext();
+            using (ContextFactory.GetForWrite())
+            {
+                Refresh(ref beatmap, Beatmaps);
 
-            Refresh(ref beatmap, Beatmaps);
-
-            if (!beatmap.Hidden) return false;
-            beatmap.Hidden = false;
-            context.SaveChanges();
+                if (!beatmap.Hidden) return false;
+                beatmap.Hidden = false;
+            }
 
             BeatmapRestored?.Invoke(beatmap);
             return true;
@@ -147,34 +147,36 @@ namespace osu.Game.Beatmaps
 
         public void Cleanup(Expression<Func<BeatmapSetInfo, bool>> query)
         {
-            var context = GetContext();
+            using (var usage = ContextFactory.GetForWrite())
+            {
+                var context = usage.Context;
 
-            var purgeable = context.BeatmapSetInfo.Where(s => s.DeletePending && !s.Protected)
-                                   .Where(query)
-                                   .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
-                                   .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
-                                   .Include(s => s.Metadata);
+                var purgeable = context.BeatmapSetInfo.Where(s => s.DeletePending && !s.Protected)
+                                       .Where(query)
+                                       .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
+                                       .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
+                                       .Include(s => s.Metadata);
 
-            // metadata is M-N so we can't rely on cascades
-            context.BeatmapMetadata.RemoveRange(purgeable.Select(s => s.Metadata));
-            context.BeatmapMetadata.RemoveRange(purgeable.SelectMany(s => s.Beatmaps.Select(b => b.Metadata).Where(m => m != null)));
+                // metadata is M-N so we can't rely on cascades
+                context.BeatmapMetadata.RemoveRange(purgeable.Select(s => s.Metadata));
+                context.BeatmapMetadata.RemoveRange(purgeable.SelectMany(s => s.Beatmaps.Select(b => b.Metadata).Where(m => m != null)));
 
-            // todo: we can probably make cascades work here with a FK in BeatmapDifficulty. just make to make it work correctly.
-            context.BeatmapDifficulty.RemoveRange(purgeable.SelectMany(s => s.Beatmaps.Select(b => b.BaseDifficulty)));
+                // todo: we can probably make cascades work here with a FK in BeatmapDifficulty. just make to make it work correctly.
+                context.BeatmapDifficulty.RemoveRange(purgeable.SelectMany(s => s.Beatmaps.Select(b => b.BaseDifficulty)));
 
-            // cascades down to beatmaps.
-            context.BeatmapSetInfo.RemoveRange(purgeable);
-            context.SaveChanges();
+                // cascades down to beatmaps.
+                context.BeatmapSetInfo.RemoveRange(purgeable);
+            }
         }
 
-        public IQueryable<BeatmapSetInfo> BeatmapSets => GetContext().BeatmapSetInfo
+        public IQueryable<BeatmapSetInfo> BeatmapSets => ContextFactory.Get().BeatmapSetInfo
                                                                      .Include(s => s.Metadata)
                                                                      .Include(s => s.Beatmaps).ThenInclude(s => s.Ruleset)
                                                                      .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
                                                                      .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
                                                                      .Include(s => s.Files).ThenInclude(f => f.FileInfo);
 
-        public IQueryable<BeatmapInfo> Beatmaps => GetContext().BeatmapInfo
+        public IQueryable<BeatmapInfo> Beatmaps => ContextFactory.Get().BeatmapInfo
                                                                .Include(b => b.BeatmapSet).ThenInclude(s => s.Metadata)
                                                                .Include(b => b.BeatmapSet).ThenInclude(s => s.Files).ThenInclude(f => f.FileInfo)
                                                                .Include(b => b.Metadata)

--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Beatmaps
         public event Action<BeatmapInfo> BeatmapHidden;
         public event Action<BeatmapInfo> BeatmapRestored;
 
-        public BeatmapStore(DatabaseContextFactory factory)
+        public BeatmapStore(IDatabaseContextFactory factory)
             : base(factory)
         {
         }

--- a/osu.Game/Database/DatabaseBackedStore.cs
+++ b/osu.Game/Database/DatabaseBackedStore.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using osu.Framework.Platform;
 
@@ -17,9 +15,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Create a new <see cref="OsuDbContext"/> instance (separate from the shared context via <see cref="GetContext"/> for performing isolated operations.
         /// </summary>
-        protected readonly Func<OsuDbContext> CreateContext;
-
-        private readonly ThreadLocal<OsuDbContext> queryContext;
+        protected readonly DatabaseContextFactory ContextFactory;
 
         /// <summary>
         /// Refresh an instance potentially from a different thread with a local context-tracked instance.
@@ -29,33 +25,27 @@ namespace osu.Game.Database
         /// <typeparam name="T">A valid EF-stored type.</typeparam>
         protected virtual void Refresh<T>(ref T obj, IEnumerable<T> lookupSource = null) where T : class, IHasPrimaryKey
         {
-            var context = GetContext();
-
-            if (context.Entry(obj).State != EntityState.Detached) return;
-
-            var id = obj.ID;
-            var foundObject = lookupSource?.SingleOrDefault(t => t.ID == id) ?? context.Find<T>(id);
-            if (foundObject != null)
+            using (var usage = ContextFactory.GetForWrite())
             {
-                obj = foundObject;
-                context.Entry(obj).Reload();
+                var context = usage.Context;
+
+                if (context.Entry(obj).State != EntityState.Detached) return;
+
+                var id = obj.ID;
+                var foundObject = lookupSource?.SingleOrDefault(t => t.ID == id) ?? context.Find<T>(id);
+                if (foundObject != null)
+                {
+                    obj = foundObject;
+                    context.Entry(obj).Reload();
+                }
+                else
+                    context.Add(obj);
             }
-            else
-                context.Add(obj);
         }
 
-        /// <summary>
-        /// Retrieve a shared context for performing lookups (or write operations on the update thread, for now).
-        /// </summary>
-        protected OsuDbContext GetContext() => queryContext.Value;
-
-        protected DatabaseBackedStore(Func<OsuDbContext> createContext, Storage storage = null)
+        protected DatabaseBackedStore(DatabaseContextFactory contextFactory, Storage storage = null)
         {
-            CreateContext = createContext;
-
-            // todo: while this seems to work quite well, we need to consider that contexts could enter a state where they are never cleaned up.
-            queryContext = new ThreadLocal<OsuDbContext>(CreateContext);
-
+            ContextFactory = contextFactory;
             Storage = storage;
         }
 

--- a/osu.Game/Database/DatabaseBackedStore.cs
+++ b/osu.Game/Database/DatabaseBackedStore.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Create a new <see cref="OsuDbContext"/> instance (separate from the shared context via <see cref="GetContext"/> for performing isolated operations.
         /// </summary>
-        protected readonly DatabaseContextFactory ContextFactory;
+        protected readonly IDatabaseContextFactory ContextFactory;
 
         /// <summary>
         /// Refresh an instance potentially from a different thread with a local context-tracked instance.
@@ -40,7 +40,7 @@ namespace osu.Game.Database
             }
         }
 
-        protected DatabaseBackedStore(DatabaseContextFactory contextFactory, Storage storage = null)
+        protected DatabaseBackedStore(IDatabaseContextFactory contextFactory, Storage storage = null)
         {
             ContextFactory = contextFactory;
             Storage = storage;

--- a/osu.Game/Database/DatabaseBackedStore.cs
+++ b/osu.Game/Database/DatabaseBackedStore.cs
@@ -34,10 +34,7 @@ namespace osu.Game.Database
                 var id = obj.ID;
                 var foundObject = lookupSource?.SingleOrDefault(t => t.ID == id) ?? context.Find<T>(id);
                 if (foundObject != null)
-                {
                     obj = foundObject;
-                    context.Entry(obj).Reload();
-                }
                 else
                     context.Add(obj);
             }

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Diagnostics;
 using System.Threading;
 using osu.Framework.Platform;
 
@@ -42,7 +41,6 @@ namespace osu.Game.Database
         {
             Monitor.Enter(writeLock);
 
-            Trace.Assert(currentWriteUsages == 0, "Database writes in a bad state");
             Interlocked.Increment(ref currentWriteUsages);
 
             return new DatabaseWriteUsage(writeContext ?? (writeContext = threadContexts.Value), usageCompleted);

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -6,7 +6,7 @@ using osu.Framework.Platform;
 
 namespace osu.Game.Database
 {
-    public class DatabaseContextFactory
+    public class DatabaseContextFactory : IDatabaseContextFactory
     {
         private readonly GameHost host;
 

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -56,7 +56,11 @@ namespace osu.Game.Database
 
                 if (currentWriteDidWrite)
                 {
+                    // explicitly dispose to ensure any outstanding flushes happen as soon as possible (and underlying resources are purged).
+                    usage.Context.Dispose();
+
                     currentWriteDidWrite = false;
+
                     // once all writes are complete, we want to refresh thread-specific contexts to make sure they don't have stale local caches.
                     recycleThreadContexts();
                 }
@@ -67,14 +71,7 @@ namespace osu.Game.Database
             }
         }
 
-        private void recycleThreadContexts()
-        {
-            if (threadContexts != null)
-                foreach (var context in threadContexts.Values)
-                    context.Dispose();
-
-            threadContexts = new ThreadLocal<OsuDbContext>(CreateContext, true);
-        }
+        private void recycleThreadContexts() => threadContexts = new ThreadLocal<OsuDbContext>(CreateContext);
 
         protected virtual OsuDbContext CreateContext()
         {

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Threading;
 using osu.Framework.Platform;
 
 namespace osu.Game.Database
@@ -11,17 +12,70 @@ namespace osu.Game.Database
 
         private const string database_name = @"client";
 
+        private ThreadLocal<OsuDbContext> threadContexts;
+
+        private readonly object writeLock = new object();
+
+        private OsuDbContext writeContext;
+
+        private volatile int currentWriteUsages;
+
         public DatabaseContextFactory(GameHost host)
         {
             this.host = host;
+            recycleThreadContexts();
         }
 
-        public OsuDbContext GetContext() => new OsuDbContext(host.Storage.GetDatabaseConnectionString(database_name));
+        /// <summary>
+        /// Get a context for read-only usage.
+        /// </summary>
+        public OsuDbContext Get() => threadContexts.Value;
+
+        /// <summary>
+        /// Request a context for write usage. Can be consumed in a nested fashion (and will return the same underlying context).
+        /// This method may block if a write is already active on a different thread.
+        /// </summary>
+        /// <returns>A usage containing a usable context.</returns>
+        public DatabaseWriteUsage GetForWrite()
+        {
+            lock (writeLock)
+            {
+                var usage = new DatabaseWriteUsage(writeContext ?? (writeContext = threadContexts.Value), usageCompleted);
+                Interlocked.Increment(ref currentWriteUsages);
+                return usage;
+            }
+        }
+
+        private void usageCompleted(DatabaseWriteUsage usage)
+        {
+            int usages = Interlocked.Decrement(ref currentWriteUsages);
+            if (usages == 0)
+            {
+                writeContext.Dispose();
+                writeContext = null;
+
+                // once all writes are complete, we want to refresh thread-specific contexts to make sure they don't have stale local caches.
+                recycleThreadContexts();
+            }
+        }
+
+        private void recycleThreadContexts() => threadContexts = new ThreadLocal<OsuDbContext>(CreateContext);
+
+        protected virtual OsuDbContext CreateContext()
+        {
+            var ctx = new OsuDbContext(host.Storage.GetDatabaseConnectionString(database_name));
+            ctx.Database.AutoTransactionsEnabled = false;
+
+            return ctx;
+        }
 
         public void ResetDatabase()
         {
-            // todo: we probably want to make sure there are no active contexts before performing this operation.
-            host.Storage.DeleteDatabase(database_name);
+            lock (writeLock)
+            {
+                recycleThreadContexts();
+                host.Storage.DeleteDatabase(database_name);
+            }
         }
     }
 }

--- a/osu.Game/Database/DatabaseWriteUsage.cs
+++ b/osu.Game/Database/DatabaseWriteUsage.cs
@@ -19,10 +19,28 @@ namespace osu.Game.Database
             usageCompleted = onCompleted;
         }
 
+        public bool PerformedWrite { get; private set; }
+
+        private bool isDisposed;
+
+        protected void Dispose(bool disposing)
+        {
+            if (isDisposed) return;
+            isDisposed = true;
+
+            PerformedWrite |= Context.SaveChanges(transaction) > 0;
+            usageCompleted?.Invoke(this);
+        }
+
         public void Dispose()
         {
-            Context.SaveChanges(transaction);
-            usageCompleted?.Invoke(this);
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~DatabaseWriteUsage()
+        {
+            Dispose(false);
         }
     }
 }

--- a/osu.Game/Database/DatabaseWriteUsage.cs
+++ b/osu.Game/Database/DatabaseWriteUsage.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace osu.Game.Database
+{
+    public class DatabaseWriteUsage : IDisposable
+    {
+        public readonly OsuDbContext Context;
+        private readonly IDbContextTransaction transaction;
+        private readonly Action<DatabaseWriteUsage> usageCompleted;
+
+        public DatabaseWriteUsage(OsuDbContext context, Action<DatabaseWriteUsage> onCompleted)
+        {
+            Context = context;
+            transaction = Context.BeginTransaction();
+            usageCompleted = onCompleted;
+        }
+
+        public void Dispose()
+        {
+            Context.SaveChanges(transaction);
+            usageCompleted?.Invoke(this);
+        }
+    }
+}

--- a/osu.Game/Database/IDatabaseContextFactory.cs
+++ b/osu.Game/Database/IDatabaseContextFactory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Game.Database
+{
+    public interface IDatabaseContextFactory
+    {
+        /// <summary>
+        /// Get a context for read-only usage.
+        /// </summary>
+        OsuDbContext Get();
+
+        /// <summary>
+        /// Request a context for write usage. Can be consumed in a nested fashion (and will return the same underlying context).
+        /// This method may block if a write is already active on a different thread.
+        /// </summary>
+        /// <returns>A usage containing a usable context.</returns>
+        DatabaseWriteUsage GetForWrite();
+    }
+}

--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -186,8 +186,6 @@ namespace osu.Game.Database
 
         public void Migrate()
         {
-            migrateFromSqliteNet();
-
             try
             {
                 Database.Migrate();
@@ -195,86 +193,6 @@ namespace osu.Game.Database
             catch (Exception e)
             {
                 throw new MigrationFailedException(e);
-            }
-        }
-
-        private void migrateFromSqliteNet()
-        {
-            try
-            {
-                // will fail if the database isn't in a sane EF-migrated state.
-                Database.ExecuteSqlCommand("SELECT MetadataID FROM BeatmapSetInfo LIMIT 1");
-            }
-            catch
-            {
-                try
-                {
-                    Database.ExecuteSqlCommand("DROP TABLE IF EXISTS __EFMigrationsHistory");
-
-                    // will fail (intentionally) if we don't have sqlite-net data present.
-                    Database.ExecuteSqlCommand("SELECT OnlineBeatmapSetId FROM BeatmapMetadata LIMIT 1");
-
-                    try
-                    {
-                        Logger.Log("Performing migration from sqlite-net to EF...", LoggingTarget.Database, Framework.Logging.LogLevel.Important);
-
-                        // we are good to perform messy migration of data!.
-                        Database.ExecuteSqlCommand("ALTER TABLE BeatmapDifficulty RENAME TO BeatmapDifficulty_Old");
-                        Database.ExecuteSqlCommand("ALTER TABLE BeatmapMetadata RENAME TO BeatmapMetadata_Old");
-                        Database.ExecuteSqlCommand("ALTER TABLE FileInfo RENAME TO FileInfo_Old");
-                        Database.ExecuteSqlCommand("ALTER TABLE KeyBinding RENAME TO KeyBinding_Old");
-                        Database.ExecuteSqlCommand("ALTER TABLE BeatmapSetInfo RENAME TO BeatmapSetInfo_Old");
-                        Database.ExecuteSqlCommand("ALTER TABLE BeatmapInfo RENAME TO BeatmapInfo_Old");
-                        Database.ExecuteSqlCommand("ALTER TABLE BeatmapSetFileInfo RENAME TO BeatmapSetFileInfo_Old");
-                        Database.ExecuteSqlCommand("ALTER TABLE RulesetInfo RENAME TO RulesetInfo_Old");
-
-                        Database.ExecuteSqlCommand("DROP TABLE StoreVersion");
-
-                        // perform EF migrations to create sane table structure.
-                        Database.Migrate();
-
-                        // copy data table by table to new structure, dropping old tables as we go.
-                        Database.ExecuteSqlCommand("INSERT INTO FileInfo SELECT * FROM FileInfo_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE FileInfo_Old");
-
-                        Database.ExecuteSqlCommand("INSERT INTO KeyBinding SELECT ID, [Action], Keys, RulesetID, Variant FROM KeyBinding_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE KeyBinding_Old");
-
-                        Database.ExecuteSqlCommand(
-                            "INSERT INTO BeatmapMetadata SELECT ID, Artist, ArtistUnicode, AudioFile, Author, BackgroundFile, PreviewTime, Source, Tags, Title, TitleUnicode FROM BeatmapMetadata_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE BeatmapMetadata_Old");
-
-                        Database.ExecuteSqlCommand(
-                            "INSERT INTO BeatmapDifficulty SELECT  `ID`, `ApproachRate`, `CircleSize`, `DrainRate`, `OverallDifficulty`, `SliderMultiplier`, `SliderTickRate` FROM BeatmapDifficulty_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE BeatmapDifficulty_Old");
-
-                        Database.ExecuteSqlCommand("INSERT INTO BeatmapSetInfo SELECT ID, DeletePending, Hash, BeatmapMetadataID, OnlineBeatmapSetID, Protected FROM BeatmapSetInfo_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE BeatmapSetInfo_Old");
-
-                        Database.ExecuteSqlCommand("INSERT INTO BeatmapSetFileInfo SELECT ID, BeatmapSetInfoID, FileInfoID, Filename FROM BeatmapSetFileInfo_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE BeatmapSetFileInfo_Old");
-
-                        Database.ExecuteSqlCommand("INSERT INTO RulesetInfo SELECT ID, Available, InstantiationInfo, Name FROM RulesetInfo_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE RulesetInfo_Old");
-
-                        Database.ExecuteSqlCommand(
-                            "INSERT INTO BeatmapInfo SELECT ID, AudioLeadIn, BaseDifficultyID, BeatDivisor, BeatmapSetInfoID, Countdown, DistanceSpacing, GridSize, Hash, IFNULL(Hidden, 0), LetterboxInBreaks, MD5Hash, NULLIF(BeatmapMetadataID, 0), NULLIF(OnlineBeatmapID, 0), Path, RulesetID, SpecialStyle, StackLeniency, StarDifficulty, StoredBookmarks, TimelineZoom, Version, WidescreenStoryboard FROM BeatmapInfo_Old");
-                        Database.ExecuteSqlCommand("DROP TABLE BeatmapInfo_Old");
-
-                        Logger.Log("Migration complete!", LoggingTarget.Database, Framework.Logging.LogLevel.Important);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new MigrationFailedException(e);
-                    }
-                }
-                catch (MigrationFailedException)
-                {
-                    throw;
-                }
-                catch
-                {
-                }
             }
         }
     }

--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Database
         public int SaveChanges(IDbContextTransaction transaction = null)
         {
             var ret = base.SaveChanges();
-            transaction?.Commit();
+            if (ret > 0) transaction?.Commit();
             return ret;
         }
 

--- a/osu.Game/Database/SingletonContextFactory.cs
+++ b/osu.Game/Database/SingletonContextFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Game.Database
+{
+    public class SingletonContextFactory : DatabaseContextFactory
+    {
+        private readonly OsuDbContext context;
+
+        public SingletonContextFactory(OsuDbContext context)
+            : base(null)
+        {
+            this.context = context;
+        }
+
+        protected override OsuDbContext CreateContext()
+        {
+            return context;
+        }
+    }
+}

--- a/osu.Game/Database/SingletonContextFactory.cs
+++ b/osu.Game/Database/SingletonContextFactory.cs
@@ -3,19 +3,17 @@
 
 namespace osu.Game.Database
 {
-    public class SingletonContextFactory : DatabaseContextFactory
+    public class SingletonContextFactory : IDatabaseContextFactory
     {
         private readonly OsuDbContext context;
 
         public SingletonContextFactory(OsuDbContext context)
-            : base(null)
         {
             this.context = context;
         }
 
-        protected override OsuDbContext CreateContext()
-        {
-            return context;
-        }
+        public OsuDbContext Get() => context;
+
+        public DatabaseWriteUsage GetForWrite() => new DatabaseWriteUsage(context, null);
     }
 }

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -21,86 +21,91 @@ namespace osu.Game.IO
 
         public new Storage Storage => base.Storage;
 
-        public FileStore(Func<OsuDbContext> createContext, Storage storage) : base(createContext, storage.GetStorageForDirectory(@"files"))
+        public FileStore(DatabaseContextFactory contextFactory, Storage storage) : base(contextFactory, storage.GetStorageForDirectory(@"files"))
         {
             Store = new StorageBackedResourceStore(Storage);
         }
 
         public FileInfo Add(Stream data, bool reference = true)
         {
-            var context = GetContext();
-
-            string hash = data.ComputeSHA2Hash();
-
-            var existing = context.FileInfo.FirstOrDefault(f => f.Hash == hash);
-
-            var info = existing ?? new FileInfo { Hash = hash };
-
-            string path = info.StoragePath;
-
-            // we may be re-adding a file to fix missing store entries.
-            if (!Storage.Exists(path))
+            using (var usage = ContextFactory.GetForWrite())
             {
-                data.Seek(0, SeekOrigin.Begin);
+                var context = usage.Context;
 
-                using (var output = Storage.GetStream(path, FileAccess.Write))
-                    data.CopyTo(output);
+                string hash = data.ComputeSHA2Hash();
 
-                data.Seek(0, SeekOrigin.Begin);
+                var existing = context.FileInfo.FirstOrDefault(f => f.Hash == hash);
+
+                var info = existing ?? new FileInfo { Hash = hash };
+
+                string path = info.StoragePath;
+
+                // we may be re-adding a file to fix missing store entries.
+                if (!Storage.Exists(path))
+                {
+                    data.Seek(0, SeekOrigin.Begin);
+
+                    using (var output = Storage.GetStream(path, FileAccess.Write))
+                        data.CopyTo(output);
+
+                    data.Seek(0, SeekOrigin.Begin);
+                }
+
+                if (reference || existing == null)
+                    Reference(info);
+
+                return info;
             }
-
-            if (reference || existing == null)
-                Reference(info);
-
-            return info;
         }
 
-        public void Reference(params FileInfo[] files) => reference(GetContext(), files);
-
-        private void reference(OsuDbContext context, FileInfo[] files)
+        public void Reference(params FileInfo[] files)
         {
-            foreach (var f in files.GroupBy(f => f.ID))
+            using (var usage = ContextFactory.GetForWrite())
             {
-                var refetch = context.Find<FileInfo>(f.First().ID) ?? f.First();
-                refetch.ReferenceCount += f.Count();
-                context.FileInfo.Update(refetch);
-            }
+                var context = usage.Context;
 
-            context.SaveChanges();
+                foreach (var f in files.GroupBy(f => f.ID))
+                {
+                    var refetch = context.Find<FileInfo>(f.First().ID) ?? f.First();
+                    refetch.ReferenceCount += f.Count();
+                    context.FileInfo.Update(refetch);
+                }
+            }
         }
 
-        public void Dereference(params FileInfo[] files) => dereference(GetContext(), files);
-
-        private void dereference(OsuDbContext context, FileInfo[] files)
+        public void Dereference(params FileInfo[] files)
         {
-            foreach (var f in files.GroupBy(f => f.ID))
+            using (var usage = ContextFactory.GetForWrite())
             {
-                var refetch = context.FileInfo.Find(f.Key);
-                refetch.ReferenceCount -= f.Count();
-                context.FileInfo.Update(refetch);
+                var context = usage.Context;
+                foreach (var f in files.GroupBy(f => f.ID))
+                {
+                    var refetch = context.FileInfo.Find(f.Key);
+                    refetch.ReferenceCount -= f.Count();
+                    context.FileInfo.Update(refetch);
+                }
             }
-
-            context.SaveChanges();
         }
 
         public override void Cleanup()
         {
-            var context = GetContext();
-
-            foreach (var f in context.FileInfo.Where(f => f.ReferenceCount < 1))
+            using (var usage = ContextFactory.GetForWrite())
             {
-                try
+                var context = usage.Context;
+
+                foreach (var f in context.FileInfo.Where(f => f.ReferenceCount < 1))
                 {
-                    Storage.Delete(f.StoragePath);
-                    context.FileInfo.Remove(f);
-                }
-                catch (Exception e)
-                {
-                    Logger.Error(e, $@"Could not delete beatmap {f}");
+                    try
+                    {
+                        Storage.Delete(f.StoragePath);
+                        context.FileInfo.Remove(f);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, $@"Could not delete beatmap {f}");
+                    }
                 }
             }
-
-            context.SaveChanges();
         }
     }
 }

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -30,11 +30,9 @@ namespace osu.Game.IO
         {
             using (var usage = ContextFactory.GetForWrite())
             {
-                var context = usage.Context;
-
                 string hash = data.ComputeSHA2Hash();
 
-                var existing = context.FileInfo.FirstOrDefault(f => f.Hash == hash);
+                var existing = usage.Context.FileInfo.FirstOrDefault(f => f.Hash == hash);
 
                 var info = existing ?? new FileInfo { Hash = hash };
 
@@ -60,6 +58,8 @@ namespace osu.Game.IO
 
         public void Reference(params FileInfo[] files)
         {
+            if (files.Length == 0) return;
+
             using (var usage = ContextFactory.GetForWrite())
             {
                 var context = usage.Context;
@@ -75,9 +75,12 @@ namespace osu.Game.IO
 
         public void Dereference(params FileInfo[] files)
         {
+            if (files.Length == 0) return;
+
             using (var usage = ContextFactory.GetForWrite())
             {
                 var context = usage.Context;
+
                 foreach (var f in files.GroupBy(f => f.ID))
                 {
                     var refetch = context.FileInfo.Find(f.Key);

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -21,7 +21,7 @@ namespace osu.Game.IO
 
         public new Storage Storage => base.Storage;
 
-        public FileStore(DatabaseContextFactory contextFactory, Storage storage) : base(contextFactory, storage.GetStorageForDirectory(@"files"))
+        public FileStore(IDatabaseContextFactory contextFactory, Storage storage) : base(contextFactory, storage.GetStorageForDirectory(@"files"))
         {
             Store = new StorageBackedResourceStore(Storage);
         }

--- a/osu.Game/Input/KeyBindingStore.cs
+++ b/osu.Game/Input/KeyBindingStore.cs
@@ -36,8 +36,6 @@ namespace osu.Game.Input
         {
             using (var usage = ContextFactory.GetForWrite())
             {
-                var context = usage.Context;
-
                 // compare counts in database vs defaults
                 foreach (var group in defaults.GroupBy(k => k.Action))
                 {
@@ -49,7 +47,7 @@ namespace osu.Game.Input
 
                     foreach (var insertable in group.Skip(count).Take(aimCount - count))
                         // insert any defaults which are missing.
-                        context.DatabasedKeyBinding.Add(new DatabasedKeyBinding
+                        usage.Context.DatabasedKeyBinding.Add(new DatabasedKeyBinding
                         {
                             KeyCombination = insertable.KeyCombination,
                             Action = insertable.Action,
@@ -75,6 +73,10 @@ namespace osu.Game.Input
             {
                 var dbKeyBinding = (DatabasedKeyBinding)keyBinding;
                 Refresh(ref dbKeyBinding);
+
+                if (dbKeyBinding.KeyCombination.Equals(keyBinding.KeyCombination))
+                    return;
+
                 dbKeyBinding.KeyCombination = keyBinding.KeyCombination;
             }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -218,7 +218,7 @@ namespace osu.Game
             CursorOverrideContainer.Child = globalBinding = new GlobalActionContainer(this)
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = content = new OsuTooltipContainer(CursorOverrideContainer.Cursor) { RelativeSizeAxes = Axes.Both　}
+                Child = content = new OsuTooltipContainer(CursorOverrideContainer.Cursor) { RelativeSizeAxes = Axes.Both }
             };
 
             base.Content.Add(new DrawSizePreservingFillContainer { Child = CursorOverrideContainer });

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -106,12 +106,12 @@ namespace osu.Game
                 Token = LocalConfig.Get<string>(OsuSetting.Token)
             });
 
-            dependencies.Cache(RulesetStore = new RulesetStore(contextFactory.GetContext));
-            dependencies.Cache(FileStore = new FileStore(contextFactory.GetContext, Host.Storage));
-            dependencies.Cache(BeatmapManager = new BeatmapManager(Host.Storage, contextFactory.GetContext, RulesetStore, API, Host));
-            dependencies.Cache(ScoreStore = new ScoreStore(Host.Storage, contextFactory.GetContext, Host, BeatmapManager, RulesetStore));
-            dependencies.Cache(KeyBindingStore = new KeyBindingStore(contextFactory.GetContext, RulesetStore));
-            dependencies.Cache(SettingsStore = new SettingsStore(contextFactory.GetContext));
+            dependencies.Cache(RulesetStore = new RulesetStore(contextFactory));
+            dependencies.Cache(FileStore = new FileStore(contextFactory, Host.Storage));
+            dependencies.Cache(BeatmapManager = new BeatmapManager(Host.Storage, contextFactory, RulesetStore, API, Host));
+            dependencies.Cache(ScoreStore = new ScoreStore(Host.Storage, contextFactory, Host, BeatmapManager, RulesetStore));
+            dependencies.Cache(KeyBindingStore = new KeyBindingStore(contextFactory, RulesetStore));
+            dependencies.Cache(SettingsStore = new SettingsStore(contextFactory));
             dependencies.Cache(new OsuColour());
 
             //this completely overrides the framework default. will need to change once we make a proper FontStore.
@@ -179,8 +179,8 @@ namespace osu.Game
         {
             try
             {
-                using (var context = contextFactory.GetContext())
-                    context.Migrate();
+                using (var db = contextFactory.GetForWrite())
+                    db.Context.Migrate();
             }
             catch (MigrationFailedException e)
             {
@@ -191,8 +191,8 @@ namespace osu.Game
                 contextFactory.ResetDatabase();
                 Logger.Log("Database purged successfully.", LoggingTarget.Database, LogLevel.Important);
 
-                using (var context = contextFactory.GetContext())
-                    context.Migrate();
+                using (var db = contextFactory.GetForWrite())
+                    db.Context.Migrate();
             }
         }
 

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets
                 loadRulesetFromFile(file);
         }
 
-        public RulesetStore(DatabaseContextFactory factory)
+        public RulesetStore(IDatabaseContextFactory factory)
             : base(factory)
         {
             AddMissingRulesets();

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets
                 loadRulesetFromFile(file);
         }
 
-        public RulesetStore(Func<OsuDbContext> factory)
+        public RulesetStore(DatabaseContextFactory factory)
             : base(factory)
         {
             AddMissingRulesets();
@@ -56,47 +56,50 @@ namespace osu.Game.Rulesets
 
         protected void AddMissingRulesets()
         {
-            var context = GetContext();
-
-            var instances = loaded_assemblies.Values.Select(r => (Ruleset)Activator.CreateInstance(r, (RulesetInfo)null)).ToList();
-
-            //add all legacy modes in correct order
-            foreach (var r in instances.Where(r => r.LegacyID >= 0).OrderBy(r => r.LegacyID))
+            using (var usage = ContextFactory.GetForWrite())
             {
-                if (context.RulesetInfo.SingleOrDefault(rsi => rsi.ID == r.RulesetInfo.ID) == null)
-                    context.RulesetInfo.Add(r.RulesetInfo);
-            }
+                var context = usage.Context;
 
-            context.SaveChanges();
+                var instances = loaded_assemblies.Values.Select(r => (Ruleset)Activator.CreateInstance(r, (RulesetInfo)null)).ToList();
 
-            //add any other modes
-            foreach (var r in instances.Where(r => r.LegacyID < 0))
-                if (context.RulesetInfo.FirstOrDefault(ri => ri.InstantiationInfo == r.RulesetInfo.InstantiationInfo) == null)
-                    context.RulesetInfo.Add(r.RulesetInfo);
-
-            context.SaveChanges();
-
-            //perform a consistency check
-            foreach (var r in context.RulesetInfo)
-            {
-                try
+                //add all legacy modes in correct order
+                foreach (var r in instances.Where(r => r.LegacyID >= 0).OrderBy(r => r.LegacyID))
                 {
-                    var instance = r.CreateInstance();
-
-                    r.Name = instance.Description;
-                    r.ShortName = instance.ShortName;
-
-                    r.Available = true;
+                    if (context.RulesetInfo.SingleOrDefault(rsi => rsi.ID == r.RulesetInfo.ID) == null)
+                        context.RulesetInfo.Add(r.RulesetInfo);
                 }
-                catch
+
+                context.SaveChanges();
+
+                //add any other modes
+                foreach (var r in instances.Where(r => r.LegacyID < 0))
+                    if (context.RulesetInfo.FirstOrDefault(ri => ri.InstantiationInfo == r.RulesetInfo.InstantiationInfo) == null)
+                        context.RulesetInfo.Add(r.RulesetInfo);
+
+                context.SaveChanges();
+
+                //perform a consistency check
+                foreach (var r in context.RulesetInfo)
                 {
-                    r.Available = false;
+                    try
+                    {
+                        var instance = r.CreateInstance();
+
+                        r.Name = instance.Description;
+                        r.ShortName = instance.ShortName;
+
+                        r.Available = true;
+                    }
+                    catch
+                    {
+                        r.Available = false;
+                    }
                 }
+
+                context.SaveChanges();
+
+                AvailableRulesets = context.RulesetInfo.Where(r => r.Available).ToList();
             }
-
-            context.SaveChanges();
-
-            AvailableRulesets = context.RulesetInfo.Where(r => r.Available).ToList();
         }
 
         private static void loadRulesetFromFile(string file)

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using osu.Framework.Platform;
@@ -27,7 +26,7 @@ namespace osu.Game.Rulesets.Scoring
         // ReSharper disable once NotAccessedField.Local (we should keep a reference to this so it is not finalised)
         private ScoreIPCChannel ipc;
 
-        public ScoreStore(Storage storage, Func<OsuDbContext> factory, IIpcHost importHost = null, BeatmapManager beatmaps = null, RulesetStore rulesets = null) : base(factory)
+        public ScoreStore(Storage storage, DatabaseContextFactory factory, IIpcHost importHost = null, BeatmapManager beatmaps = null, RulesetStore rulesets = null) : base(factory)
         {
             this.storage = storage;
             this.beatmaps = beatmaps;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -275,7 +275,9 @@
     <Compile Include="Configuration\DatabasedConfigManager.cs" />
     <Compile Include="Configuration\SpeedChangeVisualisationMethod.cs" />
     <Compile Include="Database\DatabaseContextFactory.cs" />
+    <Compile Include="Database\DatabaseWriteUsage.cs" />
     <Compile Include="Database\IHasPrimaryKey.cs" />
+    <Compile Include="Database\SingletonContextFactory.cs" />
     <Compile Include="Graphics\Containers\LinkFlowContainer.cs" />
     <Compile Include="Graphics\Textures\LargeTextureStore.cs" />
     <Compile Include="Online\API\Requests\GetUserRequest.cs" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Configuration\SpeedChangeVisualisationMethod.cs" />
     <Compile Include="Database\DatabaseContextFactory.cs" />
     <Compile Include="Database\DatabaseWriteUsage.cs" />
+    <Compile Include="Database\IDatabaseContextFactory.cs" />
     <Compile Include="Database\IHasPrimaryKey.cs" />
     <Compile Include="Database\SingletonContextFactory.cs" />
     <Compile Include="Graphics\Containers\LinkFlowContainer.cs" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Beatmaps\BeatmapDifficulty.cs" />
     <Compile Include="Beatmaps\BeatmapInfo.cs" />
     <Compile Include="Beatmaps\BeatmapManager.cs" />
+    <Compile Include="Beatmaps\BeatmapManager_WorkingBeatmap.cs" />
     <Compile Include="Beatmaps\BeatmapMetadata.cs" />
     <Compile Include="Beatmaps\BeatmapMetrics.cs" />
     <Compile Include="Beatmaps\BeatmapOnlineInfo.cs" />


### PR DESCRIPTION
- Prefers correctness over performance (imports of existing maps may be slower)
- Refactors shocking code
- Adds more tests
- Fixes EF context lifetimes
- Reduces complexity of sharing contexts between stores

Closes ppy/osu#1386 (except for rollback logic, which is pending transaction fix in EF).