### PR TITLE
Fixes on improper Catcher Size in gameplay, minor fixes on fruit borders and an important fix on Juice Stream producing

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -3,7 +3,10 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using OpenTK;
 using OpenTK.Graphics;
 
@@ -11,6 +14,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableDroplet : PalpableCatchHitObject<Droplet>
     {
+        private Circle border;
         private Pulp pulp;
 
         public DrawableDroplet(Droplet h)
@@ -24,10 +28,44 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = pulp = new Pulp
+            InternalChildren = new[]
             {
-                Size = Size
+                pulp = new Pulp
+                {
+                    Size = Size,
+                },
+                border = new Circle
+                {
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Glow,
+                        Radius = 4,
+                        Colour = HitObject.HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
+                    },
+                    Size = new Vector2(Height * 4f),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    BorderColour = Color4.White,
+                    BorderThickness = 4.0f,
+                    Children = new Framework.Graphics.Drawable[]
+                    {
+                        new Box
+                        {
+                            AlwaysPresent = true,
+                            Colour = AccentColour,
+                            Alpha = 0,
+                            RelativeSizeAxes = Axes.Both
+                        }
+                    }
+                },
             };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            border.Alpha = (float)MathHelper.Clamp((HitObject.StartTime - Time.Current) / 50, 0, 1);
         }
 
         public override Color4 AccentColour

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableDroplet : PalpableCatchHitObject<Droplet>
     {
-        private Circle border;
+        private Border border;
         private Pulp pulp;
 
         public DrawableDroplet(Droplet h)
@@ -28,36 +28,13 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChildren = new[]
+            InternalChildren = new Circle[]
             {
                 pulp = new Pulp
                 {
                     Size = Size,
                 },
-                border = new Circle
-                {
-                    EdgeEffect = new EdgeEffectParameters
-                    {
-                        Type = EdgeEffectType.Glow,
-                        Radius = 4,
-                        Colour = HitObject.HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
-                    },
-                    Size = new Vector2(Height * 4f),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    BorderColour = Color4.White,
-                    BorderThickness = 4.0f,
-                    Children = new Framework.Graphics.Drawable[]
-                    {
-                        new Box
-                        {
-                            AlwaysPresent = true,
-                            Colour = AccentColour,
-                            Alpha = 0,
-                            RelativeSizeAxes = Axes.Both
-                        }
-                    }
-                },
+                border = new Border(4.0f, new Vector2(Height * 4.0f), 4.0f, AccentColour, false),
             };
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -3,9 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -3,10 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.MathUtils;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
 using OpenTK;
@@ -17,6 +15,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
     public class DrawableFruit : PalpableCatchHitObject<Fruit>
     {
         private Border border;
+        private Pulp pulp;
 
         public DrawableFruit(Fruit h)
             : base(h)
@@ -38,7 +37,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             InternalChildren = new []
             {
                 createPulp(HitObject.VisualRepresentation),
-                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, HitObject.HyperDash),
+                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, !HitObject.HyperDash),
             };
 
             if (HitObject.HyperDash)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             // todo: this should come from the skin.
             AccentColour = colourForRrepesentation(HitObject.VisualRepresentation);
 
-            InternalChildren = new []
+            InternalChildren = new[]
             {
                 createPulp(HitObject.VisualRepresentation),
                 border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, HitObject.HyperDash),

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableFruit : PalpableCatchHitObject<Fruit>
     {
-        private Circle border;
+        private Border border;
 
         public DrawableFruit(Fruit h)
             : base(h)
@@ -35,34 +35,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             // todo: this should come from the skin.
             AccentColour = colourForRrepesentation(HitObject.VisualRepresentation);
 
-            InternalChildren = new[]
+            InternalChildren = new []
             {
                 createPulp(HitObject.VisualRepresentation),
-                border = new Circle
-                {
-                    EdgeEffect = new EdgeEffectParameters
-                    {
-                        Hollow = !HitObject.HyperDash,
-                        Type = EdgeEffectType.Glow,
-                        Radius = 4,
-                        Colour = HitObject.HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
-                    },
-                    Size = new Vector2(Height * 1.5f),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    BorderColour = Color4.White,
-                    BorderThickness = 4f,
-                    Children = new Framework.Graphics.Drawable[]
-                    {
-                        new Box
-                        {
-                            AlwaysPresent = true,
-                            Colour = AccentColour,
-                            Alpha = 0,
-                            RelativeSizeAxes = Axes.Both
-                        }
-                    }
-                },
+                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, HitObject.HyperDash),
             };
 
             if (HitObject.HyperDash)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
     public class DrawableFruit : PalpableCatchHitObject<Fruit>
     {
         private Border border;
-        private Pulp pulp;
 
         public DrawableFruit(Fruit h)
             : base(h)
@@ -37,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             InternalChildren = new []
             {
                 createPulp(HitObject.VisualRepresentation),
-                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, !HitObject.HyperDash),
+                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, HitObject.HyperDash),
             };
 
             if (HitObject.HyperDash)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -273,7 +273,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         {
             base.Update();
 
-            border.Alpha = (float)MathHelper.Clamp((HitObject.StartTime - Time.Current) / 500, 0, 1);
+            border.Alpha = (float)MathHelper.Clamp((HitObject.StartTime - Time.Current) / 50, 0, 1);
         }
 
         private Color4 colourForRrepesentation(FruitVisualRepresentation representation)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -1,0 +1,40 @@
