### PR TITLE
Always submit standardised scores

### DIFF
--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -167,6 +167,8 @@ namespace osu.Game.Rulesets.Scoring
             score.Rank = Rank;
             score.Date = DateTimeOffset.Now;
         }
+
+        public abstract double GetStandardisedScore();
     }
 
     public class ScoreProcessor<TObject> : ScoreProcessor
@@ -340,17 +342,23 @@ namespace osu.Game.Rulesets.Scoring
             if (rollingMaxBaseScore != 0)
                 Accuracy.Value = baseScore / rollingMaxBaseScore;
 
-            switch (Mode.Value)
+            TotalScore.Value = getScore(Mode.Value);
+        }
+
+        private double getScore(ScoringMode mode)
+        {
+            switch (mode)
             {
+                default:
                 case ScoringMode.Standardised:
-                    TotalScore.Value = max_score * (base_portion * baseScore / maxBaseScore + combo_portion * HighestCombo / maxHighestCombo) + bonusScore;
-                    break;
+                    return max_score * (base_portion * baseScore / maxBaseScore + combo_portion * HighestCombo / maxHighestCombo) + bonusScore;
                 case ScoringMode.Classic:
                     // should emulate osu-stable's scoring as closely as we can (https://osu.ppy.sh/help/wiki/Score/ScoreV1)
-                    TotalScore.Value = bonusScore + baseScore * (1 + Math.Max(0, HighestCombo - 1) / 25);
-                    break;
+                    return bonusScore + baseScore * (1 + Math.Max(0, HighestCombo - 1) / 25);
             }
         }
+
+        public override double GetStandardisedScore() => getScore(ScoringMode.Standardised);
 
         protected override void Reset(bool storeResults)
         {

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
+using System;
 using System.Diagnostics;
 using System.Threading;
 using osu.Framework.Allocation;
@@ -61,15 +62,21 @@ namespace osu.Game.Screens.Multi.Play
 
         protected override ScoreInfo CreateScore()
         {
+            submitScore();
+            return base.CreateScore();
+        }
+
+        private void submitScore()
+        {
             var score = base.CreateScore();
+
+            score.TotalScore = (int)Math.Round(ScoreProcessor.GetStandardisedScore());
 
             Debug.Assert(token != null);
 
             var request = new SubmitRoomScoreRequest(token.Value, room.RoomID.Value ?? 0, playlistItemId, score);
             request.Failure += e => Logger.Error(e, "Failed to submit score");
             api.Queue(request);
-
-            return score;
         }
 
         protected override Results CreateResults(ScoreInfo score) => new MatchResults(score, room);


### PR DESCRIPTION
Should suffice for now? We'll need to look into this in more depth at some point, unsure how to deal with leaderboards globally right now.

It will keep the user's scoring mode for the results screen, but always submit the standardised score.