### PR TITLE
Hide exit button if the host does not support exiting

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -91,15 +91,6 @@ namespace osu.Game.Screens.Menu
             });
 
             buttonArea.Flow.CentreTarget = iconFacade;
-
-            buttonsPlay.Add(new Button(@"solo", @"button-solo-select", FontAwesome.fa_user, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
-            buttonsPlay.Add(new Button(@"multi", @"button-generic-select", FontAwesome.fa_users, new Color4(94, 63, 186, 255), onMulti, 0, Key.M));
-            buttonsPlay.Add(new Button(@"chart", @"button-generic-select", FontAwesome.fa_osu_charts, new Color4(80, 53, 160, 255), () => OnChart?.Invoke()));
-            buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
-
-            buttonsTopLevel.Add(new Button(@"play", @"button-play-select", FontAwesome.fa_osu_logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH, Key.P));
-            buttonsTopLevel.Add(new Button(@"osu!editor", @"button-generic-select", FontAwesome.fa_osu_edit_o, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E));
-            buttonsTopLevel.Add(new Button(@"osu!direct", @"button-direct-select", FontAwesome.fa_osu_chevron_down_o, new Color4(165, 204, 0, 255), () => OnDirect?.Invoke(), 0, Key.D));
         }
 
         [Resolved(CanBeNull = true)]
@@ -114,6 +105,15 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, IdleTracker idleTracker, GameHost host)
         {
+            buttonsPlay.Add(new Button(@"solo", @"button-solo-select", FontAwesome.fa_user, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
+            buttonsPlay.Add(new Button(@"multi", @"button-generic-select", FontAwesome.fa_users, new Color4(94, 63, 186, 255), onMulti, 0, Key.M));
+            buttonsPlay.Add(new Button(@"chart", @"button-generic-select", FontAwesome.fa_osu_charts, new Color4(80, 53, 160, 255), () => OnChart?.Invoke()));
+            buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
+
+            buttonsTopLevel.Add(new Button(@"play", @"button-play-select", FontAwesome.fa_osu_logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH, Key.P));
+            buttonsTopLevel.Add(new Button(@"osu!editor", @"button-generic-select", FontAwesome.fa_osu_edit_o, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E));
+            buttonsTopLevel.Add(new Button(@"osu!direct", @"button-direct-select", FontAwesome.fa_osu_chevron_down_o, new Color4(165, 204, 0, 255), () => OnDirect?.Invoke(), 0, Key.D));
+
             if (host.CanExit)
                 buttonsTopLevel.Add(new Button(@"exit", string.Empty, FontAwesome.fa_osu_cross_o, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(), 0, Key.Q));
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Logging;
+using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Graphics;
 using osu.Game.Input;
@@ -99,10 +100,6 @@ namespace osu.Game.Screens.Menu
             buttonsTopLevel.Add(new Button(@"play", @"button-play-select", FontAwesome.fa_osu_logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH, Key.P));
             buttonsTopLevel.Add(new Button(@"osu!editor", @"button-generic-select", FontAwesome.fa_osu_edit_o, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E));
             buttonsTopLevel.Add(new Button(@"osu!direct", @"button-direct-select", FontAwesome.fa_osu_chevron_down_o, new Color4(165, 204, 0, 255), () => OnDirect?.Invoke(), 0, Key.D));
-            buttonsTopLevel.Add(new Button(@"exit", string.Empty, FontAwesome.fa_osu_cross_o, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(), 0, Key.Q));
-
-            buttonArea.AddRange(buttonsPlay);
-            buttonArea.AddRange(buttonsTopLevel);
         }
 
         [Resolved(CanBeNull = true)]
@@ -115,8 +112,14 @@ namespace osu.Game.Screens.Menu
         private NotificationOverlay notifications { get; set; }
 
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, IdleTracker idleTracker)
+        private void load(AudioManager audio, IdleTracker idleTracker, GameHost host)
         {
+            if (host.CanExit)
+                buttonsTopLevel.Add(new Button(@"exit", string.Empty, FontAwesome.fa_osu_cross_o, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(), 0, Key.Q));
+
+            buttonArea.AddRange(buttonsPlay);
+            buttonArea.AddRange(buttonsTopLevel);
+
             isIdle.ValueChanged += idle => updateIdleState(idle.NewValue);
 
             if (idleTracker != null) isIdle.BindTo(idleTracker.IsIdle);

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Menu
 {
     public class MainMenu : OsuScreen
     {
-        private readonly ButtonSystem buttons;
+        private ButtonSystem buttons;
 
         public override bool HideOverlaysOnEnter => buttons.State == ButtonSystemState.Initial;
 
@@ -35,26 +35,39 @@ namespace osu.Game.Screens.Menu
 
         private Screen songSelect;
 
-        private readonly MenuSideFlashes sideFlashes;
+        private MenuSideFlashes sideFlashes;
 
         [Resolved]
         private GameHost host { get; set; }
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenDefault();
 
-        public MainMenu()
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuGame game = null)
         {
-            sideFlashes = new MenuSideFlashes();
+            if (host.CanExit)
+                AddInternal(new ExitConfirmOverlay { Action = this.Exit });
 
-            buttons = new ButtonSystem
+            AddRangeInternal(new Drawable[]
             {
-                OnChart = delegate { this.Push(new ChartListing()); },
-                OnDirect = delegate { this.Push(new OnlineListing()); },
-                OnEdit = delegate { this.Push(new Editor()); },
-                OnSolo = onSolo,
-                OnMulti = delegate { this.Push(new Multiplayer()); },
-                OnExit = this.Exit,
-            };
+                new ParallaxContainer
+                {
+                    ParallaxAmount = 0.01f,
+                    Children = new Drawable[]
+                    {
+                        buttons = new ButtonSystem
+                        {
+                            OnChart = delegate { this.Push(new ChartListing()); },
+                            OnDirect = delegate { this.Push(new OnlineListing()); },
+                            OnEdit = delegate { this.Push(new Editor()); },
+                            OnSolo = onSolo,
+                            OnMulti = delegate { this.Push(new Multiplayer()); },
+                            OnExit = this.Exit,
+                        }
+                    }
+                },
+                sideFlashes = new MenuSideFlashes(),
+            });
 
             buttons.StateChanged += state =>
             {
@@ -69,26 +82,6 @@ namespace osu.Game.Screens.Menu
                         break;
                 }
             };
-        }
-
-        [BackgroundDependencyLoader(true)]
-        private void load(OsuGame game = null)
-        {
-            if (host.CanExit)
-            {
-                AddInternal(new ExitConfirmOverlay
-                {
-                    Action = this.Exit,
-                });
-            }
-
-            AddInternal(new ParallaxContainer
-            {
-                ParallaxAmount = 0.01f,
-                Child = buttons,
-            });
-
-            AddInternal(sideFlashes);
 
             if (game != null)
             {


### PR DESCRIPTION
Mobile platforms should not provide a method of exiting the game, as it is handled by the OS.

We now only add the main menu exit button and `ExitConfirmOverlay` if `GameHost.CanExit` is true.
