### PR TITLE
Fixed formatting issue caused by tryAddInfoRightLine().

### DIFF
--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -460,7 +460,7 @@ namespace osu.Game.Overlays.Profile
             badgeContainer.ShowBadges(user.Badges);
         }
 
-        private string Truncate(string str, int bound)
+        private string truncate(string str, int bound)
         {
             if(str.Length > bound)
                 return str.Substring(0, bound) + "...";
@@ -477,7 +477,7 @@ namespace osu.Game.Overlays.Profile
 
             var line = " " + str;
             if(line.Length > local_char_limit)
-                line = Truncate(line, local_char_limit);
+                line = truncate(line, local_char_limit);
             if (url != null)
                 infoTextRight.AddLink(line, url);
             else

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -462,7 +462,7 @@ namespace osu.Game.Overlays.Profile
 
         private void tryAddInfoRightLine(FontAwesome icon, string str, string url = null)
         {
-            const int LocalCharLimit = 31; 
+            const int LocalCharLimit = 31;
             if (string.IsNullOrEmpty(str)) return;
 
             infoTextRight.AddIcon(icon);

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -470,18 +470,18 @@ namespace osu.Game.Overlays.Profile
 
         private void tryAddInfoRightLine(FontAwesome icon, string str, string url = null)
         {
-	    const int local_char_limit = 31;
+            const int local_char_limit = 31;
             if (string.IsNullOrEmpty(str)) return;
 
             infoTextRight.AddIcon(icon);
 
-	    var line = " " + str;
-	    if(line.Length > local_char_limit)
+            var line = " " + str;
+            if(line.Length > local_char_limit)
                 line = Truncate(line, local_char_limit);
             if (url != null)
-		infoTextRight.AddLink(line, url);
+                infoTextRight.AddLink(line, url);
             else
-		infoTextRight.AddText(line);
+                infoTextRight.AddText(line);
 
             infoTextRight.NewLine();
         }

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
@@ -462,16 +462,23 @@ namespace osu.Game.Overlays.Profile
 
         private void tryAddInfoRightLine(FontAwesome icon, string str, string url = null)
         {
+            const int LocalCharLimit = 31; 
             if (string.IsNullOrEmpty(str)) return;
 
             infoTextRight.AddIcon(icon);
             if (url != null)
             {
-                infoTextRight.AddLink(" " + str, url);
+                if (str.Length > LocalCharLimit)
+                    infoTextRight.AddLink(" " + (str.Substring(0, LocalCharLimit) + "..."), url);
+                else
+                    infoTextRight.AddLink(" " + str, url);
             }
             else
             {
-                infoTextRight.AddText(" " + str);
+                if (str.Length > LocalCharLimit)
+                    infoTextRight.AddText(" " + (str.Substring(0, LocalCharLimit) + "..."));
+                else
+                    infoTextRight.AddText(" " + str);
             }
 
             infoTextRight.NewLine();

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -462,21 +462,21 @@ namespace osu.Game.Overlays.Profile
 
         private void tryAddInfoRightLine(FontAwesome icon, string str, string url = null)
         {
-            const int LocalCharLimit = 31;
+            const int local_char_limit = 31;
             if (string.IsNullOrEmpty(str)) return;
 
             infoTextRight.AddIcon(icon);
             if (url != null)
             {
-                if (str.Length > LocalCharLimit)
-                    infoTextRight.AddLink(" " + (str.Substring(0, LocalCharLimit) + "..."), url);
+                if (str.Length > local_char_limit)
+                    infoTextRight.AddLink(" " + str.Substring(0, local_char_limit) + "...", url);
                 else
                     infoTextRight.AddLink(" " + str, url);
             }
             else
             {
-                if (str.Length > LocalCharLimit)
-                    infoTextRight.AddText(" " + (str.Substring(0, LocalCharLimit) + "..."));
+                if (str.Length > local_char_limit)
+                    infoTextRight.AddText(" " + str.Substring(0, local_char_limit) + "...");
                 else
                     infoTextRight.AddText(" " + str);
             }

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -460,13 +460,13 @@ namespace osu.Game.Overlays.Profile
             badgeContainer.ShowBadges(user.Badges);
         }
 
-	private string Truncate(string str, int bound)
-	{
-		if(str.Length > bound)
-			return str.Substring(0, bound) + "...";
-		else
-			return str;
-	}
+        private string Truncate(string str, int bound)
+        {
+            if(str.Length > bound)
+                return str.Substring(0, bound) + "...";
+            else
+                return str;
+        }
 
         private void tryAddInfoRightLine(FontAwesome icon, string str, string url = null)
         {
@@ -477,7 +477,7 @@ namespace osu.Game.Overlays.Profile
 
 	    var line = " " + str;
 	    if(line.Length > local_char_limit)
-		    line = Truncate(line, local_char_limit);
+                line = Truncate(line, local_char_limit);
             if (url != null)
 		infoTextRight.AddLink(line, url);
             else

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
@@ -460,26 +460,28 @@ namespace osu.Game.Overlays.Profile
             badgeContainer.ShowBadges(user.Badges);
         }
 
+	private string Truncate(string str, int bound)
+	{
+		if(str.Length > bound)
+			return str.Substring(0, bound) + "...";
+		else
+			return str;
+	}
+
         private void tryAddInfoRightLine(FontAwesome icon, string str, string url = null)
         {
-            const int local_char_limit = 31;
+	    const int local_char_limit = 31;
             if (string.IsNullOrEmpty(str)) return;
 
             infoTextRight.AddIcon(icon);
+
+	    var line = " " + str;
+	    if(line.Length > local_char_limit)
+		    line = Truncate(line, local_char_limit);
             if (url != null)
-            {
-                if (str.Length > local_char_limit)
-                    infoTextRight.AddLink(" " + str.Substring(0, local_char_limit) + "...", url);
-                else
-                    infoTextRight.AddLink(" " + str, url);
-            }
+		infoTextRight.AddLink(line, url);
             else
-            {
-                if (str.Length > local_char_limit)
-                    infoTextRight.AddText(" " + str.Substring(0, local_char_limit) + "...");
-                else
-                    infoTextRight.AddText(" " + str);
-            }
+		infoTextRight.AddText(line);
 
             infoTextRight.NewLine();
         }


### PR DESCRIPTION
Issue #3633 demonstrates that formatting issues in the profile will occur if a supplied string in the profile header is too large. After testing, I found that supplying tryAddInfoRightLine() with a string with more than 34 characters will cause formatting to break. To replicate how this is handled on the osu.Web interface, I added a case where any string with over 34 characters supplied to tryAddInfoRightLine() will print a substring of the first 31 characters and an ellipsis to the string before passing it along to infoTextRight.AddText().

Add any details pertaining to developers above the break.

- [ ] Depends on #PR
- Closes #3633

---

Fixed formatting issue in User ProfileHeader with strings with more than 34 characters.

Add a sentence or two describing this change in plain english. This will be displayed on the [changelog](https://osu.ppy.sh/home/changelog). A single screenshot or short gif is also welcomed.