### PR TITLE
Add appveyor nuget source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="AppVeyor" value="https://ci.appveyor.com/nuget/osu-framework" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
So we don't need to tell people to/how to put it in their global config.