### PR TITLE
Fix gameplay cursor discrepancies

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestCaseGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseGameplayCursor.cs
@@ -16,18 +16,18 @@ namespace osu.Game.Rulesets.Osu.Tests
     [TestFixture]
     public class TestCaseGameplayCursor : OsuTestCase, IProvideCursor
     {
-        private GameplayCursor cursor;
+        private GameplayCursorContainer cursorContainer;
 
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(CursorTrail) };
 
-        public CursorContainer Cursor => cursor;
+        public CursorContainer Cursor => cursorContainer;
 
         public bool ProvidingUserCursor => true;
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(cursor = new GameplayCursor { RelativeSizeAxes = Axes.Both });
+            Add(cursorContainer = new GameplayCursorContainer { RelativeSizeAxes = Axes.Both });
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Cursor;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
@@ -20,7 +19,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private class OsuPlayfieldNoCursor : OsuPlayfield
         {
-            protected override CursorContainer CreateCursor() => null;
+            public OsuPlayfieldNoCursor()
+            {
+                Cursor?.Expire();
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuEditRulesetContainer.cs
@@ -16,8 +16,11 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        protected override CursorContainer CreateCursor() => null;
+        protected override Playfield CreatePlayfield() => new OsuPlayfieldNoCursor { Size = Vector2.One　};
 
-        protected override Playfield CreatePlayfield() => new OsuPlayfield { Size = Vector2.One　};
+        private class OsuPlayfieldNoCursor : OsuPlayfield
+        {
+            protected override CursorContainer CreateCursor() => null;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursorContainer.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             public OsuCursor()
             {
                 Origin = Anchor.Centre;
-                Size = new Vector2(42);
+                Size = new Vector2(28);
             }
 
             protected override void SkinChanged(ISkinSource skin, bool allowFallback)

--- a/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/GameplayCursorContainer.cs
@@ -17,7 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.UI.Cursor
 {
-    public class GameplayCursor : CursorContainer, IKeyBindingHandler<OsuAction>
+    public class GameplayCursorContainer : CursorContainer, IKeyBindingHandler<OsuAction>
     {
         protected override Drawable CreateCursor() => new OsuCursor();
 
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private readonly Container<Drawable> fadeContainer;
 
-        public GameplayCursor()
+        public GameplayCursorContainer()
         {
             InternalChild = fadeContainer = new Container
             {

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
 using osu.Game.Rulesets.UI;
 using System.Linq;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 
@@ -23,6 +24,12 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public static readonly Vector2 BASE_SIZE = new Vector2(512, 384);
 
+        private readonly PlayfieldAdjustmentContainer adjustmentContainer;
+
+        protected override Container CursorTargetContainer => adjustmentContainer;
+
+        protected override CursorContainer CreateCursor() => new GameplayCursorContainer();
+
         public OsuPlayfield()
         {
             Anchor = Anchor.Centre;
@@ -30,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
             Size = new Vector2(0.75f);
 
-            InternalChild = new PlayfieldAdjustmentContainer
+            InternalChild = adjustmentContainer = new PlayfieldAdjustmentContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
@@ -51,7 +58,6 @@ namespace osu.Game.Rulesets.Osu.UI
                         RelativeSizeAxes = Axes.Both,
                         Depth = -1,
                     },
-                    Cursor = new GameplayCursorContainer(),
                 }
             };
         }

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -10,7 +10,6 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
 using osu.Game.Rulesets.UI;
 using System.Linq;
-using osu.Framework.Graphics.Cursor;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 
@@ -36,7 +35,6 @@ namespace osu.Game.Rulesets.Osu.UI
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    Cursor,
                     connectionLayer = new FollowPointRenderer
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -53,11 +51,10 @@ namespace osu.Game.Rulesets.Osu.UI
                         RelativeSizeAxes = Axes.Both,
                         Depth = -1,
                     },
+                    Cursor = new GameplayCursorContainer(),
                 }
             };
         }
