### PR TITLE
Use LargeTextureStore for all online texture retrieval

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -108,7 +108,9 @@ namespace osu.Game
 
             dependencies.Cache(contextFactory = new DatabaseContextFactory(Host.Storage));
 
-            dependencies.Cache(new LargeTextureStore(new TextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures"))));
+            var largeStore = new LargeTextureStore(new TextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures")));
+            largeStore.AddStore(new TextureLoaderStore(new OnlineStore()));
+            dependencies.Cache(largeStore);
 
             dependencies.CacheAs(this);
             dependencies.Cache(LocalConfig);

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -104,8 +104,6 @@ namespace osu.Game.Overlays.Direct
             beatmaps.ItemAdded += setAdded;
         }
 
-        public override bool DisposeOnDeathRemoval => true;
-
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);

--- a/osu.Game/Overlays/MedalSplash/DrawableMedal.cs
+++ b/osu.Game/Overlays/MedalSplash/DrawableMedal.cs
@@ -118,9 +118,9 @@ namespace osu.Game.Overlays.MedalSplash
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, TextureStore textures)
+        private void load(OsuColour colours, TextureStore textures, LargeTextureStore largeTextures)
         {
-            medalSprite.Texture = textures.Get(medal.ImageUrl);
+            medalSprite.Texture = largeTextures.Get(medal.ImageUrl);
             medalGlow.Texture = textures.Get(@"MedalSplash/medal-glow");
             description.Colour = colours.BlueLight;
         }

--- a/osu.Game/Overlays/Profile/Header/BadgeContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BadgeContainer.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Overlays.Profile.Header
             }
 
             [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
+            private void load(LargeTextureStore textures)
             {
                 Child = new Sprite
                 {

--- a/osu.Game/Overlays/Profile/Sections/Recent/MedalIcon.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/MedalIcon.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(LargeTextureStore textures)
         {
             sprite.Texture = textures.Get(url);
         }

--- a/osu.Game/Screens/Ranking/ResultsPageScore.cs
+++ b/osu.Game/Screens/Ranking/ResultsPageScore.cs
@@ -368,7 +368,7 @@ namespace osu.Game.Screens.Ranking
             }
 
             [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
+            private void load(LargeTextureStore textures)
             {
                 if (!string.IsNullOrEmpty(user.CoverUrl))
                     cover.Texture = textures.Get(user.CoverUrl);

--- a/osu.Game/Users/Avatar.cs
+++ b/osu.Game/Users/Avatar.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Users
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(LargeTextureStore textures)
         {
             if (textures == null)
                 throw new ArgumentNullException(nameof(textures));

--- a/osu.Game/Users/UserCoverBackground.cs
+++ b/osu.Game/Users/UserCoverBackground.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Users
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(LargeTextureStore textures)
         {
             if (textures == null)
                 throw new ArgumentNullException(nameof(textures));


### PR DESCRIPTION
Until now, many online textures were retrieved via the default texture store, which causes them to never be removed from GPU memory. It also has a performance overhead due to mipmap generation (which will be avoided via ppy/osu-framework#1885).

- [x] Depends on ppy/osu-framework#1885