### PR TITLE
Close chat tabs with middle mouse button

### DIFF
--- a/osu.Game/Overlays/Chat/ChatTabControl.cs
+++ b/osu.Game/Overlays/Chat/ChatTabControl.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Overlays.Chat
             {
                 if (args.Button == MouseButton.Middle)
                     closeButton.Action();
-                return base.OnMouseUp(state, args);
+                return true;
             }
 
             protected override bool OnHover(InputState state)

--- a/osu.Game/Overlays/Chat/ChatTabControl.cs
+++ b/osu.Game/Overlays/Chat/ChatTabControl.cs
@@ -146,9 +146,10 @@ namespace osu.Game.Overlays.Chat
 
             protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
             {
-                if (args.Button == MouseButton.Middle)
+                var isMclick = args.Button == MouseButton.Middle;
+                if (isMclick)
                     closeButton.Action();
-                return true;
+                return isMclick;
             }
 
             protected override bool OnHover(InputState state)

--- a/osu.Game/Overlays/Chat/ChatTabControl.cs
+++ b/osu.Game/Overlays/Chat/ChatTabControl.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Chat;
 using OpenTK;
+using OpenTK.Input;
 using OpenTK.Graphics;
 using osu.Framework.Configuration;
 using System;
@@ -141,6 +142,13 @@ namespace osu.Game.Overlays.Chat
 
                 text.FadeIn(transition_length, Easing.OutQuint);
                 textBold.FadeOut(transition_length, Easing.OutQuint);
+            }
+
+            protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
+            {
+                if (args.Button == MouseButton.Middle)
+                    closeButton.Action();
+                return base.OnMouseUp(state, args);
             }
 
             protected override bool OnHover(InputState state)

--- a/osu.Game/Overlays/Chat/ChatTabControl.cs
+++ b/osu.Game/Overlays/Chat/ChatTabControl.cs
@@ -146,10 +146,13 @@ namespace osu.Game.Overlays.Chat
 
             protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
             {
-                var isMclick = args.Button == MouseButton.Middle;
-                if (isMclick)
+                if (args.Button == MouseButton.Middle)
+                {
                     closeButton.Action();
-                return isMclick;
+                    return true;
+                }
+
+                return false;
             }
 
             protected override bool OnHover(InputState state)


### PR DESCRIPTION
Clicks the close button when clicking a chat tab with mouseM.

- Closes #3418 

---

Clicking on a chat tab with the middle mouse button now closes the tab, just like in web browsers. -> [video](https://streamable.com/ivmbm)