### PR TITLE
Made it so that time display adjusts its self based on current time.

### DIFF
--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Play
             {
                 //since TimeSpan to string doesnt support minutes above 60, we have to do something else.
                 var timeRemain = endTime - AudioClock.CurrentTime;
-                string minutes = songCurrentTime < 0 ? "-0" : Math.Floor(TimeSpan.FromSeconds(currentSecond).TotalMinutes).ToString();
+                string minutes = songCurrentTime < 0 ? "-0" : Math.Floor(TimeSpan.FromSeconds(currentSecond).TotalMinutes).ToString("");
                 timeCurrent.Text = minutes + ':' + TimeSpan.FromSeconds(currentSecond).ToString(@"ss");
                 timeLeft.Text = "-" + Math.Floor(TimeSpan.FromMilliseconds(timeRemain).TotalMinutes) + ':' + TimeSpan.FromMilliseconds(timeRemain).ToString(@"ss");
                 previousSecond = currentSecond;

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -85,10 +85,101 @@ namespace osu.Game.Screens.Play
 
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
-                timeCurrent.Text = TimeSpan.FromSeconds(currentSecond).ToString(songCurrentTime < 0 ? @"\-m\:ss" : songCurrentTime > 3600000 ? @"h\:mm\:ss" : songCurrentTime > 600000 ? @"mm\:ss" : @"m\:ss");
+                // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using System;
+
+namespace osu.Game.Screens.Play
+{
+    public class SongProgressInfo : Container
+    {
+        private OsuSpriteText timeCurrent;
+        private OsuSpriteText timeLeft;
+        private OsuSpriteText progress;
+
+        private double startTime;
+        private double endTime;
+
+        private int? previousPercent;
+        private int? previousSecond;
+
+        private double songLength => endTime - startTime;
+
+        private const int margin = 10;
+
+        public IClock AudioClock;
+
+        public double StartTime { set { startTime = value; } }
+        public double EndTime { set { endTime = value; } }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            Children = new Drawable[]
+            {
+                timeCurrent = new OsuSpriteText
+                {
+                    Origin = Anchor.BottomLeft,
+                    Anchor = Anchor.BottomLeft,
+                    Colour = colours.BlueLighter,
+                    Font = @"Venera",
+                    Margin = new MarginPadding
+                    {
+                        Left = margin,
+                    },
+                },
+                progress = new OsuSpriteText
+                {
+                    Origin = Anchor.BottomCentre,
+                    Anchor = Anchor.BottomCentre,
+                    Colour = colours.BlueLighter,
+                    Font = @"Venera",
+                },
+                timeLeft = new OsuSpriteText
+                {
+                    Origin = Anchor.BottomRight,
+                    Anchor = Anchor.BottomRight,
+                    Colour = colours.BlueLighter,
+                    Font = @"Venera",
+                    Margin = new MarginPadding
+                    {
+                        Right = margin,
+                    },
+                }
+            };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            double songCurrentTime = AudioClock.CurrentTime - startTime;
+            int currentPercent = Math.Max(0, Math.Min(100, (int)(songCurrentTime / songLength * 100)));
+            int currentSecond = (int)Math.Floor(songCurrentTime / 1000.0);
+            if (currentPercent != previousPercent)
+            {
+                progress.Text = currentPercent.ToString() + @"%";
+                previousPercent = currentPercent;
+            }
+            if (currentSecond != previousSecond && songCurrentTime < songLength)
+            {
+                //since TimeSpan.ToString doesnt support minutes above 60, we have to seperate the minutes into something else.
                 var timeRemain = endTime - AudioClock.CurrentTime;
-                timeLeft.Text = TimeSpan.FromMilliseconds(timeRemain).ToString(timeRemain > 3600000 ? @"\-h\:mm\:ss" :timeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");
+                string minutes = songCurrentTime < 0 ? "-0" : Math.Floor(TimeSpan.FromSeconds(currentSecond).TotalMinutes).ToString();
+                timeCurrent.Text = minutes + ':' + TimeSpan.FromSeconds(currentSecond).ToString(@"ss");
+                timeLeft.Text = "-" + Math.Floor(TimeSpan.FromMilliseconds(timeRemain).TotalMinutes) + ':' + TimeSpan.FromMilliseconds(timeRemain).ToString(@"ss");
                 previousSecond = currentSecond;
+            }
+        }
+    }
+}
             }
         }
     }

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -85,9 +85,12 @@ namespace osu.Game.Screens.Play
 
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
-                timeCurrent.Text = TimeSpan.FromSeconds(currentSecond).ToString(songCurrentTime < 0 ? @"\-m\:ss" : @"m\:ss");
-                timeLeft.Text = TimeSpan.FromMilliseconds(endTime - AudioClock.CurrentTime).ToString(@"\-m\:ss");
-
+                //TIME HANDLER FOR CURRENT TIME
+                timeCurrent.Text = TimeSpan.FromSeconds(currentSecond).ToString(songCurrentTime < 0 ? @"\-m\:ss" : songCurrentTime > 3600000 ? @"h\:mm\:ss" : songCurrentTime > 600000 ? @"mm\:ss" : @"m\:ss");
+                //TIME HANDLER FOR TIME REMAINING
+                var TimeRemain = endTime - AudioClock.CurrentTime;
+                timeLeft.Text = TimeSpan.FromMilliseconds(TimeRemain).ToString(TimeRemain > 3600000 ? @"\-h\:mm\:ss" : TimeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");
+               
                 previousSecond = currentSecond;
             }
         }

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Framework.Allocation;
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Play
             {
                 timeCurrent.Text = TimeSpan.FromSeconds(currentSecond).ToString(songCurrentTime < 0 ? @"\-m\:ss" : songCurrentTime > 3600000 ? @"h\:mm\:ss" : songCurrentTime > 600000 ? @"mm\:ss" : @"m\:ss");
                 var TimeRemain = endTime - AudioClock.CurrentTime;
-                timeLeft.Text = TimeSpan.FromMilliseconds(TimeRemain).ToString(TimeRemain > 3600000 ? @"\-h\:mm\:ss" : TimeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");        
+                timeLeft.Text = TimeSpan.FromMilliseconds(TimeRemain).ToString(TimeRemain > 3600000 ? @"\-h\:mm\:ss" : TimeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");
                 previousSecond = currentSecond;
             }
         }

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -85,12 +85,9 @@ namespace osu.Game.Screens.Play
 
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
-                //TIME HANDLER FOR CURRENT TIME
                 timeCurrent.Text = TimeSpan.FromSeconds(currentSecond).ToString(songCurrentTime < 0 ? @"\-m\:ss" : songCurrentTime > 3600000 ? @"h\:mm\:ss" : songCurrentTime > 600000 ? @"mm\:ss" : @"m\:ss");
-                //TIME HANDLER FOR TIME REMAINING
                 var TimeRemain = endTime - AudioClock.CurrentTime;
-                timeLeft.Text = TimeSpan.FromMilliseconds(TimeRemain).ToString(TimeRemain > 3600000 ? @"\-h\:mm\:ss" : TimeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");
-               
+                timeLeft.Text = TimeSpan.FromMilliseconds(TimeRemain).ToString(TimeRemain > 3600000 ? @"\-h\:mm\:ss" : TimeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");        
                 previousSecond = currentSecond;
             }
         }

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -76,93 +76,6 @@ namespace osu.Game.Screens.Play
             double songCurrentTime = AudioClock.CurrentTime - startTime;
             int currentPercent = Math.Max(0, Math.Min(100, (int)(songCurrentTime / songLength * 100)));
             int currentSecond = (int)Math.Floor(songCurrentTime / 1000.0);
-
-            if (currentPercent != previousPercent)
-            {
-                progress.Text = currentPercent.ToString() + @"%";
-                previousPercent = currentPercent;
-            }
-
-            if (currentSecond != previousSecond && songCurrentTime < songLength)
-            {
-                // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
-
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Timing;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using System;
-
-namespace osu.Game.Screens.Play
-{
-    public class SongProgressInfo : Container
-    {
-        private OsuSpriteText timeCurrent;
-        private OsuSpriteText timeLeft;
-        private OsuSpriteText progress;
-
-        private double startTime;
-        private double endTime;
-
-        private int? previousPercent;
-        private int? previousSecond;
-
-        private double songLength => endTime - startTime;
-
-        private const int margin = 10;
-
-        public IClock AudioClock;
-
-        public double StartTime { set { startTime = value; } }
-        public double EndTime { set { endTime = value; } }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            Children = new Drawable[]
-            {
-                timeCurrent = new OsuSpriteText
-                {
-                    Origin = Anchor.BottomLeft,
-                    Anchor = Anchor.BottomLeft,
-                    Colour = colours.BlueLighter,
-                    Font = @"Venera",
-                    Margin = new MarginPadding
-                    {
-                        Left = margin,
-                    },
-                },
-                progress = new OsuSpriteText
-                {
-                    Origin = Anchor.BottomCentre,
-                    Anchor = Anchor.BottomCentre,
-                    Colour = colours.BlueLighter,
-                    Font = @"Venera",
-                },
-                timeLeft = new OsuSpriteText
-                {
-                    Origin = Anchor.BottomRight,
-                    Anchor = Anchor.BottomRight,
-                    Colour = colours.BlueLighter,
-                    Font = @"Venera",
-                    Margin = new MarginPadding
-                    {
-                        Right = margin,
-                    },
-                }
-            };
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            double songCurrentTime = AudioClock.CurrentTime - startTime;
-            int currentPercent = Math.Max(0, Math.Min(100, (int)(songCurrentTime / songLength * 100)));
-            int currentSecond = (int)Math.Floor(songCurrentTime / 1000.0);
             if (currentPercent != previousPercent)
             {
                 progress.Text = currentPercent.ToString() + @"%";
@@ -170,16 +83,12 @@ namespace osu.Game.Screens.Play
             }
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
-                //since TimeSpan.ToString doesnt support minutes above 60, we have to seperate the minutes into something else.
+                //since TimeSpan to string doesnt support minutes above 60, we have to do something else.
                 var timeRemain = endTime - AudioClock.CurrentTime;
                 string minutes = songCurrentTime < 0 ? "-0" : Math.Floor(TimeSpan.FromSeconds(currentSecond).TotalMinutes).ToString();
                 timeCurrent.Text = minutes + ':' + TimeSpan.FromSeconds(currentSecond).ToString(@"ss");
                 timeLeft.Text = "-" + Math.Floor(TimeSpan.FromMilliseconds(timeRemain).TotalMinutes) + ':' + TimeSpan.FromMilliseconds(timeRemain).ToString(@"ss");
                 previousSecond = currentSecond;
-            }
-        }
-    }
-}
             }
         }
     }

