### PR TITLE
Fix combos ending with JuiceStreams never leaving the catcher's plate

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -124,6 +124,9 @@ namespace osu.Game.Rulesets.Catch.Objects
                     X = X + Curve.PositionAt(reversed ? 0 : 1).X / CatchPlayfield.BASE_WIDTH
                 });
             }
+
+            if (NestedHitObjects.LastOrDefault() is IHasComboInformation lastNested)
+                lastNested.LastInCombo = LastInCombo;
         }
 
         public double EndTime => StartTime + this.SpanCount() * Curve.Distance / Velocity;


### PR DESCRIPTION
Closes #2634.