### PR TITLE
Add squirrel update log output

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -99,7 +99,6 @@ namespace osu.Desktop.Updater
             {
                 // we'll ignore this and retry later. can be triggered by no internet connection or thread abortion.
             }
-
             finally
             {
                 if (scheduleRetry)

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="4.5.0" />
-    <PackageReference Include="ppy.squirrel.windows" Version="1.9.0.2" />
+    <PackageReference Include="ppy.squirrel.windows" Version="1.9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />
   </ItemGroup>


### PR DESCRIPTION
Also updates squirrel to latest version, fixing desktop shortcut deletion on update.

---

Fixes desktop shortcuts from being deleted each update. Note that to fix this you will need to reinstall lazer from install.exe once.