### PR TITLE
Fix double-HR application in OsuDifficultyCalculator

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -61,17 +61,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (mods.Any(m => !m.Ranked))
                 return 0;
 
-            // Todo: In the future we should apply changes to PreEmpt/AR at an OsuHitObject/BaseDifficulty level, but this is done
-            // locally for now as doing so would modify animations and other things unexpectedly
-            // DO NOT MODIFY THIS
-            double ar = Beatmap.BeatmapInfo.BaseDifficulty.ApproachRate;
-            if (mods.Any(m => m is OsuModHardRock))
-                ar = Math.Min(10, ar * 1.4);
-            if (mods.Any(m => m is OsuModEasy))
-                ar = Math.Max(0, ar / 2);
-
-            double preEmpt = BeatmapDifficulty.DifficultyRange(ar, 1800, 1200, 450) / TimeRate;
             double hitWindowGreat = (Beatmap.HitObjects.First().HitWindows.Great / 2 - 0.5) / TimeRate;
+            double preEmpt = BeatmapDifficulty.DifficultyRange(Beatmap.BeatmapInfo.BaseDifficulty.ApproachRate, 1800, 1200, 450) / TimeRate;
 
             realApproachRate = preEmpt > 1200 ? (1800 - preEmpt) / 120 : (1200 - preEmpt) / 150 + 5;
             realOverallDifficulty = (80 - 0.5 - hitWindowGreat) / 6;


### PR DESCRIPTION
HR now applies to AR through the mod, this would doubly-apply the scaling factor.

There still seems to be an issue with HR, it looks like perhaps the coordinates aren't getting inverted correctly. Will look into that a bit later. Still brings calculations closer in-line.