### PR TITLE
Fix mod icons in overlay performing blocking load operations

### DIFF
--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Mods;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input.EventArgs;
 using osu.Framework.Input.States;
 
@@ -33,23 +34,32 @@ namespace osu.Game.Overlays.Mods
 
         public IEnumerable<Mod> SelectedMods => buttons.Select(b => b.SelectedMod).Where(m => m != null);
 
+        private TransformSequence<FillFlowContainer<ModButtonEmpty>> switchSequence;
+
         public IEnumerable<Mod> Mods
         {
             set
             {
-                var modContainers = value.Select(m =>
+                switchSequence = ButtonsContainer.FadeOut(200, Easing.OutQuint);
+                switchSequence.OnComplete(_ =>
                 {
-                    if (m == null)
-                        return new ModButtonEmpty();
 
-                    return new ModButton(m)
+                    var modContainers = value.Select(m =>
                     {
-                        SelectionChanged = Action,
-                    };
-                }).ToArray();
+                        if (m == null)
+                            return new ModButtonEmpty();
 
-                ButtonsContainer.Children = modContainers;
-                buttons = modContainers.OfType<ModButton>().ToArray();
+                        return new ModButton(m)
+                        {
+                            SelectionChanged = Action,
+                        };
+                    }).ToArray();
+
+                    ButtonsContainer.Children = modContainers;
+                    buttons = modContainers.OfType<ModButton>().ToArray();
+
+                    ButtonsContainer.Show();
+                });
             }
         }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2018.830.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2018.831.0" />
     <PackageReference Include="SharpCompress" Version="0.22.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
On entering song select the first time, the mod icon texture loads would cause a visible overhead (they are triggered by a bindable ruleset change, so aren't eagerly loaded with song select's async load). This offloads that to a background thread. Implementation isn't optimal, but the whole mod overlay structure needs a rewrite at which point it can be improved.

- [x] Depends on framework release.