### PR TITLE
Stop focused overlays from handling DragStart

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -44,19 +44,6 @@ namespace osu.Game.Graphics.Containers
             return base.OnClick(state);
         }
 
-        protected override bool OnDragStart(InputState state)
-        {
-            if (!base.ReceiveMouseInputAt(state.Mouse.NativeState.Position))
-            {
-                State = Visibility.Hidden;
-                return true;
-            }
-
-            return base.OnDragStart(state);
-        }
-
-        protected override bool OnDrag(InputState state) => State == Visibility.Hidden;
-
         private void onStateChanged(Visibility visibility)
         {
             switch (visibility)


### PR DESCRIPTION
This was causing weird behaviour with the key configuration section and back button in settings.

![screencast 2018-05-14 16-26-54](https://user-images.githubusercontent.com/191335/39983776-d1f7e012-5793-11e8-9dcb-9057e17bf6d4.gif)