### PR TITLE
Make BeatmapInfoWedge present until info is not null

### DIFF
--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -89,6 +89,8 @@ namespace osu.Game.Screens.Select
             }
         }
 
+        public override bool IsPresent => base.IsPresent || Info == null; // Visibility is updated in the LoadComponentAsync callback
+
         private BufferedWedgeInfo loadingInfo;
 
         private void updateDisplay()


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/1934

Due to the way that visibility is handled in `BeatmapInfoWedge` (made visible in the callback). This can probably be done more cleanly but I don't think this is too offensive for now.

This will fail due to `LoadComponentAsync` now using the local scheduler, but this is intended.