### PR TITLE
Fix overlays from not hiding when returning to initial main menu state

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -328,6 +328,9 @@ namespace osu.Game.Screens.Menu
 
                     logoDelayedAction = Scheduler.AddDelayed(() =>
                     {
+                        hideOverlaysOnEnter.Value = true;
+                        allowOpeningOverlays.Value = false;
+
                         logo.ClearTransforms(targetMember: nameof(Position));
                         logo.RelativePositionAxes = Axes.Both;
 
@@ -355,6 +358,7 @@ namespace osu.Game.Screens.Menu
                                 logoTracking = true;
 
                                 logo.Impact();
+
                                 hideOverlaysOnEnter.Value = false;
                                 allowOpeningOverlays.Value = true;
                             }, 200);


### PR DESCRIPTION
in addition to #2577 this now also hides the overlays again when going back to `MenuState.Initial` in the main menu.
Something which I wasn't able to access prior to #2600.