### PR TITLE
Fix songselect wedge sometimes not updating when localisation changes

### DIFF
--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -261,6 +261,8 @@ namespace osu.Game.Screens.Select
                         }
                     }
                 };
+
+                titleBinding.BindValueChanged(value => setMetadata(metadata.Source));
                 artistBinding.BindValueChanged(value => setMetadata(metadata.Source), true);
 
                 // no difficulty means it can't have a status to show


### PR DESCRIPTION
If the title change but the artist didn't change, then it wouldn't update.