### PR TITLE
Fix ImportBeatmapTest not working on .net core

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -264,7 +264,8 @@ namespace osu.Game.Tests.Beatmaps.IO
 
         private string createTemporaryBeatmap()
         {
-            var temp = new FileInfo(osz_path).CopyTo(Path.GetTempFileName(), true).FullName;
+            var temp = Path.GetTempFileName() + Guid.NewGuid() + ".osz";
+            File.Copy(osz_path, temp, true);
             Assert.IsTrue(File.Exists(temp));
             return temp;
         }
@@ -344,12 +345,12 @@ namespace osu.Game.Tests.Beatmaps.IO
 
         private void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 60000)
         {
-            Action waitAction = () =>
+            Task task = Task.Run(() =>
             {
                 while (!result()) Thread.Sleep(200);
-            };
+            });
 
-            Assert.IsTrue(waitAction.BeginInvoke(null, null).AsyncWaitHandle.WaitOne(timeout), failureMessage);
+            Assert.IsTrue(task.Wait(timeout), failureMessage);
         }
     }
 }

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -264,7 +264,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
         private string createTemporaryBeatmap()
         {
-            var temp = Path.GetTempFileName() + Guid.NewGuid() + ".osz";
+            var temp = Path.GetTempFileName() + ".osz";
             File.Copy(osz_path, temp, true);
             Assert.IsTrue(File.Exists(temp));
             return temp;


### PR DESCRIPTION
Action.BeginInvoke is not supported on .net core.
Also makes sure that the temporary file extension is .osz which is necessary for currently disabled test TestImportOverIPC.