### PR TITLE
Softly handle errors when no beatmap file exists in archive

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -352,7 +352,7 @@ namespace osu.Game.Beatmaps
             string mapName = reader.Filenames.FirstOrDefault(f => f.EndsWith(".osu"));
             if (string.IsNullOrEmpty(mapName))
             {
-                Logger.Log($"No beatmap files found in the beatmap archive ({reader.Name}).");
+                Logger.Log($"No beatmap files found in the beatmap archive ({reader.Name}).", LoggingTarget.Database);
                 return null;
             }
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -352,7 +352,7 @@ namespace osu.Game.Beatmaps
             string mapName = reader.Filenames.FirstOrDefault(f => f.EndsWith(".osu"));
             if (string.IsNullOrEmpty(mapName))
             {
-                Logger.Log($"No beatmap files found in the beatmap archive ({reader.Name}). Skipping.");
+                Logger.Log($"No beatmap files found in the beatmap archive ({reader.Name}).");
                 return null;
             }
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -352,9 +352,8 @@ namespace osu.Game.Beatmaps
             string mapName = reader.Filenames.FirstOrDefault(f => f.EndsWith(".osu"));
             if (string.IsNullOrEmpty(mapName))
             {
-                // Todo: This is temporary for debugging purposes
-                var files = reader.Filenames.ToList();
-                throw new InvalidOperationException($"No beatmap files found in this beatmap archive. Files ({files.Count}): {string.Join(", ", files)}");
+                Logger.Log($"No beatmap files found in the beatmap archive ({reader.Name}). Skipping.");
+                return null;
             }
 
             Beatmap beatmap;

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -390,7 +390,7 @@ namespace osu.Game.Database
         /// Actual expensive population should be done in <see cref="Populate"/>; this should just prepare for duplicate checking.
         /// </summary>
         /// <param name="archive">The archive to create the model for.</param>
-        /// <returns>A model populated with minimal information.</returns>
+        /// <returns>A model populated with minimal information. Returning a null will abort importing silently.</returns>
         protected abstract TModel CreateModel(ArchiveReader archive);
 
         /// <summary>

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -178,7 +178,8 @@ namespace osu.Game.Database
         {
             try
             {
-                return Import(CreateModel(archive), archive);
+                var model = CreateModel(archive);
+                return model == null ? null : Import(model, archive);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Resolves #3284

See attached sentry thread - errors are either .osz files in folders which wouldn't be detected by stable anyway, or .osu files having been deleted.