### PR TITLE
Make main menu elements colorable by skin

### DIFF
--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -18,6 +18,7 @@ using osu.Game.Users;
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Game.Screens.Menu
 {
@@ -86,10 +87,8 @@ namespace osu.Game.Screens.Menu
             user = api.LocalUser.GetBoundCopy();
             skin = skinManager.CurrentSkin.GetBoundCopy();
 
-            user.ValueChanged += _ => changeColour();
-            skin.ValueChanged += _ => changeColour();
-
-            changeColour();
+            user.ValueChanged += _ => updateColour();
+            skin.BindValueChanged(_ => updateColour(), true);
         }
 
         private void updateAmplitudes()
@@ -119,12 +118,14 @@ namespace osu.Game.Screens.Menu
             Scheduler.AddDelayed(updateAmplitudes, time_between_updates);
         }
 
-        private void changeColour()
+        private void updateColour()
         {
+            Color4 defaultColour = Color4.White.Opacity(0.2f);
+
             if (user.Value?.IsSupporter ?? false)
-                AccentColour = skin.Value.GetValue<SkinConfiguration, Color4?>(s => s.CustomColours.ContainsKey("MenuGlow") ? s.CustomColours["MenuGlow"] : (Color4?)null) ?? new Color4(1, 1, 1, 0.2f);
+                AccentColour = skin.Value.GetValue<SkinConfiguration, Color4?>(s => s.CustomColours.ContainsKey("MenuGlow") ? s.CustomColours["MenuGlow"] : (Color4?)null) ?? defaultColour;
             else
-                AccentColour = new Color4(1, 1, 1, 0.2f);
+                AccentColour = defaultColour;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Menu/MenuSideFlashes.cs
+++ b/osu.Game/Screens/Menu/MenuSideFlashes.cs
@@ -12,6 +12,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Skinning;
+using osu.Game.Online.API;
+using osu.Game.Users;
 using System;
 using osu.Framework.Bindables;
 
@@ -32,6 +35,12 @@ namespace osu.Game.Screens.Menu
         private const double box_fade_in_time = 65;
         private const int box_width = 200;
 
+        private Bindable<User> user;
+        private Bindable<Skin> skin;
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
         public MenuSideFlashes()
         {
             EarlyActivationMilliseconds = box_fade_in_time;
@@ -42,13 +51,15 @@ namespace osu.Game.Screens.Menu
         }
 
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours)
+        private void load(IBindable<WorkingBeatmap> beatmap, IAPIProvider api, SkinManager skinManager)
         {
             this.beatmap.BindTo(beatmap);
 
-            // linear colour looks better in this case, so let's use it for now.
-            Color4 gradientDark = colours.Blue.Opacity(0).ToLinear();
-            Color4 gradientLight = colours.Blue.Opacity(0.6f).ToLinear();
+            user = api.LocalUser.GetBoundCopy();
+            skin = skinManager.CurrentSkin.GetBoundCopy();
+
+            user.ValueChanged += _ => changeColour();
+            skin.ValueChanged += _ => changeColour();
 
             Children = new Drawable[]
             {
@@ -62,8 +73,7 @@ namespace osu.Game.Screens.Menu
                     // align off-screen to make sure our edges don't become visible during parallax.
                     X = -box_width,
                     Alpha = 0,
-                    Blending = BlendingMode.Additive,
-                    Colour = ColourInfo.GradientHorizontal(gradientLight, gradientDark)
+                    Blending = BlendingMode.Additive
                 },
                 rightBox = new Box
                 {
@@ -74,10 +84,11 @@ namespace osu.Game.Screens.Menu
                     Height = 1.5f,
                     X = box_width,
                     Alpha = 0,
-                    Blending = BlendingMode.Additive,
-                    Colour = ColourInfo.GradientHorizontal(gradientDark, gradientLight)
+                    Blending = BlendingMode.Additive
                 }
             };
+
+            changeColour();
         }
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
@@ -96,6 +107,23 @@ namespace osu.Game.Screens.Menu
             d.FadeTo(Math.Max(0, ((d.Equals(leftBox) ? amplitudes.LeftChannel : amplitudes.RightChannel) - amplitude_dead_zone) / (kiai ? kiai_multiplier : alpha_multiplier)), box_fade_in_time)
              .Then()
              .FadeOut(beatLength, Easing.In);
+        }
+
+        private void changeColour()
+        {
+            Color4 baseColour;
+
+            if (user.Value?.IsSupporter ?? false)
+                baseColour = skin.Value.GetValue<SkinConfiguration, Color4?>(s => s.CustomColours.ContainsKey("MenuGlow") ? s.CustomColours["MenuGlow"] : (Color4?)null) ?? colours.Blue;
+            else
+                baseColour = colours.Blue;
+
+            // linear colour looks better in this case, so let's use it for now.
+            Color4 gradientDark = baseColour.Opacity(0).ToLinear();
+            Color4 gradientLight = baseColour.Opacity(0.6f).ToLinear();
+
+            leftBox.Colour = ColourInfo.GradientHorizontal(gradientLight, gradientDark);
+            rightBox.Colour = ColourInfo.GradientHorizontal(gradientDark, gradientLight);
         }
     }
 }

--- a/osu.Game/Screens/Menu/MenuSideFlashes.cs
+++ b/osu.Game/Screens/Menu/MenuSideFlashes.cs
@@ -58,9 +58,6 @@ namespace osu.Game.Screens.Menu
             user = api.LocalUser.GetBoundCopy();
             skin = skinManager.CurrentSkin.GetBoundCopy();
 
-            user.ValueChanged += _ => changeColour();
-            skin.ValueChanged += _ => changeColour();
-
             Children = new Drawable[]
             {
                 leftBox = new Box
@@ -88,7 +85,8 @@ namespace osu.Game.Screens.Menu
                 }
             };
 
-            changeColour();
+            user.ValueChanged += _ => updateColour();
+            skin.BindValueChanged(_ => updateColour(), true);
         }
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
@@ -109,14 +107,12 @@ namespace osu.Game.Screens.Menu
              .FadeOut(beatLength, Easing.In);
         }
 
-        private void changeColour()
+        private void updateColour()
         {
-            Color4 baseColour;
+            Color4 baseColour = colours.Blue;
 
             if (user.Value?.IsSupporter ?? false)
-                baseColour = skin.Value.GetValue<SkinConfiguration, Color4?>(s => s.CustomColours.ContainsKey("MenuGlow") ? s.CustomColours["MenuGlow"] : (Color4?)null) ?? colours.Blue;
-            else
-                baseColour = colours.Blue;
+                baseColour = skin.Value.GetValue<SkinConfiguration, Color4?>(s => s.CustomColours.ContainsKey("MenuGlow") ? s.CustomColours["MenuGlow"] : (Color4?)null) ?? baseColour;
 
             // linear colour looks better in this case, so let's use it for now.
             Color4 gradientDark = baseColour.Opacity(0).ToLinear();


### PR DESCRIPTION
Makes use of a Legacy Skin's `MenuGlow` property to set the colors of the visualisation and side flashes.

Preview: 
![image](https://user-images.githubusercontent.com/20495991/55288903-5b918d00-53f1-11e9-8458-87b6ae640659.png)
