### PR TITLE
Remove migration log output

### DIFF
--- a/osu.Game/Migrations/20180621044111_UpdateTaikoDefaultBindings.cs
+++ b/osu.Game/Migrations/20180621044111_UpdateTaikoDefaultBindings.cs
@@ -8,7 +8,6 @@ namespace osu.Game.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql("DELETE FROM KeyBinding WHERE RulesetID = 1");
-            Logger.Log("osu!taiko bindings have been reset due to new defaults", LoggingTarget.Runtime, LogLevel.Important);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
Most people who need to see this already have. We still need to find an amicable way of doing this, but that can be saved for next usage.

- Closes #2937.

---