### PR TITLE
Make SliderPath immutable

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual;
@@ -37,13 +38,11 @@ namespace osu.Game.Rulesets.Catch.Tests
                 beatmap.HitObjects.Add(new JuiceStream
                 {
                     X = 0.5f - width / 2,
-                    ControlPoints = new[]
+                    Path = new SliderPath(PathType.Linear, new[]
                     {
                         Vector2.Zero,
                         new Vector2(width * CatchPlayfield.BASE_WIDTH, 0)
-                    },
-                    PathType = PathType.Linear,
-                    Distance = width * CatchPlayfield.BASE_WIDTH,
+                    }),
                     StartTime = i * 2000,
                     NewCombo = i % 8 == 0
                 });

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
@@ -34,9 +34,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 {
                     StartTime = obj.StartTime,
                     Samples = obj.Samples,
-                    ControlPoints = curveData.ControlPoints,
-                    PathType = curveData.PathType,
-                    Distance = curveData.Distance,
+                    Path = curveData.Path,
                     NodeSamples = curveData.NodeSamples,
                     RepeatCount = curveData.RepeatCount,
                     X = (positionData?.X ?? 0) / CatchPlayfield.BASE_WIDTH,

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             if (TickDistance == 0)
                 return;
 
-            var length = Path.GetDistance();
+            var length = Path.Distance;
             var tickDistance = Math.Min(TickDistance, length);
             var spanDuration = length / Velocity;
 
@@ -131,7 +131,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             }
         }
 
-        public double EndTime => StartTime + this.SpanCount() * Path.GetDistance() / Velocity;
+        public double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
 
         public float EndX => X + this.CurvePositionAt(1).X / CatchPlayfield.BASE_WIDTH;
 
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             set => path = value;
         }
 
-        public double Distance => Path.GetDistance();
+        public double Distance => Path.Distance;
 
         public List<List<SampleInfo>> NodeSamples { get; set; } = new List<List<SampleInfo>>();
 

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -10,7 +10,6 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
-using OpenTK;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
@@ -50,7 +49,7 @@ namespace osu.Game.Rulesets.Catch.Objects
             if (TickDistance == 0)
                 return;
 
-            var length = Path.Distance;
+            var length = Path.GetDistance();
             var tickDistance = Math.Min(TickDistance, length);
             var spanDuration = length / Velocity;
 
@@ -132,33 +131,23 @@ namespace osu.Game.Rulesets.Catch.Objects
             }
         }
 
-        public double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
+        public double EndTime => StartTime + this.SpanCount() * Path.GetDistance() / Velocity;
 
         public float EndX => X + this.CurvePositionAt(1).X / CatchPlayfield.BASE_WIDTH;
 
         public double Duration => EndTime - StartTime;
 
-        public double Distance
+        private SliderPath path;
+
+        public SliderPath Path
         {
-            get { return Path.Distance; }
-            set { Path.Distance = value; }
+            get => path;
+            set => path = value;
         }
 
-        public SliderPath Path { get; } = new SliderPath();
-
-        public Vector2[] ControlPoints
-        {
-            get { return Path.ControlPoints; }
-            set { Path.ControlPoints = value; }
-        }
+        public double Distance => Path.GetDistance();
 
         public List<List<SampleInfo>> NodeSamples { get; set; } = new List<List<SampleInfo>>();
-
-        public PathType PathType
-        {
-            get { return Path.PathType; }
-            set { Path.PathType = value; }
-        }
 
         public double? LegacyLastTickOffset { get; set; }
     }

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseSlider.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
@@ -108,13 +109,12 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(239, 176),
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.PerfectCurve, new[]
                 {
                     Vector2.Zero,
                     new Vector2(154, 28),
                     new Vector2(52, -34)
-                },
-                Distance = 700,
+                }, 700),
                 RepeatCount = repeats,
                 NodeSamples = createEmptySamples(repeats),
                 StackHeight = 10
@@ -141,12 +141,11 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-(distance / 2), 0),
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.PerfectCurve, new[]
                 {
                     Vector2.Zero,
                     new Vector2(distance, 0),
-                },
-                Distance = distance,
+                }, distance),
                 RepeatCount = repeats,
                 NodeSamples = createEmptySamples(repeats),
                 StackHeight = stackHeight
