### PR TITLE
Default ParticipantCount.Max to null

### DIFF
--- a/osu.Game/Screens/Multi/Components/ParticipantCount.cs
+++ b/osu.Game/Screens/Multi/Components/ParticipantCount.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Screens.Multi.Components
                     Font = @"Exo2.0-Light"
                 },
             };
+
+            Max = null;
         }
     }
 }

--- a/osu.Game/Screens/Multi/Components/ParticipantCount.cs
+++ b/osu.Game/Screens/Multi/Components/ParticipantCount.cs
@@ -12,28 +12,23 @@ namespace osu.Game.Screens.Multi.Components
         private const float text_size = 30;
         private const float transition_duration = 100;
 
-        private readonly OsuSpriteText count, slash, max;
+        private readonly OsuSpriteText count, slash, maxText;
 
         public int Count
         {
             set => count.Text = value.ToString();
         }
 
+        private int? max;
         public int? Max
         {
+            get => max;
             set
             {
-                if (value == null)
-                {
-                    slash.FadeOut(transition_duration);
-                    max.FadeOut(transition_duration);
-                }
-                else
-                {
-                    slash.FadeIn(transition_duration);
-                    max.Text = value.ToString();
-                    max.FadeIn(transition_duration);
-                }
+                if (value == max) return;
+                max = value;
+
+                updateMax();
             }
         }
 
@@ -56,14 +51,29 @@ namespace osu.Game.Screens.Multi.Components
                     TextSize = text_size,
                     Font = @"Exo2.0-Light"
                 },
-                max = new OsuSpriteText
+                maxText = new OsuSpriteText
                 {
                     TextSize = text_size,
                     Font = @"Exo2.0-Light"
                 },
             };
 
-            Max = null;
+            updateMax();
+        }
+
+        private void updateMax()
+        {
+            if (Max == null)
+            {
+                slash.FadeOut(transition_duration);
+                maxText.FadeOut(transition_duration);
+            }
+            else
+            {
+                slash.FadeIn(transition_duration);
+                maxText.Text = Max.ToString();
+                maxText.FadeIn(transition_duration);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes a bug in `RoomInspector` where if the first room displayed has `MaxParticipants` set to `null` then the `ParticipantCount` would leave the slash visible.