### PR TITLE
Enhancing Catch Gameplay experience

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
             if (curveData != null)
             {
-                yield return new JuiceStream
+                JuiceStream juicestream = new JuiceStream
                 {
                     StartTime = obj.StartTime,
                     Samples = obj.Samples,
@@ -44,6 +44,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                     X = positionData.X / CatchPlayfield.BASE_WIDTH,
                     NewCombo = comboData?.NewCombo ?? false
                 };
+                juicestream.ApplyDefaults(Beatmap.ControlPointInfo, Beatmap.BeatmapInfo.BaseDifficulty);
+                yield return juicestream;
 
                 yield break;
             }

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
             if (curveData != null)
             {
-                JuiceStream juicestream = new JuiceStream
+                yield return new JuiceStream
                 {
                     StartTime = obj.StartTime,
                     Samples = obj.Samples,
@@ -43,9 +43,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                     RepeatCount = curveData.RepeatCount,
                     X = positionData.X / CatchPlayfield.BASE_WIDTH,
                     NewCombo = comboData?.NewCombo ?? false
-                };
-                juicestream.ApplyDefaults(Beatmap.ControlPointInfo, Beatmap.BeatmapInfo.BaseDifficulty);
-                yield return juicestream;
+                }; ;
 
                 yield break;
             }

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -82,8 +82,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
                 double timeToNext = nextObject.StartTime - currentObject.StartTime - 4;
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
-
-
+                
                 if (timeToNext * CatcherArea.Catcher.BASE_SPEED < distanceToNext)
                 {
                     currentObject.HyperDashTarget = nextObject;
@@ -91,8 +90,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 }
                 else
                 {
-                    currentObject.DistanceToHyperDash = timeToNext - distanceToNext;
-                    lastExcess = MathHelper.Clamp(timeToNext - distanceToNext, 0, halfCatcherWidth);
+                    currentObject.DistanceToHyperDash = timeToNext * CatcherArea.Catcher.BASE_SPEED - distanceToNext;
+                    lastExcess = MathHelper.Clamp(timeToNext * CatcherArea.Catcher.BASE_SPEED - distanceToNext, 0, halfCatcherWidth);
                 }
 
                 lastDirection = thisDirection;

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             // todo: add difficulty adjust.
             double catcherWidth = (1.0f - 0.7f * (Beatmap.BeatmapInfo.BaseDifficulty.CircleSize - 5) / 5) * 0.62064f;
             double halfCatcherWidth = catcherWidth / 2;
-            //halfCatcherWidth *= halfCatcherWidth * 0.8;
+            halfCatcherWidth *= halfCatcherWidth * 0.8;
 
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -50,7 +50,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 if (currentObject is Fruit)
                     objectWithDroplets.Add(currentObject);
 
