### PR TITLE
Reduce memory overhead of LogoVisualisation

### DIFF
--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -114,10 +114,11 @@ namespace osu.Game.Graphics.Backgrounds
             if (CreateNewTriangles)
                 addTriangles(false);
 
-            float adjustedAlpha = HideAlphaDiscrepancies ?
+            float adjustedAlpha = HideAlphaDiscrepancies
+                ?
                 // Cubically scale alpha to make it drop off more sharply.
-                (float)Math.Pow(DrawInfo.Colour.AverageColour.Linear.A, 3) :
-                1;
+                (float)Math.Pow(DrawInfo.Colour.AverageColour.Linear.A, 3)
+                : 1;
 
             float elapsedSeconds = (float)Time.Elapsed / 1000;
             // Since position is relative, the velocity needs to scale inversely with DrawHeight.
@@ -185,6 +186,7 @@ namespace osu.Game.Graphics.Backgrounds
         protected override DrawNode CreateDrawNode() => new TrianglesDrawNode();
 
         private readonly TrianglesDrawNodeSharedData sharedData = new TrianglesDrawNodeSharedData();
+
         protected override void ApplyDrawNode(DrawNode node)
         {
             base.ApplyDrawNode(node);
@@ -215,6 +217,14 @@ namespace osu.Game.Graphics.Backgrounds
             public readonly List<TriangleParticle> Parts = new List<TriangleParticle>();
             public Vector2 Size;
 
+            private readonly Action<TexturedVertex2D> addAction;
+
+            public TrianglesDrawNode()
+            {
+                // reduce allocations of delegates in draw method.
+                addAction = v => Shared.VertexBatch.Add(v);
+            }
+
             public override void Draw(Action<TexturedVertex2D> vertexAction)
             {
                 base.Draw(vertexAction);
@@ -242,7 +252,7 @@ namespace osu.Game.Graphics.Backgrounds
                         triangle,
                         colourInfo,
                         null,
-                        Shared.VertexBatch.Add,
+                        addAction,
                         Vector2.Divide(localInflationAmount, size));
                 }
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -161,11 +161,19 @@ namespace osu.Game.Screens.Menu
             public Shader Shader;
             public Texture Texture;
             public VisualiserSharedData Shared;
+
+            private Action<TexturedVertex2D> addAction;
+
             //Asuming the logo is a circle, we don't need a second dimension.
             public float Size;
 
             public Color4 Colour;
             public float[] AudioData;
+
+            public VisualisationDrawNode()
+            {
+                addAction = v => Shared.VertexBatch.Add(v);
+            }
 
             public override void Draw(Action<TexturedVertex2D> vertexAction)
             {
@@ -211,7 +219,7 @@ namespace osu.Game.Screens.Menu
                                 rectangle,
                                 colourInfo,
                                 null,
-                                Shared.VertexBatch.Add,
+                                addAction,
                                 //barSize by itself will make it smooth more in the X axis than in the Y axis, this reverts that.
                                 Vector2.Divide(inflation, barSize.Yx));
                         }

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Screens.Menu
             public Texture Texture;
             public VisualiserSharedData Shared;
 
-            private Action<TexturedVertex2D> addAction;
+            private readonly Action<TexturedVertex2D> addAction;
 
             //Asuming the logo is a circle, we don't need a second dimension.
             public float Size;
@@ -172,6 +172,7 @@ namespace osu.Game.Screens.Menu
 
             public VisualisationDrawNode()
             {
+                // reduce allocations of delegates in draw method.
                 addAction = v => Shared.VertexBatch.Add(v);
             }
 


### PR DESCRIPTION
Was allocating 100+mb every 10 seconds (1.5m+ objects).