### PR TITLE
Add ManualInputManager to screen tests

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestCaseLoungeRoomsContainer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestCaseLoungeRoomsContainer.cs
@@ -27,7 +27,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Cached(Type = typeof(IRoomManager))]
         private TestRoomManager roomManager = new TestRoomManager();
 
-        public TestCaseLoungeRoomsContainer()
+        [BackgroundDependencyLoader]
+        private void load()
         {
             RoomsContainer container;
 

--- a/osu.Game.Tests/Visual/Tournament/TestCaseDrawings.cs
+++ b/osu.Game.Tests/Visual/Tournament/TestCaseDrawings.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using osu.Framework.Allocation;
 using osu.Game.Screens.Tournament;
 using osu.Game.Screens.Tournament.Teams;
 
@@ -11,7 +12,8 @@ namespace osu.Game.Tests.Visual.Tournament
     [Description("for tournament use")]
     public class TestCaseDrawings : ScreenTestCase
     {
-        public TestCaseDrawings()
+        [BackgroundDependencyLoader]
+        private void load()
         {
             LoadScreen(new Drawings
             {

--- a/osu.Game/Tests/Visual/ManualInputManagerTestCase.cs
+++ b/osu.Game/Tests/Visual/ManualInputManagerTestCase.cs
@@ -14,8 +14,7 @@ namespace osu.Game.Tests.Visual
 
         protected ManualInputManagerTestCase()
         {
-            base.Content.Add(InputManager = new ManualInputManager());
-            ReturnUserInput();
+            base.Content.Add(InputManager = new ManualInputManager { UseParentInput = true });
         }
 
         /// <summary>

--- a/osu.Game/Tests/Visual/PlayerTestCase.cs
+++ b/osu.Game/Tests/Visual/PlayerTestCase.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
@@ -23,7 +24,11 @@ namespace osu.Game.Tests.Visual
         protected PlayerTestCase(Ruleset ruleset)
         {
             this.ruleset = ruleset;
+        }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             Add(new Box
             {
                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Tests/Visual/ScreenTestCase.cs
+++ b/osu.Game/Tests/Visual/ScreenTestCase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Screens;
 
@@ -9,11 +10,12 @@ namespace osu.Game.Tests.Visual
     /// <summary>
     /// A test case which can be used to test a screen (that relies on OnEntering being called to execute startup instructions).
     /// </summary>
-    public abstract class ScreenTestCase : OsuTestCase
+    public abstract class ScreenTestCase : ManualInputManagerTestCase
     {
-        private readonly OsuScreenStack stack;
+        private OsuScreenStack stack;
 
-        protected ScreenTestCase()
+        [BackgroundDependencyLoader]
+        private void load()
         {
             Child = stack = new OsuScreenStack { RelativeSizeAxes = Axes.Both };
         }


### PR DESCRIPTION
Generally we want to perform mouse operations on screen tests.

This also moves content initialisation to ctor and other initialisation to bdl where applicable.