### PR TITLE
 Fix gameplay memory leak due to incorrect binding

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursor.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                 };
 
                 this.beatmap.BindTo(beatmap);
-                beatmap.ValueChanged += v => calculateScale();
+                this.beatmap.ValueChanged += v => calculateScale();
 
                 cursorScale = config.GetBindable<double>(OsuSetting.GameplayCursorSize);
                 cursorScale.ValueChanged += v => calculateScale();

--- a/osu.Game/Tests/Visual/TestCasePlayer.cs
+++ b/osu.Game/Tests/Visual/TestCasePlayer.cs
@@ -45,7 +45,6 @@ namespace osu.Game.Tests.Visual
                 Player p = null;
                 AddStep(ruleset.RulesetInfo.Name, () => p = loadPlayerFor(ruleset));
                 AddUntilStep(() => ContinueCondition(p));
-
             }
             else
             {

--- a/osu.Game/Tests/Visual/TestCasePlayer.cs
+++ b/osu.Game/Tests/Visual/TestCasePlayer.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Lists;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -43,6 +46,7 @@ namespace osu.Game.Tests.Visual
                 Player p = null;
                 AddStep(ruleset.RulesetInfo.Name, () => p = loadPlayerFor(ruleset));
                 AddUntilStep(() => ContinueCondition(p));
+
             }
             else
             {
@@ -51,6 +55,20 @@ namespace osu.Game.Tests.Visual
                     Player p = null;
                     AddStep(r.Name, () => p = loadPlayerFor(r));
                     AddUntilStep(() => ContinueCondition(p));
+                    AddAssert("no leaked beatmaps", () =>
+                    {
+                        p = null;
+
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        int count = 0;
+
+                        workingWeakReferences.ForEachAlive(_ => count++);
+
+                        Logger.Log($"reference count {count}");
+
+                        return count == 1;
+                    });
                 }
             }
         }
@@ -59,21 +77,29 @@ namespace osu.Game.Tests.Visual
 
         protected virtual IBeatmap CreateBeatmap(Ruleset ruleset) => new TestBeatmap(ruleset.RulesetInfo);
 
+        private readonly WeakList<WorkingBeatmap> workingWeakReferences = new WeakList<WorkingBeatmap>();
+
         private Player loadPlayerFor(RulesetInfo ri) => loadPlayerFor(ri.CreateInstance());
 
         private Player loadPlayerFor(Ruleset r)
         {
             var beatmap = CreateBeatmap(r);
+            var working = new TestWorkingBeatmap(beatmap);
 
-            Beatmap.Value = new TestWorkingBeatmap(beatmap);
+            workingWeakReferences.Add(working);
+
+            Beatmap.Value = working;
             Beatmap.Value.Mods.Value = new[] { r.GetAllMods().First(m => m is ModNoFail) };
 
-            if (Player != null)
-                Remove(Player);
+            Player?.Exit();
 
             var player = CreatePlayer(r);
 
-            LoadComponentAsync(player, LoadScreen);
+            LoadComponentAsync(player, p =>
+            {
+                Player = p;
+                LoadScreen(p);
+            });
 
             return player;
         }


### PR DESCRIPTION
Resolves the memory leak portion of #2787 (does not fix the beatmap taking 4gb to load, which will be fixed elsewhere and close that issue).