### PR TITLE
Fix taiko beatmap conversion attempting to make strong swells

### DIFF
--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 converted.HitObjects = converted.HitObjects.GroupBy(t => t.StartTime).Select(x =>
                 {
                     TaikoHitObject first = x.First();
-                    if (x.Skip(1).Any())
+                    if (x.Skip(1).Any() && !(first is Swell))
                         first.IsStrong = true;
                     return first;
                 }).ToList();


### PR DESCRIPTION
Fixes #3274 (swells can never be strong), but not the underlying issue (ruleset is changing before the beatmap changes).