### PR TITLE
Fix WaveOverlayContainer always being present

### DIFF
--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -25,13 +25,20 @@ namespace osu.Game.Overlays
         protected override void PopIn()
         {
             base.PopIn();
+
             Waves.Show();
+
+            this.FadeIn();
         }
 
         protected override void PopOut()
         {
             base.PopOut();
+
             Waves.Hide();
+
+            // this is required or we will remain present even though our waves are hidden.
+            this.Delay(WaveContainer.DISAPPEAR_DURATION).FadeOut();
         }
     }
 }


### PR DESCRIPTION
This fixes `SocialOverlay` from running scheduled web requests before it should.