### PR TITLE
Fix selecting song in playlist not starting the audio

### DIFF
--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -79,7 +79,10 @@ namespace osu.Game.Overlays.Music
             {
                 BeatmapInfo beatmap = list.FirstVisibleSet?.Beatmaps?.FirstOrDefault();
                 if (beatmap != null)
+                {
                     beatmapBacking.Value = beatmaps.GetWorkingBeatmap(beatmap);
+                    beatmapBacking.Value.Track.Restart();
+                }
             };
         }
 
@@ -109,6 +112,7 @@ namespace osu.Game.Overlays.Music
             }
 
             beatmapBacking.Value = beatmaps.GetWorkingBeatmap(set.Beatmaps.First());
+            beatmapBacking.Value.Track.Restart();
         }
     }
 


### PR DESCRIPTION
Fixes #2620.

Basically same thing that's done in `MusicController.next()` and `MusicController.prev()`.