### PR TITLE
Add build tasks for visual tests and fix broken launch tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,7 @@
                 "${workspaceRoot}/osu.Game.Tests/bin/Debug/netcoreapp2.0/osu.Game.Tests.dll"
             ],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build (Debug, dotnet)",
+            "preLaunchTask": "Build tests (Debug, dotnet)",
             "env": {},
             "console": "internalConsole"
         },
@@ -76,10 +76,10 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/osu.Game.Tests/bin/Debug/netcoreapp2.0/osu.Game.Tests.dll"
+                "${workspaceRoot}/osu.Game.Tests/bin/Release/netcoreapp2.0/osu.Game.Tests.dll"
             ],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build (Release, dotnet)",
+            "preLaunchTask": "Build tests (Release, dotnet)",
             "env": {},
             "console": "internalConsole"
         },
@@ -92,7 +92,7 @@
                 "${workspaceRoot}/osu.Desktop/bin/Debug/netcoreapp2.0/osu!.dll",
             ],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build (Debug, dotnet)",
+            "preLaunchTask": "Build osu! (Debug, dotnet)",
             "env": {},
             "console": "internalConsole"
         },
@@ -105,7 +105,7 @@
                 "${workspaceRoot}/osu.Desktop/bin/Release/netcoreapp2.0/osu!.dll",
             ],
             "cwd": "${workspaceRoot}",
-            "preLaunchTask": "Build (Release, dotnet)",
+            "preLaunchTask": "Build osu! (Release, dotnet)",
             "env": {},
             "console": "internalConsole"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,7 +31,7 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "Build (Debug, dotnet)",
+            "label": "Build osu! (Debug, dotnet)",
             "type": "shell",
             "command": "dotnet",
             "args": [
@@ -47,13 +47,46 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "Build (Release, dotnet)",
+            "label": "Build osu! (Release, dotnet)",
             "type": "shell",
             "command": "dotnet",
             "args": [
                 "build",
                 "--no-restore",
                 "osu.Desktop",
+                "/p:TargetFramework=netcoreapp2.0",
+                "/p:Configuration=Release",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/verbosity:m"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build tests (Debug, dotnet)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "--no-restore",
+                "osu.Game.Tests",
+                "/p:TargetFramework=netcoreapp2.0",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/verbosity:m"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Build tests (Release, dotnet)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "--no-restore",
+                "osu.Game.Tests",
                 "/p:TargetFramework=netcoreapp2.0",
                 "/p:Configuration=Release",
                 "/p:GenerateFullPaths=true",


### PR DESCRIPTION
What the title says. I wonder if it's possible to make the vscode tasks testable. So far, more than half the time I wanted to test something on my macbook the vscode tasks were broken.