### PR TITLE
Fixed formatting issue caused by tryAddInfoRightLine().

### DIFF
--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
@@ -462,16 +462,25 @@ namespace osu.Game.Overlays.Profile
 
         private void tryAddInfoRightLine(FontAwesome icon, string str, string url = null)
         {
+            //If the number of characters in a string exceeds 31, incorrect formatting will occur.
+            const int local_char_limit = 31; 
+
             if (string.IsNullOrEmpty(str)) return;
 
             infoTextRight.AddIcon(icon);
             if (url != null)
             {
-                infoTextRight.AddLink(" " + str, url);
+                if (str.Length > local_char_limit)
+                    infoTextRight.AddLink(" " + (str.Substring(0, local_char_limit) + "..."), url);
+                else
+                    infoTextRight.AddLink(" " + str, url);
             }
             else
             {
-                infoTextRight.AddText(" " + str);
+                if (str.Length > local_char_limit)
+                    infoTextRight.AddText(" " + (str.Substring(0, local_char_limit) + "..."));
+                else
+                    infoTextRight.AddText(" " + str);
             }
 
             infoTextRight.NewLine();


### PR DESCRIPTION
Issue #3633 demonstrates that formatting issues in the profile will occur if a supplied string in the profile header is too large. After testing, I found that supplying tryAddInfoRightLine() with a string with more than 34 characters will cause formatting to break. To replicate how this is handled on the osu.Web interface, I added a case where any string with over 34 characters supplied to tryAddInfoRightLine() will print a substring of the first 31 characters and an ellipsis to the string before passing it along to infoTextRight.AddText().

Add any details pertaining to developers above the break.

- [ ] Depends on #PR
- Closes #3633

---

Fixed formatting issue in User ProfileHeader with strings with more than 34 characters.

Add a sentence or two describing this change in plain english. This will be displayed on the [changelog](https://osu.ppy.sh/home/changelog). A single screenshot or short gif is also welcomed.