### PR TITLE
Fix polling rates

### DIFF
--- a/osu.Game/Online/PollingComponent.cs
+++ b/osu.Game/Online/PollingComponent.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Online
             pollingActive = false;
 
             if (scheduledPoll == null)
-                scheduleNextPoll();
+                pollIfNecessary();
         }
 
         private void scheduleNextPoll()

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -103,11 +103,13 @@ namespace osu.Game.Screens.Multi
 
         private readonly IBindable<bool> isIdle = new BindableBool();
 
-        [BackgroundDependencyLoader]
+        [BackgroundDependencyLoader(true)]
         private void load(IdleTracker idleTracker)
         {
             api.Register(this);
-            isIdle.BindTo(idleTracker.IsIdle);
+
+            if (idleTracker != null)
+                isIdle.BindTo(idleTracker.IsIdle);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Multi/RoomManager.cs
+++ b/osu.Game/Screens/Multi/RoomManager.cs
@@ -35,11 +35,6 @@ namespace osu.Game.Screens.Multi
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
 
-        public RoomManager()
-        {
-            TimeBetweenPolls = 5000;
-        }
-
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);


### PR DESCRIPTION
- Fixes infinite rate polling when `TimeBetweenPolls == 0` and `PollImmediately` is called.
- Reduces potential API burden by not polling when not at lounge, or when idle.