### PR TITLE
Fix importing some (broken) beatmaps looping infinitely

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -3,7 +3,6 @@
 
 using OpenTK;
 using osu.Game.Rulesets.Objects.Types;
-using System;
 using System.Collections.Generic;
 using osu.Game.Rulesets.Objects;
 using System.Linq;
@@ -120,14 +119,16 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         private void createTicks()
         {
-            if (TickDistance == 0) return;
-
             var length = Curve.Distance;
-            var tickDistance = Math.Min(TickDistance, length);
+            var tickDistance = MathHelper.Clamp(TickDistance, 0, length);
+
+            if (tickDistance == 0) return;
 
             var minDistanceFromEnd = Velocity * 0.01;
 
-            for (var span = 0; span < this.SpanCount(); span++)
+            var spanCount = this.SpanCount();
+
+            for (var span = 0; span < spanCount; span++)
             {
                 var spanStartTime = StartTime + span * SpanDuration;
                 var reversed = span % 2 == 1;

--- a/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using OpenTK;
+
 namespace osu.Game.Beatmaps.ControlPoints
 {
     public class DifficultyControlPoint : ControlPoint
@@ -8,6 +10,12 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// <summary>
         /// The speed multiplier at this control point.
         /// </summary>
-        public double SpeedMultiplier = 1;
+        public double SpeedMultiplier
+        {
+            get => speedMultiplier;
+            set => speedMultiplier = MathHelper.Clamp(value, 0.1, 10);
+        }
+
+        private double speedMultiplier = 1;
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using OpenTK;
 using osu.Game.Beatmaps.Timing;
 
 namespace osu.Game.Beatmaps.ControlPoints
@@ -15,6 +16,12 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// <summary>
         /// The beat length at this control point.
         /// </summary>
-        public double BeatLength = 1000;
+        public double BeatLength
+        {
+            get => beatLength;
+            set => beatLength = MathHelper.Clamp(value, 100, 60000);
+        }
+
+        private double beatLength = 1000;
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         public double BeatLength
         {
             get => beatLength;
-            set => beatLength = MathHelper.Clamp(value, 100, 60000);
+            set => beatLength = MathHelper.Clamp(value, 6, 60000);
         }
 
         private double beatLength = 1000;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -42,6 +42,10 @@ namespace osu.Game.Beatmaps.Formats
 
             ParseContent(stream);
 
+            // objects may be out of order *only* if a user has manually edited an .osu file.
+            // unfortunately there are ranked maps in this state (example: https://osu.ppy.sh/s/594828).
+            this.beatmap.HitObjects.Sort((x, y) => x.StartTime.CompareTo(y.StartTime));
+
             foreach (var hitObject in this.beatmap.HitObjects)
                 hitObject.ApplyDefaults(this.beatmap.ControlPointInfo, this.beatmap.BeatmapInfo.BaseDifficulty);
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -8,6 +8,7 @@ using OpenTK.Graphics;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Beatmaps.ControlPoints;
+using OpenTK;
 
 namespace osu.Game.Beatmaps.Formats
 {
@@ -319,7 +320,7 @@ namespace osu.Game.Beatmaps.Formats
                 beatmap.ControlPointInfo.TimingPoints.Add(new TimingControlPoint
                 {
                     Time = time,
-                    BeatLength = beatLength,
+                    BeatLength = MathHelper.Clamp(beatLength, 100, 60000),
                     TimeSignature = timeSignature
                 });
             }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -8,7 +8,6 @@ using OpenTK.Graphics;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Beatmaps.ControlPoints;
-using OpenTK;
 
 namespace osu.Game.Beatmaps.Formats
 {
@@ -320,7 +319,7 @@ namespace osu.Game.Beatmaps.Formats
                 beatmap.ControlPointInfo.TimingPoints.Add(new TimingControlPoint
                 {
                     Time = time,
-                    BeatLength = MathHelper.Clamp(beatLength, 100, 60000),
+                    BeatLength = beatLength,
                     TimeSignature = timeSignature
                 });
             }

--- a/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using OpenTK;
 using osu.Game.Rulesets.Objects.Types;
 using System.Collections.Generic;
@@ -29,7 +30,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Osu
                 Position = position,
                 NewCombo = newCombo,
                 ControlPoints = controlPoints,
-                Distance = length,
+                Distance = Math.Max(0, length),
                 CurveType = curveType,
                 RepeatSamples = repeatSamples,
                 RepeatCount = repeatCount


### PR DESCRIPTION
Resolves ppy/osu#1988.

Not sure on the path we want to take forward when handling these kinds of situations. An alternative to this implementation is to hard-fail on import or load when a beatmap does not match known standards.