### PR TITLE
Add music shortcuts and a small onScreenOverlay feedback

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -37,6 +37,10 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Down, GlobalAction.DecreaseVolume),
             new KeyBinding(InputKey.MouseWheelDown, GlobalAction.DecreaseVolume),
             new KeyBinding(InputKey.F4, GlobalAction.ToggleMute),
+            new KeyBinding(InputKey.X, GlobalAction.Play),
+            new KeyBinding(InputKey.C, GlobalAction.Pause),
+            new KeyBinding(InputKey.Right, GlobalAction.Next),
+            new KeyBinding(InputKey.Left, GlobalAction.Previous),
 
             new KeyBinding(InputKey.Escape, GlobalAction.Back),
             new KeyBinding(InputKey.MouseButton1, GlobalAction.Back),
@@ -77,6 +81,14 @@ namespace osu.Game.Input.Bindings
         DecreaseVolume,
         [Description("Toggle mute")]
         ToggleMute,
+        [Description("Play")]
+        Play,
+        [Description("Pause")]
+        Pause,
+        [Description("Next music")]
+        Next,
+        [Description("Previous music")]
+        Previous,
 
         // In-Game Keybindings
         [Description("Skip Cutscene")]

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -90,7 +90,7 @@ namespace osu.Game
 
         private VolumeOverlay volume;
         private OnScreenDisplay onscreenDisplay;
-        private MusicNotificationOverlay notification;
+        private MusicNotificationDisplay notification;
 
         private Bindable<int> configRuleset;
         private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
@@ -340,7 +340,7 @@ namespace osu.Game
 
             loadComponentSingleFile(volume = new VolumeOverlay(), overlayContent.Add);
             loadComponentSingleFile(onscreenDisplay = new OnScreenDisplay(), Add);
-            loadComponentSingleFile(notification = new MusicNotificationOverlay(), Add);
+            loadComponentSingleFile(notification = new MusicNotificationDisplay(), Add);
 
             loadComponentSingleFile(screenshotManager, Add);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -38,6 +38,7 @@ using osu.Game.Overlays.Volume;
 using osu.Game.Screens.Select;
 using osu.Game.Utils;
 using LogLevel = osu.Framework.Logging.LogLevel;
