### PR TITLE
Fix FastRandom using uint instead of int for NextDouble()

### DIFF
--- a/osu.Game.Rulesets.Mania/MathUtils/FastRandom.cs
+++ b/osu.Game.Rulesets.Mania/MathUtils/FastRandom.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Mania.MathUtils
     /// </summary>
     internal class FastRandom
     {
-        private const double uint_to_real = 1.0 / (uint.MaxValue + 1.0);
+        private const double int_to_real = 1.0 / (int.MaxValue + 1.0);
         private const uint int_mask = 0x7FFFFFFF;
         private const uint y = 842502087;
         private const uint z = 3579807591;
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Mania.MathUtils
         /// Generates a random double value within the range [0, 1).
         /// </summary>
         /// <returns>The random value.</returns>
-        public double NextDouble() => uint_to_real * NextUInt();
+        public double NextDouble() => int_to_real * Next();
 
         private uint bitBuffer;
         private int bitIndex = 32;


### PR DESCRIPTION
Implementation difference vs osu-stable, was causing hitobject generation to be slightly off for mania.

Note that generation is still not equivalent even with this, but the issue lies elsewhere - I'm tracking it down.