### PR TITLE
Always update children when the ruleset input manager is updated

### DIFF
--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -121,8 +121,6 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         private bool validState;
 
-        protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate && validState;
-
         private bool isAttached => replayInputHandler != null && !UseParentState;
 
         private const int max_catch_up_updates_per_frame = 50;


### PR DESCRIPTION
The value of `validState` is changed to `false` before children are updated during important sections, causing children to not get updated due to the value of `RequiresChildrenUpdate`.

This lets children always get updated when the ruleset input manager is updated. Whether additional update loops occur is controlled by the value of `validState`.

Partial resolution for #2578 . There's still more to it but this brings it down to a case where it actually is a 1 frame issue (can't pause on it anymore).