### PR TITLE
Fix beatmap importing entering a bad state

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.Game.props" />
   <PropertyGroup Label="Project">
     <TargetFrameworks>net471;netcoreapp2.0</TargetFrameworks>
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.3" />
     <PackageReference Include="squirrel.windows" Version="1.8.0" Condition="'$(TargetFramework)' == 'net471'" />
   </ItemGroup>
   <ItemGroup Label="Resources">

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
             waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
 
-            return imported.FirstOrDefault();
+            return imported.LastOrDefault();
         }
 
         private void deleteBeatmapSet(BeatmapSetInfo imported, OsuGameBase osu)

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -12,6 +12,7 @@ using osu.Framework.Platform;
 using osu.Game.IPC;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
+using SharpCompress.Archives.Zip;
 
 namespace osu.Game.Tests.Beatmaps.IO
 {
@@ -77,8 +78,69 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
-                    Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 1);
-                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
+                    Assert.AreEqual(1, manager.GetAllUsableBeatmapSets().Count);
+                    Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
+        public void TestRollbackOnFailure()
+        {
+            //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestRollbackOnFailure"))
+            {
+                try
+                {
+                    var osu = loadOsu(host);
+                    var manager = osu.Dependencies.Get<BeatmapManager>();
+
+                    int fireCount = 0;
+
+                    // ReSharper disable once AccessToModifiedClosure
+                    manager.ItemAdded += _ => fireCount++;
+                    manager.ItemRemoved += _ => fireCount++;
+
+                    var imported = loadOszIntoOsu(osu);
+
+                    Assert.AreEqual(0, fireCount -= 1);
+
+                    imported.Hash += "-changed";
+                    manager.Update(imported);
+
+                    Assert.AreEqual(0, fireCount -= 2);
+
+                    var breakTemp = createTemporaryBeatmap();
+
+                    MemoryStream brokenOsu = new MemoryStream(new byte[] { 1, 3, 3, 7 });
+                    MemoryStream brokenOsz = new MemoryStream(File.ReadAllBytes(breakTemp));
+
+                    File.Delete(breakTemp);
+
+                    using (var outStream = File.Open(breakTemp, FileMode.CreateNew))
+                    using (var zip = ZipArchive.Open(brokenOsz))
+                    {
+                        zip.AddEntry("broken.osu", brokenOsu, false);
+                        zip.SaveTo(outStream, SharpCompress.Common.CompressionType.Deflate);
+                    }
+
+                    Assert.AreEqual(1, manager.GetAllUsableBeatmapSets().Count);
+                    Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
+                    Assert.AreEqual(12, manager.QueryBeatmaps(_ => true).ToList().Count);
+
+                    // this will trigger purging of the existing beatmap (online set id match) but should rollback due to broken osu.
+                    manager.Import(breakTemp);
+
+                    // no events should be fired in the case of a rollback.
+                    Assert.AreEqual(0, fireCount);
+
+                    Assert.AreEqual(1, manager.GetAllUsableBeatmapSets().Count);
+                    Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
+                    Assert.AreEqual(12, manager.QueryBeatmaps(_ => true).ToList().Count);
                 }
                 finally
                 {
@@ -100,18 +162,17 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                     var imported = loadOszIntoOsu(osu);
 
-                    //var change = manager.QueryBeatmapSets(_ => true).First();
                     imported.Hash += "-changed";
                     manager.Update(imported);
 
                     var importedSecondTime = loadOszIntoOsu(osu);
 
-                    // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
                     Assert.IsTrue(imported.ID != importedSecondTime.ID);
                     Assert.IsTrue(imported.Beatmaps.First().ID < importedSecondTime.Beatmaps.First().ID);
 
-                    Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 1);
-                    Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
+                    // only one beatmap will exist as the online set ID matched, causing purging of the first import.
+                    Assert.AreEqual(1, manager.GetAllUsableBeatmapSets().Count);
+                    Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
                 }
                 finally
                 {
@@ -231,7 +292,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             manager.Delete(imported);
 
             Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 0);
-            Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
+            Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
             Assert.IsTrue(manager.QueryBeatmapSets(_ => true).First().DeletePending);
         }
 

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -162,8 +162,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                     var osu = loadOsu(host);
 
