### PR TITLE
Add 1/4th of a frame of grace time to hyperdash calculation

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestCaseHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseHyperDash.cs
@@ -13,7 +13,9 @@ namespace osu.Game.Rulesets.Catch.Tests
     public class TestCaseHyperDash : Game.Tests.Visual.TestCasePlayer
     {
         public TestCaseHyperDash()
-            : base(new CatchRuleset()) { }
+            : base(new CatchRuleset())
+        {
+        }
 
         protected override IBeatmap CreateBeatmap(Ruleset ruleset)
         {

--- a/osu.Game.Rulesets.Catch.Tests/TestCaseHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseHyperDash.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
@@ -11,19 +13,34 @@ namespace osu.Game.Rulesets.Catch.Tests
     public class TestCaseHyperDash : Game.Tests.Visual.TestCasePlayer
     {
         public TestCaseHyperDash()
-            : base(new CatchRuleset())
-        {
-        }
+            : base(new CatchRuleset()) { }
 
         protected override IBeatmap CreateBeatmap(Ruleset ruleset)
         {
-            var beatmap = new Beatmap { BeatmapInfo = { Ruleset = ruleset.RulesetInfo } };
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo =
+                {
+                    Ruleset = ruleset.RulesetInfo,
+                    BaseDifficulty = new BeatmapDifficulty { CircleSize = 3.6f }
+                }
+            };
+
+            // Should produce a hperdash
+            beatmap.HitObjects.Add(new Fruit { StartTime = 816, X = 308 / 512f, NewCombo = true });
+            beatmap.HitObjects.Add(new Fruit { StartTime = 1008, X = 56 / 512f, });
 
             for (int i = 0; i < 512; i++)
                 if (i % 5 < 3)
-                    beatmap.HitObjects.Add(new Fruit { X = i % 10 < 5 ? 0.02f : 0.98f, StartTime = i * 100, NewCombo = i % 8 == 0 });
+                    beatmap.HitObjects.Add(new Fruit { X = i % 10 < 5 ? 0.02f : 0.98f, StartTime = 2000 + i * 100, NewCombo = i % 8 == 0 });
 
             return beatmap;
+        }
+
+        protected override void AddCheckSteps(Func<Player> player)
+        {
+            base.AddCheckSteps(player);
+            AddAssert("First note is hyperdash", () => Beatmap.Value.Beatmap.HitObjects[0] is Fruit f && f.HyperDash);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 CatchHitObject nextObject = objectWithDroplets[i + 1];
 
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
-                double timeToNext = nextObject.StartTime - currentObject.StartTime;
+                double timeToNext = nextObject.StartTime - currentObject.StartTime - 1000f / 60f / 4; // 4 frames of grace time, taken from osu-stable
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
                 float distanceToHyper = (float)(timeToNext * CatcherArea.Catcher.BASE_SPEED - distanceToNext);
                 if (distanceToHyper < 0)

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 CatchHitObject nextObject = objectWithDroplets[i + 1];
 
                 int thisDirection = nextObject.X > currentObject.X ? 1 : -1;
-                double timeToNext = nextObject.StartTime - currentObject.StartTime - 1000f / 60f / 4; // 4 frames of grace time, taken from osu-stable
+                double timeToNext = nextObject.StartTime - currentObject.StartTime - 1000f / 60f / 4; // 1/4th of a frame of grace time, taken from osu-stable
                 double distanceToNext = Math.Abs(nextObject.X - currentObject.X) - (lastDirection == thisDirection ? lastExcess : halfCatcherWidth);
                 float distanceToHyper = (float)(timeToNext * CatcherArea.Catcher.BASE_SPEED - distanceToNext);
                 if (distanceToHyper < 0)


### PR DESCRIPTION
Stable adds 1/4th of a frame (assuming 60fps) to timeToNext during hyperdash calculations. Lazer did not do this.

Fixes #4385