### PR TITLE
Handle virtual beatmap tracks more gracefully

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Beatmaps
                 }
                 catch
                 {
-                    return new TrackVirtual();
+                    return null;
                 }
             }
 

--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -73,7 +73,18 @@ namespace osu.Game.Beatmaps
                 }
             }
 
-            protected override Waveform GetWaveform() => new Waveform(store.GetStream(getPathForFile(Metadata.AudioFile)));
+            protected override Waveform GetWaveform()
+            {
+                try
+                {
+                    var trackData = store.GetStream(getPathForFile(Metadata.AudioFile));
+                    return trackData == null ? null : new Waveform(trackData);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
 
             protected override Storyboard GetStoryboard()
             {

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Beatmaps
 
         protected override Texture GetBackground() => game?.Textures.Get(@"Backgrounds/bg4");
 
-        protected override Track GetTrack() => new TrackVirtual();
+        protected override Track GetTrack() => new TrackVirtual { Length = 1000 };
 
         private class DummyRulesetInfo : RulesetInfo
         {

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -19,7 +19,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Beatmaps
 {
-    public abstract class WorkingBeatmap : IDisposable
+    public abstract partial class WorkingBeatmap : IDisposable
     {
         public readonly BeatmapInfo BeatmapInfo;
 
@@ -145,7 +145,7 @@ namespace osu.Game.Beatmaps
         private Track populateTrack()
         {
             // we want to ensure that we always have a track, even if it's a fake one.
-            var t = GetTrack() ?? new TrackVirtual();
+            var t = GetTrack() ?? new VirtualBeatmapTrack(Beatmap);
             applyRateAdjustments(t);
             return t;
         }

--- a/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System.Linq;
+using osu.Framework.Audio.Track;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Beatmaps
+{
+    public partial class WorkingBeatmap
+    {
+        private class VirtualBeatmapTrack : TrackVirtual
+        {
+            private readonly IBeatmap beatmap;
+
+            public VirtualBeatmapTrack(IBeatmap beatmap)
+            {
+                this.beatmap = beatmap;
+            }
+
+            protected override void UpdateState()
+            {
+                updateVirtualLength();
+                base.UpdateState();
+            }
+
+            private void updateVirtualLength()
+            {
+                var lastObject = beatmap.HitObjects.LastOrDefault();
+
+                switch (lastObject)
+                {
+                    case null:
+                        Length = 1000;
+                        break;
+                    case IHasEndTime endTime:
+                        Length = endTime.EndTime + 1000;
+                        break;
+                    default:
+                        Length = lastObject.StartTime + 1000;
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// A type of <see cref="TrackVirtual"/> which provides a valid length based on the <see cref="HitObject"/>s of an <see cref="IBeatmap"/>.
         /// </summary>
-        private class VirtualBeatmapTrack : TrackVirtual
+        protected class VirtualBeatmapTrack : TrackVirtual
         {
             private readonly IBeatmap beatmap;
 

--- a/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Beatmaps
         /// </summary>
         protected class VirtualBeatmapTrack : TrackVirtual
         {
+            private const double excess_length = 1000;
+
             private readonly IBeatmap beatmap;
 
             public VirtualBeatmapTrack(IBeatmap beatmap)
@@ -35,13 +37,13 @@ namespace osu.Game.Beatmaps
                 switch (lastObject)
                 {
                     case null:
-                        Length = 1000;
+                        Length = excess_length;
                         break;
                     case IHasEndTime endTime:
-                        Length = endTime.EndTime + 1000;
+                        Length = endTime.EndTime + excess_length;
                         break;
                     default:
-                        Length = lastObject.StartTime + 1000;
+                        Length = lastObject.StartTime + excess_length;
                         break;
                 }
             }

--- a/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
@@ -16,21 +16,7 @@ namespace osu.Game.Beatmaps
         {
             private const double excess_length = 1000;
 
-            private readonly IBeatmap beatmap;
-
             public VirtualBeatmapTrack(IBeatmap beatmap)
-            {
-                this.beatmap = beatmap;
-                updateVirtualLength();
-            }
-
-            protected override void UpdateState()
-            {
-                updateVirtualLength();
-                base.UpdateState();
-            }
-
-            private void updateVirtualLength()
             {
                 var lastObject = beatmap.HitObjects.LastOrDefault();
 

--- a/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap_VirtualBeatmapTrack.cs
@@ -9,6 +9,9 @@ namespace osu.Game.Beatmaps
 {
     public partial class WorkingBeatmap
     {
+        /// <summary>
+        /// A type of <see cref="TrackVirtual"/> which provides a valid length based on the <see cref="HitObject"/>s of an <see cref="IBeatmap"/>.
+        /// </summary>
         private class VirtualBeatmapTrack : TrackVirtual
         {
             private readonly IBeatmap beatmap;
@@ -16,6 +19,7 @@ namespace osu.Game.Beatmaps
             public VirtualBeatmapTrack(IBeatmap beatmap)
             {
                 this.beatmap = beatmap;
+                updateVirtualLength();
             }
 
             protected override void UpdateState()

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
@@ -52,8 +52,6 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             if (Beatmap.Value == null)
                 return;
 
-            if (Beatmap.Value.Track.Length == double.PositiveInfinity) return;
-
             float markerPos = MathHelper.Clamp(ToLocalSpace(screenPosition).X, 0, DrawWidth);
             adjustableClock.Seek(markerPos / DrawWidth * Beatmap.Value.Track.Length);
         }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
@@ -47,8 +47,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
                 return;
             }
 
-            // Todo: This should be handled more gracefully
-            timeline.RelativeChildSize = Beatmap.Value.Track.Length == double.PositiveInfinity ? Vector2.One : new Vector2((float)Math.Max(1, Beatmap.Value.Track.Length), 1);
+            timeline.RelativeChildSize = new Vector2((float)Math.Max(1, Beatmap.Value.Track.Length), 1);
         }
 
         protected void Add(Drawable visualisation) => timeline.Add(visualisation);

--- a/osu.Game/Screens/Edit/Screens/Compose/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Screens/Compose/Timeline/Timeline.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -51,13 +52,11 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Timeline
             WaveformVisible.ValueChanged += visible => waveform.FadeTo(visible ? 1 : 0, 200, Easing.OutQuint);
 
             Beatmap.BindTo(beatmap);
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-            Beatmap.BindValueChanged(b => waveform.Waveform = b.Waveform);
-            waveform.Waveform = Beatmap.Value.Waveform;
+            Beatmap.BindValueChanged(b =>
+            {
+                waveform.Waveform = b.Waveform;
+                track = b.Track;
+            }, true);
         }
 
         /// <summary>
@@ -79,6 +78,8 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Timeline
         /// Whether the track was playing before a user drag event.
         /// </summary>
         private bool trackWasPlaying;
+
+        private Track track;
 
         protected override void Update()
         {
@@ -117,18 +118,18 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Timeline
 
         private void seekTrackToCurrent()
         {
-            if (!Beatmap.Value.TrackLoaded || !Beatmap.Value.Track.IsLoaded)
+            if (!track.IsLoaded)
                 return;
 
-            adjustableClock.Seek(Current / Content.DrawWidth * Beatmap.Value.Track.Length);
+            adjustableClock.Seek(Current / Content.DrawWidth * track.Length);
         }
 
         private void scrollToTrackTime()
         {
-            if (!Beatmap.Value.TrackLoaded || !Beatmap.Value.Track.IsLoaded)
+            if (!track.IsLoaded)
                 return;
 
-            ScrollTo((float)(adjustableClock.CurrentTime / Beatmap.Value.Track.Length) * Content.DrawWidth, false);
+            ScrollTo((float)(adjustableClock.CurrentTime / track.Length) * Content.DrawWidth, false);
         }
 
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)

--- a/osu.Game/Screens/Edit/Screens/Compose/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Screens/Compose/Timeline/Timeline.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Timeline
 
         private void seekTrackToCurrent()
         {
-            if (!Beatmap.Value.TrackLoaded)
+            if (!Beatmap.Value.TrackLoaded || !Beatmap.Value.Track.IsLoaded)
                 return;
 
             adjustableClock.Seek(Current / Content.DrawWidth * Beatmap.Value.Track.Length);
@@ -125,7 +125,7 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Timeline
 
         private void scrollToTrackTime()
         {
-            if (!Beatmap.Value.TrackLoaded)
+            if (!Beatmap.Value.TrackLoaded || !Beatmap.Value.Track.IsLoaded)
                 return;
 
             ScrollTo((float)(adjustableClock.CurrentTime / Beatmap.Value.Track.Length) * Content.DrawWidth, false);

--- a/osu.Game/Screens/Edit/Screens/Compose/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Screens/Compose/Timeline/Timeline.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -118,18 +117,15 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Timeline
 
         private void seekTrackToCurrent()
         {
-            var track = Beatmap.Value.Track;
-            if (track is TrackVirtual || !track.IsLoaded)
+            if (!Beatmap.Value.TrackLoaded)
                 return;
 
-            if (!(Beatmap.Value.Track is TrackVirtual))
-                adjustableClock.Seek(Current / Content.DrawWidth * Beatmap.Value.Track.Length);
+            adjustableClock.Seek(Current / Content.DrawWidth * Beatmap.Value.Track.Length);
         }
 
         private void scrollToTrackTime()
         {
-            var track = Beatmap.Value.Track;
-            if (track is TrackVirtual || !track.IsLoaded)
+            if (!Beatmap.Value.TrackLoaded)
                 return;
 
             ScrollTo((float)(adjustableClock.CurrentTime / Beatmap.Value.Track.Length) * Content.DrawWidth, false);

--- a/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Linq;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Tests.Beatmaps
 {
@@ -26,21 +24,6 @@ namespace osu.Game.Tests.Beatmaps
         private readonly IBeatmap beatmap;
         protected override IBeatmap GetBeatmap() => beatmap;
         protected override Texture GetBackground() => null;
-
-        protected override Track GetTrack()
-        {
-            var lastObject = beatmap.HitObjects.LastOrDefault();
-            if (lastObject != null)
-                return new TestTrack(((lastObject as IHasEndTime)?.EndTime ?? lastObject.StartTime) + 1000);
-            return new TrackVirtual();
-        }
-
-        private class TestTrack : TrackVirtual
-        {
-            public TestTrack(double length)
-            {
-                Length = length;
-            }
-        }
+        protected override Track GetTrack() => null;
     }
 }


### PR DESCRIPTION
- Fixes #2770

---

Some beatmaps that don't have tracks could cause osu! to crash due to an invalid audio length. This change calculates the virtual track length based on the last hitobject's time, circumventing any possible crashes.