-                if (currentObject is JuiceStream) {
+                if (currentObject is JuiceStream)
+                {
                     IEnumerator<HitObject> nestedHitObjectsEnumerator = currentObject.NestedHitObjects.GetEnumerator();
 
                     while (nestedHitObjectsEnumerator.MoveNext())
@@ -81,7 +82,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
                 double timeToNext = nextObject.StartTime - currentObject.StartTime - 4;
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
-                
+
 
                 if (timeToNext * CatcherArea.Catcher.BASE_SPEED < distanceToNext)
                 {

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -57,7 +57,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                     while (nestedHitObjectsEnumerator.MoveNext())
                     {
                         CatchHitObject objectInJuiceStream = (CatchHitObject)nestedHitObjectsEnumerator.Current;
-                        objectWithDroplets.Add(objectInJuiceStream);
+                        if (!(objectInJuiceStream is TinyDroplet))
+                            objectWithDroplets.Add(objectInJuiceStream);
                     }
                 }
             }
@@ -68,21 +69,13 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             {
                 CatchHitObject currentObject = objectWithDroplets[i];
 
-                // not needed?
-                if (currentObject is TinyDroplet) continue;
-
                 CatchHitObject nextObject = objectWithDroplets[i + 1];
-
-                while (nextObject is TinyDroplet)
-                {
-                    if (++i == objCount - 1) break;
-                    nextObject = objectWithDroplets[i + 1];
-                }
 
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
                 double timeToNext = nextObject.StartTime - currentObject.StartTime - 4;
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
-                
+
+
                 if (timeToNext * CatcherArea.Catcher.BASE_SPEED < distanceToNext)
                 {
                     currentObject.HyperDashTarget = nextObject;

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Objects;
 using OpenTK;
 
 namespace osu.Game.Rulesets.Catch.Beatmaps
@@ -33,35 +34,54 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
         private void initialiseHyperDash(List<CatchHitObject> objects)
         {
             // todo: add difficulty adjust.
-            double catcherWidth = (1.0f - 0.7f * (Beatmap.BeatmapInfo.BaseDifficulty.CircleSize - 5) / 5) * 0.53166f;
+            double catcherWidth = (1.0f - 0.7f * (Beatmap.BeatmapInfo.BaseDifficulty.CircleSize - 5) / 5) * 0.61f;
             double halfCatcherWidth = catcherWidth / 2;
             halfCatcherWidth *= halfCatcherWidth * 0.8;
 
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;
 
-            objects.Sort((a, b) => a.StartTime.CompareTo(b.StartTime));
+            List<CatchHitObject> objectWithDroplets = new List<CatchHitObject>();
 
-            int objCount = objects.Count;
-
-            for (int i = 0; i < objCount - 1; i++)
+            for (int i = 0; i < objects.Count; i++)
             {
                 CatchHitObject currentObject = objects[i];
 
+                if (currentObject is Fruit)
+                    objectWithDroplets.Add(currentObject);
+
+                if (currentObject is JuiceStream) {
+                    IEnumerator<HitObject> nestedHitObjectsEnumerator = currentObject.NestedHitObjects.GetEnumerator();
+
+                    while (nestedHitObjectsEnumerator.MoveNext())
+                    {
+                        CatchHitObject objectInJuiceStream = (CatchHitObject)nestedHitObjectsEnumerator.Current;
+                        objectWithDroplets.Add(objectInJuiceStream);
+                    }
+                }
+            }
+
+            int objCount = objectWithDroplets.Count;
+
+            for (int i = 0; i < objCount - 1; i++)
+            {
+                CatchHitObject currentObject = objectWithDroplets[i];
+
                 // not needed?
-                // if (currentObject is TinyDroplet) continue;
+                if (currentObject is TinyDroplet) continue;
 
-                CatchHitObject nextObject = objects[i + 1];
+                CatchHitObject nextObject = objectWithDroplets[i + 1];
 
-                // while (nextObject is TinyDroplet)
-                // {
-                //     if (++i == objCount - 1) break;
-                //     nextObject = objects[i + 1];
-                // }
+                while (nextObject is TinyDroplet)
+                {
+                    if (++i == objCount - 1) break;
+                    nextObject = objectWithDroplets[i + 1];
+                }
 
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
                 double timeToNext = nextObject.StartTime - currentObject.StartTime - 4;
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
+                
 
                 if (timeToNext * CatcherArea.Catcher.BASE_SPEED < distanceToNext)
                 {

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -33,10 +33,14 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
         private void initialiseHyperDash(List<CatchHitObject> objects)
         {
             // todo: add difficulty adjust.
-            double halfCatcherWidth = CatcherArea.CATCHER_SIZE * (objects.FirstOrDefault()?.Scale ?? 1) / CatchPlayfield.BASE_WIDTH / 2;
+            double catcherWidth = (1.0f - 0.7f * (Beatmap.BeatmapInfo.BaseDifficulty.CircleSize - 5) / 5) * 0.53166f;
+            double halfCatcherWidth = catcherWidth / 2;
+            halfCatcherWidth *= halfCatcherWidth * 0.8;
 
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;
+
+            objects.Sort((a, b) => a.StartTime.CompareTo(b.StartTime));
 
             int objCount = objects.Count;
 
@@ -56,7 +60,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 // }
 
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
-                double timeToNext = nextObject.StartTime - ((currentObject as IHasEndTime)?.EndTime ?? currentObject.StartTime) - 4;
+                double timeToNext = nextObject.StartTime - currentObject.StartTime - 4;
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
 
                 if (timeToNext * CatcherArea.Catcher.BASE_SPEED < distanceToNext)

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 }
                 else
                 {
-                    //currentObject.DistanceToHyperDash = timeToNext - distanceToNext;
+                    currentObject.DistanceToHyperDash = timeToNext - distanceToNext;
                     lastExcess = MathHelper.Clamp(timeToNext - distanceToNext, 0, halfCatcherWidth);
                 }
 

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
         private void initialiseHyperDash(List<CatchHitObject> objects)
         {
             // todo: add difficulty adjust.
-            double catcherWidth = (1.0f - 0.7f * (Beatmap.BeatmapInfo.BaseDifficulty.CircleSize - 5) / 5) * 0.61f;
+            double catcherWidth = (1.0f - 0.7f * (Beatmap.BeatmapInfo.BaseDifficulty.CircleSize - 5) / 5) * 0.62064f;
             double halfCatcherWidth = catcherWidth / 2;
-            halfCatcherWidth *= halfCatcherWidth * 0.8;
+            //halfCatcherWidth *= halfCatcherWidth * 0.8;
 
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             difficultyHitObjects.Clear();
 
             float circleSize = Beatmap.BeatmapInfo.BaseDifficulty.CircleSize;
-            float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.53166f;
+            float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.61f;
             float catcherWidthHalf = catcherWidth / 2;
             catcherWidthHalf *= 0.8f;
 

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -53,7 +53,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                     while (nestedHitObjectsEnumerator.MoveNext())
                     {
                         CatchHitObject objectInJuiceStream = (CatchHitObject)nestedHitObjectsEnumerator.Current;
-                        difficultyHitObjects.Add(new CatchDifficultyHitObject(objectInJuiceStream, catcherWidthHalf));
+                        if (!(objectInJuiceStream is TinyDroplet))
+                            difficultyHitObjects.Add(new CatchDifficultyHitObject(objectInJuiceStream, catcherWidthHalf));
                     }
                 }
             }

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -35,7 +35,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             difficultyHitObjects.Clear();
 
             float circleSize = Beatmap.BeatmapInfo.BaseDifficulty.CircleSize;
-            float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.62064f;
+            float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.62064f * 172;
+            //float catcherWidth = (float)(305.0f / 1.6f * ((102.4f * (1.0f - 0.7 * (circleSize - 5.0f)) / 5.0f) / 128.0f * 0.7f));
             float catcherWidthHalf = catcherWidth / 2;
             catcherWidthHalf *= 0.8f;
             
@@ -44,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                 // We want to only consider fruits that contribute to the combo. Droplets are addressed as accuracy and spinners are not relevant for "skill" calculations.
                 if (hitObject is Fruit)
                 {
-                    difficultyHitObjects.Add(new CatchDifficultyHitObject((CatchHitObject)hitObject, (float)TimeRate));
+                    difficultyHitObjects.Add(new CatchDifficultyHitObject((CatchHitObject)hitObject, catcherWidthHalf));
                 }
                 if (hitObject is JuiceStream)
                 {
@@ -52,7 +53,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                     while (nestedHitObjectsEnumerator.MoveNext())
                     {
                         CatchHitObject objectInJuiceStream = (CatchHitObject)nestedHitObjectsEnumerator.Current;
-                        difficultyHitObjects.Add(new CatchDifficultyHitObject(objectInJuiceStream, (float)TimeRate));
+                        difficultyHitObjects.Add(new CatchDifficultyHitObject(objectInJuiceStream, catcherWidthHalf));
                     }
                 }
             }

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
     public class CatchDifficultyCalculator : DifficultyCalculator
     {
         private const double STAR_SCALING_FACTOR = 0.145;
-        private const float PLAYFIELD_WIDTH = 512;
+        private const float PLAYFIELD_WIDTH = CatchPlayfield.BASE_WIDTH;
 
         private readonly List<CatchDifficultyHitObject> difficultyHitObjects = new List<CatchDifficultyHitObject>();
 

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         private const double STAR_SCALING_FACTOR = 0.145;
         private const float PLAYFIELD_WIDTH = 512;
 
-        internal List<CatchDifficultyHitObject> difficultyHitObjects;
+        private readonly List<CatchDifficultyHitObject> difficultyHitObjects = new List<CatchDifficultyHitObject>();
 
         public CatchDifficultyCalculator(IBeatmap beatmap)
             : base(beatmap)
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             difficultyHitObjects.Clear();
 
             float circleSize = Beatmap.BeatmapInfo.BaseDifficulty.CircleSize;
-            float catcherWidth = CatcherArea.CATCHER_SIZE * (1.0f - 0.7f * (circleSize - 5) / 5) / 1.5f;
+            float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.53166f;
             float catcherWidthHalf = catcherWidth / 2;
             catcherWidthHalf *= 0.8f;
 
@@ -57,7 +57,10 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             {
                 categoryDifficulty["Aim"] = starRating;
 
-                //double preEmpt = HitObjectManager.PreEmpt / TimeRate;
+                double ar = Beatmap.BeatmapInfo.BaseDifficulty.ApproachRate;
+                double preEmpt = BeatmapDifficulty.DifficultyRange(ar, 1800, 1200, 450) / TimeRate;
+
+                categoryDifficulty["AR"] = preEmpt > 1200.0 ? -(preEmpt - 1800.0) / 120.0 : -(preEmpt - 1200.0) / 150.0 + 5.0;
 
                 //categoryDifficulty.Add("AR", (preEmpt > 1200.0 ? -(preEmpt - 1800.0) / 120.0 : -(preEmpt - 1200.0) / 150.0 + 5.0).ToString("0.00", GameBase.nfi));
                 //categoryDifficulty.Add("Max combo", DifficultyHitObjects.Count.ToString(GameBase.nfi));

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             difficultyHitObjects.Clear();
 
             float circleSize = Beatmap.BeatmapInfo.BaseDifficulty.CircleSize;
-            float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.61f;
+            float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.62064f;
             float catcherWidthHalf = catcherWidth / 2;
             catcherWidthHalf *= 0.8f;
             

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -1,18 +1,160 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
 
 namespace osu.Game.Rulesets.Catch.Difficulty
 {
     public class CatchDifficultyCalculator : DifficultyCalculator
     {
-        public CatchDifficultyCalculator(IBeatmap beatmap) : base(beatmap)
+        private const double STAR_SCALING_FACTOR = 0.145;
+        private const float PLAYFIELD_WIDTH = 512;
+
+        internal List<CatchDifficultyHitObject> difficultyHitObjects;
+
+        public CatchDifficultyCalculator(IBeatmap beatmap)
+            : base(beatmap)
         {
         }
 
-        public override double Calculate(Dictionary<string, double> categoryDifficulty = null) => 0;
+        public CatchDifficultyCalculator(IBeatmap beatmap, Mod[] mods)
+            : base(beatmap, mods)
+        {
+        }
+
+        public override double Calculate(Dictionary<string, double> categoryDifficulty = null)
+        {
+
+            difficultyHitObjects.Clear();
+
+            float circleSize = Beatmap.BeatmapInfo.BaseDifficulty.CircleSize;
+            float catcherWidth = CatcherArea.CATCHER_SIZE * (1.0f - 0.7f * (circleSize - 5) / 5) / 1.5f;
+            float catcherWidthHalf = catcherWidth / 2;
+            catcherWidthHalf *= 0.8f;
+
+            foreach (var hitObject in Beatmap.HitObjects)
+            {
+                // We want to only consider fruits that contribute to the combo. Droplets are addressed as accuracy and spinners are not relevant for "skill" calculations.
+                if (!(hitObject is Droplet) && !(hitObject is BananaShower))
+                {
+                    difficultyHitObjects.Add(new CatchDifficultyHitObject((CatchHitObject)hitObject, (float)TimeRate));
+                }
+            }
+
+            difficultyHitObjects.Sort((a, b) => a.BaseHitObject.StartTime.CompareTo(b.BaseHitObject.StartTime));
+
+            if (!CalculateStrainValues()) return 0;
+
+            double starRating = Math.Sqrt(CalculateDifficulty()) * STAR_SCALING_FACTOR;
+
+            if (categoryDifficulty != null)
+            {
+                categoryDifficulty["Aim"] = starRating;
+
+                //double preEmpt = HitObjectManager.PreEmpt / TimeRate;
+
+                //categoryDifficulty.Add("AR", (preEmpt > 1200.0 ? -(preEmpt - 1800.0) / 120.0 : -(preEmpt - 1200.0) / 150.0 + 5.0).ToString("0.00", GameBase.nfi));
+                //categoryDifficulty.Add("Max combo", DifficultyHitObjects.Count.ToString(GameBase.nfi));
+            }
+
+            return starRating;
+        }
+
+        protected bool CalculateStrainValues()
+        {
+            // Traverse hitObjects in pairs to calculate the strain value of NextHitObject from the strain value of CurrentHitObject and environment.
+            using (List<CatchDifficultyHitObject>.Enumerator hitObjectsEnumerator = difficultyHitObjects.GetEnumerator()) {
+
+                if (!hitObjectsEnumerator.MoveNext()) return false;
+
+                CatchDifficultyHitObject currentHitObject = hitObjectsEnumerator.Current;
+                CatchDifficultyHitObject nextHitObject;
+
+                // First hitObject starts at strain 1. 1 is the default for strain values, so we don't need to set it here. See DifficultyHitObject.
+
+                while (hitObjectsEnumerator.MoveNext())
+                {
+                    nextHitObject = hitObjectsEnumerator.Current;
+                    nextHitObject.CalculateStrains(currentHitObject, TimeRate);
+                    currentHitObject = nextHitObject;
+                }
+
+            return true;
+            }
+        }
+
+
+        /// <summary>
+        /// In milliseconds. For difficulty calculation we will only look at the highest strain value in each time interval of size STRAIN_STEP.
+        /// This is to eliminate higher influence of stream over aim by simply having more HitObjects with high strain.
+        /// The higher this value, the less strains there will be, indirectly giving long beatmaps an advantage.
+        /// </summary>
+        protected const double STRAIN_STEP = 750;
+
+        /// <summary>
+        /// The weighting of each strain value decays to this number * it's previous value
+        /// </summary>
+        protected const double DECAY_WEIGHT = 0.94;
+
+        protected double CalculateDifficulty()
+        {
+            // The strain step needs to be adjusted for the algorithm to be considered equal with speed changing mods
+            double actualStrainStep = STRAIN_STEP * TimeRate;
+
+            // Find the highest strain value within each strain step
+            List<double> highestStrains = new List<double>();
+            double intervalEndTime = actualStrainStep;
+            double maximumStrain = 0; // We need to keep track of the maximum strain in the current interval
+
+            CatchDifficultyHitObject previousHitObject = null;
+            foreach (CatchDifficultyHitObject hitObject in difficultyHitObjects)
+            {
+                // While we are beyond the current interval push the currently available maximum to our strain list
+                while (hitObject.BaseHitObject.StartTime > intervalEndTime)
+                {
+                    highestStrains.Add(maximumStrain);
+
+                    // The maximum strain of the next interval is not zero by default! We need to take the last hitObject we encountered, take its strain and apply the decay
+                    // until the beginning of the next interval.
+                    if (previousHitObject == null)
+                    {
+                        maximumStrain = 0;
+                    }
+                    else
+                    {
+                        double decay = Math.Pow(CatchDifficultyHitObject.DECAY_BASE, (intervalEndTime - previousHitObject.BaseHitObject.StartTime) / 1000);
+                        maximumStrain = previousHitObject.Strain * decay;
+                    }
+
+                    // Go to the next time interval
+                    intervalEndTime += actualStrainStep;
+                }
+
+                // Obtain maximum strain
+                maximumStrain = Math.Max(hitObject.Strain, maximumStrain);
+
+                previousHitObject = hitObject;
+            }
+        
+
+            // Build the weighted sum over the highest strains for each interval
+            double difficulty = 0;
+            double weight = 1;
+            highestStrains.Sort((a, b) => b.CompareTo(a)); // Sort from highest to lowest strain.
+
+                foreach (double strain in highestStrains)
+                {
+                    difficulty += weight* strain;
+                    weight *= DECAY_WEIGHT;
+                }
+
+            return difficulty;
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Catch.Difficulty
 {
@@ -37,13 +38,22 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             float catcherWidth = (1.0f - 0.7f * (circleSize - 5) / 5) * 0.61f;
             float catcherWidthHalf = catcherWidth / 2;
             catcherWidthHalf *= 0.8f;
-
+            
             foreach (var hitObject in Beatmap.HitObjects)
             {
                 // We want to only consider fruits that contribute to the combo. Droplets are addressed as accuracy and spinners are not relevant for "skill" calculations.
-                if (!(hitObject is Droplet) && !(hitObject is BananaShower))
+                if (hitObject is Fruit)
                 {
                     difficultyHitObjects.Add(new CatchDifficultyHitObject((CatchHitObject)hitObject, (float)TimeRate));
+                }
+                if (hitObject is JuiceStream)
+                {
+                    IEnumerator<HitObject> nestedHitObjectsEnumerator = hitObject.NestedHitObjects.GetEnumerator();
+                    while (nestedHitObjectsEnumerator.MoveNext())
+                    {
+                        CatchHitObject objectInJuiceStream = (CatchHitObject)nestedHitObjectsEnumerator.Current;
+                        difficultyHitObjects.Add(new CatchDifficultyHitObject(objectInJuiceStream, (float)TimeRate));
+                    }
                 }
             }
 

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
 using OpenTK;
 
 namespace osu.Game.Rulesets.Catch.Difficulty
@@ -38,7 +37,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             float scalingFactor = NORMALIZED_HITOBJECT_RADIUS / catcherWidthHalf;
 
             playerPositioningError = ABSOLUTE_PLAYER_POSITIONING_ERROR;// * scalingFactor;
-            NormalizedPosition = baseHitObject.X * 512 * scalingFactor;
+            NormalizedPosition = baseHitObject.X * CatchPlayfield.BASE_WIDTH * scalingFactor;
         }
 
         private const double DIRECTION_CHANGE_BONUS = 12.5;
@@ -84,7 +83,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                     addition += bonus * bonusFactor;
 
                     // Bonus for tougher direction switches and "almost" hyperdashes at this point
-                    if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10.0f / 512.0f)
+                    if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10.0f / CatchPlayfield.BASE_WIDTH)
                     {
                         additionBonus += 0.3 * bonusFactor;
                     }
@@ -95,7 +94,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             }
 
             // Bonus for "almost" hyperdashes at corner points
-            if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10.0f / 512.0f)
+            if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10.0f / CatchPlayfield.BASE_WIDTH)
             {
                 if (!previousHitCircle.HyperDash)
                 {
@@ -107,7 +106,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                     PlayerPositionOffset = 0;
                 }
 
-                addition *= 1.0 + additionBonus * ((10 - previousHitCircle.DistanceToHyperDash * 512) / 10);
+                addition *= 1.0 + additionBonus * ((10 - previousHitCircle.DistanceToHyperDash * CatchPlayfield.BASE_WIDTH) / 10);
             }
 
             addition *= 850.0 / Math.Max(timeElapsed, 25);

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using osu.Game.Rulesets.Catch.Objects;
+using OpenTK;
+
+namespace osu.Game.Rulesets.Catch.Difficulty
+{
+    class CatchDifficultyHitObject
+    {
+        internal static readonly double DECAY_BASE = 0.20;
+        private const float NORMALIZED_HITOBJECT_RADIUS = 41.0f;
+        private const float ABSOLUTE_PLAYER_POSITIONING_ERROR = 16f;
+        private float playerPositioningError;
+
+        internal CatchHitObject BaseHitObject;
+
+        /// <summary>
+        /// Measures jump difficulty. CtB doesn't have something like button pressing speed or accuracy
+        /// </summary>
+        internal double Strain = 1;
+
+        /// <summary>
+        /// This is required to keep track of lazy player movement (always moving only as far as necessary)
+        /// Without this quick repeat sliders / weirdly shaped streams might become ridiculously overrated
+        /// </summary>
+        internal float PlayerPositionOffset;
+        internal float LastMovement;
+
+        internal float NormalizedPosition;
+        internal float ActualNormalizedPosition => NormalizedPosition + PlayerPositionOffset;
+
+        internal CatchDifficultyHitObject(CatchHitObject baseHitObject, float catcherWidthHalf)
+        {
+            BaseHitObject = baseHitObject;
+
+            // We will scale everything by this factor, so we can assume a uniform CircleSize among beatmaps.
+            float scalingFactor = NORMALIZED_HITOBJECT_RADIUS / catcherWidthHalf;
+
+            playerPositioningError = ABSOLUTE_PLAYER_POSITIONING_ERROR;// * scalingFactor;
+            NormalizedPosition = baseHitObject.X * scalingFactor;
+        }
+
+        private const double DIRECTION_CHANGE_BONUS = 12.5;
+        internal void CalculateStrains(CatchDifficultyHitObject previousHitObject, double timeRate)
+        {
+            // Rather simple, but more specialized things are inherently inaccurate due to the big difference playstyles and opinions make.
+            // See Taiko feedback thread.
+            double timeElapsed = (BaseHitObject.StartTime - previousHitObject.BaseHitObject.StartTime) / timeRate;
+            double decay = Math.Pow(DECAY_BASE, timeElapsed / 1000);
+
+            // Update new position with lazy movement.
+            PlayerPositionOffset =
+                MathHelper.Clamp(
+                    previousHitObject.ActualNormalizedPosition,
+                    NormalizedPosition - (NORMALIZED_HITOBJECT_RADIUS - playerPositioningError),
+                    NormalizedPosition + (NORMALIZED_HITOBJECT_RADIUS - playerPositioningError)) // Obtain new lazy position, but be stricter by allowing for an error of a certain degree of the player.
+                - NormalizedPosition; // Subtract HitObject position to obtain offset
+
+            LastMovement = DistanceTo(previousHitObject);
+            double addition = spacingWeight(LastMovement);
+
+            if (NormalizedPosition < previousHitObject.NormalizedPosition)
+            {
+                LastMovement = -LastMovement;
+            }
+
+            CatchHitObject previousHitCircle = previousHitObject.BaseHitObject;
+
+            double additionBonus = 0;
+            double sqrtTime = Math.Sqrt(Math.Max(timeElapsed, 25));
+
+            // Direction changes give an extra point!
+            if (Math.Abs(LastMovement) > 0.1)
+            {
+                if (Math.Abs(previousHitObject.LastMovement) > 0.1 && Math.Sign(LastMovement) != Math.Sign(previousHitObject.LastMovement))
+                {
+                    double bonus = DIRECTION_CHANGE_BONUS / sqrtTime;
+
+                    // Weight bonus by how 
+                    double bonusFactor = Math.Min(playerPositioningError, Math.Abs(LastMovement)) / playerPositioningError;
+
+                    // We want time to play a role twice here!
+                    addition += bonus * bonusFactor;
+
+                    // Bonus for tougher direction switches and "almost" hyperdashes at this point
+                    if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10)
+                    {
+                        additionBonus += 0.3 * bonusFactor;
+                    }
+                }
+
+                // Base bonus for every movement, giving some weight to streams.
+                addition += 7.5 * Math.Min(Math.Abs(LastMovement), NORMALIZED_HITOBJECT_RADIUS * 2) / (NORMALIZED_HITOBJECT_RADIUS * 6) / sqrtTime;
+            }
+
+            // Bonus for "almost" hyperdashes at corner points
+            if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10)
+            {
+                if (!previousHitCircle.HyperDash)
+                {
+                    additionBonus += 1.0;
+                }
+                else
+                {
+                    // After a hyperdash we ARE in the correct position. Always!
+                    PlayerPositionOffset = 0;
+                }
+
+                addition *= 1.0 + additionBonus * ((10 - previousHitCircle.DistanceToHyperDash) / 10);
+            }
+
+            addition *= 850.0 / Math.Max(timeElapsed, 25);
+
+            Strain = previousHitObject.Strain * decay + addition;
+        }
+
+        private static double spacingWeight(float distance)
+        {
+            return Math.Pow(distance, 1.3) / 500;
+        }
+
+        internal float DistanceTo(CatchDifficultyHitObject other)
+        {
+            return Math.Abs(ActualNormalizedPosition - other.ActualNormalizedPosition);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             float scalingFactor = NORMALIZED_HITOBJECT_RADIUS / catcherWidthHalf;
 
             playerPositioningError = ABSOLUTE_PLAYER_POSITIONING_ERROR;// * scalingFactor;
-            NormalizedPosition = baseHitObject.X * scalingFactor;
+            NormalizedPosition = baseHitObject.X * 512 * scalingFactor;
         }
 
         private const double DIRECTION_CHANGE_BONUS = 12.5;
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
         private static double spacingWeight(float distance)
         {
-            return Math.Pow(distance * 256, 1.3) / 1000;
+            return Math.Pow(distance, 1.3) / 500;
         }
 
         internal float DistanceTo(CatchDifficultyHitObject other)

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
         private static double spacingWeight(float distance)
         {
-            return Math.Pow(distance * 512, 1.2) / 1000;
+            return Math.Pow(distance * 256, 1.3) / 1000;
         }
 
         internal float DistanceTo(CatchDifficultyHitObject other)

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyHitObject.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                     addition += bonus * bonusFactor;
 
                     // Bonus for tougher direction switches and "almost" hyperdashes at this point
-                    if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10)
+                    if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10.0f / 512.0f)
                     {
                         additionBonus += 0.3 * bonusFactor;
                     }
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             }
 
             // Bonus for "almost" hyperdashes at corner points
-            if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10)
+            if (previousHitCircle != null && previousHitCircle.DistanceToHyperDash <= 10.0f / 512.0f)
             {
                 if (!previousHitCircle.HyperDash)
                 {
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                     PlayerPositionOffset = 0;
                 }
 
-                addition *= 1.0 + additionBonus * ((10 - previousHitCircle.DistanceToHyperDash) / 10);
+                addition *= 1.0 + additionBonus * ((10 - previousHitCircle.DistanceToHyperDash * 512) / 10);
             }
 
             addition *= 850.0 / Math.Max(timeElapsed, 25);
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
         private static double spacingWeight(float distance)
         {
-            return Math.Pow(distance, 1.3) / 500;
+            return Math.Pow(distance * 512, 1.2) / 1000;
         }
 
         internal float DistanceTo(CatchDifficultyHitObject other)

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -41,6 +41,11 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// </summary>
         public CatchHitObject HyperDashTarget;
 
