### PR TITLE
Avoid presenting beatmap when already at requested beatmap

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -254,6 +254,12 @@ namespace osu.Game
                 if (menuScreen.IsCurrentScreen())
                     menuScreen.LoadToSolo();
 
+                // we might even already be at the song
+                if (Beatmap.Value.BeatmapSetInfo.OnlineBeatmapSetID == beatmap.OnlineBeatmapSetID)
+                {
+                    return;
+                }
+
                 // Use first beatmap available for current ruleset, else switch ruleset.
                 var first = databasedSet.Beatmaps.Find(b => b.Ruleset == ruleset.Value) ?? databasedSet.Beatmaps.First();
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -255,7 +255,7 @@ namespace osu.Game
                     menuScreen.LoadToSolo();
 
                 // we might even already be at the song
-                if (Beatmap.Value.BeatmapSetInfo.OnlineBeatmapSetID == beatmap.OnlineBeatmapSetID)
+                if (Beatmap.Value.BeatmapSetInfo.Hash == databasedSet.Hash)
                 {
                     return;
                 }


### PR DESCRIPTION
We don't have to query the target beatmap if it is already selected. I'm using `OnlineBeatmapSetID` to check if the currently selected beatmap matches the target beatmap, as that seems to be the only UID that is shared between a `BeatmapSetInfo` and a `WorkingBeatmap`. There may exist a better check that I'm unaware of.

This resolves #4575 
