### PR TITLE
Add Design screen colour button components for the Beatmap Setup Screen

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseOsuColourButton.cs
+++ b/osu.Game.Tests/Visual/TestCaseOsuColourButton.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Screens.Edit.Screens.Setup.Components;
+using System;
+using System.Collections.Generic;
+
+namespace osu.Game.Tests.Visual
+{
+    [TestFixture]
+    public class TestCaseOsuColourButton : OsuTestCase
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(OsuSetupColourButton),
+            typeof(OsuColourPicker),
+            typeof(OsuColourPickerGradient),
+            typeof(OsuColourPickerHue),
+        };
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            OsuSetupColourButton osuColourButton;
+            Children = new Drawable[]
+            {
+                osuColourButton = new OsuSetupColourButton
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    BottomLabelText = "Great Test"
+                }
+            };
+
+            AddStep("Change Origin to Top Left", () => osuColourButton.ColourPickerOrigin = Anchor.TopLeft);
+            AddStep("Change Origin to Top Right", () => osuColourButton.ColourPickerOrigin = Anchor.TopRight);
+            AddStep("Change Origin to Bottom Right", () => osuColourButton.ColourPickerOrigin = Anchor.BottomRight);
+            AddStep("Change Origin to Bottom Left", () => osuColourButton.ColourPickerOrigin = Anchor.BottomLeft);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Screens/Setup/Components/NewComboColourButton.cs
+++ b/osu.Game/Screens/Edit/Screens/Setup/Components/NewComboColourButton.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using System;
+
+namespace osu.Game.Screens.Edit.Screens.Setup.Components
+{
+    public class NewComboColourButton : CircularContainer
+    {
+        private readonly Box fill;
+        private readonly CircularContainer button;
+
+        public const float SIZE_X = 75;
+        public const float SIZE_Y = 75;
+        public const float BOTTOM_LABEL_TEXT_SIZE = 14;
+        public const float COLOUR_LABEL_TEXT_SIZE = 11;
+
+        public event Action ButtonClicked;
+
+        public NewComboColourButton()
+        {
+            Size = new Vector2(SIZE_X, SIZE_Y);
+
+            Children = new Drawable[]
+            {
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Margin = new MarginPadding { Top = SIZE_Y + 5 },
+                    Colour = Color4.White,
+                    Text = "New",
+                    TextSize = BOTTOM_LABEL_TEXT_SIZE
+                },
+                button = new CircularContainer
+                {
+                    Masking = true,
+                    RelativeSizeAxes = Axes.Both,
+                    BorderThickness = 3.5f,
+                    Alpha = 0.5f,
+                    Child = fill = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White,
+                        Alpha = 0,
+                        AlwaysPresent = true
+                    },
+                },
+                new SpriteIcon
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.fa_plus,
+                    Size = new Vector2(10)
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour osuColour)
+        {
+            button.BorderColour = osuColour.Blue;
+        }
+
+        protected override bool OnClick(InputState state)
+        {
+            ButtonClicked?.Invoke();
+            return base.OnClick(state);
+        }
+
+        protected override bool OnHover(InputState state)
+        {
+            fill.FadeTo(0.2f, 500, Easing.OutQuint);
+            return base.OnHover(state);
+        }
+
+        protected override void OnHoverLost(InputState state)
+        {
+            fill.FadeTo(0, 500, Easing.OutQuint);
+            base.OnHoverLost(state);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Screens/Setup/Components/OsuSetupColourButton.cs
+++ b/osu.Game/Screens/Edit/Screens/Setup/Components/OsuSetupColourButton.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Screens.Edit.Screens.Setup.Components
+{
+    public class OsuSetupColourButton : CircularContainer, IHasCurrentValue<Color4>
+    {
+        private bool isColourPickerOpen;
+        public bool IsColourPickerOpen
+        {
+            get => isColourPickerOpen;
+            private set
+            {
+                if (isColourPickerOpen == value)
+                    return;
+
+                isColourPickerOpen = value;
+
+                if (value)
+                    ShowColourPicker();
+                else
+                    HideColourPicker();
+            }
+        }
+
+        public Anchor ColourPickerOrigin
+        {
+            get => colourPicker.Origin;
+            set => colourPicker.Origin = value;
+        }
+
+        private readonly OsuColourPicker colourPicker;
+        private readonly OsuSpriteText bottomLabel;
+
+        public const float COLLAPSED_SIZE = 75;
+        public const float EXPANDED_SIZE = 160;
+        public const float SIZE_Y = 75;
+        public const float BOTTOM_LABEL_TEXT_SIZE = 14;
+        public const float COLOUR_LABEL_TEXT_SIZE = 11;
+
+        private string bottomLabelText;
+        public string BottomLabelText
+        {
+            get => bottomLabelText;
+            set
+            {
+                bottomLabelText = value;
+                bottomLabel.Text = value;
+            }
+        }
+
+        public OsuSetupColourButton(bool expanded = false)
+        {
+            OsuSpriteText colourLabel;
+            Box fill;
+
+            Size = new Vector2(expanded ? EXPANDED_SIZE : COLLAPSED_SIZE, SIZE_Y);
+
+            Children = new Drawable[]
+            {
+                bottomLabel = new OsuSpriteText
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Margin = new MarginPadding { Top = SIZE_Y + 5 },
+                    Colour = Color4.White,
+                    TextSize = BOTTOM_LABEL_TEXT_SIZE
+                },
+                colourPicker = new OsuColourPicker
+                {
+                    Origin = Anchor.TopLeft,
+                    X = Size.X - SIZE_Y / 2,
+                    Size = new Vector2(0, SIZE_Y),
+                },
+                new CircularContainer
+                {
+                    Masking = true,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = fill = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White,
+                        AlwaysPresent = true,
+                    },
+                },
+                colourLabel = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "#ffffff",
+                    Colour = Color4.Black,
+                    TextSize = COLOUR_LABEL_TEXT_SIZE
+                },
+            };
+
+            colourPicker.ColourChanged += newColour => Current.Value = newColour;
+
+            Current.ValueChanged += newValue =>
+            {
+                fill.FadeColour(newValue, 200, Easing.OutQuint);
+                colourLabel.Text = toHexRGBString(newValue);
+                colourLabel.Colour = Color4.ToHsv(newValue).Z >= 0.5f ? Color4.Black : Color4.White;
+                colourPicker.Current.Value = newValue;
+            };
+        }
+
+        protected override bool OnClick(InputState state)
+        {
+            IsColourPickerOpen = !IsColourPickerOpen;
+
+            return base.OnClick(state);
+        }
+
+        public void ShowColourPicker() => colourPicker.Expand();
+        public void HideColourPicker() => colourPicker.Collapse();
+
+        public Bindable<Color4> Current { get; } = new Bindable<Color4>();
+
+        private string toHexRGBString(Color4 colour) => $"#{((byte)(colour.R * 255)).ToString("X2").ToLower()}{((byte)(colour.G * 255)).ToString("X2").ToLower()}{((byte)(colour.B * 255)).ToString("X2").ToLower()}";
+    }
+}


### PR DESCRIPTION
Split from #3078
- [ ] Depends on #3087

**Known issues:**
- [ ] When colour picker is shown, between the colour button and the colour picker there is some space due to the smooth corners not overlapping