### PR TITLE
Remove link colours from beatmap tags

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -135,8 +135,8 @@ namespace osu.Game.Overlays.BeatmapSet
         private void load(OsuColour colours)
         {
             successRateBackground.Colour = colours.GrayE;
-            source.TextColour = description.TextColour = colours.Gray5;
-            tags.TextColour = colours.BlueDark;
+            description.TextColour = colours.Gray5;
+            source.TextColour = tags.TextColour = colours.BlueDark;
 
             updateDisplay();
         }

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -135,8 +135,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private void load(OsuColour colours)
         {
             successRateBackground.Colour = colours.GrayE;
-            description.TextColour = colours.Gray5;
-            source.TextColour = tags.TextColour = colours.BlueDark;
+            description.TextColour = source.TextColour = tags.TextColour = colours.Gray5;
 
             updateDisplay();
         }

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private const float metadata_width = 225;
         private const float spacing = 20;
 
-        private readonly MetadataSection description, source, tags;
+        private readonly MetadataSection source, tags;
         private readonly Box successRateBackground;
         private readonly SuccessRate successRate;
 
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.BeatmapSet
                             Child = new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Child = description = new MetadataSection("Description"),
+                                Child = new MetadataSection("Description"),
                             },
                         },
                         new Container

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -135,7 +135,6 @@ namespace osu.Game.Overlays.BeatmapSet
         private void load(OsuColour colours)
         {
             successRateBackground.Colour = colours.GrayE;
-            description.TextColour = source.TextColour = tags.TextColour = colours.Gray5;
 
             updateDisplay();
         }
@@ -194,7 +193,7 @@ namespace osu.Game.Overlays.BeatmapSet
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                header.Colour = colours.Gray5;
+                header.Colour = textFlow.Colour = colours.Gray5;
             }
         }
     }

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -356,7 +356,7 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Colour = textFlow.Colour,
+                    Colour = Color4.White.Opacity(0.75f),
                     Text = text
                 }, loaded =>
                 {
@@ -366,18 +366,6 @@ namespace osu.Game.Screens.Select
                     // fade in if we haven't yet.
                     this.FadeIn(transition_duration);
                 });
-            }
-
-            public Color4 TextColour
-            {
-                get { return textFlow.Colour; }
-                set { textFlow.Colour = value; }
-            }
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                textFlow.Colour = Color4.White.Opacity(0.75f);
             }
         }
 

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -6,7 +6,6 @@ using OpenTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using System.Linq;
@@ -120,10 +119,7 @@ namespace osu.Game.Screens.Select
                                         Margin = new MarginPadding { Top = spacing * 2 },
                                         Children = new[]
                                         {
-                                            description = new MetadataSection("Description")
-                                            {
-                                                TextColour = Color4.White.Opacity(0.75f),
-                                            },
+                                            description = new MetadataSection("Description"),
                                             source = new MetadataSection("Source"),
                                             tags = new MetadataSection("Tags"),
                                         },
@@ -161,10 +157,10 @@ namespace osu.Game.Screens.Select
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, APIAccess api)
+        private void load(APIAccess api)
         {
             this.api = api;
-            source.TextColour = tags.TextColour = colours.Yellow;
+            description.TextColour = source.TextColour = tags.TextColour = Color4.White.Opacity(0.75f);
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -160,7 +160,6 @@ namespace osu.Game.Screens.Select
         private void load(APIAccess api)
         {
             this.api = api;
-            description.TextColour = source.TextColour = tags.TextColour = Color4.White.Opacity(0.75f);
         }
 
         protected override void UpdateAfterChildren()
@@ -373,6 +372,12 @@ namespace osu.Game.Screens.Select
             {
                 get { return textFlow.Colour; }
                 set { textFlow.Colour = value; }
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                textFlow.Colour = Color4.White.Opacity(0.75f);
             }
         }
 

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -124,10 +124,7 @@ namespace osu.Game.Screens.Select
                                             {
                                                 TextColour = Color4.White.Opacity(0.75f),
                                             },
-                                            source = new MetadataSection("Source")
-                                            {
-                                                TextColour = Color4.White.Opacity(0.75f),
-                                            },
+                                            source = new MetadataSection("Source"),
                                             tags = new MetadataSection("Tags"),
                                         },
                                     },
@@ -167,7 +164,7 @@ namespace osu.Game.Screens.Select
         private void load(OsuColour colours, APIAccess api)
         {
             this.api = api;
-            tags.TextColour = colours.Yellow;
+            source.TextColour = tags.TextColour = colours.Yellow;
         }
 
         protected override void UpdateAfterChildren()


### PR DESCRIPTION
~Since tags have the same colour and can link, it should be the same for sources. Not yet linked as a search term though.~