### PR TITLE
Add support for osu!mania and osu!taiko scores

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseBeatmapScoresContainer.cs
+++ b/osu.Game.Tests/Visual/TestCaseBeatmapScoresContainer.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Tests.Visual
     {
         private readonly IEnumerable<OnlineScore> scores;
         private readonly IEnumerable<OnlineScore> anotherScores;
+        private readonly IEnumerable<OnlineScore> maniaScores;
         private readonly OnlineScore topScore;
         private readonly Box background;
 
@@ -53,6 +54,8 @@ namespace osu.Game.Tests.Visual
             AddStep("resize to big", () => container.ResizeWidthTo(1, 300));
             AddStep("resize to normal", () => container.ResizeWidthTo(0.8f, 300));
             AddStep("online scores", () => scoresContainer.Beatmap = new BeatmapInfo { OnlineBeatmapSetID = 1, OnlineBeatmapID = 75, Ruleset = new OsuRuleset().RulesetInfo });
+            AddStep("mania scores", () => scoresContainer.Scores = maniaScores);
+            // TODO: Add osu!taiko scores
 
 
             scores = new[]
@@ -165,6 +168,7 @@ namespace osu.Game.Tests.Visual
                 s.Statistics.Add(HitResult.Great, RNG.Next(2000));
                 s.Statistics.Add(HitResult.Good, RNG.Next(2000));
                 s.Statistics.Add(HitResult.Meh, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Miss, RNG.Next(2000));
             }
 
             anotherScores = new[]
@@ -277,6 +281,7 @@ namespace osu.Game.Tests.Visual
                 s.Statistics.Add(HitResult.Great, RNG.Next(2000));
                 s.Statistics.Add(HitResult.Good, RNG.Next(2000));
                 s.Statistics.Add(HitResult.Meh, RNG.Next(2000));
+                s.Statistics.Add(HitResult.Miss, RNG.Next(2000));
             }
 
             topScore = new OnlineScore
@@ -304,6 +309,135 @@ namespace osu.Game.Tests.Visual
             topScore.Statistics.Add(HitResult.Great, RNG.Next(2000));
             topScore.Statistics.Add(HitResult.Good, RNG.Next(2000));
             topScore.Statistics.Add(HitResult.Meh, RNG.Next(2000));
+            topScore.Statistics.Add(HitResult.Miss, RNG.Next(2000));
+
+            maniaScores = new[]
+            {
+                new OnlineScore
+                {
+                    User = new User
+                    {
+                        Id = 4608074,
+                        Username = @"Majesty",
+                        Country = new Country
+                        {
+                            FullName = @"South Korea",
+                            FlagName = @"KR",
+                        },
+                    },
+                    Mods = new Mod[]
+                    {
+                        new OsuModNightcore(),
+                        new OsuModHidden(),
+                        new OsuModFlashlight(),
+                        new OsuModHardRock(),
+                    },
+                    Rank = ScoreRank.X,
+                    TotalScore = 1000000,
+                    Accuracy = 1,
+                },
+                new OnlineScore
+                {
+                    User = new User
+                    {
+                        Id = 6602580,
+                        Username = @"jakads",
+                        Country = new Country
+                        {
+                            FullName = @"South Korea",
+                            FlagName = @"KR",
+                        },
+                    },
+                    Mods = new Mod[]
+                    {
+                        new OsuModDoubleTime(),
+                        new OsuModHidden(),
+                        new OsuModFlashlight(),
+                        new OsuModHardRock(),
+                    },
+                    Rank = ScoreRank.XH,
+                    TotalScore = 999999,
+                    Accuracy = 0.9999,
+                },
+                new OnlineScore
+                {
+                    User = new User
+                    {
+                        Id = 7151382,
+                        Username = @"cheewee10",
+                        Country = new Country
+                        {
+                            FullName = @"Malaysia",
+                            FlagName = @"MY",
+                        },
+                    },
+                    Rank = ScoreRank.D,
+                    TotalScore = 123456,
+                    Accuracy = 0.6543,
+                },
+                new OnlineScore
+                {
+                    User = new User
+                    {
+                        Id = 1014222,
+                        Username = @"snoverpk",
+                        Country = new Country
+                        {
+                            FullName = @"Finland",
+                            FlagName = @"FI",
+                        },
+                    },
+                    Mods = new Mod[]
+                    {
+                        new OsuModDoubleTime(),
+                        new OsuModHidden(),
+                    },
+                    Rank = ScoreRank.B,
+                    TotalScore = 654321,
+                    Accuracy = 0.8765,
+                },
+                new OnlineScore
+                {
+                    User = new User
+                    {
+                        Id = 1541390,
+                        Username = @"batzourgias",
+                        Country = new Country
+                        {
+                            FullName = @"Greece",
+                            FlagName = @"GR",
+                        },
+                    },
+                    Mods = new Mod[]
+                    {
+                        new OsuModDoubleTime(),
+                    },
+                    Rank = ScoreRank.C,
+                    TotalScore = 513024,
+                    Accuracy = 0.7765,
+                },
+            };
+            foreach (var s in maniaScores)
+            {
+                if (s.User.Username == "Majesty")
+                {
+                    s.Statistics.Add(HitResult.Perfect, 9999);
+                    s.Statistics.Add(HitResult.Great, -1);
+                    s.Statistics.Add(HitResult.Good, -2);
+                    s.Statistics.Add(HitResult.Ok, -4);
+                    s.Statistics.Add(HitResult.Meh, -8);
+                    s.Statistics.Add(HitResult.Miss, -16);
+                }
+                else
+                {
+                    s.Statistics.Add(HitResult.Perfect, RNG.Next(2000));
+                    s.Statistics.Add(HitResult.Great, RNG.Next(2000));
+                    s.Statistics.Add(HitResult.Good, RNG.Next(2000));
+                    s.Statistics.Add(HitResult.Ok, RNG.Next(2000));
+                    s.Statistics.Add(HitResult.Meh, RNG.Next(2000));
+                    s.Statistics.Add(HitResult.Miss, RNG.Next(2000));
+                }
+            }
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Online/API/Requests/GetScoresRequest.cs
+++ b/osu.Game/Online/API/Requests/GetScoresRequest.cs
@@ -47,10 +47,7 @@ namespace osu.Game.Online.API.Requests
                     switch (kvp.Key)
                     {
                         case @"count_geki":
-                            if (ruleset.ID == 3) // Currently only accounting for osu!mania; will need evaluation for osu!catch
-                                newKey = HitResult.Perfect;
-                            else
-                                newKey = HitResult.Great;
+                            newKey = ruleset.ID == 3 ? HitResult.Perfect : HitResult.Great; // Currently only accounting for osu!mania; will need evaluation for osu!catch
                             break;
                         case @"count_300":
                             newKey = HitResult.Great;
@@ -59,10 +56,7 @@ namespace osu.Game.Online.API.Requests
                             newKey = HitResult.Good;
                             break;
                         case @"count_100":
-                            if (ruleset.ID == 3)
-                                newKey = HitResult.Ok;
-                            else
-                                newKey = HitResult.Good;
+                            newKey = ruleset.ID == 3 ? HitResult.Ok : HitResult.Good;
                             break;
                         case @"count_50":
                             newKey = ruleset.ID != 1 ? HitResult.Meh : HitResult.Miss; // Do not create a new key if score is about osu!taiko

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableScore.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     RelativeSizeAxes = Axes.X,
                     Width = 0.06f,
                     RelativePositionAxes = Axes.X,
-                    X = 0.42f
+                    X = 0.35f
                 },
                 new DrawableRank(score.Rank)
                 {
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     Size = new Vector2(30, 20),
                     FillMode = FillMode.Fit,
                     RelativePositionAxes = Axes.X,
-                    X = 0.55f
+                    X = 0.50f
                 },
                 new OsuSpriteText
                 {
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     Text = $@"{score.TotalScore:N0}",
                     Font = @"Venera",
                     RelativePositionAxes = Axes.X,
-                    X = 0.75f,
+                    X = 0.70f,
                     FixedWidth = true,
                 },
                 new OsuSpriteText