-
-        protected override CursorContainer CreateCursor() => new GameplayCursorContainer();
 
         public override void Add(DrawableHitObject h)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -10,7 +10,9 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
 using osu.Game.Rulesets.UI;
 using System.Linq;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.UI.Cursor;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -34,6 +36,7 @@ namespace osu.Game.Rulesets.Osu.UI
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
+                    Cursor,
                     connectionLayer = new FollowPointRenderer
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -53,6 +56,8 @@ namespace osu.Game.Rulesets.Osu.UI
                 }
             };
         }
+
+        protected override CursorContainer CreateCursor() => new GameplayCursorContainer();
 
         public override void Add(DrawableHitObject h)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuRulesetContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuRulesetContainer.cs
@@ -60,6 +60,6 @@ namespace osu.Game.Rulesets.Osu.UI
             }
         }
 
-        protected override CursorContainer CreateCursor() => new GameplayCursor();
+        protected override CursorContainer CreateCursor() => new GameplayCursorContainer();
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/OsuRulesetContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuRulesetContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
@@ -13,7 +12,6 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.Scoring;
-using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 
@@ -59,7 +57,5 @@ namespace osu.Game.Rulesets.Osu.UI
                 return first.StartTime - first.TimePreempt;
             }
         }
-
-        protected override CursorContainer CreateCursor() => new GameplayCursorContainer();
     }
 }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -56,10 +56,6 @@ namespace osu.Game.Rulesets.UI
             RelativeSizeAxes = Axes.Both;
 
             hitObjectContainerLazy = new Lazy<HitObjectContainer>(CreateHitObjectContainer);
-
-            Cursor = CreateCursor();
-            if (Cursor != null)
-                CursorTargetContainer.Add(Cursor);
         }
 
         private WorkingBeatmap beatmap;
@@ -68,6 +64,10 @@ namespace osu.Game.Rulesets.UI
         private void load(IBindable<WorkingBeatmap> beatmap)
         {
             this.beatmap = beatmap.Value;
+
+            Cursor = CreateCursor();
+            if (Cursor != null)
+                CursorTargetContainer.Add(Cursor);
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -48,8 +48,6 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         public readonly BindableBool DisplayJudgements = new BindableBool(true);
 
-        public readonly BindableBool HasReplayLoaded = new BindableBool();
-
         /// <summary>
         /// Creates a new <see cref="Playfield"/>.
         /// </summary>

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osuTK;
@@ -47,6 +48,8 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         public readonly BindableBool DisplayJudgements = new BindableBool(true);
 
+        public readonly BindableBool HasReplayLoaded = new BindableBool();
+
         /// <summary>
         /// Creates a new <see cref="Playfield"/>.
         /// </summary>
@@ -55,6 +58,8 @@ namespace osu.Game.Rulesets.UI
             RelativeSizeAxes = Axes.Both;
 
             hitObjectContainerLazy = new Lazy<HitObjectContainer>(CreateHitObjectContainer);
+
+            Cursor = CreateCursor();
         }
 
         private WorkingBeatmap beatmap;
@@ -81,6 +86,16 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         /// <param name="h">The DrawableHitObject to remove.</param>
         public virtual bool Remove(DrawableHitObject h) => HitObjectContainer.Remove(h);
+
+        /// <summary>
+        /// Creates the cursor. May be null if no cursor is required.
+        /// </summary>
+        protected virtual CursorContainer CreateCursor() => null;
+
+        /// <summary>
+        /// The cursor provided by this <see cref="RulesetContainer"/>. May be null if no cursor is provided.
+        /// </summary>
+        public CursorContainer Cursor { get; }
 
         /// <summary>
         /// Registers a <see cref="Playfield"/> as a nested <see cref="Playfield"/>.

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -58,8 +58,6 @@ namespace osu.Game.Rulesets.UI
             RelativeSizeAxes = Axes.Both;
 
             hitObjectContainerLazy = new Lazy<HitObjectContainer>(CreateHitObjectContainer);
