### PR TITLE
Use QuadBatch for LogoVisualisation

### DIFF
--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Menu
 
         private class VisualiserSharedData
         {
-            public readonly LinearBatch<TexturedVertex2D> VertexBatch = new LinearBatch<TexturedVertex2D>(100 * 4, 10, PrimitiveType.Quads);
+            public readonly QuadBatch<TexturedVertex2D> VertexBatch = new QuadBatch<TexturedVertex2D>(100, 10);
         }
 
         private class VisualisationDrawNode : DrawNode

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -3,7 +3,6 @@
 
 using osuTK;
 using osuTK.Graphics;
-using osuTK.Graphics.ES30;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Batches;


### PR DESCRIPTION
GL_QUADS is deprecated, and is not supported at all on OpenGL ES.
This fixes the logo visualisation not drawing on iOS.

- Closes #3982

---

Fixed logo visualisation not displaying on iOS.
