### PR TITLE
Revert "Fix D rank displaying as F"

### DIFF
--- a/osu.Game/Scoring/ScoreRank.cs
+++ b/osu.Game/Scoring/ScoreRank.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Scoring
     {
         [Description(@"F")]
         F,
-        [Description(@"D")]
+        [Description(@"F")]
         D,
         [Description(@"C")]
         C,


### PR DESCRIPTION
Turns out this was correct. D rank doesn't exist in new designs..