-
-            Cursor = CreateCursor();
         }
 
         private WorkingBeatmap beatmap;
@@ -88,14 +86,9 @@ namespace osu.Game.Rulesets.UI
         public virtual bool Remove(DrawableHitObject h) => HitObjectContainer.Remove(h);
 
         /// <summary>
-        /// Creates the cursor. May be null if no cursor is required.
+        /// The cursor currently being used by this <see cref="Playfield"/>. May be null if no cursor is provided.
         /// </summary>
-        protected virtual CursorContainer CreateCursor() => null;
-
-        /// <summary>
-        /// The cursor provided by this <see cref="RulesetContainer"/>. May be null if no cursor is provided.
-        /// </summary>
-        public CursorContainer Cursor { get; }
+        public CursorContainer Cursor { get; protected set; }
 
         /// <summary>
         /// Registers a <see cref="Playfield"/> as a nested <see cref="Playfield"/>.

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -56,6 +56,10 @@ namespace osu.Game.Rulesets.UI
             RelativeSizeAxes = Axes.Both;
 
             hitObjectContainerLazy = new Lazy<HitObjectContainer>(CreateHitObjectContainer);
+
+            Cursor = CreateCursor();
+            if (Cursor != null)
+                CursorTargetContainer.Add(Cursor);
         }
 
         private WorkingBeatmap beatmap;
@@ -86,7 +90,19 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// The cursor currently being used by this <see cref="Playfield"/>. May be null if no cursor is provided.
         /// </summary>
-        public CursorContainer Cursor { get; protected set; }
+        public CursorContainer Cursor { get; private set; }
+
+        /// <summary>
+        /// Provide an optional cursor which is to be used for gameplay.
+        /// If providing a cursor, <see cref="CursorTargetContainer"/> must also point to a valid target container.
+        /// </summary>
+        /// <returns>The cursor, or null if a cursor is not rqeuired.</returns>
+        protected virtual CursorContainer CreateCursor() => null;
+
+        /// <summary>
+        /// The target container to add the cursor after it is created.
+        /// </summary>
+        protected virtual Container CursorTargetContainer => null;
 
         /// <summary>
         /// Registers a <see cref="Playfield"/> as a nested <see cref="Playfield"/>.

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -16,7 +16,9 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
+using osu.Framework.Input.Events;
 using osu.Game.Configuration;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Input.Handlers;
 using osu.Game.Overlays;
 using osu.Game.Replays;
@@ -32,7 +34,7 @@ namespace osu.Game.Rulesets.UI
     /// Should not be derived - derive <see cref="RulesetContainer{TObject}"/> instead.
     /// </para>
     /// </summary>
-    public abstract class RulesetContainer : Container
+    public abstract class RulesetContainer : Container, IProvideCursor
     {
         /// <summary>
         /// The selected variant.
@@ -77,7 +79,11 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// The cursor provided by this <see cref="RulesetContainer"/>. May be null if no cursor is provided.
         /// </summary>
-        public readonly CursorContainer Cursor;
+        public CursorContainer Cursor { get; }
+
+        public bool ProvidingUserCursor => Cursor != null && !HasReplayLoaded.Value;
+
+        protected override bool OnHover(HoverEvent e) => true; // required for IProvideCursor
 
         public readonly Ruleset Ruleset;
 

--- a/osu.Game/Rulesets/UI/RulesetContainer.cs
+++ b/osu.Game/Rulesets/UI/RulesetContainer.cs
@@ -76,12 +76,9 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         public Container Overlays { get; protected set; }
 
-        /// <summary>
-        /// The cursor provided by this <see cref="RulesetContainer"/>. May be null if no cursor is provided.
-        /// </summary>
-        public CursorContainer Cursor { get; }
+        public CursorContainer Cursor => Playfield.Cursor;
 
-        public bool ProvidingUserCursor => Cursor != null && !HasReplayLoaded.Value;
+        public bool ProvidingUserCursor => Playfield.Cursor != null && !HasReplayLoaded.Value;
 
         protected override bool OnHover(HoverEvent e) => true; // required for IProvideCursor
 
@@ -107,8 +104,6 @@ namespace osu.Game.Rulesets.UI
 
                 KeyBindingInputManager.UseParentInput = !paused.NewValue;
             };
