### PR TITLE
Fix crash on exiting song select while scrolling

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -161,8 +161,6 @@ namespace osu.Game.Screens.Menu
         {
             if (!this.IsCurrentScreen())
                 return;
-
-            ((BackgroundScreenDefault)Background).Next();
         }
 
         public override void OnSuspending(IScreen next)


### PR DESCRIPTION
From what I see the bug was caused by this line. It cannot cast BackgroundScreenDefault to BackgroundScreenBeatmap, and from what I see it's unnecessary. When one presses ESC while scrolling it goes back to the main menu as it should.


- Closes #4282 

---
