### PR TITLE
Fix notifications appearing during gameplay

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -17,13 +17,13 @@ namespace osu.Game.Graphics.Containers
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
 
-        private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>(OverlayActivation.All);
+        protected readonly Bindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         [BackgroundDependencyLoader(true)]
         private void load(OsuGame osuGame, AudioManager audio)
         {
             if (osuGame != null)
-                allowOverlays.BindTo(osuGame.AllowOverlays);
+                OverlayActivationMode.BindTo(osuGame.OverlayActivationMode);
 
             samplePopIn = audio.Sample.Get(@"UI/overlay-pop-in");
             samplePopOut = audio.Sample.Get(@"UI/overlay-pop-out");
@@ -56,7 +56,7 @@ namespace osu.Game.Graphics.Containers
             switch (visibility)
             {
                 case Visibility.Visible:
-                    if (allowOverlays != OverlayActivation.Disabled)
+                    if (OverlayActivationMode != OverlayActivation.Disabled)
                         samplePopIn?.Play();
                     else
                         State = Visibility.Hidden;

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -17,9 +17,6 @@ namespace osu.Game.Graphics.Containers
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
 
-        /// <summary>
-        /// Defaults to <see cref="OverlayActivation.All"/> so that the overlay works even if BDL couldn't pass an <see cref="OsuGame"/>.
-        /// </summary>
         private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using OpenTK;
 using osu.Framework.Configuration;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.Containers
 {
@@ -16,13 +17,16 @@ namespace osu.Game.Graphics.Containers
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
 
-        private readonly BindableBool allowOpeningOverlays = new BindableBool(true);
+        /// <summary>
+        /// Defaults to <see cref="OverlayActivation.All"/> so that the overlay works even if BDL couldn't pass an <see cref="OsuGame"/>.
+        /// </summary>
+        private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         [BackgroundDependencyLoader(true)]
         private void load(OsuGame osuGame, AudioManager audio)
         {
             if (osuGame != null)
-                allowOpeningOverlays.BindTo(osuGame.AllowOpeningOverlays);
+                allowOverlays.BindTo(osuGame.AllowOverlays);
 
             samplePopIn = audio.Sample.Get(@"UI/overlay-pop-in");
             samplePopOut = audio.Sample.Get(@"UI/overlay-pop-out");
@@ -52,7 +56,7 @@ namespace osu.Game.Graphics.Containers
 
         private void onStateChanged(Visibility visibility)
         {
-            if (allowOpeningOverlays)
+            if (allowOverlays == OverlayActivation.All)
             {
                 switch (visibility)
                 {

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -53,20 +53,18 @@ namespace osu.Game.Graphics.Containers
 
         private void onStateChanged(Visibility visibility)
         {
-            if (allowOverlays == OverlayActivation.All)
+            switch (visibility)
             {
-                switch (visibility)
-                {
-                    case Visibility.Visible:
+                case Visibility.Visible:
+                    if (allowOverlays != OverlayActivation.Disabled)
                         samplePopIn?.Play();
-                        break;
-                    case Visibility.Hidden:
-                        samplePopOut?.Play();
-                        break;
-                }
+                    else
+                        State = Visibility.Hidden;
+                    break;
+                case Visibility.Hidden:
+                    samplePopOut?.Play();
+                    break;
             }
-            else
-                State = Visibility.Hidden;
         }
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -366,8 +366,6 @@ namespace osu.Game
 
             settings.StateChanged += _ => updateScreenOffset();
             notifications.StateChanged += _ => updateScreenOffset();
-
-            AllowOverlays.ValueChanged += state => notifications.Enabled.Value = state == OverlayActivation.All;
         }
 
         public void CloseAllOverlays()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -77,7 +77,7 @@ namespace osu.Game
 
         public float ToolbarOffset => Toolbar.Position.Y + Toolbar.DrawHeight;
 
-        public readonly Bindable<OverlayActivation> AllowOverlays = new Bindable<OverlayActivation>();
+        public readonly Bindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>();
 
         private OsuScreen screenStack;
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -77,8 +77,7 @@ namespace osu.Game
 
         public float ToolbarOffset => Toolbar.Position.Y + Toolbar.DrawHeight;
 
-        public readonly BindableBool HideOverlaysOnEnter = new BindableBool();
-        public readonly BindableBool AllowOpeningOverlays = new BindableBool(true);
+        public readonly Bindable<OverlayActivation> AllowOverlays = new Bindable<OverlayActivation>();
 
         private OsuScreen screenStack;
 
@@ -368,20 +367,13 @@ namespace osu.Game
             settings.StateChanged += _ => updateScreenOffset();
             notifications.StateChanged += _ => updateScreenOffset();
 
-            notifications.Enabled.BindTo(AllowOpeningOverlays);
+            AllowOverlays.ValueChanged += state => notifications.Enabled.Value = state == OverlayActivation.All;
+        }
 
-            HideOverlaysOnEnter.ValueChanged += hide =>
-            {
-                //central game screen change logic.
-                if (hide)
-                {
-                    hideAllOverlays();
-                    musicController.State = Visibility.Hidden;
-                    Toolbar.State = Visibility.Hidden;
-                }
-                else
-                    Toolbar.State = Visibility.Visible;
-            };
+        public void CloseAllOverlays()
+        {
+            hideAllOverlays();
+            musicController.State = Visibility.Hidden;
         }
 
         private void forwardLoggedErrorsToNotifications()

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -22,38 +22,12 @@ namespace osu.Game.Overlays
 
         public const float TRANSITION_LENGTH = 600;
 
-        /// <summary>
-        /// Whether posted notifications should be processed.
-        /// </summary>
-        public readonly BindableBool Enabled = new BindableBool(true);
-
         private FlowContainer<NotificationSection> sections;
 
         /// <summary>
         /// Provide a source for the toolbar height.
         /// </summary>
         public Func<float> GetToolbarHeight;
-
-        public NotificationOverlay()
-        {
-            ScheduledDelegate notificationsEnabler = null;
-            Enabled.ValueChanged += v =>
-            {
-                if (!IsLoaded)
-                {
-                    processingPosts = v;
-                    return;
-                }
-
-                notificationsEnabler?.Cancel();
-
-                if (v)
-                    // we want a slight delay before toggling notifications on to avoid the user becoming overwhelmed.
-                    notificationsEnabler = Scheduler.AddDelayed(() => processingPosts = true, 1000);
-                else
-                    processingPosts = false;
-            };
-        }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -101,6 +75,29 @@ namespace osu.Game.Overlays
                     }
                 }
             };
+        }
+
+        private ScheduledDelegate notificationsEnabler;
+        private void updateProcessingMode()
+        {
+            bool enabled = OverlayActivationMode == OverlayActivation.All || State == Visibility.Visible;
+
+            notificationsEnabler?.Cancel();
+
+            if (enabled)
+                // we want a slight delay before toggling notifications on to avoid the user becoming overwhelmed.
+                notificationsEnabler = Scheduler.AddDelayed(() => processingPosts = true, State == Visibility.Visible ? 0 : 1000);
+            else
+                processingPosts = false;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            StateChanged += _ => updateProcessingMode();
+            OverlayActivationMode.ValueChanged += _ => updateProcessingMode();
+            OverlayActivationMode.TriggerChange();
         }
 
         private int totalCount => sections.Select(c => c.DisplayedCount).Sum();

--- a/osu.Game/Overlays/OverlayActivation.cs
+++ b/osu.Game/Overlays/OverlayActivation.cs
@@ -6,7 +6,7 @@ namespace osu.Game.Overlays
     public enum OverlayActivation
     {
         Disabled,
-        //UserTriggered, // currently there is no way to discern user action
+        UserTriggered,
         All
     }
 }

