### PR TITLE
Fix mania beatmaps ending too soon when hold notes are involved

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -70,9 +70,6 @@ namespace osu.Game.Rulesets.Mania.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
             tickSpacing = timingPoint.BeatLength / difficulty.SliderTickRate;
-
-            Head.ApplyDefaults(controlPointInfo, difficulty);
-            Tail.ApplyDefaults(controlPointInfo, difficulty);
         }
 
         protected override void CreateNestedHitObjects()
@@ -80,6 +77,9 @@ namespace osu.Game.Rulesets.Mania.Objects
             base.CreateNestedHitObjects();
 
             createTicks();
+
+            AddNested(Head);
+            AddNested(Tail);
         }
 
         private void createTicks()


### PR DESCRIPTION
Since the score processor goes through nested hitobjects to generate judgement results, it wasn't considering head/tail.