### PR TITLE
Only display SupportedWindowModes in settings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private void windowModesChanged()
         {
-            if (windowModes.Count() > 1)
+            if (windowModes.Count > 1)
                 windowModeDropdown.Show();
             else
                 windowModeDropdown.Hide();

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private Bindable<ScalingMode> scalingMode;
         private Bindable<Size> sizeFullscreen;
+        private readonly BindableList<WindowMode> windowModes = new BindableList<WindowMode>();
 
         private OsuGameBase game;
         private SettingsDropdown<Size> resolutionDropdown;
@@ -51,6 +52,9 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             scalingPositionX = osuConfig.GetBindable<float>(OsuSetting.ScalingPositionX);
             scalingPositionY = osuConfig.GetBindable<float>(OsuSetting.ScalingPositionY);
 
+            if (host.Window != null)
+                windowModes.BindTo(host.Window.SupportedWindowModes);
+
             Container resolutionSettingsContainer;
 
             Children = new Drawable[]
@@ -59,7 +63,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 {
                     LabelText = "Screen mode",
                     Bindable = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode),
-                    ItemSource = host.Window?.SupportedWindowModes,
+                    ItemSource = windowModes,
                 },
                 resolutionSettingsContainer = new Container
                 {
@@ -152,6 +156,19 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
                 scalingSettings.ForEach(s => s.TransferValueOnCommit = mode.NewValue == ScalingMode.Everything);
             }, true);
+
+            windowModes.ItemsAdded += _ => windowModesChanged();
+            windowModes.ItemsRemoved += _ => windowModesChanged();
+
+            windowModesChanged();
+        }
+
+        private void windowModesChanged()
+        {
+            if (windowModes.Count() > 1)
+                windowModeDropdown.Show();
+            else
+                windowModeDropdown.Hide();
         }
 
         /// <summary>

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -11,6 +11,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Platform;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -29,7 +30,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private OsuGameBase game;
         private SettingsDropdown<Size> resolutionDropdown;
-        private SettingsEnumDropdown<WindowMode> windowModeDropdown;
+        private SettingsDropdown<WindowMode> windowModeDropdown;
 
         private Bindable<float> scalingPositionX;
         private Bindable<float> scalingPositionY;
@@ -39,7 +40,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
         private const int transition_duration = 400;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager config, OsuConfigManager osuConfig, OsuGameBase game)
+        private void load(FrameworkConfigManager config, OsuConfigManager osuConfig, OsuGameBase game, GameHost host)
         {
             this.game = game;
 
@@ -54,10 +55,11 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
             Children = new Drawable[]
             {
-                windowModeDropdown = new SettingsEnumDropdown<WindowMode>
+                windowModeDropdown = new SettingsDropdown<WindowMode>
                 {
                     LabelText = "Screen mode",
                     Bindable = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode),
+                    ItemSource = host.Window.SupportedWindowModes,
                 },
                 resolutionSettingsContainer = new Container
                 {

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 {
                     LabelText = "Screen mode",
                     Bindable = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode),
-                    ItemSource = host.Window.SupportedWindowModes,
+                    ItemSource = host.Window?.SupportedWindowModes,
                 },
                 resolutionSettingsContainer = new Container
                 {

--- a/osu.Game/Overlays/Settings/SettingsDropdown.cs
+++ b/osu.Game/Overlays/Settings/SettingsDropdown.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 
@@ -26,11 +27,25 @@ namespace osu.Game.Overlays.Settings
             }
         }
 
+        private IBindableList<T> itemSource;
+
+        public IBindableList<T> ItemSource
+        {
+            get => itemSource;
+            set
+            {
+                itemSource = value;
+
+                if (Control != null)
+                    Control.ItemSource = value;
+            }
+        }
+
         public override IEnumerable<string> FilterTerms => base.FilterTerms.Concat(Control.Items.Select(i => i.ToString()));
 
         protected sealed override Drawable CreateControl() => CreateDropdown();
 
-        protected virtual OsuDropdown<T> CreateDropdown() => new DropdownControl { Items = Items };
+        protected virtual OsuDropdown<T> CreateDropdown() => new DropdownControl { Items = Items, ItemSource = ItemSource };
 
         protected class DropdownControl : OsuDropdown<T>
         {


### PR DESCRIPTION
Currently has an issue where "revert to default" is always visible on iOS (but does nothing).  Can be fixed by setting the `Default` for the bindable on the framework side to `DefaultWindowMode`.