+        /// <summary>
+        /// The distance for a fruit to be a valid hyper, used for edge dash calculation.
+        /// </summary>
+        public double DistanceToHyperDash { get; set; }
+
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
         {
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -3,7 +3,10 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using OpenTK;
 using OpenTK.Graphics;
 
@@ -11,6 +14,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableDroplet : PalpableCatchHitObject<Droplet>
     {
+        private Circle border;
         private Pulp pulp;
 
         public DrawableDroplet(Droplet h)
@@ -24,10 +28,44 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = pulp = new Pulp
+            InternalChildren = new[]
             {
-                Size = Size
+                pulp = new Pulp
+                {
+                    Size = Size,
+                },
+                border = new Circle
+                {
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Glow,
+                        Radius = 4,
+                        Colour = HitObject.HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
+                    },
+                    Size = new Vector2(Height * 4f),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    BorderColour = Color4.White,
+                    BorderThickness = 4.0f,
+                    Children = new Framework.Graphics.Drawable[]
+                    {
+                        new Box
+                        {
+                            AlwaysPresent = true,
+                            Colour = AccentColour,
+                            Alpha = 0,
+                            RelativeSizeAxes = Axes.Both
+                        }
+                    }
+                },
             };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            border.Alpha = (float)MathHelper.Clamp((HitObject.StartTime - Time.Current) / 50, 0, 1);
         }
 
         public override Color4 AccentColour

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableDroplet : PalpableCatchHitObject<Droplet>
     {
-        private Circle border;
+        private Border border;
         private Pulp pulp;
 
         public DrawableDroplet(Droplet h)
@@ -28,36 +28,13 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChildren = new[]
+            InternalChildren = new Circle[]
             {
                 pulp = new Pulp
                 {
                     Size = Size,
                 },
-                border = new Circle
-                {
-                    EdgeEffect = new EdgeEffectParameters
-                    {
-                        Type = EdgeEffectType.Glow,
-                        Radius = 4,
-                        Colour = HitObject.HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
-                    },
-                    Size = new Vector2(Height * 4f),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    BorderColour = Color4.White,
-                    BorderThickness = 4.0f,
-                    Children = new Framework.Graphics.Drawable[]
-                    {
-                        new Box
-                        {
-                            AlwaysPresent = true,
-                            Colour = AccentColour,
-                            Alpha = 0,
-                            RelativeSizeAxes = Axes.Both
-                        }
-                    }
-                },
+                border = new Border(4.0f, new Vector2(Height * 4.0f), 4.0f, AccentColour, false),
             };
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -34,6 +34,19 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
                 },
                 border = new Border(4.0f, new Vector2(Height * 4.0f), 4.0f, AccentColour, false),
             };
