### PR TITLE
Preserve the beatmap's version when using databased BeatmapInfo

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -8,11 +8,13 @@ using OpenTK.Graphics;
 using osu.Game.Tests.Resources;
 using System.Linq;
 using osu.Game.Audio;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Catch.Beatmaps;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Skinning;
 
@@ -21,6 +23,25 @@ namespace osu.Game.Tests.Beatmaps.Formats
     [TestFixture]
     public class LegacyBeatmapDecoderTest
     {
+        [Test]
+        public void TestDecodeBeatmapVersion()
+        {
+            using (var resStream = Resource.OpenResource("beatmap-version.osu"))
+            using (var stream = new StreamReader(resStream))
+            {
+                var decoder = Decoder.GetDecoder<Beatmap>(stream);
+
+                stream.BaseStream.Position = 0;
+                stream.DiscardBufferedData();
+
+                var working = new TestWorkingBeatmap(decoder.Decode(stream));
+
+                Assert.AreEqual(6, working.BeatmapInfo.BeatmapVersion);
+                Assert.AreEqual(6, working.Beatmap.BeatmapInfo.BeatmapVersion);
+                Assert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapVersion);
+            }
+        }
+
         [Test]
         public void TestDecodeBeatmapGeneral()
         {

--- a/osu.Game.Tests/Resources/beatmap-version.osu
+++ b/osu.Game.Tests/Resources/beatmap-version.osu
@@ -1,0 +1,1 @@
+osu file format v6

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Beatmaps
         [JsonIgnore]
         public int ID { get; set; }
 
-        //TODO: should be in database
         public int BeatmapVersion;
 
         private int? onlineBeatmapID;

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -41,8 +41,13 @@ namespace osu.Game.Beatmaps
             beatmap = new RecyclableLazy<IBeatmap>(() =>
             {
                 var b = GetBeatmap() ?? new Beatmap();
-                // use the database-backed info.
+
+                // The original beatmap version needs to be preserved as the database doesn't contain it
+                BeatmapInfo.BeatmapVersion = b.BeatmapInfo.BeatmapVersion;
+
+                // Use the database-backed info for more up-to-date values (beatmap id, ranked status, etc)
                 b.BeatmapInfo = BeatmapInfo;
+
                 return b;
             });
 


### PR DESCRIPTION
Fixes #3624 
Fixes #3626

If we want to maintain that the beatmap version shouldn't be databased, then we need to transfer it over from the file manually.

Tested against osu-stable on https://osu.ppy.sh/beatmapsets/756794#osu/1605148 on a per-hitobject-position basis.
Tested against the slider in https://osu.ppy.sh/beatmapsets/568903#osu/1206093 mentioned in the relevant issue thread.