### PR TITLE
Add null check to fix crash on deselecting multiplayer room

### DIFF
--- a/osu.Game/Screens/Multi/Lounge/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Lounge/Components/RoomInspector.cs
@@ -266,7 +266,7 @@ namespace osu.Game.Screens.Multi.Lounge.Components
 
             private void updateParticipants()
             {
-                var roomId = room.RoomID.Value ?? 0;
+                var roomId = room?.RoomID.Value ?? 0;
 
                 request?.Cancel();
 


### PR DESCRIPTION
Closes #4034.