### PR TITLE
Fix extra hard-rock flipping for sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             if (slider == null)
                 return;
 
-            slider.HeadCircle.Position = new Vector2(slider.HeadCircle.Position.X, OsuPlayfield.BASE_SIZE.Y - slider.HeadCircle.Position.Y);
-            slider.TailCircle.Position = new Vector2(slider.TailCircle.Position.X, OsuPlayfield.BASE_SIZE.Y - slider.TailCircle.Position.Y);
-
             slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
             slider.NestedHitObjects.OfType<RepeatPoint>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
 


### PR DESCRIPTION
Resolves #3883.

https://github.com/ppy/osu/blob/a54951b72d6133ba428481768ccd1fa789a0e4f3/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs#L19-L40

Because `Slider.Position`'s setter automatically propagates to the position of the head and tail circles, flipping the head position again causes unexpected behavior.

No unexpected behavior is observed with the tail circle because setting the slider path afterwards triggers bindable magic which reverts the tail position to where it should be.

Note that the head drawable is actually visually in the correct place the whole time despite the flip and only its judgements are affected—this is because of `DrawableSliderHead`'s update logic.

https://github.com/ppy/osu/blob/a54951b72d6133ba428481768ccd1fa789a0e4f3/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs#L36-L45

---