### PR TITLE
Fix the toolbar being visible during startup causing a weird offset

### DIFF
--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -83,14 +83,14 @@ namespace osu.Game.Overlays.Toolbar
         [BackgroundDependencyLoader(true)]
         private void load(OsuGame osuGame)
         {
-            if (osuGame != null)
-                overlayActivationMode.BindTo(osuGame.OverlayActivationMode);
-
             StateChanged += visibility =>
             {
                 if (overlayActivationMode == OverlayActivation.Disabled)
                     State = Visibility.Hidden;
             };
+
+            if (osuGame != null)
+                overlayActivationMode.BindTo(osuGame.OverlayActivationMode);
         }
 
         public class ToolbarBackground : Container


### PR DESCRIPTION
As below, if the toolbar took too long to load, it would offset some screen elements as it faded out. This starts it in a hidden state when required.

![](https://puu.sh/BpRj3/00b16bf16f.gif)