### PR TITLE
Add legacy timing offsets

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
         [Test]
         public void TestDecodeBeatmapGeneral()
         {
-            var decoder = new LegacyBeatmapDecoder();
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
             using (var resStream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             using (var stream = new StreamReader(resStream))
             {
@@ -110,7 +110,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
         [Test]
         public void TestDecodeBeatmapEvents()
         {
-            var decoder = new LegacyBeatmapDecoder();
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
             using (var resStream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             using (var stream = new StreamReader(resStream))
             {
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
         [Test]
         public void TestDecodeBeatmapTimingPoints()
         {
-            var decoder = new LegacyBeatmapDecoder();
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
             using (var resStream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             using (var stream = new StreamReader(resStream))
             {
@@ -187,7 +187,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
         [Test]
         public void TestDecodeBeatmapHitObjects()
         {
-            var decoder = new LegacyBeatmapDecoder();
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
             using (var resStream = Resource.OpenResource("Soleily - Renatus (Gamu) [Insane].osu"))
             using (var stream = new StreamReader(resStream))
             {

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             using (var sr = new StreamReader(stream))
             {
 
-                var legacyDecoded = new LegacyBeatmapDecoder().DecodeBeatmap(sr);
+                var legacyDecoded = new LegacyBeatmapDecoder { ApplyOffsets = false }.DecodeBeatmap(sr);
                 using (var ms = new MemoryStream())
                 using (var sw = new StreamWriter(ms))
                 using (var sr2 = new StreamReader(ms))

--- a/osu.Game.Tests/Beatmaps/IO/OszArchiveReaderTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/OszArchiveReaderTest.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 Assert.AreEqual("03. Renatus - Soleily 192kbps.mp3", meta.AudioFile);
                 Assert.AreEqual("Deif", meta.AuthorString);
                 Assert.AreEqual("machinetop_background.jpg", meta.BackgroundFile);
-                Assert.AreEqual(164471, meta.PreviewTime);
+                Assert.AreEqual(164471 + LegacyBeatmapDecoder.UniversalOffset, meta.PreviewTime);
                 Assert.AreEqual(string.Empty, meta.Source);
                 Assert.AreEqual("MBC7 Unisphere 地球ヤバイEP Chikyu Yabai", meta.Tags);
                 Assert.AreEqual("Renatus", meta.Title);

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -22,7 +22,18 @@ namespace osu.Game.Beatmaps.Formats
         private LegacySampleBank defaultSampleBank;
         private int defaultSampleVolume = 100;
 
-        private readonly int timeOffset;
+        /// <summary>
+        /// lazer's audio timings in general doesn't match stable. this is the result of user testing, albeit limited.
+        /// This only seems to be required on windows. We need to eventually figure out why, with a bit of luck.
+        /// </summary>
+        public static int UniversalOffset => RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? -22 : 0;
+
+        /// <summary>
+        /// Whether or not beatmap or runtime offsets should be applied. Defaults on; only disable for testing purposes.
+        /// </summary>
+        public bool ApplyOffsets = true;
+
+        private readonly int offset = UniversalOffset;
 
         public LegacyBeatmapDecoder()
         {
@@ -33,12 +44,7 @@ namespace osu.Game.Beatmaps.Formats
             BeatmapVersion = int.Parse(header.Substring(17));
 
             // BeatmapVersion 4 and lower had an incorrect offset (stable has this set as 24ms off)
-            timeOffset += BeatmapVersion < 5 ? 24 : 0;
-
-            // lazer in general doesn't match stable. this is the result of user testing, albeit limited.
-            // only seems to be required on windows.
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
-                timeOffset += -22;
+            offset += BeatmapVersion < 5 ? 24 : 0;
         }
 
         protected override void ParseBeatmap(StreamReader stream, Beatmap beatmap)
@@ -413,8 +419,8 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private int getOffsetTime(int time) => time + timeOffset;
+        private int getOffsetTime(int time) => time + (ApplyOffsets ? offset : 0);
 
-        private double getOffsetTime(double time) => time + timeOffset;
+        private double getOffsetTime(double time) => time + (ApplyOffsets ? offset : 0);
     }
 }

--- a/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Tests.Beatmaps
 
         private Beatmap getBeatmap(string name)
         {
-            var decoder = new LegacyBeatmapDecoder();
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
             using (var resStream = openResource($"{resource_namespace}.{name}.osu"))
             using (var stream = new StreamReader(resStream))
                 return decoder.DecodeBeatmap(stream);


### PR DESCRIPTION
These have been in release builds since January, but implemented in a hacky way.

This brings them with a sane implementation.