### PR TITLE
Centralise beatmap set cover update logic

### DIFF
--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapSetCover.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapSetCover.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using OpenTK.Graphics;
+
+namespace osu.Game.Beatmaps.Drawables
+{
+    public class UpdateableBeatmapSetCover : Container
+    {
+        private Drawable displayedCover;
+
+        private BeatmapSetInfo beatmapSet;
+        public BeatmapSetInfo BeatmapSet
+        {
+            get { return beatmapSet; }
+            set
+            {
+                if (value == beatmapSet) return;
+                beatmapSet = value;
+
+                if (IsLoaded)
+                    updateCover();
+            }
+        }
+
+        private BeatmapSetCoverType coverType = BeatmapSetCoverType.Cover;
+        public BeatmapSetCoverType CoverType
+        {
+            get { return coverType; }
+            set
+            {
+                if (value == coverType) return;
+                coverType = value;
+
+                if (IsLoaded)
+                    updateCover();
+            }
+        }
+
+        public UpdateableBeatmapSetCover()
+        {
+            Child = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Color4.Black,
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateCover();
+        }
+
+        private void updateCover()
+        {
+            displayedCover?.FadeOut(400);
+            displayedCover?.Expire();
+
+            if (beatmapSet != null)
+            {
+                Add(displayedCover = new DelayedLoadWrapper(
+                    new BeatmapSetCover(beatmapSet, coverType)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        FillMode = FillMode.Fill,
+                        OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
+                    })
+                );
+            }
+        }
+    }
+}

--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapSetCover.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapSetCover.cs
@@ -59,6 +59,7 @@ namespace osu.Game.Beatmaps.Drawables
         {
             displayedCover?.FadeOut(400);
             displayedCover?.Expire();
+            displayedCover = null;
 
             if (beatmapSet != null)
             {

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private const float buttons_spacing = 5;
 
         private readonly Box tabsBg;
-        private readonly Container coverContainer;
+        private readonly UpdateableBeatmapSetCover cover;
         private readonly OsuSpriteText title, artist;
         private readonly Container noVideoButtons;
         private readonly FillFlowContainer videoButtons;
@@ -36,7 +36,6 @@ namespace osu.Game.Overlays.BeatmapSet
         public Details Details;
 
         private BeatmapManager beatmaps;
-        private DelayedLoadWrapper cover;
 
         public readonly BeatmapPicker Picker;
 
@@ -63,7 +62,7 @@ namespace osu.Game.Overlays.BeatmapSet
             artist.Text = BeatmapSet?.Metadata.Artist ?? string.Empty;
             onlineStatusPill.Status = BeatmapSet?.OnlineInfo.Status ?? BeatmapSetOnlineStatus.None;
 
-            cover?.FadeOut(400, Easing.Out);
+            cover.BeatmapSet = null;
             if (BeatmapSet != null)
             {
                 downloadButtonsContainer.FadeIn(transition_duration);
@@ -72,18 +71,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 noVideoButtons.FadeTo(BeatmapSet.OnlineInfo.HasVideo ? 0 : 1, transition_duration);
                 videoButtons.FadeTo(BeatmapSet.OnlineInfo.HasVideo ? 1 : 0, transition_duration);
 
-                coverContainer.Add(cover = new DelayedLoadWrapper(
-                    new BeatmapSetCover(BeatmapSet)
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativeSizeAxes = Axes.Both,
-                        FillMode = FillMode.Fill,
-                        OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    }, 300)
-                {
-                    RelativeSizeAxes = Axes.Both,
-                });
+                cover.BeatmapSet = BeatmapSet;
             }
             else
             {
@@ -130,12 +118,7 @@ namespace osu.Game.Overlays.BeatmapSet
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = Color4.Black,
-                                },
-                                coverContainer = new Container
+                                cover = new UpdateableBeatmapSetCover
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                 },

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -61,8 +61,8 @@ namespace osu.Game.Overlays.BeatmapSet
             title.Text = BeatmapSet?.Metadata.Title ?? string.Empty;
             artist.Text = BeatmapSet?.Metadata.Artist ?? string.Empty;
             onlineStatusPill.Status = BeatmapSet?.OnlineInfo.Status ?? BeatmapSetOnlineStatus.None;
