### PR TITLE
Account for path width correctly in LineGraph

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 path = new SmoothPath
                 {
                     Anchor = Anchor.Centre,
-                    PathWidth = 1
+                    PathRadius = 1
                 },
                 marker = new CircularContainer
                 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBody.cs
@@ -21,8 +21,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         public float PathWidth
         {
-            get => path.PathWidth;
-            set => path.PathWidth = value;
+            get => path.PathRadius;
+            set => path.PathRadius = value;
         }
 
         /// <summary>

--- a/osu.Game/Graphics/UserInterface/LineGraph.cs
+++ b/osu.Game/Graphics/UserInterface/LineGraph.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 Masking = true,
                 RelativeSizeAxes = Axes.Both,
-                Child = path = new SmoothPath { RelativeSizeAxes = Axes.Both, PathWidth = 1 }
+                Child = path = new SmoothPath { RelativeSizeAxes = Axes.Both, PathRadius = 1 }
             });
         }
 
@@ -104,8 +104,8 @@ namespace osu.Game.Graphics.UserInterface
             {
                 // Make sure that we are accounting for path width when calculating vertex positions
                 // We need to apply 2x the path radius to account for it because the full diameter of the line accounts into height
-                float x = (i + count - values.Length) / (float)(count - 1) * (DrawWidth - 2 * path.PathWidth);
-                float y = GetYPosition(values[i]) * (DrawHeight - 2 * path.PathWidth);
+                float x = (i + count - values.Length) / (float)(count - 1) * (DrawWidth - 2 * path.PathRadius);
+                float y = GetYPosition(values[i]) * (DrawHeight - 2 * path.PathRadius);
                 path.AddVertex(new Vector2(x, y));
             }
         }

--- a/osu.Game/Graphics/UserInterface/LineGraph.cs
+++ b/osu.Game/Graphics/UserInterface/LineGraph.cs
@@ -102,9 +102,9 @@ namespace osu.Game.Graphics.UserInterface
 
             for (int i = 0; i < values.Length; i++)
             {
-                float x = (i + count - values.Length) / (float)(count - 1) * DrawWidth - 1;
-                float y = GetYPosition(values[i]) * DrawHeight - 1;
-                // the -1 is for inner offset in path (actually -PathWidth)
+                // Make sure that we are accounting for path width when calculating vertex positions
+                float x = (i + count - values.Length) / (float)(count - 1) * (DrawWidth - path.PathWidth);
+                float y = GetYPosition(values[i]) * (DrawHeight - path.PathWidth);
                 path.AddVertex(new Vector2(x, y));
             }
         }

--- a/osu.Game/Graphics/UserInterface/LineGraph.cs
+++ b/osu.Game/Graphics/UserInterface/LineGraph.cs
@@ -103,8 +103,9 @@ namespace osu.Game.Graphics.UserInterface
             for (int i = 0; i < values.Length; i++)
             {
                 // Make sure that we are accounting for path width when calculating vertex positions
-                float x = (i + count - values.Length) / (float)(count - 1) * (DrawWidth - path.PathWidth);
-                float y = GetYPosition(values[i]) * (DrawHeight - path.PathWidth);
+                // We need to apply 2x the path radius to account for it because the full diameter of the line accounts into height
+                float x = (i + count - values.Length) / (float)(count - 1) * (DrawWidth - 2 * path.PathWidth);
+                float y = GetYPosition(values[i]) * (DrawHeight - 2 * path.PathWidth);
                 path.AddVertex(new Vector2(x, y));
             }
         }


### PR DESCRIPTION
~~While this fixes the fact that LineGraphs were not properly accounting for PathWidth, the path seems to be _still_ off by one pixel.~~

~~This seems to be a result of Path trying to account for pathWidth incorrectly, as minY is being set to -1 at a position of 0.~~

- Closes #4163.