### PR TITLE
Make hitcircle number skinnable using skin.ini

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -76,6 +76,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
+        public override string Font
+        {
+            get { return base.Font; }
+            set
+            {
+                base.Font = value;
+                number.Font = Font;
+            }
+        }
+
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (!userTriggered)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (HitObject is IHasComboInformation combo)
                 AccentColour = skin.GetValue<SkinConfiguration, Color4>(s => s.ComboColours.Count > 0 ? s.ComboColours[combo.ComboIndex % s.ComboColours.Count] : (Color4?)null) ?? Color4.White;
-            Font = skin.GetValue<SkinConfiguration, string>(s => s.HitboxNumberFont) ?? @"Venera";
+            Font = skin.GetValue<SkinConfiguration, string>(s => s.HitCircleNumberFont) ?? @"Venera";
         }
 
         protected virtual void UpdatePreemptState() => this.FadeIn(HitObject.TimeFadeIn);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (HitObject is IHasComboInformation combo)
                 AccentColour = skin.GetValue<SkinConfiguration, Color4>(s => s.ComboColours.Count > 0 ? s.ComboColours[combo.ComboIndex % s.ComboColours.Count] : (Color4?)null) ?? Color4.White;
+            Font = skin.GetValue<SkinConfiguration, string>(s => s.HitboxNumberFont) ?? @"Venera";
         }
 
         protected virtual void UpdatePreemptState() => this.FadeIn(HitObject.TimeFadeIn);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/NumberPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/NumberPiece.cs
@@ -22,6 +22,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             set { number.Text = value; }
         }
 
+        public string Font
+        {
+            get { return number.Font; }
+            set { number.Font = value; }
+        }
+
         public NumberPiece()
         {
             Anchor = Anchor.Centre;

--- a/osu.Game/Beatmaps/Formats/IHasHitCircleNumberFont.cs
+++ b/osu.Game/Beatmaps/Formats/IHasHitCircleNumberFont.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Collections.Generic;
-using OpenTK.Graphics;
-
 namespace osu.Game.Beatmaps.Formats
 {
-    public interface IHasHitboxNumberFont
+    public interface IHasHitCircleNumberFont
     {
-        string HitboxNumberFont { get; set; }
+        string HitCircleNumberFont { get; set; }
     }
 }

--- a/osu.Game/Beatmaps/Formats/IHasHitboxNumberFont.cs
+++ b/osu.Game/Beatmaps/Formats/IHasHitboxNumberFont.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System.Collections.Generic;
+using OpenTK.Graphics;
+
+namespace osu.Game.Beatmaps.Formats
+{
+    public interface IHasHitboxNumberFont
+    {
+        string HitboxNumberFont { get; set; }
+    }
+}

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -64,6 +64,9 @@ namespace osu.Game.Beatmaps.Formats
                 case Section.Colours:
                     handleColours(output, line);
                     return;
+                case Section.Fonts:
+                    handleFonts(output, line);
+                    return;
             }
         }
 
@@ -110,6 +113,18 @@ namespace osu.Game.Beatmaps.Formats
             {
                 if (!(output is IHasCustomColours tHasCustomColours)) return;
                 tHasCustomColours.CustomColours[pair.Key] = colour;
+            }
+        }
+
+        private void handleFonts(T output, string line)
+        {
+            var pair = SplitKeyVal(line);
+
+            string font = pair.Value;
+            if (pair.Key.Equals(@"HitboxNumberFont"))
+            {
+                if (!(output is IHasHitboxNumberFont tHasHitboxNumberFont)) return;
+                tHasHitboxNumberFont.HitboxNumberFont = font;
             }
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -121,10 +121,10 @@ namespace osu.Game.Beatmaps.Formats
             var pair = SplitKeyVal(line);
 
             string font = pair.Value;
-            if (pair.Key.Equals(@"HitboxNumberFont"))
+            if (pair.Key.Equals(@"HitCircleNumberFont"))
             {
-                if (!(output is IHasHitboxNumberFont tHasHitboxNumberFont)) return;
-                tHasHitboxNumberFont.HitboxNumberFont = font;
+                if (!(output is IHasHitCircleNumberFont tHasHitCircleNumberFont)) return;
+                tHasHitCircleNumberFont.HitCircleNumberFont = font;
             }
         }
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </summary>
         public virtual Color4 AccentColour { get; set; } = Color4.Gray;
 
+        public virtual string Font { get; set; } = @"Venera";
+
         // Todo: Rulesets should be overriding the resources instead, but we need to figure out where/when to apply overrides first
         protected virtual string SampleNamespace => null;
 

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -21,7 +21,8 @@ namespace osu.Game.Skinning
                     new Color4(102, 136, 0, 255),
                     new Color4(204, 102, 0, 255),
                     new Color4(121, 9, 13, 255)
-                }
+                },
+                HitboxNumberFont = @"Venera"
             };
         }
 

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Skinning
                     new Color4(204, 102, 0, 255),
                     new Color4(121, 9, 13, 255)
                 },
-                HitboxNumberFont = @"Venera"
+                HitCircleNumberFont = @"Venera"
             };
         }
 

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -7,7 +7,7 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Skinning
 {
-    public class SkinConfiguration : IHasComboColours, IHasCustomColours, IHasHitboxNumberFont
+    public class SkinConfiguration : IHasComboColours, IHasCustomColours, IHasHitCircleNumberFont
     {
         public readonly SkinInfo SkinInfo = new SkinInfo();
 
@@ -15,6 +15,6 @@ namespace osu.Game.Skinning
 
         public Dictionary<string, Color4> CustomColours { get; set; } = new Dictionary<string, Color4>();
 
-        public string HitboxNumberFont { get; set; } = null;
+        public string HitCircleNumberFont { get; set; }
     }
 }

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -7,12 +7,14 @@ using OpenTK.Graphics;
 
 namespace osu.Game.Skinning
 {
-    public class SkinConfiguration : IHasComboColours, IHasCustomColours
+    public class SkinConfiguration : IHasComboColours, IHasCustomColours, IHasHitboxNumberFont
     {
         public readonly SkinInfo SkinInfo = new SkinInfo();
 
         public List<Color4> ComboColours { get; set; } = new List<Color4>();
 
         public Dictionary<string, Color4> CustomColours { get; set; } = new Dictionary<string, Color4>();
+
+        public string HitboxNumberFont { get; set; } = null;
     }
 }


### PR DESCRIPTION
Adds HitboxNumberFont in skin.ini (Fonts) to make skin for number skinnable
Works in the same way as ComboColours and AccentColour
Default is Venera
Does not work if the beatmap has a skin integrated (same issue as combo colours)

- one answer to #3455 