### PR TITLE
Various performance improvements around hitobjects

### DIFF
--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using osu.Framework.Extensions.IEnumerableExtensions;
-using osu.Framework.Lists;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -58,10 +55,10 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         public HitWindows HitWindows { get; set; }
 
-        private readonly Lazy<List<HitObject>> nestedHitObjects = new Lazy<List<HitObject>>(() => new List<HitObject>());
+        private readonly List<HitObject> nestedHitObjects = new List<HitObject>();
 
         [JsonIgnore]
-        public IReadOnlyList<HitObject> NestedHitObjects => nestedHitObjects.Value;
+        public IReadOnlyList<HitObject> NestedHitObjects => nestedHitObjects;
 
         /// <summary>
         /// Applies default values to this HitObject.
@@ -72,21 +69,17 @@ namespace osu.Game.Rulesets.Objects
         {
             ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
-            if (nestedHitObjects.IsValueCreated)
-                nestedHitObjects.Value.Clear();
+            nestedHitObjects.Clear();
 
             CreateNestedHitObjects();
 
-            if (nestedHitObjects.IsValueCreated)
-            {
-                nestedHitObjects.Value.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
+            nestedHitObjects.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
 
-                nestedHitObjects.Value.ForEach(h =>
-                {
-                    h.HitWindows = HitWindows;
-                    h.ApplyDefaults(controlPointInfo, difficulty);
-                });
-            }
+            nestedHitObjects.ForEach(h =>
+            {
+                h.HitWindows = HitWindows;
+                h.ApplyDefaults(controlPointInfo, difficulty);
+            });
         }
 
         protected virtual void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
@@ -106,7 +99,7 @@ namespace osu.Game.Rulesets.Objects
         {
         }
 
-        protected void AddNested(HitObject hitObject) => nestedHitObjects.Value.Add(hitObject);
+        protected void AddNested(HitObject hitObject) => nestedHitObjects.Add(hitObject);
 
         /// <summary>
         /// Creates the <see cref="Judgement"/> that represents the scoring information for this <see cref="HitObject"/>.

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Framework.Lists;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -55,7 +56,7 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         public HitWindows HitWindows { get; set; }
 
-        private readonly List<HitObject> nestedHitObjects = new List<HitObject>();
+        private readonly SortedList<HitObject> nestedHitObjects = new SortedList<HitObject>(compareObjects);
 
         [JsonIgnore]
         public IReadOnlyList<HitObject> NestedHitObjects => nestedHitObjects;
@@ -72,8 +73,6 @@ namespace osu.Game.Rulesets.Objects
             nestedHitObjects.Clear();
 
             CreateNestedHitObjects();
-
-            nestedHitObjects.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
 
             foreach (var h in nestedHitObjects)
             {
@@ -115,5 +114,7 @@ namespace osu.Game.Rulesets.Objects
         /// </para>
         /// </summary>
         protected virtual HitWindows CreateHitWindows() => new HitWindows();
+
+        private static int compareObjects(HitObject first, HitObject second) => first.StartTime.CompareTo(second.StartTime);
     }
 }

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         public HitWindows HitWindows { get; set; }
 
-        private readonly Lazy<SortedList<HitObject>> nestedHitObjects = new Lazy<SortedList<HitObject>>(() => new SortedList<HitObject>((h1, h2) => h1.StartTime.CompareTo(h2.StartTime)));
+        private readonly Lazy<List<HitObject>> nestedHitObjects = new Lazy<List<HitObject>>(() => new List<HitObject>());
 
         [JsonIgnore]
         public IReadOnlyList<HitObject> NestedHitObjects => nestedHitObjects.Value;
@@ -79,6 +79,8 @@ namespace osu.Game.Rulesets.Objects
 
             if (nestedHitObjects.IsValueCreated)
             {
+                nestedHitObjects.Value.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
+
                 nestedHitObjects.Value.ForEach(h =>
                 {
                     h.HitWindows = HitWindows;

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -75,11 +75,11 @@ namespace osu.Game.Rulesets.Objects
 
             nestedHitObjects.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
 
-            nestedHitObjects.ForEach(h =>
+            foreach (var h in nestedHitObjects)
             {
                 h.HitWindows = HitWindows;
                 h.ApplyDefaults(controlPointInfo, difficulty);
-            });
+            }
         }
 
         protected virtual void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)


### PR DESCRIPTION
1. Using list with post-sort should help with construction of any number of nested hitobjects:

|             Method | Items |         Mean |      Error |     StdDev |
| ------------------- |------ |-------------:|-----------:|-----------:|
| SortedListAddition |     5 |     88.88 us |  0.3415 us |  0.3194 us |
|           PostSort |     5 |     35.05 us |  0.1159 us |  0.1028 us |
| SortedListAddition |    10 |    196.72 us |  0.6414 us |  0.5686 us |
|           PostSort |    10 |     49.64 us |  0.1102 us |  0.1030 us |
| SortedListAddition |   100 |  2,332.01 us |  8.7999 us |  7.8009 us |
|           PostSort |   100 |    576.11 us |  3.7329 us |  3.3091 us |
| SortedListAddition |  1000 | 27,713.55 us | 64.9245 us | 57.5539 us |
|           PostSort |  1000 |  8,373.19 us | 33.7896 us | 31.6068 us |

```
public class SortBenchmarks
{
    private List<int> list = new List<int>();

    [Params(5, 10, 100, 1000)]
    public int Items { get; set; }

    [Benchmark]
    public void SortedListAddition()
    {
        for (int it = 0; it < 1000; it++)
        {
            list.Clear();
            for (int i = 0; i < Items; i++)
                addInternal(i);
        }
    }

    [Benchmark]
    public void PostSort()
    {
        for (int it = 0; it < 1000; it++)
        {
            list.Clear();
            for (int i = 0; i < Items; i++)
                list.Add(i);
            list.Sort();
        }
    }

    // Note: Replicates what SortedList<T> does
    private void addInternal(int value)
    {
        int index = list.BinarySearch(value);
        if (index < 0)
            index = ~index;
        list.Insert(index, value);
    }
}
```

2. Size of `List<T>` is smaller than `Lazy<List<T>>` without constructing the value of the lazy:

|               Method |     Mean |    Error |   StdDev |   Median |    Gen 0 | Allocated |
| --------------------- |---------:|---------:|---------:|---------:|---------:|----------:|
|     ListConstruction | 113.1 us | 7.306 us | 21.54 us | 110.4 us | 126.9531 | 390.63 KB |
| LazyListConstruction | 175.7 us | 7.341 us | 20.09 us | 167.7 us | 228.7598 | 703.13 KB |

```
[MemoryDiagnoser]
public class ConstructionBenchmarks
{
    [Benchmark]
    public void ListConstruction()
    {
        for (int i = 0; i < 10000; i++)
        {
            new List<int>();
        }
    }

    [Benchmark]
    public void LazyListConstruction()
    {
        for (int i = 0; i < 10000; i++)
        {
            new Lazy<List<int>>();
        }
    }
}
```