### PR TITLE
Display carousel over beatmap info wedge

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -123,6 +123,16 @@ namespace osu.Game.Screens.Select
                         Padding = new MarginPadding { Top = 10, Right = 5 },
                     }
                 },
+                beatmapInfoWedge = new BeatmapInfoWedge
+                {
+                    Size = wedged_container_size,
+                    RelativeSizeAxes = Axes.X,
+                    Margin = new MarginPadding
+                    {
+                        Top = left_area_padding,
+                        Right = left_area_padding,
+                    },
+                },
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -161,16 +171,6 @@ namespace osu.Game.Screens.Select
                                 },
                             },
                         }
-                    },
-                },
-                beatmapInfoWedge = new BeatmapInfoWedge
-                {
-                    Size = wedged_container_size,
-                    RelativeSizeAxes = Axes.X,
-                    Margin = new MarginPadding
-                    {
-                        Top = left_area_padding,
-                        Right = left_area_padding,
                     },
                 },
                 new ResetScrollContainer(() => Carousel.ScrollToSelected())


### PR DESCRIPTION
- Closes #3974 

<img width="352" alt="2019-01-25 22 45 09" src="https://user-images.githubusercontent.com/27663662/51744221-36cc2100-20f3-11e9-9322-a8a23b788246.png">
