### PR TITLE
Turn cache back on for chocolatey packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ clone_depth: 1
 version: '{branch}-{build}'
 image: Visual Studio 2017
 configuration: Debug
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
 install:
   - cmd: git submodule update --init --recursive --depth=5
   - cmd: choco install resharper-clt -y


### PR DESCRIPTION
Due to multiple http failures recently, this is better to have turned on as a fallback.

---