--- a/osu.Game/Overlays/OverlayActivation.cs
+++ b/osu.Game/Overlays/OverlayActivation.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Game.Overlays
+{
+    public enum OverlayActivation
+    {
+        Disabled,
+        //UserTriggered, // currently there is no way to discern user action
+        All
+    }
+}

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -10,6 +10,8 @@ using osu.Framework.Input;
 using osu.Game.Graphics;
 using OpenTK;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 
 namespace osu.Game.Overlays.Toolbar
 {
@@ -28,6 +30,11 @@ namespace osu.Game.Overlays.Toolbar
 
         private const float alpha_hovering = 0.8f;
         private const float alpha_normal = 0.6f;
+
+        /// <summary>
+        /// Defaults to <see cref="OverlayActivation.All"/> so that the overlay works even if BDL couldn't pass an <see cref="OsuGame"/>.
+        /// </summary>
+        private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         public Toolbar()
         {
@@ -74,6 +81,19 @@ namespace osu.Game.Overlays.Toolbar
 
             RelativeSizeAxes = Axes.X;
             Size = new Vector2(1, HEIGHT);
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuGame osuGame)
+        {
+            if (osuGame != null)
+                allowOverlays.BindTo(osuGame.AllowOverlays);
+
+            StateChanged += visibility =>
+            {
+                if (allowOverlays == OverlayActivation.Disabled)
+                    State = Visibility.Hidden;
+            };
         }
 
         public class ToolbarBackground : Container

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -31,9 +31,6 @@ namespace osu.Game.Overlays.Toolbar
         private const float alpha_hovering = 0.8f;
         private const float alpha_normal = 0.6f;
 
-        /// <summary>
-        /// Defaults to <see cref="OverlayActivation.All"/> so that the overlay works even if BDL couldn't pass an <see cref="OsuGame"/>.
-        /// </summary>
         private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         public Toolbar()

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Overlays.Toolbar
         private void load(OsuGame osuGame)
         {
             if (osuGame != null)
-                allowOverlays.BindTo(osuGame.AllowOverlays);
+                allowOverlays.BindTo(osuGame.OverlayActivationMode);
 
             StateChanged += visibility =>
             {

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Overlays.Toolbar
         private const float alpha_hovering = 0.8f;
         private const float alpha_normal = 0.6f;
 
-        private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>(OverlayActivation.All);
+        private readonly Bindable<OverlayActivation> overlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         public Toolbar()
         {
@@ -84,11 +84,11 @@ namespace osu.Game.Overlays.Toolbar
         private void load(OsuGame osuGame)
         {
             if (osuGame != null)
-                allowOverlays.BindTo(osuGame.OverlayActivationMode);
+                overlayActivationMode.BindTo(osuGame.OverlayActivationMode);
 
             StateChanged += visibility =>
             {
-                if (allowOverlays == OverlayActivation.Disabled)
+                if (overlayActivationMode == OverlayActivation.Disabled)
                     State = Visibility.Hidden;
             };
         }

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -322,17 +322,18 @@ namespace osu.Game.Screens.Menu
                 case MenuState.Initial:
                     logoDelayedAction?.Cancel();
                     logoDelayedAction = Scheduler.AddDelayed(() =>
-                    {
-                        logoTracking = false;
+                        {
+                            logoTracking = false;
 
-                        game.OverlayActivationMode.Value = state == MenuState.Exit ? OverlayActivation.Disabled : OverlayActivation.UserTriggered;
+                            if (game != null)
+                                game.OverlayActivationMode.Value = state == MenuState.Exit ? OverlayActivation.Disabled : OverlayActivation.UserTriggered;
 
-                        logo.ClearTransforms(targetMember: nameof(Position));
-                        logo.RelativePositionAxes = Axes.Both;
+                            logo.ClearTransforms(targetMember: nameof(Position));
+                            logo.RelativePositionAxes = Axes.Both;
 
-                        logo.MoveTo(new Vector2(0.5f), 800, Easing.OutExpo);
-                        logo.ScaleTo(1, 800, Easing.OutExpo);
-                    }, buttonArea.Alpha * 150);
+                            logo.MoveTo(new Vector2(0.5f), 800, Easing.OutExpo);
+                            logo.ScaleTo(1, 800, Easing.OutExpo);
+                        }, buttonArea.Alpha * 150);
                     break;
                 case MenuState.TopLevel:
                 case MenuState.Play:
@@ -359,8 +360,11 @@ namespace osu.Game.Screens.Menu
                                 if (impact)
                                     logo.Impact();
 
-                                game.OverlayActivationMode.Value = OverlayActivation.All;
-                                game.Toolbar.State = Visibility.Visible;
+                                if (game != null)
+                                {
+                                    game.OverlayActivationMode.Value = OverlayActivation.All;
+                                    game.Toolbar.State = Visibility.Visible;
+                                }
                             }, 200);
                             break;
                         default:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -16,6 +16,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Threading;
 using osu.Game.Graphics;
 using osu.Game.Input.Bindings;
+using osu.Game.Overlays;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Input;
@@ -129,9 +130,12 @@ namespace osu.Game.Screens.Menu
             buttonFlow.AddRange(buttonsTopLevel);
         }
 
