### PR TITLE
Fix mania maps not being treated as mania maps in release builds

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -84,10 +84,11 @@ namespace osu.Game.Rulesets
                 {
                     try
                     {
-                        var instance = r.CreateInstance();
+                        var instanceInfo = ((Ruleset)Activator.CreateInstance(Type.GetType(r.InstantiationInfo), (RulesetInfo)null)).RulesetInfo;
 
-                        r.Name = instance.Description;
-                        r.ShortName = instance.ShortName;
+                        r.Name = instanceInfo.Name;
+                        r.ShortName = instanceInfo.ShortName;
+                        r.InstantiationInfo = instanceInfo.InstantiationInfo;
 
                         r.Available = true;
                     }


### PR DESCRIPTION
Versions of subsequent ruleset DLLs were not matching between updates since we changed to a new deploy process. This ensures sanity between updates.

- Closes #2905.

---

Fixes issues people have been seeing with mania-specific beatmaps.