### PR TITLE
Apply various fixes to bring diffcalc in-line with stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -101,8 +101,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             float approxFollowCircleRadius = (float)(slider.Radius * 3);
             var computeVertex = new Action<double>(t =>
             {
-                double progress = ((int)t - (int)slider.StartTime) / (float)(int)slider.SpanDuration;
-                if (progress % 2 > 1)
+                double progress = (t - slider.StartTime) / slider.SpanDuration;
+                if (progress % 2 >= 1)
                     progress = 1 - progress % 1;
                 else
                     progress = progress % 1;

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             if (tickDistance == 0) return;
 
-            var minDistanceFromEnd = Velocity * 0.01;
+            var minDistanceFromEnd = Velocity * 10;
 
             var spanCount = this.SpanCount();
 

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -122,14 +122,8 @@ namespace osu.Game.Beatmaps.ControlPoints
                     return list[pivot];
             }
 
-            if (l > 0)
-            {
-                // l will be the first control point with Time > time, but we want the one before it
-                return list[l - 1];
-            }
-
-            // If the binary search failed, l will be unaffected
-            return list[l];
+            // l will be the first control point with Time > time, but we want the one before it
+            return list[l - 1];
         }
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -122,8 +122,14 @@ namespace osu.Game.Beatmaps.ControlPoints
                     return list[pivot];
             }
 
-            // l will be the first control point with Time > time, but we want the one before it
-            return list[l - 1];
+            if (l > 0)
+            {
+                // l will be the first control point with Time > time, but we want the one before it
+                return list[l - 1];
+            }
+
+            // If the binary search failed, l will be unaffected
+            return list[l];
         }
     }
 }


### PR DESCRIPTION
I'm going to PR this as a "everything's final, just need to deploy" item. @Tom94 I'm going to detail the data analysis I've done in here, please give it a look through and if you approve of my conclusions we're all good to go.

The testing I did is structured into 2 important parts:
1. Beatmaps that lazer failed to compute difficulty for.
2. Beatmaps where the diff between lazer and stable is > 0.2.

# Ranked beatmaps

Data from ~80000 ranked beatmaps versus the data from https://data.ppy.sh:
https://docs.google.com/spreadsheets/d/1oVOnpaKuQuBeEa9CjFAljqTD4dTYtLE1iIAfh9DLRXY/edit#gid=1491109873

### Missed beatmaps

Lazer didn't miss any beatmaps which were not malformed.

### Diff > 0.2

I can explain the differences by one of 4 classifications:

1. osu!stable has had diff calcs updated throughout the years. The current live values are based on a build a few years past. Between changes to .NET Framework and fixes to stacking/etc, quite a bit has changed.
2. osu!stable used an unstable sort for hitobjects. The sorting order has changed in .NET Framework, but also osu!lazer uses a stable sort.
3. osu!stable only added the length of the previous slider to the difficulty if there was another slider following it. [This was fixed in osu!lazer](https://github.com/ppy/osu/commit/1cf6cd10bb1dc1fa87217c9e4e0b1d03088d7096).
4. osu!stable incorrectly calculates slider positions. This is a two-piece puzzle:
    1. When calculating the position of the slider at the end time, stable uses the _start position_ of the slider. This was an off-by-1 mistake. [This was fixed in this PR](https://github.com/ppy/osu/compare/master...smoogipoo:diffcalc-fixes?expand=1#diff-b874c7fc814219aca9e1a1d700f90713R105).
    2. When calculating the position of the slider at a point in time, osu!stable does so with very bad accuracy. This is due to stable calculating time and length as ints. To showcase an example, beatmaps like https://osu.ppy.sh/beatmapsets/764814#osu/1608232 have calculated repeat-point positions 70-80% of the way through the slider. This is much more obvious on sliders with many repeats, such as the one at `time = 34290` in the aforementioned beatmap.
    osu!lazer uses doubles everywhere and does not suffer from this inaccuracy.

Of course, all of these individually affect every single map, to varying degrees. The ones coloured in the spreadsheet represent the classification with the most effect for the beatmap.

# Unranked beatmaps

Data from ~480000 unranked beatmaps versus live-like osu!stable: https://docs.google.com/spreadsheets/d/1Zx2akN7Jk9IfW4kapCLQLbW-b_jVqrSCDJKXV6gVQg4/edit#gid=442530873

### Missed beatmaps

~100 missed beatmaps are due to having `NaN` or infinity as timing point time, causing the [control point binary search to fail](https://github.com/ppy/osu/blob/master/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs#L95). After discussion with @peppy we decided not to fix this issue in lazer, as these maps would need special handling everywhere else in the game to make them work with `NaN` values. Example: https://osu.ppy.sh/beatmapsets/594423#osu/1257291

The other ~17 beatmaps have malformed or missing `osu file version` headers. I'm not sure how we want to fix these, so I'm letting them fail for now.
Full list of beatmaps exhibiting this issue:

beatmap_id | difficultyrating
-- | --
63705 | 1.43931
66510 | 1.65675
106630 | 1.90342
181584 | 2.38931
218651 | 4.7046
414373 | 2.11018
730943 | 2.22261
821414 | 1.66252
1007049 | 2.40287
1034279 | 3.19183
1103490 | 2.07644
1127627 | 2.98405
1214081 | 1.42021
1393456 | 3.67471
1482781 | 3.9956
1548918 | 6.79769

### Diff > 0.2

This is much less colourfull and well-presented as in the ranked beatmaps, because this was the first set of data I worked on. Nevertheless I went through about 40 beatmaps of the list and classified them, and am confident I can justify all other differences via the 4 classifications listed above.