### PR TITLE
Fix multiplayer screen "pushed" by notifications overlay parallax

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -300,7 +300,7 @@ namespace osu.Game.Overlays.Mods
                                 Padding = new MarginPadding
                                 {
                                     Vertical = 10,
-                                    Horizontal = -OsuScreen.HORIZONTAL_OVERFLOW_PADDING
+                                    Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING
                                 },
                                 Child = ModSectionsContainer = new FillFlowContainer<ModSection>
                                 {

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -22,16 +22,12 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods.Sections;
+using osu.Game.Screens;
 
 namespace osu.Game.Overlays.Mods
 {
     public class ModSelectOverlay : WaveOverlayContainer
     {
-        /// <summary>
-        /// How much this container should overflow the sides of the screen to account for parallax shifting.
-        /// </summary>
-        private const float overflow_padding = 50;
-
         private const float content_width = 0.8f;
 
         protected Color4 LowMultiplierColour, HighMultiplierColour;
@@ -203,11 +199,7 @@ namespace osu.Game.Overlays.Mods
             Waves.FourthWaveColour = OsuColour.FromHex(@"003a4e");
 
             Height = 510;
-            Padding = new MarginPadding
-            {
-                Left = -overflow_padding,
-                Right = -overflow_padding
-            };
+            Padding = new MarginPadding { Horizontal = -OsuScreen.HORIZONTAL_OVERFLOW_PADDING };
 
             Children = new Drawable[]
             {
@@ -267,11 +259,7 @@ namespace osu.Game.Overlays.Mods
                                         AutoSizeAxes = Axes.Y,
                                         Direction = FillDirection.Vertical,
                                         Width = content_width,
-                                        Padding = new MarginPadding
-                                        {
-                                            Left = overflow_padding,
-                                            Right = overflow_padding
-                                        },
+                                        Padding = new MarginPadding { Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
                                         Children = new Drawable[]
                                         {
                                             new OsuSpriteText
@@ -312,8 +300,7 @@ namespace osu.Game.Overlays.Mods
                                 Padding = new MarginPadding
                                 {
                                     Vertical = 10,
-                                    Left = overflow_padding,
-                                    Right = overflow_padding
+                                    Horizontal = -OsuScreen.HORIZONTAL_OVERFLOW_PADDING
                                 },
                                 Child = ModSectionsContainer = new FillFlowContainer<ModSection>
                                 {
@@ -361,8 +348,7 @@ namespace osu.Game.Overlays.Mods
                                         Padding = new MarginPadding
                                         {
                                             Vertical = 15,
-                                            Left = overflow_padding,
-                                            Right = overflow_padding
+                                            Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING
                                         },
                                         Children = new Drawable[]
                                         {

--- a/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
@@ -29,10 +29,9 @@ namespace osu.Game.Overlays.SearchableList
         protected virtual Drawable CreateSupplementaryControls() => null;
 
         /// <summary>
-        /// Add padding to internal components of the control.
-        /// This does not affect the background and the tab strip.
+        /// The amount of padding added to content (does not affect background or tab control strip).
         /// </summary>
-        protected virtual float InternalPadding => 0;
+        protected virtual float ContentHorizontalPadding => SearchableListOverlay.WIDTH_PADDING;
 
         protected SearchableListFilterControl()
         {
@@ -71,7 +70,7 @@ namespace osu.Game.Overlays.SearchableList
                             Padding = new MarginPadding
                             {
                                 Top = padding,
-                                Horizontal = SearchableListOverlay.WIDTH_PADDING + InternalPadding
+                                Horizontal = ContentHorizontalPadding
                             },
                             Children = new Drawable[]
                             {

--- a/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
@@ -28,6 +28,12 @@ namespace osu.Game.Overlays.SearchableList
         protected abstract T DefaultTab { get; }
         protected virtual Drawable CreateSupplementaryControls() => null;
 
+        /// <summary>
+        /// Add padding to internal components of the control.
+        /// This does not affect the background and the tab strip.
+        /// </summary>
+        protected virtual float InternalPadding => 0;
+
         protected SearchableListFilterControl()
         {
             if (!typeof(T).IsEnum)
@@ -62,7 +68,11 @@ namespace osu.Game.Overlays.SearchableList
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Padding = new MarginPadding { Top = padding, Horizontal = SearchableListOverlay.WIDTH_PADDING },
+                            Padding = new MarginPadding
+                            {
+                                Top = padding,
+                                Horizontal = SearchableListOverlay.WIDTH_PADDING + InternalPadding
+                            },
                             Children = new Drawable[]
                             {
                                 Search = new FilterSearchTextBox

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Multi
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING },
+                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
                     Children = new Drawable[]
                     {
                         new FillFlowContainer

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Multi
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING },
+                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING },
                     Children = new Drawable[]
                     {
                         new FillFlowContainer

--- a/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
+++ b/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.Multi.Lounge.Components
         protected override Color4 BackgroundColour => OsuColour.FromHex(@"362e42");
         protected override PrimaryFilter DefaultTab => PrimaryFilter.Open;
 
-        protected override float InternalPadding => Multiplayer.OVERFLOW_PADDING;
+        protected override float InternalPadding => OsuScreen.HORIZONTAL_OVERFLOW_PADDING;
 
         public FilterControl()
         {

--- a/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
+++ b/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Screens.Multi.Lounge.Components
         protected override Color4 BackgroundColour => OsuColour.FromHex(@"362e42");
         protected override PrimaryFilter DefaultTab => PrimaryFilter.Open;
 
+        protected override float InternalPadding => Multiplayer.OVERFLOW_PADDING;
+
         public FilterControl()
         {
             DisplayStyleControl.Hide();

--- a/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
+++ b/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.Multi.Lounge.Components
         protected override Color4 BackgroundColour => OsuColour.FromHex(@"362e42");
         protected override PrimaryFilter DefaultTab => PrimaryFilter.Open;
 
-        protected override float InternalPadding => OsuScreen.HORIZONTAL_OVERFLOW_PADDING;
+        protected override float ContentHorizontalPadding => base.ContentHorizontalPadding + OsuScreen.HORIZONTAL_OVERFLOW_PADDING;
 
         public FilterControl()
         {

--- a/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
@@ -91,8 +91,8 @@ namespace osu.Game.Screens.Multi.Lounge
             content.Padding = new MarginPadding
             {
                 Top = Filter.DrawHeight,
-                Left = SearchableListOverlay.WIDTH_PADDING - DrawableRoom.SELECTION_BORDER_WIDTH,
-                Right = SearchableListOverlay.WIDTH_PADDING,
+                Left = SearchableListOverlay.WIDTH_PADDING - DrawableRoom.SELECTION_BORDER_WIDTH + Multiplayer.OVERFLOW_PADDING,
+                Right = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING,
             };
         }
 

--- a/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
@@ -91,8 +91,8 @@ namespace osu.Game.Screens.Multi.Lounge
             content.Padding = new MarginPadding
             {
                 Top = Filter.DrawHeight,
-                Left = SearchableListOverlay.WIDTH_PADDING - DrawableRoom.SELECTION_BORDER_WIDTH + Multiplayer.OVERFLOW_PADDING,
-                Right = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING,
+                Left = SearchableListOverlay.WIDTH_PADDING - DrawableRoom.SELECTION_BORDER_WIDTH + HORIZONTAL_OVERFLOW_PADDING,
+                Right = SearchableListOverlay.WIDTH_PADDING + HORIZONTAL_OVERFLOW_PADDING,
             };
         }
 

--- a/osu.Game/Screens/Multi/Match/Components/Header.cs
+++ b/osu.Game/Screens/Multi/Match/Components/Header.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING },
+                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
                     Children = new Drawable[]
                     {
                         new FillFlowContainer

--- a/osu.Game/Screens/Multi/Match/Components/Header.cs
+++ b/osu.Game/Screens/Multi/Match/Components/Header.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING },
+                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING },
                     Children = new Drawable[]
                     {
                         new FillFlowContainer

--- a/osu.Game/Screens/Multi/Match/Components/Info.cs
+++ b/osu.Game/Screens/Multi/Match/Components/Info.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING },
+                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING },
                     Children = new Drawable[]
                     {
                         new FillFlowContainer

--- a/osu.Game/Screens/Multi/Match/Components/Info.cs
+++ b/osu.Game/Screens/Multi/Match/Components/Info.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + Multiplayer.OVERFLOW_PADDING },
+                    Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING + OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
                     Children = new Drawable[]
                     {
                         new FillFlowContainer

--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                                 {
                                     Padding = new MarginPadding
                                     {
-                                        Horizontal = Multiplayer.OVERFLOW_PADDING,
+                                        Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING,
                                         Vertical = 10
                                     },
                                     RelativeSizeAxes = Axes.Both,
@@ -214,7 +214,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                                             Direction = FillDirection.Vertical,
                                             Spacing = new Vector2(0, 20),
                                             Margin = new MarginPadding { Vertical = 20 },
-                                            Padding = new MarginPadding { Horizontal = Multiplayer.OVERFLOW_PADDING },
+                                            Padding = new MarginPadding { Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
                                             Children = new Drawable[]
                                             {
                                                 ApplyButton = new CreateRoomButton

--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -79,7 +79,11 @@ namespace osu.Game.Screens.Multi.Match.Components
                             {
                                 new ScrollContainer
                                 {
-                                    Padding = new MarginPadding { Vertical = 10 },
+                                    Padding = new MarginPadding
+                                    {
+                                        Horizontal = Multiplayer.OVERFLOW_PADDING,
+                                        Vertical = 10
+                                    },
                                     RelativeSizeAxes = Axes.Both,
                                     Children = new[]
                                     {
@@ -210,6 +214,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                                             Direction = FillDirection.Vertical,
                                             Spacing = new Vector2(0, 20),
                                             Margin = new MarginPadding { Vertical = 20 },
+                                            Padding = new MarginPadding { Horizontal = Multiplayer.OVERFLOW_PADDING },
                                             Children = new Drawable[]
                                             {
                                                 ApplyButton = new CreateRoomButton

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -75,13 +75,23 @@ namespace osu.Game.Screens.Multi.Match
                                     {
                                         leaderboard = new MatchLeaderboard
                                         {
-                                            Padding = new MarginPadding(10),
+                                            Padding = new MarginPadding
+                                            {
+                                                Left = 10 + Multiplayer.OVERFLOW_PADDING,
+                                                Right = 10,
+                                                Vertical = 10,
+                                            },
                                             RelativeSizeAxes = Axes.Both,
                                             Room = room
                                         },
                                         new Container
                                         {
-                                            Padding = new MarginPadding(10),
+                                            Padding = new MarginPadding
+                                            {
+                                                Left = 10,
+                                                Right = 10 + Multiplayer.OVERFLOW_PADDING,
+                                                Vertical = 10,
+                                            },
                                             RelativeSizeAxes = Axes.Both,
                                             Child = chat = new MatchChatDisplay(room)
                                             {

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -118,7 +118,11 @@ namespace osu.Game.Screens.Multi.Match
                 },
             };
 
-            header.OnRequestSelectBeatmap = () => Push(new MatchSongSelect { Selected = addPlaylistItem });
+            header.OnRequestSelectBeatmap = () => Push(new MatchSongSelect
+            {
+                Selected = addPlaylistItem,
+                Padding = new MarginPadding { Horizontal = Multiplayer.OVERFLOW_PADDING }
+            });
             header.Tabs.Current.ValueChanged += t =>
             {
                 const float fade_duration = 500;

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Multi.Match
                                         {
                                             Padding = new MarginPadding
                                             {
-                                                Left = 10 + Multiplayer.OVERFLOW_PADDING,
+                                                Left = 10 + HORIZONTAL_OVERFLOW_PADDING,
                                                 Right = 10,
                                                 Vertical = 10,
                                             },
@@ -89,7 +89,7 @@ namespace osu.Game.Screens.Multi.Match
                                             Padding = new MarginPadding
                                             {
                                                 Left = 10,
-                                                Right = 10 + Multiplayer.OVERFLOW_PADDING,
+                                                Right = 10 + HORIZONTAL_OVERFLOW_PADDING,
                                                 Vertical = 10,
                                             },
                                             RelativeSizeAxes = Axes.Both,
@@ -121,8 +121,9 @@ namespace osu.Game.Screens.Multi.Match
             header.OnRequestSelectBeatmap = () => Push(new MatchSongSelect
             {
                 Selected = addPlaylistItem,
-                Padding = new MarginPadding { Horizontal = Multiplayer.OVERFLOW_PADDING }
+                Padding = new MarginPadding { Horizontal = HORIZONTAL_OVERFLOW_PADDING }
             });
+
             header.Tabs.Current.ValueChanged += t =>
             {
                 const float fade_duration = 500;

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -26,11 +26,6 @@ namespace osu.Game.Screens.Multi
     [Cached]
     public class Multiplayer : OsuScreen, IOnlineComponent
     {
-        /// <summary>
-        /// How much this container should overflow the sides of the screen to account for parallax shifting.
-        /// </summary>
-        public const float OVERFLOW_PADDING = 50;
-
         private readonly MultiplayerWaveContainer waves;
 
         public override bool AllowBeatmapRulesetChange => currentSubScreen?.AllowBeatmapRulesetChange ?? base.AllowBeatmapRulesetChange;
@@ -53,7 +48,7 @@ namespace osu.Game.Screens.Multi
                 RelativeSizeAxes = Axes.Both,
             };
 
-            Padding = new MarginPadding { Horizontal = -OVERFLOW_PADDING };
+            Padding = new MarginPadding { Horizontal = -HORIZONTAL_OVERFLOW_PADDING };
 
             waves.AddRange(new Drawable[]
             {
@@ -93,7 +88,7 @@ namespace osu.Game.Screens.Multi
                     Margin = new MarginPadding
                     {
                         Top = 10,
-                        Right = 10 + OVERFLOW_PADDING,
+                        Right = 10 + HORIZONTAL_OVERFLOW_PADDING,
                     },
                     Text = "Create room",
                     Action = () => loungeSubScreen.Push(new Room

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Multi
     public class Multiplayer : OsuScreen, IOnlineComponent
     {
         /// <summary>
-        ///How much this container should overflow the sides of the screen to account for parallax shifting.
+        /// How much this container should overflow the sides of the screen to account for parallax shifting.
         /// </summary>
         public const float OVERFLOW_PADDING = 50;
 

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -26,6 +26,11 @@ namespace osu.Game.Screens.Multi
     [Cached]
     public class Multiplayer : OsuScreen, IOnlineComponent
     {
+        /// <summary>
+        ///How much this container should overflow the sides of the screen to account for parallax shifting.
+        /// </summary>
+        public const float OVERFLOW_PADDING = 50;
+
         private readonly MultiplayerWaveContainer waves;
 
         public override bool AllowBeatmapRulesetChange => currentSubScreen?.AllowBeatmapRulesetChange ?? base.AllowBeatmapRulesetChange;
@@ -46,6 +51,12 @@ namespace osu.Game.Screens.Multi
             Child = waves = new MultiplayerWaveContainer
             {
                 RelativeSizeAxes = Axes.Both,
+            };
+
+            Padding = new MarginPadding
+            {
+                Left = -OVERFLOW_PADDING,
+                Right = -OVERFLOW_PADDING
             };
 
             waves.AddRange(new Drawable[]
@@ -86,7 +97,7 @@ namespace osu.Game.Screens.Multi
                     Margin = new MarginPadding
                     {
                         Top = 10,
-                        Right = 10,
+                        Right = 10 + OVERFLOW_PADDING,
                     },
                     Text = "Create room",
                     Action = () => loungeSubScreen.Push(new Room

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -53,11 +53,7 @@ namespace osu.Game.Screens.Multi
                 RelativeSizeAxes = Axes.Both,
             };
 
-            Padding = new MarginPadding
-            {
-                Left = -OVERFLOW_PADDING,
-                Right = -OVERFLOW_PADDING
-            };
+            Padding = new MarginPadding { Horizontal = -OVERFLOW_PADDING };
 
             waves.AddRange(new Drawable[]
             {

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -23,6 +23,12 @@ namespace osu.Game.Screens
 {
     public abstract class OsuScreen : Screen, IKeyBindingHandler<GlobalAction>, IHasDescription
     {
+        /// <summary>
+        /// The amount of negative padding that should be applied to game background content which touches both the left and right sides of the screen.
+        /// This allows for the game content to be pushed byt he options/notification overlays without causing black areas to appear.
+        /// </summary>
+        public const float HORIZONTAL_OVERFLOW_PADDING = 50;
+
         public BackgroundScreen Background { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
- Closes #4003

Adds overflow padding to `Multiplayer` screen and related components.
Fix similar to [ModSelectOverlay](https://github.com/ppy/osu/blob/dfc903fec2891e5dfa9ac35a0024f0c5858ca0e3/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L33) issue.
