### PR TITLE
Use a stable sort for hitobjects

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania.Beatmaps;
@@ -49,11 +50,9 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
             int columnCount = (Beatmap as ManiaBeatmap)?.TotalColumns ?? 7;
 
-            foreach (var hitObject in Beatmap.HitObjects)
-                difficultyHitObjects.Add(new ManiaHitObjectDifficulty((ManiaHitObject)hitObject, columnCount));
-
             // Sort DifficultyHitObjects by StartTime of the HitObjects - just to make sure.
-            difficultyHitObjects.Sort((a, b) => a.BaseHitObject.StartTime.CompareTo(b.BaseHitObject.StartTime));
+            // Note: Stable sort is done so that the ordering of hitobjects with equal start times doesn't change
+            difficultyHitObjects.AddRange(Beatmap.HitObjects.Select(h => new ManiaHitObjectDifficulty((ManiaHitObject)h, columnCount)).OrderBy(h => h.BaseHitObject.StartTime));
 
             if (!calculateStrainValues())
                 return 0;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Beatmaps.Formats
 
             // objects may be out of order *only* if a user has manually edited an .osu file.
             // unfortunately there are ranked maps in this state (example: https://osu.ppy.sh/s/594828).
-            this.beatmap.HitObjects.Sort((x, y) => x.StartTime.CompareTo(y.StartTime));
+            this.beatmap.HitObjects = this.beatmap.HitObjects.OrderBy(h => h.StartTime).ToList();
 
             foreach (var hitObject in this.beatmap.HitObjects)
                 hitObject.ApplyDefaults(this.beatmap.ControlPointInfo, this.beatmap.BeatmapInfo.BaseDifficulty);

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -54,8 +54,10 @@ namespace osu.Game.Beatmaps.Formats
 
             base.ParseStreamInto(stream, beatmap);
 
-            // objects may be out of order *only* if a user has manually edited an .osu file.
-            // unfortunately there are ranked maps in this state (example: https://osu.ppy.sh/s/594828).
+            // Objects may be out of order *only* if a user has manually edited an .osu file.
+            // Unfortunately there are ranked maps in this state (example: https://osu.ppy.sh/s/594828).
+            // OrderBy is used to guarantee that the parsing order of hitobjects with equal start times is maintained (stably-sorted)
+            // The parsing order of hitobjects matters in mania difficulty calculation
             this.beatmap.HitObjects = this.beatmap.HitObjects.OrderBy(h => h.StartTime).ToList();
 
             foreach (var hitObject in this.beatmap.HitObjects)


### PR DESCRIPTION
Would change the order of hitobjects which would change the output of mania beatmap conversion.

A stable sort is intended here, see: https://github.com/peppy/osu-stable/blob/master/osu!/GameplayElements/HitObjectManager.cs#L822-L832

Brings osu!lazer and osu!stable diffcalc within 1 d.p. of each other:

| Beatmap | Mods | Expected (strain) | Actual (strain) |
| --------- | ----- | ----------------- | -------------- |
| 1023967 | None | 7.56702 | 7.56223 |
| 1023967 | DT | 10.4857 | 10.4810 |

Further accuracy isn't really possible due to osu!stable doing an unstable sort with a different algorithm than what .NET Core does, just before difficulty calculation.