### PR TITLE
Fix some data types on ScoreInfo

### DIFF
--- a/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
+++ b/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
@@ -38,7 +38,6 @@ namespace osu.Game.Tests.Scores.IO
                         Rank = ScoreRank.B,
                         TotalScore = 987654,
                         Accuracy = 0.8,
-                        Health = 0.8,
                         MaxCombo = 500,
                         Combo = 250,
                         User = new User { Username = "Test user" },
@@ -51,7 +50,6 @@ namespace osu.Game.Tests.Scores.IO
                     Assert.AreEqual(toImport.Rank, imported.Rank);
                     Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
                     Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
-                    Assert.AreEqual(toImport.Health, imported.Health);
                     Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
                     Assert.AreEqual(toImport.Combo, imported.Combo);
                     Assert.AreEqual(toImport.User.Username, imported.User.Username);

--- a/osu.Game/Migrations/20181130113755_AddScoreInfoTables.Designer.cs
+++ b/osu.Game/Migrations/20181130113755_AddScoreInfoTables.Designer.cs
@@ -9,7 +9,7 @@ using osu.Game.Database;
 namespace osu.Game.Migrations
 {
     [DbContext(typeof(OsuDbContext))]
-    [Migration("20181130084152_AddScoreInfoTables")]
+    [Migration("20181130113755_AddScoreInfoTables")]
     partial class AddScoreInfoTables
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -309,7 +309,8 @@ namespace osu.Game.Migrations
                     b.Property<int>("ID")
                         .ValueGeneratedOnAdd();
 
-                    b.Property<double>("Accuracy");
+                    b.Property<double>("Accuracy")
+                        .HasColumnType("DECIMAL(1,4)");
 
                     b.Property<int>("BeatmapInfoID");
 
@@ -320,8 +321,6 @@ namespace osu.Game.Migrations
                     b.Property<bool>("DeletePending");
 
                     b.Property<string>("Hash");
-
-                    b.Property<double>("Health");
 
                     b.Property<int>("MaxCombo");
 
@@ -339,7 +338,7 @@ namespace osu.Game.Migrations
                     b.Property<string>("StatisticsJson")
                         .HasColumnName("Statistics");
 
-                    b.Property<double>("TotalScore");
+                    b.Property<int>("TotalScore");
 
                     b.Property<string>("UserString")
                         .HasColumnName("User");

--- a/osu.Game/Migrations/20181130113755_AddScoreInfoTables.cs
+++ b/osu.Game/Migrations/20181130113755_AddScoreInfoTables.cs
@@ -14,9 +14,8 @@ namespace osu.Game.Migrations
                     ID = table.Column<int>(nullable: false)
                         .Annotation("Sqlite:Autoincrement", true),
                     Rank = table.Column<int>(nullable: false),
-                    TotalScore = table.Column<double>(nullable: false),
-                    Accuracy = table.Column<double>(nullable: false),
-                    Health = table.Column<double>(nullable: false),
+                    TotalScore = table.Column<int>(nullable: false),
+                    Accuracy = table.Column<double>(type: "DECIMAL(1,4)", nullable: false),
                     PP = table.Column<double>(nullable: true),
                     MaxCombo = table.Column<int>(nullable: false),
                     Combo = table.Column<int>(nullable: false),

--- a/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
+++ b/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
@@ -307,7 +307,8 @@ namespace osu.Game.Migrations
                     b.Property<int>("ID")
                         .ValueGeneratedOnAdd();
 
-                    b.Property<double>("Accuracy");
+                    b.Property<double>("Accuracy")
+                        .HasColumnType("DECIMAL(1,4)");
 
                     b.Property<int>("BeatmapInfoID");
 
@@ -318,8 +319,6 @@ namespace osu.Game.Migrations
                     b.Property<bool>("DeletePending");
 
                     b.Property<string>("Hash");
-
-                    b.Property<double>("Health");
 
                     b.Property<int>("MaxCombo");
 
@@ -337,7 +336,7 @@ namespace osu.Game.Migrations
                     b.Property<string>("StatisticsJson")
                         .HasColumnName("Statistics");
 
-                    b.Property<double>("TotalScore");
+                    b.Property<int>("TotalScore");
 
                     b.Property<string>("UserString")
                         .HasColumnName("User");

--- a/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIScoreInfo.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Online.API.Requests.Responses
     public class APIScoreInfo : ScoreInfo
     {
         [JsonProperty(@"score")]
-        private double totalScore
+        private int totalScore
         {
             set => TotalScore = value;
         }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -166,7 +166,6 @@ namespace osu.Game.Rulesets.Scoring
             score.Accuracy = Math.Round(Accuracy, 4);
             score.Rank = Rank;
             score.Date = DateTimeOffset.Now;
-            score.Health = Health;
         }
     }
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -160,10 +160,10 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         public virtual void PopulateScore(ScoreInfo score)
         {
-            score.TotalScore = TotalScore;
+            score.TotalScore = (int)Math.Round(TotalScore);
             score.Combo = Combo;
             score.MaxCombo = HighestCombo;
-            score.Accuracy = Accuracy;
+            score.Accuracy = Math.Round(Accuracy, 4);
             score.Rank = Rank;
             score.Date = DateTimeOffset.Now;
             score.Health = Health;

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Scoring
         [Column(TypeName="DECIMAL(1,4)")]
         public double Accuracy { get; set; }
 
-        [NotMapped]
-        public double Health { get; set; } = 1;
-
         public double? PP { get; set; }
 
         public int MaxCombo { get; set; }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -21,10 +21,12 @@ namespace osu.Game.Scoring
 
         public ScoreRank Rank { get; set; }
 
-        public double TotalScore { get; set; }
+        public int TotalScore { get; set; }
 
+        [Column(TypeName="DECIMAL(1,4)")]
         public double Accuracy { get; set; }
 
+        [NotMapped]
         public double Health { get; set; } = 1;
 
         public double? PP { get; set; }


### PR DESCRIPTION
This is a breaking change for databases migrated to latest master (due to SQLite alter limitations). We'll figure a better way around this in the future, but as there was no release this is a non-issue this time around.