### PR TITLE
Dismiss PopupDialog on clicking outside

### DIFF
--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -102,6 +102,12 @@ namespace osu.Game.Overlays.Dialog
             return base.OnKeyDown(state, args);
         }
 
+        protected override bool OnClick(InputState state)
+        {
+            Hide();
+            return base.OnClick(state);
+        }
+
         protected override void PopIn()
         {
             base.PopIn();

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -104,8 +104,11 @@ namespace osu.Game.Overlays.Dialog
 
         protected override bool OnClick(InputState state)
         {
+            if (content.ReceiveMouseInputAt(state.Mouse.NativeState.Position))
+                return false;
+
             Hide();
-            return base.OnClick(state);
+            return true;
         }
 
         protected override void PopIn()


### PR DESCRIPTION
resolves #2917 
https://youtu.be/AebXfkFGeBA

Hovewer, I think we might want not to dismiss the dialog if the content area was clicked. I can fix this if required.