### PR TITLE
Make more gameplay elements skinnable

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
@@ -20,26 +21,27 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         {
             Origin = Anchor.Centre;
 
-            Masking = true;
-            AutoSizeAxes = Axes.Both;
-            CornerRadius = width / 2;
-            EdgeEffect = new EdgeEffectParameters
+            Child = new SkinnableDrawable("Play/osu/followpoint", _ => new Container
             {
-                Type = EdgeEffectType.Glow,
-                Colour = Color4.White.Opacity(0.2f),
-                Radius = 4,
-            };
-
-            Children = new Drawable[]
-            {
-                new Box
+                Masking = true,
+                AutoSizeAxes = Axes.Both,
+                CornerRadius = width / 2,
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Glow,
+                    Colour = Color4.White.Opacity(0.2f),
+                    Radius = 4,
+                },
+                Child = new Box
                 {
                     Size = new Vector2(width),
                     Blending = BlendingMode.Additive,
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    Alpha = 0.5f,
-                },
+                }
+            }, restrictSize: false)
+            {
+                Alpha = 0.5f,
             };
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
@@ -38,11 +38,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
                     Blending = BlendingMode.Additive,
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
+                    Alpha = 0.5f,
                 }
-            }, restrictSize: false)
-            {
-                Alpha = 0.5f,
-            };
+            }, restrictSize: false);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
                     Vector2 distanceVector = endPosition - startPosition;
                     int distance = (int)distanceVector.Length;
-                    float rotation = (float)Math.Atan2(distanceVector.Y, distanceVector.X);
+                    float rotation = (float)(Math.Atan2(distanceVector.Y, distanceVector.X) * (180 / Math.PI));
                     double duration = endTime - startTime;
 
                     for (int d = (int)(PointDistance * 1.5); d < distance - PointDistance; d += PointDistance)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
@@ -10,6 +10,7 @@ using OpenTK;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -33,11 +34,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             InternalChildren = new Drawable[]
             {
-                new SpriteIcon
+                new SkinnableDrawable("Play/osu/reversearrow", _ => new SpriteIcon
                 {
                     RelativeSizeAxes = Axes.Both,
                     Icon = FontAwesome.fa_chevron_right
-                }
+                }, restrictSize: false)
             };
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -8,6 +8,8 @@ using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+using osu.Framework.Graphics.Containers;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -22,23 +24,27 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public DrawableSliderTick(SliderTick sliderTick) : base(sliderTick)
         {
             Size = new Vector2(16) * sliderTick.Scale;
-
-            Masking = true;
-            CornerRadius = Size.X / 2;
-
             Origin = Anchor.Centre;
-
-            BorderThickness = 2;
-            BorderColour = Color4.White;
 
             InternalChildren = new Drawable[]
             {
-                new Box
+                new SkinnableDrawable("Play/osu/sliderscorepoint", _ => new Container
                 {
+                    Masking = true,
                     RelativeSizeAxes = Axes.Both,
-                    Colour = AccentColour,
-                    Alpha = 0.3f,
-                }
+                    Origin = Anchor.Centre,
+                    CornerRadius = Size.X / 2,
+
+                    BorderThickness = 2,
+                    BorderColour = Color4.White,
+
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = AccentColour,
+                        Alpha = 0.3f,
+                    }
+                }, restrictSize: false)
             };
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -35,7 +35,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         private readonly Slider slider;
         public readonly Drawable FollowCircle;
-        private Drawable fadeFollowCircle;
         private Drawable drawableBall;
 
         public SliderBall(Slider slider)
@@ -54,6 +53,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                     Anchor = Anchor.Centre,
                     Width = width,
                     Height = width,
+                    Alpha = 0,
                     Child = new SkinnableDrawable("Play/osu/sliderfollowcircle", _ => new CircularContainer
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -61,11 +61,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                         BorderThickness = 5,
                         BorderColour = Color4.Orange,
                         Blending = BlendingMode.Additive,
-                        Child = fadeFollowCircle = new Box
+                        Child = new Box
                         {
                             Colour = Color4.Orange,
                             RelativeSizeAxes = Axes.Both,
-                            Alpha = 0,
+                            Alpha = 0.2f,
                         }
                     }),
                 },
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 tracking = value;
 
                 FollowCircle.ScaleTo(tracking ? 2.8f : 1, 300, Easing.OutQuint);
-                fadeFollowCircle?.FadeTo(tracking ? 0.2f : 0, 300, Easing.OutQuint);
+                FollowCircle.FadeTo(tracking ? 1f : 0, 300, Easing.OutQuint);
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input.States;
 using osu.Game.Rulesets.Objects.Types;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         }
 
         private readonly Slider slider;
-        public readonly Box FollowCircle;
+        public readonly Drawable FollowCircle;
         private readonly Box ball;
 
         public SliderBall(Slider slider)
