### PR TITLE
Fix nullref during room creation

### DIFF
--- a/osu.Game/Screens/Multi/Match/Components/ReadyButton.cs
+++ b/osu.Game/Screens/Multi/Match/Components/ReadyButton.cs
@@ -55,6 +55,9 @@ namespace osu.Game.Screens.Multi.Match.Components
 
         private void beatmapAdded(BeatmapSetInfo model, bool existing, bool silent)
         {
+            if (Beatmap.Value == null)
+                return;
+
             if (model.Beatmaps.Any(b => b.OnlineBeatmapID == Beatmap.Value.OnlineBeatmapID))
                 Schedule(() => hasBeatmap = true);
         }


### PR DESCRIPTION
Fixes #4018

Because the beatmap is nulled when creating a room.