@@ -161,13 +160,12 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-200, 0),
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.PerfectCurve, new[]
                 {
                     Vector2.Zero,
                     new Vector2(200, 200),
                     new Vector2(400, 0)
-                },
-                Distance = 600,
+                }, 600),
                 RepeatCount = repeats,
                 NodeSamples = createEmptySamples(repeats)
             };
@@ -181,10 +179,9 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             var slider = new Slider
             {
-                PathType = PathType.Linear,
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-200, 0),
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.Linear, new[]
                 {
                     Vector2.Zero,
                     new Vector2(150, 75),
@@ -192,8 +189,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     new Vector2(300, -200),
                     new Vector2(400, 0),
                     new Vector2(430, 0)
-                },
-                Distance = 793.4417,
+                }),
                 RepeatCount = repeats,
                 NodeSamples = createEmptySamples(repeats)
             };
@@ -207,18 +203,16 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             var slider = new Slider
             {
-                PathType = PathType.Bezier,
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-200, 0),
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.Bezier, new[]
                 {
                     Vector2.Zero,
                     new Vector2(150, 75),
                     new Vector2(200, 100),
                     new Vector2(300, -200),
                     new Vector2(430, 0)
-                },
-                Distance = 480,
+                }),
                 RepeatCount = repeats,
                 NodeSamples = createEmptySamples(repeats)
             };
@@ -232,10 +226,9 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             var slider = new Slider
             {
-                PathType = PathType.Linear,
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(0, 0),
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.Linear, new[]
                 {
                     Vector2.Zero,
                     new Vector2(-200, 0),
@@ -243,8 +236,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     new Vector2(0, -200),
                     new Vector2(-200, -200),
                     new Vector2(0, -200)
-                },
-                Distance = 1000,
+                }),
                 RepeatCount = repeats,
                 NodeSamples = createEmptySamples(repeats)
             };
@@ -264,15 +256,13 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 StartTime = Time.Current + 1000,
                 Position = new Vector2(-100, 0),
