### PR TITLE
Fix legacy Taiko replays having reversed inputs

### DIFF
--- a/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
+++ b/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
@@ -63,16 +63,16 @@ namespace osu.Game.Rulesets.Taiko.Replays
                         {
                             default:
                             case 0:
-                                button = ReplayButtonState.Left1;
-                                break;
-                            case 1:
                                 button = ReplayButtonState.Right1;
                                 break;
+                            case 1:
+                                button = ReplayButtonState.Left1;
+                                break;
                             case 2:
-                                button = ReplayButtonState.Left2;
+                                button = ReplayButtonState.Right2;
                                 break;
                             case 3:
-                                button = ReplayButtonState.Right2;
+                                button = ReplayButtonState.Left2;
                                 break;
                         }
 
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Taiko.Replays
                 {
                     foreach (var tick in drumRoll.NestedHitObjects.OfType<DrumRollTick>())
                     {
-                        Frames.Add(new TaikoReplayFrame(tick.StartTime, hitButton ? ReplayButtonState.Right1 : ReplayButtonState.Right2));
+                        Frames.Add(new TaikoReplayFrame(tick.StartTime, hitButton ? ReplayButtonState.Left1 : ReplayButtonState.Left2));
                         hitButton = !hitButton;
                     }
                 }
@@ -95,16 +95,16 @@ namespace osu.Game.Rulesets.Taiko.Replays
                     if (hit is CentreHit)
                     {
                         if (h.IsStrong)
-                            button = ReplayButtonState.Right1 | ReplayButtonState.Right2;
+                            button = ReplayButtonState.Left1 | ReplayButtonState.Left2;
                         else
-                            button = hitButton ? ReplayButtonState.Right1 : ReplayButtonState.Right2;
+                            button = hitButton ? ReplayButtonState.Left1 : ReplayButtonState.Left2;
                     }
                     else
                     {
                         if (h.IsStrong)
-                            button = ReplayButtonState.Left1 | ReplayButtonState.Left2;
+                            button = ReplayButtonState.Right1 | ReplayButtonState.Right2;
                         else
-                            button = hitButton ? ReplayButtonState.Left1 : ReplayButtonState.Left2;
+                            button = hitButton ? ReplayButtonState.Right1 : ReplayButtonState.Right2;
                     }
 
                     Frames.Add(new TaikoReplayFrame(h.StartTime, button));

--- a/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
+++ b/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
@@ -63,16 +63,16 @@ namespace osu.Game.Rulesets.Taiko.Replays
                         {
                             default:
                             case 0:
-                                button = ReplayButtonState.Right1;
-                                break;
-                            case 1:
                                 button = ReplayButtonState.Left1;
                                 break;
+                            case 1:
+                                button = ReplayButtonState.Right1;
+                                break;
                             case 2:
-                                button = ReplayButtonState.Right2;
+                                button = ReplayButtonState.Left2;
                                 break;
                             case 3:
-                                button = ReplayButtonState.Left2;
+                                button = ReplayButtonState.Right2;
                                 break;
                         }
 

--- a/osu.Game.Rulesets.Taiko/Replays/TaikoFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Replays/TaikoFramedReplayInputHandler.cs
@@ -19,13 +19,13 @@ namespace osu.Game.Rulesets.Taiko.Replays
             var actions = new List<TaikoAction>();
 
             if (CurrentFrame?.MouseRight1 == true)
-                actions.Add(TaikoAction.LeftCentre);
-            if (CurrentFrame?.MouseRight2 == true)
-                actions.Add(TaikoAction.RightCentre);
-            if (CurrentFrame?.MouseLeft1 == true)
                 actions.Add(TaikoAction.LeftRim);
-            if (CurrentFrame?.MouseLeft2 == true)
+            if (CurrentFrame?.MouseRight2 == true)
                 actions.Add(TaikoAction.RightRim);
+            if (CurrentFrame?.MouseLeft1 == true)
+                actions.Add(TaikoAction.LeftCentre);
+            if (CurrentFrame?.MouseLeft2 == true)
+                actions.Add(TaikoAction.RightCentre);
 
             return new List<InputState> { new ReplayState<TaikoAction> { PressedActions = actions } };
         }


### PR DESCRIPTION
For some reasons, ReplayButtonState.Left1/2 and ReplayButtonState.Right1/2 are swapped compared to the legacy replays. 

So i simply swapped them in the code
I don't know if that's the correct way to fix this, feel free to correct