### PR TITLE
Multiplayer base screen

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseMultiHeader.cs
+++ b/osu.Game.Tests/Visual/TestCaseMultiHeader.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Screens.Multi;
+using osu.Game.Screens.Multi.Screens;
+
+namespace osu.Game.Tests.Visual
+{
+    [TestFixture]
+    public class TestCaseMultiHeader : OsuTestCase
+    {
+        public TestCaseMultiHeader()
+        {
+            Lobby lobby;
+            Children = new Drawable[]
+            {
+                lobby = new Lobby
+                {
+                    Padding = new MarginPadding { Top = Header.HEIGHT },
+                },
+                new Header(lobby),
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/TestCaseMultiScreen.cs
+++ b/osu.Game.Tests/Visual/TestCaseMultiScreen.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using NUnit.Framework;
+using osu.Game.Screens.Multi;
+
+namespace osu.Game.Tests.Visual
+{
+    [TestFixture]
+    public class TestCaseMultiScreen : OsuTestCase
+    {
+        public TestCaseMultiScreen()
+        {
+            Child = new Multiplayer();
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/TestCaseMultiScreen.cs
+++ b/osu.Game.Tests/Visual/TestCaseMultiScreen.cs
@@ -11,7 +11,11 @@ namespace osu.Game.Tests.Visual
     {
         public TestCaseMultiScreen()
         {
-            Child = new Multiplayer();
+            Multiplayer multi = new Multiplayer();
+
+            AddStep(@"show", () => Add(multi));
+            AddWaitStep(5);
+            AddStep(@"exit", multi.Exit);
         }
     }
 }

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -14,7 +14,7 @@ using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Charts;
 using osu.Game.Screens.Direct;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Multi.Screens;
+using osu.Game.Screens.Multi;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Tournament;
 
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.Menu
                             OnDirect = delegate { Push(new OnlineListing()); },
                             OnEdit = delegate { Push(new Editor()); },
                             OnSolo = delegate { Push(consumeSongSelect()); },
-                            OnMulti = delegate { Push(new Lobby()); },
+                            OnMulti = delegate { Push(new Multiplayer()); },
                             OnExit = Exit,
                         }
                     }

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Screens;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.SearchableList;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Game.Screens.Multi
+{
+    public class Header : Container
+    {
+        public const float HEIGHT = 121;
+
+        private readonly OsuSpriteText screenTitle;
+        private readonly ScreenBreadcrumbControl breadcrumbs;
+
+        public Header(Screen initialScreen)
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = HEIGHT;
+
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = OsuColour.FromHex(@"2f2043"),
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING },
+                    Children = new Drawable[]
+                    {
+                        new FillFlowContainer
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.BottomLeft,
+                            Position = new Vector2(-35f, 5f),
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(10f, 0f),
+                            Children = new Drawable[]
+                            {
+                                new SpriteIcon
+                                {
+                                    Size = new Vector2(25),
+                                    Icon = FontAwesome.fa_osu_multi,
+                                },
+                                new FillFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Horizontal,
+                                    Children = new[]
+                                    {
+                                        new OsuSpriteText
+                                        {
+                                            Text = "multiplayer ",
+                                            TextSize = 25,
+                                        },
+                                        screenTitle = new OsuSpriteText
+                                        {
+                                            TextSize = 25,
+                                            Font = @"Exo2.0-Light",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        breadcrumbs = new ScreenBreadcrumbControl(initialScreen)
+                        {
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            RelativeSizeAxes = Axes.X,
+                        },
+                    },
+                },
+            };
+
+            breadcrumbs.OnLoadComplete = d => breadcrumbs.AccentColour = Color4.White;
+
+            breadcrumbs.Current.ValueChanged += s => screenTitle.Text = s.ToString();
+            breadcrumbs.Current.TriggerChange();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            screenTitle.Colour = colours.Yellow;
+            breadcrumbs.StripColour = colours.Green;
+        }
+    }
+}

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.Multi
         public const float HEIGHT = 121;
 
         private readonly OsuSpriteText screenTitle;
-        private readonly ScreenBreadcrumbControl breadcrumbs;
+        private readonly HeaderBreadcrumbControl breadcrumbs;
 
         public Header(Screen initialScreen)
         {
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Multi
                                 },
                             },
                         },
-                        breadcrumbs = new ScreenBreadcrumbControl(initialScreen)
+                        breadcrumbs = new HeaderBreadcrumbControl(initialScreen)
                         {
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
@@ -84,8 +84,6 @@ namespace osu.Game.Screens.Multi
                     },
                 },
             };
