### PR TITLE
Fix song progress elapsed time rounding up on some cultures

### DIFF
--- a/osu.Game/Screens/Play/SongProgressInfo.cs
+++ b/osu.Game/Screens/Play/SongProgressInfo.cs
@@ -92,6 +92,6 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private string formatTime(TimeSpan timeSpan) => $"{(timeSpan < TimeSpan.Zero ? "-" : "")}{timeSpan.Duration().TotalMinutes:N0}:{timeSpan.Duration().Seconds:D2}";
+        private string formatTime(TimeSpan timeSpan) => $"{(timeSpan < TimeSpan.Zero ? "-" : "")}{Math.Floor(timeSpan.Duration().TotalMinutes)}:{timeSpan.Duration().Seconds:D2}";
     }
 }


### PR DESCRIPTION
Closes #2684.

The old approach (equivalent to `timeSpan.Duration().TotalMinutes.ToString("N0")`) just rounded the number, which resulted in 30+ seconds (-> `TotalMinutes >= 0.5`) being rounded UP to display a 1.