+            if (HitObject.HyperDash)
+            {
+                AddInternal(new Pulp
+                {
+                    RelativePositionAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AccentColour = Color4.Red,
+                    Blending = BlendingMode.Additive,
+                    Alpha = 0.5f,
+                    Scale = new Vector2(1.333f)
+                });
+            }
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableDroplet.cs
@@ -3,9 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -3,10 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.MathUtils;
 using osu.Game.Rulesets.Catch.Objects.Drawable.Pieces;
 using OpenTK;
@@ -17,6 +15,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
     public class DrawableFruit : PalpableCatchHitObject<Fruit>
     {
         private Border border;
+        private Pulp pulp;
 
         public DrawableFruit(Fruit h)
             : base(h)
@@ -38,7 +37,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             InternalChildren = new []
             {
                 createPulp(HitObject.VisualRepresentation),
-                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, HitObject.HyperDash),
+                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, !HitObject.HyperDash),
             };
 
             if (HitObject.HyperDash)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableFruit : PalpableCatchHitObject<Fruit>
     {
-        private Circle border;
+        private Border border;
 
         public DrawableFruit(Fruit h)
             : base(h)
@@ -35,34 +35,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             // todo: this should come from the skin.
             AccentColour = colourForRrepesentation(HitObject.VisualRepresentation);
 
-            InternalChildren = new[]
+            InternalChildren = new []
             {
                 createPulp(HitObject.VisualRepresentation),
-                border = new Circle
-                {
-                    EdgeEffect = new EdgeEffectParameters
-                    {
-                        Hollow = !HitObject.HyperDash,
-                        Type = EdgeEffectType.Glow,
-                        Radius = 4,
-                        Colour = HitObject.HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
-                    },
-                    Size = new Vector2(Height * 1.5f),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    BorderColour = Color4.White,
-                    BorderThickness = 4f,
-                    Children = new Framework.Graphics.Drawable[]
-                    {
-                        new Box
-                        {
-                            AlwaysPresent = true,
-                            Colour = AccentColour,
-                            Alpha = 0,
-                            RelativeSizeAxes = Axes.Both
-                        }
-                    }
-                },
+                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, HitObject.HyperDash),
             };
 
             if (HitObject.HyperDash)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
     public class DrawableFruit : PalpableCatchHitObject<Fruit>
     {
         private Border border;
-        private Pulp pulp;
 
         public DrawableFruit(Fruit h)
             : base(h)
@@ -37,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             InternalChildren = new []
             {
                 createPulp(HitObject.VisualRepresentation),
-                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, !HitObject.HyperDash),
+                border = new Border(4.0f, new Vector2(Height * 1.5f), 4.0f, AccentColour, HitObject.HyperDash),
             };
 
             if (HitObject.HyperDash)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableFruit.cs
