### PR TITLE
Fix possible MusicController nullref

### DIFF
--- a/osu.Game/Overlays/Music/PlaylistList.cs
+++ b/osu.Game/Overlays/Music/PlaylistList.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays.Music
             private void updateSelectedSet()
             {
                 foreach (PlaylistItem s in items.Children)
-                    s.Selected = s.BeatmapSetInfo.ID == beatmapBacking.Value.BeatmapSetInfo.ID;
+                    s.Selected = s.BeatmapSetInfo.ID == beatmapBacking.Value?.BeatmapSetInfo?.ID;
             }
 
             public string SearchTerm

--- a/osu.Game/Overlays/Music/PlaylistList.cs
+++ b/osu.Game/Overlays/Music/PlaylistList.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays.Music
             private void updateSelectedSet()
             {
                 foreach (PlaylistItem s in items.Children)
-                    s.Selected = s.BeatmapSetInfo.ID == beatmapBacking.Value?.BeatmapSetInfo?.ID;
+                    s.Selected = s.BeatmapSetInfo.ID == beatmapBacking.Value.BeatmapSetInfo?.ID;
             }
 
             public string SearchTerm


### PR DESCRIPTION
Because Beatmap bindable can be set by testcases, this is a possibility.

TestCases really need to not change the beatmap bindable but that's a pretty big change.