### PR TITLE
Add ability to change timings of follow point display

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -14,15 +14,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
     public class FollowPointRenderer : ConnectionRenderer<OsuHitObject>
     {
+        /// <summary>
+        /// Follow points to the next hitobject start to fade for this many milliseconds before an hitobject's end time.
+        /// Fading start time can be offset.
+        /// </summary>
         private Bindable<int> preEmpt;
+        /// <summary>
+        /// Follow points to the next hitobject start appearing offset by this many milliseconds before an hitobject's end time.
+        /// </summary>
         private Bindable<int> offset;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            /// <summary>
-            /// Follow points to the next hitobject start appearing for this(preEmpt - offset) many milliseconds before an hitobject's end time.
-            /// </summary>
             preEmpt = config.GetBindable<int>(OsuSetting.FollowPointAppearTime);
             offset = config.GetBindable<int>(OsuSetting.FollowPointDelay);
             preEmpt.ValueChanged += _ => update();

--- a/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Osu.UI
@@ -32,7 +33,25 @@ namespace osu.Game.Rulesets.Osu.UI
                     LabelText = "Snaking out sliders",
                     Bindable = config.GetBindable<bool>(OsuSetting.SnakingOutSliders)
                 },
+                new SettingsSlider<int, TimeSlider>
+                {
+                    LabelText = "Followpoint fadeout time",
+                    TransferValueOnCommit = true,
+                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointAppearTime),
+                    KeyboardStep = 1
+                },
+                new SettingsSlider<int, TimeSlider>
+                {
+                    LabelText = "Followpoint fadeout offset",
+                    TransferValueOnCommit = true,
+                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointDelay),
+                    KeyboardStep = 1
+                }
             };
+        }
+        private class TimeSlider : OsuSliderBar<int>
+        {
+            public override string TooltipText => base.TooltipText + "ms";
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
@@ -57,7 +57,6 @@ namespace osu.Game.Rulesets.Osu.UI
        public class TimeSlider : OsuSliderBar<int>
         {
             public override string TooltipText => base.TooltipText + "ms";
-
         }
         protected virtual SettingsSlider<int, TimeSlider> CreateFadeOutSettingsSlider(OsuConfigManager config)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
@@ -11,6 +11,9 @@ namespace osu.Game.Rulesets.Osu.UI
 {
     public class OsuSettings : RulesetSettingsSubsection
     {
+        public  SettingsSlider<int, TimeSlider> FollowpointFadeoutSlider;
+        public  SettingsSlider<int, TimeSlider> FollowpointDelaySlider;
+
         protected override string Header => "osu!";
 
         public OsuSettings(Ruleset ruleset)
@@ -33,25 +36,50 @@ namespace osu.Game.Rulesets.Osu.UI
                     LabelText = "Snaking out sliders",
                     Bindable = config.GetBindable<bool>(OsuSetting.SnakingOutSliders)
                 },
-                new SettingsSlider<int, TimeSlider>
+                FollowpointFadeoutSlider = CreateFadeOutSettingsSlider(config),
+                FollowpointDelaySlider = CreateOffsetSettingsSlider(config)
+            };
+            FollowpointDelaySlider.Bindable.ValueChanged += _ =>
+            {
+                if (FollowpointFadeoutSlider.Bindable.Value - FollowpointDelaySlider.Bindable.Value > 800)
                 {
-                    LabelText = "Followpoint fadeout time",
-                    TransferValueOnCommit = true,
-                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointAppearTime),
-                    KeyboardStep = 1
-                },
-                new SettingsSlider<int, TimeSlider>
+                    FollowpointFadeoutSlider.Bindable.Value = 800 + FollowpointDelaySlider.Bindable.Value;
+                }
+            };
+            FollowpointFadeoutSlider.Bindable.ValueChanged += _ =>
+            {
+                if (FollowpointFadeoutSlider.Bindable.Value - FollowpointDelaySlider.Bindable.Value > 800)
                 {
-                    LabelText = "Followpoint fadeout offset",
-                    TransferValueOnCommit = true,
-                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointDelay),
-                    KeyboardStep = 1
+                    FollowpointDelaySlider.Bindable.Value = FollowpointFadeoutSlider.Bindable.Value - 800;
                 }
             };
         }
