### PR TITLE
Fix FooterButton clicking area

### DIFF
--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Screens.Select
         private readonly Box box;
         private readonly Box light;
 
+        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => box.ReceiveMouseInputAt(screenSpacePos);
+
         public FooterButton()
         {
             Children = new Drawable[]


### PR DESCRIPTION
Fixes this. Yellow was on the edge on the old area. Blue was out of the highlighted area. Also pertains between the buttons (between mod and random).

![](https://puu.sh/AQ1Cf/40d1fe254d.png) ![](https://puu.sh/AQ1Ju/b01e74aa1f.png)

---

Should only receive input on the highlighted area.