### PR TITLE
Swap gameplay mouse settings for consistency

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -54,8 +54,8 @@ namespace osu.Game.Configuration
             Set(OsuSetting.GameplayCursorSize, 1.0, 0.5f, 2, 0.01);
             Set(OsuSetting.AutoCursorSize, false);
 
-            Set(OsuSetting.MouseDisableButtons, false);
-            Set(OsuSetting.MouseDisableWheel, false);
+            Set(OsuSetting.MouseButtons, true);
+            Set(OsuSetting.MouseWheel, true);
 
             // Graphics
             Set(OsuSetting.ShowFpsDisplay, false);
@@ -99,7 +99,7 @@ namespace osu.Game.Configuration
 
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
         {
-            new TrackedSetting<bool>(OsuSetting.MouseDisableButtons, v => new SettingDescription(!v, "gameplay mouse buttons", v ? "disabled" : "enabled"))
+            new TrackedSetting<bool>(OsuSetting.MouseButtons, v => new SettingDescription(v, "gameplay mouse buttons", v ? "enabled" : "disabled"))
         };
     }
 
@@ -116,8 +116,8 @@ namespace osu.Game.Configuration
         KeyOverlay,
         FloatingComments,
         ShowInterface,
-        MouseDisableButtons,
-        MouseDisableWheel,
+        MouseButtons,
+        MouseWheel,
         AudioOffset,
         VolumeInactive,
         MenuMusic,

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -468,7 +468,7 @@ namespace osu.Game
                     direct.ToggleVisibility();
                     return true;
                 case GlobalAction.ToggleGameplayMouseButtons:
-                    LocalConfig.Set(OsuSetting.MouseDisableButtons, !LocalConfig.Get<bool>(OsuSetting.MouseDisableButtons));
+                    LocalConfig.Set(OsuSetting.MouseButtons, !LocalConfig.Get<bool>(OsuSetting.MouseButtons));
                     return true;
             }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -45,13 +45,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Disable mouse wheel during gameplay",
-                    Bindable = osuConfig.GetBindable<bool>(OsuSetting.MouseDisableWheel)
+                    LabelText = "Mouse wheel during gameplay",
+                    Bindable = osuConfig.GetBindable<bool>(OsuSetting.MouseWheel)
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Disable mouse buttons during gameplay",
-                    Bindable = osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons)
+                    LabelText = "Mouse buttons during gameplay",
+                    Bindable = osuConfig.GetBindable<bool>(OsuSetting.MouseButtons)
                 },
             };
 

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -196,12 +196,12 @@ namespace osu.Game.Rulesets.UI
 
         #region Setting application (disables etc.)
 
-        private Bindable<bool> mouseDisabled;
+        private Bindable<bool> mouseButtons;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            mouseDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableButtons);
+            mouseButtons = config.GetBindable<bool>(OsuSetting.MouseButtons);
         }
 
         protected override void TransformState(InputState state)
@@ -215,7 +215,7 @@ namespace osu.Game.Rulesets.UI
 
             if (mouse != null)
             {
-                if (mouseDisabled.Value)
+                if (!mouseButtons.Value)
                 {
                     mouse.SetPressed(MouseButton.Left, false);
                     mouse.SetPressed(MouseButton.Right, false);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Play
 
         protected override bool AllowBackButton => false;
 
-        private Bindable<bool> mouseWheelDisabled;
+        private Bindable<bool> mouseWheel;
         private Bindable<double> userAudioOffset;
 
         public int RestartCount;
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.Play
 
             sampleRestart = audio.Sample.Get(@"Gameplay/restart");
 
-            mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
+            mouseWheel = config.GetBindable<bool>(OsuSetting.MouseWheel);
             userAudioOffset = config.GetBindable<double>(OsuSetting.AudioOffset);
 
             IBeatmap beatmap;
@@ -364,7 +364,7 @@ namespace osu.Game.Screens.Play
             Background?.FadeTo(1f, fade_out_duration);
         }
 
-        protected override bool OnWheel(InputState state) => mouseWheelDisabled.Value && !pauseContainer.IsPaused;
+        protected override bool OnWheel(InputState state) => !mouseWheel.Value && !pauseContainer.IsPaused;
 
         private void initializeStoryboard(bool asyncLoad)
         {

--- a/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
@@ -19,12 +19,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
             {
                 mouseButtonsCheckbox = new PlayerCheckbox
                 {
-                    LabelText = "Disable mouse buttons"
+                    LabelText = "Mouse buttons"
                 }
             };
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config) => mouseButtonsCheckbox.Bindable = config.GetBindable<bool>(OsuSetting.MouseDisableButtons);
+        private void load(OsuConfigManager config) => mouseButtonsCheckbox.Bindable = config.GetBindable<bool>(OsuSetting.MouseButtons);
     }
 }


### PR DESCRIPTION
Removed the `disable` and `enable` keywords on setting labels, which was only on the mouse settings. The other settings were already affected(i.e. ~disable~ storyboard on stable).

Don't know if this is a correct execution of changing the code, but it works.

Also fixes the inconsistency of this.
![before](https://user-images.githubusercontent.com/35318437/40795969-773f0236-64b8-11e8-8a55-d29bf24f4e5b.png)

![after](https://user-images.githubusercontent.com/35318437/40795972-789927ec-64b8-11e8-8a9c-674e956ff07a.png)



