### PR TITLE
Make Slider's CustumColors skinnable

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -57,6 +57,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (HitObject is IHasComboInformation combo)
                 AccentColour = skin.GetValue<SkinConfiguration, Color4>(s => s.ComboColours.Count > 0 ? s.ComboColours[combo.ComboIndex % s.ComboColours.Count] : (Color4?)null) ?? Color4.White;
+            if (this is DrawableSlider slider)
+            {
+                slider.AccentColourBody = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderTrackOverride") ? s.CustomColours["SliderTrackOverride"] : (Color4?)null) ?? slider.AccentColourBody;
+                slider.AccentColourBall = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderBall") ? s.CustomColours["SliderBall"] : (Color4?)null) ?? slider.AccentColourBall;
+                slider.AccentColourBorder = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderBorder") ? s.CustomColours["SliderBorder"] : (Color4?)null) ?? slider.AccentColourBorder;
+            }
         }
 
         protected virtual void UpdatePreemptState() => this.FadeIn(HitObject.TimeFadeIn);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -57,12 +57,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (HitObject is IHasComboInformation combo)
                 AccentColour = skin.GetValue<SkinConfiguration, Color4>(s => s.ComboColours.Count > 0 ? s.ComboColours[combo.ComboIndex % s.ComboColours.Count] : (Color4?)null) ?? Color4.White;
-            if (this is DrawableSlider slider)
-            {
-                slider.AccentColourBody = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderTrackOverride") ? s.CustomColours["SliderTrackOverride"] : (Color4?)null) ?? slider.AccentColourBody;
-                slider.AccentColourBall = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderBall") ? s.CustomColours["SliderBall"] : (Color4?)null) ?? slider.AccentColourBall;
-                slider.AccentColourBorder = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderBorder") ? s.CustomColours["SliderBorder"] : (Color4?)null) ?? slider.AccentColourBorder;
-            }
         }
 
         protected virtual void UpdatePreemptState() => this.FadeIn(HitObject.TimeFadeIn);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Scoring;
 using OpenTK.Graphics;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -101,24 +102,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        public Color4 AccentColourBody
-        {
-            get { return Body.AccentColour; }
-            set { Body.AccentColour = value; }
-        }
-
-        public Color4 AccentColourBall
-        {
-            get { return Ball.AccentColour; }
-            set { Ball.AccentColour = value; }
-        }
-
-        public Color4 AccentColourBorder
-        {
-            get { return Body.BorderColour; }
-            set { Body.BorderColour = value; }
-        }
-
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
@@ -150,6 +133,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     obj.RelativeAnchorPosition = childAnchorPosition;
                 Ball.RelativeAnchorPosition = childAnchorPosition;
             }
+        }
+
+        protected override void SkinChanged(ISkinSource skin, bool allowFallback)
+        {
+            base.SkinChanged(skin, allowFallback);
+
+            Body.AccentColour = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderTrackOverride") ? s.CustomColours["SliderTrackOverride"] : (Color4?)null) ?? Body.AccentColour;
+            Body.BorderColour = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderBorder") ? s.CustomColours["SliderBorder"] : (Color4?)null) ?? Body.BorderColour;
+            Ball.AccentColour = skin.GetValue<SkinConfiguration, Color4>(s => s.CustomColours.ContainsKey("SliderBall") ? s.CustomColours["SliderBall"] : (Color4?)null) ?? Ball.AccentColour;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -101,6 +101,24 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
+        public Color4 AccentColourBody
+        {
+            get { return Body.AccentColour; }
+            set { Body.AccentColour = value; }
+        }
+
+        public Color4 AccentColourBall
+        {
+            get { return Ball.AccentColour; }
+            set { Ball.AccentColour = value; }
+        }
+
+        public Color4 AccentColourBorder
+        {
+            get { return Body.BorderColour; }
+            set { Body.BorderColour = value; }
+        }
+
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {


### PR DESCRIPTION
Uses SliderBorder, SliderBall and SliderTrackOverride from skin.ini.

- [ ] Depends on `getValue` update (#3497)

Stable | Lazer
-- | --
![sans titre](https://user-images.githubusercontent.com/43404588/46430039-3c6ab900-c748-11e8-957c-e03db0ec5c24.png) | ![sans titre2](https://user-images.githubusercontent.com/43404588/46430052-42f93080-c748-11e8-8c1c-48e194b84737.png)

[Colours]
SliderBall: 255, 0, 0
SliderBorder: 0, 255, 0
SliderTrackOverride: 0, 0, 255



