### PR TITLE
Fix web request failures not being correctly handled at an APIRequest level

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Beatmaps
             {
                 if (error is OperationCanceledException) return;
 
-                downloadNotification.State = ProgressNotificationState.Completed;
+                downloadNotification.State = ProgressNotificationState.Cancelled;
                 Logger.Error(error, "Beatmap download failed!");
                 currentDownloads.Remove(request);
             };

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -73,6 +73,7 @@ namespace osu.Game.Online.API
                 throw new TimeoutException(@"API request timeout hit");
 
             WebRequest = CreateWebRequest();
+            WebRequest.Failed += Fail;
             WebRequest.AllowRetryOnTimeout = false;
             WebRequest.AddHeader("Authorization", $"Bearer {api.AccessToken}");
 


### PR DESCRIPTION
Fixes failed beatmap downloads sticking in a "downloading" state.