### PR TITLE
Fix osu! logo handling non-left mouse buttons

### DIFF
--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -19,6 +19,7 @@ using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using OpenTK;
 using OpenTK.Graphics;
+using OpenTK.Input;
 
 namespace osu.Game.Screens.Menu
 {
@@ -345,12 +346,16 @@ namespace osu.Game.Screens.Menu
 
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
         {
+            if (args.Button != MouseButton.Left) return false;
+
             logoBounceContainer.ScaleTo(0.9f, 1000, Easing.Out);
             return true;
         }
 
         protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
         {
+            if (args.Button != MouseButton.Left) return false;
+
             logoBounceContainer.ScaleTo(1f, 500, Easing.OutElastic);
             return true;
         }


### PR DESCRIPTION
Could potentially block user bindings such as "Back" when the logo was hovered.