### PR TITLE
Rely less on every-frame transform helpers

### DIFF
--- a/osu.Game/Graphics/Containers/ParallaxContainer.cs
+++ b/osu.Game/Graphics/Containers/ParallaxContainer.cs
@@ -8,6 +8,7 @@ using OpenTK;
 using osu.Framework.Allocation;
 using osu.Game.Configuration;
 using osu.Framework.Configuration;
+using osu.Framework.MathUtils;
 
 namespace osu.Game.Graphics.Containers
 {
@@ -61,8 +62,9 @@ namespace osu.Game.Graphics.Containers
 
             if (parallaxEnabled)
             {
-                Vector2 offset = input.CurrentState.Mouse == null ? Vector2.Zero : ToLocalSpace(input.CurrentState.Mouse.NativeState.Position) - DrawSize / 2;
-                content.MoveTo(offset * ParallaxAmount, firstUpdate ? 0 : 1000, Easing.OutQuint);
+                Vector2 offset = (input.CurrentState.Mouse == null ? Vector2.Zero : ToLocalSpace(input.CurrentState.Mouse.NativeState.Position) - DrawSize / 2) * ParallaxAmount;
+
+                content.Position = Interpolation.ValueAt(Clock.ElapsedFrameTime, content.Position, offset, 0, 1000, Easing.OutQuint);
                 content.Scale = new Vector2(1 + ParallaxAmount);
             }
 

--- a/osu.Game/Screens/Play/SongProgressBar.cs
+++ b/osu.Game/Screens/Play/SongProgressBar.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Screens.Play
         {
             var xFill = value * UsableWidth;
             fill.Width = xFill;
-            handleBase.MoveToX(xFill);
+            handleBase.X = xFill;
         }
 
         protected override void OnUserChange() => OnSeek?.Invoke(Current);


### PR DESCRIPTION
They have huge overheads. Don't merge this yet.

See ppy/osu-framework#1411.