### PR TITLE
Fixed banana generation on catch specific maps

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
@@ -28,7 +28,20 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             var endTime = obj as IHasEndTime;
 
             if (positionData == null)
+            {
+                if (endTime != null)
+                {
+                    yield return new BananaShower
+                    {
+                        StartTime = obj.StartTime,
+                        Samples = obj.Samples,
+                        Duration = endTime.Duration,
+                        NewCombo = comboData?.NewCombo ?? false
+                    };
+
+                }
                 yield break;
+            }
 
             if (curveData != null)
             {
@@ -42,19 +55,6 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                     RepeatSamples = curveData.RepeatSamples,
                     RepeatCount = curveData.RepeatCount,
                     X = positionData.X / CatchPlayfield.BASE_WIDTH,
-                    NewCombo = comboData?.NewCombo ?? false
-                };
-
-                yield break;
-            }
-
-            if (endTime != null)
-            {
-                yield return new BananaShower
-                {
-                    StartTime = obj.StartTime,
-                    Samples = obj.Samples,
-                    Duration = endTime.Duration,
                     NewCombo = comboData?.NewCombo ?? false
                 };
 

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
@@ -38,8 +38,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                         Duration = endTime.Duration,
                         NewCombo = comboData?.NewCombo ?? false
                     };
-
                 }
+
                 yield break;
             }
 

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSpinner.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSpinner.cs
@@ -8,9 +8,8 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
     /// <summary>
     /// Legacy osu!catch Spinner-type, used for parsing Beatmaps.
     /// </summary>
-    internal sealed class ConvertSpinner : HitObject, IHasEndTime, IHasXPosition
+    internal sealed class ConvertSpinner : HitObject, IHasEndTime
     {
-        public float X { get; set; }
         public double EndTime { get; set; }
 
         public double Duration => EndTime - StartTime;

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSpinner.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSpinner.cs
@@ -8,8 +8,9 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
     /// <summary>
     /// Legacy osu!catch Spinner-type, used for parsing Beatmaps.
     /// </summary>
-    internal sealed class ConvertSpinner : HitObject, IHasEndTime
+    internal sealed class ConvertSpinner : HitObject, IHasEndTime, IHasXPosition
     {
+        public float X { get; set; }
         public double EndTime { get; set; }
 
         public double Duration => EndTime - StartTime;


### PR DESCRIPTION
Fix the bug when generating bananas on catch specific maps because of lacking ` IHasXPosition` property.