### PR TITLE
Update framework with FlowContainer changes

### DIFF
--- a/osu.Game/Graphics/Containers/ReverseChildIDFillFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/ReverseChildIDFillFlowContainer.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Graphics.Containers
     {
         protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
 
-        protected override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
+        public override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
     }
 }

--- a/osu.Game/Graphics/Containers/ReverseChildIDFillFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/ReverseChildIDFillFlowContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -11,7 +9,5 @@ namespace osu.Game.Graphics.Containers
     public class ReverseChildIDFillFlowContainer<T> : FillFlowContainer<T> where T : Drawable
     {
         protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
-
-        public override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -55,6 +56,14 @@ namespace osu.Game.Graphics.UserInterface
                     i.AccentColour = value;
             }
         }
+
+        protected override TabFillFlowContainer CreateTabFlow() => new OsuTabFillFlowContainer
+        {
+            Direction = FillDirection.Full,
+            RelativeSizeAxes = Axes.Both,
+            Depth = -1,
+            Masking = true
+        };
 
         public class OsuTabItem : TabItem<T>, IHasAccentColour
         {
@@ -238,6 +247,11 @@ namespace osu.Game.Graphics.UserInterface
                     base.OnHoverLost(state);
                 }
             }
+        }
+
+        private class OsuTabFillFlowContainer : TabFillFlowContainer
+        {
+            protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
         }
     }
 }

--- a/osu.Game/Overlays/Chat/ChatTabControl.cs
+++ b/osu.Game/Overlays/Chat/ChatTabControl.cs
@@ -53,9 +53,9 @@ namespace osu.Game.Overlays.Chat
 
         protected override void AddTabItem(TabItem<Channel> item, bool addToDropdown = true)
         {
-            if (selectorTab.Depth < float.MaxValue)
+            if (item != selectorTab && TabContainer.GetLayoutPosition(selectorTab) < float.MaxValue)
                 // performTabSort might've made selectorTab's position wonky, fix it
-                TabContainer.ChangeChildDepth(selectorTab, float.MaxValue);
+                TabContainer.SetLayoutPosition(selectorTab, float.MaxValue);
 
             base.AddTabItem(item, addToDropdown);
 

--- a/osu.Game/Overlays/Music/PlaylistList.cs
+++ b/osu.Game/Overlays/Music/PlaylistList.cs
@@ -101,11 +101,10 @@ namespace osu.Game.Overlays.Music
 
             public void AddBeatmapSet(BeatmapSetInfo beatmapSet)
             {
-                items.Add(new PlaylistItem(beatmapSet)
-                {
-                    OnSelect = set => OnSelect?.Invoke(set),
-                    Depth = items.Count
-                });
+                var newItem = new PlaylistItem(beatmapSet) { OnSelect = set => OnSelect?.Invoke(set) };
+
+                items.Add(newItem);
+                items.SetLayoutPosition(newItem, items.Count);
             }
 
             public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet)
@@ -197,7 +196,7 @@ namespace osu.Game.Overlays.Music
             {
                 var itemsPos = items.ToLocalSpace(nativeDragPosition);
 
-                int srcIndex = (int)draggedItem.Depth;
+                int srcIndex = (int)items.GetLayoutPosition(draggedItem);
 
                 // Find the last item with position < mouse position. Note we can't directly use
                 // the item positions as they are being transformed
@@ -219,15 +218,15 @@ namespace osu.Game.Overlays.Music
                 if (srcIndex < dstIndex)
                 {
                     for (int i = srcIndex + 1; i <= dstIndex; i++)
-                        items.ChangeChildDepth(items[i], i - 1);
+                        items.SetLayoutPosition(items[i], i - 1);
                 }
                 else
                 {
                     for (int i = dstIndex; i < srcIndex; i++)
-                        items.ChangeChildDepth(items[i], i + 1);
+                        items.SetLayoutPosition(items[i], i + 1);
                 }
 
-                items.ChangeChildDepth(draggedItem, dstIndex);
+                items.SetLayoutPosition(draggedItem, dstIndex);
             }
 
             private class ItemSearchContainer : FillFlowContainer<PlaylistItem>, IHasFilterableChildren
@@ -242,9 +241,6 @@ namespace osu.Game.Overlays.Music
                             InvalidateLayout();
                     }
                 }
-
-                // Compare with reversed ChildID and Depth
-                protected override int Compare(Drawable x, Drawable y) => base.Compare(y, x);
 
                 public IEnumerable<IFilterable> FilterableChildren => Children;
 

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -129,7 +129,6 @@ namespace osu.Game.Overlays
         public void Post(Notification notification) => postScheduler.Add(() =>
         {
             ++runningDepth;
-            notification.Depth = notification.DisplayOnTop ? runningDepth : -runningDepth;
 
             notification.Closed += notificationClosed;
 
@@ -138,7 +137,9 @@ namespace osu.Game.Overlays
                 hasCompletionTarget.CompletionTarget = Post;
 
             var ourType = notification.GetType();
-            sections.Children.FirstOrDefault(s => s.AcceptTypes.Any(accept => accept.IsAssignableFrom(ourType)))?.Add(notification);
+
+            var section = sections.Children.FirstOrDefault(s => s.AcceptTypes.Any(accept => accept.IsAssignableFrom(ourType)));
+            section?.Add(notification, notification.DisplayOnTop ? -runningDepth : runningDepth);
 
             updateCounts();
         });

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -25,10 +25,13 @@ namespace osu.Game.Overlays.Notifications
         private FlowContainer<Notification> notifications;
 
         public int DisplayedCount => notifications.Count(n => !n.WasClosed);
