### PR TITLE
Clear delegate list rather than relying on unbinds

### DIFF
--- a/osu.Game/Skinning/LocalSkinOverrideContainer.cs
+++ b/osu.Game/Skinning/LocalSkinOverrideContainer.cs
@@ -96,6 +96,9 @@ namespace osu.Game.Skinning
 
         protected override void Dispose(bool isDisposing)
         {
+            // Must be done before base.Dispose()
+            SourceChanged = null;
+
             base.Dispose(isDisposing);
 
             if (fallbackSource != null)


### PR DESCRIPTION
It turns out that event unbinding does some really nasty allocations, and there are several tens of thousands of unbinds happening after exiting from some marathon maps.

For me, .NET seems to allocate around 700MB of LOH per chunk of disposal, triggering a GC and causing a frame stutter every few seconds:

<img width="1632" alt="screen shot 2019-02-27 at 9 05 06 pm" src="https://user-images.githubusercontent.com/1329837/53489181-e0784680-3ad3-11e9-9bbd-28e39d23a2af.png">

This is a bit of a temporary fix since we don't use skinning elsewhere other than gameplay yet, and making everything use bindables is kinda ugly.