+using osu.Game.Overlays.Music;
 
 namespace osu.Game
 {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -567,26 +567,39 @@ namespace osu.Game
                     LocalConfig.Set(OsuSetting.MouseDisableButtons, !LocalConfig.Get<bool>(OsuSetting.MouseDisableButtons));
                     return true;
                 case GlobalAction.Play:
-                    if (musicController.IsPaused())
-                        notification.Display(@"Play", FontAwesome.fa_play);
-                    else
-                        notification.Display(@"Restart", FontAwesome.fa_refresh);
-                    musicController.Reset();
+                    try
+                    {
+                        Screen temp = (MainMenu)currentScreen;
+                        if (musicController.IsPaused())
+                            notification.Display(@"Play", FontAwesome.fa_play);
+                        else
+                            notification.Display(@"Restart", FontAwesome.fa_refresh);
+                        musicController.Reset();
+                    } catch(InvalidCastException e) {}
                     return true;
                 case GlobalAction.Pause:
-                    musicController.Play();
-                    if (musicController.IsPaused())
-                        notification.Display(@"Pause", FontAwesome.fa_pause);
-                    else
-                        notification.Display(@"Play", FontAwesome.fa_play);
-                    return true;
+                    try
+                    {
+                        musicController.Play();
+                        if (musicController.IsPaused())
+                            notification.Display(@"Pause", FontAwesome.fa_pause);
+                        else
+                            notification.Display(@"Play", FontAwesome.fa_play);
+                    } catch (InvalidCastException e) { }
+            return true;
                 case GlobalAction.Next:
-                    musicController.Next();
-                    notification.Display(@"Next", FontAwesome.fa_step_forward);
+                    try
+                    {
+                        musicController.Next();
+                        notification.Display(@"Next", FontAwesome.fa_step_forward);
+                    } catch(InvalidCastException e) {}
                     return true;
                 case GlobalAction.Previous:
-                    musicController.Prev();
-                    notification.Display(@"Previous", FontAwesome.fa_step_backward);
+                    try
+                    {
+                        musicController.Prev();
+                        notification.Display(@"Previous", FontAwesome.fa_step_backward);
+                    } catch(InvalidCastException e) {}
                     return true;
             }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -569,7 +569,7 @@ namespace osu.Game
                 case GlobalAction.Play:
                     try
                     {
-                        Screen temp = (MainMenu)currentScreen;
+                        currentScreen = (MainMenu)currentScreen;
                         if (musicController.IsPaused())
                             notification.Display(@"Play", FontAwesome.fa_play);
                         else
@@ -580,6 +580,7 @@ namespace osu.Game
                 case GlobalAction.Pause:
                     try
                     {
+                        currentScreen = (MainMenu)currentScreen;
                         musicController.Play();
                         if (musicController.IsPaused())
                             notification.Display(@"Pause", FontAwesome.fa_pause);
@@ -590,6 +591,7 @@ namespace osu.Game
                 case GlobalAction.Next:
                     try
                     {
+                        currentScreen = (MainMenu)currentScreen;
                         musicController.Next();
                         notification.Display(@"Next", FontAwesome.fa_step_forward);
                     } catch(InvalidCastException e) {}
@@ -597,6 +599,7 @@ namespace osu.Game
                 case GlobalAction.Previous:
                     try
                     {
+                        currentScreen = (MainMenu)currentScreen;
                         musicController.Prev();
                         notification.Display(@"Previous", FontAwesome.fa_step_backward);
                     } catch(InvalidCastException e) {}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -566,25 +566,25 @@ namespace osu.Game
                     LocalConfig.Set(OsuSetting.MouseDisableButtons, !LocalConfig.Get<bool>(OsuSetting.MouseDisableButtons));
                     return true;
                 case GlobalAction.Play:
-                    if (musicController.isPaused())
+                    if (musicController.IsPaused())
                         notification.Display(@"Play", FontAwesome.fa_play);
                     else
                         notification.Display(@"Restart", FontAwesome.fa_refresh);
-                    musicController.reset();
+                    musicController.Reset();
                     return true;
                 case GlobalAction.Pause:
-                    musicController.play();
-                    if (musicController.isPaused())
+                    musicController.Play();
+                    if (musicController.IsPaused())
                         notification.Display(@"Pause", FontAwesome.fa_pause);
                     else
                         notification.Display(@"Play", FontAwesome.fa_play);
                     return true;
                 case GlobalAction.Next:
-                    musicController.next();
+                    musicController.Next();
                     notification.Display(@"Next", FontAwesome.fa_step_forward);
                     return true;
                 case GlobalAction.Previous:
-                    musicController.prev();
+                    musicController.Prev();
                     notification.Display(@"Previous", FontAwesome.fa_step_backward);
                     return true;
             }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -90,6 +90,7 @@ namespace osu.Game
 
         private VolumeOverlay volume;
         private OnScreenDisplay onscreenDisplay;
+        private MusicNotificationOverlay notification;
 
         private Bindable<int> configRuleset;
         private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
@@ -339,6 +340,7 @@ namespace osu.Game
 
             loadComponentSingleFile(volume = new VolumeOverlay(), overlayContent.Add);
             loadComponentSingleFile(onscreenDisplay = new OnScreenDisplay(), Add);
+            loadComponentSingleFile(notification = new MusicNotificationOverlay(), Add);
 
             loadComponentSingleFile(screenshotManager, Add);
 
@@ -562,6 +564,28 @@ namespace osu.Game
                     return true;
                 case GlobalAction.ToggleGameplayMouseButtons:
                     LocalConfig.Set(OsuSetting.MouseDisableButtons, !LocalConfig.Get<bool>(OsuSetting.MouseDisableButtons));
+                    return true;
+                case GlobalAction.Play:
+                    if (musicController.isPaused())
+                        notification.Display(@"Play", FontAwesome.fa_play);
+                    else
+                        notification.Display(@"Restart", FontAwesome.fa_refresh);
+                    musicController.reset();
+                    return true;
+                case GlobalAction.Pause:
+                    musicController.play();
+                    if (musicController.isPaused())
+                        notification.Display(@"Pause", FontAwesome.fa_pause);
+                    else
+                        notification.Display(@"Play", FontAwesome.fa_play);
+                    return true;
+                case GlobalAction.Next:
+                    musicController.next();
+                    notification.Display(@"Next", FontAwesome.fa_step_forward);
+                    return true;
+                case GlobalAction.Previous:
+                    musicController.prev();
+                    notification.Display(@"Previous", FontAwesome.fa_step_backward);
                     return true;
             }
 

--- a/osu.Game/Overlays/Music/MusicNotificationDisplay.cs
+++ b/osu.Game/Overlays/Music/MusicNotificationDisplay.cs
@@ -1,25 +1,10 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
-using System.Collections.Generic;
-using osu.Framework.Allocation;
-using osu.Framework.Configuration;
-using osu.Framework.Configuration.Tracking;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
-using OpenTK;
-using OpenTK.Graphics;
-using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Graphics.Transforms;
-using osu.Framework.Threading;
-using osu.Game.Configuration;
 using osu.Game.Graphics.Sprites;
 
