### PR TITLE
Always proxy taiko hits when hit

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -95,8 +95,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                         break;
                     case ArmedState.Hit:
                         // If we're far enough away from the left stage, we should bring outselves in front of it
-                        if (X >= -0.05f)
-                            ProxyContent();
+                        ProxyContent();
 
                         var flash = circlePiece?.FlashBox;
                         if (flash != null)


### PR DESCRIPTION
Notes that are proxied into the above layer don't get masked by the playfield. Gameplay looks awkward when this occurs randomly depending on the user's hitting accuracy.

- Closes #2853

---
Fixes taiko notes getting masked inside the playfield even when hit.