### PR TITLE
Don't update gameplay loop while paused

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -36,7 +36,10 @@ namespace osu.Game.Rulesets.UI
         private void load(GameplayClock clock)
         {
             if (clock != null)
+            {
                 parentGameplayClock = clock;
+                gameplayClock.IsPaused.BindTo(clock.IsPaused);
+            }
         }
 
         protected override void LoadComplete()
@@ -68,7 +71,7 @@ namespace osu.Game.Rulesets.UI
         public override bool UpdateSubTree()
         {
             requireMoreUpdateLoops = true;
-            validState = true;
+            validState = !gameplayClock.IsPaused.Value;
 
             int loops = 0;
 

--- a/osu.Game/Screens/Play/GameplayClock.cs
+++ b/osu.Game/Screens/Play/GameplayClock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Timing;
 
 namespace osu.Game.Screens.Play
@@ -16,6 +17,8 @@ namespace osu.Game.Screens.Play
     public class GameplayClock : IFrameBasedClock
     {
         private readonly IFrameBasedClock underlyingClock;
+
+        public readonly BindableBool IsPaused = new BindableBool();
 
         public GameplayClock(IFrameBasedClock underlyingClock)
         {

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -79,6 +79,8 @@ namespace osu.Game.Screens.Play
 
             // the clock to be exposed via DI to children.
             GameplayClock = new GameplayClock(offsetClock);
+
+            GameplayClock.IsPaused.BindTo(IsPaused);
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Prerequisite for resume logic (the gameplay cursor was previously getting state updated even though time was not moving).