### PR TITLE
Fix screen tests

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseDisclaimer.cs
+++ b/osu.Game.Tests/Visual/TestCaseDisclaimer.cs
@@ -2,27 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Shapes;
 using osu.Game.Screens.Menu;
-using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual
 {
-    public class TestCaseDisclaimer : OsuTestCase
+    public class TestCaseDisclaimer : ScreenTestCase
     {
         [BackgroundDependencyLoader]
         private void load()
         {
-            Children = new Drawable[]
-            {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Black,
-                },
-                new Disclaimer()
-            };
+            LoadScreen(new Disclaimer());
         }
     }
 }

--- a/osu.Game.Tests/Visual/TestCaseDrawings.cs
+++ b/osu.Game.Tests/Visual/TestCaseDrawings.cs
@@ -9,11 +9,11 @@ using osu.Game.Screens.Tournament.Teams;
 namespace osu.Game.Tests.Visual
 {
     [Description("for tournament use")]
-    public class TestCaseDrawings : OsuTestCase
+    public class TestCaseDrawings : ScreenTestCase
     {
         public TestCaseDrawings()
         {
-            Add(new Drawings
+            LoadScreen(new Drawings
             {
                 TeamList = new TestTeamList(),
             });

--- a/osu.Game.Tests/Visual/TestCaseMatchResults.cs
+++ b/osu.Game.Tests/Visual/TestCaseMatchResults.cs
@@ -40,10 +40,10 @@ namespace osu.Game.Tests.Visual
             Room.RoomID.Value = 1;
             Room.Name.Value = "an awesome room";
 
-            Child = new TestMatchResults(new ScoreInfo
+            LoadScreen(new TestMatchResults(new ScoreInfo
             {
                 User = new User { Id = 10 },
-            });
+            }));
         }
 
         private class TestMatchResults : MatchResults

--- a/osu.Game.Tests/Visual/TestCaseMultiScreen.cs
+++ b/osu.Game.Tests/Visual/TestCaseMultiScreen.cs
@@ -12,7 +12,7 @@ using osu.Game.Screens.Multi.Lounge.Components;
 namespace osu.Game.Tests.Visual
 {
     [TestFixture]
-    public class TestCaseMultiScreen : OsuTestCase
+    public class TestCaseMultiScreen : ScreenTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual
         {
             Multiplayer multi = new Multiplayer();
 
-            AddStep(@"show", () => Add(multi));
+            AddStep(@"show", () => LoadScreen(multi));
             AddWaitStep(5);
             AddStep(@"exit", multi.Exit);
         }

--- a/osu.Game.Tests/Visual/TestCaseOsuGame.cs
+++ b/osu.Game.Tests/Visual/TestCaseOsuGame.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Screens;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osuTK.Graphics;
@@ -29,7 +30,10 @@ namespace osu.Game.Tests.Visual
                     RelativeSizeAxes = Axes.Both,
                     Colour = Color4.Black,
                 },
-                new Loader()
+                new ScreenStack(new Loader())
+                {
+                    RelativeSizeAxes = Axes.Both,
+                }
             };
         }
     }

--- a/osu.Game.Tests/Visual/TestCaseParallaxContainer.cs
+++ b/osu.Game.Tests/Visual/TestCaseParallaxContainer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Backgrounds;
 
@@ -14,7 +16,10 @@ namespace osu.Game.Tests.Visual
 
             Add(parallax = new ParallaxContainer
             {
-                Child = new BackgroundScreenDefault { Alpha = 0.8f }
+                Child = new ScreenStack(new BackgroundScreenDefault { Alpha = 0.8f })
+                {
+                    RelativeSizeAxes = Axes.Both,
+                }
             });
 
             AddStep("default parallax", () => parallax.ParallaxAmount = ParallaxContainer.DEFAULT_PARALLAX_AMOUNT);

--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -103,22 +103,16 @@ namespace osu.Game.Tests.Visual
         }
 
         [SetUp]
