### PR TITLE
Fix not being able to drag control points mid-snake

### DIFF
--- a/osu.Game/Screens/Edit/Screens/Compose/Layers/HitObjectMaskLayer.cs
+++ b/osu.Game/Screens/Edit/Screens/Compose/Layers/HitObjectMaskLayer.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Edit.Screens.Compose.Layers
                 AddMaskFor(obj);
         }
 
-        protected override bool OnMouseDown(MouseDownEvent e)
+        protected override bool OnClick(ClickEvent e)
         {
             maskContainer.DeselectAll();
             return true;


### PR DESCRIPTION
Fixed mousedown being handled by playfield, making control points non-interactive.

![](https://puu.sh/BUEX5/0b84e8761d.gif)