-
-            Cursor = CreateCursor();
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -264,9 +259,6 @@ namespace osu.Game.Rulesets.UI
                 },
                 Playfield
             });
-
-            if (Cursor != null)
-                KeyBindingInputManager.Add(Cursor);
 
             InternalChildren = new Drawable[]
             {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -193,10 +193,6 @@ namespace osu.Game.Screens.Play
                             Origin = Anchor.Centre,
                             Breaks = beatmap.Breaks
                         },
-                        new ScalingContainer(ScalingMode.Gameplay)
-                        {
-                            Child = RulesetContainer.Cursor?.CreateProxy() ?? new Container(),
-                        },
                         HUDOverlay = new HUDOverlay(ScoreProcessor, RulesetContainer, working, adjustableClock)
                         {
                             Anchor = Anchor.Centre,

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -11,7 +11,6 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
@@ -20,7 +19,6 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Cursor;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
@@ -34,7 +32,7 @@ using osu.Game.Storyboards.Drawables;
 
 namespace osu.Game.Screens.Play
 {
-    public class Player : ScreenWithBeatmapBackground, IProvideCursor
+    public class Player : ScreenWithBeatmapBackground
     {
         protected override bool AllowBackButton => false; // handled by HoldForMenuButton
 
@@ -58,9 +56,6 @@ namespace osu.Game.Screens.Play
         private readonly Bindable<bool> storyboardReplacesBackground = new Bindable<bool>();
 
         public int RestartCount;
-
-        public CursorContainer Cursor => RulesetContainer.Cursor;
-        public bool ProvidingUserCursor => RulesetContainer?.Cursor != null && !RulesetContainer.HasReplayLoaded.Value;
 
         private IAdjustableClock sourceClock;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Screens.Play
                     OnRetry = restart,
                     OnQuit = performUserRequestedExit,
                     CheckCanPause = () => AllowPause && ValidForResume && !HasFailed && !RulesetContainer.HasReplayLoaded.Value,
-                    Children = new Container[]
+                    Children = new[]
                     {
                         StoryboardContainer = CreateStoryboardContainer(),
                         new ScalingContainer(ScalingMode.Gameplay)
@@ -193,6 +193,8 @@ namespace osu.Game.Screens.Play
                             Origin = Anchor.Centre,
                             Breaks = beatmap.Breaks
                         },
+                        // display the cursor above some HUD elements.
+                        RulesetContainer.Cursor?.CreateProxy() ?? new Container(),
                         HUDOverlay = new HUDOverlay(ScoreProcessor, RulesetContainer, working, adjustableClock)
                         {
                             Anchor = Anchor.Centre,


### PR DESCRIPTION
- [x] Depends on #4410 (to fix scaling bounds handling).
- [x] Depends on https://github.com/ppy/osu-framework/pull/2219 (to fix paused handling).
- Closes #4406.

This change moves the ruleset's cursor from `RulesetContainer` to `Playfield`. The reasoning for this is to allow the cursor to skin, scale and move relative to the underlying gameplay.

- Adjusts size accordingly, as the cursor is now inside the `PlayfieldAdjustmentContainer`. This was done based on visual inspection.
- Delegates cursor creation to the `Playfield` implementation. `Playfield`s must now set `Cursor = theirCursor` when providing a cursor.
- `IProvideCursor` is now handled at the `RulesetContainer` level. It cannot be at the `Playfield` level due to the `RulesetInputManager` interrupting the traversal `HoveredDrawables` lookup logic.