### PR TITLE
Move ModOverlay to SongSelect

### DIFF
--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -1,99 +1,28 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.Collections.Generic;
 using System.Linq;
-using osuTK.Input;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
-using osu.Framework.Configuration;
-using osu.Framework.Graphics;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics;
-using osu.Game.Overlays;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play;
-using osu.Game.Screens.Ranking;
-using osu.Game.Skinning;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Select
 {
     public class PlaySongSelect : SongSelect
     {
-        private OsuScreen player;
-        protected readonly BeatmapDetailArea BeatmapDetails;
         private bool removeAutoModOnResume;
+        private OsuScreen player;
 
-        public PlaySongSelect()
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
         {
-            LeftContent.Add(BeatmapDetails = new BeatmapDetailArea
-            {
-                RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding { Top = 10, Right = 5 },
-            });
-
-            BeatmapDetails.Leaderboard.ScoreSelected += s => Push(new Results(s));
-        }
-
-        private SampleChannel sampleConfirm;
-
-        [Cached]
-        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> selectedMods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
-
-        [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, AudioManager audio, BeatmapManager beatmaps, SkinManager skins, DialogOverlay dialogOverlay, Bindable<IEnumerable<Mod>> selectedMods)
-        {
-            if (selectedMods != null) this.selectedMods.BindTo(selectedMods);
-
-            sampleConfirm = audio.Sample.Get(@"SongSelect/confirm-selection");
-
-            BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.fa_times_circle_o, colours.Purple, null, Key.Number1);
-            BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.fa_eraser, colours.Purple, null, Key.Number2);
             BeatmapOptions.AddButton(@"Edit", @"beatmap", FontAwesome.fa_pencil, colours.Yellow, () =>
             {
                 ValidForResume = false;
                 Edit();
             }, Key.Number3);
-
-            if (dialogOverlay != null)
-            {
-                Schedule(() =>
-                {
-                    // if we have no beatmaps but osu-stable is found, let's prompt the user to import.
-                    if (!beatmaps.GetAllUsableBeatmapSets().Any() && beatmaps.StableInstallationAvailable)
-                        dialogOverlay.Push(new ImportFromStablePopup(() =>
-                        {
-                            beatmaps.ImportFromStableAsync();
-                            skins.ImportFromStableAsync();
-                        }));
-                });
-            }
-        }
-
-        protected override void ExitFromBack()
-        {
-            if (modSelect.State == Visibility.Visible)
-            {
-                modSelect.Hide();
-                return;
-            }
-
-            base.ExitFromBack();
-        }
-
-        protected override void UpdateBeatmap(WorkingBeatmap beatmap)
-        {
-            beatmap.Mods.BindTo(selectedMods);
-
-            base.UpdateBeatmap(beatmap);
-
-            BeatmapDetails.Beatmap = beatmap;
-
-            if (beatmap.Track != null)
-                beatmap.Track.Looping = true;
         }
 
         protected override void OnResuming(Screen last)
@@ -107,25 +36,7 @@ namespace osu.Game.Screens.Select
                 removeAutoModOnResume = false;
             }
 
-            BeatmapDetails.Leaderboard.RefreshScores();
-
-            Beatmap.Value.Track.Looping = true;
-
             base.OnResuming(last);
-        }
-
-        protected override bool OnExiting(Screen next)
-        {
-            if (base.OnExiting(next))
-                return true;
-
-            if (Beatmap.Value.Track != null)
-                Beatmap.Value.Track.Looping = false;
-
-            selectedMods.UnbindAll();
-            Beatmap.Value.Mods.Value = new Mod[] { };
-
-            return false;
         }
 
         protected override bool OnStart()
@@ -138,10 +49,10 @@ namespace osu.Game.Screens.Select
                 var auto = Ruleset.Value.CreateInstance().GetAutoplayMod();
                 var autoType = auto.GetType();
 
-                var mods = selectedMods.Value;
+                var mods = SelectedMods.Value;
                 if (mods.All(m => m.GetType() != autoType))
                 {
-                    selectedMods.Value = mods.Append(auto);
+                    SelectedMods.Value = mods.Append(auto);
                     removeAutoModOnResume = true;
                 }
             }
@@ -149,7 +60,7 @@ namespace osu.Game.Screens.Select
             Beatmap.Value.Track.Looping = false;
             Beatmap.Disabled = true;
 
