### PR TITLE
Fix parallax container during rewinds

### DIFF
--- a/osu.Game/Graphics/Containers/ParallaxContainer.cs
+++ b/osu.Game/Graphics/Containers/ParallaxContainer.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Graphics.Containers
             {
                 Vector2 offset = (input.CurrentState.Mouse == null ? Vector2.Zero : ToLocalSpace(input.CurrentState.Mouse.NativeState.Position) - DrawSize / 2) * ParallaxAmount;
 
-                content.Position = Interpolation.ValueAt(Clock.ElapsedFrameTime, content.Position, offset, 0, 1000, Easing.OutQuint);
+                content.Position = Interpolation.ValueAt(MathHelper.Clamp(Clock.ElapsedFrameTime, 0, 1000), content.Position, offset, 0, 1000, Easing.OutQuint);
                 content.Scale = new Vector2(1 + ParallaxAmount);
             }
 


### PR DESCRIPTION
Parallax relies on using `ElapsedTime` which can become negative in some cases. We can basically ignore these cases.

I did consider DI'ing in a higher level clock (ie. the game clock) but this is bad news if we have children which need to use their parents clock, as we deny them that inheritance.