-namespace osu.Game.Overlays
+namespace osu.Game.Overlays.Music
 {
     public class MusicNotificationDisplay : Container
     {
@@ -28,8 +13,8 @@ namespace osu.Game.Overlays
         public override bool HandleKeyboardInput => false;
         public override bool HandleMouseInput => false;
 
-        private readonly SpriteText text;
-        private readonly SpriteIcon icon;
+        private readonly SpriteText notificationText;
+        private readonly SpriteIcon notificationIcon;
 
         private const float height = 52;
         private const float height_contracted = height * 0.9f;
@@ -85,12 +70,12 @@ namespace osu.Game.Overlays
             };
         }
 
-        public void Display(string _text, FontAwesome _icon)
+        public void Display(string text, FontAwesome icon)
         {
             Schedule(() =>
             {
-                text.Text = _text;
-                icon.Icon = _icon;
+                notificationText.Text = _text;
+                notificationIcon.Icon = _icon;
 
                 DisplayTemporarily(box);
             });

--- a/osu.Game/Overlays/Music/MusicNotificationDisplay.cs
+++ b/osu.Game/Overlays/Music/MusicNotificationDisplay.cs
@@ -1,6 +1,14 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Transforms;
+using osu.Framework.Threading;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 
@@ -49,7 +57,7 @@ namespace osu.Game.Overlays.Music
                             Width = 80,
                             RelativeSizeAxes = Axes.Y,
                         },
-                        text = new OsuSpriteText
+                        notificationText = new OsuSpriteText
                         {
                             Padding = new MarginPadding(10),
                             Font = @"Exo2.0-Black",
@@ -58,7 +66,7 @@ namespace osu.Game.Overlays.Music
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                         },
-                        icon = new SpriteIcon
+                        notificationIcon = new SpriteIcon
                         {
                             Size = new Vector2(12),
                             Margin = new MarginPadding(16),
@@ -74,8 +82,8 @@ namespace osu.Game.Overlays.Music
         {
             Schedule(() =>
             {
-                notificationText.Text = _text;
-                notificationIcon.Icon = _icon;
+                notificationText.Text = text;
+                notificationIcon.Icon = icon;
 
                 DisplayTemporarily(box);
             });

--- a/osu.Game/Overlays/Music/MusicNotificationDisplay.cs
+++ b/osu.Game/Overlays/Music/MusicNotificationDisplay.cs
@@ -21,7 +21,7 @@ using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Overlays
 {
-    public class MusicNotificationOverlay : Container
+    public class MusicNotificationDisplay : Container
     {
         private readonly Container box;
 
@@ -34,7 +34,7 @@ namespace osu.Game.Overlays
         private const float height = 52;
         private const float height_contracted = height * 0.9f;
 
-        public MusicNotificationOverlay()
+        public MusicNotificationDisplay()
         {
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Overlays/Music/MusicNotificationOverlay.cs
+++ b/osu.Game/Overlays/Music/MusicNotificationOverlay.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Configuration.Tracking;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Transforms;
+using osu.Framework.Threading;
+using osu.Game.Configuration;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Overlays
+{
+    public class MusicNotificationOverlay : Container
+    {
+        private readonly Container box;
+
+        public override bool HandleKeyboardInput => false;
+        public override bool HandleMouseInput => false;
+
+        private readonly SpriteText text;
+        private readonly SpriteIcon icon;
+
+        private const float height = 52;
+        private const float height_contracted = height * 0.9f;
+
+        public MusicNotificationOverlay()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            Children = new Drawable[]
+            {
+                box = new Container
+                {
+                    Origin = Anchor.Centre,
+                    RelativePositionAxes = Axes.Both,
+                    Position = new Vector2(0.5f, 0.75f),
+                    Masking = true,
+                    AutoSizeAxes = Axes.X,
+                    Alpha = 0,
+                    CornerRadius = 20,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Black,
+                            Alpha = 0.7f,
+                        },
+                        new Container // purely to add a minimum width
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Width = 80,
+                            RelativeSizeAxes = Axes.Y,
+                        },
+                        text = new OsuSpriteText
+                        {
+                            Padding = new MarginPadding(10),
+                            Font = @"Exo2.0-Black",
+                            Spacing = new Vector2(1, 0),
+                            TextSize = 11,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                        },
+                        icon = new SpriteIcon
+                        {
+                            Size = new Vector2(12),
+                            Margin = new MarginPadding(16),
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                        },
+                    }
+                },
+            };
+        }
+
+        public void Display(string _text, FontAwesome _icon)
+        {
+            Schedule(() =>
+            {
+                text.Text = _text;
+                icon.Icon = _icon;
+
+                DisplayTemporarily(box);
+            });
+        }
+
+        private TransformSequence<Drawable> fadeIn;
+        private ScheduledDelegate fadeOut;
+
+        protected virtual void DisplayTemporarily(Drawable toDisplay)
+        {
+            // avoid starting a new fade-in if one is already active.
+            if (fadeIn == null)
+            {
+                fadeIn = toDisplay.Animate(
+                    b => b.FadeIn(500, Easing.OutQuint),
+                    b => b.ResizeHeightTo(height, 500, Easing.OutQuint)
+                );
+
+                fadeIn.Finally(_ => fadeIn = null);
+            }
+
+            fadeOut?.Cancel();
+            fadeOut = Scheduler.AddDelayed(() =>
+            {
+                toDisplay.Animate(
+                    b => b.FadeOutFromOne(1500, Easing.InQuint),
+                    b => b.ResizeHeightTo(height_contracted, 1500, Easing.InQuint));
+            }, 500);
+        }
+    }
+}

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Overlays
                                                 {
                                                     Anchor = Anchor.Centre,
                                                     Origin = Anchor.Centre,
-                                                    Action = prev,
+                                                    Action = Prev,
                                                     Icon = FontAwesome.fa_step_backward,
                                                 },
                                                 playButton = new MusicIconButton
@@ -155,14 +155,14 @@ namespace osu.Game.Overlays
                                                     Origin = Anchor.Centre,
                                                     Scale = new Vector2(1.4f),
                                                     IconScale = new Vector2(1.4f),
-                                                    Action = play,
+                                                    Action = Play,
                                                     Icon = FontAwesome.fa_play_circle_o,
                                                 },
                                                 nextButton = new MusicIconButton
                                                 {
                                                     Anchor = Anchor.Centre,
                                                     Origin = Anchor.Centre,
-                                                    Action = () => next(),
+                                                    Action = () => Next(),
                                                     Icon = FontAwesome.fa_step_forward,
                                                 },
                                             }
