### PR TITLE
Fix fatal test result on temporary file deletion failures

### DIFF
--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -54,6 +54,12 @@ namespace osu.Game.Tests.Visual
             public new BeatmapCarousel Carousel => base.Carousel;
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            factory.ResetDatabase();
+            base.Dispose(isDisposing);
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game/Tests/Visual/OsuTestCase.cs
+++ b/osu.Game/Tests/Visual/OsuTestCase.cs
@@ -62,7 +62,16 @@ namespace osu.Game.Tests.Visual
             }
 
             if (localStorage.IsValueCreated)
-                localStorage.Value.DeleteDirectory(".");
+            {
+                try
+                {
+                    localStorage.Value.DeleteDirectory(".");
+                }
+                catch
+                {
+                    // we don't really care if this fails; it will just leave folders lying around from test runs.
+                }
+            }
         }
 
         protected override ITestCaseTestRunner CreateRunner() => new OsuTestCaseTestRunner();


### PR DESCRIPTION
Not sure we have a better solution for handling this (the `ResetDatabase` method is already doing basically everything it can short of arbitrarily `Thread.Sleep`ing.