### PR TITLE
Fix mouse cursor appearing prematurely during startup

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -337,6 +337,11 @@ namespace osu.Game
         {
             base.LoadComplete();
 
+            // The next time this is updated is in UpdateAfterChildren, which occurs too late and results
+            // in the cursor being shown for a few frames during the intro.
+            // This prevents the cursor from showing until we have a screen with CursorVisible = true
+            MenuCursorContainer.CanShowCursor = menuScreen?.CursorVisible ?? false;
+
             // todo: all archive managers should be able to be looped here.
             SkinManager.PostNotification = n => notifications?.Post(n);
             SkinManager.GetStableStorage = GetStorageForStableInstall;

--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Screens
 
         public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
 
+        public override bool CursorVisible => false;
+
         protected override bool AllowBackButton => false;
 
         public Loader()


### PR DESCRIPTION
Happens due to `OsuGame` not propagating `CursorVisible` early enough, which results in `MenuCursorContainer` defaulting to show the cursor initially.