-                PathType = PathType.Catmull,
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.Catmull, new[]
                 {
                     Vector2.Zero,
                     new Vector2(50, -50),
                     new Vector2(150, 50),
                     new Vector2(200, 0)
-                },
-                Distance = 300,
+                }),
                 RepeatCount = repeats,
                 NodeSamples = repeatSamples
             };

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseSliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseSliderSelectionBlueprint.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
@@ -35,14 +36,12 @@ namespace osu.Game.Rulesets.Osu.Tests
             var slider = new Slider
             {
                 Position = new Vector2(256, 192),
-                ControlPoints = new[]
+                Path = new SliderPath(PathType.Bezier, new[]
                 {
                     Vector2.Zero,
                     new Vector2(150, 150),
                     new Vector2(300, 0)
-                },
-                PathType = PathType.Bezier,
-                Distance = 350
+                })
             };
 
             slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = 2 });

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapConverter.cs
@@ -35,9 +35,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                 {
                     StartTime = original.StartTime,
                     Samples = original.Samples,
-                    ControlPoints = curveData.ControlPoints,
-                    PathType = curveData.PathType,
-                    Distance = curveData.Distance,
+                    Path = curveData.Path,
                     NodeSamples = curveData.NodeSamples,
                     RepeatCount = curveData.RepeatCount,
                     Position = positionData?.Position ?? Vector2.Zero,

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -56,7 +55,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
             base.Update();
 
-            Position = slider.StackedPosition + slider.Path.ControlPoints[index];
+            Position = slider.StackedPosition + slider.Path.ControlPoints.Span[index];
 
             marker.Colour = isSegmentSeparator ? colours.Red : colours.Yellow;
 
@@ -65,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (index != slider.Path.ControlPoints.Length - 1)
             {
                 path.AddVertex(Vector2.Zero);
-                path.AddVertex(slider.Path.ControlPoints[index + 1] - slider.Path.ControlPoints[index]);
+                path.AddVertex(slider.Path.ControlPoints.Span[index + 1] - slider.Path.ControlPoints.Span[index]);
             }
 
             path.OriginPosition = path.PositionInBoundingBox(Vector2.Zero);
@@ -106,8 +105,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private bool isSegmentSeparator => isSegmentSeparatorWithNext || isSegmentSeparatorWithPrevious;
 
-        private bool isSegmentSeparatorWithNext => index < slider.Path.ControlPoints.Length - 1 && slider.Path.ControlPoints[index + 1] == slider.Path.ControlPoints[index];
+        private bool isSegmentSeparatorWithNext => index < slider.Path.ControlPoints.Length - 1 && slider.Path.ControlPoints.Span[index + 1] == slider.Path.ControlPoints.Span[index];
 
-        private bool isSegmentSeparatorWithPrevious => index > 0 && slider.Path.ControlPoints[index - 1] == slider.Path.ControlPoints[index];
+        private bool isSegmentSeparatorWithPrevious => index > 0 && slider.Path.ControlPoints.Span[index - 1] == slider.Path.ControlPoints.Span[index];
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -55,7 +56,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
             base.Update();
 
-            Position = slider.StackedPosition + slider.Path.ControlPoints.Span[index];
+            Position = slider.StackedPosition + slider.Path.ControlPoints[index];
 
             marker.Colour = isSegmentSeparator ? colours.Red : colours.Yellow;
 
@@ -64,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (index != slider.Path.ControlPoints.Length - 1)
             {
                 path.AddVertex(Vector2.Zero);
-                path.AddVertex(slider.Path.ControlPoints.Span[index + 1] - slider.Path.ControlPoints.Span[index]);
+                path.AddVertex(slider.Path.ControlPoints[index + 1] - slider.Path.ControlPoints[index]);
             }
 
             path.OriginPosition = path.PositionInBoundingBox(Vector2.Zero);
@@ -105,8 +106,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private bool isSegmentSeparator => isSegmentSeparatorWithNext || isSegmentSeparatorWithPrevious;
 
-        private bool isSegmentSeparatorWithNext => index < slider.Path.ControlPoints.Length - 1 && slider.Path.ControlPoints.Span[index + 1] == slider.Path.ControlPoints.Span[index];
+        private bool isSegmentSeparatorWithNext => index < slider.Path.ControlPoints.Length - 1 && slider.Path.ControlPoints[index + 1] == slider.Path.ControlPoints[index];
 
-        private bool isSegmentSeparatorWithPrevious => index > 0 && slider.Path.ControlPoints.Span[index - 1] == slider.Path.ControlPoints.Span[index];
+        private bool isSegmentSeparatorWithPrevious => index > 0 && slider.Path.ControlPoints[index - 1] == slider.Path.ControlPoints[index];
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using OpenTK;
 
@@ -55,16 +56,16 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
             base.Update();
 
-            Position = slider.StackedPosition + slider.ControlPoints[index];
+            Position = slider.StackedPosition + slider.Path.ControlPoints[index];
 
             marker.Colour = isSegmentSeparator ? colours.Red : colours.Yellow;
 
             path.ClearVertices();
 
-            if (index != slider.ControlPoints.Length - 1)
+            if (index != slider.Path.ControlPoints.Length - 1)
             {
                 path.AddVertex(Vector2.Zero);
-                path.AddVertex(slider.ControlPoints[index + 1] - slider.ControlPoints[index]);
+                path.AddVertex(slider.Path.ControlPoints[index + 1] - slider.Path.ControlPoints[index]);
             }
 
             path.OriginPosition = path.PositionInBoundingBox(Vector2.Zero);
@@ -76,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         protected override bool OnDrag(DragEvent e)
         {
-            var newControlPoints = slider.ControlPoints.ToArray();
+            var newControlPoints = slider.Path.ControlPoints.ToArray();
 
             if (index == 0)
             {
@@ -96,8 +97,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (isSegmentSeparatorWithPrevious)
                 newControlPoints[index - 1] = newControlPoints[index];
 
-            slider.ControlPoints = newControlPoints;
-            slider.Path.Calculate(true);
+            slider.Path = new SliderPath(slider.Path.Type, newControlPoints);
 
             return true;
         }
@@ -106,8 +106,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private bool isSegmentSeparator => isSegmentSeparatorWithNext || isSegmentSeparatorWithPrevious;
 
-        private bool isSegmentSeparatorWithNext => index < slider.ControlPoints.Length - 1 && slider.ControlPoints[index + 1] == slider.ControlPoints[index];
+        private bool isSegmentSeparatorWithNext => index < slider.Path.ControlPoints.Length - 1 && slider.Path.ControlPoints[index + 1] == slider.Path.ControlPoints[index];
 
-        private bool isSegmentSeparatorWithPrevious => index > 0 && slider.ControlPoints[index - 1] == slider.ControlPoints[index];
+        private bool isSegmentSeparatorWithPrevious => index > 0 && slider.Path.ControlPoints[index - 1] == slider.Path.ControlPoints[index];
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -19,15 +19,15 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
             InternalChild = pieces = new Container<PathControlPointPiece> { RelativeSizeAxes = Axes.Both };
 
-            slider.ControlPointsChanged += _ => updatePathControlPoints();
+            slider.PathChanged += _ => updatePathControlPoints();
             updatePathControlPoints();
         }
 
         private void updatePathControlPoints()
         {
-            while (slider.ControlPoints.Length > pieces.Count)
+            while (slider.Path.ControlPoints.Length > pieces.Count)
                 pieces.Add(new PathControlPointPiece(slider, pieces.Count));
-            while (slider.ControlPoints.Length < pieces.Count)
+            while (slider.Path.ControlPoints.Length < pieces.Count)
                 pieces.Remove(pieces[pieces.Count - 1]);
         }
     }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
             base.Update();
 
