### PR TITLE
Don't compute keymod difficulties for mania-specific beatmap

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -29,9 +29,12 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         /// </summary>
         private const double decay_weight = 0.9;
 
+        private readonly bool isForCurrentRuleset;
+
         public ManiaDifficultyCalculator(Ruleset ruleset, WorkingBeatmap beatmap)
             : base(ruleset, beatmap)
         {
+            isForCurrentRuleset = beatmap.BeatmapInfo.Ruleset.Equals(new ManiaRuleset().RulesetInfo);
         }
 
         protected override DifficultyAttributes Calculate(IBeatmap beatmap, Mod[] mods, double timeRate)
@@ -129,22 +132,38 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             return difficulty;
         }
 
-        protected override Mod[] DifficultyAdjustmentMods => new Mod[]
+        protected override Mod[] DifficultyAdjustmentMods
         {
-            new ManiaModDoubleTime(),
-            new ManiaModHalfTime(),
-            new ManiaModEasy(),
-            new ManiaModHardRock(),
-            new ManiaModKey1(),
-            new ManiaModKey2(),
-            new ManiaModKey3(),
-            new ManiaModKey4(),
-            new ManiaModKey5(),
-            new ManiaModKey6(),
-            new ManiaModKey7(),
-            new ManiaModKey8(),
-            new ManiaModKey9(),
-        };
+            get
+            {
+                if (isForCurrentRuleset)
+                {
+                    return new Mod[]
+                    {
+                        new ManiaModDoubleTime(),
+                        new ManiaModHalfTime(),
+                        new ManiaModEasy(),
+                        new ManiaModHardRock(),
+                    };
+                }
 
+                return new Mod[]
+                {
+                    new ManiaModDoubleTime(),
+                    new ManiaModHalfTime(),
+                    new ManiaModEasy(),
+                    new ManiaModHardRock(),
+                    new ManiaModKey1(),
+                    new ManiaModKey2(),
+                    new ManiaModKey3(),
+                    new ManiaModKey4(),
+                    new ManiaModKey5(),
+                    new ManiaModKey6(),
+                    new ManiaModKey7(),
+                    new ManiaModKey8(),
+                    new ManiaModKey9(),
+                };
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -136,23 +136,20 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         {
             get
             {
-                if (isForCurrentRuleset)
-                {
-                    return new Mod[]
-                    {
-                        new ManiaModDoubleTime(),
-                        new ManiaModHalfTime(),
-                        new ManiaModEasy(),
-                        new ManiaModHardRock(),
-                    };
-                }
-
-                return new Mod[]
+                var mods = new Mod[]
                 {
                     new ManiaModDoubleTime(),
                     new ManiaModHalfTime(),
                     new ManiaModEasy(),
                     new ManiaModHardRock(),
+                };
+
+                if (isForCurrentRuleset)
+                    return mods;
+
+                // if we are a convert, we can be played in any key mod.
+                return mods.Concat(new Mod[]
+                {
                     new ManiaModKey1(),
                     new ManiaModKey2(),
                     new ManiaModKey3(),
@@ -162,7 +159,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
                     new ManiaModKey7(),
                     new ManiaModKey8(),
                     new ManiaModKey9(),
-                };
+                }).ToArray();
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         public ManiaDifficultyCalculator(Ruleset ruleset, WorkingBeatmap beatmap)
             : base(ruleset, beatmap)
         {
-            isForCurrentRuleset = beatmap.BeatmapInfo.Ruleset.Equals(new ManiaRuleset().RulesetInfo);
+            isForCurrentRuleset = beatmap.BeatmapInfo.Ruleset.Equals(ruleset.RulesetInfo);
         }
 
         protected override DifficultyAttributes Calculate(IBeatmap beatmap, Mod[] mods, double timeRate)


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/2802

Since keymods don't change mania-specific beatmaps.