### PR TITLE
Update TabControl subclasses to use AddInternal

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             TabContainer.Spacing = new Vector2(10f, 0f);
 
-            Add(strip = new Box
+            AddInternal(strip = new Box
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Overlays
                 TabContainer.AutoSizeAxes |= Axes.X;
                 TabContainer.Anchor |= Anchor.x1;
                 TabContainer.Origin |= Anchor.x1;
-                Add(bottom = new Box
+                AddInternal(bottom = new Box
                 {
                     RelativeSizeAxes = Axes.X,
                     Height = 1,

--- a/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
+++ b/osu.Game/Screens/Edit/Menus/ScreenSelectionTabControl.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Edit.Menus
             TabContainer.AutoSizeAxes = Axes.X;
             TabContainer.Padding = new MarginPadding();
 
-            Add(new Box
+            AddInternal(new Box
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2018.730.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2018.731.0" />
     <PackageReference Include="SharpCompress" Version="0.17.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />


### PR DESCRIPTION
Since `TabControl` became a `CompositeDrawable` in https://github.com/ppy/osu-framework/pull/1747, this PR changes any instances of `Add` to use `AddInternal`.