### PR TITLE
Change osu! default keys back to Z/X

### DIFF
--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Rulesets.Osu
 
         public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => new[]
         {
-            new KeyBinding(InputKey.A, OsuAction.LeftButton),
-            new KeyBinding(InputKey.S, OsuAction.RightButton),
+            new KeyBinding(InputKey.Z, OsuAction.LeftButton),
+            new KeyBinding(InputKey.X, OsuAction.RightButton),
             new KeyBinding(InputKey.MouseLeft, OsuAction.LeftButton),
             new KeyBinding(InputKey.MouseRight, OsuAction.RightButton),
         };


### PR DESCRIPTION
A/S was no better as far as keyboard layout agnostic-ness. And people are confused if we change the defaults. Need to take a step back and reassess.