### PR TITLE
Fix out of bounds exception during sample-point indexing

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -122,8 +122,14 @@ namespace osu.Game.Beatmaps.ControlPoints
                     return list[pivot];
             }
 
-            // l will be the first control point with Time > time, but we want the one before it
-            return list[l - 1];
+            if (l > 0)
+            {
+                // l will be the first control point with Time > time, but we want the one before it
+                return list[l - 1];
+            }
+
+            // If the binary search failed, l will be unaffected
+            return list[l];
         }
     }
 }


### PR DESCRIPTION
Fixes cases such as:
```
/b/30645
/b/30745
/b/35109
/b/38902
/b/38945
```
Which have timing point definitions of the form:
```
[TimingPoints]
NaN,346.820809248555,4,1,0,100,1,0
157.615318344093,373.59900373599,4,1,0,100,1,0
```