+        private OsuGame game;
+
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio)
+        private void load(AudioManager audio, OsuGame game)
         {
+            this.game = game;
             sampleBack = audio.Sample.Get(@"Menu/button-back-select");
         }
 
@@ -321,6 +325,8 @@ namespace osu.Game.Screens.Menu
                     {
                         logoTracking = false;
 
+                        game.OverlayActivationMode.Value = state == MenuState.Exit ? OverlayActivation.Disabled : OverlayActivation.UserTriggered;
+
                         logo.ClearTransforms(targetMember: nameof(Position));
                         logo.RelativePositionAxes = Axes.Both;
 
@@ -352,6 +358,9 @@ namespace osu.Game.Screens.Menu
 
                                 if (impact)
                                     logo.Impact();
+
+                                game.OverlayActivationMode.Value = OverlayActivation.All;
+                                game.Toolbar.State = Visibility.Visible;
                             }, 200);
                             break;
                         default:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -8,7 +8,6 @@ using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -20,15 +19,12 @@ using osu.Game.Input.Bindings;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Input;
-using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Menu
 {
     public class ButtonSystem : Container, IStateful<MenuState>, IKeyBindingHandler<GlobalAction>
     {
         public event Action<MenuState> StateChanged;
-
-        private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>();
 
         public Action OnEdit;
         public Action OnExit;
@@ -134,11 +130,8 @@ namespace osu.Game.Screens.Menu
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, OsuGame game)
+        private void load(AudioManager audio)
         {
-            if (game != null)
-                allowOverlays.BindTo(game.AllowOverlays);
-
             sampleBack = audio.Sample.Get(@"Menu/button-back-select");
         }
 
@@ -329,7 +322,6 @@ namespace osu.Game.Screens.Menu
                 case MenuState.Exit:
                 case MenuState.Initial:
                     logoTracking = false;
-                    allowOverlays.Value = OverlayActivation.Disabled;
 
                     logoDelayedAction = Scheduler.AddDelayed(() =>
                     {
@@ -338,9 +330,6 @@ namespace osu.Game.Screens.Menu
 
                         logo.MoveTo(new Vector2(0.5f), 800, Easing.OutExpo);
                         logo.ScaleTo(1, 800, Easing.OutExpo);
-
-                        if(state != MenuState.Exit)
-                            allowOverlays.Value = OverlayActivation.All;
                     }, 150);
                     break;
                 case MenuState.TopLevel:

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.Menu
         private Color4 iconColour;
 
         protected override bool HideOverlaysOnEnter => true;
-        protected override OverlayActivation OverlayActivationLevel => OverlayActivation.Disabled;
+        protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
 
         public override bool CursorVisible => false;
 

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -9,6 +9,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Menu
 {
@@ -19,7 +20,6 @@ namespace osu.Game.Screens.Menu
         private Color4 iconColour;
 
         protected override bool HideOverlaysOnEnter => true;
-        protected override bool AllowOpeningOverlays => false;
 
         public override bool CursorVisible => false;
 
@@ -93,6 +93,8 @@ namespace osu.Game.Screens.Menu
             LoadComponentAsync(intro = new Intro());
 
             iconColour = colours.Yellow;
+
+            AllowOverlays.Value = OverlayActivation.Disabled;
         }
 
         protected override void OnEntering(Screen last)

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Screens.Menu
         private Color4 iconColour;
 
         protected override bool HideOverlaysOnEnter => true;
+        protected override OverlayActivation OverlayActivationLevel => OverlayActivation.Disabled;
 
         public override bool CursorVisible => false;
 
@@ -93,8 +94,6 @@ namespace osu.Game.Screens.Menu
             LoadComponentAsync(intro = new Intro());
 
             iconColour = colours.Yellow;
-
-            AllowOverlays.Value = OverlayActivation.Disabled;
         }
 
         protected override void OnEntering(Screen last)

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Screens.Menu
         private SampleChannel seeya;
 
         protected override bool HideOverlaysOnEnter => true;
