### PR TITLE
Use binary bitmap fonts

### DIFF
--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2018.1102.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2018.1103.0" />
     <PackageReference Include="SharpCompress" Version="0.22.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
This just implements ppy/osu-framework#1969 in osu.
osu-resources is also updated (to include ppy/osu-resources#44) because it holds the updated font files.

---

Change font files to use a binary format for better performance.