### PR TITLE
Fix mods being reused for difficulty calculation

### DIFF
--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -57,9 +57,9 @@ namespace osu.Game.Rulesets.Difficulty
             foreach (var combination in CreateDifficultyAdjustmentModCombinations())
             {
                 if (combination is MultiMod multi)
-                    yield return Calculate(multi.Mods.Select(m => m.CreateCopy()).ToArray());
+                    yield return Calculate(multi.Mods);
                 else
-                    yield return Calculate(combination.CreateCopy());
+                    yield return Calculate(combination);
             }
         }
 

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Rulesets.Difficulty
         /// <returns>A structure describing the difficulty of the beatmap.</returns>
         public DifficultyAttributes Calculate(params Mod[] mods)
         {
+            mods = mods.Select(m => m.CreateCopy()).ToArray();
+
             beatmap.Mods.Value = mods;
             IBeatmap playableBeatmap = beatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
 
@@ -55,9 +57,9 @@ namespace osu.Game.Rulesets.Difficulty
             foreach (var combination in CreateDifficultyAdjustmentModCombinations())
             {
                 if (combination is MultiMod multi)
-                    yield return Calculate(multi.Mods);
+                    yield return Calculate(multi.Mods.Select(m => m.CreateCopy()).ToArray());
                 else
-                    yield return Calculate(combination);
+                    yield return Calculate(combination.CreateCopy());
             }
         }
 

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -65,5 +65,10 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         [JsonIgnore]
         public virtual Type[] IncompatibleMods => new Type[] { };
+
+        /// <summary>
+        /// Creates a copy of this <see cref="Mod"/> initialised to a default state.
+        /// </summary>
+        public virtual Mod CreateCopy() => (Mod)Activator.CreateInstance(GetType());
     }
 }


### PR DESCRIPTION
Due to the statefulness of mods, we need to use fresh mods with each iteration of the difficulty calculator.