### PR TITLE
Fix updater

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -26,7 +26,7 @@ namespace osu.Desktop.Updater
         public void PrepareUpdate()
         {
             // Squirrel returns execution to us after the update process is started, so it's safe to use Wait() here
-            UpdateManager.RestartAppWhenExited().Wait();
+            UpdateManager.RestartAppWhenExited("osu!.exe").Wait();
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Squirrel was trying to run the entry assembly name, which was `osu!.dll` instead of `osu!.exe`
Luckily, `RestartAppWhenExited` has a parameter to specify the exe filename
However, I don't know if this will fix the desktop icon disappearing when updating

---

Fix updater not reopening osu!