-            slider.Path.Calculate();
-
             var vertices = new List<Vector2>();
             slider.Path.GetPathToProgress(vertices, 0, 1);
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderCirclePiece.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             this.slider = slider;
             this.position = position;
 
-            slider.ControlPointsChanged += _ => UpdatePosition();
+            slider.PathChanged += _ => UpdatePosition();
         }
 
         protected override void UpdatePosition()

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -1,16 +1,15 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
-using osu.Framework.MathUtils;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using OpenTK;
@@ -119,12 +118,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateSlider()
         {
-            for (int i = 0; i < segments.Count; i++)
-                segments[i].Calculate(i == segments.Count - 1 ? (Vector2?)cursor : null);
-
-            HitObject.ControlPoints = segments.SelectMany(s => s.ControlPoints).Concat(cursor.Yield()).ToArray();
-            HitObject.PathType = HitObject.ControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear;
-            HitObject.Distance = segments.Sum(s => s.Distance);
+            var newControlPoints = segments.SelectMany(s => s.ControlPoints).Concat(cursor.Yield()).ToArray();
+            HitObject.Path = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints);
         }
 
         private void setState(PlacementState newState)
@@ -140,40 +135,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private class Segment
         {
-            public float Distance { get; private set; }
-
             public readonly List<Vector2> ControlPoints = new List<Vector2>();
 
             public Segment(Vector2 offset)
             {
                 ControlPoints.Add(offset);
-            }
-
-            public void Calculate(Vector2? cursor = null)
-            {
-                Span<Vector2> allControlPoints = stackalloc Vector2[ControlPoints.Count + (cursor.HasValue ? 1 : 0)];
-
-                for (int i = 0; i < ControlPoints.Count; i++)
-                    allControlPoints[i] = ControlPoints[i];
-                if (cursor.HasValue)
-                    allControlPoints[allControlPoints.Length - 1] = cursor.Value;
-
-                List<Vector2> result;
-
-                switch (allControlPoints.Length)
-                {
-                    case 1:
-                    case 2:
-                        result = PathApproximator.ApproximateLinear(allControlPoints);
-                        break;
-                    default:
-                        result = PathApproximator.ApproximateBezier(allControlPoints);
-                        break;
-                }
-
-                Distance = 0;
-                for (int i = 0; i < result.Count - 1; i++)
-                    Distance += Vector2.Distance(result[i], result[i + 1]);
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             var newControlPoints = new Vector2[slider.Path.ControlPoints.Length];
             for (int i = 0; i < slider.Path.ControlPoints.Length; i++)
-                newControlPoints[i] = new Vector2(slider.Path.ControlPoints[i].X, -slider.Path.ControlPoints[i].Y);
+                newControlPoints[i] = new Vector2(slider.Path.ControlPoints.Span[i].X, -slider.Path.ControlPoints.Span[i].Y);
 
             slider.Path = new SliderPath(slider.Path.Type, newControlPoints, slider.Path.ExpectedDistance);
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             var newControlPoints = new Vector2[slider.Path.ControlPoints.Length];
             for (int i = 0; i < slider.Path.ControlPoints.Length; i++)
-                newControlPoints[i] = new Vector2(slider.Path.ControlPoints.Span[i].X, -slider.Path.ControlPoints.Span[i].Y);
+                newControlPoints[i] = new Vector2(slider.Path.ControlPoints[i].X, -slider.Path.ControlPoints[i].Y);
 
             slider.Path = new SliderPath(slider.Path.Type, newControlPoints, slider.Path.ExpectedDistance);
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -32,12 +32,11 @@ namespace osu.Game.Rulesets.Osu.Mods
             slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
             slider.NestedHitObjects.OfType<RepeatPoint>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
 
-            var newControlPoints = new Vector2[slider.ControlPoints.Length];
-            for (int i = 0; i < slider.ControlPoints.Length; i++)
-                newControlPoints[i] = new Vector2(slider.ControlPoints[i].X, -slider.ControlPoints[i].Y);
+            var newControlPoints = new Vector2[slider.Path.ControlPoints.Length];
+            for (int i = 0; i < slider.Path.ControlPoints.Length; i++)
+                newControlPoints[i] = new Vector2(slider.Path.ControlPoints[i].X, -slider.Path.ControlPoints[i].Y);
 
-            slider.ControlPoints = newControlPoints;
-            slider.Path?.Calculate(); // Recalculate the slider curve
+            slider.Path = new SliderPath(slider.Path.Type, newControlPoints, slider.Path.ExpectedDistance);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 Ball.Scale = new Vector2(HitObject.Scale);
             };
 
-            slider.ControlPointsChanged += _ => Body.Refresh();
+            slider.PathChanged += _ => Body.Refresh();
         }
 
         public override Color4 AccentColour

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             this.slider = slider;
 
             h.PositionChanged += _ => updatePosition();
