### PR TITLE
Fix ScalableContainer irrepairably altering content size

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -30,10 +30,10 @@ namespace osu.Game.Rulesets.Catch.UI
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;
 
-            ScaledContent.Anchor = Anchor.BottomLeft;
-            ScaledContent.Origin = Anchor.BottomLeft;
+            base.Content.Anchor = Anchor.BottomLeft;
+            base.Content.Origin = Anchor.BottomLeft;
 
-            ScaledContent.AddRange(new Drawable[]
+            base.Content.AddRange(new Drawable[]
             {
                 explodingFruitContainer = new Container
                 {

--- a/osu.Game.Rulesets.Osu/Replays/OsuReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuReplayInputHandler.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             {
                 new ReplayState<OsuAction>
                 {
-                    Mouse = new ReplayMouseState(ToScreenSpace(Position ?? Vector2.Zero)),
+                    Mouse = new ReplayMouseState(GamefieldToScreenSpace(Position ?? Vector2.Zero)),
                     PressedActions = CurrentFrame.Actions
                 }
             };

--- a/osu.Game.Tests/Visual/TestCaseScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/TestCaseScrollingHitObjects.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual
                 Direction = direction;
 
                 Padding = new MarginPadding(2);
-                ScaledContent.Masking = true;
+                Content.Masking = true;
 
                 AddInternal(new Box
                 {

--- a/osu.Game/Input/Handlers/ReplayInputHandler.cs
+++ b/osu.Game/Input/Handlers/ReplayInputHandler.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Input.Handlers
     public abstract class ReplayInputHandler : InputHandler
     {
         /// <summary>
-        /// A function provided to convert replay coordinates from gamefield to screen space.
+        /// A function that converts coordinates from gamefield to screen space.
         /// </summary>
-        public Func<Vector2, Vector2> ToScreenSpace { protected get; set; }
+        public Func<Vector2, Vector2> GamefieldToScreenSpace { protected get; set; }
 
         /// <summary>
         /// Update the current frame based on an incoming time value.

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -290,7 +290,7 @@ namespace osu.Game.Rulesets.UI
             base.SetReplay(replay);
 
             if (ReplayInputManager?.ReplayInputHandler != null)
-                ReplayInputManager.ReplayInputHandler.ToScreenSpace = input => Playfield.ScaledContent.ToScreenSpace(input);
+                ReplayInputManager.ReplayInputHandler.GamefieldToScreenSpace = Playfield.GamefieldToScreenSpace;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #2192.

Basically:

1. `DrawScale` was affected, `DrawSize` wasn't.
2. `RelativeChildSize` was affected when it really shouldn't have been - we should always be working in 0-1 coordinates, without variation by window size.

Also took it a step further and removed one layer of nested containers.

Note: Spinners are now slightly smaller than before because we actually have a 4:3 size container. We'll need to alter this back if we want it to overfill the screen. I've held back on this for now, but let me know if you want me to make this change in this PR.