### PR TITLE
Fix transparent background in some screen scaling modes

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -401,6 +401,7 @@ namespace osu.Game.Screens.Play
         {
             float fadeOutDuration = instant ? 0 : 250;
             Content.FadeOut(fadeOutDuration);
+            Background?.FadeColour(OsuColour.Gray(1f), fadeOutDuration, Easing.OutQuint);
         }
 
         protected override bool OnScroll(ScrollEvent e) => mouseWheelDisabled.Value && !pauseContainer.IsPaused;
@@ -438,7 +439,7 @@ namespace osu.Game.Screens.Play
                 .FadeTo(storyboardVisible && BackgroundOpacity > 0 ? 1 : 0, BACKGROUND_FADE_DURATION, Easing.OutQuint);
 
             if (storyboardVisible && beatmap.Storyboard.ReplacesBackground)
-                Background?.FadeTo(0, BACKGROUND_FADE_DURATION, Easing.OutQuint);
+                Background?.FadeColour(OsuColour.Gray(0f), BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }
 
         protected virtual Results CreateResults(ScoreInfo score) => new SoloResults(score);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -32,6 +32,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Skinning;
 using osu.Game.Storyboards.Drawables;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play
 {
@@ -401,7 +402,7 @@ namespace osu.Game.Screens.Play
         {
             float fadeOutDuration = instant ? 0 : 250;
             Content.FadeOut(fadeOutDuration);
-            Background?.FadeColour(OsuColour.Gray(1f), fadeOutDuration, Easing.OutQuint);
+            Background?.FadeColour(Color4.White, fadeOutDuration, Easing.OutQuint);
         }
 
         protected override bool OnScroll(ScrollEvent e) => mouseWheelDisabled.Value && !pauseContainer.IsPaused;
@@ -439,7 +440,7 @@ namespace osu.Game.Screens.Play
                 .FadeTo(storyboardVisible && BackgroundOpacity > 0 ? 1 : 0, BACKGROUND_FADE_DURATION, Easing.OutQuint);
 
             if (storyboardVisible && beatmap.Storyboard.ReplacesBackground)
-                Background?.FadeColour(OsuColour.Gray(0f), BACKGROUND_FADE_DURATION, Easing.OutQuint);
+                Background?.FadeColour(Color4.Black, BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }
 
         protected virtual Results CreateResults(ScoreInfo score) => new SoloResults(score);

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Screens.Play
 
         protected override void InitializeBackgroundElements()
         {
-            Background?.FadeTo(1, BACKGROUND_FADE_DURATION, Easing.OutQuint);
+            Background?.FadeColour(Color4.White, BACKGROUND_FADE_DURATION, Easing.OutQuint);
             Background?.BlurTo(background_blur, BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }
 

--- a/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
+++ b/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Play
         protected virtual void InitializeBackgroundElements() => UpdateBackgroundElements();
 
         /// <summary>
-        /// Called wen background elements require updates, usually due to a user changing a setting.
+        /// Called when background elements require updates, usually due to a user changing a setting.
         /// </summary>
         /// <param name="userChange"></param>
         protected virtual void UpdateBackgroundElements()

--- a/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
+++ b/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
@@ -6,6 +6,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Screens.Backgrounds;
 using osuTK;
 
@@ -67,7 +68,7 @@ namespace osu.Game.Screens.Play
         {
             if (!IsCurrentScreen) return;
 
-            Background?.FadeTo(BackgroundOpacity, BACKGROUND_FADE_DURATION, Easing.OutQuint);
+            Background?.FadeColour(OsuColour.Gray(BackgroundOpacity), BACKGROUND_FADE_DURATION, Easing.OutQuint);
             Background?.BlurTo(new Vector2((float)BlurLevel.Value * 25), BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }
     }


### PR DESCRIPTION
by replacing `.FadeTo` at the necessary places with `.FadeColour`.
restoring the `.FadeColour` in `fadeOut` of the Player Screen which is ran in every exit scenario.
- Closes #4123

---

Fix transparent backgrounds in some screen scaling modes