### PR TITLE
Fix KeyCounter counting clicks when game is paused

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Screens.Play
                     OnPause = () =>
                     {
                         pauseContainer.Retries = RestartCount;
-                        hudOverlay.KeyCounter.IsCounting = pauseContainer.IsPaused;
+                        hudOverlay.KeyCounter.IsCounting = !pauseContainer.IsPaused;
                     },
                     OnResume = () => hudOverlay.KeyCounter.IsCounting = true,
                     Children = new[]


### PR DESCRIPTION
- Closes #3032

Did a quick test. Now the counter stays the same when clicking in pause screen, but the clicking animation is still playing, like in stable.

