### PR TITLE
Fix logo flying off-screen when exiting game

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -278,7 +278,7 @@ namespace osu.Game.Screens.Menu
 
             if (logo != null)
             {
-                if (logoTracking && iconFacade.IsLoaded)
+                if (logoTracking && logo.RelativePositionAxes == Axes.None && iconFacade.IsLoaded)
                     logo.Position = logoTrackingPosition;
 
                 iconFacade.Width = logo.SizeForFlow * 0.5f;


### PR DESCRIPTION
Ensure that logo position updates never propagate when the position axes are set to relative.