### PR TITLE
Fix deleted beatmaps still being accessible in MusicController

### DIFF
--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
@@ -19,17 +19,15 @@ namespace osu.Game.Overlays.Music
     public class PlaylistOverlay : OverlayContainer
     {
         private const float transition_duration = 600;
-
         private const float playlist_height = 510;
 
+        public Action<BeatmapSetInfo, int> OrderChanged;
+
+        private BeatmapManager beatmaps;
         private FilterControl filter;
         private PlaylistList list;
 
-        private BeatmapManager beatmaps;
-
         private readonly Bindable<WorkingBeatmap> beatmapBacking = new Bindable<WorkingBeatmap>();
-
-        public IEnumerable<BeatmapSetInfo> BeatmapSets => list.BeatmapSets;
 
         [BackgroundDependencyLoader]
         private void load(OsuGameBase game, BeatmapManager beatmaps, OsuColour colours)
@@ -60,7 +58,8 @@ namespace osu.Game.Overlays.Music
                         {
                             RelativeSizeAxes = Axes.Both,
                             Padding = new MarginPadding { Top = 95, Bottom = 10, Right = 10 },
-                            OnSelect = itemSelected,
+                            Selected = itemSelected,
+                            OrderChanged = (s, i) => OrderChanged?.Invoke(s, i)
                         },
                         filter = new FilterControl
                         {
@@ -74,29 +73,15 @@ namespace osu.Game.Overlays.Music
                 },
             };
 
-            beatmaps.ItemAdded += handleBeatmapAdded;
-            beatmaps.ItemRemoved += handleBeatmapRemoved;
-
-            list.BeatmapSets = beatmaps.GetAllUsableBeatmapSets();
-
             beatmapBacking.BindTo(game.Beatmap);
 
             filter.Search.OnCommit = (sender, newText) =>
             {
-                var beatmap = list.FirstVisibleSet?.Beatmaps?.FirstOrDefault();
-                if (beatmap != null) playSpecified(beatmap);
+                BeatmapInfo beatmap = list.FirstVisibleSet?.Beatmaps?.FirstOrDefault();
+                if (beatmap != null)
+                    beatmapBacking.Value = beatmaps.GetWorkingBeatmap(beatmap);
             };
         }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-            beatmapBacking.ValueChanged += b => list.SelectedSet = b?.BeatmapSetInfo;
-            beatmapBacking.TriggerChange();
-        }
-
-        private void handleBeatmapAdded(BeatmapSetInfo setInfo) => Schedule(() => list.AddBeatmapSet(setInfo));
-        private void handleBeatmapRemoved(BeatmapSetInfo setInfo) => Schedule(() => list.RemoveBeatmapSet(setInfo));
 
         protected override void PopIn()
         {
@@ -123,49 +108,7 @@ namespace osu.Game.Overlays.Music
                 return;
             }
 
-            playSpecified(set.Beatmaps.First());
-        }
-
-        public void PlayPrevious()
-        {
-            var playable = list.PreviousSet;
-
-            if (playable != null)
-            {
-                playSpecified(playable.Beatmaps.First());
-                list.SelectedSet = playable;
-            }
-        }
-
-        public void PlayNext()
-        {
-            var playable = list.NextSet;
-
-            if (playable != null)
-            {
-                playSpecified(playable.Beatmaps.First());
-                list.SelectedSet = playable;
-            }
-        }
-
-        private void playSpecified(BeatmapInfo info)
-        {
-            beatmapBacking.Value = beatmaps.GetWorkingBeatmap(info, beatmapBacking);
-
-            var track = beatmapBacking.Value.Track;
-
-            track.Restart();
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (beatmaps != null)
-            {
-                beatmaps.ItemAdded -= handleBeatmapAdded;
-                beatmaps.ItemRemoved -= handleBeatmapRemoved;
-            }
+            beatmapBacking.Value = beatmaps.GetWorkingBeatmap(set.Beatmaps.First());
         }
     }
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -306,7 +306,10 @@ namespace osu.Game.Overlays
 
             var playable = beatmapSets.TakeWhile(i => i.ID != current.BeatmapSetInfo.ID).LastOrDefault() ?? beatmapSets.LastOrDefault();
             if (playable != null)
-                playSpecified(playable.Beatmaps.First());
+            {
+                beatmapBacking.Value = beatmaps.GetWorkingBeatmap(playable.Beatmaps.First(), beatmapBacking);
+                beatmapBacking.Value.Track.Restart();
+            }
         }
 
         private void next(bool instant = false)
@@ -315,13 +318,10 @@ namespace osu.Game.Overlays
 
             var playable = beatmapSets.SkipWhile(i => i.ID != current.BeatmapSetInfo.ID).Skip(1).FirstOrDefault() ?? beatmapSets.FirstOrDefault();
             if (playable != null)
-                playSpecified(playable.Beatmaps.First());
-        }
-
-        private void playSpecified(BeatmapInfo info)
-        {
-            beatmapBacking.Value = beatmaps.GetWorkingBeatmap(info, beatmapBacking);
-            beatmapBacking.Value.Track.Restart();
+            {
+                beatmapBacking.Value = beatmaps.GetWorkingBeatmap(playable.Beatmaps.First(), beatmapBacking);
+                beatmapBacking.Value.Track.Restart();
+            }
         }
 
         private WorkingBeatmap current;

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
@@ -50,7 +51,10 @@ namespace osu.Game.Overlays
 
         private LocalisationEngine localisation;
 
+        private BeatmapManager beatmaps;
         private readonly Bindable<WorkingBeatmap> beatmapBacking = new Bindable<WorkingBeatmap>();
+        private List<BeatmapSetInfo> beatmapSets;
+        private BeatmapSetInfo currentSet;
 
         private Container dragContainer;
         private Container playerContainer;