-                    var temp = prepareTempCopy(osz_path);
-                    Assert.IsTrue(File.Exists(temp));
+                    var temp = createTemporaryBeatmap();
 
                     var importer = new ArchiveImportIPCChannel(client);
                     if (!importer.ImportAsync(temp).Wait(10000))
@@ -188,8 +187,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 try
                 {
                     var osu = loadOsu(host);
-                    var temp = prepareTempCopy(osz_path);
-                    Assert.IsTrue(File.Exists(temp), "Temporary file copy never substantiated");
+                    var temp = createTemporaryBeatmap();
                     using (File.OpenRead(temp))
                         osu.Dependencies.Get<BeatmapManager>().Import(temp);
                     ensureLoaded(osu);
@@ -203,11 +201,16 @@ namespace osu.Game.Tests.Beatmaps.IO
             }
         }
 
-        private BeatmapSetInfo loadOszIntoOsu(OsuGameBase osu)
+        private string createTemporaryBeatmap()
         {
-            var temp = prepareTempCopy(osz_path);
-
+            var temp = new FileInfo(osz_path).CopyTo(Path.GetTempFileName(), true).FullName;
             Assert.IsTrue(File.Exists(temp));
+            return temp;
+        }
+
+        private BeatmapSetInfo loadOszIntoOsu(OsuGameBase osu, string path = null)
+        {
+            var temp = path ?? createTemporaryBeatmap();
 
             var manager = osu.Dependencies.Get<BeatmapManager>();
 
@@ -230,12 +233,6 @@ namespace osu.Game.Tests.Beatmaps.IO
             Assert.IsTrue(manager.GetAllUsableBeatmapSets().Count == 0);
             Assert.IsTrue(manager.QueryBeatmapSets(_ => true).ToList().Count == 1);
             Assert.IsTrue(manager.QueryBeatmapSets(_ => true).First().DeletePending);
-        }
-
-        private string prepareTempCopy(string path)
-        {
-            var temp = Path.GetTempFileName();
-            return new FileInfo(path).CopyTo(temp, true).FullName;
         }
 
         private OsuGameBase loadOsu(GameHost host)

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -240,12 +240,8 @@ namespace osu.Game.Database
         /// <param name="item">The item to delete.</param>
         public void Delete(TModel item)
         {
-            using (var usage = ContextFactory.GetForWrite())
+            using (ContextFactory.GetForWrite())
             {
-                var context = usage.Context;
-
-                context.ChangeTracker.AutoDetectChangesEnabled = false;
-
                 // re-fetch the model on the import context.
                 var foundModel = queryModel().Include(s => s.Files).ThenInclude(f => f.FileInfo).First(s => s.ID == item.ID);
 
@@ -253,8 +249,6 @@ namespace osu.Game.Database
 
                 if (ModelStore.Delete(foundModel))
                     Files.Dereference(foundModel.Files.Select(f => f.FileInfo).ToArray());
-
-                context.ChangeTracker.AutoDetectChangesEnabled = true;
             }
         }
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -206,8 +206,9 @@ namespace osu.Game.Database
                     }
                 }
             }
-            catch
+            catch (Exception e)
             {
+                Logger.Error(e, $"Import of {archive.Name} failed and has been rolled back.", LoggingTarget.Database);
                 item = null;
             }
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -58,13 +58,20 @@ namespace osu.Game.Database
 
         private readonly List<Action> cachedEvents = new List<Action>();
 
+        /// <summary>
+        /// Allows delaying of outwards events until an operation is confirmed (at a database level).
+        /// </summary>
         private bool delayingEvents;
 
