### PR TITLE
Restore old tooltip appear delay behaviour

### DIFF
--- a/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
+++ b/osu.Game/Graphics/Cursor/OsuTooltipContainer.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Graphics.Cursor
         {
         }
 
+        protected override double AppearDelay => (1 - CurrentTooltip.Alpha) * base.AppearDelay; // reduce appear delay if the tooltip is already partly visible.
+
         public class OsuTooltip : Tooltip
         {
             private readonly Box background;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2018.711.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2018.712.0" />
     <PackageReference Include="SharpCompress" Version="0.17.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />


### PR DESCRIPTION
- [x] Depends on ppy/osu-framework#1708

---

Tooltips should display faster if the tooltip is already partly visible. This regressed with the addition of custon `AppearDelay`.