+        protected override OverlayActivation OverlayActivationLevel => OverlayActivation.Disabled;
 
         public override bool CursorVisible => false;
 
@@ -77,8 +78,6 @@ namespace osu.Game.Screens.Menu
 
             welcome = audio.Sample.Get(@"welcome");
             seeya = audio.Sample.Get(@"seeya");
-
-            AllowOverlays.Value = OverlayActivation.Disabled;
         }
 
         protected override void OnEntering(Screen last)

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Menu
         private SampleChannel seeya;
 
         protected override bool HideOverlaysOnEnter => true;
-        protected override OverlayActivation OverlayActivationLevel => OverlayActivation.Disabled;
+        protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
 
         public override bool CursorVisible => false;
 

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -15,6 +15,7 @@ using osu.Game.IO.Archives;
 using osu.Game.Screens.Backgrounds;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Menu
 {
@@ -32,7 +33,6 @@ namespace osu.Game.Screens.Menu
         private SampleChannel seeya;
 
         protected override bool HideOverlaysOnEnter => true;
-        protected override bool AllowOpeningOverlays => false;
 
         public override bool CursorVisible => false;
 
@@ -77,6 +77,8 @@ namespace osu.Game.Screens.Menu
 
             welcome = audio.Sample.Get(@"welcome");
             seeya = audio.Sample.Get(@"seeya");
+
+            AllowOverlays.Value = OverlayActivation.Disabled;
         }
 
         protected override void OnEntering(Screen last)

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -10,7 +10,6 @@ using osu.Framework.Input;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
-using osu.Game.Overlays;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Charts;
 using osu.Game.Screens.Direct;