-        private void cacheEvents()
-        {
-            delayingEvents = true;
-        }
+        /// <summary>
+        /// Begin delaying outwards events.
+        /// </summary>
+        private void delayEvents() => delayingEvents = true;
 
+        /// <summary>
+        /// Flush delayed events and disable delaying.
+        /// </summary>
+        /// <param name="perform">Whether the flushed events should be performed.</param>
         private void flushEvents(bool perform)
         {
             if (perform)
@@ -167,8 +174,8 @@ namespace osu.Game.Database
         /// <param name="archive">The archive to be imported.</param>
         public TModel Import(ArchiveReader archive)
         {
-            TModel item = null;
-            cacheEvents();
+            TModel item;
+            delayEvents();
 
             try
             {
@@ -196,6 +203,7 @@ namespace osu.Game.Database
                 item = null;
             }
 
+            // we only want to flush events after we've confirmed the write context didn't have any errors.
             flushEvents(item != null);
             return item;
         }

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Database
         /// <param name="archive">The archive to be imported.</param>
         public TModel Import(ArchiveReader archive)
         {
-            TModel item;
+            TModel item = null;
             delayEvents();
 
             try
@@ -211,9 +211,12 @@ namespace osu.Game.Database
                 Logger.Error(e, $"Import of {archive.Name} failed and has been rolled back.", LoggingTarget.Database);
                 item = null;
             }
+            finally
+            {
+                // we only want to flush events after we've confirmed the write context didn't have any errors.
+                flushEvents(item != null);
+            }
 
-            // we only want to flush events after we've confirmed the write context didn't have any errors.
-            flushEvents(item != null);
             return item;
         }
 

