### PR TITLE
Fix API getting stuck in eternal failing state if login request fails

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -101,6 +101,9 @@ namespace osu.Game.Online.API
                         //todo: replace this with a ping request.
                         log.Add(@"In a failing state, waiting a bit before we try again...");
                         Thread.Sleep(5000);
+
+                        if (!IsLoggedIn) goto case APIState.Connecting;
+
                         if (queue.Count == 0)
                         {
                             log.Add(@"Queueing a ping request");


### PR DESCRIPTION
Due to the conditional on `IsLoggedIn` relying on the user id being set (which is not set until the login request completes) we could end up in going `Offline` -> `Connecting` -> `Failing` and never return to a good state.