### PR TITLE
Remove ComboColour from HitObjects

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 }
 
                 obj.IndexInBeatmap = index++;
-                obj.ComboColour = beatmap.ComboColours[colourIndex];
+                obj.AccentColour = beatmap.ComboColours[colourIndex];
 
                 lastObj = obj;
             }

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -16,29 +16,13 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
     {
         public override void PostProcess(Beatmap<CatchHitObject> beatmap)
         {
-            if (beatmap.ComboColours.Count == 0)
-                return;
-
-            int index = 0;
-            int colourIndex = 0;
-
-            CatchHitObject lastObj = null;
-
             initialiseHyperDash(beatmap.HitObjects);
 
+            base.PostProcess(beatmap);
+
+            int index = 0;
             foreach (var obj in beatmap.HitObjects)
-            {
-                if (obj.NewCombo)
-                {
-                    if (lastObj != null) lastObj.LastInCombo = true;
-                    colourIndex = (colourIndex + 1) % beatmap.ComboColours.Count;
-                }
-
                 obj.IndexInBeatmap = index++;
-                obj.AccentColour = beatmap.ComboColours[colourIndex];
-
-                lastObj = obj;
-            }
         }
 
         private void initialiseHyperDash(List<CatchHitObject> objects)

--- a/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.MathUtils;
 using osu.Game.Rulesets.Objects.Types;
-using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
@@ -32,23 +31,9 @@ namespace osu.Game.Rulesets.Catch.Objects
                 AddNested(new Banana
                 {
                     Samples = Samples,
-                    ComboColour = getNextComboColour(),
                     StartTime = i,
                     X = RNG.NextSingle()
                 });
-        }
-
-        private Color4 getNextComboColour()
-        {
-            switch (RNG.Next(0, 3))
-            {
-                default:
-                    return new Color4(255, 240, 0, 255);
-                case 1:
-                    return new Color4(255, 192, 0, 255);
-                case 2:
-                    return new Color4(214, 221, 28, 255);
-            }
         }
 
         public double EndTime => StartTime + Duration;

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -8,7 +8,7 @@ using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
-    public abstract class CatchHitObject : HitObject, IHasXPosition, IHasComboIndex
+    public abstract class CatchHitObject : HitObject, IHasXPosition, IHasComboInformation
     {
         public const double OBJECT_RADIUS = 44;
 

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -5,23 +5,24 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
-using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
-    public abstract class CatchHitObject : HitObject, IHasXPosition, IHasCombo
+    public abstract class CatchHitObject : HitObject, IHasXPosition, IHasComboIndex
     {
         public const double OBJECT_RADIUS = 44;
 
         public float X { get; set; }
-
-        public Color4 ComboColour { get; set; }
 
         public int IndexInBeatmap { get; set; }
 
         public virtual FruitVisualRepresentation VisualRepresentation => (FruitVisualRepresentation)(IndexInBeatmap % 4);
 
         public virtual bool NewCombo { get; set; }
+
+        public int IndexInCurrentCombo { get; set; }
+
+        public int ComboIndex { get; set; }
 
         /// <summary>
         /// The next fruit starts a new combo. Used for explodey.

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -5,28 +5,39 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
 using OpenTK;
+using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableDroplet : PalpableCatchHitObject<Droplet>
     {
+        private Pulp pulp;
+
         public DrawableDroplet(Droplet h)
             : base(h)
         {
             Origin = Anchor.Centre;
             Size = new Vector2((float)CatchHitObject.OBJECT_RADIUS) / 4;
-            AccentColour = h.ComboColour;
             Masking = false;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = new Pulp
+            InternalChild = pulp = new Pulp
             {
-                AccentColour = AccentColour,
                 Size = Size
             };
+        }
+
+        public override Color4 AccentColour
+        {
+            get { return base.AccentColour; }
+            set
+            {
+                base.AccentColour = value;
+                pulp.AccentColour = AccentColour;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -24,7 +24,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             Origin = Anchor.Centre;
 
             Size = new Vector2((float)CatchHitObject.OBJECT_RADIUS);
-            AccentColour = HitObject.ComboColour;
             Masking = false;
 
             Rotation = (float)(RNG.NextDouble() - 0.5f) * 40;
@@ -33,6 +32,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         [BackgroundDependencyLoader]
         private void load()
         {
+            // todo: this should come from the skin.
+            AccentColour = colourForRrepesentation(HitObject.VisualRepresentation);
+
             InternalChildren = new[]
             {
                 createPulp(HitObject.VisualRepresentation),
@@ -272,6 +274,32 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             base.Update();
 
             border.Alpha = (float)MathHelper.Clamp((HitObject.StartTime - Time.Current) / 500, 0, 1);
+        }
+
+        private Color4 colourForRrepesentation(FruitVisualRepresentation representation)
+        {
+            switch (representation)
+            {
+                default:
+                case FruitVisualRepresentation.Pear:
+                    return new Color4(17, 136, 170, 255);
+                case FruitVisualRepresentation.Grape:
+                    return new Color4(204, 102, 0, 255);
+                case FruitVisualRepresentation.Raspberry:
+                    return new Color4(121, 9, 13, 255);
+                case FruitVisualRepresentation.Pineapple:
+                    return new Color4(102, 136, 0, 255);
+                case FruitVisualRepresentation.Banana:
+                    switch (RNG.Next(0, 3))
+                    {
+                        default:
+                            return new Color4(255, 240, 0, 255);
+                        case 1:
+                            return new Color4(255, 192, 0, 255);
+                        case 2:
+                            return new Color4(214, 221, 28, 255);
+                    }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             var catchObject = (DrawableCatchHitObject)h;
 
             catchObject.CheckPosition = o => CheckPosition?.Invoke(o) ?? false;
-            catchObject.AccentColour = HitObject.ComboColour;
 
             dropletContainer.Add(h);
             base.AddNested(h);

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -60,7 +60,6 @@ namespace osu.Game.Rulesets.Catch.Objects
             AddNested(new Fruit
             {
                 Samples = Samples,
-                ComboColour = ComboColour,
                 StartTime = StartTime,
                 X = X
             });
@@ -82,7 +81,6 @@ namespace osu.Game.Rulesets.Catch.Objects
                     AddNested(new Droplet
                     {
                         StartTime = lastTickTime,
-                        ComboColour = ComboColour,
                         X = X + Curve.PositionAt(distanceProgress).X / CatchPlayfield.BASE_WIDTH,
                         Samples = new List<SampleInfo>(Samples.Select(s => new SampleInfo
                         {
@@ -104,7 +102,6 @@ namespace osu.Game.Rulesets.Catch.Objects
                     AddNested(new TinyDroplet
                     {
                         StartTime = spanStartTime + t,
-                        ComboColour = ComboColour,
                         X = X + Curve.PositionAt(progress).X / CatchPlayfield.BASE_WIDTH,
                         Samples = new List<SampleInfo>(Samples.Select(s => new SampleInfo
                         {
@@ -118,7 +115,6 @@ namespace osu.Game.Rulesets.Catch.Objects
                 AddNested(new Fruit
                 {
                     Samples = Samples,
-                    ComboColour = ComboColour,
                     StartTime = spanStartTime + spanDuration,
                     X = X + Curve.PositionAt(reversed ? 0 : 1).X / CatchPlayfield.BASE_WIDTH
                 });

--- a/osu.Game.Rulesets.Catch/Tests/TestCaseFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch/Tests/TestCaseFruitObjects.cs
@@ -6,13 +6,11 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.MathUtils;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawable;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
 using osu.Game.Tests.Visual;
 using OpenTK;
-using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
@@ -62,8 +60,6 @@ namespace osu.Game.Rulesets.Catch.Tests
                 Scale = 1.5f,
             };
 
-            fruit.ComboColour = colourForRrepesentation(fruit.VisualRepresentation);
-
             return new DrawableFruit(fruit)
             {
                 Anchor = Anchor.Centre,
@@ -73,32 +69,6 @@ namespace osu.Game.Rulesets.Catch.Tests
                 LifetimeStart = double.NegativeInfinity,
                 LifetimeEnd = double.PositiveInfinity,
             };
-        }
-
-        private Color4 colourForRrepesentation(FruitVisualRepresentation representation)
-        {
-            switch (representation)
-            {
-                default:
-                case FruitVisualRepresentation.Pear:
-                    return new Color4(17, 136, 170, 255);
-                case FruitVisualRepresentation.Grape:
-                    return new Color4(204, 102, 0, 255);
-                case FruitVisualRepresentation.Raspberry:
-                    return new Color4(121, 9, 13, 255);
-                case FruitVisualRepresentation.Pineapple:
-                    return new Color4(102, 136, 0, 255);
-                case FruitVisualRepresentation.Banana:
-                    switch (RNG.Next(0, 3))
-                    {
-                        default:
-                            return new Color4(255, 240, 0, 255);
-                        case 1:
-                            return new Color4(255, 192, 0, 255);
-                        case 2:
-                            return new Color4(214, 221, 28, 255);
-                    }
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -54,7 +54,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 if (caughtFruit == null) return;
 
-                caughtFruit.AccentColour = fruit.AccentColour;
                 caughtFruit.RelativePositionAxes = Axes.None;
                 caughtFruit.Position = new Vector2(MovableCatcher.ToLocalSpace(fruit.ScreenSpaceDrawQuad.Centre).X - MovableCatcher.DrawSize.X / 2, 0);
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Framework.Graphics;
-using OpenTK.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
@@ -27,17 +26,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
             if (action != null)
                 Action = action.Value;
-        }
-
-        public override Color4 AccentColour
-        {
-            get { return base.AccentColour; }
-            set
-            {
-                if (base.AccentColour == value)
-                    return;
-                base.AccentColour = value;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -48,13 +48,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             get { return base.AccentColour; }
             set
             {
-                if (base.AccentColour == value)
-                    return;
                 base.AccentColour = value;
-
-                laneGlowPiece.AccentColour = value;
-                GlowPiece.AccentColour = value;
-                headPiece.AccentColour = value;
+                laneGlowPiece.AccentColour = AccentColour;
+                GlowPiece.AccentColour = AccentColour;
+                headPiece.AccentColour = AccentColour;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapProcessor.cs
@@ -13,24 +13,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
         public override void PostProcess(Beatmap<OsuHitObject> beatmap)
         {
             applyStacking(beatmap);
-
-            if (beatmap.ComboColours.Count == 0)
-                return;
-
-            int comboIndex = 0;
-            int colourIndex = 0;
-
-            foreach (var obj in beatmap.HitObjects)
-            {
-                if (obj.NewCombo)
-                {
-                    comboIndex = 0;
-                    colourIndex = (colourIndex + 1) % beatmap.ComboColours.Count;
-                }
-
-                obj.IndexInCurrentCombo = comboIndex++;
-                obj.ComboColour = beatmap.ComboColours[colourIndex];
-            }
+            base.PostProcess(beatmap);
         }
 
         private void applyStacking(Beatmap<OsuHitObject> beatmap)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
 using OpenTK;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
+using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -21,7 +22,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly NumberPiece number;
         private readonly GlowPiece glow;
 
-        public DrawableHitCircle(HitCircle h) : base(h)
+        public DrawableHitCircle(HitCircle h)
+            : base(h)
         {
             Origin = Anchor.Centre;
 
@@ -30,13 +32,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             InternalChildren = new Drawable[]
             {
-                glow = new GlowPiece
-                {
-                    Colour = AccentColour
-                },
+                glow = new GlowPiece(),
                 circle = new CirclePiece
                 {
-                    Colour = AccentColour,
                     Hit = () =>
                     {
                         if (AllJudged)
@@ -52,15 +50,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 },
                 ring = new RingPiece(),
                 flash = new FlashPiece(),
-                explode = new ExplodePiece
-                {
-                    Colour = AccentColour,
-                },
+                explode = new ExplodePiece(),
                 ApproachCircle = new ApproachCircle
                 {
                     Alpha = 0,
                     Scale = new Vector2(4),
-                    Colour = AccentColour,
                 }
             };
 
@@ -68,6 +62,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Size = circle.DrawSize;
 
             HitObject.PositionChanged += _ => Position = HitObject.StackedPosition;
+        }
+
+        public override Color4 AccentColour
+        {
+            get { return base.AccentColour; }
+            set
+            {
+                base.AccentColour = value;
+                explode.Colour = AccentColour;
+                glow.Colour = AccentColour;
+                circle.Colour = AccentColour;
+                ApproachCircle.Colour = AccentColour;
+            }
         }
 
         protected override void CheckForJudgements(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected DrawableOsuHitObject(OsuHitObject hitObject)
             : base(hitObject)
         {
-            AccentColour = HitObject.ComboColour;
             Alpha = 0;
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Osu.Judgements;
 using osu.Framework.Graphics.Primitives;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Scoring;
+using OpenTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -41,7 +42,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 Body = new SliderBody(s)
                 {
-                    AccentColour = AccentColour,
                     PathWidth = s.Scale * 64,
                 },
                 ticks = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
@@ -50,7 +50,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 {
                     BypassAutoSizeAxes = Axes.Both,
                     Scale = new Vector2(s.Scale),
-                    AccentColour = AccentColour,
                     AlwaysPresent = true,
                     Alpha = 0
                 },
@@ -85,6 +84,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
 
             HitObject.PositionChanged += _ => Position = HitObject.StackedPosition;
+        }
+
+        public override Color4 AccentColour
+        {
+            get { return base.AccentColour; }
+            set
+            {
+                base.AccentColour = value;
+                Body.AccentColour = AccentColour;
+                Ball.AccentColour = AccentColour;
+            }
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBody.cs
@@ -173,6 +173,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             texture.SetData(upload);
             path.Texture = texture;
+
+            container.ForceRedraw();
         }
 
         private void computeSize()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBody.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         public double? SnakedStart { get; private set; }
         public double? SnakedEnd { get; private set; }
 
-        private Color4 accentColour;
+        private Color4 accentColour = Color4.White;
         /// <summary>
         /// Used to colour the path.
         /// </summary>

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -10,7 +10,7 @@ using osu.Game.Beatmaps.ControlPoints;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {
-    public abstract class OsuHitObject : HitObject, IHasComboIndex, IHasPosition
+    public abstract class OsuHitObject : HitObject, IHasComboInformation, IHasPosition
     {
         public const double OBJECT_RADIUS = 64;
 

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -6,13 +6,11 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using OpenTK;
 using osu.Game.Rulesets.Objects.Types;
-using OpenTK.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Rulesets.Edit.Types;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {
-    public abstract class OsuHitObject : HitObject, IHasCombo, IHasEditablePosition
+    public abstract class OsuHitObject : HitObject, IHasComboIndex, IHasPosition
     {
         public const double OBJECT_RADIUS = 64;
 
@@ -53,9 +51,13 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public float Scale { get; set; } = 1;
 
-        public Color4 ComboColour { get; set; } = Color4.Gray;
         public virtual bool NewCombo { get; set; }
+
         public int IndexInCurrentCombo { get; set; }
+
+        public int ComboIndex { get; set; }
+
+        public bool LastInCombo { get; set; }
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
         {

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -99,10 +99,10 @@ namespace osu.Game.Rulesets.Osu.Objects
             {
                 StartTime = StartTime,
                 Position = Position,
-                IndexInCurrentCombo = IndexInCurrentCombo,
-                ComboColour = ComboColour,
                 Samples = Samples,
-                SampleControlPoint = SampleControlPoint
+                SampleControlPoint = SampleControlPoint,
+                IndexInCurrentCombo = IndexInCurrentCombo,
+                ComboIndex = ComboIndex,
             };
 
             TailCircle = new SliderCircle(this)
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                 StartTime = EndTime,
                 Position = EndPosition,
                 IndexInCurrentCombo = IndexInCurrentCombo,
-                ComboColour = ComboColour
+                ComboIndex = ComboIndex,
             };
 
             AddNested(HeadCircle);
@@ -160,7 +160,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                         Position = Position + Curve.PositionAt(distanceProgress),
                         StackHeight = StackHeight,
                         Scale = Scale,
-                        ComboColour = ComboColour,
                         Samples = sampleList
                     });
                 }
@@ -179,7 +178,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                     Position = Position + Curve.PositionAt(repeat % 2),
                     StackHeight = StackHeight,
                     Scale = Scale,
-                    ComboColour = ComboColour,
                     Samples = new List<SampleInfo>(RepeatSamples[repeatIndex])
                 });
             }

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseHitCircle.cs
@@ -10,7 +10,6 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Tests.Visual;
 using OpenTK;
-using OpenTK.Graphics;
 using osu.Game.Rulesets.Osu.Judgements;
 using System.Collections.Generic;
 using System;
@@ -61,7 +60,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000 + timeOffset,
                 Position = positionOffset.Value,
-                ComboColour = Color4.LightSeaGreen
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = circleSize });

--- a/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
+++ b/osu.Game.Rulesets.Osu/Tests/TestCaseSlider.cs
@@ -117,7 +117,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-(distance / 2), 0),
-                ComboColour = Color4.LightSeaGreen,
                 ControlPoints = new List<Vector2>
                 {
                     Vector2.Zero,
@@ -138,7 +137,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-200, 0),
-                ComboColour = Color4.LightSeaGreen,
                 ControlPoints = new List<Vector2>
                 {
                     Vector2.Zero,
@@ -162,7 +160,6 @@ namespace osu.Game.Rulesets.Osu.Tests
                 CurveType = CurveType.Linear,
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-200, 0),
-                ComboColour = Color4.LightSeaGreen,
                 ControlPoints = new List<Vector2>
                 {
                     Vector2.Zero,
@@ -189,7 +186,6 @@ namespace osu.Game.Rulesets.Osu.Tests
                 CurveType = CurveType.Bezier,
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-200, 0),
-                ComboColour = Color4.LightSeaGreen,
                 ControlPoints = new List<Vector2>
                 {
                     Vector2.Zero,
@@ -215,7 +211,6 @@ namespace osu.Game.Rulesets.Osu.Tests
                 CurveType = CurveType.Linear,
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(0, 0),
-                ComboColour = Color4.LightSeaGreen,
                 ControlPoints = new List<Vector2>
                 {
                     Vector2.Zero,
@@ -245,7 +240,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-100, 0),
-                ComboColour = Color4.LightSeaGreen,
                 CurveType = CurveType.Catmull,
                 ControlPoints = new List<Vector2>
                 {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -20,11 +20,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
     public class DrawableDrumRoll : DrawableTaikoHitObject<DrumRoll>
     {
         /// <summary>
-        /// Number of rolling hits required to reach the dark/final accent colour.
+        /// Number of rolling hits required to reach the dark/final colour.
         /// </summary>
-        private const int rolling_hits_for_dark_accent = 5;
-
-        private Color4 accentDarkColour;
+        private const int rolling_hits_for_engaged_colour = 5;
 
         /// <summary>
         /// Rolling number of tick hits. This increases for hits and decreases for misses.
@@ -53,11 +51,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool OnPressed(TaikoAction action) => false;
 
+        private Color4 colourIdle;
+        private Color4 colourEngaged;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            MainPiece.AccentColour = AccentColour = colours.YellowDark;
-            accentDarkColour = colours.YellowDarker;
+            MainPiece.AccentColour = colourIdle = colours.YellowDark;
+            colourEngaged = colours.YellowDarker;
         }
 
         private void onTickJudgement(DrawableHitObject obj, Judgement judgement)
@@ -67,10 +68,10 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             else
                 rollingHits--;
 
-            rollingHits = MathHelper.Clamp(rollingHits, 0, rolling_hits_for_dark_accent);
+            rollingHits = MathHelper.Clamp(rollingHits, 0, rolling_hits_for_engaged_colour);
 
-            Color4 newAccent = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_dark_accent, AccentColour, accentDarkColour, 0, 1);
-            MainPiece.FadeAccent(newAccent, 100);
+            Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
+            MainPiece.FadeAccent(newColour, 100);
         }
 
         protected override void CheckForJudgements(bool userTriggered, double timeOffset)

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmap">The Beatmap to process.</param>
         public virtual void PostProcess(Beatmap<TObject> beatmap)
         {
-            IHasComboIndex lastObj = null;
+            IHasComboInformation lastObj = null;
 
-            foreach (var obj in beatmap.HitObjects.OfType<IHasComboIndex>())
+            foreach (var obj in beatmap.HitObjects.OfType<IHasComboInformation>())
             {
                 if (obj.NewCombo)
                 {

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Linq;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Beatmaps
 {
@@ -19,6 +21,29 @@ namespace osu.Game.Beatmaps
         /// </para>
         /// </summary>
         /// <param name="beatmap">The Beatmap to process.</param>
-        public virtual void PostProcess(Beatmap<TObject> beatmap) { }
+        public virtual void PostProcess(Beatmap<TObject> beatmap)
+        {
+            IHasComboIndex lastObj = null;
+
+            foreach (var obj in beatmap.HitObjects.OfType<IHasComboIndex>())
+            {
+                if (obj.NewCombo)
+                {
+                    obj.IndexInCurrentCombo = 0;
+                    if (lastObj != null)
+                    {
+                        lastObj.LastInCombo = true;
+                        obj.ComboIndex = lastObj.ComboIndex + 1;
+                    }
+                }
+                else if (lastObj != null)
+                {
+                    obj.IndexInCurrentCombo = lastObj.IndexInCurrentCombo + 1;
+                    obj.ComboIndex = lastObj.ComboIndex;
+                }
+
+                lastObj = obj;
+            }
+        }
     }
 }

--- a/osu.Game/Rulesets/Objects/Types/IHasComboIndex.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasComboIndex.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Game.Rulesets.Objects.Types
+{
+    /// <summary>
+    /// A HitObject that is part of a combo and has extended information about its position relative to other combo objects.
+    /// </summary>
+    public interface IHasComboIndex : IHasCombo
+    {
+        /// <summary>
+        /// The offset of this hitobject in the current combo.
+        /// </summary>
+        int IndexInCurrentCombo { get; set; }
+
+        /// <summary>
+        /// The offset of this hitobject in the current combo.
+        /// </summary>
+        int ComboIndex { get; set; }
+
+        /// <summary>
+        /// Whether this is the last object in the current combo.
+        /// </summary>
+        bool LastInCombo { get; set; }
+    }
+}

--- a/osu.Game/Rulesets/Objects/Types/IHasComboIndex.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasComboIndex.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Objects.Types
         int IndexInCurrentCombo { get; set; }
 
         /// <summary>
-        /// The offset of this hitobject in the current combo.
+        /// The offset of this combo in relation to the beatmap.
         /// </summary>
         int ComboIndex { get; set; }
 

--- a/osu.Game/Rulesets/Objects/Types/IHasComboInformation.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasComboInformation.cs
@@ -6,7 +6,7 @@ namespace osu.Game.Rulesets.Objects.Types
     /// <summary>
     /// A HitObject that is part of a combo and has extended information about its position relative to other combo objects.
     /// </summary>
-    public interface IHasComboIndex : IHasCombo
+    public interface IHasComboInformation : IHasCombo
     {
         /// <summary>
         /// The offset of this hitobject in the current combo.

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -374,7 +374,7 @@
     <Compile Include="Overlays\Social\SocialPanel.cs" />
     <Compile Include="Rulesets\Mods\IApplicableToDrawableHitObject.cs" />
     <Compile Include="Rulesets\Objects\HitWindows.cs" />
-    <Compile Include="Rulesets\Objects\Types\IHasComboIndex.cs" />
+    <Compile Include="Rulesets\Objects\Types\IHasComboInformation.cs" />
     <Compile Include="Rulesets\Replays\Legacy\LegacyReplayFrame.cs" />
     <Compile Include="Rulesets\Replays\Legacy\ReplayButtonState.cs" />
     <Compile Include="Rulesets\Replays\ReplayFrame.cs" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -374,6 +374,7 @@
     <Compile Include="Overlays\Social\SocialPanel.cs" />
     <Compile Include="Rulesets\Mods\IApplicableToDrawableHitObject.cs" />
     <Compile Include="Rulesets\Objects\HitWindows.cs" />
+    <Compile Include="Rulesets\Objects\Types\IHasComboIndex.cs" />
     <Compile Include="Rulesets\Replays\Legacy\LegacyReplayFrame.cs" />
     <Compile Include="Rulesets\Replays\Legacy\ReplayButtonState.cs" />
     <Compile Include="Rulesets\Replays\ReplayFrame.cs" />


### PR DESCRIPTION
Prerequisite step to having combo colours provided by external sources (skins, beatmap).

Prepares `AccentColour` setters to correctly update `DrawableHitObject` pieces.

Note that merging this will remove combo colour assignment temporarily.