### PR TITLE
Fix volume control adjustment being extreme when precision scrolling

### DIFF
--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -167,9 +167,25 @@ namespace osu.Game.Overlays.Volume
             private set => Bindable.Value = value;
         }
 
-        public void Increase() => Volume += 0.05f;
+        private const float adjust_step = 0.05f;
 
-        public void Decrease() => Volume -= 0.05f;
+        public void Increase() => adjust(1);
+        public void Decrease() => adjust(-1);
+
+        private void adjust(int direction)
+        {
+            float amount = adjust_step * direction;
+
+            var mouse = GetContainingInputManager().CurrentState.Mouse;
+            if (mouse.HasPreciseScroll)
+            {
+                float scrollDelta = mouse.ScrollDelta.Y;
+                if (scrollDelta != 0)
+                    amount *= Math.Abs(scrollDelta / 10);
+            }
+
+            Volume += amount;
+        }
 
         public bool OnPressed(GlobalAction action)
         {


### PR DESCRIPTION
Obviously this implementation is not optimal, but I'm struggling to find a better way to handle this. OnPressed doesn't provide any data directly, so I'm resorting to directly checking the state for scroll delta presence.

This has the issue of potentially adjusting incorrectly under *very* specific conditions (all of these below must be true):

- User has bound other volume adjust keys
- User has unbound scroll wheel from volume adjust
- User has a precise scrolling device
- User presses key bind and scrolls in the same input frame

Note that even in this case, the only outcome will be a slightly different adjust amount to usual.

Open to suggestion if anyone has a better way of handling this, but at very least this is a huge improvement over how it handles now (scrolling 2mm on trackpad will change volume from 0 to 100; it's impossible to adjust currently)