### PR TITLE
Fix RoomInspector image inadvertently changing when cancelling MP room creation

### DIFF
--- a/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
@@ -107,6 +107,14 @@ namespace osu.Game.Screens.Multi.Lounge
             Filter.Search.HoldFocus = false;
         }
 
+        public override void OnResuming(IScreen last)
+        {
+            base.OnResuming(last);
+
+            if (currentRoom.Value?.RoomID.Value == null)
+                currentRoom.Value = new Room();
+        }
+
         private void joinRequested(Room room)
         {
             processingOverlay.Show();

--- a/osu.Game/Screens/Multi/Match/Components/Header.cs
+++ b/osu.Game/Screens/Multi/Match/Components/Header.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -13,6 +14,7 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays.SearchableList;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Multi.Components;
 using osu.Game.Screens.Play.HUD;
 using osuTK;
@@ -108,7 +110,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                 },
             };
 
-            CurrentItem.BindValueChanged(item => modDisplay.Current.Value = item.NewValue?.RequiredMods, true);
+            CurrentItem.BindValueChanged(item => modDisplay.Current.Value = item.NewValue?.RequiredMods ?? Enumerable.Empty<Mod>(), true);
 
             beatmapButton.Action = () => RequestBeatmapSelection?.Invoke();
         }

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -53,6 +53,9 @@ namespace osu.Game.Screens.Multi.Match
 
         private MatchLeaderboard leaderboard;
 
+        [Resolved]
+        private Bindable<Room> currentRoom { get; set; }
+
         public MatchSubScreen(Room room)
         {
             Title = room.RoomID.Value == null ? "New room" : room.Name.Value;
@@ -182,6 +185,10 @@ namespace osu.Game.Screens.Multi.Match
         public override bool OnExiting(IScreen next)
         {
             RoomManager?.PartRoom();
+
+            if (roomId.Value == null)
+                currentRoom.Value = new Room();
+
             return base.OnExiting(next);
         }
 

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -53,9 +53,6 @@ namespace osu.Game.Screens.Multi.Match
 
         private MatchLeaderboard leaderboard;
 
-        [Resolved]
-        private Bindable<Room> currentRoom { get; set; }
-
         public MatchSubScreen(Room room)
         {
             Title = room.RoomID.Value == null ? "New room" : room.Name.Value;
@@ -185,10 +182,6 @@ namespace osu.Game.Screens.Multi.Match
         public override bool OnExiting(IScreen next)
         {
             RoomManager?.PartRoom();
-
-            if (roomId.Value == null)
-                currentRoom.Value = new Room();
-
             return base.OnExiting(next);
         }
 

--- a/osu.Game/Screens/Select/MatchSongSelect.cs
+++ b/osu.Game/Screens/Select/MatchSongSelect.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -61,7 +62,7 @@ namespace osu.Game.Screens.Select
                 return true;
 
             Beatmap.Value = beatmaps.GetWorkingBeatmap(CurrentItem.Value?.Beatmap);
-            Beatmap.Value.Mods.Value = selectedMods.Value = CurrentItem.Value?.RequiredMods;
+            Beatmap.Value.Mods.Value = selectedMods.Value = CurrentItem.Value?.RequiredMods ?? Enumerable.Empty<Mod>();
             Ruleset.Value = CurrentItem.Value?.Ruleset;
 
             Beatmap.Disabled = true;


### PR DESCRIPTION
- [x] Depends on #4419 to fix the changing sprite flashing to the selected beatmap and back again that this PR introduces

Fixes #4309