-        public virtual void SetUp()
-        {
-            Schedule(() =>
-            {
-                manager?.Delete(manager.GetAllUsableBeatmapSets());
-                LoadScreen(songSelect = new TestSongSelect());
-                AddUntilStep(() => songSelect.IsPresent, "wait for present");
-            });
-        }
+        public virtual void SetUp() =>
+            Schedule(() => { manager?.Delete(manager.GetAllUsableBeatmapSets()); });
 
         [Test]
         public void TestDummy()
         {
+            createSongSelect();
             AddAssert("dummy selected", () => songSelect.CurrentBeatmap == defaultBeatmap);
 
-            AddAssert("dummy shown on wedge", () => songSelect.CurrentBeatmapDetailsBeatmap == defaultBeatmap);
+            AddUntilStep(() => songSelect.CurrentBeatmapDetailsBeatmap == defaultBeatmap, "dummy shown on wedge");
 
             addManyTestMaps();
             AddWaitStep(3);
@@ -129,6 +123,7 @@ namespace osu.Game.Tests.Visual
         [Test]
         public void TestSorting()
         {
+            createSongSelect();
             addManyTestMaps();
             AddWaitStep(3);
 
@@ -144,6 +139,7 @@ namespace osu.Game.Tests.Visual
         [Ignore("needs fixing")]
         public void TestImportUnderDifferentRuleset()
         {
+            createSongSelect();
             changeRuleset(2);
             importForRuleset(0);
             AddUntilStep(() => songSelect.Carousel.SelectedBeatmap == null, "no selection");
@@ -152,6 +148,7 @@ namespace osu.Game.Tests.Visual
         [Test]
         public void TestImportUnderCurrentRuleset()
         {
+            createSongSelect();
             changeRuleset(2);
             importForRuleset(2);
             importForRuleset(1);
@@ -167,6 +164,7 @@ namespace osu.Game.Tests.Visual
         [Test]
         public void TestRulesetChangeResetsMods()
         {
+            createSongSelect();
             changeRuleset(0);
 
             changeMods(new OsuModHardRock());
@@ -196,6 +194,7 @@ namespace osu.Game.Tests.Visual
         [Test]
         public void TestStartAfterUnMatchingFilterDoesNotStart()
         {
+            createSongSelect();
             addManyTestMaps();
             AddUntilStep(() => songSelect.Carousel.SelectedBeatmap != null, "has selection");
 
@@ -222,6 +221,12 @@ namespace osu.Game.Tests.Visual
         private void changeMods(params Mod[] mods) => AddStep($"change mods to {string.Join(", ", mods.Select(m => m.Acronym))}", () => selectedMods.Value = mods);
 
         private void changeRuleset(int id) => AddStep($"change ruleset to {id}", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == id));
+
+        private void createSongSelect()
+        {
+            AddStep("create song select", () => LoadScreen(songSelect = new TestSongSelect()));
+            AddUntilStep(() => songSelect.IsCurrentScreen(), "wait for present");
+        }
 
         private void addManyTestMaps()
         {

--- a/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/TestCasePlaySongSelect.cs
@@ -12,6 +12,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Extensions;
 using osu.Framework.MathUtils;
 using osu.Framework.Platform;
+using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Rulesets;
@@ -25,7 +26,7 @@ using osu.Game.Screens.Select.Filter;
 namespace osu.Game.Tests.Visual
 {
     [TestFixture]
-    public class TestCasePlaySongSelect : OsuTestCase
+    public class TestCasePlaySongSelect : ScreenTestCase
     {
         private BeatmapManager manager;
 
@@ -107,7 +108,8 @@ namespace osu.Game.Tests.Visual
             Schedule(() =>
             {
                 manager?.Delete(manager.GetAllUsableBeatmapSets());
-                Child = songSelect = new TestSongSelect();
+                LoadScreen(songSelect = new TestSongSelect());
+                AddUntilStep(() => songSelect.IsPresent, "wait for present");
             });
         }
 

--- a/osu.Game.Tests/Visual/TestCaseResults.cs
+++ b/osu.Game.Tests/Visual/TestCaseResults.cs
@@ -16,7 +16,7 @@ using osu.Game.Users;
 namespace osu.Game.Tests.Visual
 {
     [TestFixture]
-    public class TestCaseResults : OsuTestCase
+    public class TestCaseResults : ScreenTestCase
     {
         private BeatmapManager beatmaps;
 
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual
             if (beatmapInfo != null)
                 Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo);
 
-            Add(new SoloResults(new ScoreInfo
+            LoadScreen(new SoloResults(new ScoreInfo
             {
                 TotalScore = 2845370,
                 Accuracy = 0.98,

--- a/osu.Game/Tests/OsuTestBrowser.cs
+++ b/osu.Game/Tests/OsuTestBrowser.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Framework.Platform;
+using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osu.Game.Screens.Backgrounds;
@@ -14,10 +16,10 @@ namespace osu.Game.Tests
         {
             base.LoadComplete();
 
-            LoadComponentAsync(new BackgroundScreenDefault
+            LoadComponentAsync(new ScreenStack(new BackgroundScreenDefault { Colour = OsuColour.Gray(0.5f) })
             {
-                Colour = OsuColour.Gray(0.5f),
-                Depth = 10
+                Depth = 10,
+                RelativeSizeAxes = Axes.Both,
             }, AddInternal);
 
             // Have to construct this here, rather than in the constructor, because

--- a/osu.Game/Tests/Visual/MultiplayerTestCase.cs
+++ b/osu.Game/Tests/Visual/MultiplayerTestCase.cs
@@ -7,7 +7,7 @@ using osu.Game.Online.Multiplayer;
 
 namespace osu.Game.Tests.Visual
 {
-    public abstract class MultiplayerTestCase : OsuTestCase
+    public abstract class MultiplayerTestCase : ScreenTestCase
     {
         [Cached]
         private readonly Bindable<Room> currentRoom = new Bindable<Room>(new Room());

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.128.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.214.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.215.0" />
     <PackageReference Include="SharpCompress" Version="0.22.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -105,8 +105,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.128.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.214.0" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.214.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.215.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.215.0" />
     <PackageReference Include="SharpCompress" Version="0.22.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
With the introduction of `ScreenStack`, many tests began to silently fail.

- All failing tests have been fixed.
- An extra fix for `TestCasePlaySongSelect` to avoid intermittent CI failures.
- An exception was added framework-side to fix this, which is part of the framework update on this branch.