### PR TITLE
Always perform non-seeked scroll in the editor while audio is playing

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -181,9 +181,9 @@ namespace osu.Game.Screens.Edit
         protected override bool OnScroll(InputState state)
         {
             if (state.Mouse.ScrollDelta.X + state.Mouse.ScrollDelta.Y > 0)
-                clock.SeekBackward(true);
+                clock.SeekBackward(!clock.IsRunning);
             else
-                clock.SeekForward(true);
+                clock.SeekForward(!clock.IsRunning);
             return true;
         }
 


### PR DESCRIPTION
Without this, while the audio is playing you could never scroll backwards beyond the current beat.