### PR TITLE
Allow perfect judgements to be hidden

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/ManiaStage.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaStage.cs
@@ -167,6 +167,9 @@ namespace osu.Game.Rulesets.Mania.UI
             if (!judgedObject.DisplayJudgement)
                 return;
 
+            if (judgement.Result == judgement.MaxResult && !ShowPerfectJudgements)
+                return;
+
             judgements.Clear();
             judgements.Add(new DrawableManiaJudgement(judgement, judgedObject)
             {

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -71,6 +71,9 @@ namespace osu.Game.Rulesets.Osu.UI
             if (!judgedObject.DisplayJudgement || !DisplayJudgements)
                 return;
 
+            if (judgement.Result == judgement.MaxResult && !ShowPerfectJudgements)
+                return;
+
             DrawableOsuJudgement explosion = new DrawableOsuJudgement(judgement, judgedObject)
             {
                 Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -225,13 +225,16 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             if (judgedObject.DisplayJudgement && judgementContainer.FirstOrDefault(j => j.JudgedObject == judgedObject) == null)
             {
-                judgementContainer.Add(new DrawableTaikoJudgement(judgement, judgedObject)
+                if (!(judgement.Result == judgement.MaxResult && !ShowPerfectJudgements))
                 {
-                    Anchor = judgement.IsHit ? Anchor.TopLeft : Anchor.CentreLeft,
-                    Origin = judgement.IsHit ? Anchor.BottomCentre : Anchor.Centre,
-                    RelativePositionAxes = Axes.X,
-                    X = judgement.IsHit ? judgedObject.Position.X : 0,
-                });
+                    judgementContainer.Add(new DrawableTaikoJudgement(judgement, judgedObject)
+                    {
+                        Anchor = judgement.IsHit ? Anchor.TopLeft : Anchor.CentreLeft,
+                        Origin = judgement.IsHit ? Anchor.BottomCentre : Anchor.Centre,
+                        RelativePositionAxes = Axes.X,
+                        X = judgement.IsHit ? judgedObject.Position.X : 0,
+                    });
+                }
             }
 
             if (!judgement.IsHit)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -87,6 +87,8 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.IncreaseFirstObjectVisibility, true);
 
+            Set(OsuSetting.ShowPerfectJudgements, true);
+
             // Update
             Set(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
 
@@ -151,6 +153,7 @@ namespace osu.Game.Configuration
         BeatmapSkins,
         BeatmapHitsounds,
         IncreaseFirstObjectVisibility,
-        ScoreDisplayMode
+        ScoreDisplayMode,
+        ShowPerfectJudgements
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Overlays.Settings.Sections
                     LabelText = "Adjust gameplay cursor size based on current beatmap",
                     Bindable = config.GetBindable<bool>(OsuSetting.AutoCursorSize)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Show perfect judgements",
+                    Bindable = config.GetBindable<bool>(OsuSetting.ShowPerfectJudgements)
+                }
             };
 
             skins.ItemAdded += onItemsChanged;

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Allocation;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -20,6 +21,8 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         public IReadOnlyList<Playfield> NestedPlayfields => nestedPlayfields;
         private List<Playfield> nestedPlayfields;
+
+        protected bool ShowPerfectJudgements;
 
         /// <summary>
         /// A container for keeping track of DrawableHitObjects.
@@ -37,8 +40,10 @@ namespace osu.Game.Rulesets.UI
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuConfigManager config)
         {
+            ShowPerfectJudgements = config.Get<bool>(OsuSetting.ShowPerfectJudgements);
+
             HitObjects = CreateHitObjectContainer();
             HitObjects.RelativeSizeAxes = Axes.Both;
 


### PR DESCRIPTION
Closes #2106 

I'm uncertain about the implementation details, but I thought I might as well get this started.

---

The judgement display text for greats (in osu! and taiko) and perfects (in mania) can [now be hidden](https://streamable.com/c7d14) by enabling an option.