### PR TITLE
Adjust osu!catch proportions

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             base.Content.Anchor = Anchor.BottomLeft;
             base.Content.Origin = Anchor.BottomLeft;
-            base.Content.Position = new Vector2(0, 215);
+            base.Content.Position = new Vector2(0, 215); // matches stable's vertical offset for catcher plate
 
             base.Content.AddRange(new Drawable[]
             {

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -10,7 +10,6 @@ using osu.Game.Rulesets.Catch.Objects.Drawable;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
-using OpenTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -34,10 +34,10 @@ namespace osu.Game.Rulesets.Catch.UI
 
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;
-            base.Content.Position = new Vector2(0, 215);
 
             base.Content.Anchor = Anchor.BottomLeft;
             base.Content.Origin = Anchor.BottomLeft;
+            base.Content.Position = new Vector2(0, 215);
 
             base.Content.AddRange(new Drawable[]
             {

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Catch.Objects.Drawable;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
+using OpenTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
@@ -33,6 +34,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;
+            base.Content.Position = new Vector2(0, 215);
 
             base.Content.Anchor = Anchor.BottomLeft;
             base.Content.Origin = Anchor.BottomLeft;

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
             base.Content.Anchor = Anchor.BottomLeft;
             base.Content.Origin = Anchor.BottomLeft;
-            base.Content.Position = new Vector2(0, 215); // matches stable's vertical offset for catcher plate
 
             base.Content.AddRange(new Drawable[]
             {

--- a/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public override PassThroughInputManager CreateInputManager() => new CatchInputManager(Ruleset.RulesetInfo);
 
-        protected override Vector2 PlayfieldArea => new Vector2(0.86f); // matches stable's vertical offset for catcher plate
+        protected override Vector2 PlayfieldArea => new Vector2(0.58f); // matches stable's vertical offset for catcher plate
 
         protected override DrawableHitObject<CatchHitObject> GetVisualRepresentation(CatchHitObject h)
         {

--- a/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public override PassThroughInputManager CreateInputManager() => new CatchInputManager(Ruleset.RulesetInfo);
 
-        protected override Vector2 PlayfieldArea => new Vector2(0.58f); // matches stable's vertical offset for catcher plate
+        protected override Vector2 PlayfieldArea => new Vector2(0.58f); // matches stable's playfield width
 
         protected override DrawableHitObject<CatchHitObject> GetVisualRepresentation(CatchHitObject h)
         {

--- a/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchRulesetContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public override PassThroughInputManager CreateInputManager() => new CatchInputManager(Ruleset.RulesetInfo);
 
-        protected override Vector2 PlayfieldArea => new Vector2(0.58f); // matches stable's playfield width
+        protected override Vector2 PlayfieldArea => new Vector2(0.58f, 0.86f); // matches stable's playfield width, and platter's height
 
         protected override DrawableHitObject<CatchHitObject> GetVisualRepresentation(CatchHitObject h)
         {

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public static float GetCatcherSize(BeatmapDifficulty difficulty)
         {
-            return CATCHER_SIZE / CatchPlayfield.BASE_WIDTH * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
+            return CATCHER_SIZE / CatchPlayfield.BASE_WIDTH * 1.3f * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
         }
 
         public class Catcher : Container, IKeyBindingHandler<CatchAction>
@@ -135,7 +135,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2(1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
+                    Scale = new Vector2(1.3f * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5));
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Catch.UI
 {
     public class CatcherArea : Container
     {
-        public const float CATCHER_SIZE = 84;
+        public const float CATCHER_SIZE = 109;
 
         protected readonly Catcher MovableCatcher;
 
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public static float GetCatcherSize(BeatmapDifficulty difficulty)
         {
-            return CATCHER_SIZE / CatchPlayfield.BASE_WIDTH * 1.3f * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
+            return CATCHER_SIZE / CatchPlayfield.BASE_WIDTH * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
         }
 
         public class Catcher : Container, IKeyBindingHandler<CatchAction>
@@ -135,7 +135,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 Size = new Vector2(CATCHER_SIZE);
                 if (difficulty != null)
-                    Scale = new Vector2(1.3f * (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5));
+                    Scale = new Vector2(1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
Adjusted playfield width and catcher plate width to better match stable's. I'm not pretending it's perfect but it's way better. Here is a comparison picture.
![dsbuffer bmp](https://user-images.githubusercontent.com/10192642/45589665-b538db00-b929-11e8-943f-7e9460d98960.png)
