### PR TITLE
Fix conflicting Hash and Online IDs on beatmap import

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -20,6 +20,8 @@
     <StartupObject>osu.Desktop.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup Label="Project References">
+    <!-- This can be removed after .NET Core SDK version 2.1.300; see https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dotnet -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.3" />
     <ProjectReference Include="..\osu-framework\osu.Framework\osu.Framework.csproj" />
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
     <ProjectReference Include="..\osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj" />
@@ -35,5 +37,9 @@
   </ItemGroup>
   <ItemGroup Label="Resources">
     <EmbeddedResource Include="lazer.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- This can be removed after .NET Core SDK version 2.1.300; see https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dotnet -->
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Beatmaps
 
         protected override void Populate(BeatmapSetInfo model, ArchiveReader archive)
         {
-            model.Beatmaps = createBeatmapDifficulties(archive);
+            model.Beatmaps = createBeatmapDifficulties(model, archive);
 
             // remove metadata from difficulties where it matches the set
             foreach (BeatmapInfo b in model.Beatmaps)
@@ -322,7 +322,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Create all required <see cref="BeatmapInfo"/>s for the provided archive.
         /// </summary>
-        private List<BeatmapInfo> createBeatmapDifficulties(ArchiveReader reader)
+        private List<BeatmapInfo> createBeatmapDifficulties(BeatmapSetInfo model, ArchiveReader reader)
         {
             var beatmapInfos = new List<BeatmapInfo>();
 
@@ -341,6 +341,14 @@ namespace osu.Game.Beatmaps
                     beatmap.BeatmapInfo.Path = name;
                     beatmap.BeatmapInfo.Hash = ms.ComputeSHA2Hash();
                     beatmap.BeatmapInfo.MD5Hash = ms.ComputeMD5Hash();
+
+                    // ensure we have the same online set ID as the set itself.
+                    beatmap.BeatmapInfo.OnlineBeatmapSetID = model.OnlineBeatmapSetID;
+                    beatmap.BeatmapInfo.Metadata.OnlineBeatmapSetID = model.OnlineBeatmapSetID;
+
+                    // check that no existing beatmap exists that is imported with the same online beatmap ID. if so, give it precedence.
+                    if (beatmap.BeatmapInfo.OnlineBeatmapID.HasValue && QueryBeatmap(b => b.OnlineBeatmapID.Value == beatmap.BeatmapInfo.OnlineBeatmapID.Value) != null)
+                        beatmap.BeatmapInfo.OnlineBeatmapID = null;
 
                     RulesetInfo ruleset = rulesets.GetRuleset(beatmap.BeatmapInfo.RulesetID);
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -107,6 +107,7 @@ namespace osu.Game.Beatmaps
                 {
                     Delete(existingOnlineId);
                     beatmaps.PurgeDeletable(s => s.ID == existingOnlineId.ID);
+                    Logger.Log($"Found existing beatmap set with same OnlineBeatmapSetID ({model.OnlineBeatmapSetID}). It has been purged.", LoggingTarget.Database);
                 }
             }
 
@@ -303,7 +304,7 @@ namespace osu.Game.Beatmaps
         {
             // let's make sure there are actually .osu files to import.
             string mapName = reader.Filenames.FirstOrDefault(f => f.EndsWith(".osu"));
-            if (string.IsNullOrEmpty(mapName)) throw new InvalidOperationException("No beatmap files found in the map folder.");
+            if (string.IsNullOrEmpty(mapName)) throw new InvalidOperationException("No beatmap files found in this beatmap archive.");
 
             BeatmapMetadata metadata;
             using (var stream = new StreamReader(reader.GetStream(mapName)))

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -190,7 +190,11 @@ namespace osu.Game.Database
 
                         var existing = CheckForExisting(item);
 
-                        if (existing != null) return existing;
+                        if (existing != null)
+                        {
+                            Logger.Log($"Found existing {typeof(TModel)} for {archive.Name} (ID {existing.ID}). Skipping import.", LoggingTarget.Database);
+                            return existing;
+                        }
 
                         item.Files = createFileInfos(archive, Files);
 
@@ -205,9 +209,12 @@ namespace osu.Game.Database
                         throw;
                     }
                 }
+
+                Logger.Log($"Import of {archive.Name} successfully completed!", LoggingTarget.Database);
             }
             catch
             {
+                Logger.Log($"Import of {archive.Name} failed and has been rolled back.", LoggingTarget.Database);
                 item = null;
             }
 

--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -82,8 +82,8 @@ namespace osu.Game.Database
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Entity<BeatmapInfo>().HasIndex(b => b.OnlineBeatmapID).IsUnique();
-            modelBuilder.Entity<BeatmapInfo>().HasIndex(b => b.MD5Hash).IsUnique();
-            modelBuilder.Entity<BeatmapInfo>().HasIndex(b => b.Hash).IsUnique();
+            modelBuilder.Entity<BeatmapInfo>().HasIndex(b => b.MD5Hash);
+            modelBuilder.Entity<BeatmapInfo>().HasIndex(b => b.Hash);
 
             modelBuilder.Entity<BeatmapSetInfo>().HasIndex(b => b.OnlineBeatmapSetID).IsUnique();
             modelBuilder.Entity<BeatmapSetInfo>().HasIndex(b => b.DeletePending);

--- a/osu.Game/Migrations/20180529055154_RemoveUniqueHashConstraints.Designer.cs
+++ b/osu.Game/Migrations/20180529055154_RemoveUniqueHashConstraints.Designer.cs
@@ -10,9 +10,10 @@ using System;
 namespace osu.Game.Migrations
 {
     [DbContext(typeof(OsuDbContext))]
-    partial class OsuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180529055154_RemoveUniqueHashConstraints")]
+    partial class RemoveUniqueHashConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/osu.Game/Migrations/20180529055154_RemoveUniqueHashConstraints.cs
+++ b/osu.Game/Migrations/20180529055154_RemoveUniqueHashConstraints.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.Migrations
+{
+    public partial class RemoveUniqueHashConstraints : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_BeatmapInfo_Hash",
+                table: "BeatmapInfo");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BeatmapInfo_MD5Hash",
+                table: "BeatmapInfo");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BeatmapInfo_Hash",
+                table: "BeatmapInfo",
+                column: "Hash");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BeatmapInfo_MD5Hash",
+                table: "BeatmapInfo",
+                column: "MD5Hash");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_BeatmapInfo_Hash",
+                table: "BeatmapInfo");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BeatmapInfo_MD5Hash",
+                table: "BeatmapInfo");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BeatmapInfo_Hash",
+                table: "BeatmapInfo",
+                column: "Hash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BeatmapInfo_MD5Hash",
+                table: "BeatmapInfo",
+                column: "MD5Hash",
+                unique: true);
+        }
+    }
+}


### PR DESCRIPTION
Removes unique constraints and manually handles collisions on import.

- [x] Depends on #2665.
- Addresses part of #2236.