### PR TITLE
Allow subclasses of LegacyScoreParser to specify beatmap/ruleset retrieval

### DIFF
--- a/osu.Game/Rulesets/Scoring/Legacy/DatabasedLegacyScoreParser.cs
+++ b/osu.Game/Rulesets/Scoring/Legacy/DatabasedLegacyScoreParser.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Scoring.Legacy
+{
+    /// <summary>
+    /// A <see cref="LegacyScoreParser"/> which retrieves the applicable <see cref="Beatmap"/> and <see cref="Ruleset"/>
+    /// for the score from the database.
+    /// </summary>
+    public class DatabasedLegacyScoreParser : LegacyScoreParser
+    {
+        private readonly RulesetStore rulesets;
+        private readonly BeatmapManager beatmaps;
+
+        public DatabasedLegacyScoreParser(RulesetStore rulesets, BeatmapManager beatmaps)
+        {
+            this.rulesets = rulesets;
+            this.beatmaps = beatmaps;
+        }
+
+        protected override Ruleset GetRuleset(int rulesetId) => rulesets.GetRuleset(rulesetId).CreateInstance();
+        protected override WorkingBeatmap GetBeatmap(string md5Hash) => beatmaps.GetWorkingBeatmap(beatmaps.QueryBeatmap(b => b.MD5Hash == md5Hash));
+    }
+}

--- a/osu.Game/Rulesets/Scoring/Legacy/LegacyScoreParser.cs
+++ b/osu.Game/Rulesets/Scoring/Legacy/LegacyScoreParser.cs
@@ -14,21 +14,8 @@ using System.Linq;
 
 namespace osu.Game.Rulesets.Scoring.Legacy
 {
-    public class LegacyScoreParser
+    public abstract class LegacyScoreParser
     {
-        private readonly RulesetStore rulesets;
-        private readonly BeatmapManager beatmaps;
-
-        public LegacyScoreParser(RulesetStore rulesets, BeatmapManager beatmaps)
-        {
-            this.rulesets = rulesets;
-            this.beatmaps = beatmaps;
-        }
-
-        protected LegacyScoreParser()
-        {
-        }
-
         private IBeatmap currentBeatmap;
         private Ruleset currentRuleset;
 
@@ -185,7 +172,18 @@ namespace osu.Game.Rulesets.Scoring.Legacy
             return frame;
         }
 
-        protected virtual Ruleset GetRuleset(int rulesetId) => rulesets.GetRuleset(rulesetId).CreateInstance();
-        protected virtual WorkingBeatmap GetBeatmap(string md5Hash) => beatmaps.GetWorkingBeatmap(beatmaps.QueryBeatmap(b => b.MD5Hash == md5Hash));
+        /// <summary>
+        /// Retrieves the <see cref="Ruleset"/> for a specific id.
+        /// </summary>
+        /// <param name="rulesetId">The id.</param>
+        /// <returns>The <see cref="Ruleset"/>.</returns>
+        protected abstract Ruleset GetRuleset(int rulesetId);
+
+        /// <summary>
+        /// Retrieves the <see cref="WorkingBeatmap"/> corresponding to an MD5 hash.
+        /// </summary>
+        /// <param name="md5Hash">The MD5 hash.</param>
+        /// <returns>The <see cref="WorkingBeatmap"/>.</returns>
+        protected abstract WorkingBeatmap GetBeatmap(string md5Hash);
     }
 }

--- a/osu.Game/Rulesets/Scoring/Legacy/LegacyScoreParser.cs
+++ b/osu.Game/Rulesets/Scoring/Legacy/LegacyScoreParser.cs
@@ -25,6 +25,10 @@ namespace osu.Game.Rulesets.Scoring.Legacy
             this.beatmaps = beatmaps;
         }
 
+        protected LegacyScoreParser()
+        {
+        }
+
         private IBeatmap currentBeatmap;
         private Ruleset currentRuleset;
 
@@ -34,16 +38,15 @@ namespace osu.Game.Rulesets.Scoring.Legacy
 
             using (SerializationReader sr = new SerializationReader(stream))
             {
-                score = new Score { Ruleset = rulesets.GetRuleset(sr.ReadByte()) };
-                currentRuleset = score.Ruleset.CreateInstance();
+                currentRuleset = GetRuleset(sr.ReadByte());
+                score = new Score { Ruleset = currentRuleset.RulesetInfo };
 
                 /* score.Pass = true;*/
                 var version = sr.ReadInt32();
 
                 /* score.FileChecksum = */
-                var beatmapHash = sr.ReadString();
-                score.Beatmap = beatmaps.QueryBeatmap(b => b.MD5Hash == beatmapHash);
-                currentBeatmap = beatmaps.GetWorkingBeatmap(score.Beatmap).Beatmap;
+                currentBeatmap = GetBeatmap(sr.ReadString()).Beatmap;
+                score.Beatmap = currentBeatmap.BeatmapInfo;
 
                 /* score.PlayerName = */
                 score.User = new User { Username = sr.ReadString() };
@@ -181,5 +184,8 @@ namespace osu.Game.Rulesets.Scoring.Legacy
 
             return frame;
         }
+
+        protected virtual Ruleset GetRuleset(int rulesetId) => rulesets.GetRuleset(rulesetId).CreateInstance();
+        protected virtual WorkingBeatmap GetBeatmap(string md5Hash) => beatmaps.GetWorkingBeatmap(beatmaps.QueryBeatmap(b => b.MD5Hash == md5Hash));
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreStore.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreStore.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Scoring
         public Score ReadReplayFile(string replayFilename)
         {
             using (Stream s = storage.GetStream(Path.Combine(replay_folder, replayFilename)))
-                return new LegacyScoreParser(rulesets, beatmaps).Parse(s);
+                return new DatabasedLegacyScoreParser(rulesets, beatmaps).Parse(s);
         }
     }
 }


### PR DESCRIPTION
Used for PerformanceCalculator osu!tool, which now doesn't use BeatmapManager/RulesetStore.