@@ -80,8 +79,6 @@ namespace osu.Game.Screens.Menu
             }
 
             preloadSongSelect();
-
-            AllowOverlays.Value = OverlayActivation.Disabled;
         }
 
         private void preloadSongSelect()

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -63,8 +63,6 @@ namespace osu.Game.Screens.Menu
                 },
                 sideFlashes = new MenuSideFlashes(),
             };
-
-            buttons.StateChanged += state => UpdateOverlayStates?.Invoke();
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Charts;
 using osu.Game.Screens.Direct;
@@ -25,7 +26,6 @@ namespace osu.Game.Screens.Menu
         private readonly ButtonSystem buttons;
 
         protected override bool HideOverlaysOnEnter => buttons.State == MenuState.Initial;
-        protected override bool AllowOpeningOverlays => buttons.State != MenuState.Initial;
 
         protected override bool AllowBackButton => buttons.State != MenuState.Initial;
 
@@ -64,6 +64,8 @@ namespace osu.Game.Screens.Menu
                 },
                 sideFlashes = new MenuSideFlashes(),
             };
+
+            buttons.StateChanged += state => UpdateOverlayStates?.Invoke();
         }
 
         [BackgroundDependencyLoader(true)]
@@ -78,6 +80,8 @@ namespace osu.Game.Screens.Menu
             }
 
             preloadSongSelect();
