### PR TITLE
Fix SettingsTextBox having width of 0

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsTextBox.cs
+++ b/osu.Game/Overlays/Settings/SettingsTextBox.cs
@@ -8,6 +8,10 @@ namespace osu.Game.Overlays.Settings
 {
     public class SettingsTextBox : SettingsItem<string>
     {
-        protected override Drawable CreateControl() => new OsuTextBox();
+        protected override Drawable CreateControl() => new OsuTextBox
+        {
+            Margin = new MarginPadding { Top = 5 },
+            RelativeSizeAxes = Axes.X,
+        };
     }
 }


### PR DESCRIPTION
This PR gives the OsuTextBox in SettingsTextBox a RelativeSizeAxes and Margin similar to SettingsDropdown.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/13605369/48513935-75c13900-e85d-11e8-83e7-b406714b113b.png) | ![image](https://user-images.githubusercontent.com/13605369/48514102-cb95e100-e85d-11e8-955b-4cdec47ea29c.png) |

---

Fix SettingsTextBox having no width or padding, and so being invisible. 
![image](https://user-images.githubusercontent.com/13605369/48513745-e1ef6d00-e85c-11e8-9d79-036e92befa0d.png)
