### PR TITLE
Only read numbers when handling colors.

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -62,32 +62,34 @@ namespace osu.Game.Beatmaps.Formats
 
         protected override void ParseLine(Beatmap beatmap, Section section, string line)
         {
+            var stripped_line = StripComments(line);
+
             switch (section)
             {
                 case Section.General:
-                    handleGeneral(line);
+                    handleGeneral(stripped_line);
                     return;
                 case Section.Editor:
-                    handleEditor(line);
+                    handleEditor(stripped_line);
                     return;
                 case Section.Metadata:
                     handleMetadata(line);
                     return;
                 case Section.Difficulty:
-                    handleDifficulty(line);
+                    handleDifficulty(stripped_line);
                     return;
                 case Section.Events:
-                    handleEvent(line);
+                    handleEvent(stripped_line);
                     return;
                 case Section.TimingPoints:
-                    handleTimingPoint(line);
+                    handleTimingPoint(stripped_line);
                     return;
                 case Section.HitObjects:
-                    handleHitObject(line);
+                    handleHitObject(stripped_line);
                     return;
             }
 
-            base.ParseLine(beatmap, section, line);
+            base.ParseLine(beatmap, section, stripped_line);
         }
 
         private void handleGeneral(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Beatmaps.Formats
                     return;
             }
 
-            base.ParseLine(beatmap, section, strippedLine);
+            base.ParseLine(beatmap, section, line);
         }
 
         private void handleGeneral(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -62,34 +62,34 @@ namespace osu.Game.Beatmaps.Formats
 
         protected override void ParseLine(Beatmap beatmap, Section section, string line)
         {
-            var stripped_line = StripComments(line);
+            var strippedLine = StripComments(line);
 
             switch (section)
             {
                 case Section.General:
-                    handleGeneral(stripped_line);
+                    handleGeneral(strippedLine);
                     return;
                 case Section.Editor:
-                    handleEditor(stripped_line);
+                    handleEditor(strippedLine);
                     return;
                 case Section.Metadata:
                     handleMetadata(line);
                     return;
                 case Section.Difficulty:
-                    handleDifficulty(stripped_line);
+                    handleDifficulty(strippedLine);
                     return;
                 case Section.Events:
-                    handleEvent(stripped_line);
+                    handleEvent(strippedLine);
                     return;
                 case Section.TimingPoints:
-                    handleTimingPoint(stripped_line);
+                    handleTimingPoint(strippedLine);
                     return;
                 case Section.HitObjects:
-                    handleHitObject(stripped_line);
+                    handleHitObject(strippedLine);
                     return;
             }
 
-            base.ParseLine(beatmap, section, stripped_line);
+            base.ParseLine(beatmap, section, strippedLine);
         }
 
         private void handleGeneral(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using osu.Framework.Logging;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
@@ -73,10 +74,12 @@ namespace osu.Game.Beatmaps.Formats
 
             bool isCombo = pair.Key.StartsWith(@"Combo");
 
-            string[] split = pair.Value.Split(',');
+            line = Regex.Replace(pair.Value, "[^0-9,]", "");
+
+            string[] split = line.Split(',');
 
             if (split.Length != 3)
-                throw new InvalidOperationException($@"Color specified in incorrect format (should be R,G,B): {pair.Value}");
+                throw new InvalidOperationException($@"Color specified in incorrect format (should be R,G,B): {line}");
 
             if (!byte.TryParse(split[0], out var r) || !byte.TryParse(split[1], out var g) || !byte.TryParse(split[2], out var b))
                 throw new InvalidOperationException(@"Color must be specified with 8-bit integer components");

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -66,7 +66,8 @@ namespace osu.Game.Beatmaps.Formats
                     return;
             }
         }
-        internal string StripComments(string line)
+
+        protected string StripComments(string line)
         {
             var index = line.IndexOf("//", StringComparison.Ordinal);
             if (index > 0)

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -58,12 +58,21 @@ namespace osu.Game.Beatmaps.Formats
 
         protected virtual void ParseLine(T output, Section section, string line)
         {
+            line = StripComments(line);
+
             switch (section)
             {
                 case Section.Colours:
                     handleColours(output, line);
                     return;
             }
+        }
+        internal string StripComments(string line)
+        {
+            var index = line.IndexOf("//");
+            if (index > 0)
+                return line.Substring(0, index);
+            return line;
         }
 
         private bool hasComboColours;
@@ -74,12 +83,10 @@ namespace osu.Game.Beatmaps.Formats
 
             bool isCombo = pair.Key.StartsWith(@"Combo");
 
-            line = Regex.Replace(pair.Value, "[^0-9,]", "");
-
-            string[] split = line.Split(',');
+            string[] split = pair.Value.Split(',');
 
             if (split.Length != 3)
-                throw new InvalidOperationException($@"Color specified in incorrect format (should be R,G,B): {line}");
+                throw new InvalidOperationException($@"Color specified in incorrect format (should be R,G,B): {pair.Value}");
 
             if (!byte.TryParse(split[0], out var r) || !byte.TryParse(split[1], out var g) || !byte.TryParse(split[2], out var b))
                 throw new InvalidOperationException(@"Color must be specified with 8-bit integer components");

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using osu.Framework.Logging;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Beatmaps.Formats
         }
         internal string StripComments(string line)
         {
-            var index = line.IndexOf("//");
+            var index = line.IndexOf("//", StringComparison.Ordinal);
             if (index > 0)
                 return line.Substring(0, index);
             return line;

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Beatmaps.Formats
 
         protected override void ParseLine(Storyboard storyboard, Section section, string line)
         {
+            line = StripComments(line);
+
             switch (section)
             {
                 case Section.Events:

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Skinning
 
         protected override void ParseLine(SkinConfiguration skin, Section section, string line)
         {
+            line = StripComments(line);
+
             switch (section)
             {
                 case Section.General:


### PR DESCRIPTION
Some beatmaps have comments in them which causes TryParse to fail, this makes it so that it only reads the first 3 characters of each color

Reflection 2018 on https://mega.nz/#F!ZNYBTZgD!-9dduPVjq3HCh08rAo0sAQ is an example of this, where it writes "255,240,141 //yellow" as the color.


---

Fix some beatmaps not loading colors properly when there are comments.