### PR TITLE
Instantly hide fail overlay for quick retry

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -219,6 +219,7 @@ namespace osu.Game.Screens.Play
                         if (!IsCurrentScreen) return;
 
                         pauseContainer.Hide();
+                        failOverlay.FadeOut();
                         Restart();
                     },
                 }


### PR DESCRIPTION
`.FadeOut()` instead of `.Hide()`, since it was, I suppose, written (or overriden) in such a way, that it doesn't disappear instantaneously.

---