### PR TITLE
Fix initial state of visual settings expand button colour

### DIFF
--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     content.ResizeHeightTo(0, transition_duration, Easing.OutQuint);
                 }
 
-                button.FadeColour(expanded ? expandedColour : Color4.White, 200, Easing.OutQuint);
+                updateExpanded();
             }
         }
 
@@ -130,10 +130,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            button.FadeColour(expanded ? colours.Yellow : Color4.White);
-
             expandedColour = colours.Yellow;
+
+            updateExpanded();
         }
+
+        private void updateExpanded() => button.FadeColour(expanded ? expandedColour : Color4.White, 200, Easing.InOutQuint);
 
         protected override Container<Drawable> Content => content;
 

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
@@ -50,11 +50,11 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     content.ResizeHeightTo(0, transition_duration, Easing.OutQuint);
                 }
 
-                button.FadeColour(expanded ? buttonActiveColour : Color4.White, 200, Easing.OutQuint);
+                button.FadeColour(expanded ? expandedColour : Color4.White, 200, Easing.OutQuint);
             }
         }
 
-        private Color4 buttonActiveColour;
+        private Color4 expandedColour;
 
         protected PlayerSettingsGroup()
         {
@@ -130,7 +130,16 @@ namespace osu.Game.Screens.Play.PlayerSettings
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            button.Colour = buttonActiveColour = colours.Yellow;
+            if (expanded)
+            {
+                button.Colour = colours.Yellow;
+            }
+            else
+            {
+                button.Colour = Color4.White;
+            }
+
+            expandedColour = colours.Yellow;
         }
 
         protected override Container<Drawable> Content => content;

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
@@ -130,14 +130,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            if (expanded)
-            {
-                button.Colour = colours.Yellow;
-            }
-            else
-            {
-                button.Colour = Color4.White;
-            }
+            button.FadeColour(expanded ? colours.Yellow : Color4.White);
 
             expandedColour = colours.Yellow;
         }


### PR DESCRIPTION
Shows the right colour now on the button for default collapsed player menus.
![defaults](https://user-images.githubusercontent.com/35318437/40866307-d883cf6e-65b1-11e8-9bc7-94f61b07fcab.png)

Changed the naming because the colour is shown on expanded menus.