--- a/osu.Game/Database/DatabaseWriteUsage.cs
+++ b/osu.Game/Database/DatabaseWriteUsage.cs
@@ -2,26 +2,31 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
-using Microsoft.EntityFrameworkCore.Storage;
+using System.Collections.Generic;
 
 namespace osu.Game.Database
 {
     public class DatabaseWriteUsage : IDisposable
     {
         public readonly OsuDbContext Context;
-        private readonly IDbContextTransaction transaction;
         private readonly Action<DatabaseWriteUsage> usageCompleted;
 
         public DatabaseWriteUsage(OsuDbContext context, Action<DatabaseWriteUsage> onCompleted)
         {
             Context = context;
-            transaction = Context.BeginTransaction();
             usageCompleted = onCompleted;
         }
 
         public bool PerformedWrite { get; private set; }
 
         private bool isDisposed;
+        public List<Exception> Errors = new List<Exception>();
+
+        /// <summary>
+        /// Whether this write usage will commit a transaction on completion.
+        /// If false, there is a parent usage responsible for transaction commit.
+        /// </summary>
+        public bool IsTransactionLeader = false;
 
         protected void Dispose(bool disposing)
         {
@@ -30,12 +35,11 @@ namespace osu.Game.Database
 
             try
             {
-                PerformedWrite |= Context.SaveChanges(transaction) > 0;
+                PerformedWrite |= Context.SaveChanges() > 0;
             }
             catch (Exception e)
             {
-                transaction?.Rollback();
-                throw;
+                Errors.Add(e);
             }
             finally
             {

--- a/osu.Game/Database/DatabaseWriteUsage.cs
+++ b/osu.Game/Database/DatabaseWriteUsage.cs
@@ -28,8 +28,19 @@ namespace osu.Game.Database
             if (isDisposed) return;
             isDisposed = true;
 
-            PerformedWrite |= Context.SaveChanges(transaction) > 0;
-            usageCompleted?.Invoke(this);
+            try
+            {
+                PerformedWrite |= Context.SaveChanges(transaction) > 0;
+            }
+            catch (Exception e)
+            {
+                transaction?.Rollback();
+                throw;
+            }
+            finally
+            {
+                usageCompleted?.Invoke(this);
+            }
         }
 
         public void Dispose()

--- a/osu.Game/Database/DatabaseWriteUsage.cs
+++ b/osu.Game/Database/DatabaseWriteUsage.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Database
             catch (Exception e)
             {
                 Errors.Add(e);
+                throw;
             }
             finally
             {

--- a/osu.Game/Database/IDatabaseContextFactory.cs
+++ b/osu.Game/Database/IDatabaseContextFactory.cs
@@ -14,7 +14,8 @@ namespace osu.Game.Database
         /// Request a context for write usage. Can be consumed in a nested fashion (and will return the same underlying context).
         /// This method may block if a write is already active on a different thread.
         /// </summary>
+        /// <param name="withTransaction">Whether to start a transaction for this write.</param>
         /// <returns>A usage containing a usable context.</returns>
-        DatabaseWriteUsage GetForWrite();
+        DatabaseWriteUsage GetForWrite(bool withTransaction = true);
     }
 }

--- a/osu.Game/Database/MutableDatabaseBackedStore.cs
+++ b/osu.Game/Database/MutableDatabaseBackedStore.cs
@@ -50,11 +50,10 @@ namespace osu.Game.Database
         /// <param name="item">The item to update.</param>
         public void Update(T item)
         {
-            ItemRemoved?.Invoke(item);
-
             using (var usage = ContextFactory.GetForWrite())
                 usage.Context.Update(item);
 
+            ItemRemoved?.Invoke(item);
             ItemAdded?.Invoke(item);
         }
 

--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -106,8 +106,7 @@ namespace osu.Game.Database
 
         public IDbContextTransaction BeginTransaction()
         {
-            // return Database.BeginTransaction();
-            return null;
+            return Database.BeginTransaction();
         }
 
         public int SaveChanges(IDbContextTransaction transaction = null)

--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using osu.Framework.Logging;
@@ -102,18 +101,6 @@ namespace osu.Game.Database
             modelBuilder.Entity<RulesetInfo>().HasIndex(b => b.ShortName).IsUnique();
 
             modelBuilder.Entity<BeatmapInfo>().HasOne(b => b.BaseDifficulty);
-        }
-
-        public IDbContextTransaction BeginTransaction()
-        {
-            return Database.BeginTransaction();
-        }
-
-        public int SaveChanges(IDbContextTransaction transaction = null)
-        {
-            var ret = base.SaveChanges();
-            if (ret > 0) transaction?.Commit();
-            return ret;
         }
 
         private class OsuDbLoggerFactory : ILoggerFactory

--- a/osu.Game/Database/SingletonContextFactory.cs
+++ b/osu.Game/Database/SingletonContextFactory.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Database
 
         public OsuDbContext Get() => context;
 
-        public DatabaseWriteUsage GetForWrite() => new DatabaseWriteUsage(context, null);
+        public DatabaseWriteUsage GetForWrite(bool withTransaction = true) => new DatabaseWriteUsage(context, null);
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -208,7 +208,7 @@ namespace osu.Game
         {
             try
             {
-                using (var db = contextFactory.GetForWrite())
+                using (var db = contextFactory.GetForWrite(false))
                     db.Context.Migrate();
             }
             catch (MigrationFailedException e)
@@ -220,7 +220,7 @@ namespace osu.Game
                 contextFactory.ResetDatabase();
                 Logger.Log("Database purged successfully.", LoggingTarget.Database, LogLevel.Important);
 
-                using (var db = contextFactory.GetForWrite())
+                using (var db = contextFactory.GetForWrite(false))
                     db.Context.Migrate();
             }
         }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -17,7 +17,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Humanizer" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="SharpCompress" Version="0.18.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />


### PR DESCRIPTION
Previously a single failed import would cause all further imports to fail.

This doesn't fix the remaining known cause of imports failing, which will be addressed in a separate PR. Adds back transaction support, with accompanying EF updates to support transactions correctly.

Note that I had to restructure transactions a bit as EF doesn't allow nested transactions. Now there is a write context which becomes transaction "leader" which is performing the commit.

Partly addresses #2236 