### PR TITLE
Prevent overlays from showing in intro/outro sequences

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -16,18 +16,18 @@ namespace osu.Game.Graphics.Containers
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
 
-        protected BindableBool ShowOverlays = new BindableBool(true);
+        protected BindableBool AllowOverlays = new BindableBool(true);
 
         [BackgroundDependencyLoader(true)]
         private void load(OsuGame osuGame, AudioManager audio)
         {
+            if (osuGame != null)
+                AllowOverlays.BindTo(osuGame.AllowOverlays);
+
             samplePopIn = audio.Sample.Get(@"UI/overlay-pop-in");
             samplePopOut = audio.Sample.Get(@"UI/overlay-pop-out");
 
             StateChanged += onStateChanged;
-
-            if (osuGame != null)
-                ShowOverlays.BindTo(osuGame.ShowOverlays);
         }
 
         /// <summary>
@@ -52,21 +52,20 @@ namespace osu.Game.Graphics.Containers
 
         private void onStateChanged(Visibility visibility)
         {
-            if (!ShowOverlays)
+            if (AllowOverlays)
             {
+                switch (visibility)
+                {
+                    case Visibility.Visible:
+                        samplePopIn?.Play();
+                        break;
+                    case Visibility.Hidden:
+                        samplePopOut?.Play();
+                        break;
+                }
+            }
+            else
                 State = Visibility.Hidden;
-                return;
-            }
-
-            switch (visibility)
-            {
-                case Visibility.Visible:
-                    samplePopIn?.Play();
-                    break;
-                case Visibility.Hidden:
-                    samplePopOut?.Play();
-                    break;
-            }
         }
     }
 }

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -16,13 +16,13 @@ namespace osu.Game.Graphics.Containers
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
 
