### PR TITLE
Fix taiko slider multiplier being applied twice

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TaikoBeatmapConversionTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoBeatmapConversionTest.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
         [NonParallelizable]
-        [TestCase("basic", false), Ignore("See: https://github.com/ppy/osu/issues/2152")]
-        [TestCase("slider-generating-drumroll", false)]
+        [TestCase("basic")]
+        [TestCase("slider-generating-drumroll")]
         public new void Test(string name)
         {
             base.Test(name);

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -98,12 +98,12 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 double distance = distanceData.Distance * spans * legacy_velocity_multiplier;
 
                 // The velocity of the taiko hit object - calculated as the velocity of a drum roll
-                double taikoVelocity = taiko_base_distance * beatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier * legacy_velocity_multiplier / speedAdjustedBeatLength;
+                double taikoVelocity = taiko_base_distance * beatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier / speedAdjustedBeatLength;
                 // The duration of the taiko hit object
                 double taikoDuration = distance / taikoVelocity;
 
                 // The velocity of the osu! hit object - calculated as the velocity of a slider
-                double osuVelocity = osu_base_scoring_distance * beatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier * legacy_velocity_multiplier / speedAdjustedBeatLength;
+                double osuVelocity = osu_base_scoring_distance * beatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier / speedAdjustedBeatLength;
                 // The duration of the osu! hit object
                 double osuDuration = distance / osuVelocity;
 


### PR DESCRIPTION
The previous code (https://github.com/ppy/osu/commit/397d93660aad78e1ba4a759c48d28b54ba99d7cd#diff-bb91a927383b6458b59e4536e8d51c27L54-L55) updated a _cloned_ difficulty but then didn't do anything with it.

This is actually broken. The previous PR fixed it by actually modifying the difficulty, but broke this along the way.