### PR TITLE
Remove low BPM barline increase in taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoRulesetContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoRulesetContainer.cs
@@ -70,8 +70,6 @@ namespace osu.Game.Rulesets.Taiko.UI
                 Playfield.Add(isMajor ? new DrawableBarLineMajor(barLine) : new DrawableBarLine(barLine));
 
                 double bl = currentPoint.BeatLength;
-                if (bl < 800)
-                    bl *= (int)currentPoint.TimeSignature;
 
                 time += bl;
                 currentBeat++;


### PR DESCRIPTION
Remove code that I am almost 100% sure that makes barlines every 1/1 instead of 4/1 at or below 75bpm. 

Currently it is unrankable to have a map at or below 75 bpm. Having the BPM of a map subject to rules is utterly silly. There are examples of this rule being enforced, such as https://osu.ppy.sh/forum/p/6255493#p6255493 and in this mapset https://osu.ppy.sh/s/673311 . This isn't a ranking criteria issue though, this is a game engine issue. If it is unrankable to have unpleasing barlines that the game itself creates, the solution isn't to force the mapper to deal with it. Its to fix the game. Thats what I suggest to do. There should be barlines every 4/1 no matter the BPM. It shouldn't be on the mapper to correct barline issues, it should be on the game.

---

Currently in osu!taiko, if the bpm of a map is at or below 75bpm bar lines are drawn every 1/1 instead of every 4/1 which is the norm for maps above 75 bpm. This is problematic, as it goes against the taiko ranking criteria. It "[hinders] gameplay experience aesthetically by adding unnecessary bar lines.".

This change removes these extra bar lines.