--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -86,8 +86,8 @@ namespace osu.Game.Screens.Play
             if (currentSecond != previousSecond && songCurrentTime < songLength)
             {
                 timeCurrent.Text = TimeSpan.FromSeconds(currentSecond).ToString(songCurrentTime < 0 ? @"\-m\:ss" : songCurrentTime > 3600000 ? @"h\:mm\:ss" : songCurrentTime > 600000 ? @"mm\:ss" : @"m\:ss");
-                var TimeRemain = endTime - AudioClock.CurrentTime;
-                timeLeft.Text = TimeSpan.FromMilliseconds(TimeRemain).ToString(TimeRemain > 3600000 ? @"\-h\:mm\:ss" : TimeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");
+                var timeRemain = endTime - AudioClock.CurrentTime;
+                timeLeft.Text = TimeSpan.FromMilliseconds(timeRemain).ToString(timeRemain > 3600000 ? @"\-h\:mm\:ss" :timeRemain > 600000 ? @"\-mm\:ss" : @"\-m\:ss");
                 previousSecond = currentSecond;
             }
         }


### PR DESCRIPTION
When there is < 10 minutes, timer displays m:ss, when it is above 10 minutes, it displays mm:ss, and so on. This also happens with the hours and time remaining.
Can't seem to find a way to combine this pull request with the one I posted before, so I am making a new one. I'll reference this one in the orignal post.
This was suggested by swoolcock.
#2475

Resolves #2466.