### PR TITLE
Use LargeTextureStore for online retrievals

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BeatmapSetCover.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapSetCover.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Beatmaps.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(LargeTextureStore textures)
         {
             string resource = null;
 


### PR DESCRIPTION
Else they get stored to infinite backing atlases.