### PR TITLE
Fix error when changing beatmap and starting player at the same time

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -53,6 +53,8 @@ namespace osu.Game.Screens.Select
 
         public override bool HandleNonPositionalInput => AllowSelection;
         public override bool HandlePositionalInput => AllowSelection;
+        public override bool PropagateNonPositionalInputSubTree => AllowSelection;
+        public override bool PropagatePositionalInputSubTree => AllowSelection;
 
         /// <summary>
         /// Used to avoid firing null selections before the initial beatmaps have been loaded via <see cref="BeatmapSets"/>.

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Screens.Select
         private bool removeAutoModOnResume;
         private OsuScreen player;
 
+        private bool allowBeatmapRulesetChange = true;
+        public override bool AllowBeatmapRulesetChange => allowBeatmapRulesetChange;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
@@ -59,12 +62,14 @@ namespace osu.Game.Screens.Select
 
             Beatmap.Value.Track.Looping = false;
             Beatmap.Disabled = true;
+            allowBeatmapRulesetChange = false;
 
             SampleConfirm?.Play();
 
             LoadComponentAsync(player = new PlayerLoader(() => new Player()), l =>
             {
                 if (IsCurrentScreen) Push(player);
+                allowBeatmapRulesetChange = true;
             });
 
             return true;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -603,7 +603,14 @@ namespace osu.Game.Screens.Select
                 base.Ruleset.ValueChanged += updateSelectedRuleset;
                 Ruleset.ValueChanged += r => base.Ruleset.Value = r;
 
-                Beatmap.BindDisabledChanged(disabled => Carousel.AllowSelection = !disabled, true);
+                Beatmap.BindDisabledChanged(disabled =>
+                {
+                    Carousel.AllowSelection = !disabled;
+                    if (disabled)
+                        FilterControl.Deactivate();
+                    else
+                        FilterControl.Activate();
+                }, true);
                 Beatmap.BindValueChanged(workingBeatmapChanged);
             }
 


### PR DESCRIPTION
Fixes #3666 

Should fix occasional errors when:
- Beatmap is changed with arrow keys while entering player
- Typing while entering player
- Clicking on a beatmap while entering player