@@ -99,13 +99,15 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     Text = $@"{score.Accuracy:P2}",
                     Font = @"Exo2.0-RegularItalic",
                     RelativePositionAxes = Axes.X,
-                    X = 0.85f
+                    X = 0.80f
                 },
                 new OsuSpriteText
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Text = $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Meh]}",
+                    Text = score.Statistics.ContainsKey(HitResult.Meh) ? score.Statistics.ContainsKey(HitResult.Perfect) ? $"{score.Statistics[HitResult.Perfect]}/{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Ok]}/{score.Statistics[HitResult.Meh]}/{score.Statistics[HitResult.Miss]}"
+                                                                                                                         : $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Meh]}/{score.Statistics[HitResult.Miss]}"
+                                                                       : $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Miss]}", // Long
                     Font = @"Exo2.0-RegularItalic",
                     Margin = new MarginPadding { Right = side_margin }
                 },

--- a/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/DrawableTopScore.cs
@@ -58,7 +58,21 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
 
                 totalScore.Value = $@"{score.TotalScore:N0}";
                 accuracy.Value = $@"{score.Accuracy:P2}";
-                statistics.Value = $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Meh]}";
+                if (score.Statistics.ContainsKey(HitResult.Perfect)) // Only osu!mania contains this judgement type currently
+                {
+                    statistics.HeaderText = "MAX/300/200/100/50/Miss";
+                    statistics.Value = $"{score.Statistics[HitResult.Perfect]}/{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Ok]}/{score.Statistics[HitResult.Meh]}/{score.Statistics[HitResult.Miss]}";
+                }
+                else if (score.Statistics.ContainsKey(HitResult.Meh)) // Only osu!taiko does not contain this judgement type
+                {
+                    statistics.HeaderText = "300/100/50/Miss";
+                    statistics.Value = $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Meh]}/{score.Statistics[HitResult.Miss]}";
+                }
+                else
+                {
+                    statistics.HeaderText = "300/100/Miss";
+                    statistics.Value = $"{score.Statistics[HitResult.Great]}/{score.Statistics[HitResult.Good]}/{score.Statistics[HitResult.Miss]}";
+                }
 
                 modsContainer.Clear();
                 foreach (Mod mod in score.Mods)
@@ -201,6 +215,16 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             private readonly OsuSpriteText headerText;
             private readonly OsuSpriteText valueText;
 
+            public string HeaderText
+            {
+                set
+                {
+                    if (headerText.Text == value)
+                        return;
+                    headerText.Text = value;
+                }
+                get { return headerText.Text; }
+            }
             public string Value
             {
                 set


### PR DESCRIPTION
Displays the count of misses, correctly displays the scores for an osu!mania or osu!taiko score.

This does affect the score overview in the replay score overview circle, overflowing osu!mania scores, but that's to be taken care of separately.

To be considered:
- Use multiple columns with spacing for each judgement type in order to avoid confusion

TODO:
- [ ] Add support for osu!catch scores (will need to decide on the judgement types that will be shown)