### PR TITLE
Further fixes to catch HR application

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Catch.Mods
         private void applyRandomOffset(ref float position, double maxOffset)
         {
             bool right = RNG.NextBool();
-            float rand = Math.Min(20, (float)RNG.NextDouble(0, maxOffset)) / CatchPlayfield.BASE_WIDTH;
+            float rand = Math.Min(20, (float)RNG.NextDouble(0, Math.Max(0, maxOffset))) / CatchPlayfield.BASE_WIDTH;
 
             if (right)
             {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHardRock.cs
@@ -20,6 +20,13 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         public void ApplyToHitObject(HitObject hitObject)
         {
+            if (hitObject is JuiceStream stream)
+            {
+                lastPosition = stream.EndX;
+                lastStartTime = stream.EndTime;
+                return;
+            }
+
             if (!(hitObject is Fruit))
                 return;
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/2269

JuiceStreams don't go through `WarpSpacing` so this code was missed.