### PR TITLE
Don't use ConcurrentQueue for API

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -163,14 +163,16 @@ namespace osu.Game.Online.API
                     continue;
                 }
 
-                APIRequest req = null;
-
-                lock (queue)
-                    if (queue.Count > 0)
-                        req = queue.Dequeue();
-
-                if (req != null)
+                while (true)
                 {
+                    APIRequest req;
+
+                    lock (queue)
+                    {
+                        if (queue.Count == 0) break;
+                        req = queue.Dequeue();
+                    }
+
                     // TODO: handle failures better
                     handleRequest(req);
                 }

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Threading;
-using System.Threading.Tasks;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Logging;
@@ -54,7 +53,13 @@ namespace osu.Game.Online.API
             authentication.TokenString = config.Get<string>(OsuSetting.Token);
             authentication.Token.ValueChanged += onTokenChanged;
 
-            Task.Factory.StartNew(run, cancellationToken.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            var thread = new Thread(run)
+            {
+                Name = "APIAccess",
+                IsBackground = true
+            };
+
+            thread.Start();
         }
 
         private void onTokenChanged(OAuthToken token) => config.Set(OsuSetting.Token, config.Get<bool>(OsuSetting.SavePassword) ? authentication.TokenString : string.Empty);


### PR DESCRIPTION
This queue type can hold several references to already dequeued requests. In our usage, this can cause old api calls to hold references to already-disposed screens (and in turn, very large memory portions).