+
+            AllowOverlays.Value = OverlayActivation.Disabled;
         }
 
         private void preloadSongSelect()

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Screens
             if (osuGame != null)
             {
                 Ruleset.BindTo(osuGame.Ruleset);
-                allowOverlays.BindTo(osuGame.AllowOverlays);
+                allowOverlays.BindTo(osuGame.OverlayActivationMode);
 
                 updateOverlayStates = () =>
                 {

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Screens
                 backgroundParallaxContainer.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT * BackgroundParallaxAmount;
 
             allowOverlays.Value = OverlayActivationLevel;
-            
+
             updateOverlayStates?.Invoke();
         }
 

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -54,11 +54,12 @@ namespace osu.Game.Screens
         /// </summary>
         protected virtual bool HideOverlaysOnEnter => false;
 
+        private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>();
+
         /// <summary>
-        /// Whether overlays should be able to be opened.
-        /// It's bound at load which means changes at construction will potentially disappear.
+        /// Whether overlays should be able to be opened once this screen is entered or resumed.
         /// </summary>
-        protected readonly Bindable<OverlayActivation> AllowOverlays = new Bindable<OverlayActivation>();
+        protected virtual OverlayActivation OverlayActivationLevel => OverlayActivation.All;
 
         /// <summary>
         /// Whether this <see cref="OsuScreen"/> allows the cursor to be displayed.
@@ -109,7 +110,7 @@ namespace osu.Game.Screens
             if (osuGame != null)
             {
                 Ruleset.BindTo(osuGame.Ruleset);
-                AllowOverlays.BindTo(osuGame.AllowOverlays);
+                allowOverlays.BindTo(osuGame.AllowOverlays);
 
                 updateOverlayStates = () =>
                 {
@@ -252,6 +253,8 @@ namespace osu.Game.Screens
             if (backgroundParallaxContainer != null)
                 backgroundParallaxContainer.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT * BackgroundParallaxAmount;
 
+            allowOverlays.Value = OverlayActivationLevel;
+            
             updateOverlayStates?.Invoke();
         }
 

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -45,21 +45,16 @@ namespace osu.Game.Screens
         private Action updateOverlayStates;
 
         /// <summary>
-        /// Allows manually updating visibility of all overlays if <see cref="HideOverlaysOnEnter"/> is not enough.
-        /// </summary>
-        protected Action UpdateOverlayStates => updateOverlayStates;
-
-        /// <summary>
         /// Whether all overlays should be hidden when this screen is entered or resumed.
         /// </summary>
         protected virtual bool HideOverlaysOnEnter => false;
 
-        private readonly Bindable<OverlayActivation> allowOverlays = new Bindable<OverlayActivation>();
+        protected readonly Bindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>();
 
         /// <summary>
         /// Whether overlays should be able to be opened once this screen is entered or resumed.
         /// </summary>
-        protected virtual OverlayActivation OverlayActivationLevel => OverlayActivation.All;
+        protected virtual OverlayActivation InitialOverlayActivationMode => OverlayActivation.All;
 
         /// <summary>
         /// Whether this <see cref="OsuScreen"/> allows the cursor to be displayed.
@@ -110,15 +105,12 @@ namespace osu.Game.Screens
             if (osuGame != null)
             {
                 Ruleset.BindTo(osuGame.Ruleset);
-                allowOverlays.BindTo(osuGame.OverlayActivationMode);
+                OverlayActivationMode.BindTo(osuGame.OverlayActivationMode);
 
                 updateOverlayStates = () =>
                 {
                     if (HideOverlaysOnEnter)
-                    {
                         osuGame.CloseAllOverlays();
-                        osuGame.Toolbar.State = Visibility.Hidden;
-                    }
                     else
                         osuGame.Toolbar.State = Visibility.Visible;
                 };
@@ -257,7 +249,7 @@ namespace osu.Game.Screens
             if (backgroundParallaxContainer != null)
                 backgroundParallaxContainer.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT * BackgroundParallaxAmount;
 
-            allowOverlays.Value = OverlayActivationLevel;
+            OverlayActivationMode.Value = InitialOverlayActivationMode;
 
             updateOverlayStates?.Invoke();
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Play
 
         protected override bool HideOverlaysOnEnter => true;
 
-        protected override OverlayActivation OverlayActivationLevel => OverlayActivation.UserTriggered;
+        protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.UserTriggered;
 
         public Action RestartRequested;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -21,6 +21,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
+using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -36,6 +37,8 @@ namespace osu.Game.Screens.Play
         protected override float BackgroundParallaxAmount => 0.1f;
 
         protected override bool HideOverlaysOnEnter => true;
+
+        protected override OverlayActivation OverlayActivationLevel => OverlayActivation.UserTriggered;
 
         public Action RestartRequested;
 


### PR DESCRIPTION
+ Resolves #2649
+ fix `Toolbar` being toggleable when it shouldn't be able to, e.g. `Intro` (can't find the issue D:)
+ allow opening overlays in `MenuState.Initial` again (resolves #2643)

This isn't *complete* as it's missing `OverlayActivation.UserTriggered` but I'm not sure how to do that yet and I thought that this PR could either be used
a) for feedback how to accomplish that or
b) may be valid before adding the last bit of functionality.