### PR TITLE
Fix mods being erroneously applied when entering editor from song select

### DIFF
--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Select
             BeatmapOptions.AddButton(@"Edit", @"beatmap", FontAwesome.fa_pencil, colours.Yellow, () =>
             {
                 ValidForResume = false;
-                EditSelected();
+                Edit();
             }, Key.Number3);
 
             if (dialogOverlay != null)

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Select
             BeatmapOptions.AddButton(@"Edit", @"beatmap", FontAwesome.fa_pencil, colours.Yellow, () =>
             {
                 ValidForResume = false;
-                Push(new Editor());
+                EditSelected();
             }, Key.Number3);
 
             if (dialogOverlay != null)

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -16,7 +16,6 @@ using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Screens.Edit;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Skinning;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -225,7 +225,7 @@ namespace osu.Game.Screens.Select
 
         public void Edit(BeatmapInfo beatmap)
         {
-            Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap, Beatmap.Value);
+            Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap);
             Push(new Editor());
         }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -223,13 +223,11 @@ namespace osu.Game.Screens.Select
             Carousel.LoadBeatmapSetsFromManager(this.beatmaps);
         }
 
-        public void Edit(BeatmapInfo beatmap)
+        public void Edit(BeatmapInfo beatmap = null)
         {
-            Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap);
+            Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmap ?? beatmapNoDebounce);
             Push(new Editor());
         }
-
-        protected void EditSelected() => Edit(beatmapNoDebounce);
 
         /// <summary>
         /// Call to make a selection and perform the default action for this SongSelect.

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -229,6 +229,8 @@ namespace osu.Game.Screens.Select
             Push(new Editor());
         }
 
+        protected void EditSelected() => Edit(beatmapNoDebounce);
+
         /// <summary>
         /// Call to make a selection and perform the default action for this SongSelect.
         /// </summary>


### PR DESCRIPTION
Fixes #3630

Fix mods being applied when entering the editor from beatmap options overlay or right-click dialogue.