### PR TITLE
Fix osu! replays potentially missing at sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -283,6 +283,16 @@ namespace osu.Game.Rulesets.Osu.Replays
                 }
             }
 
+            // We need to move the cursor to the slider before we click the slider,
+            // because framework update the hovered information would delay one frame.
+            // TODO: The update CirclePiece.IsHovered of DrawableSlider will delay one frame, maybe the root problem is in framework
+            if (h is Slider && index >= 0)
+            {
+                var previousFrame = (OsuReplayFrame)Frames[index];
+                double preClickTime = Math.Max((previousFrame.Time + h.StartTime) / 2.0 , h.StartTime - 1);
+                AddFrameToReplay(new OsuReplayFrame(preClickTime, new Vector2(startPosition.X, startPosition.Y)));
+            }
+
             AddFrameToReplay(startFrame);
 
             switch (h)


### PR DESCRIPTION
I found the replay will sometimes get miss at the head of slider.
The reason is `CirclePiece.IsHovered` in the `DrawableSlider` will delay one frame to update. (compare to `DrawableSlider.IsHovered`)
So the quick patch is add a replay frame to move to the slider, let `CirclePiece.IsHovered` has one frame time to be update.
We still need to find out the root reason of synchronize, the root problem maybe in the framework.

- Depends on #3404 
- Closes #3404 

---

Add a sentence or two describing this change in plain english. This will be displayed on the [changelog](https://osu.ppy.sh/home/changelog). A single screenshot or short gif is also welcomed.