### PR TITLE
Fix crash that happened when joining a channel failed

### DIFF
--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -20,6 +20,7 @@ using osu.Game.Online.Chat;
 using osu.Game.Overlays.Chat;
 using osu.Game.Overlays.Chat.Selection;
 using osu.Game.Overlays.Chat.Tabs;
+using System.Linq;
 
 namespace osu.Game.Overlays
 {
@@ -209,7 +210,8 @@ namespace osu.Game.Overlays
             {
                 textbox.Current.Disabled = true;
                 currentChannelContainer.Clear(false);
-                channelTabControl.Current.Value = null;
+                // channelTabControl does not support setting it to null.
+                channelTabControl.Current.Value = channelTabControl.Items.First();
                 return;
             }
 


### PR DESCRIPTION
Fixes that osu! crashes when the selected channel in the channel overlay is null.

This happened because channelTabControl.Current con not be set to null.

- Closes #3750

---

Fix crash that happened when joining a channel failed.