### PR TITLE
Change sidebarbutton indicator colour to match with stable design

### DIFF
--- a/osu.Game/Overlays/Settings/SidebarButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarButton.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Overlays.Settings
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            selectionIndicator.Colour = colours.Yellow;
+            selectionIndicator.Colour = colours.Pink;
         }
 
         protected override bool OnClick(InputState state)


### PR DESCRIPTION
Before:
![](https://puu.sh/A80ue/4d808828f5.png)
After:
![](https://puu.sh/A80nB/77cea91f54.png)

Reasons:
The colour is similar to the default setting indicator.
Stable is using a pink colour.
![](https://puu.sh/A80xi/844f16b8db.png)