### PR TITLE
Fix background dim persisting when hovering player settings and exiting

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -228,6 +228,7 @@ namespace osu.Game.Screens.Play
         {
             Content.ScaleTo(0.7f, 150, Easing.InQuint);
             this.FadeOut(150);
+            Background?.FadeColour(Color4.White, BACKGROUND_FADE_DURATION, Easing.OutQuint);
             cancelLoad();
 
             return base.OnExiting(next);


### PR DESCRIPTION
`onExiting` did not yet restore the `FadeColour` which replaced the `FadeTo` in PR #4131 

- Closes #4165 

---

Fixes the background dim persisting into the song selection screen when hovering the player settings in the map loading screen and then exiting into song selection screen.