@@ -46,13 +47,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             BorderThickness = 10;
             BorderColour = Color4.Orange;
 
-            Children = new Drawable[]
+            Children = new[]
             {
-                FollowCircle = new Box
+                FollowCircle = new Container
                 {
+                    Child = new SkinnableDrawable("Play/osu/sliderfollowcircle", _ => new Box
+                    {
+                        Colour = Color4.Orange,
+                        RelativeSizeAxes = Axes.Both,
+                    }, restrictSize: false),
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    Colour = Color4.Orange,
                     Width = width,
                     Height = width,
                     Alpha = 0,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -28,14 +28,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             set
             {
                 accentColour = value;
-                if (ball != null)
-                    ball.Colour = value;
+                if (drawableBall != null)
+                    drawableBall.Colour = value;
             }
         }
 
         private readonly Slider slider;
         public readonly Drawable FollowCircle;
-        private readonly Box ball;
+        private Drawable drawableBall;
 
         public SliderBall(Slider slider)
         {
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                     {
                         Colour = Color4.Orange,
                         RelativeSizeAxes = Axes.Both,
-                    }, restrictSize: false),
+                    }),
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
                     Width = width,
@@ -68,18 +68,26 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                     AutoSizeAxes = Axes.Both,
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    BorderThickness = 10,
-                    BorderColour = Color4.White,
                     Alpha = 1,
-                    Children = new[]
+                    Child = new Container
                     {
-                        ball = new Box
+                        Width = width,
+                        Height = width,
+                        // TODO: support skin filename animation (sliderb0, sliderb1...)
+                        Child = new SkinnableDrawable("Play/osu/sliderb", _ => new CircularContainer
                         {
-                            Colour = AccentColour,
-                            Alpha = 0.4f,
-                            Width = width,
-                            Height = width,
-                        },
+                            Masking = true,
+                            RelativeSizeAxes = Axes.Both,
+                            BorderThickness = 10,
+                            BorderColour = Color4.White,
+                            Alpha = 1,
+                            Child = drawableBall = new Box
+                            {
+                                Colour = AccentColour,
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0.4f,
+                            }
+                        }),
                     }
                 }
             };

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         private const float width = 128;
 
         private Color4 accentColour = Color4.Black;
+
         /// <summary>
         /// The colour that is used for the slider ball.
         /// </summary>
@@ -131,6 +132,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         }
 
         private bool tracking;
+
         public bool Tracking
         {
             get { return tracking; }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         private readonly Slider slider;
         public readonly Drawable FollowCircle;
+        private Drawable fadeFollowCircle;
         private Drawable drawableBall;
 
         public SliderBall(Slider slider)
@@ -44,23 +45,29 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             AutoSizeAxes = Axes.Both;
             Blending = BlendingMode.Additive;
             Origin = Anchor.Centre;
-            BorderThickness = 10;
-            BorderColour = Color4.Orange;
 
             Children = new[]
             {
                 FollowCircle = new Container
                 {
-                    Child = new SkinnableDrawable("Play/osu/sliderfollowcircle", _ => new Box
-                    {
-                        Colour = Color4.Orange,
-                        RelativeSizeAxes = Axes.Both,
-                    }),
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
                     Width = width,
                     Height = width,
-                    Alpha = 0,
+                    Child = new SkinnableDrawable("Play/osu/sliderfollowcircle", _ => new CircularContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        BorderThickness = 5,
+                        BorderColour = Color4.Orange,
+                        Blending = BlendingMode.Additive,
+                        Child = fadeFollowCircle = new Box
+                        {
+                            Colour = Color4.Orange,
+                            RelativeSizeAxes = Axes.Both,
+                            Alpha = 0,
+                        }
+                    }),
                 },
                 new CircularContainer
                 {
@@ -134,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 tracking = value;
 
                 FollowCircle.ScaleTo(tracking ? 2.8f : 1, 300, Easing.OutQuint);
-                FollowCircle.FadeTo(tracking ? 0.2f : 0, 300, Easing.OutQuint);
+                fadeFollowCircle?.FadeTo(tracking ? 0.2f : 0, 300, Easing.OutQuint);
             }
         }
 


### PR DESCRIPTION
There are still some issues which needs to be addressed in separate PRs: 

- skin animations based on filenames are not supported yet (sliderb0, sliderb1...)
- the slider ball doesn't rotate when following the slider
- skin versioning is not taken in account

This PR also fixes a rotation bug on the FollowPoints

You can easily test this with this skin: https://osu.ppy.sh/community/forums/topics/129191

- [x] Depends on #3148.

---

Adds skinning support for:

- sliderscorepoint (Slider ticks)
- reversearrow
- sliderfollowcircle
- sliderb (Slider ball)
- followpoint