### PR TITLE
RoomInspector improvements

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseRoomInspector.cs
+++ b/osu.Game.Tests/Visual/TestCaseRoomInspector.cs
@@ -71,6 +71,8 @@ namespace osu.Game.Tests.Visual
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Width = 0.5f,
             });
 
             AddStep(@"set room", () => inspector.Room = room);

--- a/osu.Game.Tests/Visual/TestCaseRoomInspector.cs
+++ b/osu.Game.Tests/Visual/TestCaseRoomInspector.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual
         {
             base.LoadComplete();
 
-            var room = new Room
+            Room room = new Room
             {
                 Name = { Value = @"My Awesome Room" },
                 Host = { Value = new User { Username = @"flyte", Id = 3103765, Country = new Country { FlagName = @"JP" } } },
@@ -71,9 +71,11 @@ namespace osu.Game.Tests.Visual
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Room = room,
             });
 
+            AddStep(@"set room", () => inspector.Room = room);
+            AddStep(@"null room", () => inspector.Room = null);
+            AddStep(@"set room", () => inspector.Room = room);
             AddStep(@"change title", () => room.Name.Value = @"A Better Room Than The Above");
             AddStep(@"change host", () => room.Host.Value = new User { Username = @"DrabWeb", Id = 6946022, Country = new Country { FlagName = @"CA" } });
             AddStep(@"change status", () => room.Status.Value = new RoomStatusPlaying());
@@ -88,7 +90,7 @@ namespace osu.Game.Tests.Visual
 
             AddStep(@"change room", () =>
             {
-                var newRoom = new Room
+                Room newRoom = new Room
                 {
                     Name = { Value = @"My New, Better Than Ever Room" },
                     Host = { Value = new User { Username = @"Angelsim", Id = 1777162, Country = new Country { FlagName = @"KR" } } },

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -79,8 +79,6 @@ namespace osu.Game.Screens.Multi.Components
 
         public RoomInspector()
         {
-            Width = 520;
-            RelativeSizeAxes = Axes.Y;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -75,10 +74,6 @@ namespace osu.Game.Screens.Multi.Components
 
                 updateState();
             }
-        }
-
-        public RoomInspector()
-        {
         }
 
         [BackgroundDependencyLoader]
@@ -363,23 +358,31 @@ namespace osu.Game.Screens.Multi.Components
         {
             status.Text = s.Message;
 
-            foreach (Drawable d in new Drawable[] { statusStrip, status })
-                d.FadeColour(s.GetAppropriateColour(colours), transition_duration);
+            Color4 c = s.GetAppropriateColour(colours);
+            statusStrip.FadeColour(c, transition_duration);
+            status.FadeColour(c, transition_duration);
         }
 
         private void updateState()
         {
             if (Room == null)
             {
-                foreach (Drawable d in new Drawable[] { coverContainer, participantsFlow, participantNumbersFlow, infoPanelFlow, name, participantInfo })
-                    d.FadeOut(transition_duration);
+                coverContainer.FadeOut(transition_duration);
+                participantsFlow.FadeOut(transition_duration);
+                participantNumbersFlow.FadeOut(transition_duration);
+                infoPanelFlow.FadeOut(transition_duration);
+                name.FadeOut(transition_duration);
+                participantInfo.FadeOut(transition_duration);
 
                 displayStatus(new RoomStatusNoneSelected());
             }
             else
             {
-                foreach (Drawable d in new Drawable[] { participantsFlow, participantNumbersFlow, infoPanelFlow, name, participantInfo })
-                    d.FadeIn(transition_duration);
+                participantsFlow.FadeIn(transition_duration);
+                participantNumbersFlow.FadeIn(transition_duration);
+                infoPanelFlow.FadeIn(transition_duration);
+                name.FadeIn(transition_duration);
+                participantInfo.FadeIn(transition_duration);
 
                 statusBind.TriggerChange();
                 beatmapBind.TriggerChange();

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -61,15 +61,15 @@ namespace osu.Game.Screens.Multi.Components
                 maxParticipantsBind.UnbindBindings();
                 participantsBind.UnbindBindings();
 
-                if (Room != null)
+                if (room != null)
                 {
-                    nameBind.BindTo(Room.Name);
-                    hostBind.BindTo(Room.Host);
-                    statusBind.BindTo(Room.Status);
-                    typeBind.BindTo(Room.Type);
-                    beatmapBind.BindTo(Room.Beatmap);
-                    maxParticipantsBind.BindTo(Room.MaxParticipants);
-                    participantsBind.BindTo(Room.Participants);
+                    nameBind.BindTo(room.Name);
+                    hostBind.BindTo(room.Host);
+                    statusBind.BindTo(room.Status);
+                    typeBind.BindTo(room.Type);
+                    beatmapBind.BindTo(room.Beatmap);
+                    maxParticipantsBind.BindTo(room.MaxParticipants);
+                    participantsBind.BindTo(room.Participants);
                 }
 
                 updateState();


### PR DESCRIPTION
Does a lot of the same changes from #2522, but for `RoomInspector`.

* Create draw hierarchy in load.
* Remove all the unneeded private `display*` methods.
* Allow `Room` to be set to null.
* Don't set a static width in the ctor.