### PR TITLE
Disable tab switching for add channel button

### DIFF
--- a/osu.Game/Overlays/Chat/ChatTabControl.cs
+++ b/osu.Game/Overlays/Chat/ChatTabControl.cs
@@ -307,6 +307,8 @@ namespace osu.Game.Overlays.Chat
             {
                 public override bool IsRemovable => false;
 
+                public override bool IsSwitchable => false;
+
                 public ChannelSelectorTabItem(Channel value) : base(value)
                 {
                     Depth = float.MaxValue;


### PR DESCRIPTION
Make sure the "add channel" button cannot be tab switched to.

Updates framework to include ppy/osu-framework#1363