### PR TITLE
Fix beatmap background fade not being updated on retry

### DIFF
--- a/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
+++ b/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
@@ -46,6 +46,12 @@ namespace osu.Game.Screens.Play
             UpdateBackgroundElements();
         }
 
+        protected override void OnResuming(Screen last)
+        {
+            base.OnResuming(last);
+            UpdateBackgroundElements();
+        }
+
         protected virtual void UpdateBackgroundElements()
         {
             if (!IsCurrentScreen) return;


### PR DESCRIPTION
Fixes #2287.

Background is faded to 1 when `Player` exits.