### PR TITLE
Fix ScoreProcessor's population

### DIFF
--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
@@ -72,5 +73,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
         }
 
         protected override JudgementResult CreateResult(Judgement judgement) => new OsuJudgementResult(judgement);
+
+        protected override HitWindows CreateHitWindows() => new OsuHitWindows();
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -163,8 +163,6 @@ namespace osu.Game.Rulesets.Scoring
                 AllJudged?.Invoke();
         }
 
-        private readonly Dictionary<HitResult, int> scoreResultCounts = new Dictionary<HitResult, int>();
-
         /// <summary>
         /// Retrieve a score populated with data for the current play this processor is responsible for.
         /// </summary>
@@ -180,8 +178,10 @@ namespace osu.Game.Rulesets.Scoring
             var hitWindows = CreateHitWindows();
 
             foreach (var result in Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r > HitResult.None && hitWindows.IsHitResultAllowed(r)))
-                score.Statistics[result] = scoreResultCounts.GetOrDefault(result);
+                score.Statistics[result] = GetStatistic(result);
         }
+
+        protected abstract int GetStatistic(HitResult result);
 
         public abstract double GetStandardisedScore();
     }
@@ -377,6 +377,8 @@ namespace osu.Game.Rulesets.Scoring
                     return bonusScore + baseScore * (1 + Math.Max(0, HighestCombo - 1) / 25);
             }
         }
+
+        protected override int GetStatistic(HitResult result) => scoreResultCounts.GetOrDefault(result);
 
         public override double GetStandardisedScore() => getScore(ScoringMode.Standardised);
 


### PR DESCRIPTION
1. OsuHitWindows weren't being created.
2. The incorrect dictionary was being used.

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/1329837/50485069-0f702e80-0a37-11e9-9d31-13142f272ca0.png">

<img width="782" alt="image" src="https://user-images.githubusercontent.com/1329837/50485093-23b42b80-0a37-11e9-9331-d15c61ee22e6.png">