-            sampleConfirm?.Play();
+            SampleConfirm?.Play();
 
             LoadComponentAsync(player = new PlayerLoader(new Player()), l =>
             {

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -9,12 +9,10 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
@@ -25,19 +23,11 @@ namespace osu.Game.Screens.Select
     public class PlaySongSelect : SongSelect
     {
         private OsuScreen player;
-        private readonly ModSelectOverlay modSelect;
         protected readonly BeatmapDetailArea BeatmapDetails;
         private bool removeAutoModOnResume;
 
         public PlaySongSelect()
         {
-            FooterPanels.Add(modSelect = new ModSelectOverlay
-            {
-                RelativeSizeAxes = Axes.X,
-                Origin = Anchor.BottomCentre,
-                Anchor = Anchor.BottomCentre,
-            });
-
             LeftContent.Add(BeatmapDetails = new BeatmapDetailArea
             {
                 RelativeSizeAxes = Axes.Both,
@@ -59,8 +49,6 @@ namespace osu.Game.Screens.Select
             if (selectedMods != null) this.selectedMods.BindTo(selectedMods);
 
             sampleConfirm = audio.Sample.Get(@"SongSelect/confirm-selection");
-
-            Footer.AddButton(@"mods", colours.Yellow, modSelect, Key.F1, float.MaxValue);
 
             BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.fa_times_circle_o, colours.Purple, null, Key.Number1);
             BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.fa_eraser, colours.Purple, null, Key.Number2);
@@ -115,7 +103,7 @@ namespace osu.Game.Screens.Select
             if (removeAutoModOnResume)
             {
                 var autoType = Ruleset.Value.CreateInstance().GetAutoplayMod().GetType();
-                modSelect.DeselectTypes(new[] { autoType }, true);
+                ModSelect.DeselectTypes(new[] { autoType }, true);
                 removeAutoModOnResume = false;
             }
 
@@ -124,13 +112,6 @@ namespace osu.Game.Screens.Select
             Beatmap.Value.Track.Looping = true;
 
             base.OnResuming(last);
-        }
-
-        protected override void OnSuspending(Screen next)
-        {
-            modSelect.Hide();
-
-            base.OnSuspending(next);
         }
 
         protected override bool OnExiting(Screen next)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osuTK;
 using osuTK.Input;
@@ -27,7 +28,9 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Menu;
+using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select.Options;
+using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Select
 {
@@ -61,8 +64,6 @@ namespace osu.Game.Screens.Select
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenBeatmap();
 
-        protected Container LeftContent;
-
         protected readonly BeatmapCarousel Carousel;
         private readonly BeatmapInfoWedge beatmapInfoWedge;
         private DialogOverlay dialogOverlay;
@@ -70,22 +71,17 @@ namespace osu.Game.Screens.Select
 
         protected readonly ModSelectOverlay ModSelect;
 
+        protected SampleChannel SampleConfirm;
         private SampleChannel sampleChangeDifficulty;
         private SampleChannel sampleChangeBeatmap;
 
+        protected readonly BeatmapDetailArea BeatmapDetails;
+
         protected new readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
 
-        private DependencyContainer dependencies;
-
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-        {
-            dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-            dependencies.CacheAs(this);
-            dependencies.CacheAs(Ruleset);
-            dependencies.CacheAs<IBindable<RulesetInfo>>(Ruleset);
-
-            return dependencies;
-        }
+        [Cached]
+        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
+        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
 
         protected SongSelect()
         {
@@ -108,7 +104,7 @@ namespace osu.Game.Screens.Select
                         }
                     }
                 },
-                LeftContent = new Container
+                new Container
                 {
                     Origin = Anchor.BottomLeft,
                     Anchor = Anchor.BottomLeft,
@@ -120,6 +116,11 @@ namespace osu.Game.Screens.Select
                         Top = wedged_container_size.Y + left_area_padding,
                         Left = left_area_padding,
                         Right = left_area_padding * 2,
+                    },
+                    Child = BeatmapDetails = new BeatmapDetailArea
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Top = 10, Right = 5 },
                     }
                 },
                 new Container
@@ -208,13 +209,16 @@ namespace osu.Game.Screens.Select
                     }
                 });
             }
+
+            BeatmapDetails.Leaderboard.ScoreSelected += s => Push(new Results(s));
         }
 
-        protected virtual void ExitFromBack() => Exit();
-
         [BackgroundDependencyLoader(true)]
-        private void load(BeatmapManager beatmaps, AudioManager audio, DialogOverlay dialog, OsuColour colours)
+        private void load(BeatmapManager beatmaps, AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, Bindable<IEnumerable<Mod>> selectedMods)
         {
+            if (selectedMods != null)
+                SelectedMods.BindTo(selectedMods);
+
             if (Footer != null)
             {
                 Footer.AddButton(@"mods", colours.Yellow, ModSelect, Key.F1);
@@ -222,6 +226,8 @@ namespace osu.Game.Screens.Select
                 Footer.AddButton(@"options", colours.Blue, BeatmapOptions, Key.F3);
 
                 BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.fa_trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo), Key.Number4, float.MaxValue);
+                BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.fa_times_circle_o, colours.Purple, null, Key.Number1);
+                BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.fa_eraser, colours.Purple, null, Key.Number2);
             }
 
             if (this.beatmaps == null)
@@ -236,8 +242,46 @@ namespace osu.Game.Screens.Select
 
             sampleChangeDifficulty = audio.Sample.Get(@"SongSelect/select-difficulty");
             sampleChangeBeatmap = audio.Sample.Get(@"SongSelect/select-expand");
