### PR TITLE
Improve visuals of difficulty icons

### DIFF
--- a/osu.Game/Beatmaps/Drawables/DifficultyColouredContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyColouredContainer.cs
@@ -9,14 +9,14 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    public class DifficultyColouredContainer : Container, IHasAccentColour
+    public abstract class DifficultyColouredContainer : Container, IHasAccentColour
     {
         public Color4 AccentColour { get; set; }
 
         private readonly BeatmapInfo beatmap;
         private OsuColour palette;
 
-        public DifficultyColouredContainer(BeatmapInfo beatmap)
+        protected DifficultyColouredContainer(BeatmapInfo beatmap)
         {
             this.beatmap = beatmap;
         }

--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -3,10 +3,14 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using OpenTK;
+using OpenTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
@@ -14,7 +18,8 @@ namespace osu.Game.Beatmaps.Drawables
     {
         private readonly BeatmapInfo beatmap;
 
-        public DifficultyIcon(BeatmapInfo beatmap) : base(beatmap)
+        public DifficultyIcon(BeatmapInfo beatmap)
+            : base(beatmap)
         {
             if (beatmap == null)
                 throw new ArgumentNullException(nameof(beatmap));
@@ -28,16 +33,29 @@ namespace osu.Game.Beatmaps.Drawables
         {
             Children = new Drawable[]
             {
-                new SpriteIcon
+                new CircularContainer
                 {
+                    RelativeSizeAxes = Axes.Both,
+                    Scale = new Vector2(0.84f),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = AccentColour,
-                    Icon = FontAwesome.fa_circle
+                    Masking = true,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Colour = Color4.Black.Opacity(0.08f),
+                        Type = EdgeEffectType.Shadow,
+                        Radius = 5,
+                    },
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = AccentColour,
+                    },
                 },
                 new ConstrainedIconContainer
                 {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
                     // the null coalesce here is only present to make unit tests work (ruleset dlls aren't copied correctly for testing at the moment)
                     Icon = beatmap.Ruleset?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.fa_question_circle_o }


### PR DESCRIPTION
There's still minor edge imperfections, but it looks to be stemming from the underlying font being stored/read incorrectly. This fixes the ugly peeking background fill.

---

Before:

![image](https://user-images.githubusercontent.com/191335/42680584-605c2c18-86c0-11e8-9ccb-f4bd7a89b919.png)

After:

![image](https://user-images.githubusercontent.com/191335/42681056-9b5e64ce-86c1-11e8-854c-23657e64a92f.png)


