### PR TITLE
Remove explicit clock in TestCaseBreakOverlay

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseBreakOverlay.cs
+++ b/osu.Game.Tests/Visual/TestCaseBreakOverlay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Framework.Timing;
 using osu.Game.Beatmaps.Timing;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -16,8 +15,6 @@ namespace osu.Game.Tests.Visual
 
         public TestCaseBreakOverlay()
         {
-            Clock = new FramedClock();
-
             Child = breakOverlay = new BreakOverlay(true);
 
             AddStep("2s break", () => startBreak(2000));


### PR DESCRIPTION
So that you can now use the testcase speed slider to slow it down/make it faster.