### PR TITLE
Fix caps warning occuring when pressing caps on Login section

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
-            if (args.Key == Key.CapsLock)
+            if (args.Key == Key.CapsLock && HasFocus)
                 updateCapsWarning(host.CapsLockEnabled);
             return base.OnKeyDown(state, args);
         }


### PR DESCRIPTION
No longer will the caps warning appear except for when you are focused on the password box. This closes #2234