### PR TITLE
Unify texts and tooltips for join and last seen dates with osu-web

### DIFF
--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -10,9 +10,13 @@ using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Graphics
 {
+    // This gives a text with a formatted absolute date and a formatted tooltip
+    // unlike DrawableDate
     public class DrawableDate : OsuSpriteText, IHasTooltip
     {
         private readonly DateTimeOffset date;
+        private readonly String dateFormat;
+        private readonly String tooltipFormat;
 
         public DrawableDate(DateTimeOffset date)
         {
@@ -20,6 +24,50 @@ namespace osu.Game.Graphics
             Font = "Exo2.0-RegularItalic";
 
             this.date = date.ToLocalTime();
+            // if date's format is not specified, set it to an empty string,
+            // so that later we will know to humanize it
+            this.dateFormat = "";
+            // if tooltip's format is not specified, set it to an empty string
+            // so later we will know to default to a default time format
+            this.tooltipFormat = "";
+        }
+
+        public DrawableDate(string dateFormat, DateTimeOffset date)
+        {
+            AutoSizeAxes = Axes.Both;
+            Font = "Exo2.0-RegularItalic";
+
+            this.date = date.ToLocalTime();
+            // set a date format for later from an argument
+            this.dateFormat = dateFormat;
+            // if tooltip's format is not specified, set it to an empty string,
+            // so later we will know to default to a default time format
+            this.tooltipFormat = "";
+        }
+
+        public DrawableDate(DateTimeOffset date, string tooltipFormat)
+        {
+            AutoSizeAxes = Axes.Both;
+            Font = "Exo2.0-RegularItalic";
+
+            this.date = date.ToLocalTime();
+            // if date's format is not specified, set it to an empty string,
+            // so that later we will know to humanize it
+            this.dateFormat = "";
+            // set a tooltip format for later from an argument
+            this.tooltipFormat = tooltipFormat;
+        }
+
+        public DrawableDate(string dateFormat, DateTimeOffset date, string tooltipFormat)
+        {
+            AutoSizeAxes = Axes.Both;
+            Font = "Exo2.0-RegularItalic";
+
+            this.date = date.ToLocalTime();
+            // set a date format for text generator from an argument
+            this.dateFormat = dateFormat;
+            // set a tooltip format for tooltip generator from an argument
+            this.tooltipFormat = tooltipFormat;
         }
 
         [BackgroundDependencyLoader]
@@ -58,8 +106,18 @@ namespace osu.Game.Graphics
 
         public override bool HandleMouseInput => true;
 
-        private void updateTime() => Text = date.Humanize();
+        // if date's format is specified
+        private void updateTime() => Text = (dateFormat != "") ?
+            // format it as requested in a passed argument
+            (String.Format(dateFormat, date)) :
+            // otherwise, humanize it (for example: 2 hours ago)
+            (date.Humanize());
 
-        public string TooltipText => date.ToString();
+        // if we know that the tooltip format exists
+        public string TooltipText => (tooltipFormat != "") ?
+            // then we format the tooltip text using that format
+            (String.Format(tooltipFormat, date)) :
+            // but otherwise, simply convert the date to string
+            (date.ToString());
     }
 }

--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -10,8 +10,6 @@ using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Graphics
 {
-    // This gives a text with a formatted absolute date and a formatted tooltip
-    // unlike DrawableDate
     public class DrawableDate : OsuSpriteText, IHasTooltip
     {
         private readonly DateTimeOffset date;

--- a/osu.Game/Graphics/DrawableDate.cs
+++ b/osu.Game/Graphics/DrawableDate.cs
@@ -24,10 +24,10 @@ namespace osu.Game.Graphics
             this.date = date.ToLocalTime();
             // if date's format is not specified, set it to an empty string,
             // so that later we will know to humanize it
-            this.dateFormat = "";
+            dateFormat = "";
             // if tooltip's format is not specified, set it to an empty string
             // so later we will know to default to a default time format
-            this.tooltipFormat = "";
+            tooltipFormat = "";
         }
 
         public DrawableDate(string dateFormat, DateTimeOffset date)
@@ -40,7 +40,7 @@ namespace osu.Game.Graphics
             this.dateFormat = dateFormat;
             // if tooltip's format is not specified, set it to an empty string,
             // so later we will know to default to a default time format
-            this.tooltipFormat = "";
+            tooltipFormat = "";
         }
 
         public DrawableDate(DateTimeOffset date, string tooltipFormat)
@@ -51,7 +51,7 @@ namespace osu.Game.Graphics
             this.date = date.ToLocalTime();
             // if date's format is not specified, set it to an empty string,
             // so that later we will know to humanize it
-            this.dateFormat = "";
+            dateFormat = "";
             // set a tooltip format for later from an argument
             this.tooltipFormat = tooltipFormat;
         }
@@ -105,17 +105,17 @@ namespace osu.Game.Graphics
         public override bool HandleMouseInput => true;
 
         // if date's format is specified
-        private void updateTime() => Text = (dateFormat != "") ?
+        private void updateTime() => Text = dateFormat != "" ?
             // format it as requested in a passed argument
-            (String.Format(dateFormat, date)) :
+            String.Format(dateFormat, date) :
             // otherwise, humanize it (for example: 2 hours ago)
-            (date.Humanize());
+            date.Humanize();
 
         // if we know that the tooltip format exists
-        public string TooltipText => (tooltipFormat != "") ?
+        public string TooltipText => tooltipFormat != "" ?
             // then we format the tooltip text using that format
-            (String.Format(tooltipFormat, date)) :
+            String.Format(tooltipFormat, date) :
             // but otherwise, simply convert the date to string
-            (date.ToString());
+            date.ToString();
     }
 }

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -364,12 +364,12 @@ namespace osu.Game.Overlays.Profile
             else
             {
                 infoTextLeft.AddText("Joined ", lightText);
-                infoTextLeft.AddText(new DrawableDate(user.JoinDate), boldItalic);
+                infoTextLeft.AddText(new DrawableDate("{0:MMMM yyyy}", user.JoinDate, "{0:d MMMM yyyy}"), boldItalic);
             }
 
             infoTextLeft.NewLine();
             infoTextLeft.AddText("Last seen ", lightText);
-            infoTextLeft.AddText(new DrawableDate(user.LastVisit), boldItalic);
+            infoTextLeft.AddText(new DrawableDate(user.LastVisit, "{0:d MMMM yyyy H:mm \"UTC\"z}"), boldItalic);
             infoTextLeft.NewParagraph();
 
             if (user.PlayStyle?.Length > 0)


### PR DESCRIPTION
Made to resolve #2590 

Got as close as I could, but tooltips can't be formatted like on the web, as far as I'm aware. Also I have no idea what I'm doing, so please revise these changes and tell me what I did wrong and what I can make better.