### PR TITLE
Add perfect mod icon

### DIFF
--- a/osu.Game/Graphics/SpriteIcon.cs
+++ b/osu.Game/Graphics/SpriteIcon.cs
@@ -988,7 +988,7 @@ namespace osu.Game.Graphics
         fa_osu_expert_mania = 0xe028,
 
         // mod icons
-        fa_osu_mod_perfect = 0xe02d,
+        fa_osu_mod_perfect = 0xe049,
         fa_osu_mod_autopilot = 0xe03a,
         fa_osu_mod_auto = 0xe03b,
         fa_osu_mod_cinema = 0xe03c,

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "Perfect";
         public override string ShortenedName => "PF";
-        public override FontAwesome Icon => FontAwesome.fa_question;
+        public override FontAwesome Icon => FontAwesome.fa_osu_mod_perfect;
         public override string Description => "SS or quit.";
 
         protected override bool FailCondition(ScoreProcessor scoreProcessor) => scoreProcessor.Accuracy.Value != 1;


### PR DESCRIPTION
The old unicode or whatever showed was blank. Got the unicode from another PR, but how to know what unicode belongs to which icon?
![](https://puu.sh/zNFYQ/45446a6f18.png) ![](https://puu.sh/zNFWC/9ad6329367.png)