### PR TITLE
Fix converted beatmap hitwindows not working correctly

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -84,10 +84,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                 yield break;
 
             foreach (ManiaHitObject obj in objects)
-            {
-                obj.HitWindows = original.HitWindows;
                 yield return obj;
-            }
         }
 
         private readonly List<double> prevNoteTimes = new List<double>(max_notes_for_density);

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -191,6 +191,13 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         /// </summary>
         private class DrawableTailNote : DrawableNote
         {
+            /// <summary>
+            /// Lenience of release hit windows. This is to make cases where the hold note release
+            /// is timed alongside presses of other hit objects less awkward.
+            /// Todo: This shouldn't exist for non-LegacyBeatmapDecoder beatmaps
+            /// </summary>
+            private const double release_window_lenience = 1.5;
+
             private readonly DrawableHoldNote holdNote;
 
             public DrawableTailNote(DrawableHoldNote holdNote, ManiaAction action)
@@ -203,6 +210,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
             protected override void CheckForJudgements(bool userTriggered, double timeOffset)
             {
+                // Factor in the release lenience
+                timeOffset /= release_window_lenience;
+
                 if (!userTriggered)
                 {
                     if (!HitObject.HitWindows.CanBeHit(timeOffset))

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Mania.Objects
         /// <summary>
         /// The tail note of the hold.
         /// </summary>
-        public readonly Note Tail = new TailNote();
+        public readonly Note Tail = new Note();
 
         /// <summary>
         /// The time between ticks of this hold.
@@ -92,26 +92,6 @@ namespace osu.Game.Rulesets.Mania.Objects
                     StartTime = t,
                     Column = Column
                 });
-            }
-        }
-
-        /// <summary>
-        /// The tail of the hold note.
-        /// </summary>
-        private class TailNote : Note
-        {
-            /// <summary>
-            /// Lenience of release hit windows. This is to make cases where the hold note release
-            /// is timed alongside presses of other hit objects less awkward.
-            /// Todo: This shouldn't exist for non-LegacyBeatmapDecoder beatmaps
-            /// </summary>
-            private const double release_window_lenience = 1.5;
-
-            protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
-            {
-                base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
-
-                HitWindows *= release_window_lenience;
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Objects/ManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/ManiaHitObject.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Mania.Objects.Types;
 using osu.Game.Rulesets.Objects;
 
@@ -12,12 +10,6 @@ namespace osu.Game.Rulesets.Mania.Objects
     {
         public virtual int Column { get; set; }
 
-        protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
-        {
-            base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
-
-            HitWindows.AllowsPerfect = true;
-            HitWindows.AllowsOk = true;
-        }
+        protected override HitWindows CreateHitWindows() => new ManiaHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Objects/ManiaHitWindows.cs
@@ -3,11 +3,12 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
-namespace osu.Game.Rulesets.Objects.Legacy.Mania
+namespace osu.Game.Rulesets.Mania.Objects
 {
-    public class ConvertHitWindows : HitWindows
+    public class ManiaHitWindows : HitWindows
     {
         private static readonly IReadOnlyDictionary<HitResult, (double od0, double od5, double od10)> base_ranges = new Dictionary<HitResult, (double, double, double)>
         {
@@ -21,6 +22,9 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
 
         public override void SetDifficulty(double difficulty)
         {
+            AllowsPerfect = true;
+            AllowsOk = true;
+
             Perfect = BeatmapDifficulty.DifficultyRange(difficulty, base_ranges[HitResult.Perfect]);
             Great = BeatmapDifficulty.DifficultyRange(difficulty, base_ranges[HitResult.Great]);
             Good = BeatmapDifficulty.DifficultyRange(difficulty, base_ranges[HitResult.Good]);

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapConverter.cs
@@ -40,8 +40,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                     RepeatSamples = curveData.RepeatSamples,
                     RepeatCount = curveData.RepeatCount,
                     Position = positionData?.Position ?? Vector2.Zero,
-                    NewCombo = comboData?.NewCombo ?? false,
-                    HitWindows = original.HitWindows
+                    NewCombo = comboData?.NewCombo ?? false
                 };
             }
             else if (endTimeData != null)
@@ -51,8 +50,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                     StartTime = original.StartTime,
                     Samples = original.Samples,
                     EndTime = endTimeData.EndTime,
-                    Position = positionData?.Position ?? OsuPlayfield.BASE_SIZE / 2,
-                    HitWindows = original.HitWindows
+                    Position = positionData?.Position ?? OsuPlayfield.BASE_SIZE / 2
                 };
             }
             else
@@ -62,8 +60,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                     StartTime = original.StartTime,
                     Samples = original.Samples,
                     Position = positionData?.Position ?? Vector2.Zero,
-                    NewCombo = comboData?.NewCombo ?? false,
-                    HitWindows = original.HitWindows
+                    NewCombo = comboData?.NewCombo ?? false
                 };
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -71,5 +71,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         }
 
         public virtual void OffsetPosition(Vector2 offset) => Position += offset;
+
+        protected override HitWindows CreateHitWindows() => new OsuHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitWindows.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitWindows.cs
@@ -3,11 +3,12 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
-namespace osu.Game.Rulesets.Objects.Legacy.Osu
+namespace osu.Game.Rulesets.Osu.Objects
 {
-    public class ConvertHitWindows : HitWindows
+    public class OsuHitWindows : HitWindows
     {
         private static readonly IReadOnlyDictionary<HitResult, (double od0, double od5, double od10)> base_ranges = new Dictionary<HitResult, (double, double, double)>
         {

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -132,8 +132,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                             {
                                 StartTime = j,
                                 Samples = currentSamples,
-                                IsStrong = strong,
-                                HitWindows = obj.HitWindows
+                                IsStrong = strong
                             };
                         }
                         else
@@ -142,8 +141,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                             {
                                 StartTime = j,
                                 Samples = currentSamples,
-                                IsStrong = strong,
-                                HitWindows = obj.HitWindows
+                                IsStrong = strong
                             };
                         }
 
@@ -158,8 +156,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                         Samples = obj.Samples,
                         IsStrong = strong,
                         Duration = taikoDuration,
-                        TickRate = beatmap.BeatmapInfo.BaseDifficulty.SliderTickRate == 3 ? 3 : 4,
-                        HitWindows = obj.HitWindows
+                        TickRate = beatmap.BeatmapInfo.BaseDifficulty.SliderTickRate == 3 ? 3 : 4
                     };
                 }
             }
