### PR TITLE
Slightly improve performance of beatmap/storyboard parsing

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Beatmaps.Formats
                 if (ShouldSkipLine(line))
                     continue;
 
-                if (line.StartsWith(@"[") && line.EndsWith(@"]"))
+                if (line.StartsWith(@"[", StringComparison.Ordinal) && line.EndsWith(@"]", StringComparison.Ordinal))
                 {
                     if (!Enum.TryParse(line.Substring(1, line.Length - 2), out section))
                     {
@@ -53,7 +53,7 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        protected virtual bool ShouldSkipLine(string line) => string.IsNullOrWhiteSpace(line) || line.StartsWith("//");
+        protected virtual bool ShouldSkipLine(string line) => string.IsNullOrWhiteSpace(line) || line.StartsWith("//", StringComparison.Ordinal);
 
         protected virtual void ParseLine(T output, Section section, string line)
         {

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Beatmaps.Formats
         private void handleEvents(string line)
         {
             var depth = 0;
-            while (line.StartsWith(" ") || line.StartsWith("_"))
+            while (line.StartsWith(" ", StringComparison.Ordinal) || line.StartsWith("_", StringComparison.Ordinal))
             {
                 ++depth;
                 line = line.Substring(1);


### PR DESCRIPTION
Depending on the beatmap and complexity of storyboard, these functions were top 1 or 2 in tracing. This shaves a few seconds off in some cases.

Before:

![screen shot 2018-08-21 at 11 33 48 am](https://user-images.githubusercontent.com/1329837/44377095-581e5500-a536-11e8-8b7f-f6ae7dd58ea3.png)

After:

![screen shot 2018-08-21 at 11 34 11 am](https://user-images.githubusercontent.com/1329837/44377102-5bb1dc00-a536-11e8-8040-5d35822a043f.png)

Tested on https://osu.ppy.sh/beatmapsets/470977/#osu/1006822 and https://osu.ppy.sh/beatmapsets/494284#osu/1052460