### PR TITLE
Implement skin support for (most) hitsounds and (osu!) hitcircles

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ApproachCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ApproachCircle.cs
@@ -6,30 +6,24 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class ApproachCircle : Container
     {
-        private readonly Sprite approachCircle;
-
         public ApproachCircle()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            AutoSizeAxes = Axes.Both;
-
-            Children = new Drawable[]
-            {
-                approachCircle = new Sprite()
-            };
+            RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
         private void load(TextureStore textures)
         {
-            approachCircle.Texture = textures.Get(@"Play/osu/approachcircle");
+            Child = new SkinnableDrawable("Play/osu/approachcircle", name => new Sprite { Texture = textures.Get(name) });
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs
@@ -2,20 +2,16 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
+using osu.Game.Skinning;
 using OpenTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class CirclePiece : Container, IKeyBindingHandler<OsuAction>
     {
-        private readonly Sprite disc;
-
         public Func<bool> Hit;
 
         public CirclePiece()
@@ -27,26 +23,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            Children = new Drawable[]
-            {
-                disc = new Sprite
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
-                },
-                new TrianglesPiece
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Blending = BlendingMode.Additive,
-                    Alpha = 0.5f,
-                }
-            };
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
-        {
-            disc.Texture = textures.Get(@"Play/osu/disc");
+            InternalChild = new SkinnableDrawable("Play/osu/hitcircle", _ => new DefaultCirclePiece());
         }
 
         public bool OnPressed(OsuAction action)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultCirclePiece.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
+{
+    public class DefaultCirclePiece : Container
+    {
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
+        {
+            RelativeSizeAxes = Axes.Both;
+            Children = new Drawable[]
+            {
+                new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Texture = textures.Get(@"Play/osu/disc"),
+                },
+                new TrianglesPiece
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Blending = BlendingMode.Additive,
+                    Alpha = 0.5f,
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/GlowPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/GlowPiece.cs
@@ -6,34 +6,30 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class GlowPiece : Container
     {
-        private readonly Sprite layer;
-
         public GlowPiece()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-
-            Children = new[]
-            {
-                layer = new Sprite
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Blending = BlendingMode.Additive,
-                    Alpha = 0.5f
-                }
-            };
+            RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
         private void load(TextureStore textures)
         {
-            layer.Texture = textures.Get(@"Play/osu/ring-glow");
+            Child = new SkinnableDrawable("Play/osu/ring-glow", name => new Sprite
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Texture = textures.Get(name),
+                Blending = BlendingMode.Additive,
+                Alpha = 0.5f
+            }, false);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/NumberPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/NumberPiece.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.Sprites;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
@@ -28,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Children = new Drawable[]
             {
-                new CircularContainer
+                new SkinnableDrawable("Play/osu/number-glow", name => new CircularContainer
                 {
                     Masking = true,
                     Origin = Anchor.Centre,
@@ -38,11 +39,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                         Radius = 60,
                         Colour = Color4.White.Opacity(0.5f),
                     },
-                    Children = new[]
-                    {
-                        new Box()
-                    }
-                },
+                    Child = new Box()
+                }, false),
                 number = new OsuSpriteText
                 {
                     Text = @"1",

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/RingPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/RingPiece.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics.Containers;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
@@ -15,24 +16,26 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         {
             Size = new Vector2(128);
 
-            Masking = true;
-            CornerRadius = Size.X / 2;
-
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            BorderThickness = 10;
-            BorderColour = Color4.White;
-
-            Children = new Drawable[]
+            InternalChild = new SkinnableDrawable("Play/osu/hitcircleoverlay", _ => new Container
             {
-                new Box
+                Masking = true,
+                CornerRadius = Size.X / 2,
+                BorderThickness = 10,
+                BorderColour = Color4.White,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
                 {
-                    AlwaysPresent = true,
-                    Alpha = 0,
-                    RelativeSizeAxes = Axes.Both
+                    new Box
+                    {
+                        AlwaysPresent = true,
+                        Alpha = 0,
+                        RelativeSizeAxes = Axes.Both
+                    }
                 }
-            };
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+++ b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Objects\Drawables\IRequireTracking.cs" />
     <Compile Include="Objects\Drawables\ITrackSnaking.cs" />
     <Compile Include="Objects\Drawables\Pieces\ApproachCircle.cs" />
+    <Compile Include="Objects\Drawables\Pieces\DefaultCirclePiece.cs" />
     <Compile Include="Objects\Drawables\Pieces\SpinnerBackground.cs" />
     <Compile Include="Objects\Drawables\Pieces\CirclePiece.cs" />
     <Compile Include="Objects\Drawables\DrawableSlider.cs" />

--- a/osu.Game.Rulesets.Taiko/Audio/DrumSampleMapping.cs
+++ b/osu.Game.Rulesets.Taiko/Audio/DrumSampleMapping.cs
@@ -29,8 +29,8 @@ namespace osu.Game.Rulesets.Taiko.Audio
             {
                 mappings[s.Time] = new DrumSample
                 {
-                    Centre = s.GetSampleInfo().GetChannel(audio.Sample, "Taiko"),
-                    Rim = s.GetSampleInfo(SampleInfo.HIT_CLAP).GetChannel(audio.Sample, "Taiko")
+                    Centre = s.GetSampleInfo().GetChannel(audio.Sample.Get, "Taiko"),
+                    Rim = s.GetSampleInfo(SampleInfo.HIT_CLAP).GetChannel(audio.Sample.Get, "Taiko")
                 };
             }
         }

--- a/osu.Game.Rulesets.Taiko/Audio/DrumSampleMapping.cs
+++ b/osu.Game.Rulesets.Taiko/Audio/DrumSampleMapping.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Audio
         private readonly ControlPointInfo controlPoints;
         private readonly Dictionary<double, DrumSample> mappings = new Dictionary<double, DrumSample>();
 
-        public readonly List<SkinnableSound> Drawables = new List<SkinnableSound>();
+        public readonly List<SkinnableSound> Sounds = new List<SkinnableSound>();
 
         public DrumSampleMapping(ControlPointInfo controlPoints)
         {
@@ -37,16 +37,16 @@ namespace osu.Game.Rulesets.Taiko.Audio
 
                 mappings[s.Time] = new DrumSample
                 {
-                    Centre = addDrawableSound(centre),
-                    Rim = addDrawableSound(rim)
+                    Centre = addSound(centre),
+                    Rim = addSound(rim)
                 };
             }
         }
 
-        private SkinnableSound addDrawableSound(SampleInfo rim)
+        private SkinnableSound addSound(SampleInfo sampleInfo)
         {
-            var drawable = new SkinnableSound(rim);
-            Drawables.Add(drawable);
+            var drawable = new SkinnableSound(sampleInfo);
+            Sounds.Add(drawable);
             return drawable;
         }
 

--- a/osu.Game.Rulesets.Taiko/Audio/DrumSampleMapping.cs
+++ b/osu.Game.Rulesets.Taiko/Audio/DrumSampleMapping.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System.Collections.Generic;
-using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Audio
 {
@@ -14,7 +13,9 @@ namespace osu.Game.Rulesets.Taiko.Audio
         private readonly ControlPointInfo controlPoints;
         private readonly Dictionary<double, DrumSample> mappings = new Dictionary<double, DrumSample>();
 
-        public DrumSampleMapping(ControlPointInfo controlPoints, AudioManager audio)
+        public readonly List<SkinnableSound> Drawables = new List<SkinnableSound>();
+
+        public DrumSampleMapping(ControlPointInfo controlPoints)
         {
             this.controlPoints = controlPoints;
 
@@ -27,20 +28,34 @@ namespace osu.Game.Rulesets.Taiko.Audio
 
             foreach (var s in samplePoints)
             {
+                var centre = s.GetSampleInfo();
+                var rim = s.GetSampleInfo(SampleInfo.HIT_CLAP);
+
+                // todo: this is ugly
+                centre.Namespace = "taiko";
+                rim.Namespace = "taiko";
+
                 mappings[s.Time] = new DrumSample
                 {
-                    Centre = s.GetSampleInfo().GetChannel(audio.Sample.Get, "Taiko"),
-                    Rim = s.GetSampleInfo(SampleInfo.HIT_CLAP).GetChannel(audio.Sample.Get, "Taiko")
+                    Centre = addDrawableSound(centre),
+                    Rim = addDrawableSound(rim)
                 };
             }
+        }
+
+        private SkinnableSound addDrawableSound(SampleInfo rim)
+        {
+            var drawable = new SkinnableSound(rim);
+            Drawables.Add(drawable);
+            return drawable;
         }
 
         public DrumSample SampleAt(double time) => mappings[controlPoints.SamplePointAt(time).Time];
 
         public class DrumSample
         {
-            public SampleChannel Centre;
-            public SampleChannel Rim;
+            public SkinnableSound Centre;
+            public SkinnableSound Rim;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                 }
             };
 
-            AddRangeInternal(sampleMappings.Drawables);
+            AddRangeInternal(sampleMappings.Sounds);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
@@ -4,7 +4,6 @@
 using System;
 using OpenTK;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -34,9 +33,9 @@ namespace osu.Game.Rulesets.Taiko.UI
         }
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        private void load()
         {
-            var sampleMappings = new DrumSampleMapping(controlPoints, audio);
+            var sampleMappings = new DrumSampleMapping(controlPoints);
 
             Children = new Drawable[]
             {
@@ -63,6 +62,8 @@ namespace osu.Game.Rulesets.Taiko.UI
                     CentreAction = TaikoAction.RightCentre
                 }
             };
+
+            AddRangeInternal(sampleMappings.Drawables);
         }
 
         /// <summary>

--- a/osu.Game/Audio/SampleInfo.cs
+++ b/osu.Game/Audio/SampleInfo.cs
@@ -14,16 +14,16 @@ namespace osu.Game.Audio
         public const string HIT_NORMAL = @"hitnormal";
         public const string HIT_CLAP = @"hitclap";
 
-        public SampleChannel GetChannel(SampleManager manager, string resourceNamespace = null)
+        public SampleChannel GetChannel(Func<string, SampleChannel> getChannel, string resourceNamespace = null)
         {
             SampleChannel channel = null;
 
             if (resourceNamespace != null)
-                channel = manager.Get($"Gameplay/{resourceNamespace}/{Bank}-{Name}");
+                channel = getChannel($"Gameplay/{resourceNamespace}/{Bank}-{Name}");
 
             // try without namespace as a fallback.
             if (channel == null)
-                channel = manager.Get($"Gameplay/{Bank}-{Name}");
+                channel = getChannel($"Gameplay/{Bank}-{Name}");
 
             if (channel != null)
                 channel.Volume.Value = Volume / 100.0;

--- a/osu.Game/Audio/SampleInfo.cs
+++ b/osu.Game/Audio/SampleInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
-using osu.Framework.Audio.Sample;
 
 namespace osu.Game.Audio
 {
@@ -14,22 +13,10 @@ namespace osu.Game.Audio
         public const string HIT_NORMAL = @"hitnormal";
         public const string HIT_CLAP = @"hitclap";
 
-        public SampleChannel GetChannel(Func<string, SampleChannel> getChannel, string resourceNamespace = null)
-        {
-            SampleChannel channel = null;
-
-            if (resourceNamespace != null)
-                channel = getChannel($"Gameplay/{resourceNamespace}/{Bank}-{Name}");
-
-            // try without namespace as a fallback.
-            if (channel == null)
-                channel = getChannel($"Gameplay/{Bank}-{Name}");
-
-            if (channel != null)
-                channel.Volume.Value = Volume / 100.0;
-
-            return channel;
-        }
+        /// <summary>
+        /// An optional ruleset namespace.
+        /// </summary>
+        public string Namespace;
 
         /// <summary>
         /// The bank to load the sample from.

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
@@ -106,7 +106,7 @@ namespace osu.Game
 
             runMigrations();
 
-            dependencies.Cache(SkinManager = new SkinManager(Host.Storage, contextFactory, Host));
+            dependencies.Cache(SkinManager = new SkinManager(Host.Storage, contextFactory, Host, Audio));
 
             dependencies.Cache(API = new APIAccess
             {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -33,10 +33,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         protected SkinnableSound Samples;
 
-        protected virtual IEnumerable<SampleInfo> GetSamples()
-        {
-            return HitObject.Samples;
-        }
+        protected virtual IEnumerable<SampleInfo> GetSamples() => HitObject.Samples;
 
         private List<DrawableHitObject> nestedHitObjects;
         public IReadOnlyList<DrawableHitObject> NestedHitObjects => nestedHitObjects;

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -1,0 +1,17 @@
+﻿using osu.Framework.Audio.Sample;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Skinning
+{
+    public class DefaultSkin : Skin
+    {
+        public DefaultSkin()
+            : base(SkinInfo.Default)
+        {
+        }
+
+        public override Drawable GetDrawableComponent(string componentName) => null;
+
+        public override SampleChannel GetSample(string sampleName) => null;
+    }
+}

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Audio.Sample;
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 
 namespace osu.Game.Skinning
@@ -10,8 +13,14 @@ namespace osu.Game.Skinning
         {
         }
 
-        public override Drawable GetDrawableComponent(string componentName) => null;
+        public override Drawable GetDrawableComponent(string componentName)
+        {
+            return null;
+        }
 
-        public override SampleChannel GetSample(string sampleName) => null;
+        public override SampleChannel GetSample(string sampleName)
+        {
+            return null;
+        }
     }
 }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.IO;
+using System.Linq;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+
+namespace osu.Game.Skinning
+{
+    public class LegacySkin : Skin
+    {
+        private readonly TextureStore textures;
+
+        private readonly SampleManager samples;
+
+        public LegacySkin(SkinInfo skin, IResourceStore<byte[]> storage, AudioManager audioManager)
+            : base(skin)
+        {
+            var audioStore = new ResourceStore<byte[]>(storage);
+
+            samples = audioManager.GetSampleManager(audioStore);
+            textures = new TextureStore(new RawTextureLoaderStore(storage));
+        }
+
+        private string getPathForFile(string filename) =>
+            SkinInfo.Files.FirstOrDefault(f => string.Equals(Path.GetFileNameWithoutExtension(f.Filename), filename, StringComparison.InvariantCultureIgnoreCase))?.FileInfo.StoragePath;
+
+        public override Drawable GetDrawableComponent(string componentName)
+        {
+            var texture = textures.Get(getPathForFile(componentName.Split('/').Last()));
+            if (texture == null) return null;
+
+            return new Sprite
+            {
+                RelativeSizeAxes = Axes.Both,
+                FillMode = FillMode.Fit,
+                Texture = texture,
+            };
+        }
+
+        public override SampleChannel GetSample(string sampleName) => samples.Get(getPathForFile(sampleName.Split('/').Last()));
+    }
+}

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -22,9 +22,7 @@ namespace osu.Game.Skinning
         public LegacySkin(SkinInfo skin, IResourceStore<byte[]> storage, AudioManager audioManager)
             : base(skin)
         {
-            var audioStore = new ResourceStore<byte[]>(storage);
-
-            samples = audioManager.GetSampleManager(audioStore);
+            samples = audioManager.GetSampleManager(storage);
             textures = new TextureStore(new RawTextureLoaderStore(storage));
         }
 

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Audio.Sample;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Skinning
+{
+    public abstract class Skin
+    {
+        public readonly SkinInfo SkinInfo;
+
+        public abstract Drawable GetDrawableComponent(string componentName);
+
+        public abstract SampleChannel GetSample(string sampleName);
+
+        protected Skin(SkinInfo skin)
+        {
+            SkinInfo = skin;
+        }
+    }
+}

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using osu.Framework.Audio;
 using osu.Framework.Configuration;
 using osu.Framework.Platform;
 using osu.Game.Database;
@@ -15,6 +16,9 @@ namespace osu.Game.Skinning
 {
     public class SkinManager : ArchiveModelManager<SkinInfo, SkinFileInfo>
     {
+        private readonly AudioManager audio;
+
+        public readonly Bindable<Skin> CurrentSkin = new Bindable<Skin>(new DefaultSkin());
         public readonly Bindable<SkinInfo> CurrentSkinInfo = new Bindable<SkinInfo>(SkinInfo.Default) { Default = SkinInfo.Default };
 
         public override string[] HandledExtensions => new[] { ".osk" };
@@ -30,13 +34,37 @@ namespace osu.Game.Skinning
             return userSkins;
         }
 
-        protected override SkinInfo CreateModel(ArchiveReader archive) => new SkinInfo { Name = archive.Name };
+        protected override SkinInfo CreateModel(ArchiveReader archive) => new SkinInfo
+        {
+            Name = archive.Name
+        };
+
+        /// <summary>
+        /// Retrieve a <see cref="Skin"/> instance for the provided <see cref="SkinInfo"/>
+        /// </summary>
+        /// <param name="skinInfo">The skin to lookup.</param>
+        /// <returns>A <see cref="Skin"/> instance correlating to the provided <see cref="SkinInfo"/>.</returns>
+        public Skin GetSkin(SkinInfo skinInfo)
+        {
+            if (skinInfo == SkinInfo.Default)
+                return new DefaultSkin();
+
+            return new LegacySkin(skinInfo, Files.Store, audio);
+        }
 
         private SkinStore store;
 
-        public SkinManager(Storage storage, DatabaseContextFactory contextFactory, IIpcHost importHost)
+        public SkinManager(Storage storage, DatabaseContextFactory contextFactory, IIpcHost importHost, AudioManager audio)
             : base(storage, contextFactory, new SkinStore(contextFactory, storage), importHost)
         {
+            this.audio = audio;
+
+            CurrentSkinInfo.ValueChanged += info => { CurrentSkin.Value = GetSkin(info); };
+            CurrentSkin.ValueChanged += skin =>
+            {
+                if (skin.SkinInfo != CurrentSkinInfo.Value)
+                    throw new InvalidOperationException($"Setting {nameof(CurrentSkin)}'s value directly is not supported. Use {nameof(CurrentSkinInfo)} isntead.");
+            };
         }
 
         /// <summary>

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
@@ -59,7 +59,7 @@ namespace osu.Game.Skinning
         {
             this.audio = audio;
 
-            CurrentSkinInfo.ValueChanged += info => { CurrentSkin.Value = GetSkin(info); };
+            CurrentSkinInfo.ValueChanged += info => CurrentSkin.Value = GetSkin(info);
             CurrentSkin.ValueChanged += skin =>
             {
                 if (skin.SkinInfo != CurrentSkinInfo.Value)

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Skinning
             CurrentSkin.ValueChanged += skin =>
             {
                 if (skin.SkinInfo != CurrentSkinInfo.Value)
-                    throw new InvalidOperationException($"Setting {nameof(CurrentSkin)}'s value directly is not supported. Use {nameof(CurrentSkinInfo)} isntead.");
+                    throw new InvalidOperationException($"Setting {nameof(CurrentSkin)}'s value directly is not supported. Use {nameof(CurrentSkinInfo)} instead.");
             };
         }
 

--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Skinning
         private readonly bool allowDefaultFallback;
 
         /// <summary>
-        /// Create a new
+        /// Create a new <see cref="SkinReloadableDrawable"/>
         /// </summary>
         /// <param name="fallback">Whether fallback to default skin should be allowed if the custom skin is missing this resource.</param>
         protected SkinReloadableDrawable(bool fallback = true)

--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// A drawable which has a callback when the skin changes.
+    /// </summary>
+    public abstract class SkinReloadableDrawable : CompositeDrawable
+    {
+        private Bindable<Skin> skin;
+
+        /// <summary>
+        /// Whether fallback to default skin should be allowed if the custom skin is missing this resource.
+        /// </summary>
+        private readonly bool allowDefaultFallback;
+
+        /// <summary>
+        /// Create a new
+        /// </summary>
+        /// <param name="fallback">Whether fallback to default skin should be allowed if the custom skin is missing this resource.</param>
+        protected SkinReloadableDrawable(bool fallback = true)
+        {
+            allowDefaultFallback = fallback;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(SkinManager skinManager)
+        {
+            skin = skinManager.CurrentSkin.GetBoundCopy();
+            skin.ValueChanged += skin => SkinChanged(skin, allowDefaultFallback || skin.SkinInfo == SkinInfo.Default);
+        }
+
+        protected override void LoadAsyncComplete()
+        {
+            base.LoadAsyncComplete();
+            skin.TriggerChange();
+        }
+
+        /// <summary>
+        /// Called when a change is made to the skin.
+        /// </summary>
+        /// <param name="skin">The new skin.</param>
+        /// <param name="allowFallback">Whether fallback to default skin should be allowed if the custom skin is missing this resource.</param>
+        protected virtual void SkinChanged(Skin skin, bool allowFallback)
+        {
+        }
+    }
+}

--- a/osu.Game/Skinning/SkinnableDrawable.cs
+++ b/osu.Game/Skinning/SkinnableDrawable.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
-using osu.Framework.Allocation;
-using osu.Framework.Configuration;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 
 namespace osu.Game.Skinning
 {
@@ -14,40 +11,29 @@ namespace osu.Game.Skinning
         public SkinnableDrawable(string name, Func<string, Drawable> defaultImplementation, bool fallback = true)
             : base(name, defaultImplementation, fallback)
         {
-            RelativeSizeAxes = Axes.Both;
         }
     }
 
-    public class SkinnableDrawable<T> : CompositeDrawable
+    public class SkinnableDrawable<T> : SkinReloadableDrawable
         where T : Drawable
     {
-        private Bindable<Skin> skin;
-        protected Func<string, T> CreateDefault;
+        private readonly Func<string, T> createDefault;
 
-        public readonly string ComponentName;
+        private readonly string componentName;
 
-        public readonly bool DefaultFallback;
-
-        public SkinnableDrawable(string name, Func<string, T> defaultImplementation, bool fallback = true)
+        public SkinnableDrawable(string name, Func<string, T> defaultImplementation, bool fallback = true) : base(fallback)
         {
-            DefaultFallback = fallback;
-            ComponentName = name;
-            CreateDefault = defaultImplementation;
+            componentName = name;
+            createDefault = defaultImplementation;
+
+            RelativeSizeAxes = Axes.Both;
         }
 
-        [BackgroundDependencyLoader]
-        private void load(SkinManager skinManager)
+        protected override void SkinChanged(Skin skin, bool allowFallback)
         {
-            skin = skinManager.CurrentSkin.GetBoundCopy();
-            skin.ValueChanged += updateComponent;
-            skin.TriggerChange();
-        }
-
-        private void updateComponent(Skin skin)
-        {
-            var drawable = skin.GetDrawableComponent(ComponentName);
-            if (drawable == null && (DefaultFallback || skin.SkinInfo == SkinInfo.Default))
-                drawable = CreateDefault(ComponentName);
+            var drawable = skin.GetDrawableComponent(componentName);
+            if (drawable == null && allowFallback)
+                drawable = createDefault(componentName);
 
             if (drawable != null)
                 InternalChild = drawable;

--- a/osu.Game/Skinning/SkinnableDrawable.cs
+++ b/osu.Game/Skinning/SkinnableDrawable.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Skinning
+{
+    public class SkinnableDrawable : SkinnableDrawable<Drawable>
+    {
+        public SkinnableDrawable(string name, Func<string, Drawable> defaultImplementation, bool fallback = true)
+            : base(name, defaultImplementation, fallback)
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+    }
+
+    public class SkinnableDrawable<T> : CompositeDrawable
+        where T : Drawable
+    {
+        private Bindable<Skin> skin;
+        protected Func<string, T> CreateDefault;
+
+        public string ComponentName { get; set; }
+
+        public readonly bool DefaultFallback;
+
+        public SkinnableDrawable(string name, Func<string, T> defaultImplementation, bool fallback = true)
+        {
+            DefaultFallback = fallback;
+            ComponentName = name;
+            CreateDefault = defaultImplementation;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(SkinManager skinManager)
+        {
+            skin = skinManager.CurrentSkin.GetBoundCopy();
+            skin.ValueChanged += updateComponent;
+            skin.TriggerChange();
+        }
+
+        private void updateComponent(Skin skin)
+        {
+            var drawable = skin.GetDrawableComponent(ComponentName);
+            if (drawable == null && (DefaultFallback || skin.SkinInfo == SkinInfo.Default))
+                drawable = CreateDefault(ComponentName);
+
+            if (drawable != null)
+                InternalChild = drawable;
+            else
+                ClearInternal();
+        }
+    }
+}

--- a/osu.Game/Skinning/SkinnableDrawable.cs
+++ b/osu.Game/Skinning/SkinnableDrawable.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Skinning
         private Bindable<Skin> skin;
         protected Func<string, T> CreateDefault;
 
-        public string ComponentName { get; set; }
+        public readonly string ComponentName;
 
         public readonly bool DefaultFallback;
 

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Game.Audio;
+
+namespace osu.Game.Skinning
+{
+    public class SkinnableSound : SkinReloadableDrawable
+    {
+        private readonly SampleInfo[] samples;
+        private SampleChannel[] channels;
+
+        private AudioManager audio;
+
+        public SkinnableSound(params SampleInfo[] samples)
+        {
+            this.samples = samples;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            this.audio = audio;
+        }
+
+        public void Play() => channels?.ForEach(c => c.Play());
+
+        protected override void SkinChanged(Skin skin, bool allowFallback)
+        {
+            channels = samples.Select(s =>
+            {
+                var ch = loadChannel(s, skin.GetSample);
+                if (ch == null && allowFallback)
+                    ch = loadChannel(s, audio.Sample.Get);
+                return ch;
+            }).ToArray();
+        }
+
+        private SampleChannel loadChannel(SampleInfo info, Func<string, SampleChannel> getSampleFunction)
+        {
+            SampleChannel ch = null;
+
+            if (info.Namespace != null)
+                ch = getSampleFunction($"Gameplay/{info.Namespace}/{info.Bank}-{info.Name}");
+
+            // try without namespace as a fallback.
+            if (ch == null)
+                ch = getSampleFunction($"Gameplay/{info.Bank}-{info.Name}");
+
+            if (ch != null)
+                ch.Volume.Value = info.Volume / 100.0;
+
+            return ch;
+        }
+    }
+}

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <Import Project="..\osu.Game.props" />
   <PropertyGroup>
@@ -861,6 +861,8 @@
     <Compile Include="Skinning\SkinInfo.cs" />
     <Compile Include="Skinning\SkinManager.cs" />
     <Compile Include="Skinning\SkinnableDrawable.cs" />
+    <Compile Include="Skinning\SkinnableSound.cs" />
+    <Compile Include="Skinning\SkinReloadableDrawable.cs" />
     <Compile Include="Skinning\SkinStore.cs" />
     <Compile Include="Storyboards\CommandLoop.cs" />
     <Compile Include="Storyboards\CommandTimeline.cs" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <Import Project="..\osu.Game.props" />
   <PropertyGroup>
@@ -854,6 +854,9 @@
     <Compile Include="Screens\Tournament\Teams\DrawingsTeam.cs" />
     <Compile Include="Screens\Tournament\Teams\ITeamList.cs" />
     <Compile Include="Screens\Tournament\Teams\StorageBackedTeamList.cs" />
+    <Compile Include="Skinning\DefaultSkin.cs" />
+    <Compile Include="Skinning\LegacySkin.cs" />
+    <Compile Include="Skinning\Skin.cs" />
     <Compile Include="Skinning\SkinFileInfo.cs" />
     <Compile Include="Skinning\SkinInfo.cs" />
     <Compile Include="Skinning\SkinManager.cs" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -860,6 +860,7 @@
     <Compile Include="Skinning\SkinFileInfo.cs" />
     <Compile Include="Skinning\SkinInfo.cs" />
     <Compile Include="Skinning\SkinManager.cs" />
+    <Compile Include="Skinning\SkinnableDrawable.cs" />
     <Compile Include="Skinning\SkinStore.cs" />
     <Compile Include="Storyboards\CommandLoop.cs" />
     <Compile Include="Storyboards\CommandTimeline.cs" />


### PR DESCRIPTION
- Adds basic hitsound replacement (doesn't check ruleset prefixes, yet)
- Adds basic hitcircle skinnability (osu! ruleset)

also

- [x] Depends on #2103
- [x] Depends on ppy/osu-framework#1410

As `skin.ini` is not yet parsed, depending on the skin it may not yet look as expected. skin.ini parsing will be implemented in the next PR.

I have visual tests in the works for testing skinning, will push to this branch when ready. For now testing can be done by loading an `.osk` manually.