### PR TITLE
Ensure all OsuFocusedOverlayContainers contribute to screen fading

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -24,7 +24,11 @@ namespace osu.Game.Graphics.Containers
 
         protected override bool BlockNonPositionalInput => true;
 
-        private PreviewTrackManager previewTrackManager;
+        [Resolved(CanBeNull = true)]
+        private OsuGame osuGame { get; set; }
+
+        [Resolved]
+        private PreviewTrackManager previewTrackManager { get; set; }
 
         protected readonly Bindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
@@ -36,10 +40,8 @@ namespace osu.Game.Graphics.Containers
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuGame osuGame, AudioManager audio, PreviewTrackManager previewTrackManager)
+        private void load(AudioManager audio)
         {
-            this.previewTrackManager = previewTrackManager;
-
             if (osuGame != null)
                 OverlayActivationMode.BindTo(osuGame.OverlayActivationMode);
 
@@ -93,6 +95,7 @@ namespace osu.Game.Graphics.Containers
                     if (OverlayActivationMode.Value != OverlayActivation.Disabled)
                     {
                         if (PlaySamplesOnStateChange) samplePopIn?.Play();
+                        if (BlockScreenWideMouse) osuGame?.AddBlockingOverlay(this);
                     }
                     else
                         State = Visibility.Hidden;
@@ -100,6 +103,7 @@ namespace osu.Game.Graphics.Containers
                     break;
                 case Visibility.Hidden:
                     if (PlaySamplesOnStateChange) samplePopOut?.Play();
+                    if (BlockScreenWideMouse) osuGame?.RemoveBlockingOverlay(this);
                     break;
             }
         }
@@ -108,6 +112,12 @@ namespace osu.Game.Graphics.Containers
         {
             base.PopOut();
             previewTrackManager.StopAnyPlaying(this);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            osuGame?.RemoveBlockingOverlay(this);
         }
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -142,8 +142,7 @@ namespace osu.Game
 
         public void RemoveBlockingOverlay(OverlayContainer overlay)
         {
-            if (visibleBlockingOverlays.Contains(overlay))
-                visibleBlockingOverlays.Remove(overlay);
+            visibleBlockingOverlays.Remove(overlay);
             updateBlockingOverlayFade();
         }
 


### PR DESCRIPTION
Fixes LoginOverlay not dimming the screen, etc.

Currently the only focused overlays extending `FocusedOverlayContainer` rather than `OsuFocusedOverlayContainer` are `MatchSettingsOverlay` and `MedalOverlay`, neither of which currently contribute to screen dimming.

The only `OsuFocusedOverlayContainer` that should not contribute to screen dimming is `BeatmapOptionsOverlay`, which already has `BlockScreenWideMouse => false`.

None of these situations should cause a regression.