### PR TITLE
Fix TestCaseBackgroundScreenBeatmap getting stuck

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
+++ b/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Visual.Background
         public void PlayerLoaderSettingsHoverTest()
         {
             setupUserSettings();
-            AddStep("Start player loader", () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new TestPlayer())));
+            AddStep("Start player loader", () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new TestPlayer { Ready = false })));
             AddUntilStep("Wait for Player Loader to load", () => playerLoader?.IsLoaded ?? false);
             AddAssert("Background retained from song select", () => songSelect.IsBackgroundCurrent());
             AddStep("Trigger background preview", () =>
@@ -255,14 +255,7 @@ namespace osu.Game.Tests.Visual.Background
         {
             setupUserSettings();
 
-            AddStep("Start player loader", () =>
-            {
-                songSelect.Push(playerLoader = new TestPlayerLoader(player = new TestPlayer
-                {
-                    AllowPause = allowPause,
-                    Ready = true,
-                }));
-            });
+            AddStep("Start player loader", () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new TestPlayer { AllowPause = allowPause, })));
             AddUntilStep("Wait for Player Loader to load", () => playerLoader.IsLoaded);
             AddStep("Move mouse to center of screen", () => InputManager.MoveMouseTo(playerLoader.ScreenPos));
             AddUntilStep("Wait for player to load", () => player.IsLoaded);
@@ -351,7 +344,7 @@ namespace osu.Game.Tests.Visual.Background
             public UserDimContainer CurrentStoryboardContainer => StoryboardContainer;
 
             // Whether or not the player should be allowed to load.
-            public bool Ready;
+            public bool Ready = true;
 
             public Bindable<bool> StoryboardEnabled;
             public readonly Bindable<bool> ReplacesBackground = new Bindable<bool>();
@@ -362,10 +355,11 @@ namespace osu.Game.Tests.Visual.Background
             public bool IsStoryboardInvisible() => ((TestUserDimContainer)CurrentStoryboardContainer).CurrentAlpha <= 1;
 
             [BackgroundDependencyLoader]
-            private void load(OsuConfigManager config)
+            private void load(OsuConfigManager config, CancellationToken token)
             {
-                while (!Ready)
+                while (!Ready && !token.IsCancellationRequested)
                     Thread.Sleep(1);
+
                 StoryboardEnabled = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
                 ReplacesBackground.BindTo(Background.StoryboardReplacesBackground);
                 DrawableRuleset.IsPaused.BindTo(IsPaused);

--- a/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
+++ b/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Visual.Background
         public void PlayerLoaderSettingsHoverTest()
         {
             setupUserSettings();
-            AddStep("Start player loader", () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new TestPlayer { Ready = false })));
+            AddStep("Start player loader", () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new TestPlayer { BlockLoad = true })));
             AddUntilStep("Wait for Player Loader to load", () => playerLoader?.IsLoaded ?? false);
             AddAssert("Background retained from song select", () => songSelect.IsBackgroundCurrent());
             AddStep("Trigger background preview", () =>
@@ -344,7 +344,7 @@ namespace osu.Game.Tests.Visual.Background
             public UserDimContainer CurrentStoryboardContainer => StoryboardContainer;
 
             // Whether or not the player should be allowed to load.
-            public bool Ready = true;
+            public bool BlockLoad;
 
             public Bindable<bool> StoryboardEnabled;
             public readonly Bindable<bool> ReplacesBackground = new Bindable<bool>();
@@ -357,7 +357,7 @@ namespace osu.Game.Tests.Visual.Background
             [BackgroundDependencyLoader]
             private void load(OsuConfigManager config, CancellationToken token)
             {
-                while (!Ready && !token.IsCancellationRequested)
+                while (BlockLoad && !token.IsCancellationRequested)
                     Thread.Sleep(1);
 
                 StoryboardEnabled = config.GetBindable<bool>(OsuSetting.ShowStoryboard);


### PR DESCRIPTION
Also inverted the default of the ready flag so that it now defaults to true, and adjusted the test accordingly.

Partial fix for https://github.com/ppy/osu/issues/4499