### PR TITLE
Make focused overlays block "select" and keys

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -22,7 +22,10 @@ namespace osu.Game.Graphics.Containers
 
         protected virtual bool PlaySamplesOnStateChange => true;
 
+        protected override bool BlockPassThroughKeyboard => true;
+
         private PreviewTrackManager previewTrackManager;
+
 
         protected readonly Bindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -69,10 +69,13 @@ namespace osu.Game.Graphics.Containers
 
         public virtual bool OnPressed(GlobalAction action)
         {
-            if (action == GlobalAction.Back)
+            switch (action)
             {
-                State = Visibility.Hidden;
-                return true;
+                case GlobalAction.Back:
+                    State = Visibility.Hidden;
+                    return true;
+                case GlobalAction.Select:
+                    return true;
             }
 
             return false;


### PR DESCRIPTION
Fixes keys and actions transmitting behind the music controller and other overlays.