### PR TITLE
Multiplayer shared logic encapsulation

### DIFF
--- a/osu.Game/Screens/Multi/Components/BeatmapModeInfo.cs
+++ b/osu.Game/Screens/Multi/Components/BeatmapModeInfo.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Multiplayer;
+using OpenTK;
+
+namespace osu.Game.Screens.Multi.Components
+{
+    public class BeatmapModeInfo : FillFlowContainer
+    {
+        private readonly ModeTypeInfo modeTypeInfo;
+        private readonly BeatmapTitle beatmapTitle;
+        private readonly OsuSpriteText beatmapAuthor;
+
+        public BeatmapInfo Beatmap
+        {
+            set
+            {
+                modeTypeInfo.Beatmap = beatmapTitle.Beatmap = value;
+
+                if (value == null)
+                    beatmapAuthor.Text = string.Empty;
+                else
+                    beatmapAuthor.Text = $"mapped by {value.Metadata.Author}";
+            }
+        }
+
+        public GameType Type
+        {
+            set { modeTypeInfo.Type = value; }
+        }
+
+        public BeatmapModeInfo()
+        {
+            AutoSizeAxes = Axes.Both;
+            Direction = FillDirection.Horizontal;
+            LayoutDuration = 100;
+            Spacing = new Vector2(5f, 0f);
+
+            Children = new Drawable[]
+            {
+                modeTypeInfo = new ModeTypeInfo(),
+                new Container
+                {
+                    AutoSizeAxes = Axes.X,
+                    Height = 30,
+                    Margin = new MarginPadding { Left = 5 },
+                    Children = new Drawable[]
+                    {
+                        beatmapTitle = new BeatmapTitle(),
+                        beatmapAuthor = new OsuSpriteText
+                        {
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            TextSize = 14,
+                        },
+                    },
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            beatmapAuthor.Colour = colours.Gray9;
+        }
+    }
+}

--- a/osu.Game/Screens/Multi/Components/BeatmapTitle.cs
+++ b/osu.Game/Screens/Multi/Components/BeatmapTitle.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Screens.Multi.Components
+{
+    public class BeatmapTitle : FillFlowContainer<OsuSpriteText>
+    {
+        private readonly OsuSpriteText beatmapTitle, beatmapDash, beatmapArtist;
+
+        private LocalisationEngine localisation;
+
+        public float TextSize
+        {
+            set { beatmapTitle.TextSize = beatmapDash.TextSize = beatmapArtist.TextSize = value; }
+        }
+
+        private BeatmapInfo beatmap;
+        public BeatmapInfo Beatmap
+        {
+            get { return beatmap; }
+            set
+            {
+                if (value == beatmap) return;
+                beatmap = value;
+
+                if (IsLoaded)
+                    updateText();
+            }
+        }
+
+        public BeatmapTitle()
+        {
+            AutoSizeAxes = Axes.Both;
+            Direction = FillDirection.Horizontal;
+
+            Children = new[]
+            {
+                beatmapTitle = new OsuSpriteText
+                {
+                    Font = @"Exo2.0-BoldItalic",
+                },
+                beatmapDash = new OsuSpriteText
+                {
+                    Font = @"Exo2.0-BoldItalic",
+                },
+                beatmapArtist = new OsuSpriteText
+                {
+                    Font = @"Exo2.0-RegularItalic",
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(LocalisationEngine localisation)
+        {
+            this.localisation = localisation;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            updateText();
+        }
+
+        private void updateText()
+        {
+            if (beatmap == null)
+            {
+                beatmapTitle.Current = beatmapArtist.Current = null;
+
+                beatmapTitle.Text = "Changing map";
+                beatmapDash.Text = beatmapArtist.Text = string.Empty;
+            }
+            else
+            {
+                beatmapTitle.Current = localisation.GetUnicodePreference(beatmap.Metadata.TitleUnicode, beatmap.Metadata.Title);
+                beatmapDash.Text = @" - ";
+                beatmapArtist.Current = localisation.GetUnicodePreference(beatmap.Metadata.ArtistUnicode, beatmap.Metadata.Artist);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Multi/Components/BeatmapTitle.cs
+++ b/osu.Game/Screens/Multi/Components/BeatmapTitle.cs
@@ -24,7 +24,6 @@ namespace osu.Game.Screens.Multi.Components
         private BeatmapInfo beatmap;
         public BeatmapInfo Beatmap
         {
-            get { return beatmap; }
             set
             {
                 if (value == beatmap) return;

--- a/osu.Game/Screens/Multi/Components/BeatmapTitle.cs
+++ b/osu.Game/Screens/Multi/Components/BeatmapTitle.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Screens.Multi.Components
         }
 
         private BeatmapInfo beatmap;
+
         public BeatmapInfo Beatmap
         {
             set
@@ -41,18 +42,9 @@ namespace osu.Game.Screens.Multi.Components
 
             Children = new[]
             {
-                beatmapTitle = new OsuSpriteText
-                {
-                    Font = @"Exo2.0-BoldItalic",
-                },
-                beatmapDash = new OsuSpriteText
-                {
-                    Font = @"Exo2.0-BoldItalic",
-                },
-                beatmapArtist = new OsuSpriteText
-                {
-                    Font = @"Exo2.0-RegularItalic",
-                },
+                beatmapTitle = new OsuSpriteText { Font = @"Exo2.0-BoldItalic", },
+                beatmapDash = new OsuSpriteText { Font = @"Exo2.0-BoldItalic", },
+                beatmapArtist = new OsuSpriteText { Font = @"Exo2.0-RegularItalic", },
             };
         }
 
@@ -65,7 +57,6 @@ namespace osu.Game.Screens.Multi.Components
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
             updateText();
         }
 
@@ -74,7 +65,6 @@ namespace osu.Game.Screens.Multi.Components
             if (beatmap == null)
             {
                 beatmapTitle.Current = beatmapArtist.Current = null;
-
                 beatmapTitle.Text = "Changing map";
                 beatmapDash.Text = beatmapArtist.Text = string.Empty;
             }

--- a/osu.Game/Screens/Multi/Components/BeatmapTypeInfo.cs
+++ b/osu.Game/Screens/Multi/Components/BeatmapTypeInfo.cs
@@ -23,11 +23,7 @@ namespace osu.Game.Screens.Multi.Components
             set
             {
                 modeTypeInfo.Beatmap = beatmapTitle.Beatmap = value;
-
-                if (value == null)
-                    beatmapAuthor.Text = string.Empty;
-                else
-                    beatmapAuthor.Text = $"mapped by {value.Metadata.Author}";
+                beatmapAuthor.Text = value == null ? string.Empty : $"mapped by {value.Metadata.Author}";
             }
         }
 

--- a/osu.Game/Screens/Multi/Components/BeatmapTypeInfo.cs
+++ b/osu.Game/Screens/Multi/Components/BeatmapTypeInfo.cs
@@ -12,7 +12,7 @@ using OpenTK;
 
 namespace osu.Game.Screens.Multi.Components
 {
-    public class BeatmapModeInfo : FillFlowContainer
+    public class BeatmapTypeInfo : FillFlowContainer
     {
         private readonly ModeTypeInfo modeTypeInfo;
         private readonly BeatmapTitle beatmapTitle;
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Multi.Components
             set { modeTypeInfo.Type = value; }
         }
 
-        public BeatmapModeInfo()
+        public BeatmapTypeInfo()
         {
             AutoSizeAxes = Axes.Both;
             Direction = FillDirection.Horizontal;

--- a/osu.Game/Screens/Multi/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/Multi/Components/DrawableRoom.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
-using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
@@ -108,7 +107,7 @@ namespace osu.Game.Screens.Multi.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, LocalisationEngine localisation)
+        private void load(OsuColour colours)
         {
             Box sideStrip;
             UpdateableBeatmapSetCover cover;

--- a/osu.Game/Screens/Multi/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/Multi/Components/DrawableRoom.cs
@@ -227,18 +227,9 @@ namespace osu.Game.Screens.Multi.Components
 
             beatmapBind.ValueChanged += b =>
             {
+                cover.BeatmapSet = b?.BeatmapSet;
+                beatmapTitle.Beatmap = b;
                 modeTypeInfo.Beatmap = b;
-
-                if (b != null)
-                {
-                    cover.BeatmapSet = b.BeatmapSet;
-                    beatmapTitle.Beatmap = b;
-                }
-                else
-                {
-                    cover.BeatmapSet = null;
-                    beatmapTitle.Beatmap = null;
-                }
             };
 
             nameBind.BindTo(Room.Name);

--- a/osu.Game/Screens/Multi/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/Multi/Components/DrawableRoom.cs
@@ -112,8 +112,9 @@ namespace osu.Game.Screens.Multi.Components
         {
             Box sideStrip;
             UpdateableBeatmapSetCover cover;
-            OsuSpriteText name, status, beatmapTitle, beatmapDash, beatmapArtist;
+            OsuSpriteText name, status;
             ParticipantInfo participantInfo;
+            BeatmapTitle beatmapTitle;
             ModeTypeInfo modeTypeInfo;
 
             Children = new Drawable[]
@@ -193,30 +194,10 @@ namespace osu.Game.Screens.Multi.Components
                                                 TextSize = 14,
                                                 Font = @"Exo2.0-Bold",
                                             },
-                                            new FillFlowContainer<OsuSpriteText>
+                                            beatmapTitle = new BeatmapTitle
                                             {
-                                                RelativeSizeAxes = Axes.X,
-                                                AutoSizeAxes = Axes.Y,
-                                                Colour = colours.Gray9,
-                                                Direction = FillDirection.Horizontal,
-                                                Children = new[]
-                                                {
-                                                    beatmapTitle = new OsuSpriteText
-                                                    {
-                                                        TextSize = 14,
-                                                        Font = @"Exo2.0-BoldItalic",
-                                                    },
-                                                    beatmapDash = new OsuSpriteText
-                                                    {
-                                                        TextSize = 14,
-                                                        Font = @"Exo2.0-BoldItalic",
-                                                    },
-                                                    beatmapArtist = new OsuSpriteText
-                                                    {
-                                                        TextSize = 14,
-                                                        Font = @"Exo2.0-RegularItalic",
-                                                    },
-                                                },
+                                                TextSize = 14,
+                                                Colour = colours.Gray9
                                             },
                                         },
                                     },
@@ -252,19 +233,12 @@ namespace osu.Game.Screens.Multi.Components
                 if (b != null)
                 {
                     cover.BeatmapSet = b.BeatmapSet;
-                    beatmapTitle.Current = localisation.GetUnicodePreference(b.Metadata.TitleUnicode, b.Metadata.Title);
-                    beatmapDash.Text = @" - ";
-                    beatmapArtist.Current = localisation.GetUnicodePreference(b.Metadata.ArtistUnicode, b.Metadata.Artist);
+                    beatmapTitle.Beatmap = b;
                 }
                 else
                 {
                     cover.BeatmapSet = null;
-
-                    beatmapTitle.Current = null;
-                    beatmapArtist.Current = null;
-
-                    beatmapTitle.Text = "Changing map";
-                    beatmapDash.Text = beatmapArtist.Text = string.Empty;
+                    beatmapTitle.Beatmap = null;
                 }
             };
 

--- a/osu.Game/Screens/Multi/Components/ModeTypeInfo.cs
+++ b/osu.Game/Screens/Multi/Components/ModeTypeInfo.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Screens.Multi.Components
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(5f, 0f),
+                    LayoutDuration = 100,
                     Children = new[]
                     {
                         rulesetContainer = new Container

--- a/osu.Game/Screens/Multi/Components/ModeTypeInfo.cs
+++ b/osu.Game/Screens/Multi/Components/ModeTypeInfo.cs
@@ -55,8 +55,7 @@ namespace osu.Game.Screens.Multi.Components
 
         public ModeTypeInfo()
         {
-            AutoSizeAxes = Axes.X;
-            Height = height;
+            AutoSizeAxes = Axes.Both;
 
             Children = new[]
             {

--- a/osu.Game/Screens/Multi/Components/ModeTypeInfo.cs
+++ b/osu.Game/Screens/Multi/Components/ModeTypeInfo.cs
@@ -55,7 +55,8 @@ namespace osu.Game.Screens.Multi.Components
 
         public ModeTypeInfo()
         {
-            AutoSizeAxes = Axes.Both;
+            AutoSizeAxes = Axes.X;
+            Height = height;
 
             Children = new[]
             {

--- a/osu.Game/Screens/Multi/Components/ParticipantCount.cs
+++ b/osu.Game/Screens/Multi/Components/ParticipantCount.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Multi.Components
 
         public int Count
         {
-            set { count.Text = value.ToString(); }
+            set => count.Text = value.ToString();
         }
 
         public int? Max
@@ -31,8 +31,8 @@ namespace osu.Game.Screens.Multi.Components
                 else
                 {
                     slash.FadeIn(transition_duration);
-                    max.FadeIn(transition_duration);
                     max.Text = value.ToString();
+                    max.FadeIn(transition_duration);
                 }
             }
         }

--- a/osu.Game/Screens/Multi/Components/ParticipantCount.cs
+++ b/osu.Game/Screens/Multi/Components/ParticipantCount.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Screens.Multi.Components
+{
+    public class ParticipantCount : FillFlowContainer
+    {
+        private const float text_size = 30;
+        private const float transition_duration = 100;
+
+        private readonly OsuSpriteText count, slash, max;
+
+        public int Count
+        {
+            set { count.Text = value.ToString(); }
+        }
+
+        public int? Max
+        {
+            set
+            {
+                if (value == null)
+                {
+                    slash.FadeOut(transition_duration);
+                    max.FadeOut(transition_duration);
+                }
+                else
+                {
+                    slash.FadeIn(transition_duration);
+                    max.FadeIn(transition_duration);
+                    max.Text = value.ToString();
+                }
+            }
+        }
+
+        public ParticipantCount()
+        {
+            AutoSizeAxes = Axes.Both;
+            Direction = FillDirection.Horizontal;
+            LayoutDuration = transition_duration;
+
+            Children = new[]
+            {
+                count = new OsuSpriteText
+                {
+                    TextSize = text_size,
+                    Font = @"Exo2.0-Bold"
+                },
+                slash = new OsuSpriteText
+                {
+                    Text = @"/",
+                    TextSize = text_size,
+                    Font = @"Exo2.0-Light"
+                },
+                max = new OsuSpriteText
+                {
+                    TextSize = text_size,
+                    Font = @"Exo2.0-Light"
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
@@ -39,8 +38,9 @@ namespace osu.Game.Screens.Multi.Components
         private OsuColour colours;
         private Box statusStrip;
         private UpdateableBeatmapSetCover cover;
-        private FillFlowContainer topFlow, participantsFlow, participantNumbersFlow, infoPanelFlow;
+        private FillFlowContainer topFlow, participantsFlow, participantNumbersFlow;
         private OsuSpriteText name, status;
+        private BeatmapModeInfo beatmapModeInfo;
         private ScrollContainer participantsScroll;
         private ParticipantInfo participantInfo;
 
@@ -77,13 +77,12 @@ namespace osu.Game.Screens.Multi.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, LocalisationEngine localisation)
+        private void load(OsuColour colours)
         {
             this.colours = colours;
 
             ModeTypeInfo modeTypeInfo;
             OsuSpriteText participants, participantsSlash, maxParticipants, beatmapAuthor;
-            BeatmapTitle beatmapTitle;
 
             Children = new Drawable[]
             {
@@ -189,35 +188,7 @@ namespace osu.Game.Screens.Multi.Components
                                             TextSize = 14,
                                             Font = @"Exo2.0-Bold",
                                         },
-                                        infoPanelFlow = new FillFlowContainer
-                                        {
-                                            AutoSizeAxes = Axes.X,
-                                            Height = 30,
-                                            Direction = FillDirection.Horizontal,
-                                            LayoutDuration = transition_duration,
-                                            Spacing = new Vector2(5f, 0f),
-                                            Children = new Drawable[]
-                                            {
-                                                modeTypeInfo = new ModeTypeInfo(),
-                                                new Container
-                                                {
-                                                    AutoSizeAxes = Axes.X,
-                                                    RelativeSizeAxes = Axes.Y,
-                                                    Margin = new MarginPadding { Left = 5 },
-                                                    Children = new Drawable[]
-                                                    {
-                                                        beatmapTitle = new BeatmapTitle(),
-                                                        beatmapAuthor = new OsuSpriteText
-                                                        {
-                                                            Anchor = Anchor.BottomLeft,
-                                                            Origin = Anchor.BottomLeft,
-                                                            TextSize = 14,
-                                                            Colour = colours.Gray9,
-                                                        },
-                                                    },
-                                                },
-                                            },
-                                        },
+                                        beatmapModeInfo = new BeatmapModeInfo(),
                                     },
                                 },
                             },
@@ -255,26 +226,13 @@ namespace osu.Game.Screens.Multi.Components
 
             nameBind.ValueChanged += n => name.Text = n;
             hostBind.ValueChanged += h => participantInfo.Host = h;
-            typeBind.ValueChanged += t => modeTypeInfo.Type = t;
+            typeBind.ValueChanged += t => beatmapModeInfo.Type = t;
             statusBind.ValueChanged += displayStatus;
 
             beatmapBind.ValueChanged += b =>
             {
-                modeTypeInfo.Beatmap = b;
-
-                if (b != null)
-                {
-                    cover.BeatmapSet = b.BeatmapSet;
-                    beatmapTitle.Beatmap = b;
-                    beatmapAuthor.Text = $"mapped by {b.Metadata.Author}";
-                }
-                else
-                {
-                    cover.BeatmapSet = null;
-                    beatmapTitle.Beatmap = null;
-
-                    beatmapAuthor.Text = string.Empty;
-                }
+                cover.BeatmapSet = b?.BeatmapSet;
+                beatmapModeInfo.Beatmap = b;
             };
 
             maxParticipantsBind.ValueChanged += m =>
@@ -325,7 +283,7 @@ namespace osu.Game.Screens.Multi.Components
                 cover.BeatmapSet = null;
                 participantsFlow.FadeOut(transition_duration);
                 participantNumbersFlow.FadeOut(transition_duration);
-                infoPanelFlow.FadeOut(transition_duration);
+                beatmapModeInfo.FadeOut(transition_duration);
                 name.FadeOut(transition_duration);
                 participantInfo.FadeOut(transition_duration);
 
@@ -335,7 +293,7 @@ namespace osu.Game.Screens.Multi.Components
             {
                 participantsFlow.FadeIn(transition_duration);
                 participantNumbersFlow.FadeIn(transition_duration);
-                infoPanelFlow.FadeIn(transition_duration);
+                beatmapModeInfo.FadeIn(transition_duration);
                 name.FadeIn(transition_duration);
                 participantInfo.FadeIn(transition_duration);
 

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Multi.Components
         private UpdateableBeatmapSetCover cover;
         private FillFlowContainer topFlow, participantsFlow, participantNumbersFlow;
         private OsuSpriteText name, status;
-        private BeatmapModeInfo beatmapModeInfo;
+        private BeatmapTypeInfo beatmapTypeInfo;
         private ScrollContainer participantsScroll;
         private ParticipantInfo participantInfo;
 
@@ -188,7 +188,7 @@ namespace osu.Game.Screens.Multi.Components
                                             TextSize = 14,
                                             Font = @"Exo2.0-Bold",
                                         },
-                                        beatmapModeInfo = new BeatmapModeInfo(),
+                                        beatmapTypeInfo = new BeatmapTypeInfo(),
                                     },
                                 },
                             },
@@ -226,13 +226,13 @@ namespace osu.Game.Screens.Multi.Components
 
             nameBind.ValueChanged += n => name.Text = n;
             hostBind.ValueChanged += h => participantInfo.Host = h;
-            typeBind.ValueChanged += t => beatmapModeInfo.Type = t;
+            typeBind.ValueChanged += t => beatmapTypeInfo.Type = t;
             statusBind.ValueChanged += displayStatus;
 
             beatmapBind.ValueChanged += b =>
             {
                 cover.BeatmapSet = b?.BeatmapSet;
-                beatmapModeInfo.Beatmap = b;
+                beatmapTypeInfo.Beatmap = b;
             };
 
             maxParticipantsBind.ValueChanged += m =>
@@ -283,7 +283,7 @@ namespace osu.Game.Screens.Multi.Components
                 cover.BeatmapSet = null;
                 participantsFlow.FadeOut(transition_duration);
                 participantNumbersFlow.FadeOut(transition_duration);
-                beatmapModeInfo.FadeOut(transition_duration);
+                beatmapTypeInfo.FadeOut(transition_duration);
                 name.FadeOut(transition_duration);
                 participantInfo.FadeOut(transition_duration);
 
@@ -293,7 +293,7 @@ namespace osu.Game.Screens.Multi.Components
             {
                 participantsFlow.FadeIn(transition_duration);
                 participantNumbersFlow.FadeIn(transition_duration);
-                beatmapModeInfo.FadeIn(transition_duration);
+                beatmapTypeInfo.FadeIn(transition_duration);
                 name.FadeIn(transition_duration);
                 participantInfo.FadeIn(transition_duration);
 

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -38,7 +38,8 @@ namespace osu.Game.Screens.Multi.Components
         private OsuColour colours;
         private Box statusStrip;
         private UpdateableBeatmapSetCover cover;
-        private FillFlowContainer topFlow, participantsFlow, participantNumbersFlow;
+        private ParticipantCount participantCount;
+        private FillFlowContainer topFlow, participantsFlow;
         private OsuSpriteText name, status;
         private BeatmapTypeInfo beatmapTypeInfo;
         private ScrollContainer participantsScroll;
@@ -81,9 +82,6 @@ namespace osu.Game.Screens.Multi.Components
         {
             this.colours = colours;
 
-            ModeTypeInfo modeTypeInfo;
-            OsuSpriteText participants, participantsSlash, maxParticipants, beatmapAuthor;
-
             Children = new Drawable[]
             {
                 new Box
@@ -120,32 +118,10 @@ namespace osu.Game.Screens.Multi.Components
                                     Padding = new MarginPadding(20),
                                     Children = new Drawable[]
                                     {
-                                        participantNumbersFlow = new FillFlowContainer
+                                        participantCount = new ParticipantCount
                                         {
                                             Anchor = Anchor.TopRight,
                                             Origin = Anchor.TopRight,
-                                            AutoSizeAxes = Axes.Both,
-                                            Direction = FillDirection.Horizontal,
-                                            LayoutDuration = transition_duration,
-                                            Children = new[]
-                                            {
-                                                participants = new OsuSpriteText
-                                                {
-                                                    TextSize = 30,
-                                                    Font = @"Exo2.0-Bold"
-                                                },
-                                                participantsSlash = new OsuSpriteText
-                                                {
-                                                    Text = @"/",
-                                                    TextSize = 30,
-                                                    Font = @"Exo2.0-Light"
-                                                },
-                                                maxParticipants = new OsuSpriteText
-                                                {
-                                                    TextSize = 30,
-                                                    Font = @"Exo2.0-Light"
-                                                },
-                                            },
                                         },
                                         name = new OsuSpriteText
                                         {
@@ -227,6 +203,7 @@ namespace osu.Game.Screens.Multi.Components
             nameBind.ValueChanged += n => name.Text = n;
             hostBind.ValueChanged += h => participantInfo.Host = h;
             typeBind.ValueChanged += t => beatmapTypeInfo.Type = t;
+            maxParticipantsBind.ValueChanged += m => participantCount.Max = m;
             statusBind.ValueChanged += displayStatus;
 
             beatmapBind.ValueChanged += b =>
@@ -235,24 +212,9 @@ namespace osu.Game.Screens.Multi.Components
                 beatmapTypeInfo.Beatmap = b;
             };
 
-            maxParticipantsBind.ValueChanged += m =>
-            {
-                if (m == null)
-                {
-                    participantsSlash.FadeOut(transition_duration);
-                    maxParticipants.FadeOut(transition_duration);
-                }
-                else
-                {
-                    participantsSlash.FadeIn(transition_duration);
-                    maxParticipants.FadeIn(transition_duration);
-                    maxParticipants.Text = m.ToString();
-                }
-            };
-
             participantsBind.ValueChanged += p =>
             {
-                participants.Text = p.Length.ToString();
+                participantCount.Count = p.Length;
                 participantInfo.Participants = p;
                 participantsFlow.ChildrenEnumerable = p.Select(u => new UserTile(u));
             };
@@ -282,7 +244,7 @@ namespace osu.Game.Screens.Multi.Components
             {
                 cover.BeatmapSet = null;
                 participantsFlow.FadeOut(transition_duration);
-                participantNumbersFlow.FadeOut(transition_duration);
+                participantCount.FadeOut(transition_duration);
                 beatmapTypeInfo.FadeOut(transition_duration);
                 name.FadeOut(transition_duration);
                 participantInfo.FadeOut(transition_duration);
@@ -292,7 +254,7 @@ namespace osu.Game.Screens.Multi.Components
             else
             {
                 participantsFlow.FadeIn(transition_duration);
-                participantNumbersFlow.FadeIn(transition_duration);
+                participantCount.FadeIn(transition_duration);
                 beatmapTypeInfo.FadeIn(transition_duration);
                 name.FadeIn(transition_duration);
                 participantInfo.FadeIn(transition_duration);

--- a/osu.Game/Screens/Multi/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Components/RoomInspector.cs
@@ -82,7 +82,8 @@ namespace osu.Game.Screens.Multi.Components
             this.colours = colours;
 
             ModeTypeInfo modeTypeInfo;
-            OsuSpriteText participants, participantsSlash, maxParticipants, beatmapTitle, beatmapDash, beatmapArtist, beatmapAuthor;
+            OsuSpriteText participants, participantsSlash, maxParticipants, beatmapAuthor;
+            BeatmapTitle beatmapTitle;
 
             Children = new Drawable[]
             {
@@ -203,28 +204,9 @@ namespace osu.Game.Screens.Multi.Components
                                                     AutoSizeAxes = Axes.X,
                                                     RelativeSizeAxes = Axes.Y,
                                                     Margin = new MarginPadding { Left = 5 },
-                                                    Children = new[]
+                                                    Children = new Drawable[]
                                                     {
-                                                        new FillFlowContainer
-                                                        {
-                                                            AutoSizeAxes = Axes.Both,
-                                                            Direction = FillDirection.Horizontal,
-                                                            Children = new[]
-                                                            {
-                                                                beatmapTitle = new OsuSpriteText
-                                                                {
-                                                                    Font = @"Exo2.0-BoldItalic",
-                                                                },
-                                                                beatmapDash = new OsuSpriteText
-                                                                {
-                                                                    Font = @"Exo2.0-BoldItalic",
-                                                                },
-                                                                beatmapArtist = new OsuSpriteText
-                                                                {
-                                                                    Font = @"Exo2.0-RegularItalic",
-                                                                },
-                                                            },
-                                                        },
+                                                        beatmapTitle = new BeatmapTitle(),
                                                         beatmapAuthor = new OsuSpriteText
                                                         {
                                                             Anchor = Anchor.BottomLeft,
@@ -283,20 +265,15 @@ namespace osu.Game.Screens.Multi.Components
                 if (b != null)
                 {
                     cover.BeatmapSet = b.BeatmapSet;
-                    beatmapTitle.Current = localisation.GetUnicodePreference(b.Metadata.TitleUnicode, b.Metadata.Title);
-                    beatmapDash.Text = @" - ";
-                    beatmapArtist.Current = localisation.GetUnicodePreference(b.Metadata.ArtistUnicode, b.Metadata.Artist);
+                    beatmapTitle.Beatmap = b;
                     beatmapAuthor.Text = $"mapped by {b.Metadata.Author}";
                 }
                 else
                 {
                     cover.BeatmapSet = null;
+                    beatmapTitle.Beatmap = null;
 
-                    beatmapTitle.Current = null;
-                    beatmapArtist.Current = null;
-
-                    beatmapTitle.Text = "Changing map";
-                    beatmapDash.Text = beatmapArtist.Text = beatmapAuthor.Text = string.Empty;
+                    beatmapAuthor.Text = string.Empty;
                 }
             };
 


### PR DESCRIPTION
Moves some shared logic between `DrawableRoom` and `RoomInspector` into their own classes.

* `BeatmapTitle` - Beatmap title/artist and saying "Changing map" when beatmap is `null`.
* `BeatmapTypeInfo` - Beatmap and `GameType` info from `RoomInspector`, to be shared with the `Match` screen.
* `ParticipantCount` - Count and max amount of participants from `RoomInspector`, to be shared with the `Match` screen.

- [x] Depends on #2667.