### PR TITLE
Fix Tooltip not updating in special case

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -94,7 +94,6 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void LoadComplete()
         {
-            updateTooltipText(Current.Value);
             base.LoadComplete();
             CurrentNumber.BindValueChanged(updateTooltipText, true);
         }

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             updateTooltipText(Current.Value);
             base.LoadComplete();
-            CurrentNumber.ValueChanged += _ => updateTooltipText(_);
+            CurrentNumber.ValueChanged += updateTooltipText;
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             updateTooltipText(Current.Value);
             base.LoadComplete();
-            CurrentNumber.ValueChanged += updateTooltipText;
+            CurrentNumber.BindValueChanged(updateTooltipText, true);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -96,6 +96,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             updateTooltipText(Current.Value);
             base.LoadComplete();
+            CurrentNumber.ValueChanged += _ => updateTooltipText(_);
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -126,7 +127,6 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.OnUserChange(value);
             playSample(value);
-            updateTooltipText(value);
         }
 
         private void playSample(T value)

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -127,6 +127,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.OnUserChange(value);
             playSample(value);
+            updateTooltipText(value);
         }
 
         private void playSample(T value)


### PR DESCRIPTION
When the Bindvalue of a Sliderbar gets changed by a line like "Bindable.Value = ..." the sliderbar will only update the nubs but wont run any methods which contain the updateToolTipText(T value) function.
Example scenario:
Two interlinked sliderbars which change the value of each other in certain cases.


---

Fix sliderbar tooltip text not updating in certain cases.