### PR TITLE
Don't use BufferedContainer for OsuLogo

### DIFF
--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Screens.Menu
                                                     Alpha = 0.5f,
                                                     Size = new Vector2(0.96f)
                                                 },
-                                                new BufferedContainer
+                                                new Container
                                                 {
                                                     AutoSizeAxes = Axes.Both,
                                                     Children = new Drawable[]


### PR DESCRIPTION
Minor performance improvement. Not sure why this was done but it's not required any more.