### PR TITLE
Add button to Skin Section

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Overlays.Settings.Sections
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = "Use beatmap skins",
+                    Bindable = config.GetBindable<bool>(OsuSetting.BeatmapSkins)
+                },
+                new SettingsCheckbox
+                {
                     LabelText = "Adjust gameplay cursor size based on current beatmap",
                     Bindable = config.GetBindable<bool>(OsuSetting.AutoCursorSize)
                 },


### PR DESCRIPTION
Added "Use beatmap skin" button to general settings.

- [ ] Depends on #PR
- Closes #4088

---

Adds a button to toggle beatmap skins in the general settings, allowing users to modify this setting outside of the visual settings.

![image](https://user-images.githubusercontent.com/35433620/51348550-a5144200-1a68-11e9-89c9-bd38230525fb.png)