-            slider.ControlPointsChanged += _ => updatePosition();
+            slider.PathChanged += _ => updatePosition();
 
             updatePosition();
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             AlwaysPresent = true;
 
             hitCircle.PositionChanged += _ => updatePosition();
-            slider.ControlPointsChanged += _ => updatePosition();
+            slider.PathChanged += _ => updatePosition();
 
             updatePosition();
         }

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -22,9 +22,9 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// </summary>
         private const float base_scoring_distance = 100;
 
-        public event Action<Vector2[]> ControlPointsChanged;
+        public event Action<SliderPath> PathChanged;
 
-        public double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
+        public double EndTime => StartTime + this.SpanCount() * Path.GetDistance() / Velocity;
         public double Duration => EndTime - StartTime;
 
         public Vector2 StackedPositionAt(double t) => StackedPosition + this.CurvePositionAt(t);
@@ -52,35 +52,23 @@ namespace osu.Game.Rulesets.Osu.Objects
             }
         }
 
-        public SliderPath Path { get; } = new SliderPath();
+        private SliderPath path;
 
-        public Vector2[] ControlPoints
+        public SliderPath Path
         {
-            get => Path.ControlPoints;
+            get => path;
             set
             {
-                if (Path.ControlPoints == value)
-                    return;
-                Path.ControlPoints = value;
+                path = value;
 
-                ControlPointsChanged?.Invoke(value);
+                PathChanged?.Invoke(value);
 
                 if (TailCircle != null)
                     TailCircle.Position = EndPosition;
             }
         }
 
-        public PathType PathType
-        {
-            get { return Path.PathType; }
-            set { Path.PathType = value; }
-        }
-
-        public double Distance
-        {
-            get { return Path.Distance; }
-            set { Path.Distance = value; }
-        }
+        public double Distance => Path.GetDistance();
 
         public override Vector2 Position
         {
@@ -190,7 +178,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         private void createTicks()
         {
-            var length = Path.Distance;
+            var length = Path.GetDistance();
             var tickDistance = MathHelper.Clamp(TickDistance, 0, length);
 
             if (tickDistance == 0) return;

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public event Action<SliderPath> PathChanged;
 
-        public double EndTime => StartTime + this.SpanCount() * Path.GetDistance() / Velocity;
+        public double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
         public double Duration => EndTime - StartTime;
 
         public Vector2 StackedPositionAt(double t) => StackedPosition + this.CurvePositionAt(t);
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             }
         }
 