+            cover.BeatmapSet = BeatmapSet;
 
-            cover.BeatmapSet = null;
             if (BeatmapSet != null)
             {
                 downloadButtonsContainer.FadeIn(transition_duration);
@@ -70,8 +70,6 @@ namespace osu.Game.Overlays.BeatmapSet
 
                 noVideoButtons.FadeTo(BeatmapSet.OnlineInfo.HasVideo ? 0 : 1, transition_duration);
                 videoButtons.FadeTo(BeatmapSet.OnlineInfo.HasVideo ? 1 : 0, transition_duration);
-
-                cover.BeatmapSet = BeatmapSet;
             }
             else
             {

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -27,8 +27,6 @@ namespace osu.Game.Overlays.Direct
     {
         public readonly BeatmapSetInfo SetInfo;
 
-        protected Box BlackBackground;
-
         private const double hover_transition_time = 400;
 
         private Container content;
@@ -81,12 +79,6 @@ namespace osu.Game.Overlays.Direct
                 EdgeEffect = edgeEffectNormal,
                 Children = new[]
                 {
-                    // temporary blackness until the actual background loads.
-                    BlackBackground = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.Black,
-                    },
                     CreateBackground(),
                     progressBar = new ProgressBar
                     {
@@ -215,21 +207,10 @@ namespace osu.Game.Overlays.Direct
             return icons;
         }
 
-        protected Drawable CreateBackground() => new DelayedLoadWrapper(
-            new BeatmapSetCover(SetInfo)
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.Both,
-                FillMode = FillMode.Fill,
-                OnLoadComplete = d =>
-                {
-                    d.FadeInFromZero(400, Easing.Out);
-                    BlackBackground.Delay(400).FadeOut();
-                },
-            }, 300)
+        protected Drawable CreateBackground() => new UpdateableBeatmapSetCover
         {
             RelativeSizeAxes = Axes.Both,
+            BeatmapSet = SetInfo,
         };
 
         public class Statistic : FillFlowContainer

--- a/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedRow.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedRow.cs
@@ -24,19 +24,13 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
             this.playCount = playCount;
         }
 
-        protected override Drawable CreateLeftVisual() => new DelayedLoadWrapper(new BeatmapSetCover(beatmap.BeatmapSet, BeatmapSetCoverType.List)
+        protected override Drawable CreateLeftVisual() => new UpdateableBeatmapSetCover
         {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            FillMode = FillMode.Fit,
-            RelativeSizeAxes = Axes.Both,
-            OnLoadComplete = d => d.FadeInFromZero(500, Easing.OutQuint)
-        })
-        {
-            Origin = Anchor.CentreLeft,
             Anchor = Anchor.CentreLeft,
-            RelativeSizeAxes = Axes.None,
+            Origin = Anchor.CentreLeft,
             Size = new Vector2(80, 50),
+            BeatmapSet = beatmap.BeatmapSet,
+            CoverType = BeatmapSetCoverType.List,
         };
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Screens/Multi/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/Multi/Components/DrawableRoom.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Screens.Multi.Components
         private void load(OsuColour colours, LocalisationEngine localisation)
         {
             Box sideStrip;
-            Container coverContainer;
+            UpdateableBeatmapSetCover cover;
             OsuSpriteText name, status, beatmapTitle, beatmapDash, beatmapArtist;
             ParticipantInfo participantInfo;
             ModeTypeInfo modeTypeInfo;
@@ -146,24 +146,12 @@ namespace osu.Game.Screens.Multi.Components
                                 RelativeSizeAxes = Axes.Y,
                                 Width = side_strip_width,
                             },
