### PR TITLE
Add beatmap skin/hitsound checkboxes to general settings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 new SettingsSlider<double> { LabelText = "Master (window inactive)", Bindable = config.GetBindable<double>(OsuSetting.VolumeInactive), KeyboardStep = 0.01f },
                 new SettingsSlider<double> { LabelText = "Effect", Bindable = audio.VolumeSample, KeyboardStep = 0.01f },
                 new SettingsSlider<double> { LabelText = "Music", Bindable = audio.VolumeTrack, KeyboardStep = 0.01f },
-                new SettingsCheckbox       { LabelText = "Use beatmap hitsounds", Bindable = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds) },
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 new SettingsSlider<double> { LabelText = "Master (window inactive)", Bindable = config.GetBindable<double>(OsuSetting.VolumeInactive), KeyboardStep = 0.01f },
                 new SettingsSlider<double> { LabelText = "Effect", Bindable = audio.VolumeSample, KeyboardStep = 0.01f },
                 new SettingsSlider<double> { LabelText = "Music", Bindable = audio.VolumeTrack, KeyboardStep = 0.01f },
+                new SettingsCheckbox       { LabelText = "Use beatmap hitsounds", Bindable = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds) },
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Overlays.Settings.Sections
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = "Use beatmap skins",
+                    Bindable = config.GetBindable<bool>(OsuSetting.BeatmapSkins)
+                },
+                new SettingsCheckbox
+                {
                     LabelText = "Adjust gameplay cursor size based on current beatmap",
                     Bindable = config.GetBindable<bool>(OsuSetting.AutoCursorSize)
                 },

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -54,6 +54,11 @@ namespace osu.Game.Overlays.Settings.Sections
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = "Use beatmap hitsounds",
+                    Bindable = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds)
+                },
+                new SettingsCheckbox
+                {
                     LabelText = "Adjust gameplay cursor size based on current beatmap",
                     Bindable = config.GetBindable<bool>(OsuSetting.AutoCursorSize)
                 },

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -49,18 +49,18 @@ namespace osu.Game.Overlays.Settings.Sections
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Use beatmap skins",
+                    LabelText = "Adjust gameplay cursor size based on current beatmap",
+                    Bindable = config.GetBindable<bool>(OsuSetting.AutoCursorSize)
+                },
+                new SettingsCheckbox
+                {
+                    LabelText = "Beatmap skins",
                     Bindable = config.GetBindable<bool>(OsuSetting.BeatmapSkins)
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Use beatmap hitsounds",
+                    LabelText = "Beatmap hitsounds",
                     Bindable = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds)
-                },
-                new SettingsCheckbox
-                {
-                    LabelText = "Adjust gameplay cursor size based on current beatmap",
-                    Bindable = config.GetBindable<bool>(OsuSetting.AutoCursorSize)
                 },
             };
 

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
                 showStoryboardToggle = new PlayerCheckbox { LabelText = "Storyboards" },
                 beatmapSkinsToggle = new PlayerCheckbox { LabelText = "Beatmap skins" },
-                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = "Beatmap hit sounds" }
+                beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = "Beatmap hitsounds" }
             };
         }
 


### PR DESCRIPTION
Added "Use beatmap skins" button to general settings
Added "Use beatmap hitsounds" button to general settings

- Closes #4088

Beatmap skins button
![image](https://user-images.githubusercontent.com/35433620/51357527-034f1e00-1a85-11e9-8de2-15fcd8a299fe.png)

Beatmap hitsounds button
![image](https://user-images.githubusercontent.com/35433620/51374825-c8bba480-1ac9-11e9-828e-4c77d6ef4fcf.png)


---

Having this button along with the one in the visual settings should reduce confusion from users switching from osu! to osu!lazer.