### PR TITLE
Fix rulesets not loading in debug builds after running a release build

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -84,7 +84,13 @@ namespace osu.Game.Rulesets
                 {
                     try
                     {
-                        var instanceInfo = ((Ruleset)Activator.CreateInstance(Type.GetType(r.InstantiationInfo), (RulesetInfo)null)).RulesetInfo;
+                        var instanceInfo = ((Ruleset)Activator.CreateInstance(Type.GetType(r.InstantiationInfo, asm =>
+                        {
+                            // for the time being, let's ignore the version being loaded.
+                            // this allows for debug builds to successfully load rulesets (even though debug rulesets have a 0.0.0 version).
+                            asm.Version = null;
+                            return Assembly.Load(asm);
+                        }, null), (RulesetInfo)null)).RulesetInfo;
 
                         r.Name = instanceInfo.Name;
                         r.ShortName = instanceInfo.ShortName;


### PR DESCRIPTION
Release builds will populate the database with a non-zero version, which will then cause debug builds to not load their (lower versioned) rulesets.

---
