### PR TITLE
Fix replays being played in the selected ruleset

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -201,6 +201,8 @@ namespace osu.Game
                 return;
             }
 
+            Ruleset.Value = s.Ruleset;
+
             Beatmap.Value = BeatmapManager.GetWorkingBeatmap(s.Beatmap);
             Beatmap.Value.Mods.Value = s.Mods;
 


### PR DESCRIPTION
This simple fix sets the game's ruleset to the score's ruleset.
It prevents the game from crashing, trying to read ReplayFrames from a different Ruleset