### PR TITLE
Fix incorrect newlines in ProfileHeader.

### DIFF
--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -396,11 +396,11 @@ namespace osu.Game.Overlays.Profile
                 infoTextLeft.NewLine();
                 infoTextLeft.AddText("Last seen ", lightText);
                 infoTextLeft.AddText(new DrawableDate(user.LastVisit.Value), boldItalic);
-                infoTextLeft.NewParagraph();
             }
 
             if (user.PlayStyle?.Length > 0)
             {
+                infoTextLeft.NewParagraph();
                 infoTextLeft.AddText("Plays with ", lightText);
                 infoTextLeft.AddText(string.Join(", ", user.PlayStyle), boldItalic);
             }


### PR DESCRIPTION
![](https://i.imgur.com/rxo1vcS.png) (Missing newline if there's no "last seen")

![](https://i.imgur.com/mxLeK79.png) (Duplicated newline if there's "last seen" but no "plays with")

Both are fixed here.

- Closes #3962 

---

Improve the text on user profiles.