### PR TITLE
Don't log disk space related IO errors

### DIFF
--- a/osu.Game/Utils/RavenLogger.cs
+++ b/osu.Game/Utils/RavenLogger.cs
@@ -36,8 +36,15 @@ namespace osu.Game.Utils
 
                 if (exception != null)
                 {
-                    if (exception is IOException ioe && ioe.Message.StartsWith("There is not enough space on the disk"))
-                        return;
+                    if (exception is IOException ioe)
+                    {
+                        // disk full exceptions, see https://stackoverflow.com/a/9294382
+                        const int hr_error_handle_disk_full = unchecked((int)0x80070027);
+                        const int hr_error_disk_full = unchecked((int)0x80070070);
+
+                        if (ioe.HResult == hr_error_handle_disk_full || ioe.HResult == hr_error_disk_full)
+                            return;
+                    }
 
                     // since we let unhandled exceptions go ignored at times, we want to ensure they don't get submitted on subsequent reports.
                     if (lastException != null &&

--- a/osu.Game/Utils/RavenLogger.cs
+++ b/osu.Game/Utils/RavenLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using osu.Framework.Logging;
 using SharpRaven;
@@ -35,6 +36,9 @@ namespace osu.Game.Utils
 
                 if (exception != null)
                 {
+                    if (exception is IOException ioe && ioe.Message.StartsWith("There is not enough space on the disk"))
+                        return;
+
                     // since we let unhandled exceptions go ignored at times, we want to ensure they don't get submitted on subsequent reports.
                     if (lastException != null &&
                         lastException.Message == exception.Message && exception.StackTrace.StartsWith(lastException.StackTrace))


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/3299

Should stop "disk is full" errors from hitting sentry. Can't seem to find a better way of identifying them than this.