### PR TITLE
Match beatmap overlay author styling with web

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/AuthorInfo.cs
+++ b/osu.Game/Overlays/BeatmapSet/AuthorInfo.cs
@@ -49,8 +49,8 @@ namespace osu.Game.Overlays.BeatmapSet
 
             fields.Children = new Drawable[]
             {
-                new Field("made by", BeatmapSet.Metadata.Author.Username, @"Exo2.0-RegularItalic"),
-                new Field("submitted on", online.Submitted.ToString(@"MMM d, yyyy"), @"Exo2.0-Bold")
+                new Field("mapped by", BeatmapSet.Metadata.Author.Username, @"Exo2.0-RegularItalic"),
+                new Field("submitted on", online.Submitted.ToString(@"MMMM d, yyyy"), @"Exo2.0-Bold")
                 {
                     Margin = new MarginPadding { Top = 5 },
                 },
@@ -58,11 +58,11 @@ namespace osu.Game.Overlays.BeatmapSet
 
             if (online.Ranked.HasValue)
             {
-                fields.Add(new Field("ranked on ", online.Ranked.Value.ToString(@"MMM d, yyyy"), @"Exo2.0-Bold"));
+                fields.Add(new Field("ranked on", online.Ranked.Value.ToString(@"MMMM d, yyyy"), @"Exo2.0-Bold"));
             }
             else if (online.LastUpdated.HasValue)
             {
-                fields.Add(new Field("last updated on ", online.LastUpdated.Value.ToString(@"MMM d, yyyy"), @"Exo2.0-Bold"));
+                fields.Add(new Field("last updated on", online.LastUpdated.Value.ToString(@"MMMM d, yyyy"), @"Exo2.0-Bold"));
             }
         }
 


### PR DESCRIPTION
Fixes and changes:
- Removed extra space.
- Do not shorten months.

![infobefore](https://user-images.githubusercontent.com/35318437/40809609-e972f200-64df-11e8-9288-9375d931d496.png)
![infoafter](https://user-images.githubusercontent.com/35318437/40809612-eb64bf6c-64df-11e8-833a-1a333b79d06e.png)

Problems:
Doesn't check beatmap status (stays at `ranked on`, wrong check I think)