### PR TITLE
Use correct DifficultyAttributes where possible

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             difficultyHitObjects.AddRange(beatmap.HitObjects.Select(h => new ManiaHitObjectDifficulty((ManiaHitObject)h, columnCount)).OrderBy(h => h.BaseHitObject.StartTime));
 
             if (!calculateStrainValues(difficultyHitObjects, timeRate))
-                return new DifficultyAttributes(mods, 0);
+                return new ManiaDifficultyAttributes(mods, 0);
 
             double starRating = calculateDifficulty(difficultyHitObjects, timeRate) * star_scaling_factor;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             difficultyHitObjects.Sort((a, b) => a.BaseHitObject.StartTime.CompareTo(b.BaseHitObject.StartTime));
 
             if (!calculateStrainValues(difficultyHitObjects, timeRate))
-                return new DifficultyAttributes(mods, 0);
+                return new TaikoDifficultyAttributes(mods, 0);
 
             double starRating = calculateDifficulty(difficultyHitObjects, timeRate) * star_scaling_factor;
 


### PR DESCRIPTION
Makes it so the current `Calculate` implementations of DifficultyCalculators return the overridden version of `DifficultyAttributes`, which are expected by the PerformanceCalculators. This fixes an issue in #3909 where Taiko (and possibly Mania) ppcalc would throw an InvalidCastException when calculating for 0 hitobjects.

---

Fixes crash when calculating performance for 0 hitobjects in Taiko or Mania.