@@ -273,7 +273,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
         {
             base.Update();
 
-            border.Alpha = (float)MathHelper.Clamp((HitObject.StartTime - Time.Current) / 500, 0, 1);
+            border.Alpha = (float)MathHelper.Clamp((HitObject.StartTime - Time.Current) / 50, 0, 1);
         }
 
         private Color4 colourForRrepesentation(FruitVisualRepresentation representation)

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -1,0 +1,40 @@
+﻿using osu.Framework.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Game.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
+{
+    public class Border : Circle
+    {
+        public Border(float GlowRadius, Vector2 size, float borderthickness, Color4 AccentColour, bool HyperDash)
+        {
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Hollow = !HyperDash,
+                Type = EdgeEffectType.Glow,
+                Radius = GlowRadius,
+                Colour = HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
+            };
+            Size = size;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            BorderColour = Color4.White;
+            BorderThickness = borderthickness;
+            Children = new Framework.Graphics.Drawable[]
+            {
+                new Box
+                {
+                    AlwaysPresent = true,
+                    Colour = AccentColour,
+                    Alpha = 0,
+                    RelativeSizeAxes = Axes.Both
+                }
+            };
+        }
+        
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -12,26 +12,26 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
 {
     public class Border : Circle
     {
-        public Border(float GlowRadius, Vector2 size, float borderthickness, Color4 AccentColour, bool HyperDash)
+        public Border(float glowRadius, Vector2 size, float borderThickness, Color4 accentColour, bool hyperDash)
         {
             EdgeEffect = new EdgeEffectParameters
             {
-                Hollow = !HyperDash,
+                Hollow = !hyperDash,
                 Type = EdgeEffectType.Glow,
-                Radius = GlowRadius,
-                Colour = HyperDash ? Color4.Red : AccentColour.Darken(1).Opacity(0.6f)
+                Radius = glowRadius,
+                Colour = hyperDash ? Color4.Red : accentColour.Darken(1).Opacity(0.6f)
             };
             Size = size;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             BorderColour = Color4.White;
-            BorderThickness = borderthickness;
+            BorderThickness = borderThickness;
             Children = new Framework.Graphics.Drawable[]
             {
                 new Box
                 {
                     AlwaysPresent = true,
-                    Colour = AccentColour,
+                    Colour = accentColour,
                     Alpha = 0,
                     RelativeSizeAxes = Axes.Both
                 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -36,6 +36,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
                     RelativeSizeAxes = Axes.Both
                 }
             };
-        }    
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -1,6 +1,8 @@
-﻿using osu.Framework.Graphics;
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Game.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using OpenTK;

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/Pieces/Border.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable.Pieces
                     RelativeSizeAxes = Axes.Both
                 }
             };
-        }
-        
+        }    
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             {
                 var spanStartTime = StartTime + span * spanDuration;
                 var reversed = span % 2 == 1;
-
+                
                 for (double d = 0; d <= length; d += tickDistance)
                 {
                     var timeProgress = d / length;
@@ -86,20 +86,23 @@ namespace osu.Game.Rulesets.Catch.Objects
                     {
                         double progress = reversed ? 1 - (t - spanStartTime) / spanDuration : (t - spanStartTime) / spanDuration;
 
-                        AddNested(new TinyDroplet
-                        {
-                            StartTime = t,
-                            X = X + Curve.PositionAt(progress).X / CatchPlayfield.BASE_WIDTH,
-                            Samples = new List<SampleInfo>(Samples.Select(s => new SampleInfo
+                        // Prevent FruitDroplets from stacking over Fruits!
+                        if (Math.Abs(t - (spanStartTime + spanDuration)) > 5)
+                            AddNested(new TinyDroplet
                             {
-                                Bank = s.Bank,
-                                Name = @"slidertick",
-                                Volume = s.Volume
-                            }))
-                        });
+                                StartTime = t,
+                                X = X + Curve.PositionAt(progress).X / CatchPlayfield.BASE_WIDTH,
+                                Samples = new List<SampleInfo>(Samples.Select(s => new SampleInfo
+                                {
+                                    Bank = s.Bank,
+                                    Name = @"slidertick",
+                                    Volume = s.Volume
+                                }))
+                            });
                     }
 
-                    if (d > minDistanceFromEnd && Math.Abs(d - length) > minDistanceFromEnd)
+                    // Prevent FruitDroplets from stacking over Fruits!
+                    if (d > minDistanceFromEnd && Math.Abs(d - length) > minDistanceFromEnd && Math.Abs(time - (spanStartTime + spanDuration)) > 5)
                     {
                         AddNested(new Droplet
                         {

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -71,7 +71,8 @@ namespace osu.Game.Rulesets.Catch.Objects
                 var spanStartTime = StartTime + span * spanDuration;
                 var reversed = span % 2 == 1;
 
-                for (double d = 0; d <= length; d += tickDistance)
+                // add a timing shift 5 to make sure all sliders are generated properly.
+                for (double d = 0; d <= length + 5; d += tickDistance)
                 {
                     var timeProgress = d / length;
                     var distanceProgress = reversed ? 1 - timeProgress : timeProgress;

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             {
                 var spanStartTime = StartTime + span * spanDuration;
                 var reversed = span % 2 == 1;
-                
+
                 for (double d = 0; d <= length; d += tickDistance)
                 {
                     var timeProgress = d / length;

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) * 0.61f); // Using a bad way to fix the scale, might be some better methods.
+                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) * 0.62064f); // Using a bad way to fix the scale, might be some better methods.
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -117,7 +117,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2(1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
+                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 1.5f); // Using a bad way to fix the scale, might be some better methods.
+
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 1.5f); // Using a bad way to fix the scale, might be some better methods.
+                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) * 0.53166f); // Using a bad way to fix the scale, might be some better methods.
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) * 0.53166f); // Using a bad way to fix the scale, might be some better methods.
+                    Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) * 0.61f); // Using a bad way to fix the scale, might be some better methods.
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -118,7 +118,6 @@ namespace osu.Game.Rulesets.Catch.UI
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
                     Scale = new Vector2((1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 1.5f); // Using a bad way to fix the scale, might be some better methods.
-
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -110,13 +110,13 @@ namespace osu.Game.Beatmaps
             foreach (var mod in Mods.Value.OfType<IApplicableToDifficulty>())
                 mod.ApplyToDifficulty(converted.BeatmapInfo.BaseDifficulty);
 
-            // Post-process
-            rulesetInstance.CreateBeatmapProcessor(converted)?.PostProcess();
-
             // Compute default values for hitobjects, including creating nested hitobjects in-case they're needed
             foreach (var obj in converted.HitObjects)
                 obj.ApplyDefaults(converted.ControlPointInfo, converted.BeatmapInfo.BaseDifficulty);
 
+            // Post-process
+            rulesetInstance.CreateBeatmapProcessor(converted)?.PostProcess();
+            
             foreach (var mod in Mods.Value.OfType<IApplicableToHitObject>())
             foreach (var obj in converted.HitObjects)
                 mod.ApplyToHitObject(obj);

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -59,6 +59,8 @@ namespace osu.Game.Rulesets.Objects
 
         private readonly Lazy<SortedList<HitObject>> nestedHitObjects = new Lazy<SortedList<HitObject>>(() => new SortedList<HitObject>((h1, h2) => h1.StartTime.CompareTo(h2.StartTime)));
 
+        public bool HasNestedHitObjects => nestedHitObjects.IsValueCreated && nestedHitObjects.Value.Count > 0;
+
         [JsonIgnore]
         public IReadOnlyList<HitObject> NestedHitObjects => nestedHitObjects.Value;
 

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSpinner.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSpinner.cs
@@ -8,8 +8,9 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
     /// <summary>
     /// Legacy osu!catch Spinner-type, used for parsing Beatmaps.
     /// </summary>
-    internal sealed class ConvertSpinner : HitObject, IHasEndTime
+    internal sealed class ConvertSpinner : HitObject, IHasEndTime, IHasXPosition
     {
+        public float X { get; set; }
         public double EndTime { get; set; }
 
         public double Duration => EndTime - StartTime;


### PR DESCRIPTION
It's an extention of this repo https://github.com/ppy/osu/pull/2574, since I fixed some other serious bugs, I'd like to combine these things together for easier code review.

## Updates inside this PR
### Resize Catcher Size
Regarding #2063, I'm fixing the catcher size by making it smaller by 0.62064x, which is a result of  = 106.75/172, it works perfectly and is a right value for catcher resize.

### Rework the borders of Fruits and FruitDrops
Current borders feel more like Hidden mode, with 500ms fadeout. I tried 100/200/50 for test and found that 50 works pretty nice, so I rewrite the border fadeout to 50. Also I added the borders to FruitDroplets.

### Rewrite JuiceStream producing method to prevent stackings of Fruits & droplets
This is some serious issue inside current lazer version. Causing by random shift float numbers, there can be fruitdrops&droplets stacking over a fruit, which is not supposed to be seen in this gamemode, so I added judgements to make sure there will be no stackings.

Adding to this, there're some tinydroplets not generated properly because of float number comparing, so I added some loose boundaries to it.

### Rewrite hyper fruit producing method
As written in https://github.com/ppy/osu/issues/2586, current hypers are not calculated properly, mainly caused by nested objects in JuiceStream. This is fixed inside this pr.

### Implementing Star Rating algorithm in catch difficulties
The star rating algorithm is transplanted from https://gist.github.com/peppy/beac8bf3d0da2191ef14d420ff1119e4 and works perfectly.

### Fixing improper spinner/BananaShower load in catch specific maps.
Current lazer client can't load spinners in catch maps because of lacking **IHasXPosition** property, this is also fixed inside this PR.