### PR TITLE
Reduce square graph overhead

### DIFF
--- a/osu.Game.Tests/Visual/TestCaseSongProgress.cs
+++ b/osu.Game.Tests/Visual/TestCaseSongProgress.cs
@@ -72,7 +72,6 @@ namespace osu.Game.Tests.Visual
             progress.OnSeek = pos => clock.Seek(pos);
         }
 
-
         private class TestSongProgressGraph : SongProgressGraph
         {
             public int CreationCount { get; private set; }
@@ -82,7 +81,6 @@ namespace osu.Game.Tests.Visual
                 base.RecreateGraph();
                 CreationCount++;
             }
-
         }
     }
 }

--- a/osu.Game.Tests/Visual/TestCaseSongProgress.cs
+++ b/osu.Game.Tests/Visual/TestCaseSongProgress.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Tests.Visual
     public class TestCaseSongProgress : OsuTestCase
     {
         private readonly SongProgress progress;
-        private readonly SongProgressGraph graph;
+        private readonly TestSongProgressGraph graph;
 
         private readonly StopwatchClock clock;
 
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual
                 Origin = Anchor.BottomLeft,
             });
 
-            Add(graph = new SongProgressGraph
+            Add(graph = new TestSongProgressGraph
             {
                 RelativeSizeAxes = Axes.X,
                 Height = 200,
@@ -39,13 +39,24 @@ namespace osu.Game.Tests.Visual
                 Origin = Anchor.TopLeft,
             });
 
+            AddWaitStep(5);
+            AddAssert("ensure not created", () => graph.CreationCount == 0);
+
+            AddStep("display values", displayNewValues);
+            AddWaitStep(5);
+            AddUntilStep(() => graph.CreationCount == 1, "wait for creation count");
+
             AddStep("Toggle Bar", () => progress.AllowSeeking = !progress.AllowSeeking);
             AddWaitStep(5);
+            AddUntilStep(() => graph.CreationCount == 1, "wait for creation count");
+
             AddStep("Toggle Bar", () => progress.AllowSeeking = !progress.AllowSeeking);
-            AddWaitStep(2);
+            AddWaitStep(5);
+            AddUntilStep(() => graph.CreationCount == 1, "wait for creation count");
             AddRepeatStep("New Values", displayNewValues, 5);
 
-            displayNewValues();
+            AddWaitStep(5);
+            AddAssert("ensure debounced", () => graph.CreationCount == 2);
         }
 
         private void displayNewValues()
@@ -59,6 +70,19 @@ namespace osu.Game.Tests.Visual
 
             progress.AudioClock = clock;
             progress.OnSeek = pos => clock.Seek(pos);
+        }
+
+
+        private class TestSongProgressGraph : SongProgressGraph
+        {
+            public int CreationCount { get; private set; }
+
+            protected override void RecreateGraph()
+            {
+                base.RecreateGraph();
+                CreationCount++;
+            }
+
         }
     }
 }

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -121,7 +121,6 @@ namespace osu.Game.Screens.Play
             }
 
             cts?.Cancel();
-            cts = new CancellationTokenSource();
 
             LoadComponentAsync(newColumns, c =>
             {
@@ -131,7 +130,7 @@ namespace osu.Game.Screens.Play
                 recalculateValues();
                 redrawFilled();
                 redrawProgress();
-            }, cts.Token);
+            }, (cts = new CancellationTokenSource()).Token);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -12,6 +12,8 @@ using osu.Framework.Graphics.Containers;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.MathUtils;
+using osu.Framework.Allocation;
 
 namespace osu.Game.Screens.Play
 {
@@ -66,20 +68,16 @@ namespace osu.Game.Screens.Play
 
         private Cached layout = new Cached();
 
-        public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
-        {
-            if ((invalidation & Invalidation.DrawSize) > 0)
-                layout.Invalidate();
-            return base.Invalidate(invalidation, source, shallPropagate);
-        }
+        private float lastDrawWidth;
 
         protected override void Update()
         {
             base.Update();
 
-            if (!layout.IsValid)
+            if (values != null && (!layout.IsValid || !Precision.AlmostEquals(lastDrawWidth, DrawWidth, 5)))
             {
                 recreateGraph();
+                lastDrawWidth = DrawWidth;
                 layout.Validate();
             }
         }
@@ -203,21 +201,20 @@ namespace osu.Game.Screens.Play
                 }
             }
 
-            public Column()
+            public Column(float height)
             {
                 Width = WIDTH;
+                Height = height;
             }
 
-            protected override void LoadComplete()
+            [BackgroundDependencyLoader]
+            private void load()
             {
-                for (int r = 0; r < cubeCount; r++)
+                drawableRows.AddRange(Enumerable.Range(0, (int)cubeCount).Select(r => new Box
                 {
-                    drawableRows.Add(new Box
-                    {
-                        Size = new Vector2(cube_size),
-                        Position = new Vector2(0, r * WIDTH + padding),
-                    });
-                }
+                    Size = new Vector2(cube_size),
+                    Position = new Vector2(0, r * WIDTH + padding),
+                }));
 
                 Children = drawableRows;
 

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -73,6 +73,7 @@ namespace osu.Game.Screens.Play
         }
 
         private Cached layout = new Cached();
+        private ScheduledDelegate scheduledCreate;
 
         protected override void Update()
         {
@@ -80,27 +81,21 @@ namespace osu.Game.Screens.Play
 
             if (values != null && !layout.IsValid)
             {
-                schedulerRecreateGraph();
+                columns?.FadeOut(500, Easing.OutQuint).Expire();
+
+                scheduledCreate?.Cancel();
+                scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
+
                 layout.Validate();
             }
         }
 
-        private ScheduledDelegate scheduledCreate;
+        private CancellationTokenSource cts;
 
         /// <summary>
         /// Recreates the entire graph.
         /// </summary>
-        private void schedulerRecreateGraph()
-        {
-            columns?.FadeOut(500, Easing.OutQuint).Expire();
-
-            scheduledCreate?.Cancel();
-            scheduledCreate = Scheduler.AddDelayed(recreateGraph, 500);
-        }
-
-        private CancellationTokenSource cts;
-
-        private void recreateGraph()
+        protected virtual void RecreateGraph()
         {
             var newColumns = new BufferedContainer<Column>
             {


### PR DESCRIPTION
Previously every time layout changed, the graph would be created on the spot, potentially resulting in thousands of drawables per frame.

This debounces the creation and also asyncs it completely.