### PR TITLE
Fix notifications appearing too early in load process

### DIFF
--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -96,8 +96,7 @@ namespace osu.Game.Overlays
             base.LoadComplete();
 
             StateChanged += _ => updateProcessingMode();
-            OverlayActivationMode.ValueChanged += _ => updateProcessingMode();
-            OverlayActivationMode.TriggerChange();
+            OverlayActivationMode.BindValueChanged(_ => updateProcessingMode(), true);
         }
 
         private int totalCount => sections.Select(c => c.DisplayedCount).Sum();

--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Shaders;
 using osu.Game.Screens.Menu;
 using OpenTK;
 using osu.Framework.Screens;
+using osu.Game.Overlays;
 
 namespace osu.Game.Screens
 {
@@ -17,6 +18,8 @@ namespace osu.Game.Screens
         private bool showDisclaimer;
 
         protected override bool HideOverlaysOnEnter => true;
+
+        protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
 
         protected override bool AllowBackButton => false;
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -174,6 +174,9 @@ namespace osu.Game.Screens.Menu
                 ButtonSystemState lastState = state;
                 state = value;
 
+                if (game != null)
+                    game.OverlayActivationMode.Value = state == ButtonSystemState.Exit ? OverlayActivation.Disabled : OverlayActivation.All;
+
                 updateLogoState(lastState);
 
                 Logger.Log($"{nameof(ButtonSystem)}'s state changed from {lastState} to {state}");
@@ -205,11 +208,7 @@ namespace osu.Game.Screens.Menu
                         {
                             logoTracking = false;
 
-                            if (game != null)
-                            {
-                                game.OverlayActivationMode.Value = state == ButtonSystemState.Exit ? OverlayActivation.Disabled : OverlayActivation.All;
-                                game.Toolbar.Hide();
-                            }
+                            game?.Toolbar.Hide();
 
                             logo.ClearTransforms(targetMember: nameof(Position));
                             logo.RelativePositionAxes = Axes.Both;
@@ -243,11 +242,7 @@ namespace osu.Game.Screens.Menu
                                 if (impact)
                                     logo.Impact();
 
-                                if (game != null)
-                                {
-                                    game.OverlayActivationMode.Value = OverlayActivation.All;
-                                    game.Toolbar.State = Visibility.Visible;
-                                }
+                                game?.Toolbar.Show();
                             }, 200);
                             break;
                         default:


### PR DESCRIPTION
It was intended that these were to be blocked. Unfortunately, `Loader` wasn't enforcing the blocking behaviour. Other changes are just code quality.