+            SampleConfirm = audio.Sample.Get(@"SongSelect/confirm-selection");
 
             Carousel.LoadBeatmapSetsFromManager(this.beatmaps);
+
+            if (dialogOverlay != null)
+            {
+                Schedule(() =>
+                {
+                    // if we have no beatmaps but osu-stable is found, let's prompt the user to import.
+                    if (!beatmaps.GetAllUsableBeatmapSets().Any() && beatmaps.StableInstallationAvailable)
+                        dialogOverlay.Push(new ImportFromStablePopup(() =>
+                        {
+                            beatmaps.ImportFromStableAsync();
+                            skins.ImportFromStableAsync();
+                        }));
+                });
+            }
+        }
+
+        private DependencyContainer dependencies;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            dependencies.CacheAs(this);
+            dependencies.CacheAs(Ruleset);
+            dependencies.CacheAs<IBindable<RulesetInfo>>(Ruleset);
+
+            return dependencies;
+        }
+
+        protected virtual void ExitFromBack()
+        {
+            if (ModSelect.State == Visibility.Visible)
+            {
+                ModSelect.Hide();
+                return;
+            }
+
+            Exit();
         }
 
         public void Edit(BeatmapInfo beatmap = null)
@@ -434,6 +478,10 @@ namespace osu.Game.Screens.Select
 
         protected override void OnResuming(Screen last)
         {
+            BeatmapDetails.Leaderboard.RefreshScores();
+
+            Beatmap.Value.Track.Looping = true;
+
             if (Beatmap != null && !Beatmap.Value.BeatmapSetInfo.DeletePending)
             {
                 UpdateBeatmap(Beatmap.Value);
@@ -477,6 +525,12 @@ namespace osu.Game.Screens.Select
 
             FilterControl.Deactivate();
 
+            if (Beatmap.Value.Track != null)
+                Beatmap.Value.Track.Looping = false;
+
+            SelectedMods.UnbindAll();
+            Beatmap.Value.Mods.Value = new Mod[] { };
+
             return base.OnExiting(next);
         }
 
@@ -502,6 +556,8 @@ namespace osu.Game.Screens.Select
         /// <param name="beatmap">The working beatmap.</param>
         protected virtual void UpdateBeatmap(WorkingBeatmap beatmap)
         {
+            beatmap.Mods.BindTo(SelectedMods);
+
             Logger.Log($"working beatmap updated to {beatmap}");
 
             if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
@@ -512,6 +568,11 @@ namespace osu.Game.Screens.Select
             }
 
             beatmapInfoWedge.Beatmap = beatmap;
+
+            BeatmapDetails.Beatmap = beatmap;
+
+            if (beatmap.Track != null)
+                beatmap.Track.Looping = true;
         }
 
         private void ensurePlayingSelected(bool preview = false)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -21,6 +21,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Backgrounds;
@@ -66,6 +67,8 @@ namespace osu.Game.Screens.Select
         private readonly BeatmapInfoWedge beatmapInfoWedge;
         private DialogOverlay dialogOverlay;
         private BeatmapManager beatmaps;
+
+        protected readonly ModSelectOverlay ModSelect;
 
         private SampleChannel sampleChangeDifficulty;
         private SampleChannel sampleChangeBeatmap;
@@ -194,7 +197,16 @@ namespace osu.Game.Screens.Select
                     OnBack = ExitFromBack,
                 });
 
-                FooterPanels.Add(BeatmapOptions = new BeatmapOptionsOverlay());
+                FooterPanels.AddRange(new Drawable[]
+                {
+                    BeatmapOptions = new BeatmapOptionsOverlay(),
+                    ModSelect = new ModSelectOverlay
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Origin = Anchor.BottomCentre,
+                        Anchor = Anchor.BottomCentre,
+                    }
+                });
             }
         }
 
@@ -205,6 +217,7 @@ namespace osu.Game.Screens.Select
         {
             if (Footer != null)
             {
+                Footer.AddButton(@"mods", colours.Yellow, ModSelect, Key.F1);
                 Footer.AddButton(@"random", colours.Green, triggerRandom, Key.F2);
                 Footer.AddButton(@"options", colours.Blue, BeatmapOptions, Key.F3);
 
@@ -438,6 +451,8 @@ namespace osu.Game.Screens.Select
 
         protected override void OnSuspending(Screen next)
         {
+            ModSelect.Hide();
+
             Content.ScaleTo(1.1f, 250, Easing.InSine);
 
             Content.FadeOut(250);
@@ -448,6 +463,12 @@ namespace osu.Game.Screens.Select
 
         protected override bool OnExiting(Screen next)
         {
+            if (ModSelect.State == Visibility.Visible)
+            {
+                ModSelect.Hide();
+                return true;
+            }
+
             FinaliseSelection(performStartAction: false);
 
             beatmapInfoWedge.State = Visibility.Hidden;


### PR DESCRIPTION
As we discussed, edit mode isn't going to use `SongSelect`, so the only places where `SongSelect` will be used exist in the context of playability (play, multi) where mods are required.