### PR TITLE
 Fix resetting database failing due to incorrect disposal logic

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -224,7 +224,7 @@ namespace osu.Game
                 // todo: we probably want a better (non-destructive) migrations/recovery process at a later point than this.
                 contextFactory.ResetDatabase();
 
-                Logger.Log("Database purged successfully.", LoggingTarget.Database, LogLevel.Important);
+                Logger.Log("Database purged successfully.", LoggingTarget.Database);
 
                 // only run once more, then hard bail.
                 using (var db = contextFactory.GetForWrite(false))


### PR DESCRIPTION
- Closes #2711.

It turns out that while `ThreadLocal` does has a finalizer, it will never actually run due to internal static references.

---
