### PR TITLE
Fix playback speed being set incorrectly

### DIFF
--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 }
             };
 
-            sliderbar.Bindable.ValueChanged += rateMultiplier => multiplierText.Text = $"{sliderbar.Bar.TooltipText}x";
+            sliderbar.Bindable.ValueChanged += rateMultiplier => Schedule(() => multiplierText.Text = $"{sliderbar.Bar.TooltipText}x");
             sliderbar.Bindable.TriggerChange();
         }
 


### PR DESCRIPTION
Fixes #2460.

Due to ordering of bindable value propagation, this was being called too early.