-
-            breadcrumbs.OnLoadComplete = d => breadcrumbs.AccentColour = Color4.White;
 
             breadcrumbs.Current.ValueChanged += s => screenTitle.Text = s.ToString();
             breadcrumbs.Current.TriggerChange();
@@ -96,6 +94,19 @@ namespace osu.Game.Screens.Multi
         {
             screenTitle.Colour = colours.Yellow;
             breadcrumbs.StripColour = colours.Green;
+        }
+
+        private class HeaderBreadcrumbControl : ScreenBreadcrumbControl
+        {
+            public HeaderBreadcrumbControl(Screen initialScreen) : base(initialScreen)
+            {
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                AccentColour = Color4.White;
+            }
         }
     }
 }

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Screens;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Backgrounds;
+using osu.Game.Graphics.Containers;
+using osu.Game.Screens.Multi.Screens;
+
+namespace osu.Game.Screens.Multi
+{
+    public class Multiplayer : OsuScreen
+    {
+        private readonly MultiplayerWaveContainer waves;
+
+        protected override Container<Drawable> Content => waves;
+
+        public Multiplayer()
+        {
+            InternalChild = waves = new MultiplayerWaveContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+            };
+
+            Lobby lobby;
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = OsuColour.FromHex(@"3e3a44"),
+                        },
+                        new Triangles
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            ColourLight = OsuColour.FromHex(@"3c3842"),
+                            ColourDark = OsuColour.FromHex(@"393540"),
+                            TriangleScale = 5,
+                        },
+                    },
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Top = Header.HEIGHT },
+                    Child = lobby = new Lobby(),
+                },
+                new Header(lobby),
+            };
+
+            lobby.Exited += s => Exit();
+        }
+
+        protected override void OnEntering(Screen last)
+        {
+            base.OnEntering(last);
+            waves.Show();
+        }
+
+        protected override bool OnExiting(Screen next)
+        {
+            waves.Hide();
+            return base.OnExiting(next);
+        }
+
+        protected override void OnResuming(Screen last)
+        {
+            base.OnResuming(last);
+            waves.Show();
+        }
+
+        protected override void OnSuspending(Screen next)
+        {
+            base.OnSuspending(next);
+            waves.Hide();
+        }
+
+        private class MultiplayerWaveContainer : WaveContainer
+        {
+            protected override bool StartHidden => true;
+
+            public MultiplayerWaveContainer()
+            {
+                FirstWaveColour = OsuColour.FromHex(@"654d8c");
+                SecondWaveColour = OsuColour.FromHex(@"554075");
+                ThirdWaveColour = OsuColour.FromHex(@"44325e");
+                FourthWaveColour = OsuColour.FromHex(@"392850");
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Select/MatchSongSelect.cs
+++ b/osu.Game/Screens/Select/MatchSongSelect.cs
@@ -7,7 +7,12 @@ namespace osu.Game.Screens.Select
     {
         protected override bool OnSelectionFinalised()
         {
-            Exit();
+            Schedule(() =>
+            {
+                // needs to be scheduled else we enter an infinite feedback loop.
+                if (IsCurrentScreen) Exit();
+            });
+
             return true;
         }
     }


### PR DESCRIPTION
Currently only uses the placeholder whitebox screens, so the display names in the header are off.

* [x] Depends on #2521.