### PR TITLE
Fix various leaderboard data races

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -282,24 +282,29 @@ namespace osu.Game.Screens.Select.Leaderboards
             api.Queue(getScoresRequest);
         }
 
+        private Placeholder currentPlaceholder;
+
         private void replacePlaceholder(Placeholder placeholder)
         {
-            var existingPlaceholder = placeholderContainer.Children.LastOrDefault() as Placeholder;
-
-            if (placeholder != null && placeholder.Equals(existingPlaceholder))
+            if (placeholder != null && placeholder.Equals(currentPlaceholder))
                 return;
 
-            existingPlaceholder?.FadeOut(150, Easing.OutQuint).Expire();
+            currentPlaceholder?.FadeOut(150, Easing.OutQuint).Expire();
 
             if (placeholder == null)
+            {
+                currentPlaceholder = null;
                 return;
+            }
 
             Scores = null;
 
-            placeholderContainer.Add(placeholder);
+            placeholderContainer.Child = placeholder;
 
             placeholder.ScaleTo(0.8f).Then().ScaleTo(1, fade_duration * 3, Easing.OutQuint);
             placeholder.FadeInFromZero(fade_duration, Easing.OutQuint);
+
+            currentPlaceholder = placeholder;
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -255,23 +255,15 @@ namespace osu.Game.Screens.Select.Leaderboards
             PlaceholderState = PlaceholderState.Retrieving;
             loading.Show();
 
-            var localBeatmap = Beatmap;
-
             getScoresRequest = new GetScoresRequest(Beatmap, osuGame?.Ruleset.Value ?? Beatmap.Ruleset, Scope);
             getScoresRequest.Success += r => Schedule(() =>
             {
-                if (localBeatmap != Beatmap)
-                    return;
-
                 Scores = r.Scores;
                 PlaceholderState = Scores.Any() ? PlaceholderState.Successful : PlaceholderState.NoScores;
             });
 
             getScoresRequest.Failure += e => Schedule(() =>
             {
-                if (localBeatmap != Beatmap)
-                    return;
-
                 if (e is OperationCanceledException)
                     return;
 

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -293,8 +293,6 @@ namespace osu.Game.Screens.Select.Leaderboards
                 return;
             }
 
-            Scores = null;
-
             placeholderContainer.Child = placeholder;
 
             placeholder.ScaleTo(0.8f).Then().ScaleTo(1, fade_duration * 3, Easing.OutQuint);

--- a/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/Leaderboard.cs
@@ -109,6 +109,10 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         private PlaceholderState placeholderState;
 
+        /// <summary>
+        /// Update the placeholder visibility.
+        /// Setting this to anything other than PlaceholderState.Successful will cancel all existing retrieval requests and hide scores.
+        /// </summary>
         protected PlaceholderState PlaceholderState
         {
             get { return placeholderState; }


### PR DESCRIPTION
Fixes #2327, fixes #1859.

I'll explain this in order of commits. For these explanations to take place consider the following situation:

```
Beatmap A : Ranked      <- Selected
Beatmap B : Unranked
Beatmap C : Ranked
```

1b9d54a:

Scores are loaded on background threads, either through `LoadComponentAsync` or through webrequest results.
* When switching A -> B or C -> B, it was possible to set the scores to prior to the `Schedule` inside Scores_set being run.
* When switching rapidly between A/B or B/C, it may be possible to get into a state where both the unavailable placeholder and scores were visible. This is likewise due to the presence of the `Schedule`.


b9220a1:

When switching from Unranked -> Ranked -> Unranked beatmap (e.g. A -> B -> C -> B), leaving no more than 150ms between switches:
* B will set the placeholder to Unavailable.
* C will fadeout the placeholder and then expire it.
* Since the placeholder isn't expired yet, it'll still be in the container, and the check `if (placeholder.Equals(currentPlaceholder)) return;` will succeed, where the placeholder is in the process of expiring.