### PR TITLE
Allow drag clicking footer and filter on song select

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -190,7 +190,5 @@ namespace osu.Game.Screens.Select
         protected override bool OnMouseMove(InputState state) => true;
 
         protected override bool OnClick(InputState state) => true;
-
-        protected override bool OnDragStart(InputState state) => true;
     }
 }

--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -141,7 +141,5 @@ namespace osu.Game.Screens.Select
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => true;
 
         protected override bool OnClick(InputState state) => true;
-
-        protected override bool OnDragStart(InputState state) => true;
     }
 }


### PR DESCRIPTION
This is the correct input behavior for mostly everything that is not a scroll container.
The buttons will activate when releasing anywhere inside the button if you previously click and drag. The previous behavior was that you have to release it near the area you clicked on.
![](https://puu.sh/AoRpQ/9d263321ad.png)
![](https://puu.sh/AoRqj/df71b28559.png)

Same behavior as the leaderboard filter which was already fine.
![](https://puu.sh/Aq1sG/cc96c7dd01.png)

Don't know this but isn't OnDragStart only used on scroll containers or the like?