### PR TITLE
Creates a default Ruleset Cursor, that fades out on idle.

### DIFF
--- a/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
+++ b/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.UI.Cursor
         ///<summary/>
         public double IdleDelay = 2000;
 
-        public RulesetCursor() : base()
+        public RulesetCursor()
         {
             Hide();
         }

--- a/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
+++ b/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Rulesets.UI.Cursor
                 if (State == Visibility.Hidden)
                 {
                     Show();
-                    PopIn();
                 }
             }
 
@@ -33,7 +32,6 @@ namespace osu.Game.Rulesets.UI.Cursor
             if (State == Visibility.Visible && idleTime > 2000)
             {
                 Hide();
-                PopOut();
             }
         }
     }

--- a/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
+++ b/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.UI.Cursor
         private StopwatchClock clock = new StopwatchClock(true);
         private double idleTime => clock.CurrentTime - lastActiveTime;
         ///<summary> 
-        ///Time of idling after which the cursor is hidden.true
+        ///Time of idling after which the cursor is hidden.
         ///<summary/>
         public double IdleDelay = 2000;
 

--- a/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
+++ b/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
@@ -10,13 +10,18 @@ namespace osu.Game.Rulesets.UI.Cursor
 {
     public class RulesetCursor : MenuCursor
     {
-        private double lastActiveTime = 0;
-        private StopwatchClock clock = new StopwatchClock(true);
+        private double lastActiveTime;
+        private readonly StopwatchClock clock = new StopwatchClock(true);
         private double idleTime => clock.CurrentTime - lastActiveTime;
         ///<summary> 
         ///Time of idling after which the cursor is hidden.
         ///<summary/>
         public double IdleDelay = 2000;
+
+        public RulesetCursor() : base()
+        {
+            Hide();
+        }
 
         protected override bool OnMouseMove(InputState state)
         {

--- a/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
+++ b/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
@@ -1,0 +1,40 @@
+using osu.Game.Graphics.Cursor;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.States;
+using osu.Framework.Timing;
+
+namespace osu.Game.Rulesets.UI.Cursor
+{
+    public class RulesetCursor : MenuCursor
+    {
+        private double lastActiveTime = 0;
+        private StopwatchClock clock = new StopwatchClock(true);
+        private double idleTime => clock.CurrentTime - lastActiveTime;
+
+        protected override bool OnMouseMove(InputState state)
+        {
+            if (ActiveCursor.Position != state.Mouse.Position)
+            {
+                lastActiveTime = clock.CurrentTime;
+                if (State == Visibility.Hidden)
+                {
+                    Show();
+                    PopIn();
+                }
+            }
+
+            return base.OnMouseMove(state);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (State == Visibility.Visible && idleTime > 2000)
+            {
+                Hide();
+                PopOut();
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
+++ b/osu.Game/Rulesets/UI/Cursor/RulesetCursor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
 using osu.Game.Graphics.Cursor;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.States;
@@ -10,6 +13,10 @@ namespace osu.Game.Rulesets.UI.Cursor
         private double lastActiveTime = 0;
         private StopwatchClock clock = new StopwatchClock(true);
         private double idleTime => clock.CurrentTime - lastActiveTime;
+        ///<summary> 
+        ///Time of idling after which the cursor is hidden.true
+        ///<summary/>
+        public double IdleDelay = 2000;
 
         protected override bool OnMouseMove(InputState state)
         {
@@ -17,9 +24,7 @@ namespace osu.Game.Rulesets.UI.Cursor
             {
                 lastActiveTime = clock.CurrentTime;
                 if (State == Visibility.Hidden)
-                {
                     Show();
-                }
             }
 
             return base.OnMouseMove(state);
@@ -29,10 +34,8 @@ namespace osu.Game.Rulesets.UI.Cursor
         {
             base.Update();
 
-            if (State == Visibility.Visible && idleTime > 2000)
-            {
+            if (State == Visibility.Visible && idleTime > IdleDelay)
                 Hide();
-            }
         }
     }
 }

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -22,6 +22,7 @@ using osu.Game.Overlays;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI.Cursor;
 using OpenTK;
 
 namespace osu.Game.Rulesets.UI
@@ -70,7 +71,8 @@ namespace osu.Game.Rulesets.UI
         public Playfield Playfield => playfield.Value;
 
         /// <summary>
-        /// The cursor provided by this <see cref="RulesetContainer"/>. May be null if no cursor is provided.
+        /// The cursor provided by this <see cref="RulesetContainer"/>.
+        /// Defaults to <see cref="RulesetCursor"/> if the <see cref="RulesetContainer"/> doesn't provide a custom cursor.
         /// </summary>
         public readonly CursorContainer Cursor;
 
@@ -149,9 +151,9 @@ namespace osu.Game.Rulesets.UI
         }
 
         /// <summary>
-        /// Creates the cursor. May be null if the <see cref="RulesetContainer"/> doesn't provide a custom cursor.
+        /// Creates the cursor. Defaults to <see cref="RulesetCursor"/> if the <see cref="RulesetContainer"/> doesn't provide a custom cursor.
         /// </summary>
-        protected virtual CursorContainer CreateCursor() => null;
+        protected virtual CursorContainer CreateCursor() => new RulesetCursor();
 
         /// <summary>
         /// Creates a Playfield.


### PR DESCRIPTION
RulesetContainer now has a default cursor, that fades out when idle for 2 seconds (delay that is inserted before the start of the beatmap), and pop back in when active. Previous behaviour was that MenuCursor was present throughout the game.