### PR TITLE
Remove composer from player loader

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -309,11 +309,6 @@ namespace osu.Game.Screens.Play
                                 Origin = Anchor.TopCentre,
                                 Anchor = Anchor.TopCentre,
                             },
-                            new MetadataLine("Composer", string.Empty)
-                            {
-                                Origin = Anchor.TopCentre,
-                                Anchor = Anchor.TopCentre,
-                            },
                             new MetadataLine("Mapper", metadata.AuthorString)
                             {
                                 Origin = Anchor.TopCentre,


### PR DESCRIPTION
If it was meant for the artist of the song, it is already shown on top. We should add genre and language (if it was implemented) here next time (idk how), so users will know the song features.