### PR TITLE
Make hud overlay's content always present to fix input issues

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Play
             Add(content = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-
+                AlwaysPresent = true, // The hud may be hidden but certain elements may need to still be updated
                 Children = new Drawable[]
                 {
                     ComboCounter = CreateComboCounter(),


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/3762

Temporary fix for now - in the end we want the ability to hide individual elements anyway, so they should implement their own `Show()`/`Hide()` methods + be individually hidden/shown from `HUDOverlay`.