### PR TITLE
Ensure import continues if an existing item's online IDs are in a bad state

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -207,6 +207,41 @@ namespace osu.Game.Tests.Beatmaps.IO
             }
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestImportThenDeleteThenImportWithOnlineIDMismatch(bool set)
+        {
+            //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost($"TestImportThenDeleteThenImport-{set}"))
+            {
+                try
+                {
+                    var osu = loadOsu(host);
+
+                    var imported = LoadOszIntoOsu(osu);
+
+                    if (set)
+                        imported.OnlineBeatmapSetID = 1234;
+                    else
+                        imported.Beatmaps.First().OnlineBeatmapID = 1234;
+
+                    osu.Dependencies.Get<BeatmapManager>().Update(imported);
+
+                    deleteBeatmapSet(imported, osu);
+
+                    var importedSecondTime = LoadOszIntoOsu(osu);
+
+                    // check the newly "imported" beatmap has been reimported due to mismatch (even though hashes matched)
+                    Assert.IsTrue(imported.ID != importedSecondTime.ID);
+                    Assert.IsTrue(imported.Beatmaps.First().ID != importedSecondTime.Beatmaps.First().ID);
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
         [Test]
         [NonParallelizable]
         [Ignore("Binding IPC on Appveyor isn't working (port in use). Need to figure out why")]

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -106,7 +106,10 @@ namespace osu.Game.Beatmaps
 
             foreach (BeatmapInfo b in beatmapSet.Beatmaps)
                 fetchAndPopulateOnlineValues(b, beatmapSet.Beatmaps);
+        }
 
+        protected override void PreImport(BeatmapSetInfo beatmapSet)
+        {
             // check if a set already exists with the same online id, delete if it does.
             if (beatmapSet.OnlineBeatmapSetID != null)
             {
@@ -253,6 +256,15 @@ namespace osu.Game.Beatmaps
         /// <param name="query">The query.</param>
         /// <returns>The first result for the provided query, or null if no results were found.</returns>
         public BeatmapSetInfo QueryBeatmapSet(Expression<Func<BeatmapSetInfo, bool>> query) => beatmaps.ConsumableItems.AsNoTracking().FirstOrDefault(query);
+
+        protected override bool CanUndelete(BeatmapSetInfo existing, BeatmapSetInfo import)
+        {
+            if (!base.CanUndelete(existing, import))
+                return false;
+
+            // force re-import if we are not in a sane state.
+            return existing.OnlineBeatmapSetID == import.OnlineBeatmapSetID;
+        }
 
         /// <summary>
         /// Returns a list of all usable <see cref="BeatmapSetInfo"/>s.


### PR DESCRIPTION
Came across a case where an import did not have correct online IDs populated.

This change ensures that on re-import, online IDs are thoroughly checked. Reimports are guaranteed if any discrepancies are found.

This will potentially slow down imports under some very specific scenarios, but for the time being correctness is more important.

- `Populate` is now run before early import exiting due to duplicates (via `CheckForExisting`).

- A new method `CanUndelete` allows control over where an import should be skipped on an item with a matching `Hash`. Returning false will delete the existing database item in favour of the import. This is used by `BeatmapManager` to guarantee online ID correctness.

https://github.com/ppy/osu/blob/3a8c32d41b83cf980eb778ab8a9162c32586ae0c/osu.Game/Database/ArchiveModelManager.cs#L570-L577

- A new method `PreImport` is available to `ArchiveModelManagers` to perform operations just before the database import happens. This allows decoupling sanity operations from `Populate`.

https://github.com/ppy/osu/blob/3a8c32d41b83cf980eb778ab8a9162c32586ae0c/osu.Game/Database/ArchiveModelManager.cs#L555-L561

