### PR TITLE
 Implement xexxar/mbmasher’s length bonus summation

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -10,7 +10,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         public double AimStrain;
         public double SpeedStrain;
-        public double LengthBonus;
+        public double AimLengthBonus;
+        public double SpeedLengthBonus;
         public double ApproachRate;
         public double OverallDifficulty;
         public int MaxCombo;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         public double AimStrain;
         public double SpeedStrain;
+        public double LengthBonus;
         public double ApproachRate;
         public double OverallDifficulty;
         public int MaxCombo;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -17,10 +17,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         private const int section_length = 400;
         private const double difficulty_multiplier = 0.0675;
-        private const double c = 0.5;
-        private const double beta = 0.6;
-        private const double m = 0.85;
-        private const double alpha = 0.6;
+        private const double c = 0.38;
+        private const double beta = 0.45;
 
         public OsuDifficultyCalculator(Ruleset ruleset, WorkingBeatmap beatmap)
             : base(ruleset, beatmap)
@@ -68,8 +66,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedRating = Math.Sqrt(speedDifficulty) * difficulty_multiplier;
             double starRating = aimRating + speedRating + Math.Abs(aimRating - speedRating) / 2;
 
-            double aimLengthBonus = Math.Max(m, c + beta * (Math.Log10(aimTotal) - Math.Log10(aimDifficulty) - alpha));
-            double speedLengthBonus = Math.Max(m, c + beta * (Math.Log10(speedTotal) - Math.Log10(speedDifficulty) - alpha));
+            double aimLengthBonus = c + beta * (Math.Log10(aimTotal + aimDifficulty) - Math.Log10(aimDifficulty));
+            double speedLengthBonus = c + beta * (Math.Log10(speedTotal + speedDifficulty) - Math.Log10(speedDifficulty));
 
             // Todo: These int casts are temporary to achieve 1:1 results with osu!stable, and should be removed in the future
             double hitWindowGreat = (int)(beatmap.HitObjects.First().HitWindows.Great / 2) / timeRate;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         private const double difficulty_multiplier = 0.0675;
         private const double c = 0.5;
         private const double beta = 0.6;
-        private const double m = 0.8;
+        private const double m = 0.85;
         private const double alpha = 0.6;
 
         public OsuDifficultyCalculator(Ruleset ruleset, WorkingBeatmap beatmap)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -68,8 +68,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedRating = Math.Sqrt(speedDifficulty) * difficulty_multiplier;
             double starRating = aimRating + speedRating + Math.Abs(aimRating - speedRating) / 2;
 
-            double aimLengthBonus = Math.Max(m, c + beta * (Math.Log10(aimTotal) - Math.Log10(aimRating) - alpha));
-            double speedLengthBonus = Math.Max(m, c + beta * (Math.Log10(speedTotal) - Math.Log10(speedRating) - alpha));
+            double aimLengthBonus = Math.Max(m, c + beta * (Math.Log10(aimTotal) - Math.Log10(aimDifficulty) - alpha));
+            double speedLengthBonus = Math.Max(m, c + beta * (Math.Log10(speedTotal) - Math.Log10(speedDifficulty) - alpha));
 
             // Todo: These int casts are temporary to achieve 1:1 results with osu!stable, and should be removed in the future
             double hitWindowGreat = (int)(beatmap.HitObjects.First().HitWindows.Great / 2) / timeRate;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         private const int section_length = 400;
         private const double difficulty_multiplier = 0.0675;
-        private const double c = 0.38;
-        private const double beta = 0.45;
+        private const double c = 0.32;
+        private const double beta = 0.5;
 
         public OsuDifficultyCalculator(Ruleset ruleset, WorkingBeatmap beatmap)
             : base(ruleset, beatmap)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -17,8 +17,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         private const int section_length = 400;
         private const double difficulty_multiplier = 0.0675;
-        private const double length_bonus_base = -1.28;
-        private const double length_balancing_factor = 1.6;
+        private const double c = 0.5;
+        private const double beta = 0.6;
+        private const double m = 0.8;
+        private const double alpha = 0.6;
 
         public OsuDifficultyCalculator(Ruleset ruleset, WorkingBeatmap beatmap)
             : base(ruleset, beatmap)
@@ -66,7 +68,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedRating = Math.Sqrt(speedDifficulty) * difficulty_multiplier;
             double starRating = aimRating + speedRating + Math.Abs(aimRating - speedRating) / 2;
 
-            double lengthBonus = length_bonus_base + length_balancing_factor * ((2 + Math.Log10(aimTotal + speedTotal)) / (2 + Math.Log10(starRating)) - 1);
+            double aimLengthBonus = Math.Max(m, c + beta * (Math.Log10(aimTotal) - Math.Log10(aimRating) - alpha));
+            double speedLengthBonus = Math.Max(m, c + beta * (Math.Log10(speedTotal) - Math.Log10(speedRating) - alpha));
 
             // Todo: These int casts are temporary to achieve 1:1 results with osu!stable, and should be removed in the future
             double hitWindowGreat = (int)(beatmap.HitObjects.First().HitWindows.Great / 2) / timeRate;
@@ -80,7 +83,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             {
                 AimStrain = aimRating,
                 SpeedStrain = speedRating,
-                LengthBonus = lengthBonus,
+                AimLengthBonus = aimLengthBonus,
+                SpeedLengthBonus = speedLengthBonus,
                 ApproachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5,
                 OverallDifficulty = (80 - hitWindowGreat) / 6,
                 MaxCombo = maxCombo

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Skill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Skill.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public abstract class Skill
     {
-        private const double difficulty_spike_factor = 1.12;
+        private const double difficulty_spike_factor = 1.2;
         /// <summary>
         /// Strain values are multiplied by this number for the given skill. Used to balance the value of different skills between each other.
         /// </summary>

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Skill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Skill.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public abstract class Skill
     {
+        private const double difficulty_spike_factor = 1.12;
         /// <summary>
         /// Strain values are multiplied by this number for the given skill. Used to balance the value of different skills between each other.
         /// </summary>
@@ -73,21 +74,23 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         /// <summary>
         /// Returns the calculated difficulty value representing all processed <see cref="OsuDifficultyHitObject"/>s.
         /// </summary>
-        public double DifficultyValue()
+        public (double total, double difficulty) DifficultyValue()
         {
             strainPeaks.Sort((a, b) => b.CompareTo(a)); // Sort from highest to lowest strain.
 
+            double total = 0;
             double difficulty = 0;
             double weight = 1;
 
             // Difficulty is the weighted sum of the highest strains from every section.
             foreach (double strain in strainPeaks)
             {
+                total += Math.Pow(strain, difficulty_spike_factor);
                 difficulty += strain * weight;
                 weight *= 0.9;
             }
 
-            return difficulty;
+            return (total, difficulty);
         }
 
         /// <summary>


### PR DESCRIPTION
Don’t merge. PRing for visibility in-case people want to follow along.

Implements the diffcalc changes discussed in https://github.com/ppy/osu-performance/issues/64.

Requires https://github.com/smoogipoo/osu-server/tree/mbmasher-lengthbonus for osu-server (code is not up to scratch, so it’s not PR’d yet).