### PR TITLE
Fix context menu in chat overlay being clipped by the scroll

### DIFF
--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -9,7 +9,6 @@ using osuTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Cursor;
 using osu.Game.Online.Chat;
 
 namespace osu.Game.Overlays.Chat
@@ -34,17 +33,12 @@ namespace osu.Game.Overlays.Chat
                     // Some chat lines have effects that slightly protrude to the bottom,
                     // which we do not want to mask away, hence the padding.
                     Padding = new MarginPadding { Bottom = 5 },
-                    Child = new OsuContextMenuContainer
+                    Child = ChatLineFlow = new ChatLineContainer
                     {
+                        Padding = new MarginPadding { Left = 20, Right = 20 },
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Child = ChatLineFlow = new ChatLineContainer
-                        {
-                            Padding = new MarginPadding { Left = 20, Right = 20 },
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Direction = FillDirection.Vertical,
-                        }
+                        Direction = FillDirection.Vertical,
                     },
                 }
             };

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -21,6 +21,7 @@ using osu.Game.Overlays.Chat;
 using osu.Game.Overlays.Chat.Selection;
 using osu.Game.Overlays.Chat.Tabs;
 using osuTK.Input;
+using osu.Game.Graphics.Cursor;
 
 namespace osu.Game.Overlays
 {
@@ -82,13 +83,14 @@ namespace osu.Game.Overlays
                         },
                     },
                 },
-                chatContainer = new Container
+                chatContainer = new OsuContextMenuContainer
                 {
                     Name = @"chat container",
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     RelativeSizeAxes = Axes.Both,
                     Height = DEFAULT_HEIGHT,
+                    Masking = true,
                     Children = new[]
                     {
                         new Container


### PR DESCRIPTION
- Resolves #3799 

![image](https://i.imgur.com/bOa9X3p.jpg)