### PR TITLE
Fix hitobjects getting masked away before receiving a result

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
@@ -163,6 +165,14 @@ namespace osu.Game.Rulesets.Objects.Drawables
                     State.Value = ArmedState.Idle;
                 }
             }
+        }
+
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
+        {
+            if (!AllJudged)
+                return false;
+
+            return base.UpdateSubTreeMasking(source, maskingBounds);
         }
 
         protected override void UpdateAfterChildren()


### PR DESCRIPTION
This was noticeable in mania, where notes would move off the screen and you couldn't hit them even if their hit windows allowed it.

Mania is still messed up in other ways right now, will perform additional fixes in subsequent PRs. Can't find anything wrong with osu!/taiko...