### PR TITLE
Add support for the HitCircleOverlap property of legacy skins

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestCaseHitCircleLongCombo.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseHitCircleLongCombo.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Osu.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [TestFixture]
+    public class TestCaseHitCircleLongCombo : Game.Tests.Visual.TestCasePlayer
+    {
+        public TestCaseHitCircleLongCombo()
+            : base(new OsuRuleset())
+        {
+        }
+
+        protected override IBeatmap CreateBeatmap(Ruleset ruleset)
+        {
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    BaseDifficulty = new BeatmapDifficulty { CircleSize = 6 },
+                    Ruleset = ruleset.RulesetInfo
+                }
+            };
+
+            for (int i = 0; i < 512; i++)
+                beatmap.HitObjects.Add(new HitCircle { Position = new Vector2(256, 192), StartTime = i * 100 });
+
+            return beatmap;
+        }
+    }
+}

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -58,7 +58,14 @@ namespace osu.Game.Skinning
                     componentName = "hit300";
                     break;
                 case "Play/osu/number-text":
-                    return !hasFont(Configuration.HitCircleFont) ? null : new LegacySpriteText(Textures, Configuration.HitCircleFont) { Scale = new Vector2(0.96f) };
+                    return !hasFont(Configuration.HitCircleFont)
+                        ? null
+                        : new LegacySpriteText(Textures, Configuration.HitCircleFont)
+                        {
+                            Scale = new Vector2(0.96f),
+                            // Spacing value was reverse-engineered from the ratio of the rendered sprite size in the visual inspector vs the actual texture size
+                            Spacing = new Vector2(-Configuration.HitCircleOverlap * 0.89f, 0)
+                        };
             }
 
             var texture = GetTexture(componentName);

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Skinning
                         case "HitCirclePrefix":
                             skin.HitCircleFont = pair.Value;
                             break;
+                        case "HitCircleOverlap":
+                            skin.HitCircleOverlap = int.Parse(pair.Value);
+                            break;
                     }
 
                     break;

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Skinning
         public Dictionary<string, Color4> CustomColours { get; set; } = new Dictionary<string, Color4>();
 
         public string HitCircleFont { get; set; } = "default";
+
         public int HitCircleOverlap { get; set; }
 
         public bool? CursorExpand { get; set; } = true;

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Skinning
         public Dictionary<string, Color4> CustomColours { get; set; } = new Dictionary<string, Color4>();
 
         public string HitCircleFont { get; set; } = "default";
+        public int HitCircleOverlap { get; set; }
 
         public bool? CursorExpand { get; set; } = true;
     }


### PR DESCRIPTION
Fixes #4198, also adds a test that generates a looong combo to visually confirm the fix.