### PR TITLE
Fix player metadata not being centred

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -218,7 +218,7 @@ namespace osu.Game.Screens.Play
 
         private class BeatmapMetadataDisplay : Container
         {
-            private class MetadataLine : Container
+            private class MetadataLine : FillFlowContainer
             {
                 public MetadataLine(string left, string right)
                 {


### PR DESCRIPTION
Fixes #2414. `MetadataLine` inherited `Container`. Changed it to inherit `FillFlowContainer` to make it work.
![metadata](https://user-images.githubusercontent.com/35318437/41370808-6ffd8228-6efd-11e8-8351-07d5738cfc70.png)