-
         public int UnreadCount => notifications.Count(n => !n.WasClosed && !n.Read);
 
-        public void Add(Notification notification) => notifications.Add(notification);
+        public void Add(Notification notification, float position)
+        {
+            notifications.Add(notification);
+            notifications.SetLayoutPosition(notification, position);
+        }
 
         public IEnumerable<Type> AcceptTypes;
 

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -40,16 +40,18 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
         [BackgroundDependencyLoader(true)]
         private void load(OsuColour colour)
         {
-            RightFlowContainer.Add(new OsuSpriteText
+            var text = new OsuSpriteText
             {
                 Text = $"accuracy: {Score.Accuracy:P2}",
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
                 Colour = colour.GrayA,
                 TextSize = 11,
-                Font = "Exo2.0-RegularItalic",
-                Depth = -1,
-            });
+                Font = "Exo2.0-RegularItalic"
+            };
+
+            RightFlowContainer.Add(text);
+            RightFlowContainer.SetLayoutPosition(text, 1);
 
             LeftFlowContainer.Add(new BeatmapMetadataContainer(Score.Beatmap));
             LeftFlowContainer.Add(new OsuSpriteText

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -45,7 +45,8 @@ namespace osu.Game.Overlays.Settings
                 if (text == null)
                 {
                     // construct lazily for cases where the label is not needed (may be provided by the Control).
-                    Add(text = new OsuSpriteText { Depth = 1 });
+                    Add(text = new OsuSpriteText());
+                    FlowContent.SetLayoutPosition(text, -1);
                 }
 
                 text.Text = value;

--- a/osu.Game/Screens/Menu/FlowContainerWithOrigin.cs
+++ b/osu.Game/Screens/Menu/FlowContainerWithOrigin.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Menu
 
         protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
 
-        protected override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
+        public override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
 
         public override Anchor Origin => Anchor.Custom;
 

--- a/osu.Game/Screens/Menu/FlowContainerWithOrigin.cs
+++ b/osu.Game/Screens/Menu/FlowContainerWithOrigin.cs
@@ -4,8 +4,6 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using OpenTK;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Screens.Menu
 {
@@ -21,8 +19,6 @@ namespace osu.Game.Screens.Menu
         public Drawable CentreTarget;
 
         protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
-
-        public override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
 
         public override Anchor Origin => Anchor.Custom;
 

--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -41,19 +41,25 @@ namespace osu.Game.Screens.Select
         /// <para>Higher depth to be put on the left, and lower to be put on the right.</para>
         /// <para>Notice this is different to <see cref="Options.BeatmapOptionsOverlay"/>!</para>
         /// </param>
-        public void AddButton(string text, Color4 colour, Action action, Key? hotkey = null, float depth = 0) => buttons.Add(new FooterButton
+        public void AddButton(string text, Color4 colour, Action action, Key? hotkey = null, float depth = 0)
         {
-            Text = text,
-            Height = play_song_select_button_height,
-            Width = play_song_select_button_width,
-            Depth = depth,
-            SelectedColour = colour,
-            DeselectedColour = colour.Opacity(0.5f),
-            Hotkey = hotkey,
-            Hovered = updateModeLight,
-            HoverLost = updateModeLight,
-            Action = action,
-        });
+            var button = new FooterButton
+            {
+                Text = text,
+                Height = play_song_select_button_height,
+                Width = play_song_select_button_width,
+                Depth = depth,
+                SelectedColour = colour,
+                DeselectedColour = colour.Opacity(0.5f),
+                Hotkey = hotkey,
+                Hovered = updateModeLight,
+                HoverLost = updateModeLight,
+                Action = action,
+            };
+
+            buttons.Add(button);
+            buttons.SetLayoutPosition(button, -depth);
+        }
 
         private readonly List<OverlayContainer> overlays = new List<OverlayContainer>();
 

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Select.Options
         /// </param>
         public void AddButton(string firstLine, string secondLine, FontAwesome icon, Color4 colour, Action action, Key? hotkey = null, float depth = 0)
         {
-            buttonsContainer.Add(new BeatmapOptionsButton
+            var button = new BeatmapOptionsButton
             {
                 FirstLineText = firstLine,
                 SecondLineText = secondLine,
@@ -108,7 +108,10 @@ namespace osu.Game.Screens.Select.Options
                     action?.Invoke();
                 },
                 HotKey = hotkey
-            });
+            };
+
+            buttonsContainer.Add(button);
+            buttonsContainer.SetLayoutPosition(button, depth);
         }
     }
 }


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/1447/files
- [x] https://github.com/ppy/osu-framework/pull/1446

Essentially the main changes are:
* Change `ChangeChildDepth` to `SetLayoutPosition`.
* Anywhere where depth was used for re-ordering, `SetLayoutPosition` is now used. This value is typically negated from its original (e.g. notifications, footer buttons), because a -1 depth previously meant being closer to the end of the flow and -1 depth now means being closer to the start of the flow.
* No more reversal of `FlowingChildren`, in the custom reversed fill flows - this was previously used to reverse the reversal that the comparer provides, however `FlowContainer` sorts `FlowingChildren` in the exact order we want (the non-reversed).