### PR TITLE
Fix cancelling completed webrequests throwing exceptions

### DIFF
--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -92,7 +92,11 @@ namespace osu.Game.Online.API
 
         public void Fail(Exception e)
         {
-            if (cancelled) return;
+            if (WebRequest?.Completed == true)
+                return;
+
+            if (cancelled)
+                return;
 
             cancelled = true;
             WebRequest?.Abort();


### PR DESCRIPTION
1. Queue a webrequest
2. Wait for completion
3. Invoke request.Cancel()

Will trigger an `OperationCancelledException`.