-        public double Distance => Path.GetDistance();
+        public double Distance => Path.Distance;
 
         public override Vector2 Position
         {
@@ -178,7 +178,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         private void createTicks()
         {
-            var length = Path.GetDistance();
+            var length = Path.Distance;
             var tickDistance = MathHelper.Clamp(TickDistance, 0, length);
 
             if (tickDistance == 0) return;

--- a/osu.Game.Tests/Visual/TestCaseHitObjectComposer.cs
+++ b/osu.Game.Tests/Visual/TestCaseHitObjectComposer.cs
@@ -11,6 +11,7 @@ using OpenTK;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
@@ -53,12 +54,11 @@ namespace osu.Game.Tests.Visual
                     new Slider
                     {
                         Position = new Vector2(128, 256),
-                        ControlPoints = new[]
+                        Path = new SliderPath(PathType.Linear, new[]
                         {
                             Vector2.Zero,
                             new Vector2(216, 0),
-                        },
-                        Distance = 216,
+                        }),
                         Scale = 0.5f,
                     }
                 },

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
@@ -50,9 +50,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
                 X = position.X,
                 NewCombo = FirstObject || newCombo,
                 ComboOffset = comboOffset,
-                ControlPoints = controlPoints,
-                Distance = length,
-                PathType = pathType,
+                Path = new SliderPath(pathType, controlPoints, length),
                 NodeSamples = nodeSamples,
                 RepeatCount = repeatCount
             };

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -3,7 +3,6 @@
 
 using osu.Game.Rulesets.Objects.Types;
 using System.Collections.Generic;
-using OpenTK;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -20,11 +19,9 @@ namespace osu.Game.Rulesets.Objects.Legacy
         /// <summary>
         /// <see cref="ConvertSlider"/>s don't need a curve since they're converted to ruleset-specific hitobjects.
         /// </summary>
-        public SliderPath Path { get; } = null;
-        public Vector2[] ControlPoints { get; set; }
-        public PathType PathType { get; set; }
+        public SliderPath Path { get; set; }
 
-        public double Distance { get; set; }
+        public double Distance => Path.GetDistance();
 
         public List<List<SampleInfo>> NodeSamples { get; set; }
         public int RepeatCount { get; set; }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
         /// </summary>
         public SliderPath Path { get; set; }
 
-        public double Distance => Path.GetDistance();
+        public double Distance => Path.Distance;
 
         public List<List<SampleInfo>> NodeSamples { get; set; }
         public int RepeatCount { get; set; }

--- a/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHitObjectParser.cs
@@ -31,9 +31,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
             return new ConvertSlider
             {
                 X = position.X,
-                ControlPoints = controlPoints,
-                Distance = length,
-                PathType = pathType,
+                Path = new SliderPath(pathType, controlPoints, length),
                 NodeSamples = nodeSamples,
                 RepeatCount = repeatCount
             };

--- a/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
@@ -51,9 +51,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Osu
                 Position = position,
                 NewCombo = FirstObject || newCombo,
                 ComboOffset = comboOffset,
-                ControlPoints = controlPoints,
-                Distance = Math.Max(0, length),
-                PathType = pathType,
+                Path = new SliderPath(pathType, controlPoints, Math.Max(0, length)),
                 NodeSamples = nodeSamples,
                 RepeatCount = repeatCount
             };

--- a/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHitObjectParser.cs
@@ -27,9 +27,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Taiko
         {
             return new ConvertSlider
             {
-                ControlPoints = controlPoints,
-                Distance = length,
-                PathType = pathType,
+                Path = new SliderPath(pathType, controlPoints, length),
                 NodeSamples = nodeSamples,
                 RepeatCount = repeatCount
             };

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Objects
 
         private double progressToDistance(double progress)
         {
-            return MathHelper.Clamp(progress, 0, 1) * GetDistance();
+            return MathHelper.Clamp(progress, 0, 1) * Distance;
         }
 
         private Vector2 interpolateVertices(int i, double d)
@@ -164,7 +164,7 @@ namespace osu.Game.Rulesets.Objects
             return p0 + (p1 - p0) * (float)w;
         }
 
-        public double GetDistance() => cumulativeLength.Count == 0 ? 0 : cumulativeLength[cumulativeLength.Count - 1];
+        public double Distance => cumulativeLength.Count == 0 ? 0 : cumulativeLength[cumulativeLength.Count - 1];
 
         /// <summary>
         /// Computes the slider path until a given progress that ranges from 0 (beginning of the slider)

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// The distance of the path after lengthening/shortening to account for <see cref="ExpectedDistance"/>.
         /// </summary>