@@ -173,8 +170,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     Samples = obj.Samples,
                     IsStrong = strong,
                     Duration = endTimeData.Duration,
-                    RequiredHits = (int)Math.Max(1, endTimeData.Duration / 1000 * hitMultiplier),
-                    HitWindows = obj.HitWindows
+                    RequiredHits = (int)Math.Max(1, endTimeData.Duration / 1000 * hitMultiplier)
                 };
             }
             else
@@ -187,8 +183,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     {
                         StartTime = obj.StartTime,
                         Samples = obj.Samples,
-                        IsStrong = strong,
-                        HitWindows = obj.HitWindows
+                        IsStrong = strong
                     };
                 }
                 else
@@ -197,8 +192,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     {
                         StartTime = obj.StartTime,
                         Samples = obj.Samples,
-                        IsStrong = strong,
-                        HitWindows = obj.HitWindows
+                        IsStrong = strong
                     };
                 }
             }

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoHitObject.cs
@@ -27,5 +27,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
         /// Strong hit objects give more points for hitting the hit object with both keys.
         /// </summary>
         public bool IsStrong;
+
+        protected override HitWindows CreateHitWindows() => new TaikoHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoHitWindows.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoHitWindows.cs
@@ -3,11 +3,12 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
-namespace osu.Game.Rulesets.Objects.Legacy.Taiko
+namespace osu.Game.Rulesets.Taiko.Objects
 {
-    public class ConvertHitWindows : HitWindows
+    public class TaikoHitWindows : HitWindows
     {
         private static readonly IReadOnlyDictionary<HitResult, (double od0, double od5, double od10)> base_ranges = new Dictionary<HitResult, (double, double, double)>
         {

--- a/osu.Game/Rulesets/Objects/HitWindows.cs
+++ b/osu.Game/Rulesets/Objects/HitWindows.cs
@@ -135,39 +135,5 @@ namespace osu.Game.Rulesets.Objects
         /// <param name="timeOffset">The time offset.</param>
         /// <returns>Whether the <see cref="HitObject"/> can be hit at any point in the future from this time offset.</returns>
         public bool CanBeHit(double timeOffset) => timeOffset <= HalfWindowFor(HitResult.Meh);
-
-        /// <summary>
-        /// Multiplies all hit windows by a value.
-        /// </summary>
-        /// <param name="windows">The hit windows to multiply.</param>
-        /// <param name="value">The value to multiply each hit window by.</param>
-        public static HitWindows operator *(HitWindows windows, double value)
-        {
-            windows.Perfect *= value;
-            windows.Great *= value;
-            windows.Good *= value;
-            windows.Ok *= value;
-            windows.Meh *= value;
-            windows.Miss *= value;
-
-            return windows;
-        }
-
-        /// <summary>
-        /// Divides all hit windows by a value.
-        /// </summary>
-        /// <param name="windows">The hit windows to divide.</param>
-        /// <param name="value">The value to divide each hit window by.</param>
-        public static HitWindows operator /(HitWindows windows, double value)
-        {
-            windows.Perfect /= value;
-            windows.Great /= value;
-            windows.Good /= value;
-            windows.Ok /= value;
-            windows.Meh /= value;
-            windows.Miss /= value;
-
-            return windows;
-        }
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHit.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHit.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
 
         public bool NewCombo { get; set; }
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHold.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHold.cs
@@ -13,6 +13,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
 
         public double Duration => EndTime - StartTime;
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertSlider.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
 
         public bool NewCombo { get; set; }
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertSpinner.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertSpinner.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
 
         public float X { get; set; }
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHit.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHit.cs
@@ -19,6 +19,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Osu
 
         public bool NewCombo { get; set; }
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertSlider.cs
@@ -19,6 +19,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Osu
 
         public bool NewCombo { get; set; }
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertSpinner.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertSpinner.cs
@@ -21,6 +21,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Osu
 
         public float Y => Position.Y;
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHit.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHit.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Taiko
     {
         public bool NewCombo { get; set; }
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertSlider.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Taiko
     {
         public bool NewCombo { get; set; }
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertSpinner.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertSpinner.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Rulesets.Objects.Legacy.Taiko
 
         public double Duration => EndTime - StartTime;
 
-        protected override HitWindows CreateHitWindows() => new ConvertHitWindows();
+        protected override HitWindows CreateHitWindows() => null;
     }
 }


### PR DESCRIPTION
There were two issues:
1. Hit windows were correct when the ruleset matched the beatmap's ruleset, i.e. mania beatmap with mania ruleset. But hit windows were not correct when the rulesets didn't match - mania would use osu!'s hit windows.
2. Because hit windows were passed from the convert hitobjects, which are retained for the same working beatmap, mania could mangle the hit windows and add lenience / allow-oks / allow-perfects, and osu! would next time use those same mangled hit windows.