### PR TITLE
Fix Player Settings being interactable with when hiding HUD with shift+tab

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -58,8 +58,8 @@ namespace osu.Game.Screens.Play
                         ModDisplay = CreateModsContainer(),
                     }
                 },
-                PlayerSettingsOverlay = CreatePlayerSettingsOverlay(), 
-                new FillFlowContainer                                  
+                PlayerSettingsOverlay = CreatePlayerSettingsOverlay(),
+                new FillFlowContainer
                 {
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -56,10 +56,10 @@ namespace osu.Game.Screens.Play
                         HealthDisplay = CreateHealthDisplay(),
                         Progress = CreateProgress(),
                         ModDisplay = CreateModsContainer(),
-                        PlayerSettingsOverlay = CreatePlayerSettingsOverlay(),
                     }
                 },
-                new FillFlowContainer
+                PlayerSettingsOverlay = CreatePlayerSettingsOverlay(), 
+                new FillFlowContainer                                  
                 {
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,


### PR DESCRIPTION
separate PlayerSettingsOverlay from the other HUD elements in the Visibility Container.
makes the player settings being able to be toggled with ctrl+H while shift+tab is for the remaining HUD

- Closes #4110 

---

Separated hiding of the HUD(shift+tab) and the player settings overlay(ctrl+H)