### PR TITLE
Fix osu!catch autoplay missing starts/ends of JuiceStreams

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
@@ -13,9 +13,9 @@ using OpenTK;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
-    public class TestCaseJuiceStream : TestCasePlayer
+    public class TestCaseAutoJuiceStream : TestCasePlayer
     {
-        public TestCaseJuiceStream()
+        public TestCaseAutoJuiceStream()
             : base(new CatchRuleset())
         {
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestCaseJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseJuiceStream.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+using OpenTK;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public class TestCaseJuiceStream : TestCasePlayer
+    {
+        public TestCaseJuiceStream()
+            : base(new CatchRuleset())
+        {
+        }
+
+        protected override Beatmap CreateBeatmap(Ruleset ruleset)
+        {
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    BaseDifficulty = new BeatmapDifficulty { CircleSize = 6, SliderMultiplier = 3 },
+                    Ruleset = ruleset.RulesetInfo
+                }
+            };
+
+            for (int i = 0; i < 100; i++)
+            {
+                float width = (i % 10 + 1) / 20f;
+
+                beatmap.HitObjects.Add(new JuiceStream
+                {
+                    X = 0.5f - width / 2,
+                    ControlPoints = new List<Vector2>
+                    {
+                        Vector2.Zero,
+                        new Vector2(width * CatchPlayfield.BASE_WIDTH, 0)
+                    },
+                    CurveType = CurveType.Linear,
+                    Distance = width * CatchPlayfield.BASE_WIDTH,
+                    StartTime = i * 2000,
+                    NewCombo = i % 8 == 0
+                });
+            }
+
+            return beatmap;
+        }
+
+        protected override Player CreatePlayer(WorkingBeatmap beatmap, Ruleset ruleset)
+        {
+            beatmap.Mods.Value = beatmap.Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            return base.CreatePlayer(beatmap, ruleset);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -108,6 +108,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                         case BananaShower.Banana _:
                         case TinyDroplet _:
                         case Droplet _:
+                        case Fruit _:
                             moveToNext(nestedObj);
                             break;
                     }


### PR DESCRIPTION
Fixes #2328.

Would only happen when ticks and ends were spaced too far apart (or there were no ticks in a juicestream).