@@ -93,8 +97,9 @@ namespace osu.Game.Overlays
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuGameBase game, OsuColour colours, LocalisationEngine localisation)
+        private void load(OsuGameBase game, BeatmapManager beatmaps, OsuColour colours, LocalisationEngine localisation)
         {
+            this.beatmaps = beatmaps;
             this.localisation = localisation;
 
             Children = new Drawable[]
@@ -111,6 +116,7 @@ namespace osu.Game.Overlays
                         {
                             RelativeSizeAxes = Axes.X,
                             Y = player_height + 10,
+                            OrderChanged = playlistOrderChanged
                         },
                         playerContainer = new Container
                         {
@@ -185,7 +191,7 @@ namespace osu.Game.Overlays
                                                 {
                                                     Anchor = Anchor.Centre,
                                                     Origin = Anchor.Centre,
-                                                    Action = next,
+                                                    Action = () => next(),
                                                     Icon = FontAwesome.fa_step_forward,
                                                 },
                                             }
@@ -214,10 +220,23 @@ namespace osu.Game.Overlays
                 }
             };
 
+            beatmapSets = beatmaps.GetAllUsableBeatmapSets();
+            beatmaps.ItemAdded += handleBeatmapAdded;
+            beatmaps.ItemRemoved += handleBeatmapRemoved;
+
             beatmapBacking.BindTo(game.Beatmap);
 
             playlist.StateChanged += s => playlistButton.FadeColour(s == Visibility.Visible ? colours.Yellow : Color4.White, 200, Easing.OutQuint);
         }
+
+        private void playlistOrderChanged(BeatmapSetInfo beatmapSetInfo, int index)
+        {
+            beatmapSets.Remove(beatmapSetInfo);
+            beatmapSets.Insert(index, beatmapSetInfo);
+        }
+
+        private void handleBeatmapAdded(BeatmapSetInfo obj) => beatmapSets.Add(obj);
+        private void handleBeatmapRemoved(BeatmapSetInfo obj) => beatmapSets.RemoveAll(s => s.ID == obj.ID);
 
         protected override void LoadComplete()
         {
@@ -257,7 +276,7 @@ namespace osu.Game.Overlays
 
                 playButton.Icon = track.IsRunning ? FontAwesome.fa_pause_circle_o : FontAwesome.fa_play_circle_o;
 
-                if (track.HasCompleted && !track.Looping && !beatmapBacking.Disabled && playlist.BeatmapSets.Any())
+                if (track.HasCompleted && !track.Looping && !beatmapBacking.Disabled && beatmapSets.Any())
                     next();
             }
             else
@@ -271,7 +290,7 @@ namespace osu.Game.Overlays
             if (track == null)
             {
                 if (!beatmapBacking.Disabled)
-                    playlist.PlayNext();
+                    next(true);
                 return;
             }
 
@@ -284,13 +303,25 @@ namespace osu.Game.Overlays
         private void prev()
         {
             queuedDirection = TransformDirection.Prev;
-            playlist.PlayPrevious();
+
+            var playable = beatmapSets.TakeWhile(i => i.ID != current.BeatmapSetInfo.ID).LastOrDefault() ?? beatmapSets.LastOrDefault();
+            if (playable != null)
+                playSpecified(playable.Beatmaps.First());
         }
 
-        private void next()
+        private void next(bool instant = false)
         {
             queuedDirection = TransformDirection.Next;
-            playlist.PlayNext();
+
+            var playable = beatmapSets.SkipWhile(i => i.ID != current.BeatmapSetInfo.ID).Skip(1).FirstOrDefault() ?? beatmapSets.FirstOrDefault();
+            if (playable != null)
+                playSpecified(playable.Beatmaps.First());
+        }
+
+        private void playSpecified(BeatmapInfo info)
+        {
+            beatmapBacking.Value = beatmaps.GetWorkingBeatmap(info, beatmapBacking);
+            beatmapBacking.Value.Track.Restart();
         }
 
         private WorkingBeatmap current;
@@ -314,8 +345,8 @@ namespace osu.Game.Overlays
                 else
                 {
                     //figure out the best direction based on order in playlist.
-                    var last = playlist.BeatmapSets.TakeWhile(b => b.ID != current.BeatmapSetInfo?.ID).Count();
-                    var next = beatmap == null ? -1 : playlist.BeatmapSets.TakeWhile(b => b.ID != beatmap.BeatmapSetInfo?.ID).Count();
+                    var last = beatmapSets.TakeWhile(b => b.ID != current.BeatmapSetInfo?.ID).Count();
+                    var next = beatmap == null ? -1 : beatmapSets.TakeWhile(b => b.ID != beatmap.BeatmapSetInfo?.ID).Count();
 
                     direction = last > next ? TransformDirection.Prev : TransformDirection.Next;
                 }

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -314,7 +314,8 @@ namespace osu.Game.Overlays
 
         private void next(bool instant = false)
         {
-            queuedDirection = TransformDirection.Next;
+            if (!instant)
+                queuedDirection = TransformDirection.Next;
 
             var playable = beatmapSets.SkipWhile(i => i.ID != current.BeatmapSetInfo.ID).Skip(1).FirstOrDefault() ?? beatmapSets.FirstOrDefault();
             if (playable != null)


### PR DESCRIPTION
Fixes #2511.

`PlaylistOverlay` isn't present so it doesn't update its beatmap sets list when beatmaps are added/removed because the scheduler doesn't run.

This moves all handling of beatmap sets to `MusicController`, which is where it should've been anyway. `PlaylistOverlay` now exposes `OrderChanged` to signal `MusicController` to change the ordering of its list.

Cleans up a lot in the process.