### PR TITLE
Fix scores being stored as ints

### DIFF
--- a/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
+++ b/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.0-rtm-35687");
+                .HasAnnotation("ProductVersion", "2.2.1-servicing-10028");
 
             modelBuilder.Entity("osu.Game.Beatmaps.BeatmapDifficulty", b =>
                 {
@@ -336,7 +336,7 @@ namespace osu.Game.Migrations
                     b.Property<string>("StatisticsJson")
                         .HasColumnName("Statistics");
 
-                    b.Property<int>("TotalScore");
+                    b.Property<long>("TotalScore");
 
                     b.Property<string>("UserString")
                         .HasColumnName("User");

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         public virtual void PopulateScore(ScoreInfo score)
         {
-            score.TotalScore = (int)Math.Round(TotalScore.Value);
+            score.TotalScore = (long)Math.Round(TotalScore.Value);
             score.Combo = Combo.Value;
             score.MaxCombo = HighestCombo.Value;
             score.Accuracy = Math.Round(Accuracy.Value, 4);

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Scoring
         public ScoreRank Rank { get; set; }
 
         [JsonProperty("total_score")]
-        public int TotalScore { get; set; }
+        public long TotalScore { get; set; }
 
         [JsonProperty("accuracy")]
         [Column(TypeName="DECIMAL(1,4)")]


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/3970

Temporary fix for now. In the future we want to instead store `BaseScore`, `MaxCombo`, and `BonusScore` and compute scores on the fly, while removing `TotalScore`. That's a much larger change to be done though.