### PR TITLE
Fix crash when config doesn't have track-able settings

### DIFF
--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -160,6 +160,10 @@ namespace osu.Game.Overlays
         {
             if (configManager == null) throw new ArgumentNullException(nameof(configManager));
 
+            var trackedSettings = configManager.CreateTrackedSettings();
+            if (trackedSettings == null)
+                return;
+
             if (!trackedConfigManagers.TryGetValue((source, configManager), out var existing))
                 throw new InvalidOperationException($"{nameof(configManager)} is not registered.");
 

--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -160,12 +160,8 @@ namespace osu.Game.Overlays
         {
             if (configManager == null) throw new ArgumentNullException(nameof(configManager));
 
-            var trackedSettings = configManager.CreateTrackedSettings();
-            if (trackedSettings == null)
-                return;
-
             if (!trackedConfigManagers.TryGetValue((source, configManager), out var existing))
-                throw new InvalidOperationException($"{nameof(configManager)} is not registered.");
+                return;
 
             existing.Unload();
             existing.SettingChanged -= display;


### PR DESCRIPTION
`OnScreenDisplay.BeginTracking()` wouldn't start tracking if the passed `ITrackableConfigManager` has no track-able settings. This check doesn't exist on `OnScreenDisplay.StopTracking()` though, so it throws.