+        [JsonIgnore]
         public double Distance
         {
             get

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Objects
 {
     public readonly struct SliderPath
     {
-        public readonly Vector2[] ControlPoints;
+        public readonly ReadOnlyMemory<Vector2> ControlPoints;
         public readonly PathType Type;
         public readonly double? ExpectedDistance;
 
@@ -73,9 +73,9 @@ namespace osu.Game.Rulesets.Objects
             {
                 end++;
 
-                if (i == ControlPoints.Length - 1 || ControlPoints[i] == ControlPoints[i + 1])
+                if (i == ControlPoints.Length - 1 || ControlPoints.Span[i] == ControlPoints.Span[i + 1])
                 {
-                    ReadOnlySpan<Vector2> cpSpan = ControlPoints.AsSpan().Slice(start, end - start);
+                    ReadOnlySpan<Vector2> cpSpan = ControlPoints.Span.Slice(start, end - start);
 
                     foreach (Vector2 t in calculateSubpath(cpSpan))
                         if (calculatedPath.Count == 0 || calculatedPath.Last() != t)

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -14,11 +14,6 @@ namespace osu.Game.Rulesets.Objects
     public struct SliderPath : IEquatable<SliderPath>
     {
         /// <summary>
-        /// The control points of the path.
-        /// </summary>
-        public readonly Vector2[] ControlPoints;
-
-        /// <summary>
         /// The user-set distance of the path. If non-null, <see cref="Distance"/> will match this value,
         /// and the path will be shortened/lengthened to match this length.
         /// </summary>
@@ -28,6 +23,9 @@ namespace osu.Game.Rulesets.Objects
         /// The type of path.
         /// </summary>
         public readonly PathType Type;
+
+        [JsonProperty]
+        private Vector2[] controlPoints;
 
         private List<Vector2> calculatedPath;
         private List<double> cumulativeLength;
@@ -46,12 +44,25 @@ namespace osu.Game.Rulesets.Objects
         public SliderPath(PathType type, Vector2[] controlPoints, double? expectedDistance = null)
         {
             this = default;
+            this.controlPoints = controlPoints;
 
-            ControlPoints = controlPoints;
             Type = type;
             ExpectedDistance = expectedDistance;
 
             ensureInitialised();
+        }
+
+        /// <summary>
+        /// The control points of the path.
+        /// </summary>
+        [JsonIgnore]
+        public ReadOnlySpan<Vector2> ControlPoints
+        {
+            get
+            {
+                ensureInitialised();
+                return controlPoints.AsSpan();
+            }
         }
 
         /// <summary>
@@ -116,6 +127,7 @@ namespace osu.Game.Rulesets.Objects
                 return;
             isInitialised = true;
 
+            controlPoints = controlPoints ?? Array.Empty<Vector2>();
             calculatedPath = new List<Vector2>();
             cumulativeLength = new List<double>();
 
@@ -166,7 +178,7 @@ namespace osu.Game.Rulesets.Objects
 
                 if (i == ControlPoints.Length - 1 || ControlPoints[i] == ControlPoints[i + 1])
                 {
-                    ReadOnlySpan<Vector2> cpSpan = ControlPoints.AsSpan().Slice(start, end - start);
+                    ReadOnlySpan<Vector2> cpSpan = ControlPoints.Slice(start, end - start);
 
                     foreach (Vector2 t in calculateSubpath(cpSpan))
                         if (calculatedPath.Count == 0 || calculatedPath.Last() != t)

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using osu.Framework.MathUtils;
 using osu.Game.Rulesets.Objects.Types;
 using OpenTK;
@@ -41,6 +42,7 @@ namespace osu.Game.Rulesets.Objects
         /// <param name="expectedDistance">A user-set distance of the path that may be shorter or longer than the true distance between all
         /// <paramref name="controlPoints"/>. The path will be shortened/lengthened to match this length.
         /// If null, the path will use the true distance between all <paramref name="controlPoints"/>.</param>
+        [JsonConstructor]
         public SliderPath(PathType type, Vector2[] controlPoints, double? expectedDistance = null)
         {
             this = default;

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// The control points of the path.
         /// </summary>
-        public readonly ReadOnlyMemory<Vector2> ControlPoints;
+        public readonly Vector2[] ControlPoints;
 
         /// <summary>
         /// The type of path.
@@ -137,9 +137,9 @@ namespace osu.Game.Rulesets.Objects
             {
                 end++;
 
-                if (i == ControlPoints.Length - 1 || ControlPoints.Span[i] == ControlPoints.Span[i + 1])
+                if (i == ControlPoints.Length - 1 || ControlPoints[i] == ControlPoints[i + 1])
                 {
-                    ReadOnlySpan<Vector2> cpSpan = ControlPoints.Span.Slice(start, end - start);
+                    ReadOnlySpan<Vector2> cpSpan = ControlPoints.AsSpan().Slice(start, end - start);
 
                     foreach (Vector2 t in calculateSubpath(cpSpan))
                         if (calculatedPath.Count == 0 || calculatedPath.Last() != t)

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -12,13 +12,33 @@ namespace osu.Game.Rulesets.Objects
 {
     public readonly struct SliderPath
     {
+        /// <summary>
+        /// The control points of the path.
+        /// </summary>
         public readonly ReadOnlyMemory<Vector2> ControlPoints;
+
+        /// <summary>
+        /// The type of path.
+        /// </summary>
         public readonly PathType Type;
+
+        /// <summary>
+        /// The user-set distance of the path. If non-null, <see cref="Distance"/> will match this value,
+        /// and the path will be shortened/lengthened to match this length.
+        /// </summary>
         public readonly double? ExpectedDistance;
 
         private readonly List<Vector2> calculatedPath;
         private readonly List<double> cumulativeLength;
 
+        /// <summary>
+        /// Creates a new <see cref="SliderPath"/>.
+        /// </summary>
+        /// <param name="type">The type of path.</param>
+        /// <param name="controlPoints">The control points of the path.</param>
+        /// <param name="expectedDistance">A user-set distance of the path that may be shorter or longer than the true distance between all
+        /// <paramref name="controlPoints"/>. The path will be shortened/lengthened to match this length.
+        /// If null, the path will use the true distance between all <paramref name="controlPoints"/>.</param>
         public SliderPath(PathType type, Vector2[] controlPoints, double? expectedDistance = null)
         {
             ControlPoints = controlPoints;
@@ -32,6 +52,9 @@ namespace osu.Game.Rulesets.Objects
             calculateCumulativeLength();
         }
 
+        /// <summary>
+        /// The distance of the path after lengthening/shortening to account for <see cref="ExpectedDistance"/>.
+        /// </summary>
         public double Distance => cumulativeLength.Count == 0 ? 0 : cumulativeLength[cumulativeLength.Count - 1];
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -11,7 +11,7 @@ using OpenTK;
 
 namespace osu.Game.Rulesets.Objects
 {
-    public struct SliderPath
+    public struct SliderPath : IEquatable<SliderPath>
     {
         /// <summary>
         /// The control points of the path.
@@ -253,6 +253,22 @@ namespace osu.Game.Rulesets.Objects
 
             double w = (d - d0) / (d1 - d0);
             return p0 + (p1 - p0) * (float)w;
+        }
+
+        public bool Equals(SliderPath other)
+        {
+            if (ControlPoints == null && other.ControlPoints != null)
+                return false;
+            if (other.ControlPoints == null && ControlPoints != null)
+                return false;
+
+            return ControlPoints.SequenceEqual(other.ControlPoints) && ExpectedDistance.Equals(other.ExpectedDistance) && Type == other.Type;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is SliderPath other && Equals(other);
         }
     }
 }

--- a/osu.Game/Rulesets/Objects/Types/IHasCurve.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasCurve.cs
@@ -14,16 +14,6 @@ namespace osu.Game.Rulesets.Objects.Types
         /// The curve.
         /// </summary>
         SliderPath Path { get; }
-
-        /// <summary>
-        /// The control points that shape the curve.
-        /// </summary>
-        Vector2[] ControlPoints { get; }
-
-        /// <summary>
-        /// The type of curve.
-        /// </summary>
-        PathType PathType { get; }
     }
 
     public static class HasCurveExtensions


### PR DESCRIPTION
The `SliderPath` object can no longer be changed, and now has to be re-instantiated. It's a struct so that there's no impact to memory versus the current model (except the array for new control points).

This also means that `IHasCurve` no longer contains members for `ControlPoints` and `PathType`.

Fixes the 1-frame issue in the editor.