### PR TITLE
Don't revert beatmap on exiting leased state

### DIFF
--- a/osu.Game/Screens/OsuScreenDependencies.cs
+++ b/osu.Game/Screens/OsuScreenDependencies.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens
                 Beatmap = parent.Get<LeasedBindable<WorkingBeatmap>>()?.GetBoundCopy();
                 if (Beatmap == null)
                 {
-                    Cache(Beatmap = parent.Get<Bindable<WorkingBeatmap>>().BeginLease(true));
+                    Cache(Beatmap = parent.Get<Bindable<WorkingBeatmap>>().BeginLease(false));
                 }
 
                 Ruleset = parent.Get<LeasedBindable<RulesetInfo>>()?.GetBoundCopy();


### PR DESCRIPTION
While generally we *do* want to revert the ruleset choice after a lease, beatmap (for all existing cases) should not be reverted as we want it to continue playing in the interface.

In the future we may need to add per-use specification of this, but in all existing cases this is what we want for now, so KISS.

- Closes #4037