### PR TITLE
Add a maximum length for slider ticks to be generated

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -24,6 +24,12 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// </summary>
         private const float base_scoring_distance = 100;
 
+        /// <summary>
+        /// A very lenient maximum length of a slider for ticks to be generated.
+        /// This exists for edge cases such as /b/1573664 where the beatmap has been edited by the user, and should never be reached in normal usage.
+        /// </summary>
+        private const double max_length_for_ticks = 100000;
+
         public double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
         public double Duration => EndTime - StartTime;
 
@@ -189,7 +195,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         private void createTicks()
         {
-            var length = Path.Distance;
+            var length = Math.Min(max_length_for_ticks, Path.Distance);
             var tickDistance = MathHelper.Clamp(TickDistance, 0, length);
 
             if (tickDistance == 0) return;

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -24,12 +24,6 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// </summary>
         private const float base_scoring_distance = 100;
 
-        /// <summary>
-        /// A very lenient maximum length of a slider for ticks to be generated.
-        /// This exists for edge cases such as /b/1573664 where the beatmap has been edited by the user, and should never be reached in normal usage.
-        /// </summary>
-        private const double max_length_for_ticks = 100000;
-
         public double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
         public double Duration => EndTime - StartTime;
 
@@ -195,7 +189,11 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         private void createTicks()
         {
-            var length = Math.Min(max_length_for_ticks, Path.Distance);
+            // A very lenient maximum length of a slider for ticks to be generated.
+            // This exists for edge cases such as /b/1573664 where the beatmap has been edited by the user, and should never be reached in normal usage.
+            const double max_length = 100000;
+
+            var length = Math.Min(max_length, Path.Distance);
             var tickDistance = MathHelper.Clamp(TickDistance, 0, length);
 
             if (tickDistance == 0) return;


### PR DESCRIPTION
This is the best way I can think of to universally tackle cases such as https://osu.ppy.sh/beatmapsets/746686#osu/1573664, which has:
- An 'expected distance' of an extremely high number (i.e. a very large path excess)
- A curve with a very large physical distance (2147483648)

100000 length is conservative enough to allow some crazyness without destroying performance by generating millions of ticks, after which point ticks aren't generated anymore.