-                            new Container
+                            cover = new UpdateableBeatmapSetCover
                             {
                                 Width = cover_width,
                                 RelativeSizeAxes = Axes.Y,
                                 Masking = true,
                                 Margin = new MarginPadding { Left = side_strip_width },
-                                Children = new Drawable[]
-                                {
-                                    new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.Black,
-                                    },
-                                    coverContainer = new Container
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                    },
-                                },
                             },
                             new Container
                             {
@@ -263,23 +251,14 @@ namespace osu.Game.Screens.Multi.Components
 
                 if (b != null)
                 {
-                    coverContainer.FadeIn(transition_duration);
-
-                    LoadComponentAsync(new BeatmapSetCover(b.BeatmapSet)
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        FillMode = FillMode.Fill,
-                        OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    }, coverContainer.Add);
-
+                    cover.BeatmapSet = b.BeatmapSet;
                     beatmapTitle.Current = localisation.GetUnicodePreference(b.Metadata.TitleUnicode, b.Metadata.Title);
                     beatmapDash.Text = @" - ";
                     beatmapArtist.Current = localisation.GetUnicodePreference(b.Metadata.ArtistUnicode, b.Metadata.Artist);
                 }
                 else
                 {
-                    coverContainer.FadeOut(transition_duration);
+                    cover.BeatmapSet = null;
 
                     beatmapTitle.Current = null;
                     beatmapArtist.Current = null;

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Multi.Components
 
         private OsuColour colours;
         private Box statusStrip;
-        private Container coverContainer;
+        private UpdateableBeatmapSetCover cover;
         private FillFlowContainer topFlow, participantsFlow, participantNumbersFlow, infoPanelFlow;
         private OsuSpriteText name, status;
         private ScrollContainer participantsScroll;
@@ -105,21 +105,9 @@ namespace osu.Game.Screens.Multi.Components
                             Masking = true,
                             Children = new Drawable[]
                             {
-                                new Container
+                                cover = new UpdateableBeatmapSetCover
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.Black,
-                                        },
-                                        coverContainer = new Container
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                        },
-                                    },
                                 },
                                 new Box
                                 {
@@ -294,17 +282,7 @@ namespace osu.Game.Screens.Multi.Components
 
                 if (b != null)
                 {
-                    coverContainer.FadeIn(transition_duration);
-
-                    LoadComponentAsync(new BeatmapSetCover(b.BeatmapSet)
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        FillMode = FillMode.Fill,
-                        OnLoadComplete = d => d.FadeInFromZero(400, Easing.Out),
-                    }, coverContainer.Add);
-
+                    cover.BeatmapSet = b.BeatmapSet;
                     beatmapTitle.Current = localisation.GetUnicodePreference(b.Metadata.TitleUnicode, b.Metadata.Title);
                     beatmapDash.Text = @" - ";
                     beatmapArtist.Current = localisation.GetUnicodePreference(b.Metadata.ArtistUnicode, b.Metadata.Artist);
@@ -312,7 +290,7 @@ namespace osu.Game.Screens.Multi.Components
                 }
                 else
                 {
-                    coverContainer.FadeOut(transition_duration);
+                    cover.BeatmapSet = null;
 
                     beatmapTitle.Current = null;
                     beatmapArtist.Current = null;
@@ -367,7 +345,7 @@ namespace osu.Game.Screens.Multi.Components
         {
             if (Room == null)
             {
-                coverContainer.FadeOut(transition_duration);
+                cover.BeatmapSet = null;
                 participantsFlow.FadeOut(transition_duration);
                 participantNumbersFlow.FadeOut(transition_duration);
                 infoPanelFlow.FadeOut(transition_duration);


### PR DESCRIPTION
This logic was copy pasted everywhere, so I put it into a `UpdateableBeatmapSetCover` class. Functions similar to `UpdateableAvatar`.