### PR TITLE
Fixes hyperdash computation (for nested objects)

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -74,42 +74,43 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
         private void initialiseHyperDash(List<CatchHitObject> objects)
         {
-            // todo: add difficulty adjust.
-            double halfCatcherWidth = CatcherArea.CATCHER_SIZE * (objects.FirstOrDefault()?.Scale ?? 1) / CatchPlayfield.BASE_WIDTH / 2;
+            if (objects.Count == 0)
+                return;
 
+            List<CatchHitObject> objectWithDroplets = new List<CatchHitObject>();
+
+            foreach (var currentObject in objects)
+            {
+                if (currentObject is Fruit)
+                    objectWithDroplets.Add(currentObject);
+                if (currentObject is JuiceStream)
+                    foreach (var currentJuiceElement in currentObject.NestedHitObjects)
+                        if (!(currentJuiceElement is TinyDroplet))
+                            objectWithDroplets.Add((CatchHitObject)currentJuiceElement);
+            }
+
+            double halfCatcherWidth = CatcherArea.CATCHER_SIZE * objectWithDroplets[0].Scale / CatchPlayfield.BASE_WIDTH / 2;
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;
 
-            int objCount = objects.Count;
-
-            for (int i = 0; i < objCount - 1; i++)
+            for (int i = 0; i < objectWithDroplets.Count - 1; i++)
             {
-                CatchHitObject currentObject = objects[i];
-
-                // not needed?
-                // if (currentObject is TinyDroplet) continue;
-
-                CatchHitObject nextObject = objects[i + 1];
-
-                // while (nextObject is TinyDroplet)
-                // {
-                //     if (++i == objCount - 1) break;
-                //     nextObject = objects[i + 1];
-                // }
+                CatchHitObject currentObject = objectWithDroplets[i];
+                CatchHitObject nextObject = objectWithDroplets[i + 1];
 
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
-                double timeToNext = nextObject.StartTime - ((currentObject as IHasEndTime)?.EndTime ?? currentObject.StartTime) - 4;
+                double timeToNext = nextObject.StartTime - currentObject.StartTime;
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
-
-                if (timeToNext * CatcherArea.Catcher.BASE_SPEED < distanceToNext)
+                float distanceToHyper = (float)(timeToNext * CatcherArea.Catcher.BASE_SPEED - distanceToNext);
+                if (distanceToHyper < 0)
                 {
                     currentObject.HyperDashTarget = nextObject;
                     lastExcess = halfCatcherWidth;
                 }
                 else
                 {
-                    //currentObject.DistanceToHyperDash = timeToNext - distanceToNext;
-                    lastExcess = MathHelper.Clamp(timeToNext - distanceToNext, 0, halfCatcherWidth);
+                    currentObject.DistanceToHyperDash = distanceToHyper;
+                    lastExcess = MathHelper.Clamp(distanceToHyper, 0, halfCatcherWidth);
                 }
 
                 lastDirection = thisDirection;

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -74,9 +74,6 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
         private void initialiseHyperDash(List<CatchHitObject> objects)
         {
-            if (objects.Count == 0)
-                return;
-
             List<CatchHitObject> objectWithDroplets = new List<CatchHitObject>();
 
             foreach (var currentObject in objects)
@@ -89,7 +86,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                             objectWithDroplets.Add((CatchHitObject)currentJuiceElement);
             }
 
-            double halfCatcherWidth = CatcherArea.CATCHER_SIZE * objectWithDroplets[0].Scale / CatchPlayfield.BASE_WIDTH / 2;
+            double halfCatcherWidth = CatcherArea.GetCatcherSize(Beatmap.BeatmapInfo.BaseDifficulty) / 2;
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;
 

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -86,6 +86,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                             objectWithDroplets.Add((CatchHitObject)currentJuiceElement);
             }
 
+            objectWithDroplets.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
+
             double halfCatcherWidth = CatcherArea.GetCatcherSize(Beatmap.BeatmapInfo.BaseDifficulty) / 2;
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Catch.Objects
         public int ComboIndex { get; set; }
 
         /// <summary>
-        /// The difference between the distance of the next object 
-        /// and the distance that would have triggered hyper dashing.
-        /// A value close to 0 indicates a difficult jump (for SR calculation)
+        /// Difference between the distance to the next object
+        /// and the distance that would have triggered a hyper dash.
+        /// A value close to 0 indicates a difficult jump (for difficulty calculation).
         /// </summary>
         public float DistanceToHyperDash { get; set; }
 

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -27,7 +27,9 @@ namespace osu.Game.Rulesets.Catch.Objects
         public int ComboIndex { get; set; }
 
         /// <summary>
-        /// The distance for a fruit to to next hyper if it's not a hyper.
+        /// The difference between the distance of the next object 
+        /// and the distance that would have triggered hyper dashing.
+        /// A value close to 0 indicates a difficult jump (for SR calculation)
         /// </summary>
         public float DistanceToHyperDash { get; set; }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public static float GetCatcherSize(BeatmapDifficulty difficulty)
         {
-            return (CATCHER_SIZE / CatchPlayfield.BASE_WIDTH) * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
+            return CATCHER_SIZE / CatchPlayfield.BASE_WIDTH * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
         }
 
         public class Catcher : Container, IKeyBindingHandler<CatchAction>

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -107,6 +107,11 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public bool AttemptCatch(CatchHitObject obj) => MovableCatcher.AttemptCatch(obj);
 
+        public static float GetCatcherSize(BeatmapDifficulty difficulty)
+        {
+            return (CATCHER_SIZE / CatchPlayfield.BASE_WIDTH) * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
+        }
+
         public class Catcher : Container, IKeyBindingHandler<CatchAction>
         {
             /// <summary>


### PR DESCRIPTION
Fix #2586 
Rewrite from #2610 
Fixes hyperdash computation to take juice streams into account correctly.
I tested the patch, with high/low CS, converted/native and did not notice anything fondamently wrong. 
