### PR TITLE
Offset the body of the sliderbodypath instead of everything else.

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -120,15 +120,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             foreach (var t in components.OfType<IRequireTracking>()) t.Tracking = Ball.Tracking;
 
             Size = Body.Size;
-            OriginPosition = Body.PathOffset;
-
-            if (DrawSize != Vector2.Zero)
-            {
-                var childAnchorPosition = Vector2.Divide(OriginPosition, DrawSize);
-                foreach (var obj in NestedHitObjects)
-                    obj.RelativeAnchorPosition = childAnchorPosition;
-                Ball.RelativeAnchorPosition = childAnchorPosition;
-            }
+            Body.OriginPosition = Body.PathOffset;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)


### PR DESCRIPTION
Currently the slider is offsetted by the bodypath and then the children are offsetted back into position .

This is confusing and unnessasary. 

You archive the same effect by only offsetting the body in a way cleaner and readable way.