### PR TITLE
Fix crash if the skin stored in the config doesn't exist anymore

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -56,7 +56,13 @@ namespace osu.Game.Overlays.Settings.Sections
 
             reloadSkins();
 
-            skinDropdown.Bindable = config.GetBindable<int>(OsuSetting.Skin);
+            var skinBindable = config.GetBindable<int>(OsuSetting.Skin);
+
+            // Todo: This should not be necessary when OsuConfigManager is databased
+            if (skinDropdown.Items.All(s => s.Value != skinBindable.Value))
+                skinBindable.Value = 0;
+
+            skinDropdown.Bindable = skinBindable;
         }
 
         private void reloadSkins() => skinDropdown.Items = skins.GetAllUsableSkins().Select(s => new KeyValuePair<string, int>(s.ToString(), s.ID));


### PR DESCRIPTION
- Closes #2922

This has happened quite a few times now, so let's add some basic protection to this, at least until OsuConfigManager is databased itself.

---

If the database fails to migrate, it's possible for the skin stored in the config to get out of sync with the skins present in the database, causing a crash at startup.