### PR TITLE
Removing "mouse wheel disabled" checkbox from visual settings in gameplay

### DIFF
--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private readonly PlayerSliderBar<double> dimSliderBar;
         private readonly PlayerSliderBar<double> blurSliderBar;
         private readonly PlayerCheckbox showStoryboardToggle;
-        private readonly PlayerCheckbox mouseWheelDisabledToggle;
 
         public VisualSettings()
         {
@@ -35,8 +34,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 {
                     Text = "Toggles:"
                 },
-                showStoryboardToggle = new PlayerCheckbox { LabelText = "Storyboards" },
-                mouseWheelDisabledToggle = new PlayerCheckbox { LabelText = "Disable mouse wheel" }
+                showStoryboardToggle = new PlayerCheckbox { LabelText = "Storyboards" }
             };
         }
 
@@ -46,7 +44,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
             dimSliderBar.Bindable = config.GetBindable<double>(OsuSetting.DimLevel);
             blurSliderBar.Bindable = config.GetBindable<double>(OsuSetting.BlurLevel);
             showStoryboardToggle.Bindable = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
-            mouseWheelDisabledToggle.Bindable = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
         }
     }
 }


### PR DESCRIPTION
Removed "Disable mouse wheel" checkbox and binding from VisualSettings
Fixes #2180 