### PR TITLE
Remove osu! playfield scale from the editor

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/ManiaRulesetContainer.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaRulesetContainer.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Mania.UI
             return null;
         }
 
-        protected override Vector2 GetAspectAdjustedSize() => new Vector2(1, 0.8f);
+        protected override Vector2 PlayfieldArea => new Vector2(1, 0.8f);
 
         protected override FramedReplayInputHandler CreateReplayInputHandler(Replay replay) => new ManiaFramedReplayInputHandler(replay, this);
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
+using OpenTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -16,6 +17,12 @@ namespace osu.Game.Rulesets.Osu.Edit
         }
 
         protected override Playfield CreatePlayfield() => new OsuEditPlayfield();
+
+        protected override Vector2 GetAspectAdjustedSize()
+        {
+            var aspectSize = DrawSize.X * 0.75f < DrawSize.Y ? new Vector2(DrawSize.X, DrawSize.X * 0.75f) : new Vector2(DrawSize.Y * 4f / 3f, DrawSize.Y);
+            return new Vector2(aspectSize.X / DrawSize.X, aspectSize.Y / DrawSize.Y);
+        }
 
         protected override CursorContainer CreateCursor() => null;
     }

--- a/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
@@ -18,11 +18,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         protected override Playfield CreatePlayfield() => new OsuEditPlayfield();
 
-        protected override Vector2 GetAspectAdjustedSize()
-        {
-            var aspectSize = DrawSize.X * 0.75f < DrawSize.Y ? new Vector2(DrawSize.X, DrawSize.X * 0.75f) : new Vector2(DrawSize.Y * 4f / 3f, DrawSize.Y);
-            return new Vector2(aspectSize.X / DrawSize.X, aspectSize.Y / DrawSize.Y);
-        }
+        protected override Vector2 PlayfieldArea => Vector2.One;
 
         protected override CursorContainer CreateCursor() => null;
     }

--- a/osu.Game.Rulesets.Osu/UI/OsuRulesetContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuRulesetContainer.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.UI
         protected override Vector2 GetAspectAdjustedSize()
         {
             var aspectSize = DrawSize.X * 0.75f < DrawSize.Y ? new Vector2(DrawSize.X, DrawSize.X * 0.75f) : new Vector2(DrawSize.Y * 4f / 3f, DrawSize.Y);
-            return new Vector2(aspectSize.X / DrawSize.X, aspectSize.Y / DrawSize.Y) * 0.75f;
+            return new Vector2(aspectSize.X / DrawSize.X, aspectSize.Y / DrawSize.Y);
         }
 
         protected override CursorContainer CreateCursor() => new GameplayCursor();

--- a/osu.Game.Rulesets.Taiko/UI/TaikoRulesetContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoRulesetContainer.cs
@@ -88,6 +88,8 @@ namespace osu.Game.Rulesets.Taiko.UI
             return new Vector2(1, default_relative_height * aspectAdjust);
         }
 
+        protected override Vector2 PlayfieldArea => Vector2.One;
+
         public override ScoreProcessor CreateScoreProcessor() => new TaikoScoreProcessor(this);
 
         protected override BeatmapConverter<TaikoHitObject> CreateBeatmapConverter() => new TaikoBeatmapConverter(IsForCurrentRuleset);

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -319,7 +319,7 @@ namespace osu.Game.Rulesets.UI
         {
             base.Update();
 
-            Playfield.Size = GetAspectAdjustedSize();
+            Playfield.Size = GetAspectAdjustedSize() * PlayfieldArea;
         }
 
         /// <summary>
@@ -330,11 +330,17 @@ namespace osu.Game.Rulesets.UI
         protected virtual BeatmapProcessor<TObject> CreateBeatmapProcessor() => new BeatmapProcessor<TObject>();
 
         /// <summary>
-        /// Computes the final size of the <see cref="Playfield"/> in relative coordinate space after all
-        /// aspect and scale adjustments.
+        /// Computes the size of the <see cref="Playfield"/> in relative coordinate space after aspect adjustments.
         /// </summary>
         /// <returns>The aspect-adjusted size.</returns>
-        protected virtual Vector2 GetAspectAdjustedSize() => new Vector2(0.75f); // A sane default
+        protected virtual Vector2 GetAspectAdjustedSize() => Vector2.One;
+
+        /// <summary>
+        /// The area of this <see cref="RulesetContainer"/> that is available for the <see cref="Playfield"/> to use.
+        /// Must be specified in relative coordinate space to this <see cref="RulesetContainer"/>.
+        /// This affects the final size of the <see cref="Playfield"/> but does not affect the <see cref="Playfield"/>'s scale.
+        /// </summary>
+        protected virtual Vector2 PlayfieldArea => new Vector2(0.75f); // A sane default
 
         /// <summary>
         /// Creates a converter to convert Beatmap to a specific mode.


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/2090

From:

<img width="627" alt="screen shot 2018-02-20 at 2 12 56 pm" src="https://user-images.githubusercontent.com/1329837/36408383-59ab1002-1648-11e8-9482-8af0b35e52f7.png">

To:

<img width="639" alt="screen shot 2018-02-20 at 2 13 22 pm" src="https://user-images.githubusercontent.com/1329837/36408393-6018f8fa-1648-11e8-946b-57b179db772c.png">

Gives us a little bit more room to play around with.