### PR TITLE
Fix difficulty calculator regression when applying mods

### DIFF
--- a/osu.Game/Beatmaps/DifficultyCalculator.cs
+++ b/osu.Game/Beatmaps/DifficultyCalculator.cs
@@ -41,12 +41,12 @@ namespace osu.Game.Beatmaps
             foreach (var mod in Mods.OfType<IApplicableToDifficulty>())
                 mod.ApplyToDifficulty(Beatmap.BeatmapInfo.BaseDifficulty);
 
+            foreach (var h in Beatmap.HitObjects)
+                h.ApplyDefaults(Beatmap.ControlPointInfo, Beatmap.BeatmapInfo.BaseDifficulty);
+
             foreach (var mod in mods.OfType<IApplicableToHitObject<T>>())
                 foreach (var obj in Beatmap.HitObjects)
                     mod.ApplyToHitObject(obj);
-
-            foreach (var h in Beatmap.HitObjects)
-                h.ApplyDefaults(Beatmap.ControlPointInfo, Beatmap.BeatmapInfo.BaseDifficulty);
         }
 
         protected virtual void PreprocessHitObjects()


### PR DESCRIPTION
Null ref (osu! / HardRock) due to defaults not being applied in the correct order.