### PR TITLE
Only use osu.Desktop to determine test assemblies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ build:
   project: osu.sln
   parallel: true
   verbosity: minimal
+test:
+  assemblies:
+    only:
+      - 'osu.Desktop\**\*.dll'
 after_build:
   - cmd: inspectcode --o="inspectcodereport.xml" --projects:osu.Game* --caches-home="inspectcode" osu.sln > NUL
   - cmd: NVika parsereport "inspectcodereport.xml" --treatwarningsaserrors

--- a/osu.Game.Rulesets.Catch/Tests/TestCaseFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCaseFruitObjects.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.MathUtils;
@@ -15,6 +16,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
+    [TestFixture]
     public class TestCaseFruitObjects : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Rulesets.Catch/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCasePerformancePoints.cs
@@ -1,8 +1,11 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
+
 namespace osu.Game.Rulesets.Catch.Tests
 {
+    [TestFixture]
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()

--- a/osu.Game.Rulesets.Mania/Tests/TestCaseAutoGeneration.cs
+++ b/osu.Game.Rulesets.Mania/Tests/TestCaseAutoGeneration.cs
@@ -9,6 +9,7 @@ using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests
 {
+    [TestFixture]
     public class TestCaseAutoGeneration : OsuTestCase
     {
         [Test]

--- a/osu.Game.Rulesets.Mania/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Mania/Tests/TestCasePerformancePoints.cs
@@ -1,8 +1,11 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
+
 namespace osu.Game.Rulesets.Mania.Tests
 {
+    [TestFixture]
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseHitCircle.cs
@@ -16,10 +16,12 @@ using System.Collections.Generic;
 using System;
 using osu.Game.Rulesets.Mods;
 using System.Linq;
+using NUnit.Framework;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
+    [TestFixture]
     public class TestCaseHitCircle : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseHitCircleHidden.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseHitCircleHidden.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
+    [TestFixture]
     public class TestCaseHitCircleHidden : TestCaseHitCircle
     {
         public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[] { typeof(OsuModHidden) }).ToList();

--- a/osu.Game.Rulesets.Osu/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCasePerformancePoints.cs
@@ -1,8 +1,11 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
+
 namespace osu.Game.Rulesets.Osu.Tests
 {
+    [TestFixture]
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
@@ -15,6 +15,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Game.Rulesets.Mods;
 using System.Linq;
+using NUnit.Framework;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -23,6 +24,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
+    [TestFixture]
     public class TestCaseSlider : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseSliderHidden.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseSliderHidden.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
+    [TestFixture]
     public class TestCaseSliderHidden : TestCaseSlider
     {
         public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[] { typeof(OsuModHidden) }).ToList();

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseSpinner.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
@@ -16,6 +17,7 @@ using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
+    [TestFixture]
     public class TestCaseSpinner : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseSpinnerHidden.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseSpinnerHidden.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
+    [TestFixture]
     public class TestCaseSpinnerHidden : TestCaseSpinner
     {
         public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[] { typeof(OsuModHidden) }).ToList();

--- a/osu.Game.Rulesets.Taiko/Tests/TestCaseInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/Tests/TestCaseInputDrum.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using OpenTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,6 +15,7 @@ using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {
+    [TestFixture]
     public class TestCaseInputDrum : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Rulesets.Taiko/Tests/TestCasePerformancePoints.cs
+++ b/osu.Game.Rulesets.Taiko/Tests/TestCasePerformancePoints.cs
@@ -1,8 +1,11 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
+
 namespace osu.Game.Rulesets.Taiko.Tests
 {
+    [TestFixture]
     public class TestCasePerformancePoints : Game.Tests.Visual.TestCasePerformancePoints
     {
         public TestCasePerformancePoints()

--- a/osu.Game.Tests/Visual/TestCaseAllPlayers.cs
+++ b/osu.Game.Tests/Visual/TestCaseAllPlayers.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
+
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseAllPlayers : TestCasePlayer
     {
     }

--- a/osu.Game.Tests/Visual/TestCaseBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatSyncedContainer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using NUnit.Framework;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -17,6 +18,7 @@ using osu.Framework.Lists;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseBeatSyncedContainer : OsuTestCase
     {
         private readonly MusicController mc;

--- a/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapCarousel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
@@ -17,6 +18,7 @@ using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseBeatmapCarousel : OsuTestCase
     {
         private TestBeatmapCarousel carousel;

--- a/osu.Game.Tests/Visual/TestCaseBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapInfoWedge.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using OpenTK;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
@@ -18,6 +19,7 @@ using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseBeatmapInfoWedge : OsuTestCase
     {
         private RulesetStore rulesets;

--- a/osu.Game.Tests/Visual/TestCaseBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapSetOverlay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
@@ -12,6 +13,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseBeatmapSetOverlay : OsuTestCase
     {
         private readonly BeatmapSetOverlay overlay;

--- a/osu.Game.Tests/Visual/TestCaseBreadcrumbs.cs
+++ b/osu.Game.Tests/Visual/TestCaseBreadcrumbs.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseBreadcrumbs : OsuTestCase
     {
         public TestCaseBreadcrumbs()

--- a/osu.Game.Tests/Visual/TestCaseBreakOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseBreakOverlay.cs
@@ -5,9 +5,11 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Screens.Play.BreaksOverlay;
 using System.Collections.Generic;
+using NUnit.Framework;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseBreakOverlay : OsuTestCase
     {
         private readonly BreakOverlay breakOverlay;

--- a/osu.Game.Tests/Visual/TestCaseButtonSystem.cs
+++ b/osu.Game.Tests/Visual/TestCaseButtonSystem.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Shapes;
@@ -9,6 +10,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseButtonSystem : OsuTestCase
     {
         public TestCaseButtonSystem()

--- a/osu.Game.Tests/Visual/TestCaseChatLink.cs
+++ b/osu.Game.Tests/Visual/TestCaseChatLink.cs
@@ -12,12 +12,14 @@ using osu.Game.Users;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseChatLink : OsuTestCase
     {
         private readonly TestChatLineContainer textContainer;

--- a/osu.Game.Tests/Visual/TestCaseContextMenu.cs
+++ b/osu.Game.Tests/Visual/TestCaseContextMenu.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -13,6 +14,7 @@ using osu.Game.Graphics.Cursor;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseContextMenu : OsuTestCase
     {
         private const int start_time = 0;

--- a/osu.Game.Tests/Visual/TestCaseCursors.cs
+++ b/osu.Game.Tests/Visual/TestCaseCursors.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -16,6 +17,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseCursors : OsuTestCase
     {
         private readonly ManualInputManager inputManager;

--- a/osu.Game.Tests/Visual/TestCaseDialogOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseDialogOverlay.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseDialogOverlay : OsuTestCase
     {
         public TestCaseDialogOverlay()

--- a/osu.Game.Tests/Visual/TestCaseDirect.cs
+++ b/osu.Game.Tests/Visual/TestCaseDirect.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
@@ -9,6 +10,7 @@ using osu.Game.Rulesets;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseDirect : OsuTestCase
     {
         private DirectOverlay direct;

--- a/osu.Game.Tests/Visual/TestCaseDrawableRoom.cs
+++ b/osu.Game.Tests/Visual/TestCaseDrawableRoom.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -12,6 +13,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseDrawableRoom : OsuTestCase
     {
         private RulesetStore rulesets;

--- a/osu.Game.Tests/Visual/TestCaseEditor.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Edit;
@@ -10,6 +11,7 @@ using osu.Game.Screens.Edit.Screens;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseEditor : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(Editor), typeof(EditorScreen) };

--- a/osu.Game.Tests/Visual/TestCaseEditorCompose.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditorCompose.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Edit.Screens.Compose;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseEditorCompose : OsuTestCase
     {
         private readonly Random random;

--- a/osu.Game.Tests/Visual/TestCaseEditorComposeRadioButtons.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditorComposeRadioButtons.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Edit.Screens.Compose.RadioButtons;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseEditorComposeRadioButtons : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(DrawableRadioButton) };

--- a/osu.Game.Tests/Visual/TestCaseEditorComposeTimeline.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditorComposeTimeline.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using OpenTK;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -12,6 +13,7 @@ using osu.Game.Screens.Edit.Screens.Compose.Timeline;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseEditorComposeTimeline : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(ScrollableTimeline), typeof(ScrollingTimelineContainer), typeof(BeatmapWaveformGraph), typeof(TimelineButton) };

--- a/osu.Game.Tests/Visual/TestCaseEditorMenuBar.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditorMenuBar.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -11,6 +12,7 @@ using osu.Game.Screens.Edit.Menus;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseEditorMenuBar : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(EditorMenuBar), typeof(ScreenSelectionTabControl) };

--- a/osu.Game.Tests/Visual/TestCaseEditorSelectionLayer.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditorSelectionLayer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using OpenTK;
 using osu.Game.Beatmaps;
@@ -18,6 +19,7 @@ using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseEditorSelectionLayer : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestCaseEditorSummaryTimeline.cs
+++ b/osu.Game.Tests/Visual/TestCaseEditorSummaryTimeline.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics;
@@ -14,6 +15,7 @@ using osu.Framework.Configuration;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseEditorSummaryTimeline : OsuTestCase
     {
         private const int length = 60000;

--- a/osu.Game.Tests/Visual/TestCaseGamefield.cs
+++ b/osu.Game.Tests/Visual/TestCaseGamefield.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Game.Beatmaps.ControlPoints;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseGamefield : OsuTestCase
     {
         protected override void LoadComplete()

--- a/osu.Game.Tests/Visual/TestCaseGraph.cs
+++ b/osu.Game.Tests/Visual/TestCaseGraph.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 using OpenTK;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseGraph : OsuTestCase
     {
         public TestCaseGraph()

--- a/osu.Game.Tests/Visual/TestCaseHistoricalSection.cs
+++ b/osu.Game.Tests/Visual/TestCaseHistoricalSection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -13,6 +14,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseHistoricalSection : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes =>

--- a/osu.Game.Tests/Visual/TestCaseIconButton.cs
+++ b/osu.Game.Tests/Visual/TestCaseIconButton.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
@@ -12,6 +13,7 @@ using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseIconButton : OsuTestCase
     {
         public TestCaseIconButton()

--- a/osu.Game.Tests/Visual/TestCaseIntroSequence.cs
+++ b/osu.Game.Tests/Visual/TestCaseIntroSequence.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -12,6 +13,7 @@ using osu.Game.Screens.Menu;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseIntroSequence : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestCaseKeyConfiguration.cs
+++ b/osu.Game.Tests/Visual/TestCaseKeyConfiguration.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseKeyConfiguration : OsuTestCase
     {
         private readonly KeyBindingOverlay overlay;

--- a/osu.Game.Tests/Visual/TestCaseKeyCounter.cs
+++ b/osu.Game.Tests/Visual/TestCaseKeyCounter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.MathUtils;
 using osu.Game.Screens.Play;
@@ -8,6 +9,7 @@ using OpenTK.Input;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseKeyCounter : OsuTestCase
     {
         public TestCaseKeyCounter()

--- a/osu.Game.Tests/Visual/TestCaseMedalOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseMedalOverlay.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Game.Overlays;
 using osu.Game.Overlays.MedalSplash;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseMedalOverlay : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestCaseMusicController.cs
+++ b/osu.Game.Tests/Visual/TestCaseMusicController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
@@ -11,6 +12,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseMusicController : OsuTestCase
     {
         private readonly Bindable<WorkingBeatmap> beatmapBacking = new Bindable<WorkingBeatmap>();

--- a/osu.Game.Tests/Visual/TestCaseNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseNotificationOverlay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -13,6 +14,7 @@ using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseNotificationOverlay : OsuTestCase
     {
         private readonly NotificationOverlay manager;

--- a/osu.Game.Tests/Visual/TestCaseOnScreenDisplay.cs
+++ b/osu.Game.Tests/Visual/TestCaseOnScreenDisplay.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseOnScreenDisplay : OsuTestCase
     {
         private FrameworkConfigManager config;

--- a/osu.Game.Tests/Visual/TestCaseOsuGame.cs
+++ b/osu.Game.Tests/Visual/TestCaseOsuGame.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Timing;
@@ -12,6 +13,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseOsuGame : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.MathUtils;
@@ -19,6 +20,7 @@ using osu.Game.Tests.Platform;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCasePlaySongSelect : OsuTestCase
     {
         private BeatmapManager manager;

--- a/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaybackControl.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Edit.Components;
@@ -9,6 +10,7 @@ using OpenTK;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCasePlaybackControl : OsuTestCase
     {
         public TestCasePlaybackControl()

--- a/osu.Game.Tests/Visual/TestCasePopupDialog.cs
+++ b/osu.Game.Tests/Visual/TestCasePopupDialog.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCasePopupDialog : OsuTestCase
     {
         public TestCasePopupDialog()

--- a/osu.Game.Tests/Visual/TestCaseRankGraph.cs
+++ b/osu.Game.Tests/Visual/TestCaseRankGraph.cs
@@ -9,11 +9,13 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using System.Collections.Generic;
 using System;
+using NUnit.Framework;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseRankGraph : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestCaseReplaySettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseReplaySettingsOverlay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Play.HUD;
@@ -8,6 +9,7 @@ using osu.Game.Screens.Play.PlayerSettings;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseReplaySettingsOverlay : OsuTestCase
     {
         public TestCaseReplaySettingsOverlay()

--- a/osu.Game.Tests/Visual/TestCaseResults.cs
+++ b/osu.Game.Tests/Visual/TestCaseResults.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
@@ -11,6 +12,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseResults : OsuTestCase
     {
         private BeatmapManager beatmaps;

--- a/osu.Game.Tests/Visual/TestCaseRoomInspector.cs
+++ b/osu.Game.Tests/Visual/TestCaseRoomInspector.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
@@ -11,6 +12,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseRoomInspector : OsuTestCase
     {
         private RulesetStore rulesets;

--- a/osu.Game.Tests/Visual/TestCaseScoreCounter.cs
+++ b/osu.Game.Tests/Visual/TestCaseScoreCounter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.MathUtils;
@@ -10,6 +11,7 @@ using OpenTK;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseScoreCounter : OsuTestCase
     {
         public TestCaseScoreCounter()

--- a/osu.Game.Tests/Visual/TestCaseScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/TestCaseScrollingHitObjects.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using OpenTK;
 using osu.Framework.Graphics;
@@ -16,6 +17,7 @@ using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseScrollingHitObjects : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(Playfield) };

--- a/osu.Game.Tests/Visual/TestCaseSettings.cs
+++ b/osu.Game.Tests/Visual/TestCaseSettings.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseSettings : OsuTestCase
     {
         private readonly SettingsOverlay settings;

--- a/osu.Game.Tests/Visual/TestCaseSkipButton.cs
+++ b/osu.Game.Tests/Visual/TestCaseSkipButton.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseSkipButton : OsuTestCase
     {
         protected override void LoadComplete()

--- a/osu.Game.Tests/Visual/TestCaseSocial.cs
+++ b/osu.Game.Tests/Visual/TestCaseSocial.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Social;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseSocial : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestCaseSongProgress.cs
+++ b/osu.Game.Tests/Visual/TestCaseSongProgress.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System.Collections.Generic;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.MathUtils;
 using osu.Framework.Timing;
@@ -10,6 +11,7 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseSongProgress : OsuTestCase
     {
         private readonly SongProgress progress;

--- a/osu.Game.Tests/Visual/TestCaseStoryboard.cs
+++ b/osu.Game.Tests/Visual/TestCaseStoryboard.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
@@ -14,6 +15,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseStoryboard : OsuTestCase
     {
         private readonly Bindable<WorkingBeatmap> beatmapBacking = new Bindable<WorkingBeatmap>();

--- a/osu.Game.Tests/Visual/TestCaseTextAwesome.cs
+++ b/osu.Game.Tests/Visual/TestCaseTextAwesome.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -10,6 +11,7 @@ using OpenTK;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseTextAwesome : OsuTestCase
     {
         public TestCaseTextAwesome()

--- a/osu.Game.Tests/Visual/TestCaseToolbar.cs
+++ b/osu.Game.Tests/Visual/TestCaseToolbar.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays.Toolbar;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseToolbar : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestCaseUserPanel.cs
+++ b/osu.Game.Tests/Visual/TestCaseUserPanel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Users;
@@ -8,6 +9,7 @@ using OpenTK;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseUserPanel : OsuTestCase
     {
         public TestCaseUserPanel()

--- a/osu.Game.Tests/Visual/TestCaseUserProfile.cs
+++ b/osu.Game.Tests/Visual/TestCaseUserProfile.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Profile;
@@ -11,6 +12,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseUserProfile : OsuTestCase
     {
         private readonly TestUserProfileOverlay profile;

--- a/osu.Game.Tests/Visual/TestCaseUserRanks.cs
+++ b/osu.Game.Tests/Visual/TestCaseUserRanks.cs
@@ -10,9 +10,11 @@ using osu.Game.Overlays.Profile.Sections.Ranks;
 using osu.Game.Users;
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseUserRanks : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(DrawableProfileScore), typeof(RanksSection) };

--- a/osu.Game.Tests/Visual/TestCaseWaveform.cs
+++ b/osu.Game.Tests/Visual/TestCaseWaveform.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using NUnit.Framework;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
@@ -15,6 +16,7 @@ using osu.Game.Screens.Edit.Screens.Compose.Timeline;
 
 namespace osu.Game.Tests.Visual
 {
+    [TestFixture]
     public class TestCaseWaveform : OsuTestCase
     {
         private readonly Bindable<WorkingBeatmap> beatmapBacking = new Bindable<WorkingBeatmap>();

--- a/osu.Game/Tests/TestTestCase.cs
+++ b/osu.Game/Tests/TestTestCase.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+
+namespace osu.Game.Tests
+{
+    [TestFixture]
+    internal class TestTestCase : TestCase
+    {
+        // This TestCase is required for nunit to not throw errors
+        // See: https://github.com/nunit/nunit/issues/1118
+    }
+}

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -886,6 +886,7 @@
     <Compile Include="Tests\Beatmaps\TestWorkingBeatmap.cs" />
     <Compile Include="Tests\CleanRunHeadlessGameHost.cs" />
     <Compile Include="Tests\Platform\TestStorage.cs" />
+    <Compile Include="Tests\TestTestCase.cs" />
     <Compile Include="Tests\Visual\OsuTestCase.cs" />
     <Compile Include="Tests\Visual\TestCasePerformancePoints.cs" />
     <Compile Include="Tests\Visual\ScreenTestCase.cs" />


### PR DESCRIPTION
Should significantly reduce the time CI takes to run, since several assemblies are run multiple times.

Also fixes Rulesets.Osu testcases never running (let's add [TestFixture] everywhere now).