### PR TITLE
Move binding to LoadComplete

### DIFF
--- a/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
@@ -45,6 +45,11 @@ namespace osu.Game.Input.Bindings
         private void load(KeyBindingStore keyBindings)
         {
             store = keyBindings;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
             store.KeyBindingChanged += ReloadMappings;
         }
 

--- a/osu.Game/Skinning/LocalSkinOverrideContainer.cs
+++ b/osu.Game/Skinning/LocalSkinOverrideContainer.cs
@@ -55,12 +55,17 @@ namespace osu.Game.Skinning
             var dependencies = new DependencyContainer(base.CreateLocalDependencies(parent));
 
             fallbackSource = dependencies.Get<ISkinSource>();
-            if (fallbackSource != null)
-                fallbackSource.SourceChanged += onSourceChanged;
-
             dependencies.CacheAs<ISkinSource>(this);
 
             return dependencies;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (fallbackSource != null)
+                fallbackSource.SourceChanged += onSourceChanged;
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Previously there was a chance that it would still never get disposed, as the event was bound in async load, before it was in a state it can be recursively disposed via the PlayerLoader call.