### PR TITLE
Fruit type now depends on combo (osu!catch)

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         public int IndexInBeatmap { get; set; }
 
-        public virtual FruitVisualRepresentation VisualRepresentation => (FruitVisualRepresentation)(IndexInBeatmap % 4);
+        public virtual FruitVisualRepresentation VisualRepresentation => (FruitVisualRepresentation)(ComboIndex % 4);
 
         public virtual bool NewCombo { get; set; }
 

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Beatmaps
 
         public virtual void PostProcess()
         {
-            void UpdateNestedCombo(Rulesets.Objects.HitObject obj, int comboIndex, int indexInCurrentCombo)
+            void updateNestedCombo(Rulesets.Objects.HitObject obj, int comboIndex, int indexInCurrentCombo)
             {
                 if (obj is IHasComboInformation)
                 {
@@ -52,7 +52,7 @@ namespace osu.Game.Beatmaps
                     objectComboInfo.ComboIndex = comboIndex;
                     objectComboInfo.IndexInCurrentCombo = indexInCurrentCombo;
                     foreach (var nestedObjet in obj.NestedHitObjects)
-                        UpdateNestedCombo(nestedObjet, comboIndex, indexInCurrentCombo);
+                        updateNestedCombo(nestedObjet, comboIndex, indexInCurrentCombo);
                 }
             }
             foreach (var hitObject in Beatmap.HitObjects)
@@ -60,7 +60,7 @@ namespace osu.Game.Beatmaps
                 {
                     var objectComboInfo = (IHasComboInformation)hitObject;
                     foreach (var nested in hitObject.NestedHitObjects)
-                        UpdateNestedCombo(nested, objectComboInfo.ComboIndex, objectComboInfo.IndexInCurrentCombo);
+                        updateNestedCombo(nested, objectComboInfo.ComboIndex, objectComboInfo.IndexInCurrentCombo);
                 }
         }
     }

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -44,13 +44,24 @@ namespace osu.Game.Beatmaps
 
         public virtual void PostProcess()
         {
+            void UpdateNestedCombo(Rulesets.Objects.HitObject obj, int comboIndex, int indexInCurrentCombo)
+            {
+                if (obj is IHasComboInformation)
+                {
+                    var objectComboInfo = (IHasComboInformation)obj;
+                    objectComboInfo.ComboIndex = comboIndex;
+                    objectComboInfo.IndexInCurrentCombo = indexInCurrentCombo;
+                    foreach (var nestedObjet in obj.NestedHitObjects)
+                        UpdateNestedCombo(nestedObjet, comboIndex, indexInCurrentCombo);
+                }
+            }
             foreach (var hitObject in Beatmap.HitObjects)
             {
-                var objectComboInfo = (IHasComboInformation)hitObject;
-                foreach (var obj in hitObject.NestedHitObjects.OfType<IHasComboInformation>())
+                if (hitObject is IHasComboInformation)
                 {
-                    obj.IndexInCurrentCombo = objectComboInfo.IndexInCurrentCombo;
-                    obj.ComboIndex = objectComboInfo.ComboIndex;
+                    var objectComboInfo = (IHasComboInformation)hitObject;
+                    foreach (var nested in hitObject.NestedHitObjects)
+                        UpdateNestedCombo(nested, objectComboInfo.ComboIndex, objectComboInfo.IndexInCurrentCombo);
                 }
             }
         }

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -56,14 +56,12 @@ namespace osu.Game.Beatmaps
                 }
             }
             foreach (var hitObject in Beatmap.HitObjects)
-            {
                 if (hitObject is IHasComboInformation)
                 {
                     var objectComboInfo = (IHasComboInformation)hitObject;
                     foreach (var nested in hitObject.NestedHitObjects)
                         UpdateNestedCombo(nested, objectComboInfo.ComboIndex, objectComboInfo.IndexInCurrentCombo);
                 }
-            }
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -44,6 +44,15 @@ namespace osu.Game.Beatmaps
 
         public virtual void PostProcess()
         {
+            foreach (var hitObject in Beatmap.HitObjects)
+            {
+                var objectComboInfo = (IHasComboInformation)hitObject;
+                foreach (var obj in hitObject.NestedHitObjects.OfType<IHasComboInformation>())
+                {
+                    obj.IndexInCurrentCombo = objectComboInfo.IndexInCurrentCombo;
+                    obj.ComboIndex = objectComboInfo.ComboIndex;
+                }
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System.Linq;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Beatmaps
@@ -44,24 +45,25 @@ namespace osu.Game.Beatmaps
 
         public virtual void PostProcess()
         {
-            void updateNestedCombo(Rulesets.Objects.HitObject obj, int comboIndex, int indexInCurrentCombo)
+            void updateNestedCombo(HitObject obj, int comboIndex, int indexInCurrentCombo)
             {
-                if (obj is IHasComboInformation)
+                if (obj is IHasComboInformation objectComboInfo)
                 {
-                    var objectComboInfo = (IHasComboInformation)obj;
                     objectComboInfo.ComboIndex = comboIndex;
                     objectComboInfo.IndexInCurrentCombo = indexInCurrentCombo;
-                    foreach (var nestedObjet in obj.NestedHitObjects)
-                        updateNestedCombo(nestedObjet, comboIndex, indexInCurrentCombo);
+                    foreach (var nestedObject in obj.NestedHitObjects)
+                        updateNestedCombo(nestedObject, comboIndex, indexInCurrentCombo);
                 }
             }
+
             foreach (var hitObject in Beatmap.HitObjects)
-                if (hitObject is IHasComboInformation)
+            {
+                if (hitObject is IHasComboInformation objectComboInfo)
                 {
-                    var objectComboInfo = (IHasComboInformation)hitObject;
                     foreach (var nested in hitObject.NestedHitObjects)
                         updateNestedCombo(nested, objectComboInfo.ComboIndex, objectComboInfo.IndexInCurrentCombo);
                 }
+            }
         }
     }
 }


### PR DESCRIPTION
In relation with issue #2224
The Fruit type is now determined based on combo (like in stable) instead of changing for every fruit.
To do that, nested objects combo information is now computed in Beatmap post processing. As a consequence, every nested object has the same combo information as its parent. Another option would be to move Combo Information Computation altogether to post proccessing. 