### PR TITLE
Fix results screen parallax being cut off

### DIFF
--- a/osu.Game/Screens/Ranking/Results.cs
+++ b/osu.Game/Screens/Ranking/Results.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Screens.Ranking
         {
             base.OnEntering(last);
             (Background as BackgroundScreenBeatmap)?.BlurTo(background_blur, 2500, Easing.OutQuint);
+            Background.ScaleTo(1.1f, transition_time, Easing.OutQuint);
 
             allCircles.ForEach(c =>
             {
@@ -101,6 +102,8 @@ namespace osu.Game.Screens.Ranking
             {
                 c.ScaleTo(0, transition_time, Easing.OutSine);
             });
+
+            Background.ScaleTo(1f, transition_time / 4, Easing.OutQuint);
 
             Content.FadeOut(transition_time / 4);
 
@@ -160,7 +163,6 @@ namespace osu.Game.Screens.Ranking
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     ParallaxAmount = 0.01f,
-                                    Scale = new Vector2(1 / circle_outer_scale / overscan),
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
                                     Children = new Drawable[]


### PR DESCRIPTION
Alternative to / closes #2549.

Didn't want to reference the toolbar as was done, also wanted to remove the awkward scaling factors so rather than scaling down the inner one, we scale up the outer one.