-        protected BindableBool AllowOverlays = new BindableBool(true);
+        private readonly BindableBool allowOpeningOverlays = new BindableBool(true);
 
         [BackgroundDependencyLoader(true)]
         private void load(OsuGame osuGame, AudioManager audio)
         {
             if (osuGame != null)
-                AllowOverlays.BindTo(osuGame.AllowOverlays);
+                allowOpeningOverlays.BindTo(osuGame.AllowOpeningOverlays);
 
             samplePopIn = audio.Sample.Get(@"UI/overlay-pop-in");
             samplePopOut = audio.Sample.Get(@"UI/overlay-pop-out");
@@ -52,7 +52,7 @@ namespace osu.Game.Graphics.Containers
 
         private void onStateChanged(Visibility visibility)
         {
-            if (AllowOverlays)
+            if (allowOpeningOverlays)
             {
                 switch (visibility)
                 {

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using OpenTK;
+using osu.Framework.Configuration;
 
 namespace osu.Game.Graphics.Containers
 {
@@ -15,13 +16,17 @@ namespace osu.Game.Graphics.Containers
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
 
+        protected BindableBool ShowOverlays = new BindableBool();
+
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        private void load(OsuGame osuGame, AudioManager audio)
         {
             samplePopIn = audio.Sample.Get(@"UI/overlay-pop-in");
             samplePopOut = audio.Sample.Get(@"UI/overlay-pop-out");
 
             StateChanged += onStateChanged;
+
+            ShowOverlays.BindTo(osuGame.ShowOverlays);
         }
 
         /// <summary>
@@ -46,6 +51,9 @@ namespace osu.Game.Graphics.Containers
 
         private void onStateChanged(Visibility visibility)
         {
+            if (!ShowOverlays)
+                State = Visibility.Hidden;
+
             switch (visibility)
             {
                 case Visibility.Visible:

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -16,9 +16,9 @@ namespace osu.Game.Graphics.Containers
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
 
-        protected BindableBool ShowOverlays = new BindableBool();
+        protected BindableBool ShowOverlays = new BindableBool(true);
 
-        [BackgroundDependencyLoader]
+        [BackgroundDependencyLoader(true)]
         private void load(OsuGame osuGame, AudioManager audio)
         {
             samplePopIn = audio.Sample.Get(@"UI/overlay-pop-in");
@@ -26,7 +26,8 @@ namespace osu.Game.Graphics.Containers
 
             StateChanged += onStateChanged;
 
-            ShowOverlays.BindTo(osuGame.ShowOverlays);
+            if (osuGame != null)
+                ShowOverlays.BindTo(osuGame.ShowOverlays);
         }
 
         /// <summary>
@@ -52,7 +53,10 @@ namespace osu.Game.Graphics.Containers
         private void onStateChanged(Visibility visibility)
         {
             if (!ShowOverlays)
+            {
                 State = Visibility.Hidden;
+                return;
+            }
 
             switch (visibility)
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -77,7 +77,8 @@ namespace osu.Game
 
         public float ToolbarOffset => Toolbar.Position.Y + Toolbar.DrawHeight;
 
-        public readonly BindableBool AllowOverlays = new BindableBool();
+        public readonly BindableBool HideOverlaysOnEnter = new BindableBool();
+        public readonly BindableBool AllowOpeningOverlays = new BindableBool(true);
 
         private OsuScreen screenStack;
 
@@ -367,12 +368,12 @@ namespace osu.Game
             settings.StateChanged += _ => updateScreenOffset();
             notifications.StateChanged += _ => updateScreenOffset();
 
-            notifications.Enabled.BindTo(AllowOverlays);
+            notifications.Enabled.BindTo(AllowOpeningOverlays);
 
-            AllowOverlays.ValueChanged += show =>
+            HideOverlaysOnEnter.ValueChanged += hide =>
             {
                 //central game screen change logic.
-                if (!show)
+                if (hide)
                 {
                     hideAllOverlays();
                     musicController.State = Visibility.Hidden;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -77,7 +77,7 @@ namespace osu.Game
 
         public float ToolbarOffset => Toolbar.Position.Y + Toolbar.DrawHeight;
 
-        public readonly BindableBool ShowOverlays = new BindableBool();
+        public readonly BindableBool AllowOverlays = new BindableBool();
 
         private OsuScreen screenStack;
 
@@ -367,9 +367,9 @@ namespace osu.Game
             settings.StateChanged += _ => updateScreenOffset();
             notifications.StateChanged += _ => updateScreenOffset();
 
-            notifications.Enabled.BindTo(ShowOverlays);
+            notifications.Enabled.BindTo(AllowOverlays);
 
-            ShowOverlays.ValueChanged += show =>
+            AllowOverlays.ValueChanged += show =>
             {
                 //central game screen change logic.
                 if (!show)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Edit
     {
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenCustom(@"Backgrounds/bg4");
 
-        public override bool HideOverlaysOnEnter => true;
+        protected override bool HideOverlaysOnEnter => true;
         public override bool AllowBeatmapRulesetChange => false;
 
         private Box bottomBackground;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Edit
     {
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenCustom(@"Backgrounds/bg4");
 
-        public override bool ShowOverlaysOnEnter => false;
+        public override bool HideOverlaysOnEnter => true;
         public override bool AllowBeatmapRulesetChange => false;
 
         private Box bottomBackground;

--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens
     {
         private bool showDisclaimer;
 
-        public override bool HideOverlaysOnEnter => true;
+        protected override bool HideOverlaysOnEnter => true;
 
         protected override bool AllowBackButton => false;
 

--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Screens
     {
         private bool showDisclaimer;
 
-        public override bool ShowOverlaysOnEnter => false;
+        public override bool HideOverlaysOnEnter => true;
 
         protected override bool AllowBackButton => false;
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -27,7 +27,8 @@ namespace osu.Game.Screens.Menu
     {
         public event Action<MenuState> StateChanged;
 
-        private readonly BindableBool allowOverlays = new BindableBool();
+        private readonly BindableBool hideOverlaysOnEnter = new BindableBool();
+        private readonly BindableBool allowOpeningOverlays = new BindableBool();
 
         public Action OnEdit;
         public Action OnExit;
@@ -136,7 +137,10 @@ namespace osu.Game.Screens.Menu
         private void load(AudioManager audio, OsuGame game)
         {
             if (game != null)
-                allowOverlays.BindTo(game.AllowOverlays);
+            {
+                hideOverlaysOnEnter.BindTo(game.HideOverlaysOnEnter);
+                allowOpeningOverlays.BindTo(game.AllowOpeningOverlays);
+            }
 
             sampleBack = audio.Sample.Get(@"Menu/button-back-select");
         }
@@ -324,8 +328,6 @@ namespace osu.Game.Screens.Menu
 
                     logoDelayedAction = Scheduler.AddDelayed(() =>
                     {
-                        allowOverlays.Value = false;
-
                         logo.ClearTransforms(targetMember: nameof(Position));
                         logo.RelativePositionAxes = Axes.Both;
 
@@ -353,7 +355,8 @@ namespace osu.Game.Screens.Menu
                                 logoTracking = true;
 
                                 logo.Impact();
-                                allowOverlays.Value = true;
+                                hideOverlaysOnEnter.Value = false;
+                                allowOpeningOverlays.Value = true;
                             }, 200);
                             break;
                         default:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Menu
     {
         public event Action<MenuState> StateChanged;
 
-        private readonly BindableBool showOverlays = new BindableBool();
+        private readonly BindableBool allowOverlays = new BindableBool();
 
         public Action OnEdit;
         public Action OnExit;
@@ -135,7 +135,9 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, OsuGame game)
         {
-            if (game != null) showOverlays.BindTo(game.ShowOverlays);
+            if (game != null)
+                allowOverlays.BindTo(game.AllowOverlays);
+
             sampleBack = audio.Sample.Get(@"Menu/button-back-select");
         }
 
@@ -322,7 +324,7 @@ namespace osu.Game.Screens.Menu
 
                     logoDelayedAction = Scheduler.AddDelayed(() =>
                     {
-                        showOverlays.Value = false;
+                        allowOverlays.Value = false;
 
                         logo.ClearTransforms(targetMember: nameof(Position));
                         logo.RelativePositionAxes = Axes.Both;
@@ -351,7 +353,7 @@ namespace osu.Game.Screens.Menu
                                 logoTracking = true;
 
                                 logo.Impact();
-                                showOverlays.Value = true;
+                                allowOverlays.Value = true;
                             }, 200);
                             break;
                         default:

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Menu
         private readonly SpriteIcon icon;
         private Color4 iconColour;
 
-        public override bool ShowOverlaysOnEnter => false;
+        public override bool HideOverlaysOnEnter => true;
         public override bool CursorVisible => false;
 
         public Disclaimer()

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -18,7 +18,8 @@ namespace osu.Game.Screens.Menu
         private readonly SpriteIcon icon;
         private Color4 iconColour;
 
-        public override bool HideOverlaysOnEnter => true;
+        protected override bool HideOverlaysOnEnter => true;
+
         public override bool CursorVisible => false;
 
         public Disclaimer()

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Menu
         private SampleChannel welcome;
         private SampleChannel seeya;
 
-        public override bool ShowOverlaysOnEnter => false;
+        public override bool HideOverlaysOnEnter => true;
         public override bool CursorVisible => false;
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenEmpty();

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -31,7 +31,9 @@ namespace osu.Game.Screens.Menu
         private SampleChannel welcome;
         private SampleChannel seeya;
 
-        public override bool HideOverlaysOnEnter => true;
+        protected override bool HideOverlaysOnEnter => true;
+        protected override bool AllowOpeningOverlays => false;
+
         public override bool CursorVisible => false;
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenEmpty();

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -24,7 +24,8 @@ namespace osu.Game.Screens.Menu
     {
         private readonly ButtonSystem buttons;
 
-        public override bool HideOverlaysOnEnter => buttons.State == MenuState.Initial;
+        protected override bool HideOverlaysOnEnter => buttons.State == MenuState.Initial;
+        protected override bool AllowOpeningOverlays => buttons.State != MenuState.Initial;
 
         protected override bool AllowBackButton => buttons.State != MenuState.Initial;
 

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.Menu
     {
         private readonly ButtonSystem buttons;
 
-        public override bool ShowOverlaysOnEnter => buttons.State != MenuState.Initial;
+        public override bool HideOverlaysOnEnter => buttons.State == MenuState.Initial;
 
         protected override bool AllowBackButton => buttons.State != MenuState.Initial;
 

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -32,12 +32,12 @@ namespace osu.Game.Screens
         /// </summary>
         protected virtual BackgroundScreen CreateBackground() => null;
 
-        protected BindableBool ShowOverlays = new BindableBool();
+        protected BindableBool AllowOverlays = new BindableBool();
 
         /// <summary>
-        /// Whether overlays should be shown when this screen is entered or resumed.
+        /// Whether overlays should be hidden when this screen is entered or resumed.
         /// </summary>
-        public virtual bool ShowOverlaysOnEnter => true;
+        public virtual bool HideOverlaysOnEnter => false;
 
         /// <summary>
         /// Whether this <see cref="OsuScreen"/> allows the cursor to be displayed.
@@ -88,7 +88,7 @@ namespace osu.Game.Screens
             if (osuGame != null)
             {
                 Ruleset.BindTo(osuGame.Ruleset);
-                ShowOverlays.BindTo(osuGame.ShowOverlays);
+                AllowOverlays.BindTo(osuGame.AllowOverlays);
             }
 
             sampleExit = audio.Sample.Get(@"UI/screen-back");
@@ -220,7 +220,7 @@ namespace osu.Game.Screens
             if (backgroundParallaxContainer != null)
                 backgroundParallaxContainer.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT * BackgroundParallaxAmount;
 
-            ShowOverlays.Value = ShowOverlaysOnEnter;
+            AllowOverlays.Value = !HideOverlaysOnEnter;
         }
 
         private void onExitingLogo()

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -32,12 +32,19 @@ namespace osu.Game.Screens
         /// </summary>
         protected virtual BackgroundScreen CreateBackground() => null;
 
-        protected BindableBool AllowOverlays = new BindableBool();
+        private readonly BindableBool hideOverlaysOnEnter = new BindableBool();
 
         /// <summary>
         /// Whether overlays should be hidden when this screen is entered or resumed.
         /// </summary>
-        public virtual bool HideOverlaysOnEnter => false;
+        protected virtual bool HideOverlaysOnEnter => hideOverlaysOnEnter;
+
+        private readonly BindableBool allowOpeningOverlays = new BindableBool();
+
+        /// <summary>
+        /// Whether overlays should be able to be opened while this screen is active.
+        /// </summary>
+        protected virtual bool AllowOpeningOverlays => allowOpeningOverlays;
 
         /// <summary>
         /// Whether this <see cref="OsuScreen"/> allows the cursor to be displayed.
@@ -88,7 +95,8 @@ namespace osu.Game.Screens
             if (osuGame != null)
             {
                 Ruleset.BindTo(osuGame.Ruleset);
-                AllowOverlays.BindTo(osuGame.AllowOverlays);
+                hideOverlaysOnEnter.BindTo(osuGame.HideOverlaysOnEnter);
+                allowOpeningOverlays.BindTo(osuGame.AllowOpeningOverlays);
             }
 
             sampleExit = audio.Sample.Get(@"UI/screen-back");
@@ -220,7 +228,8 @@ namespace osu.Game.Screens
             if (backgroundParallaxContainer != null)
                 backgroundParallaxContainer.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT * BackgroundParallaxAmount;
 
-            AllowOverlays.Value = !HideOverlaysOnEnter;
+            hideOverlaysOnEnter.Value = HideOverlaysOnEnter;
+            allowOpeningOverlays.Value = AllowOpeningOverlays;
         }
 
         private void onExitingLogo()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Play
     {
         protected override float BackgroundParallaxAmount => 0.1f;
 
-        public override bool HideOverlaysOnEnter => true;
+        protected override bool HideOverlaysOnEnter => true;
 
         public Action RestartRequested;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Play
     {
         protected override float BackgroundParallaxAmount => 0.1f;
 
-        public override bool ShowOverlaysOnEnter => false;
+        public override bool HideOverlaysOnEnter => true;
 
         public Action RestartRequested;
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -25,8 +25,8 @@ namespace osu.Game.Screens.Play
 
         private BeatmapMetadataDisplay info;
 
-        private bool showOverlays = true;
-        public override bool ShowOverlaysOnEnter => showOverlays;
+        private bool allowOverlays = true;
+        public override bool HideOverlaysOnEnter => !allowOverlays;
 
         private Task loadTask;
 
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Play
 
             player.RestartRequested = () =>
             {
-                showOverlays = false;
+                allowOverlays = false;
                 ValidForResume = true;
             };
         }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -25,8 +25,8 @@ namespace osu.Game.Screens.Play
 
         private BeatmapMetadataDisplay info;
 
-        private bool allowOverlays = true;
-        public override bool HideOverlaysOnEnter => !allowOverlays;
+        private bool hideOverlays;
+        protected override bool HideOverlaysOnEnter => hideOverlays;
 
         private Task loadTask;
 
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Play
 
             player.RestartRequested = () =>
             {
-                allowOverlays = false;
+                hideOverlays = true;
                 ValidForResume = true;
             };
         }

--- a/osu.Game/Screens/Tournament/Drawings.cs
+++ b/osu.Game/Screens/Tournament/Drawings.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Tournament
     {
         private const string results_filename = "drawings_results.txt";
 
-        public override bool ShowOverlaysOnEnter => false;
+        public override bool HideOverlaysOnEnter => true;
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenDefault();
 

--- a/osu.Game/Screens/Tournament/Drawings.cs
+++ b/osu.Game/Screens/Tournament/Drawings.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Tournament
     {
         private const string results_filename = "drawings_results.txt";
 
-        public override bool HideOverlaysOnEnter => true;
+        protected override bool HideOverlaysOnEnter => true;
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenDefault();
 


### PR DESCRIPTION
closes #2461

An alternative I found would be to add it right in `OsuGame.OnPressed` but that would basically stop all global keybinds...