@@ -257,7 +257,7 @@ namespace osu.Game.Overlays
                 playButton.Icon = FontAwesome.fa_play_circle_o;
         }
 
-        public void play()
+        public void Play()
         {
             var track = current?.Track;
 
@@ -274,7 +274,7 @@ namespace osu.Game.Overlays
                 track.Start();
         }
 
-        public void reset()
+        public void Reset()
         {
             var track = current?.Track;
 
@@ -287,7 +287,7 @@ namespace osu.Game.Overlays
                 track.Start();
         }
 
-        public bool isPaused()
+        public bool IsPaused()
         {
             var track = current?.Track;
 
@@ -297,7 +297,7 @@ namespace osu.Game.Overlays
             return !track.IsRunning;
         }
 
-        public void prev()
+        public void Prev()
         {
             queuedDirection = TransformDirection.Prev;
 
@@ -309,7 +309,7 @@ namespace osu.Game.Overlays
             }
         }
 
-        public void next(bool instant = false)
+        public void Next(bool instant = false)
         {
             if (!instant)
                 queuedDirection = TransformDirection.Next;

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Overlays
                 playButton.Icon = track.IsRunning ? FontAwesome.fa_pause_circle_o : FontAwesome.fa_play_circle_o;
 
                 if (track.HasCompleted && !track.Looping && !beatmap.Disabled && beatmapSets.Any())
-                    next();
+                    Next();
             }
             else
                 playButton.Icon = FontAwesome.fa_play_circle_o;
@@ -264,7 +264,7 @@ namespace osu.Game.Overlays
             if (track == null)
             {
                 if (!beatmap.Disabled)
-                    next(true);
+                    Next(true);
                 return;
             }
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Overlays
                 playButton.Icon = FontAwesome.fa_play_circle_o;
         }
 
-        private void play()
+        public void play()
         {
             var track = current?.Track;
 
@@ -274,7 +274,30 @@ namespace osu.Game.Overlays
                 track.Start();
         }
 
-        private void prev()
+        public void reset()
+        {
+            var track = current?.Track;
+
+            if (track == null)
+                return;
+
+            if (track.IsRunning)
+                track.Restart();
+            else
+                track.Start();
+        }
+
+        public bool isPaused()
+        {
+            var track = current?.Track;
+
+            if (track == null)
+                return false;
+
+            return !track.IsRunning;
+        }
+
+        public void prev()
         {
             queuedDirection = TransformDirection.Prev;
 
@@ -286,7 +309,7 @@ namespace osu.Game.Overlays
             }
         }
 
-        private void next(bool instant = false)
+        public void next(bool instant = false)
         {
             if (!instant)
                 queuedDirection = TransformDirection.Next;


### PR DESCRIPTION
I added the osu! music shortcuts feature with a adapted copy of the onScreenDisplay ~~(crap, I thought it was Overlay)~~ to give a little feedback. I am still wondering if it's better to add the onPressed to the MusicControler or to keep it in OsuGame, because it will only work when it's visible.