### PR TITLE
Catch OperationCanceledException in single file load sequence

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -504,16 +504,25 @@ namespace osu.Game
             // schedule is here to ensure that all component loads are done after LoadComplete is run (and thus all dependencies are cached).
             // with some better organisation of LoadComplete to do construction and dependency caching in one step, followed by calls to loadComponentSingleFile,
             // we could avoid the need for scheduling altogether.
-            Schedule(() => { asyncLoadStream = asyncLoadStream?.ContinueWith(async t =>
+            Schedule(() =>
             {
-                try
+                if (asyncLoadStream != null)
                 {
-                    await LoadComponentAsync(d, add);
+                    //chain with existing load stream
+                    asyncLoadStream = asyncLoadStream.ContinueWith(async t =>
+                    {
+                        try
+                        {
+                            await LoadComponentAsync(d, add);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                        }
+                    });
                 }
-                catch (OperationCanceledException)
-                {
-                }
-            }) ?? LoadComponentAsync(d, add); });
+                else
+                    asyncLoadStream = LoadComponentAsync(d, add);
+            });
         }
 
         public bool OnPressed(GlobalAction action)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -504,7 +504,16 @@ namespace osu.Game
             // schedule is here to ensure that all component loads are done after LoadComplete is run (and thus all dependencies are cached).
             // with some better organisation of LoadComplete to do construction and dependency caching in one step, followed by calls to loadComponentSingleFile,
             // we could avoid the need for scheduling altogether.
-            Schedule(() => { asyncLoadStream = asyncLoadStream?.ContinueWith(t => LoadComponentAsync(d, add).Wait()) ?? LoadComponentAsync(d, add); });
+            Schedule(() => { asyncLoadStream = asyncLoadStream?.ContinueWith(async t =>
+            {
+                try
+                {
+                    await LoadComponentAsync(d, add);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }) ?? LoadComponentAsync(d, add); });
         }
 
         public bool OnPressed(GlobalAction action)


### PR DESCRIPTION
Now that cancellation is supported framework-side, we need to catch this case.