### PR TITLE
Fix crash when attempting to select objects that don't have masks

### DIFF
--- a/osu.Game/Screens/Edit/Screens/Compose/Layers/HitObjectMaskLayer.cs
+++ b/osu.Game/Screens/Edit/Screens/Compose/Layers/HitObjectMaskLayer.cs
@@ -51,7 +51,11 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Layers
 
         private SelectionBox currentSelectionBox;
 
-        public void AddSelectionOverlay() => AddInternal(currentSelectionBox = composer.CreateSelectionOverlay(overlayContainer));
+        public void AddSelectionOverlay()
+        {
+            if (overlayContainer.Count > 0)
+                AddInternal(currentSelectionBox = composer.CreateSelectionOverlay(overlayContainer));
+        }
 
         public void RemoveSelectionOverlay()
         {


### PR DESCRIPTION
E.g. because DrawableSpinner doesn't (currently) create a mask, SelectionBox was being constructed with 0 hitobjects and then calculating a non-finite size for itself.