### PR TITLE
Fade MetadataSection back in if non-null Text is set

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -307,10 +307,10 @@ namespace osu.Game.Screens.Select
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
-                Alpha = 0;
 
                 InternalChild = textContainer = new FillFlowContainer
                 {
+                    Alpha = 0,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Spacing = new Vector2(spacing / 2),
@@ -337,16 +337,13 @@ namespace osu.Game.Screens.Select
                 {
                     if (string.IsNullOrEmpty(value))
                     {
-                        this.FadeOut(transition_duration);
+                        textContainer.FadeOut(transition_duration);
                         return;
                     }
 
-                    this.FadeIn(transition_duration);
                     setTextAsync(value);
                 }
             }
-
-            public override bool IsPresent => base.IsPresent || textFlow == null; // Visibility is updated in the LoadComponentAsync callback
 
             private void setTextAsync(string text)
             {
@@ -362,7 +359,7 @@ namespace osu.Game.Screens.Select
                     textContainer.Add(textFlow = loaded);
 
                     // fade in if we haven't yet.
-                    this.FadeIn(transition_duration);
+                    textContainer.FadeIn(transition_duration);
                 });
             }
         }

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -341,6 +341,7 @@ namespace osu.Game.Screens.Select
                         return;
                     }
 
+                    this.FadeIn(transition_duration);
                     setTextAsync(value);
                 }
             }


### PR DESCRIPTION
MetadataSections were not fading back in when assigning a normal value after it was null/blank.

- Closes #3579

---

Fixes Source and Tags not reappearing if they are once set to null.