### PR TITLE
Check if object to be deleted actually exists

### DIFF
--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -286,9 +286,10 @@ namespace osu.Game.Database
             using (ContextFactory.GetForWrite())
             {
                 // re-fetch the model on the import context.
-                var foundModel = queryModel().Include(s => s.Files).ThenInclude(f => f.FileInfo).First(s => s.ID == item.ID);
+                var foundModel = queryModel().Include(s => s.Files).ThenInclude(f => f.FileInfo).FirstOrDefault(s => s.ID == item.ID);
 
-                if (foundModel.DeletePending) return;
+                // Test for null since FirstOrDefault will return null if nothing is found
+                if (foundModel == null || foundModel.DeletePending) return;
 
                 if (ModelStore.Delete(foundModel))
                     Files.Dereference(foundModel.Files.Select(f => f.FileInfo).ToArray());

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -290,7 +290,6 @@ namespace osu.Game.Database
                 // re-fetch the model on the import context.
                 var foundModel = queryModel().Include(s => s.Files).ThenInclude(f => f.FileInfo).FirstOrDefault(s => s.ID == item.ID);
 
-                // Test for null since FirstOrDefault will return null if nothing is found
                 if (foundModel == null || foundModel.DeletePending) return false;
 
                 if (ModelStore.Delete(foundModel))

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -281,7 +281,8 @@ namespace osu.Game.Database
         /// Is a no-op for already deleted items.
         /// </summary>
         /// <param name="item">The item to delete.</param>
-        public void Delete(TModel item)
+        /// <returns>false if no operation was performed</returns>
+        public bool Delete(TModel item)
         {
             using (ContextFactory.GetForWrite())
             {
@@ -289,10 +290,11 @@ namespace osu.Game.Database
                 var foundModel = queryModel().Include(s => s.Files).ThenInclude(f => f.FileInfo).FirstOrDefault(s => s.ID == item.ID);
 
                 // Test for null since FirstOrDefault will return null if nothing is found
-                if (foundModel == null || foundModel.DeletePending) return;
+                if (foundModel == null || foundModel.DeletePending) return false;
 
                 if (ModelStore.Delete(foundModel))
                     Files.Dereference(foundModel.Files.Select(f => f.FileInfo).ToArray());
+                return true;
             }
         }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -538,7 +538,7 @@ namespace osu.Game.Screens.Select
         {
             if (beatmap == null) return;
             // Null check because no beatmaps actually causes beatmap.Beatmaps to be null
-            if (!(beatmap.Beatmaps?.Any() ?? false)) return;
+            if (beatmap == null || beatmap.ID <= 0) return;
             dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
         }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -537,6 +537,8 @@ namespace osu.Game.Screens.Select
         private void delete(BeatmapSetInfo beatmap)
         {
             if (beatmap == null) return;
+            // Null check because no beatmaps actually causes beatmap.Beatmaps to be null
+            if (!(beatmap.Beatmaps?.Any() ?? false)) return;
             dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
         }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -536,8 +536,6 @@ namespace osu.Game.Screens.Select
 
         private void delete(BeatmapSetInfo beatmap)
         {
-            if (beatmap == null) return;
-            // Null check because no beatmaps actually causes beatmap.Beatmaps to be null
             if (beatmap == null || beatmap.ID <= 0) return;
             dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
         }


### PR DESCRIPTION
Fix #3463 

The bug happens because the query `First` will expects there to be something, but there are no beatmaps in the user's carousel.