### PR TITLE
Implement taiko performance calculation

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty
@@ -32,6 +33,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
         public TaikoDifficultyCalculator(IBeatmap beatmap)
             : base(beatmap)
+        {
+        }
+
+        public TaikoDifficultyCalculator(IBeatmap beatmap, Mod[] mods)
+            : base(beatmap, mods)
         {
         }
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -57,10 +57,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double starRating = calculateDifficulty() * star_scaling_factor;
 
             if (categoryDifficulty != null)
-            {
-                categoryDifficulty.Add("Strain", starRating);
-                categoryDifficulty.Add("Hit window 300", 35 /*HitObjectManager.HitWindow300*/ / TimeRate);
-            }
+                categoryDifficulty["Strain"] = starRating;
 
             return starRating;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Objects;
+
+namespace osu.Game.Rulesets.Taiko.Difficulty
+{
+    public class TaikoPerformanceCalculator : PerformanceCalculator
+    {
+        private readonly int beatmapMaxCombo;
+
+        private Mod[] mods;
+        private int countGreat;
+        private int countGood;
+        private int countMeh;
+        private int countMiss;
+
+        public TaikoPerformanceCalculator(Ruleset ruleset, IBeatmap beatmap, Score score)
+            : base(ruleset, beatmap, score)
+        {
+            beatmapMaxCombo = beatmap.HitObjects.Count(h => h is Hit);
+        }
+
+        public override double Calculate(Dictionary<string, double> categoryDifficulty = null)
+        {
+            mods = Score.Mods;
+            countGreat = Convert.ToInt32(Score.Statistics[HitResult.Great]);
+            countGood = Convert.ToInt32(Score.Statistics[HitResult.Good]);
+            countMeh = Convert.ToInt32(Score.Statistics[HitResult.Meh]);
+            countMiss = Convert.ToInt32(Score.Statistics[HitResult.Miss]);
+
+            // Don't count scores made with supposedly unranked mods
+            if (mods.Any(m => !m.Ranked))
+                return 0;
+
+            // Custom multipliers for NoFail and SpunOut.
+            double multiplier = 1.1; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things
+
+            if (mods.Any(m => m is ModNoFail))
+                multiplier *= 0.90;
+
+            if (mods.Any(m => m is ModHidden))
+                multiplier *= 1.10;
+
+            double strainValue = computeStrainValue();
+            double accuracyValue = computeAccuracyValue();
+            double totalValue =
+                Math.Pow(
+                    Math.Pow(strainValue, 1.1) +
+                    Math.Pow(accuracyValue, 1.1), 1.0 / 1.1
+                ) * multiplier;
+
+            if (categoryDifficulty != null)
+            {
+                categoryDifficulty["Strain"] = strainValue;
+                categoryDifficulty["Accuracy"] = accuracyValue;
+            }
+
+            return totalValue;
+        }
+
+        private double computeStrainValue()
+        {
+            double strainValue = Math.Pow(5.0 * Math.Max(1.0, Attributes["Strain"] / 0.0075) - 4.0, 2.0) / 100000.0;
+
+            // Longer maps are worth more
+            double lengthBonus = 1 + 0.1f * Math.Min(1.0, totalHits / 1500.0);
+            strainValue *= lengthBonus;
+
+            // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
+            strainValue *= Math.Pow(0.985, countMiss);
+
+            // Combo scaling
+            if (beatmapMaxCombo > 0)
+                strainValue *= Math.Min(Math.Pow(Score.MaxCombo, 0.5) / Math.Pow(beatmapMaxCombo, 0.5), 1.0);
+
+            if (mods.Any(m => m is ModHidden))
+                strainValue *= 1.025;
+
+            if (mods.Any(m => m is ModFlashlight))
+                // Apply length bonus again if flashlight is on simply because it becomes a lot harder on longer maps.
+                strainValue *= 1.05 * lengthBonus;
+
+            // Scale the speed value with accuracy _slightly_
+            return strainValue * Score.Accuracy;
+        }
+
+        private double computeAccuracyValue()
+        {
+            double hitWindowGreat = (Beatmap.HitObjects.First().HitWindows.Great / 2 - 0.5) / TimeRate;
+            if (hitWindowGreat <= 0)
+                return 0;
+
+            // Lots of arbitrary values from testing.
+            // Considering to use derivation from perfect accuracy in a probabilistic manner - assume normal distribution
+            double accValue = Math.Pow(150.0 / hitWindowGreat, 1.1) * Math.Pow(Score.Accuracy, 15) * 22.0;
+
+            // Bonus for many hitcircles - it's harder to keep good accuracy up for longer
+            return accValue * Math.Min(1.15, Math.Pow(totalHits / 1500.0, 0.3));
+        }
+
+        private int totalHits => countGreat + countGood + countMeh + countMiss;
+    }
+}

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.Taiko
 
         public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.fa_osu_taiko_o };
 
-        public override DifficultyCalculator CreateDifficultyCalculator(IBeatmap beatmap, Mod[] mods = null) => new TaikoDifficultyCalculator(beatmap);
+        public override DifficultyCalculator CreateDifficultyCalculator(IBeatmap beatmap, Mod[] mods = null) => new TaikoDifficultyCalculator(beatmap, mods);
 
         public override int? LegacyID => 1;
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Taiko.Replays;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.Taiko.Difficulty;
 
@@ -145,6 +146,8 @@ namespace osu.Game.Rulesets.Taiko
         public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.fa_osu_taiko_o };
 
         public override DifficultyCalculator CreateDifficultyCalculator(IBeatmap beatmap, Mod[] mods = null) => new TaikoDifficultyCalculator(beatmap, mods);
+
+        public override PerformanceCalculator CreatePerformanceCalculator(IBeatmap beatmap, Score score) => new TaikoPerformanceCalculator(this, beatmap, score);
 
         public override int? LegacyID => 1;
 


### PR DESCRIPTION
Tested against https://osu.ppy.sh/b/1413771

| Mods | Expected (Strain) | Actual (Strain) | Expected (pp) | Actual (pp) |
| ----- | ------------------ | -------------- | -------------- | ------------ |
| None | 7.976 | 7.976 | 458.361 | 458.361 |
| DT | 10.024 | 10.024 | 708.853 | 708.856 |
| DT, HR | 10.024 | 10.024 | - | - |

Not sure why the actual pp is different from the expected value in the DT row, but it's not of big significance.