### PR TITLE
Fix null beatmap possibly being selected

### DIFF
--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -57,11 +57,19 @@ namespace osu.Game.Tests.Visual
 
         private class TestSongSelect : PlaySongSelect
         {
+            public Action StartRequested;
+
             public new Bindable<RulesetInfo> Ruleset => base.Ruleset;
 
             public WorkingBeatmap CurrentBeatmap => Beatmap.Value;
             public WorkingBeatmap CurrentBeatmapDetailsBeatmap => BeatmapDetails.Beatmap;
             public new BeatmapCarousel Carousel => base.Carousel;
+
+            protected override bool OnStart()
+            {
+                StartRequested?.Invoke();
+                return base.OnStart();
+            }
         }
 
         private TestSongSelect songSelect;
@@ -180,6 +188,27 @@ namespace osu.Game.Tests.Visual
 
             void onModChange(IEnumerable<Mod> mods) => modChangeIndex = actionIndex++;
             void onRulesetChange(RulesetInfo ruleset) => rulesetChangeIndex = actionIndex--;
+        }
+
+        [Test]
+        public void TestStartAfterUnMatchingFilterDoesNotStart()
+        {
+            addManyTestMaps();
+            AddUntilStep(() => songSelect.Carousel.SelectedBeatmap != null, "has selection");
+
+            bool startRequested = false;
+
+            AddStep("set filter and finalize", () =>
+            {
+                songSelect.StartRequested = () => startRequested = true;
+
+                songSelect.Carousel.Filter(new FilterCriteria { SearchText = "somestringthatshouldn'tbematchable" });
+                songSelect.FinaliseSelection();
+
+                songSelect.StartRequested = null;
+            });
+
+            AddAssert("start not requested", () => !startRequested);
         }
 
         private void importForRuleset(int id) => AddStep($"import test map for ruleset {id}", () => manager.Import(createTestBeatmapSet(getImportId(), rulesets.AvailableRulesets.Where(r => r.ID == id).ToArray())));

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -297,13 +297,13 @@ namespace osu.Game.Screens.Select
         /// <param name="performStartAction">Whether to trigger <see cref="OnStart"/>.</param>
         public void FinaliseSelection(BeatmapInfo beatmap = null, bool performStartAction = true)
         {
-            // avoid attempting to continue before a selection has been obtained.
-            // this could happen via a user interaction while the carousel is still in a loading state.
-            if (Carousel.SelectedBeatmap == null) return;
-
             // if we have a pending filter operation, we want to run it now.
             // it could change selection (ie. if the ruleset has been changed).
             Carousel.FlushPendingFilterOperations();
+
+            // avoid attempting to continue before a selection has been obtained.
+            // this could happen via a user interaction while the carousel is still in a loading state.
+            if (Carousel.SelectedBeatmap == null) return;
 
             if (beatmap != null)
                 Carousel.SelectBeatmap(beatmap);


### PR DESCRIPTION
Kind-of unrelated to any issues I was testing:

1. Fixes match song select crashing.
2. Fixes being able to go into player with the null beatmap (you already couldn't go into player with no beatmap selected otherwise).

Replication:
1. Apply a filter that removes all beatmaps.
2. Press enter very quickly aftewards.