### PR TITLE
Log all files when no beatmap files in archive error occurs

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -351,7 +351,11 @@ namespace osu.Game.Beatmaps
             // let's make sure there are actually .osu files to import.
             string mapName = reader.Filenames.FirstOrDefault(f => f.EndsWith(".osu"));
             if (string.IsNullOrEmpty(mapName))
-                throw new InvalidOperationException($"No beatmap files found in this beatmap archive ({reader.Name}).");
+            {
+                // Todo: This is temporary for debugging purposes
+                var files = reader.Filenames.ToList();
+                throw new InvalidOperationException($"No beatmap files found in this beatmap archive. Files ({files.Count}): {string.Join(", ", files)}");
+            }
 
             Beatmap beatmap;
             using (var stream = new StreamReader(reader.GetStream(mapName)))


### PR DESCRIPTION
At this point I'm practically ready to say that the archives are empty, since the long filename stuff is maintained:

![image](https://user-images.githubusercontent.com/1329837/44500427-5c2bad80-a6c3-11e8-8986-2f41f64d80a8.png)

But I still want to be super sure before ignoring this error.