### PR TITLE
Lowercase back button

### DIFF
--- a/osu.Game/Graphics/UserInterface/BackButton.cs
+++ b/osu.Game/Graphics/UserInterface/BackButton.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Graphics.UserInterface
     {
         public BackButton()
         {
-            Text = @"Back";
+            Text = @"back";
             Icon = FontAwesome.fa_osu_left_o;
             Anchor = Anchor.BottomLeft;
             Origin = Anchor.BottomLeft;


### PR DESCRIPTION
Preview:
![](https://puu.sh/A1EXM/26d4e8697e.png)

Reasons:
![](https://puu.sh/A1EXU/b8089252b6.png)
The menus on the right are lowercased.
Stable's default back button is lowercased.