### PR TITLE
Add storyboard icon and fix preview button overlap on direct panels

### DIFF
--- a/osu.Game/Beatmaps/BeatmapSetOnlineInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetOnlineInfo.cs
@@ -37,6 +37,11 @@ namespace osu.Game.Beatmaps
         public bool HasVideo { get; set; }
 
         /// <summary>
+        /// Whether or not this beatmap set has a storyboard.
+        /// </summary>
+        public bool HasStoryboard { get; set; }
+
+        /// <summary>
         /// The different sizes of cover art for this beatmap set.
         /// </summary>
         public BeatmapSetOnlineCovers Covers { get; set; }

--- a/osu.Game/Online/API/Requests/APIResponseBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/APIResponseBeatmapSet.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Online.API.Requests
         [JsonProperty(@"video")]
         private bool hasVideo { get; set; }
 
+        [JsonProperty(@"storyboard")]
+        private bool hasStoryboard { get; set; }
+
         [JsonProperty(@"status")]
         private BeatmapSetOnlineStatus status { get; set; }
 
@@ -65,6 +68,7 @@ namespace osu.Game.Online.API.Requests
                     BPM = bpm,
                     Status = status,
                     HasVideo = hasVideo,
+                    HasStoryboard = hasStoryboard,
                     Submitted = submitted,
                     Ranked = ranked,
                     LastUpdated = lastUpdated,

--- a/osu.Game/Overlays/Direct/DirectGridPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectGridPanel.cs
@@ -223,34 +223,22 @@ namespace osu.Game.Overlays.Direct
             {
                 Status = SetInfo.OnlineInfo?.Status ?? BeatmapSetOnlineStatus.None,
             });
+
+            PreviewPlaying.ValueChanged += _ => updateStatusContainer();
         }
 
         protected override bool OnHover(InputState state)
         {
-            statusContainer.FadeOut(120, Easing.InOutQuint);
-
+            updateStatusContainer();
             return base.OnHover(state);
         }
 
         protected override void OnHoverLost(InputState state)
         {
             base.OnHoverLost(state);
-
-            statusContainer.FadeIn(120, Easing.InOutQuint);
+            updateStatusContainer();
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            if (PreviewPlaying)
-            {
-                statusContainer.Hide();
-            }
-            else if (!IsHovered)
-            {
-                statusContainer.Show();
-            }
-        }
+        private void updateStatusContainer() => statusContainer.FadeTo(IsHovered || PreviewPlaying ? 0 : 1, 120, Easing.InOutQuint);
     }
 }

--- a/osu.Game/Overlays/Direct/DirectGridPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectGridPanel.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Overlays.Direct
                                             {
                                                 new OsuSpriteText
                                                 {
-                                                    Text = $"from {SetInfo.Metadata.Source}",
+                                                    Text = $"{SetInfo.Metadata.Source}",
                                                     TextSize = 14,
                                                     Shadow = false,
                                                     Colour = colours.Gray5,
@@ -195,23 +195,28 @@ namespace osu.Game.Overlays.Direct
                         new Statistic(FontAwesome.fa_heart, SetInfo.OnlineInfo?.FavouriteCount ?? 0),
                     },
                 },
-                playButton = new PlayButton(SetInfo)
-                {
-                    Margin = new MarginPadding { Top = 5, Left = 10 },
-                    Size = new Vector2(30),
-                    Alpha = 0,
-                },
                 statusContainer = new FillFlowContainer
                 {
                     AutoSizeAxes = Axes.Both,
                     Margin = new MarginPadding { Top = 5, Left = 5 },
                     Spacing = new Vector2(5),
                 },
+                playButton = new PlayButton(SetInfo)
+                {
+                    Margin = new MarginPadding { Top = 5, Left = 10 },
+                    Size = new Vector2(30),
+                    Alpha = 0,
+                },
             });
 
             if (SetInfo.OnlineInfo?.HasVideo ?? false)
             {
                 statusContainer.Add(new IconPill(FontAwesome.fa_film));
+            }
+
+            if (SetInfo.OnlineInfo?.HasStoryboard ?? false)
+            {
+                statusContainer.Add(new IconPill(FontAwesome.fa_image));
             }
 
             statusContainer.Add(new BeatmapSetOnlineStatusPill(12, new MarginPadding { Horizontal = 10, Vertical = 5 })
@@ -232,6 +237,20 @@ namespace osu.Game.Overlays.Direct
             base.OnHoverLost(state);
 
             statusContainer.FadeIn(120, Easing.InOutQuint);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (PreviewPlaying)
+            {
+                statusContainer.Hide();
+            }
+            else if (!IsHovered)
+            {
+                statusContainer.Show();
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Direct/PlayButton.cs
+++ b/osu.Game/Overlays/Direct/PlayButton.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Overlays.Direct
                 return;
             }
 
-            icon.Icon = playing ? FontAwesome.fa_pause : FontAwesome.fa_play;
+            icon.Icon = playing ? FontAwesome.fa_stop : FontAwesome.fa_play;
             icon.FadeColour(playing || IsHovered ? hoverColour : Color4.White, 120, Easing.InOutQuint);
 
             if (playing)


### PR DESCRIPTION
Bug fixes:
Play button is now on top of status container.
No more overlaps from the two.

Changes and additions:
Added storyboard marker (not yet implemented on web).
Removed `from` in front of source.
Uses the stop icon instead of the pause icon.