### PR TITLE
Use more inheritance for UserStatus

### DIFF
--- a/osu.Game/Users/UserStatus.cs
+++ b/osu.Game/Users/UserStatus.cs
@@ -12,12 +12,13 @@ namespace osu.Game.Users
         public abstract Color4 GetAppropriateColour(OsuColour colours);
     }
 
-    public abstract class UserStatusAvailable : UserStatus
+    public class UserStatusOnline : UserStatus
     {
+        public override string Message => @"Online";
         public override Color4 GetAppropriateColour(OsuColour colours) => colours.BlueDarker;
     }
 
-    public abstract class UserStatusBusy : UserStatus
+    public abstract class UserStatusBusy : UserStatusOnline
     {
         public override Color4 GetAppropriateColour(OsuColour colours) => colours.YellowDark;
     }
@@ -28,17 +29,12 @@ namespace osu.Game.Users
         public override Color4 GetAppropriateColour(OsuColour colours) => colours.Gray7;
     }
 
-    public class UserStatusOnline : UserStatusAvailable
-    {
-        public override string Message => @"Online";
-    }
-
-    public class UserStatusSpectating : UserStatusAvailable
+    public class UserStatusSpectating : UserStatusOnline
     {
         public override string Message => @"Spectating a game";
     }
 
-    public class UserStatusInLobby : UserStatusAvailable
+    public class UserStatusInLobby : UserStatusOnline
     {
         public override string Message => @"in Multiplayer Lobby";
     }
@@ -53,13 +49,13 @@ namespace osu.Game.Users
         public override string Message => @"Multiplaying";
     }
 
-    public class UserStatusModding : UserStatus
+    public class UserStatusModding : UserStatusOnline
     {
         public override string Message => @"Modding a map";
         public override Color4 GetAppropriateColour(OsuColour colours) => colours.PurpleDark;
     }
 
-    public class UserStatusDoNotDisturb : UserStatus
+    public class UserStatusDoNotDisturb : UserStatusBusy
     {
         public override string Message => @"Do not disturb";
         public override Color4 GetAppropriateColour(OsuColour colours) => colours.RedDark;


### PR DESCRIPTION
Modding, playing multiplayer/singleplayer, Busy, etc are all done when user is online so they may just be a class of type UserStatusOnline(used to be UserStatusAvailable but since available and online are basically the same i just made available be online). I don’t know how PM’s are handled but i assume that the client receives the PM and then decides what to do based on your status. By doing this you can interrupt the user with the message if typeof(status) != typeof(UserStatusBusy), making multiplaying, solo game, etc not interrupt the user, but if they're are just online you can interrupt