+﻿using osu.Framework.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Game.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
+{
+    public class Border : Circle
+    {
+        public Border(float GlowRadius, Vector2 size, float borderthickness, Color4 AccentColour, bool HyperDash)
+        {
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Hollow = !HyperDash,
+                Type = EdgeEffectType.Glow,
+                Radius = GlowRadius,
+                Colour = HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
+            };
+            Size = size;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            BorderColour = Color4.White;
+            BorderThickness = borderthickness;
+            Children = new Framework.Graphics.Drawable[]
+            {
+                new Box
+                {
+                    AlwaysPresent = true,
+                    Colour = AccentColour,
+                    Alpha = 0,
+                    RelativeSizeAxes = Axes.Both
+                }
+            };
+        }
+        
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -12,26 +12,26 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
 {
     public class Border : Circle
     {
-        public Border(float GlowRadius, Vector2 size, float borderthickness, Color4 AccentColour, bool HyperDash)
+        public Border(float glowRadius, Vector2 size, float borderThickness, Color4 accentColour, bool hyperDash)
         {
             EdgeEffect = new EdgeEffectParameters
             {
-                Hollow = !HyperDash,
+                Hollow = !hyperDash,
                 Type = EdgeEffectType.Glow,
-                Radius = GlowRadius,
-                Colour = HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
+                Radius = glowRadius,
+                Colour = hyperDash ? Color4.Red : accentColour.Darken(1).Opacity(0.6f)
             };
             Size = size;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             BorderColour = Color4.White;
-            BorderThickness = borderthickness;
+            BorderThickness = borderThickness;
             Children = new Framework.Graphics.Drawable[]
             {
                 new Box
                 {
                     AlwaysPresent = true,
-                    Colour = AccentColour,
+                    Colour = accentColour,
                     Alpha = 0,
                     RelativeSizeAxes = Axes.Both
                 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -36,6 +36,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
                     RelativeSizeAxes = Axes.Both
                 }
             };
-        }    
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -1,6 +1,8 @@
-﻿using osu.Framework.Graphics;
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Game.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using OpenTK;

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
                     RelativeSizeAxes = Axes.Both
                 }
             };
-        }
-        
+        }    
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             {
                 var spanStartTime = StartTime + span * spanDuration;
                 var reversed = span % 2 == 1;
-
+                
                 for (double d = 0; d <= length; d += tickDistance)
                 {
                     var timeProgress = d / length;
@@ -86,20 +86,23 @@ namespace osu.Game.Rulesets.Catch.Objects
                     {
                         double progress = reversed ? 1 - (t - spanStartTime) / spanDuration : (t - spanStartTime) / spanDuration;
 
-                        AddNested(new TinyDroplet
-                        {
-                            StartTime = t,
-                            X = X + Curve.PositionAt(progress).X / CatchPlayfield.BASE_WIDTH,
-                            Samples = new List<SampleInfo>(Samples.Select(s => new SampleInfo
+                        // Prevent FruitDroplets from stacking over Fruits!
+                        if (Math.Abs(t - (spanStartTime + spanDuration)) > 5)
+                            AddNested(new TinyDroplet
                             {
-                                Bank = s.Bank,
-                                Name = @"slidertick",
-                                Volume = s.Volume
-                            }))
-                        });
+                                StartTime = t,
+                                X = X + Curve.PositionAt(progress).X / CatchPlayfield.BASE_WIDTH,
+                                Samples = new List<SampleInfo>(Samples.Select(s => new SampleInfo
+                                {
+                                    Bank = s.Bank,
+                                    Name = @"slidertick",
+                                    Volume = s.Volume
+                                }))
+                            });
                     }
 
-                    if (d > minDistanceFromEnd && Math.Abs(d - length) > minDistanceFromEnd)
+                    // Prevent FruitDroplets from stacking over Fruits!
+                    if (d > minDistanceFromEnd && Math.Abs(d - length) > minDistanceFromEnd && Math.Abs(time - (spanStartTime + spanDuration)) > 5)
                     {
                         AddNested(new Droplet
                         {

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -71,7 +71,8 @@ namespace osu.Game.Rulesets.Catch.Objects
                 var spanStartTime = StartTime + span * spanDuration;
                 var reversed = span % 2 == 1;
 
-                for (double d = 0; d <= length; d += tickDistance)
+                // add a timing shift 5 to make sure all sliders are generated properly.
+                for (double d = 0; d <= length + 5; d += tickDistance)
                 {
                     var timeProgress = d / length;
                     var distanceProgress = reversed ? 1 - timeProgress : timeProgress;

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             {
                 var spanStartTime = StartTime + span * spanDuration;
                 var reversed = span % 2 == 1;
-                
+
                 for (double d = 0; d <= length; d += tickDistance)
                 {
                     var timeProgress = d / length;

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 1.5f); // Using a bad way to fix the scale, might be some better methods.
+                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) * 0.62064f);
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -117,7 +117,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2(1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
+                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 1.5f); // Using a bad way to fix the scale, might be some better methods.
+
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -118,7 +118,6 @@ namespace osu.Game.Rulesets.Catch.UI
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
                     Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 1.5f); // Using a bad way to fix the scale, might be some better methods.
-
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
## Updates inside this PR
### Resize Catcher Size
Regarding https://github.com/ppy/osu/issues/2063, I'm fixing the catcher size by making it smaller by 1.5x, but I guess there should be some more elegant way fixing this. I can't get the current catcher info so I think dev team can help me get a more accurate value.
### Rework the borders of Fruits and FruitDrops
Current borders feel more like Hidden mode, with 500ms fadeout. I tried 100/200/50 for test and found that 50 works pretty nice, so I rewrite the border fadeout to 50. Also I added the borders to FruitDroplets.
### Rewrite JuiceStream producing method to prevent stackings of Fruits & droplets
This is some serious issue inside current lazer version. Causing by random shift float numbers, there can be fruitdrops&droplets stacking over a fruit, which is not supposed to be seen in this gamemode, so I added judgements to make sure there will be no stackings.