### PR TITLE
Fix operation cancelled exception when changing visual settings

### DIFF
--- a/osu.Game/Skinning/LocalSkinOverrideContainer.cs
+++ b/osu.Game/Skinning/LocalSkinOverrideContainer.cs
@@ -85,12 +85,10 @@ namespace osu.Game.Skinning
         private void load(OsuConfigManager config)
         {
             beatmapSkins = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
-            beatmapSkins.ValueChanged += val => onSourceChanged();
-            beatmapSkins.TriggerChange();
+            beatmapSkins.BindValueChanged(_ => onSourceChanged());
 
             beatmapHitsounds = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
-            beatmapHitsounds.ValueChanged += val => onSourceChanged();
-            beatmapHitsounds.TriggerChange();
+            beatmapHitsounds.BindValueChanged(_ => onSourceChanged(), true);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -57,7 +57,8 @@ namespace osu.Game.Skinning
         {
             base.Dispose(isDisposing);
 
-            skin.SourceChanged -= onChange;
+            if (skin != null)
+                skin.SourceChanged -= onChange;
         }
     }
 }

--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -52,5 +52,12 @@ namespace osu.Game.Skinning
         protected virtual void SkinChanged(ISkinSource skin, bool allowFallback)
         {
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            skin.SourceChanged -= onChange;
+        }
     }
 }


### PR DESCRIPTION
Fixes #3297

There are really two fixes involved here. This one and ppy/osu-framework#1808. Without the framework-side PR this will still work, but sounds will trigger twice until the last player's visualsettings' bindables get finalised.