### PR TITLE
Make buttons only accept input when expanded

### DIFF
--- a/osu.Game/Screens/Menu/Button.cs
+++ b/osu.Game/Screens/Menu/Button.cs
@@ -222,7 +222,7 @@ namespace osu.Game.Screens.Menu
             boxHoverLayer.FadeOut(800, Easing.OutExpo);
         }
 
-        public override bool HandleKeyboardInput => state != ButtonState.Exploded;
+        public override bool HandleKeyboardInput => state == ButtonState.Expanded;
         public override bool HandleMouseInput => state != ButtonState.Exploded && box.Scale.X >= 0.8f;
 
         protected override void Update()


### PR DESCRIPTION
Closes #2385.
I think that buttons should (at least for KB) only accept input when they are actually expanded. Not only because it fixes the bug at hand, but because it is more intuitive to the user when navigating through the menu by keyboard.