### PR TITLE
Fix mod selection when switching from menu to mods panel

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -30,6 +30,7 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.Play;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Select;
 using OpenTK.Graphics;
 
 namespace osu.Game
@@ -492,15 +493,18 @@ namespace osu.Game
         private void screenAdded(Screen newScreen)
         {
             currentScreen = (OsuScreen)newScreen;
-
             newScreen.ModePushed += screenAdded;
             newScreen.Exited += screenRemoved;
+
+            if (newScreen is PlaySongSelect)
+            {
+                newScreen.Exited += s => SelectedMods.UnbindAll();
+            }
         }
 
         private void screenRemoved(Screen newScreen)
         {
             currentScreen = (OsuScreen)newScreen;
-
             if (newScreen == null)
                 Exit();
         }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -119,8 +119,6 @@ namespace osu.Game.Screens.Select
                 return true;
             }
 
-            modSelect.SelectedMods.UnbindBindings();
-
             if (base.OnExiting(next))
                 return true;
 

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -119,6 +119,8 @@ namespace osu.Game.Screens.Select
                 return true;
             }
 
+            modSelect.SelectedMods.UnbindBindings();
+
             if (base.OnExiting(next))
                 return true;
 


### PR DESCRIPTION
Fixes #2018 
Each time you instanciate PlaySongSelect, it will bind a newly created modSelect.SelectedMods to game.SelectedMods.
The thing is it never gets unbound when exiting PlaySongSelect, causing weird issues when going back to it (it seemed to bind old values)