### PR TITLE
Switch NotificationOverlay and LoginOverlay depth order

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -431,7 +431,7 @@ namespace osu.Game
             loadComponentSingleFile(volume = new VolumeOverlay(), leftFloatingOverlayContent.Add);
             loadComponentSingleFile(onscreenDisplay = new OnScreenDisplay(), Add);
 
-            loadComponentSingleFile(loginOverlay = new LoginOverlay
+            loadComponentSingleFile(notifications = new NotificationOverlay
             {
                 GetToolbarHeight = () => ToolbarOffset,
                 Anchor = Anchor.TopRight,
@@ -449,7 +449,7 @@ namespace osu.Game
             loadComponentSingleFile(userProfile = new UserProfileOverlay(), overlayContent.Add);
             loadComponentSingleFile(beatmapSetOverlay = new BeatmapSetOverlay(), overlayContent.Add);
 
-            loadComponentSingleFile(notifications = new NotificationOverlay
+            loadComponentSingleFile(loginOverlay = new LoginOverlay
             {
                 GetToolbarHeight = () => ToolbarOffset,
                 Anchor = Anchor.TopRight,

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -103,6 +103,9 @@ namespace osu.Game.Screens.Menu
         [Resolved(CanBeNull = true)]
         private NotificationOverlay notifications { get; set; }
 
+        [Resolved]
+        private LoginOverlay loginOverlay { get; set; }
+
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, IdleTracker idleTracker, GameHost host)
         {
@@ -134,8 +137,13 @@ namespace osu.Game.Screens.Menu
             {
                 notifications?.Post(new SimpleNotification
                 {
-                    Text = "You gotta be logged in to multi 'yo!",
-                    Icon = FontAwesome.Solid.Globe
+                    Text = "You gotta be logged in to multi 'yo!",                   
+                    Icon = FontAwesome.Solid.Globe,
+                    Activated = () =>
+                    {
+                        loginOverlay.Show();
+                        return true;
+                    }
                 });
 
                 return;

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Screens.Menu
             {
                 notifications?.Post(new SimpleNotification
                 {
-                    Text = "You gotta be logged in to multi 'yo!",                   
+                    Text = "You gotta be logged in to multi 'yo!",
                     Icon = FontAwesome.Solid.Globe,
                     Activated = () =>
                     {

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.Menu
         [Resolved(CanBeNull = true)]
         private NotificationOverlay notifications { get; set; }
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private LoginOverlay loginOverlay { get; set; }
 
         [BackgroundDependencyLoader(true)]
@@ -141,7 +141,7 @@ namespace osu.Game.Screens.Menu
                     Icon = FontAwesome.Solid.Globe,
                     Activated = () =>
                     {
-                        loginOverlay.Show();
+                        loginOverlay?.Show();
                         return true;
                     }
                 });


### PR DESCRIPTION
Closes #4598

| Before  | After |
| ------------- | ------------- |
|![before](https://user-images.githubusercontent.com/20256717/55672183-553f5d00-5898-11e9-94bc-ac16584ba32f.png) | ![after](https://user-images.githubusercontent.com/20256717/55672185-583a4d80-5898-11e9-913b-c14676cf4b2d.png)|

Also, clicking on the notification asking for signing in to play multi now opens the login overlay