### PR TITLE
Fix race condition causing TestCaseLounge to randomly fail

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseLounge.cs
+++ b/osu.Game.Tests/Visual/TestCaseLounge.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Tests.Visual
             AddStep(@"set rooms", () => lounge.Rooms = rooms);
             selectAssert(1);
             AddStep(@"open room 1", () => clickRoom(1));
-            AddUntilStep(() => !lounge.IsCurrentScreen, "wait until room current");
+            AddUntilStep(() => lounge.ChildScreen?.IsCurrentScreen == true, "wait until room current");
             AddStep(@"make lounge current", lounge.MakeCurrent);
             filterAssert(@"THE FINAL", LoungeTab.Public, 1);
             filterAssert(string.Empty, LoungeTab.Public, 2);


### PR DESCRIPTION
As seen [here](https://ci.appveyor.com/project/peppy/osu/build/master-9634) the `IsCurrentScreen` check is not enough due to `Push`'s async logic.


---