-        private class TimeSlider : OsuSliderBar<int>
+       public class TimeSlider : OsuSliderBar<int>
         {
             public override string TooltipText => base.TooltipText + "ms";
+
+        }
+
+        protected virtual SettingsSlider<int, TimeSlider> CreateFadeOutSettingsSlider(OsuConfigManager config)
+        {
+            return new SettingsSlider<int, TimeSlider>
+            {
+                LabelText = "Followpoint fadeout time",
+                TransferValueOnCommit = true,
+                Bindable = config.GetBindable<int>(OsuSetting.FollowPointAppearTime),
+                KeyboardStep = 1
+            };
+        }
+
+        protected virtual SettingsSlider<int, TimeSlider> CreateOffsetSettingsSlider(OsuConfigManager config)
+        {
+            return new SettingsSlider<int, TimeSlider>
+            {
+                LabelText = "Followpoint fadeout offset",
+                TransferValueOnCommit = true,
+                Bindable = config.GetBindable<int>(OsuSetting.FollowPointDelay),
+                KeyboardStep = 1
+            };
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettings.cs
@@ -59,7 +59,6 @@ namespace osu.Game.Rulesets.Osu.UI
             public override string TooltipText => base.TooltipText + "ms";
 
         }
-
         protected virtual SettingsSlider<int, TimeSlider> CreateFadeOutSettingsSlider(OsuConfigManager config)
         {
             return new SettingsSlider<int, TimeSlider>

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.IncreaseFirstObjectVisibility, true);
 
-            Set(OsuSetting.FollowPointAppearTime, 800, 100, 1000);
+            Set(OsuSetting.FollowPointAppearTime, 800, 0, 800);
             Set(OsuSetting.FollowPointDelay, 0, -500, 500);
 
             // Update

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -88,6 +88,9 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.IncreaseFirstObjectVisibility, true);
 
+            Set(OsuSetting.FollowPointAppearTime, 800, 100, 1000);
+            Set(OsuSetting.FollowPointDelay, 0, -500, 500);
+
             // Update
             Set(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
 
@@ -170,6 +173,8 @@ namespace osu.Game.Configuration
         ScalingPositionY,
         ScalingSizeX,
         ScalingSizeY,
-        UIScale
+        UIScale,
+        FollowPointAppearTime,
+        FollowPointDelay
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -44,26 +44,8 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 {
                     LabelText = "Score display mode",
                     Bindable = config.GetBindable<ScoringMode>(OsuSetting.ScoreDisplayMode)
-                },
-                new SettingsSlider<int, TimeSlider>
-                {
-                    LabelText = "Followpoint fadeout time",
-                    TransferValueOnCommit = true,
-                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointAppearTime),
-                    KeyboardStep = 1
-                },
-                new SettingsSlider<int, TimeSlider>
-                {
-                    LabelText = "Followpoint fadeout offset",
-                    TransferValueOnCommit = true,
-                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointDelay),
-                    KeyboardStep = 1
                 }
             };
-        }
-        private class TimeSlider : OsuSliderBar<int>
-        {
-            public override string TooltipText => base.TooltipText + "ms";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Overlays.Settings.Sections.Gameplay

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Overlays.Settings.Sections.Gameplay
@@ -43,8 +44,26 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 {
                     LabelText = "Score display mode",
                     Bindable = config.GetBindable<ScoringMode>(OsuSetting.ScoreDisplayMode)
+                },
+                new SettingsSlider<int, TimeSlider>
+                {
+                    LabelText = "Followpoint fadeout time",
+                    TransferValueOnCommit = true,
+                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointAppearTime),
+                    KeyboardStep = 1
+                },
+                new SettingsSlider<int, TimeSlider>
+                {
+                    LabelText = "Followpoint fadeout offset",
+                    TransferValueOnCommit = true,
+                    Bindable = config.GetBindable<int>(OsuSetting.FollowPointDelay),
+                    KeyboardStep = 1
                 }
             };
+        }
+        private class TimeSlider : OsuSliderBar<int>
+        {
+            public override string TooltipText => base.TooltipText + "ms";
         }
     }
 }


### PR DESCRIPTION
two sliderbars added that change the values for the fadeout delay(preEmpt) and the time at which followpoints start to appear(offset value)

might as well add an option to change the point distance if this seems to be a nice idea.

---

Added settings under gameplay to modify slider rendering.
[short video](https://puu.sh/CA3Eo/2c82af79d0.mp4)
