### PR TITLE
Remove mods from WorkingBeatmap

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            SelectedMods.Value = SelectedMods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            Mods.Value = Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
             return base.CreatePlayer(ruleset);
         }
     }

--- a/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            Beatmap.Value.Mods.Value = Beatmap.Value.Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            SelectedMods.Value = SelectedMods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
             return base.CreatePlayer(ruleset);
         }
     }

--- a/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestCaseAutoJuiceStream.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            Mods.Value = Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            Mods.Value = Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() }).ToArray();
             return base.CreatePlayer(ruleset);
         }
     }

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch
 {
     public class CatchRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableCatchRuleset(this, beatmap, mods);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods) => new DrawableCatchRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new CatchBeatmapConverter(beatmap);
         public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new CatchBeatmapProcessor(beatmap);
 

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch
 {
     public class CatchRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap) => new DrawableCatchRuleset(this, beatmap);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableCatchRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new CatchBeatmapConverter(beatmap);
         public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new CatchBeatmapProcessor(beatmap);
 

--- a/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         protected override bool UserScrollSpeedAdjustment => false;
 
-        public DrawableCatchRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        public DrawableCatchRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
             Direction.Value = ScrollingDirection.Down;

--- a/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -10,6 +11,7 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawable;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Catch.Scoring;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
@@ -23,8 +25,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
         protected override bool UserScrollSpeedAdjustment => false;
 
-        public DrawableCatchRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            : base(ruleset, beatmap)
+        public DrawableCatchRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            : base(ruleset, beatmap, mods)
         {
             Direction.Value = ScrollingDirection.Down;
             TimeRange.Value = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.ApproachRate, 1800, 1200, 450);

--- a/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestCase.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestCase.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -8,6 +10,7 @@ using osu.Framework.Timing;
 using osu.Game.Rulesets.Mania.Edit;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Tests.Visual;
@@ -20,6 +23,9 @@ namespace osu.Game.Rulesets.Mania.Tests
     public abstract class ManiaPlacementBlueprintTestCase : PlacementBlueprintTestCase, IManiaHitObjectComposer
     {
         private readonly Column column;
+
+        [Cached(typeof(IReadOnlyList<Mod>))]
+        private IReadOnlyList<Mod> mods { get; set; } = Array.Empty<Mod>();
 
         protected ManiaPlacementBlueprintTestCase()
         {

--- a/osu.Game.Rulesets.Mania.Tests/TestCaseColumn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestCaseColumn.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mania.UI.Components;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -30,6 +31,9 @@ namespace osu.Game.Rulesets.Mania.Tests
             typeof(ColumnKeyArea),
             typeof(ColumnHitObjectArea)
         };
+
+        [Cached(typeof(IReadOnlyList<Mod>))]
+        private IReadOnlyList<Mod> mods { get; set; } = Array.Empty<Mod>();
 
         private readonly List<Column> columns = new List<Column>();
 

--- a/osu.Game.Rulesets.Mania.Tests/TestCaseStage.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestCaseStage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -13,6 +14,7 @@ using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -23,6 +25,9 @@ namespace osu.Game.Rulesets.Mania.Tests
     public class TestCaseStage : ManiaInputTestCase
     {
         private const int columns = 4;
+
+        [Cached(typeof(IReadOnlyList<Mod>))]
+        private IReadOnlyList<Mod> mods { get; set; } = Array.Empty<Mod>();
 
         private readonly List<ManiaStage> stages = new List<ManiaStage>();
 

--- a/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditRuleset.cs
+++ b/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditRuleset.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Mania.Edit
     {
         public new IScrollingInfo ScrollingInfo => base.ScrollingInfo;
 
-        public DrawableManiaEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        public DrawableManiaEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
         }

--- a/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditRuleset.cs
+++ b/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditRuleset.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osuTK;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 
@@ -14,8 +16,8 @@ namespace osu.Game.Rulesets.Mania.Edit
     {
         public new IScrollingInfo ScrollingInfo => base.ScrollingInfo;
 
-        public DrawableManiaEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            : base(ruleset, beatmap)
+        public DrawableManiaEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            : base(ruleset, beatmap, mods)
         {
         }
 

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
@@ -41,9 +42,9 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         public int TotalColumns => ((ManiaPlayfield)DrawableRuleset.Playfield).TotalColumns;
 
-        protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
+        protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
         {
-            DrawableRuleset = new DrawableManiaEditRuleset(ruleset, beatmap);
+            DrawableRuleset = new DrawableManiaEditRuleset(ruleset, beatmap, mods);
 
             // This is the earliest we can cache the scrolling info to ourselves, before masks are added to the hierarchy and inject it
             dependencies.CacheAs(DrawableRuleset.ScrollingInfo);

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         public int TotalColumns => ((ManiaPlayfield)DrawableRuleset.Playfield).TotalColumns;
 
-        protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
         {
             DrawableRuleset = new DrawableManiaEditRuleset(ruleset, beatmap, mods);
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Mania
 {
     public class ManiaRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap) => new DrawableManiaRuleset(this, beatmap);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableManiaRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new ManiaBeatmapConverter(beatmap);
         public override PerformanceCalculator CreatePerformanceCalculator(WorkingBeatmap beatmap, ScoreInfo score) => new ManiaPerformanceCalculator(this, beatmap, score);
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Mania
 {
     public class ManiaRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableManiaRuleset(this, beatmap, mods);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods) => new DrawableManiaRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new ManiaBeatmapConverter(beatmap);
         public override PerformanceCalculator CreatePerformanceCalculator(WorkingBeatmap beatmap, ScoreInfo score) => new ManiaPerformanceCalculator(this, beatmap, score);
 

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private readonly Bindable<ManiaScrollingDirection> configDirection = new Bindable<ManiaScrollingDirection>();
 
-        public DrawableManiaRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        public DrawableManiaRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
             // Generate the bar lines

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
@@ -39,8 +40,8 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private readonly Bindable<ManiaScrollingDirection> configDirection = new Bindable<ManiaScrollingDirection>();
 
-        public DrawableManiaRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            : base(ruleset, beatmap)
+        public DrawableManiaRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            : base(ruleset, beatmap, mods)
         {
             // Generate the bar lines
             double lastObjectTime = (Objects.LastOrDefault() as IHasEndTime)?.EndTime ?? Objects.LastOrDefault()?.StartTime ?? double.MaxValue;

--- a/osu.Game.Rulesets.Osu.Tests/StackingTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/StackingTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             using (var reader = new StreamReader(stream))
             {
                 var beatmap = Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
-                var converted = new TestWorkingBeatmap(beatmap).GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Enumerable.Empty<Mod>());
+                var converted = new TestWorkingBeatmap(beatmap).GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>());
 
                 var objects = converted.HitObjects.ToList();
 

--- a/osu.Game.Rulesets.Osu.Tests/StackingTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/StackingTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Tests.Beatmaps;
 using Decoder = osu.Game.Beatmaps.Formats.Decoder;
@@ -22,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             using (var reader = new StreamReader(stream))
             {
                 var beatmap = Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
-                var converted = new TestWorkingBeatmap(beatmap).GetPlayableBeatmap(new OsuRuleset().RulesetInfo);
+                var converted = new TestWorkingBeatmap(beatmap).GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Enumerable.Empty<Mod>());
 
                 var objects = converted.HitObjects.ToList();
 

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseHitCircle.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Osu.Tests
         protected override Container<Drawable> Content => content;
 
         private int depthIndex;
-        protected readonly List<Mod> Mods = new List<Mod>();
 
         public TestCaseHitCircle()
         {
@@ -68,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Depth = depthIndex++
             };
 
-            foreach (var mod in Mods.OfType<IApplicableToDrawableHitObjects>())
+            foreach (var mod in Mods.Value.OfType<IApplicableToDrawableHitObjects>())
                 mod.ApplyToDrawableHitObjects(new[] { drawable });
 
             Add(drawable);

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseHitCircleHidden.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseHitCircleHidden.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         public TestCaseHitCircleHidden()
         {
-            Mods.Add(new OsuModHidden());
+            Mods.Value = new[] { new OsuModHidden() };
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseSlider.cs
@@ -44,7 +44,6 @@ namespace osu.Game.Rulesets.Osu.Tests
         protected override Container<Drawable> Content => content;
 
         private int depthIndex;
-        protected readonly List<Mod> Mods = new List<Mod>();
 
         public TestCaseSlider()
         {
@@ -292,7 +291,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Depth = depthIndex++
             };
 
-            foreach (var mod in Mods.OfType<IApplicableToDrawableHitObjects>())
+            foreach (var mod in Mods.Value.OfType<IApplicableToDrawableHitObjects>())
                 mod.ApplyToDrawableHitObjects(new[] { drawable });
 
             drawable.OnNewResult += onNewResult;

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseSliderHidden.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseSliderHidden.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         public TestCaseSliderHidden()
         {
-            Mods.Add(new OsuModHidden());
+            Mods.Value = new[] { new OsuModHidden() };
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseSpinner.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseSpinner.cs
@@ -31,7 +31,6 @@ namespace osu.Game.Rulesets.Osu.Tests
         protected override Container<Drawable> Content => content;
 
         private int depthIndex;
-        protected readonly List<Mod> Mods = new List<Mod>();
 
         public TestCaseSpinner()
         {
@@ -57,7 +56,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Depth = depthIndex++
             };
 
-            foreach (var mod in Mods.OfType<IApplicableToDrawableHitObjects>())
+            foreach (var mod in Mods.Value.OfType<IApplicableToDrawableHitObjects>())
                 mod.ApplyToDrawableHitObjects(new[] { drawable });
 
             Add(drawable);

--- a/osu.Game.Rulesets.Osu.Tests/TestCaseSpinnerHidden.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestCaseSpinnerHidden.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         public TestCaseSpinnerHidden()
         {
-            Mods.Add(new OsuModHidden());
+            Mods.Value = new[] { new OsuModHidden() };
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -10,8 +12,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 {
     public class DrawableOsuEditRuleset : DrawableOsuRuleset
     {
-        public DrawableOsuEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            : base(ruleset, beatmap)
+        public DrawableOsuEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            : base(ruleset, beatmap, mods)
         {
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 {
     public class DrawableOsuEditRuleset : DrawableOsuRuleset
     {
-        public DrawableOsuEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        public DrawableOsuEditRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        protected override DrawableRuleset<OsuHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        protected override DrawableRuleset<OsuHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             => new DrawableOsuEditRuleset(ruleset, beatmap, mods);
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
@@ -23,8 +24,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        protected override DrawableRuleset<OsuHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            => new DrawableOsuEditRuleset(ruleset, beatmap);
+        protected override DrawableRuleset<OsuHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            => new DrawableOsuEditRuleset(ruleset, beatmap, mods);
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]
         {

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu
 {
     public class OsuRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableOsuRuleset(this, beatmap, mods);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods) => new DrawableOsuRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new OsuBeatmapConverter(beatmap);
         public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new OsuBeatmapProcessor(beatmap);
 

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu
 {
     public class OsuRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap) => new DrawableOsuRuleset(this, beatmap);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableOsuRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new OsuBeatmapConverter(beatmap);
         public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new OsuBeatmapProcessor(beatmap);
 

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
@@ -22,8 +24,8 @@ namespace osu.Game.Rulesets.Osu.UI
     {
         protected new OsuRulesetConfigManager Config => (OsuRulesetConfigManager)base.Config;
 
-        public DrawableOsuRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            : base(ruleset, beatmap)
+        public DrawableOsuRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            : base(ruleset, beatmap, mods)
         {
         }
 

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.UI
     {
         protected new OsuRulesetConfigManager Config => (OsuRulesetConfigManager)base.Config;
 
-        public DrawableOsuRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        public DrawableOsuRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
         }

--- a/osu.Game.Rulesets.Taiko.Tests/TestCaseTaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestCaseTaikoPlayfield.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -88,7 +87,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.X,
                 Height = 768,
-                Children = new[] { drawableRuleset = new DrawableTaikoRuleset(new TaikoRuleset(), beatmap, Enumerable.Empty<Mod>()) }
+                Children = new[] { drawableRuleset = new DrawableTaikoRuleset(new TaikoRuleset(), beatmap, Array.Empty<Mod>()) }
             });
         }
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestCaseTaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestCaseTaikoPlayfield.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -11,6 +12,7 @@ using osu.Framework.MathUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Judgements;
@@ -86,7 +88,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.X,
                 Height = 768,
-                Children = new[] { drawableRuleset = new DrawableTaikoRuleset(new TaikoRuleset(), beatmap) }
+                Children = new[] { drawableRuleset = new DrawableTaikoRuleset(new TaikoRuleset(), beatmap, Enumerable.Empty<Mod>()) }
             });
         }
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Taiko
 {
     public class TaikoRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableTaikoRuleset(this, beatmap, mods);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods) => new DrawableTaikoRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new TaikoBeatmapConverter(beatmap);
 
         public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => new[]

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Taiko
 {
     public class TaikoRuleset : Ruleset
     {
-        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap) => new DrawableTaikoRuleset(this, beatmap);
+        public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods) => new DrawableTaikoRuleset(this, beatmap, mods);
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new TaikoBeatmapConverter(beatmap);
 
         public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => new[]

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -16,6 +17,7 @@ using osu.Framework.Input;
 using osu.Game.Configuration;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Taiko.UI
@@ -26,8 +28,8 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         protected override bool UserScrollSpeedAdjustment => false;
 
-        public DrawableTaikoRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            : base(ruleset, beatmap)
+        public DrawableTaikoRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            : base(ruleset, beatmap, mods)
         {
             Direction.Value = ScrollingDirection.Left;
             TimeRange.Value = 7000;

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         protected override bool UserScrollSpeedAdjustment => false;
 
-        public DrawableTaikoRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        public DrawableTaikoRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
             Direction.Value = ScrollingDirection.Left;

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Catch.Beatmaps;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Osu;
@@ -39,7 +40,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 Assert.AreEqual(6, working.BeatmapInfo.BeatmapVersion);
                 Assert.AreEqual(6, working.Beatmap.BeatmapInfo.BeatmapVersion);
-                Assert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapVersion);
+                Assert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Enumerable.Empty<Mod>()).BeatmapInfo.BeatmapVersion);
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
 using NUnit.Framework;
 using osuTK;
@@ -40,7 +41,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 Assert.AreEqual(6, working.BeatmapInfo.BeatmapVersion);
                 Assert.AreEqual(6, working.Beatmap.BeatmapInfo.BeatmapVersion);
-                Assert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Enumerable.Empty<Mod>()).BeatmapInfo.BeatmapVersion);
+                Assert.AreEqual(6, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo, Array.Empty<Mod>()).BeatmapInfo.BeatmapVersion);
             }
         }
 

--- a/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
+++ b/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Tests.Visual.Background
             AddUntilStep("Song select has selection", () => songSelect.Carousel.SelectedBeatmap != null);
             AddStep("Set default user settings", () =>
             {
-                Beatmap.Value.Mods.Value = Beatmap.Value.Mods.Value.Concat(new[] { new OsuModNoFail() });
+                SelectedMods.Value = SelectedMods.Value.Concat(new[] { new OsuModNoFail() });
                 songSelect.DimLevel.Value = 0.7f;
                 songSelect.BlurLevel.Value = 0.4f;
             });

--- a/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
+++ b/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Tests.Visual.Background
             AddUntilStep("Song select has selection", () => songSelect.Carousel.SelectedBeatmap != null);
             AddStep("Set default user settings", () =>
             {
-                SelectedMods.Value = SelectedMods.Value.Concat(new[] { new OsuModNoFail() });
+                Mods.Value = Mods.Value.Concat(new[] { new OsuModNoFail() });
                 songSelect.DimLevel.Value = 0.7f;
                 songSelect.BlurLevel.Value = 0.4f;
             });

--- a/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
+++ b/osu.Game.Tests/Visual/Background/TestCaseBackgroundScreenBeatmap.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Tests.Visual.Background
             AddUntilStep("Song select has selection", () => songSelect.Carousel.SelectedBeatmap != null);
             AddStep("Set default user settings", () =>
             {
-                Mods.Value = Mods.Value.Concat(new[] { new OsuModNoFail() });
+                Mods.Value = Mods.Value.Concat(new[] { new OsuModNoFail() }).ToArray();
                 songSelect.DimLevel.Value = 0.7f;
                 songSelect.BlurLevel.Value = 0.4f;
             });

--- a/osu.Game.Tests/Visual/Gameplay/TestCaseAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseAutoplay.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            Beatmap.Value.Mods.Value = Beatmap.Value.Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            SelectedMods.Value = SelectedMods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
             return new ScoreAccessiblePlayer();
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestCaseAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseAutoplay.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            SelectedMods.Value = SelectedMods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            Mods.Value = Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
             return new ScoreAccessiblePlayer();
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestCaseAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseAutoplay.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            Mods.Value = Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() });
+            Mods.Value = Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() }).ToArray();
             return new ScoreAccessiblePlayer();
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestCaseReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseReplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
 using System.Linq;
 using osu.Game.Rulesets;
@@ -16,7 +17,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, Enumerable.Empty<Mod>());
+            var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, Array.Empty<Mod>());
 
             return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod().CreateReplayScore(beatmap));
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestCaseReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseReplay.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Linq;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
@@ -15,7 +16,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo);
+            var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, Enumerable.Empty<Mod>());
 
             return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod().CreateReplayScore(beatmap));
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestCaseScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseScrollingHitObjects.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Timing;
@@ -22,6 +24,9 @@ namespace osu.Game.Tests.Visual.Gameplay
     public class TestCaseScrollingHitObjects : OsuTestCase
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(Playfield) };
+
+        [Cached(typeof(IReadOnlyList<Mod>))]
+        private IReadOnlyList<Mod> mods { get; set; } = Array.Empty<Mod>();
 
         private readonly ScrollingTestContainer[] scrollContainers = new ScrollingTestContainer[4];
         private readonly TestPlayfield[] playfields = new TestPlayfield[4];

--- a/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
@@ -175,12 +175,12 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("change ruleset", () =>
             {
-                songSelect.CurrentBeatmap.Mods.ValueChanged += onModChange;
+                SelectedMods.ValueChanged += onModChange;
                 songSelect.Ruleset.ValueChanged += onRulesetChange;
 
                 Ruleset.Value = new TaikoRuleset().RulesetInfo;
 
-                songSelect.CurrentBeatmap.Mods.ValueChanged -= onModChange;
+                SelectedMods.ValueChanged -= onModChange;
                 songSelect.Ruleset.ValueChanged -= onRulesetChange;
             });
 

--- a/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
@@ -171,17 +171,17 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("change ruleset", () =>
             {
-                SelectedMods.ValueChanged += onModChange;
+                Mods.ValueChanged += onModChange;
                 songSelect.Ruleset.ValueChanged += onRulesetChange;
 
                 Ruleset.Value = new TaikoRuleset().RulesetInfo;
 
-                SelectedMods.ValueChanged -= onModChange;
+                Mods.ValueChanged -= onModChange;
                 songSelect.Ruleset.ValueChanged -= onRulesetChange;
             });
 
             AddAssert("mods changed before ruleset", () => modChangeIndex < rulesetChangeIndex);
-            AddAssert("empty mods", () => !SelectedMods.Value.Any());
+            AddAssert("empty mods", () => !Mods.Value.Any());
 
             void onModChange(ValueChangedEvent<IEnumerable<Mod>> e) => modChangeIndex = actionIndex++;
             void onRulesetChange(ValueChangedEvent<RulesetInfo> e) => rulesetChangeIndex = actionIndex--;
@@ -214,7 +214,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         private static int importId;
         private int getImportId() => ++importId;
 
-        private void changeMods(params Mod[] mods) => AddStep($"change mods to {string.Join(", ", mods.Select(m => m.Acronym))}", () => SelectedMods.Value = mods);
+        private void changeMods(params Mod[] mods) => AddStep($"change mods to {string.Join(", ", mods.Select(m => m.Acronym))}", () => Mods.Value = mods);
 
         private void changeRuleset(int id) => AddStep($"change ruleset to {id}", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == id));
 

--- a/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
@@ -183,7 +183,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("mods changed before ruleset", () => modChangeIndex < rulesetChangeIndex);
             AddAssert("empty mods", () => !Mods.Value.Any());
 
-            void onModChange(ValueChangedEvent<IEnumerable<Mod>> e) => modChangeIndex = actionIndex++;
+            void onModChange(ValueChangedEvent<IReadOnlyList<Mod>> e) => modChangeIndex = actionIndex++;
             void onRulesetChange(ValueChangedEvent<RulesetInfo> e) => rulesetChangeIndex = actionIndex--;
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestCasePlaySongSelect.cs
@@ -35,10 +35,6 @@ namespace osu.Game.Tests.Visual.SongSelect
         private WorkingBeatmap defaultBeatmap;
         private DatabaseContextFactory factory;
 
-        [Cached]
-        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> selectedMods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
-
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
             typeof(Screens.Select.SongSelect),
@@ -185,7 +181,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
 
             AddAssert("mods changed before ruleset", () => modChangeIndex < rulesetChangeIndex);
-            AddAssert("empty mods", () => !selectedMods.Value.Any());
+            AddAssert("empty mods", () => !SelectedMods.Value.Any());
 
             void onModChange(ValueChangedEvent<IEnumerable<Mod>> e) => modChangeIndex = actionIndex++;
             void onRulesetChange(ValueChangedEvent<RulesetInfo> e) => rulesetChangeIndex = actionIndex--;
@@ -218,7 +214,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         private static int importId;
         private int getImportId() => ++importId;
 
-        private void changeMods(params Mod[] mods) => AddStep($"change mods to {string.Join(", ", mods.Select(m => m.Acronym))}", () => selectedMods.Value = mods);
+        private void changeMods(params Mod[] mods) => AddStep($"change mods to {string.Join(", ", mods.Select(m => m.Acronym))}", () => SelectedMods.Value = mods);
 
         private void changeRuleset(int id) => AddStep($"change ruleset to {id}", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == id));
 

--- a/osu.Game.Tests/Visual/UserInterface/TestCaseMods.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestCaseMods.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private class TestModSelectOverlay : ModSelectOverlay
         {
-            public new Bindable<IEnumerable<Mod>> SelectedMods => base.SelectedMods;
+            public new Bindable<IReadOnlyList<Mod>> SelectedMods => base.SelectedMods;
 
             public ModButton GetModButton(Mod mod)
             {

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Beatmaps
             {
                 public override IEnumerable<Mod> GetModsFor(ModType type) => new Mod[] { };
 
-                public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+                public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
                 {
                     throw new NotImplementedException();
                 }

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Beatmaps
             {
                 public override IEnumerable<Mod> GetModsFor(ModType type) => new Mod[] { };
 
-                public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap)
+                public override DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods)
                 {
                     throw new NotImplementedException();
                 }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -46,14 +46,7 @@ namespace osu.Game.Beatmaps
                 return b;
             });
 
-            track = new RecyclableLazy<Track>(() =>
-            {
-                // we want to ensure that we always have a track, even if it's a fake one.
-                var t = GetTrack() ?? new VirtualBeatmapTrack(Beatmap);
-                // applyRateAdjustments(t);
-                return t;
-            });
-
+            track = new RecyclableLazy<Track>(() => GetTrack() ?? new VirtualBeatmapTrack(Beatmap));
             background = new RecyclableLazy<Texture>(GetBackground, BackgroundStillValid);
             waveform = new RecyclableLazy<Waveform>(GetWaveform);
             storyboard = new RecyclableLazy<Storyboard>(GetStoryboard);
@@ -182,16 +175,6 @@ namespace osu.Game.Beatmaps
         /// Accessing track again will load a fresh instance.
         /// </summary>
         public void RecycleTrack() => track.Recycle();
-
-        // private void applyRateAdjustments(Track t = null)
-        // {
-        //     if (t == null && track.IsResultAvailable) t = Track;
-        //     if (t == null) return;
-        //
-        //     t.ResetSpeedAdjustments();
-        //     foreach (var mod in Mods.Value.OfType<IApplicableToClock>())
-        //         mod.ApplyToClock(t);
-        // }
 
         public class RecyclableLazy<T>
         {

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -11,7 +11,6 @@ using osu.Framework.IO.File;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using osu.Framework.Bindables;
 using osu.Game.IO.Serialization;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
@@ -28,15 +27,11 @@ namespace osu.Game.Beatmaps
 
         public readonly BeatmapMetadata Metadata;
 
-        public readonly Bindable<IEnumerable<Mod>> Mods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
-
         protected WorkingBeatmap(BeatmapInfo beatmapInfo)
         {
             BeatmapInfo = beatmapInfo;
             BeatmapSetInfo = beatmapInfo.BeatmapSet;
             Metadata = beatmapInfo.Metadata ?? BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
-
-            Mods.ValueChanged += _ => applyRateAdjustments();
 
             beatmap = new RecyclableLazy<IBeatmap>(() =>
             {
@@ -55,7 +50,7 @@ namespace osu.Game.Beatmaps
             {
                 // we want to ensure that we always have a track, even if it's a fake one.
                 var t = GetTrack() ?? new VirtualBeatmapTrack(Beatmap);
-                applyRateAdjustments(t);
+                // applyRateAdjustments(t);
                 return t;
             });
 
@@ -87,7 +82,7 @@ namespace osu.Game.Beatmaps
         /// <param name="ruleset">The <see cref="RulesetInfo"/> to create a playable <see cref="IBeatmap"/> for.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
-        public IBeatmap GetPlayableBeatmap(RulesetInfo ruleset)
+        public IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IEnumerable<Mod> mods)
         {
             var rulesetInstance = ruleset.CreateInstance();
 
@@ -98,19 +93,19 @@ namespace osu.Game.Beatmaps
                 throw new BeatmapInvalidForRulesetException($"{nameof(Beatmaps.Beatmap)} can not be converted for the ruleset (ruleset: {ruleset.InstantiationInfo}, converter: {converter}).");
 
             // Apply conversion mods
-            foreach (var mod in Mods.Value.OfType<IApplicableToBeatmapConverter>())
+            foreach (var mod in mods.OfType<IApplicableToBeatmapConverter>())
                 mod.ApplyToBeatmapConverter(converter);
 
             // Convert
             IBeatmap converted = converter.Convert();
 
             // Apply difficulty mods
-            if (Mods.Value.Any(m => m is IApplicableToDifficulty))
+            if (mods.Any(m => m is IApplicableToDifficulty))
             {
                 converted.BeatmapInfo = converted.BeatmapInfo.Clone();
                 converted.BeatmapInfo.BaseDifficulty = converted.BeatmapInfo.BaseDifficulty.Clone();
 
-                foreach (var mod in Mods.Value.OfType<IApplicableToDifficulty>())
+                foreach (var mod in mods.OfType<IApplicableToDifficulty>())
                     mod.ApplyToDifficulty(converted.BeatmapInfo.BaseDifficulty);
             }
 
@@ -122,7 +117,7 @@ namespace osu.Game.Beatmaps
             foreach (var obj in converted.HitObjects)
                 obj.ApplyDefaults(converted.ControlPointInfo, converted.BeatmapInfo.BaseDifficulty);
 
-            foreach (var mod in Mods.Value.OfType<IApplicableToHitObject>())
+            foreach (var mod in mods.OfType<IApplicableToHitObject>())
             foreach (var obj in converted.HitObjects)
                 mod.ApplyToHitObject(obj);
 
@@ -188,15 +183,15 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public void RecycleTrack() => track.Recycle();
 
-        private void applyRateAdjustments(Track t = null)
-        {
-            if (t == null && track.IsResultAvailable) t = Track;
-            if (t == null) return;
-
-            t.ResetSpeedAdjustments();
-            foreach (var mod in Mods.Value.OfType<IApplicableToClock>())
-                mod.ApplyToClock(t);
-        }
+        // private void applyRateAdjustments(Track t = null)
+        // {
+        //     if (t == null && track.IsResultAvailable) t = Track;
+        //     if (t == null) return;
+        //
+        //     t.ResetSpeedAdjustments();
+        //     foreach (var mod in Mods.Value.OfType<IApplicableToClock>())
+        //         mod.ApplyToClock(t);
+        // }
 
         public class RecyclableLazy<T>
         {

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Beatmaps
         /// <param name="ruleset">The <see cref="RulesetInfo"/> to create a playable <see cref="IBeatmap"/> for.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
-        public IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IEnumerable<Mod> mods)
+        public IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IReadOnlyList<Mod> mods)
         {
             var rulesetInstance = ruleset.CreateInstance();
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -113,7 +113,7 @@ namespace osu.Game
         // todo: move this to SongSelect once Screen has the ability to unsuspend.
         [Cached]
         [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> selectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
+        private readonly Bindable<IEnumerable<Mod>> mods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
 
         public OsuGame(string[] args = null)
         {
@@ -294,7 +294,7 @@ namespace osu.Game
             {
                 ruleset.Value = databasedScoreInfo.Ruleset;
                 Beatmap.Value = BeatmapManager.GetWorkingBeatmap(databasedBeatmap);
-                selectedMods.Value = databasedScoreInfo.Mods;
+                mods.Value = databasedScoreInfo.Mods;
 
                 menuScreen.Push(new PlayerLoader(() => new ReplayPlayer(databasedScore)));
             }, $"watch {databasedScoreInfo}", bypassScreenAllowChecks: true);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -293,9 +293,8 @@ namespace osu.Game
             performFromMainMenu(() =>
             {
                 ruleset.Value = databasedScoreInfo.Ruleset;
-
                 Beatmap.Value = BeatmapManager.GetWorkingBeatmap(databasedBeatmap);
-                Beatmap.Value.Mods.Value = databasedScoreInfo.Mods;
+                selectedMods.Value = databasedScoreInfo.Mods;
 
                 menuScreen.Push(new PlayerLoader(() => new ReplayPlayer(databasedScore)));
             }, $"watch {databasedScoreInfo}", bypassScreenAllowChecks: true);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -113,7 +113,7 @@ namespace osu.Game
         // todo: move this to SongSelect once Screen has the ability to unsuspend.
         [Cached]
         [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> selectedMods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
+        private readonly Bindable<IEnumerable<Mod>> selectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
 
         public OsuGame(string[] args = null)
         {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -112,8 +112,8 @@ namespace osu.Game
 
         // todo: move this to SongSelect once Screen has the ability to unsuspend.
         [Cached]
-        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> mods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
+        [Cached(typeof(IBindable<IReadOnlyList<Mod>>))]
+        private readonly Bindable<IReadOnlyList<Mod>> mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         public OsuGame(string[] args = null)
         {

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -42,12 +42,12 @@ namespace osu.Game.Overlays.Mods
 
         protected readonly FillFlowContainer<ModSection> ModSectionsContainer;
 
-        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
+        protected readonly Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         protected readonly IBindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, IBindable<RulesetInfo> ruleset, AudioManager audio, Bindable<IEnumerable<Mod>> mods)
+        private void load(OsuColour colours, IBindable<RulesetInfo> ruleset, AudioManager audio, Bindable<IReadOnlyList<Mod>> mods)
         {
             LowMultiplierColour = colours.Red;
             HighMultiplierColour = colours.Green;
@@ -87,14 +87,14 @@ namespace osu.Game.Overlays.Mods
 
             // attempt to re-select any already selected mods.
             // this may be the first time we are receiving the ruleset, in which case they will still match.
-            selectedModsChanged(new ValueChangedEvent<IEnumerable<Mod>>(SelectedMods.Value, SelectedMods.Value));
+            selectedModsChanged(new ValueChangedEvent<IReadOnlyList<Mod>>(SelectedMods.Value, SelectedMods.Value));
 
             // write the mods back to the SelectedMods bindable in the case a change was not applicable.
             // this generally isn't required as the previous line will perform deselection; just here for safety.
             refreshSelectedMods();
         }
 
-        private void selectedModsChanged(ValueChangedEvent<IEnumerable<Mod>> e)
+        private void selectedModsChanged(ValueChangedEvent<IReadOnlyList<Mod>> e)
         {
             foreach (ModSection section in ModSectionsContainer.Children)
                 section.SelectTypes(e.NewValue.Select(m => m.GetType()).ToList());

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -42,19 +42,19 @@ namespace osu.Game.Overlays.Mods
 
         protected readonly FillFlowContainer<ModSection> ModSectionsContainer;
 
-        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
+        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
 
         protected readonly IBindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, IBindable<RulesetInfo> ruleset, AudioManager audio, Bindable<IEnumerable<Mod>> selectedMods)
+        private void load(OsuColour colours, IBindable<RulesetInfo> ruleset, AudioManager audio, Bindable<IEnumerable<Mod>> mods)
         {
             LowMultiplierColour = colours.Red;
             HighMultiplierColour = colours.Green;
             UnrankedLabel.Colour = colours.Blue;
 
             Ruleset.BindTo(ruleset);
-            if (selectedMods != null) SelectedMods.BindTo(selectedMods);
+            if (mods != null) SelectedMods.BindTo(mods);
 
             sampleOn = audio.Sample.Get(@"UI/check-on");
             sampleOff = audio.Sample.Get(@"UI/check-off");

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -22,6 +22,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Music;
+using osu.Game.Rulesets.Mods;
 using osuTK;
 using osuTK.Graphics;
 
@@ -54,7 +55,11 @@ namespace osu.Game.Overlays
         private Container dragContainer;
         private Container playerContainer;
 
-        private readonly Bindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
+        [Resolved]
+        private Bindable<WorkingBeatmap> beatmap { get; set; }
+
+        [Resolved]
+        private IBindable<IEnumerable<Mod>> selectedMods { get; set; }
 
         /// <summary>
         /// Provide a source for the toolbar height.
@@ -73,7 +78,6 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load(Bindable<WorkingBeatmap> beatmap, BeatmapManager beatmaps, OsuColour colours)
         {
-            this.beatmap.BindTo(beatmap);
             this.beatmaps = beatmaps;
 
             Children = new Drawable[]
@@ -231,6 +235,7 @@ namespace osu.Game.Overlays
         {
             beatmap.BindValueChanged(beatmapChanged, true);
             beatmap.BindDisabledChanged(beatmapDisabledChanged, true);
+            selectedMods.BindValueChanged(_ => updateAudioAdjustments(), true);
             base.LoadComplete();
         }
 
@@ -354,8 +359,21 @@ namespace osu.Game.Overlays
             progressBar.CurrentTime = 0;
 
             updateDisplay(current, direction);
+            updateAudioAdjustments();
 
             queuedDirection = null;
+        }
+
+        private void updateAudioAdjustments()
+        {
+            var track = current?.Track;
+            if (track == null)
+                return;
+
+            track.ResetSpeedAdjustments();
+
+            foreach (var mod in selectedMods.Value.OfType<IApplicableToClock>())
+                mod.ApplyToClock(track);
         }
 
         private void currentTrackCompleted() => Schedule(() =>

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays
         private Bindable<WorkingBeatmap> beatmap { get; set; }
 
         [Resolved]
-        private IBindable<IEnumerable<Mod>> selectedMods { get; set; }
+        private IBindable<IEnumerable<Mod>> mods { get; set; }
 
         /// <summary>
         /// Provide a source for the toolbar height.
@@ -235,7 +235,7 @@ namespace osu.Game.Overlays
         {
             beatmap.BindValueChanged(beatmapChanged, true);
             beatmap.BindDisabledChanged(beatmapDisabledChanged, true);
-            selectedMods.BindValueChanged(_ => updateAudioAdjustments(), true);
+            mods.BindValueChanged(_ => updateAudioAdjustments(), true);
             base.LoadComplete();
         }
 
@@ -372,7 +372,7 @@ namespace osu.Game.Overlays
 
             track.ResetSpeedAdjustments();
 
-            foreach (var mod in selectedMods.Value.OfType<IApplicableToClock>())
+            foreach (var mod in mods.Value.OfType<IApplicableToClock>())
                 mod.ApplyToClock(track);
         }
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays
         private Bindable<WorkingBeatmap> beatmap { get; set; }
 
         [Resolved]
-        private IBindable<IEnumerable<Mod>> mods { get; set; }
+        private IBindable<IReadOnlyList<Mod>> mods { get; set; }
 
         /// <summary>
         /// Provide a source for the toolbar height.

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.Difficulty
         /// </summary>
         public Mod[] CreateDifficultyAdjustmentModCombinations()
         {
-            return createDifficultyAdjustmentModCombinations(Enumerable.Empty<Mod>(), DifficultyAdjustmentMods).ToArray();
+            return createDifficultyAdjustmentModCombinations(Array.Empty<Mod>(), DifficultyAdjustmentMods).ToArray();
 
             IEnumerable<Mod> createDifficultyAdjustmentModCombinations(IEnumerable<Mod> currentSet, Mod[] adjustmentSet, int currentSetCount = 0, int adjustmentSetStart = 0)
             {

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -39,8 +39,7 @@ namespace osu.Game.Rulesets.Difficulty
         {
             mods = mods.Select(m => m.CreateCopy()).ToArray();
 
-            beatmap.Mods.Value = mods;
-            IBeatmap playableBeatmap = beatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
+            IBeatmap playableBeatmap = beatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 
             var clock = new StopwatchClock();
             mods.OfType<IApplicableToClock>().ForEach(m => m.ApplyToClock(clock));

--- a/osu.Game/Rulesets/Difficulty/PerformanceCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceCalculator.cs
@@ -26,8 +26,7 @@ namespace osu.Game.Rulesets.Difficulty
             Ruleset = ruleset;
             Score = score;
 
-            beatmap.Mods.Value = score.Mods;
-            Beatmap = beatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
+            Beatmap = beatmap.GetPlayableBeatmap(ruleset.RulesetInfo, score.Mods);
 
             Attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(score.Mods);
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -14,6 +14,7 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
@@ -185,8 +186,8 @@ namespace osu.Game.Rulesets.Edit
         }
 
         internal override DrawableEditRuleset CreateDrawableRuleset()
-            => new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, Beatmap.Value));
+            => new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, Beatmap.Value, Enumerable.Empty<Mod>()));
 
-        protected abstract DrawableRuleset<TObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap);
+        protected abstract DrawableRuleset<TObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods);
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -186,8 +186,8 @@ namespace osu.Game.Rulesets.Edit
         }
 
         internal override DrawableEditRuleset CreateDrawableRuleset()
-            => new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, Beatmap.Value, Enumerable.Empty<Mod>()));
+            => new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, Beatmap.Value, Array.Empty<Mod>()));
 
-        protected abstract DrawableRuleset<TObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods);
+        protected abstract DrawableRuleset<TObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods);
     }
 }

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets
         /// <param name="beatmap">The beatmap to create the hit renderer for.</param>
         /// <exception cref="BeatmapInvalidForRulesetException">Unable to successfully load the beatmap to be usable with this ruleset.</exception>
         /// <returns></returns>
-        public abstract DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap);
+        public abstract DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods);
 
         /// <summary>
         /// Creates a <see cref="IBeatmapConverter"/> to convert a <see cref="IBeatmap"/> to one that is applicable for this <see cref="Ruleset"/>.

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets
         /// <param name="beatmap">The beatmap to create the hit renderer for.</param>
         /// <exception cref="BeatmapInvalidForRulesetException">Unable to successfully load the beatmap to be usable with this ruleset.</exception>
         /// <returns></returns>
-        public abstract DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IEnumerable<Mod> mods);
+        public abstract DrawableRuleset CreateDrawableRulesetWith(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods);
 
         /// <summary>
         /// Creates a <see cref="IBeatmapConverter"/> to convert a <see cref="IBeatmap"/> to one that is applicable for this <see cref="Ruleset"/>.

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -81,9 +81,8 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// The mods which are to be applied.
         /// </summary>
-        [Cached]
-        [Cached(typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> mods = new Bindable<IEnumerable<Mod>>();
+        [Cached(typeof(IReadOnlyList<Mod>))]
+        private readonly IReadOnlyList<Mod> mods;
 
         private FrameStabilityContainer frameStabilityContainer;
 
@@ -100,7 +99,7 @@ namespace osu.Game.Rulesets.UI
             if (workingBeatmap == null)
                 throw new ArgumentException("Beatmap cannot be null.", nameof(workingBeatmap));
 
-            this.mods.Value = mods;
+            this.mods = mods.ToArray();
 
             RelativeSizeAxes = Axes.Both;
 
@@ -160,7 +159,7 @@ namespace osu.Game.Rulesets.UI
                         .WithChild(ResumeOverlay)));
             }
 
-            applyRulesetMods(mods.Value, config);
+            applyRulesetMods(mods, config);
 
             loadObjects();
         }
@@ -175,7 +174,7 @@ namespace osu.Game.Rulesets.UI
 
             Playfield.PostProcess();
 
-            foreach (var mod in mods.Value.OfType<IApplicableToDrawableHitObjects>())
+            foreach (var mod in mods.OfType<IApplicableToDrawableHitObjects>())
                 mod.ApplyToDrawableHitObjects(Playfield.HitObjectContainer.Objects);
         }
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         /// <param name="ruleset">The ruleset being represented.</param>
         /// <param name="workingBeatmap">The beatmap to create the hit renderer for.</param>
-        protected DrawableRuleset(Ruleset ruleset, WorkingBeatmap workingBeatmap, IEnumerable<Mod> mods)
+        protected DrawableRuleset(Ruleset ruleset, WorkingBeatmap workingBeatmap, IReadOnlyList<Mod> mods)
             : base(ruleset)
         {
             if (workingBeatmap == null)
@@ -257,7 +257,7 @@ namespace osu.Game.Rulesets.UI
         /// Applies the active mods to the Beatmap.
         /// </summary>
         /// <param name="mods"></param>
-        private void applyBeatmapMods(IEnumerable<Mod> mods)
+        private void applyBeatmapMods(IReadOnlyList<Mod> mods)
         {
             if (mods == null)
                 return;
@@ -270,7 +270,7 @@ namespace osu.Game.Rulesets.UI
         /// Applies the active mods to this DrawableRuleset.
         /// </summary>
         /// <param name="mods"></param>
-        private void applyRulesetMods(IEnumerable<Mod> mods, OsuConfigManager config)
+        private void applyRulesetMods(IReadOnlyList<Mod> mods, OsuConfigManager config)
         {
             if (mods == null)
                 return;

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.UI
         private IBindable<WorkingBeatmap> beatmap { get; set; }
 
         [Resolved]
-        private IBindable<IEnumerable<Mod>> selectedMods { get; set; }
+        private IBindable<IEnumerable<Mod>> mods { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -125,7 +125,7 @@ namespace osu.Game.Rulesets.UI
             base.Update();
 
             if (beatmap != null)
-                foreach (var mod in selectedMods.Value)
+                foreach (var mod in mods.Value)
                     if (mod is IUpdatableByPlayfield updatable)
                         updatable.Update(this);
         }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.UI
         private IBindable<WorkingBeatmap> beatmap { get; set; }
 
         [Resolved]
-        private IBindable<IEnumerable<Mod>> mods { get; set; }
+        private IReadOnlyList<Mod> mods { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -125,7 +125,7 @@ namespace osu.Game.Rulesets.UI
             base.Update();
 
             if (beatmap != null)
-                foreach (var mod in mods.Value)
+                foreach (var mod in mods)
                     if (mod is IUpdatableByPlayfield updatable)
                         updatable.Update(this);
         }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -57,13 +57,15 @@ namespace osu.Game.Rulesets.UI
             hitObjectContainerLazy = new Lazy<HitObjectContainer>(CreateHitObjectContainer);
         }
 
-        private WorkingBeatmap beatmap;
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; }
+
+        [Resolved]
+        private IBindable<IEnumerable<Mod>> selectedMods { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap)
+        private void load()
         {
-            this.beatmap = beatmap.Value;
-
             Cursor = CreateCursor();
             if (Cursor != null)
                 AddInternal(Cursor);
@@ -123,7 +125,7 @@ namespace osu.Game.Rulesets.UI
             base.Update();
 
             if (beatmap != null)
-                foreach (var mod in beatmap.Mods.Value)
+                foreach (var mod in selectedMods.Value)
                     if (mod is IUpdatableByPlayfield updatable)
                         updatable.Update(this);
         }

--- a/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
         [Cached(Type = typeof(IScrollingInfo))]
         private readonly LocalScrollingInfo scrollingInfo;
 
-        protected DrawableScrollingRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+        protected DrawableScrollingRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
             scrollingInfo = new LocalScrollingInfo();

--- a/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
@@ -13,6 +13,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
 using osu.Game.Input.Bindings;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Timing;
@@ -80,8 +81,8 @@ namespace osu.Game.Rulesets.UI.Scrolling
         [Cached(Type = typeof(IScrollingInfo))]
         private readonly LocalScrollingInfo scrollingInfo;
 
-        protected DrawableScrollingRuleset(Ruleset ruleset, WorkingBeatmap beatmap)
-            : base(ruleset, beatmap)
+        protected DrawableScrollingRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            : base(ruleset, beatmap, mods)
         {
             scrollingInfo = new LocalScrollingInfo();
             scrollingInfo.Direction.BindTo(Direction);

--- a/osu.Game/Screens/Multi/Match/Components/Header.cs
+++ b/osu.Game/Screens/Multi/Match/Components/Header.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -110,7 +109,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                 },
             };
 
-            CurrentItem.BindValueChanged(item => modDisplay.Current.Value = item.NewValue?.RequiredMods ?? Enumerable.Empty<Mod>(), true);
+            CurrentItem.BindValueChanged(item => modDisplay.Current.Value = item.NewValue?.RequiredMods?.ToArray() ?? Array.Empty<Mod>(), true);
 
             beatmapButton.Action = () => RequestBeatmapSelection?.Invoke();
         }

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -178,6 +178,9 @@ namespace osu.Game.Screens.Multi.Match
         public override bool OnExiting(IScreen next)
         {
             RoomManager?.PartRoom();
+
+            SelectedMods.Value = Enumerable.Empty<Mod>();
+
             return base.OnExiting(next);
         }
 

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -222,8 +222,6 @@ namespace osu.Game.Screens.Multi.Match
 
         private void onStart()
         {
-            Beatmap.Value.Mods.Value = SelectedMods.Value.ToArray();
-
             switch (type.Value)
             {
                 default:

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Screens.Multi.Match
         {
             RoomManager?.PartRoom();
 
-            SelectedMods.Value = Enumerable.Empty<Mod>();
+            Mods.Value = Enumerable.Empty<Mod>();
 
             return base.OnExiting(next);
         }
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.Multi.Match
             var localBeatmap = e.NewValue?.Beatmap == null ? null : beatmapManager.QueryBeatmap(b => b.OnlineBeatmapID == e.NewValue.Beatmap.OnlineBeatmapID);
 
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
-            SelectedMods.Value = e.NewValue?.RequiredMods ?? Enumerable.Empty<Mod>();
+            Mods.Value = e.NewValue?.RequiredMods ?? Enumerable.Empty<Mod>();
             if (e.NewValue?.Ruleset != null)
                 Ruleset.Value = e.NewValue.Ruleset;
         }

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -41,9 +40,6 @@ namespace osu.Game.Screens.Multi.Match
 
         [Resolved(typeof(Room))]
         protected Bindable<PlaylistItem> CurrentItem { get; private set; }
-
-        [Resolved]
-        protected Bindable<IEnumerable<Mod>> SelectedMods { get; private set; }
 
         [Resolved]
         private BeatmapManager beatmapManager { get; set; }

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -179,7 +179,7 @@ namespace osu.Game.Screens.Multi.Match
         {
             RoomManager?.PartRoom();
 
-            Mods.Value = Enumerable.Empty<Mod>();
+            Mods.Value = Array.Empty<Mod>();
 
             return base.OnExiting(next);
         }
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.Multi.Match
             var localBeatmap = e.NewValue?.Beatmap == null ? null : beatmapManager.QueryBeatmap(b => b.OnlineBeatmapID == e.NewValue.Beatmap.OnlineBeatmapID);
 
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
-            Mods.Value = e.NewValue?.RequiredMods ?? Enumerable.Empty<Mod>();
+            Mods.Value = e.NewValue?.RequiredMods?.ToArray() ?? Array.Empty<Mod>();
             if (e.NewValue?.Ruleset != null)
                 Ruleset.Value = e.NewValue.Ruleset;
         }

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -14,7 +13,6 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Multi.Ranking;
 using osu.Game.Screens.Play;
@@ -37,9 +35,6 @@ namespace osu.Game.Screens.Multi.Play
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; }
 
-        [Resolved]
-        private Bindable<IEnumerable<Mod>> selectedMods { get; set; }
-
         public TimeshiftPlayer(PlaylistItem playlistItem)
         {
             this.playlistItem = playlistItem;
@@ -61,7 +56,7 @@ namespace osu.Game.Screens.Multi.Play
             if (ruleset.Value.ID != playlistItem.Ruleset.ID)
                 throw new InvalidOperationException("Current Ruleset does not match PlaylistItem's Ruleset");
 
-            if (!playlistItem.RequiredMods.All(m => selectedMods.Value.Contains(m)))
+            if (!playlistItem.RequiredMods.All(m => SelectedMods.Value.Contains(m)))
                 throw new InvalidOperationException("Current Mods do not match PlaylistItem's RequiredMods");
 
             var req = new CreateRoomScoreRequest(roomId.Value ?? 0, playlistItem.ID);

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.Multi.Play
             if (ruleset.Value.ID != playlistItem.Ruleset.ID)
                 throw new InvalidOperationException("Current Ruleset does not match PlaylistItem's Ruleset");
 
-            if (!playlistItem.RequiredMods.All(m => SelectedMods.Value.Contains(m)))
+            if (!playlistItem.RequiredMods.All(m => Mods.Value.Contains(m)))
                 throw new InvalidOperationException("Current Mods do not match PlaylistItem's RequiredMods");
 
             var req = new CreateRoomScoreRequest(roomId.Value ?? 0, playlistItem.ID);

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Internal;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -14,6 +15,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Menu;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Screens
 {
@@ -63,12 +65,15 @@ namespace osu.Game.Screens
 
         public Bindable<RulesetInfo> Ruleset { get; set; }
 
+        public Bindable<IEnumerable<Mod>> SelectedMods { get; set; }
+
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             var screenDependencies = new OsuScreenDependencies(DisallowExternalBeatmapRulesetChanges, parent);
 
             Beatmap = screenDependencies.Beatmap;
             Ruleset = screenDependencies.Ruleset;
+            SelectedMods = screenDependencies.SelectedMods;
 
             return base.CreateChildDependencies(screenDependencies);
         }

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens
 
         public Bindable<RulesetInfo> Ruleset { get; private set; }
 
-        public Bindable<IEnumerable<Mod>> SelectedMods { get; private set; }
+        public Bindable<IEnumerable<Mod>> Mods { get; private set; }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -73,7 +73,7 @@ namespace osu.Game.Screens
 
             Beatmap = screenDependencies.Beatmap;
             Ruleset = screenDependencies.Ruleset;
-            SelectedMods = screenDependencies.SelectedMods;
+            Mods = screenDependencies.Mods;
 
             return base.CreateChildDependencies(screenDependencies);
         }

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens
 
         public Bindable<RulesetInfo> Ruleset { get; private set; }
 
-        public Bindable<IEnumerable<Mod>> Mods { get; private set; }
+        public Bindable<IReadOnlyList<Mod>> Mods { get; private set; }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -61,11 +61,11 @@ namespace osu.Game.Screens
 
         public virtual float BackgroundParallaxAmount => 1;
 
-        public Bindable<WorkingBeatmap> Beatmap { get; set; }
+        public Bindable<WorkingBeatmap> Beatmap { get; private set; }
 
-        public Bindable<RulesetInfo> Ruleset { get; set; }
+        public Bindable<RulesetInfo> Ruleset { get; private set; }
 
-        public Bindable<IEnumerable<Mod>> SelectedMods { get; set; }
+        public Bindable<IEnumerable<Mod>> SelectedMods { get; private set; }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {

--- a/osu.Game/Screens/OsuScreenDependencies.cs
+++ b/osu.Game/Screens/OsuScreenDependencies.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Screens
 {
@@ -14,6 +16,8 @@ namespace osu.Game.Screens
 
         public Bindable<RulesetInfo> Ruleset { get; }
 
+        public Bindable<IEnumerable<Mod>> SelectedMods { get; }
+
         public OsuScreenDependencies(bool requireLease, IReadOnlyDependencyContainer parent)
             : base(parent)
         {
@@ -21,20 +25,21 @@ namespace osu.Game.Screens
             {
                 Beatmap = parent.Get<LeasedBindable<WorkingBeatmap>>()?.GetBoundCopy();
                 if (Beatmap == null)
-                {
                     Cache(Beatmap = parent.Get<Bindable<WorkingBeatmap>>().BeginLease(false));
-                }
 
                 Ruleset = parent.Get<LeasedBindable<RulesetInfo>>()?.GetBoundCopy();
                 if (Ruleset == null)
-                {
                     Cache(Ruleset = parent.Get<Bindable<RulesetInfo>>().BeginLease(true));
-                }
+
+                SelectedMods = parent.Get<LeasedBindable<IEnumerable<Mod>>>()?.GetBoundCopy();
+                if (SelectedMods == null)
+                    Cache(SelectedMods = parent.Get<Bindable<IEnumerable<Mod>>>().BeginLease(true));
             }
             else
             {
                 Beatmap = (parent.Get<LeasedBindable<WorkingBeatmap>>() ?? parent.Get<Bindable<WorkingBeatmap>>()).GetBoundCopy();
                 Ruleset = (parent.Get<LeasedBindable<RulesetInfo>>() ?? parent.Get<Bindable<RulesetInfo>>()).GetBoundCopy();
+                SelectedMods = (parent.Get<LeasedBindable<IEnumerable<Mod>>>() ?? parent.Get<Bindable<IEnumerable<Mod>>>()).GetBoundCopy();
             }
         }
     }

--- a/osu.Game/Screens/OsuScreenDependencies.cs
+++ b/osu.Game/Screens/OsuScreenDependencies.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens
 
         public Bindable<RulesetInfo> Ruleset { get; }
 
-        public Bindable<IEnumerable<Mod>> SelectedMods { get; }
+        public Bindable<IEnumerable<Mod>> Mods { get; }
 
         public OsuScreenDependencies(bool requireLease, IReadOnlyDependencyContainer parent)
             : base(parent)
@@ -31,15 +31,15 @@ namespace osu.Game.Screens
                 if (Ruleset == null)
                     Cache(Ruleset = parent.Get<Bindable<RulesetInfo>>().BeginLease(true));
 
-                SelectedMods = parent.Get<LeasedBindable<IEnumerable<Mod>>>()?.GetBoundCopy();
-                if (SelectedMods == null)
-                    Cache(SelectedMods = parent.Get<Bindable<IEnumerable<Mod>>>().BeginLease(true));
+                Mods = parent.Get<LeasedBindable<IEnumerable<Mod>>>()?.GetBoundCopy();
+                if (Mods == null)
+                    Cache(Mods = parent.Get<Bindable<IEnumerable<Mod>>>().BeginLease(true));
             }
             else
             {
                 Beatmap = (parent.Get<LeasedBindable<WorkingBeatmap>>() ?? parent.Get<Bindable<WorkingBeatmap>>()).GetBoundCopy();
                 Ruleset = (parent.Get<LeasedBindable<RulesetInfo>>() ?? parent.Get<Bindable<RulesetInfo>>()).GetBoundCopy();
-                SelectedMods = (parent.Get<LeasedBindable<IEnumerable<Mod>>>() ?? parent.Get<Bindable<IEnumerable<Mod>>>()).GetBoundCopy();
+                Mods = (parent.Get<LeasedBindable<IEnumerable<Mod>>>() ?? parent.Get<Bindable<IEnumerable<Mod>>>()).GetBoundCopy();
             }
         }
     }

--- a/osu.Game/Screens/OsuScreenDependencies.cs
+++ b/osu.Game/Screens/OsuScreenDependencies.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens
 
         public Bindable<RulesetInfo> Ruleset { get; }
 
-        public Bindable<IEnumerable<Mod>> Mods { get; }
+        public Bindable<IReadOnlyList<Mod>> Mods { get; }
 
         public OsuScreenDependencies(bool requireLease, IReadOnlyDependencyContainer parent)
             : base(parent)
@@ -31,15 +31,15 @@ namespace osu.Game.Screens
                 if (Ruleset == null)
                     Cache(Ruleset = parent.Get<Bindable<RulesetInfo>>().BeginLease(true));
 
-                Mods = parent.Get<LeasedBindable<IEnumerable<Mod>>>()?.GetBoundCopy();
+                Mods = parent.Get<LeasedBindable<IReadOnlyList<Mod>>>()?.GetBoundCopy();
                 if (Mods == null)
-                    Cache(Mods = parent.Get<Bindable<IEnumerable<Mod>>>().BeginLease(true));
+                    Cache(Mods = parent.Get<Bindable<IReadOnlyList<Mod>>>().BeginLease(true));
             }
             else
             {
                 Beatmap = (parent.Get<LeasedBindable<WorkingBeatmap>>() ?? parent.Get<Bindable<WorkingBeatmap>>()).GetBoundCopy();
                 Ruleset = (parent.Get<LeasedBindable<RulesetInfo>>() ?? parent.Get<Bindable<RulesetInfo>>()).GetBoundCopy();
-                Mods = (parent.Get<LeasedBindable<IEnumerable<Mod>>>() ?? parent.Get<Bindable<IEnumerable<Mod>>>()).GetBoundCopy();
+                Mods = (parent.Get<LeasedBindable<IReadOnlyList<Mod>>>() ?? parent.Get<Bindable<IReadOnlyList<Mod>>>()).GetBoundCopy();
             }
         }
     }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework;
@@ -22,7 +23,7 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public class GameplayClockContainer : Container
     {
-        private readonly WorkingBeatmap beatmap;
+        private readonly IEnumerable<Mod> mods;
 
         /// <summary>
         /// The original source (usually a <see cref="WorkingBeatmap"/>'s track).
@@ -54,9 +55,9 @@ namespace osu.Game.Screens.Play
 
         private readonly FramedOffsetClock offsetClock;
 
-        public GameplayClockContainer(WorkingBeatmap beatmap, double gameplayStartTime)
+        public GameplayClockContainer(WorkingBeatmap beatmap, IEnumerable<Mod> mods, double gameplayStartTime)
         {
-            this.beatmap = beatmap;
+            this.mods = mods;
 
             RelativeSizeAxes = Axes.Both;
 
@@ -154,7 +155,7 @@ namespace osu.Game.Screens.Play
             else
                 sourceClock.Rate = UserPlaybackRate.Value;
 
-            foreach (var mod in beatmap.Mods.Value.OfType<IApplicableToClock>())
+            foreach (var mod in mods.OfType<IApplicableToClock>())
                 mod.ApplyToClock(sourceClock);
         }
     }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.Play
     public class GameplayClockContainer : Container
     {
         private readonly WorkingBeatmap beatmap;
-        private readonly IEnumerable<Mod> mods;
+        private readonly IReadOnlyList<Mod> mods;
 
         /// <summary>
         /// The original source (usually a <see cref="WorkingBeatmap"/>'s track).
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Play
 
         private readonly FramedOffsetClock platformOffsetClock;
 
-        public GameplayClockContainer(WorkingBeatmap beatmap, IEnumerable<Mod> mods, double gameplayStartTime)
+        public GameplayClockContainer(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods, double gameplayStartTime)
         {
             this.beatmap = beatmap;
             this.mods = mods;

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -18,15 +18,15 @@ using osu.Game.Graphics;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public class ModDisplay : Container, IHasCurrentValue<IEnumerable<Mod>>
+    public class ModDisplay : Container, IHasCurrentValue<IReadOnlyList<Mod>>
     {
         private const int fade_duration = 1000;
 
         public bool DisplayUnrankedText = true;
 
-        private readonly Bindable<IEnumerable<Mod>> current = new Bindable<IEnumerable<Mod>>();
+        private readonly Bindable<IReadOnlyList<Mod>> current = new Bindable<IReadOnlyList<Mod>>();
 
-        public Bindable<IEnumerable<Mod>> Current
+        public Bindable<IReadOnlyList<Mod>> Current
         {
             get => current;
             set

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Play
 
         public Action<double> RequestSeek;
 
-        public HUDOverlay(ScoreProcessor scoreProcessor, DrawableRuleset drawableRuleset, IEnumerable<Mod> mods)
+        public HUDOverlay(ScoreProcessor scoreProcessor, DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods)
         {
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -2,16 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
-using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play.HUD;
@@ -42,7 +43,7 @@ namespace osu.Game.Screens.Play
 
         public Action<double> RequestSeek;
 
-        public HUDOverlay(ScoreProcessor scoreProcessor, DrawableRuleset drawableRuleset, WorkingBeatmap working)
+        public HUDOverlay(ScoreProcessor scoreProcessor, DrawableRuleset drawableRuleset, IEnumerable<Mod> mods)
         {
             RelativeSizeAxes = Axes.Both;
 
@@ -96,7 +97,7 @@ namespace osu.Game.Screens.Play
             Progress.AllowSeeking = drawableRuleset.HasReplayLoaded.Value;
             Progress.RequestSeek = time => RequestSeek(time);
 
-            ModDisplay.Current.BindTo(working.Mods);
+            ModDisplay.Current.Value = mods;
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.Play
             if (!ScoreProcessor.Mode.Disabled)
                 config.BindWith(OsuSetting.ScoreDisplayMode, ScoreProcessor.Mode);
 
-            InternalChild = GameplayClockContainer = new GameplayClockContainer(working, DrawableRuleset.GameplayStartTime);
+            InternalChild = GameplayClockContainer = new GameplayClockContainer(working, SelectedMods.Value, DrawableRuleset.GameplayStartTime);
 
             GameplayClockContainer.Children = new[]
             {
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Play
                 },
                 // display the cursor above some HUD elements.
                 DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),
-                HUDOverlay = new HUDOverlay(ScoreProcessor, DrawableRuleset, working)
+                HUDOverlay = new HUDOverlay(ScoreProcessor, DrawableRuleset, SelectedMods.Value)
                 {
                     HoldToQuit = { Action = performUserRequestedExit },
                     PlayerSettingsOverlay = { PlaybackSettings = { UserPlaybackRate = { BindTarget = GameplayClockContainer.UserPlaybackRate } } },
@@ -170,7 +170,7 @@ namespace osu.Game.Screens.Play
             ScoreProcessor.AllJudged += onCompletion;
             ScoreProcessor.Failed += onFail;
 
-            foreach (var mod in Beatmap.Value.Mods.Value.OfType<IApplicableToScoreProcessor>())
+            foreach (var mod in SelectedMods.Value.OfType<IApplicableToScoreProcessor>())
                 mod.ApplyToScoreProcessor(ScoreProcessor);
         }
 
@@ -192,7 +192,7 @@ namespace osu.Game.Screens.Play
 
                 try
                 {
-                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(working);
+                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(working, SelectedMods.Value);
                 }
                 catch (BeatmapInvalidForRulesetException)
                 {
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.Play
                     // let's try again forcing the beatmap's ruleset.
                     ruleset = beatmap.BeatmapInfo.Ruleset;
                     rulesetInstance = ruleset.CreateInstance();
-                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(Beatmap.Value);
+                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(Beatmap.Value, SelectedMods.Value);
                 }
 
                 if (!DrawableRuleset.Objects.Any())
@@ -271,7 +271,7 @@ namespace osu.Game.Screens.Play
             {
                 Beatmap = Beatmap.Value.BeatmapInfo,
                 Ruleset = ruleset,
-                Mods = Beatmap.Value.Mods.Value.ToArray(),
+                Mods = SelectedMods.Value.ToArray(),
                 User = api.LocalUser.Value,
             };
 
@@ -325,7 +325,7 @@ namespace osu.Game.Screens.Play
 
         private bool onFail()
         {
-            if (Beatmap.Value.Mods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail))
+            if (SelectedMods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail))
                 return false;
 
             GameplayClockContainer.Stop();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.Play
             if (!ScoreProcessor.Mode.Disabled)
                 config.BindWith(OsuSetting.ScoreDisplayMode, ScoreProcessor.Mode);
 
-            InternalChild = GameplayClockContainer = new GameplayClockContainer(working, SelectedMods.Value, DrawableRuleset.GameplayStartTime);
+            InternalChild = GameplayClockContainer = new GameplayClockContainer(working, Mods.Value, DrawableRuleset.GameplayStartTime);
 
             GameplayClockContainer.Children = new[]
             {
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Play
                 },
                 // display the cursor above some HUD elements.
                 DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),
-                HUDOverlay = new HUDOverlay(ScoreProcessor, DrawableRuleset, SelectedMods.Value)
+                HUDOverlay = new HUDOverlay(ScoreProcessor, DrawableRuleset, Mods.Value)
                 {
                     HoldToQuit = { Action = performUserRequestedExit },
                     PlayerSettingsOverlay = { PlaybackSettings = { UserPlaybackRate = { BindTarget = GameplayClockContainer.UserPlaybackRate } } },
@@ -170,7 +170,7 @@ namespace osu.Game.Screens.Play
             ScoreProcessor.AllJudged += onCompletion;
             ScoreProcessor.Failed += onFail;
 
-            foreach (var mod in SelectedMods.Value.OfType<IApplicableToScoreProcessor>())
+            foreach (var mod in Mods.Value.OfType<IApplicableToScoreProcessor>())
                 mod.ApplyToScoreProcessor(ScoreProcessor);
         }
 
@@ -192,7 +192,7 @@ namespace osu.Game.Screens.Play
 
                 try
                 {
-                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(working, SelectedMods.Value);
+                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(working, Mods.Value);
                 }
                 catch (BeatmapInvalidForRulesetException)
                 {
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.Play
                     // let's try again forcing the beatmap's ruleset.
                     ruleset = beatmap.BeatmapInfo.Ruleset;
                     rulesetInstance = ruleset.CreateInstance();
-                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(Beatmap.Value, SelectedMods.Value);
+                    DrawableRuleset = rulesetInstance.CreateDrawableRulesetWith(Beatmap.Value, Mods.Value);
                 }
 
                 if (!DrawableRuleset.Objects.Any())
@@ -271,7 +271,7 @@ namespace osu.Game.Screens.Play
             {
                 Beatmap = Beatmap.Value.BeatmapInfo,
                 Ruleset = ruleset,
-                Mods = SelectedMods.Value.ToArray(),
+                Mods = Mods.Value.ToArray(),
                 User = api.LocalUser.Value,
             };
 
@@ -325,7 +325,7 @@ namespace osu.Game.Screens.Play
 
         private bool onFail()
         {
-            if (SelectedMods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail))
+            if (Mods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail))
                 return false;
 
             GameplayClockContainer.Stop();

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Play
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    info = new BeatmapMetadataDisplay(Beatmap.Value, SelectedMods.Value)
+                    info = new BeatmapMetadataDisplay(Beatmap.Value, Mods.Value)
                     {
                         Alpha = 0,
                         Anchor = Anchor.Centre,

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
@@ -16,6 +17,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Play.PlayerSettings;
@@ -66,7 +68,7 @@ namespace osu.Game.Screens.Play
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    info = new BeatmapMetadataDisplay(Beatmap.Value)
+                    info = new BeatmapMetadataDisplay(Beatmap.Value, SelectedMods.Value)
                     {
                         Alpha = 0,
                         Anchor = Anchor.Centre,
@@ -299,6 +301,7 @@ namespace osu.Game.Screens.Play
             }
 
             private readonly WorkingBeatmap beatmap;
+            private readonly IEnumerable<Mod> mods;
             private LoadingAnimation loading;
             private Sprite backgroundSprite;
             private ModDisplay modDisplay;
@@ -320,9 +323,10 @@ namespace osu.Game.Screens.Play
                 }
             }
 
-            public BeatmapMetadataDisplay(WorkingBeatmap beatmap)
+            public BeatmapMetadataDisplay(WorkingBeatmap beatmap, IEnumerable<Mod> mods)
             {
                 this.beatmap = beatmap;
+                this.mods = mods;
             }
 
             [BackgroundDependencyLoader]
@@ -403,7 +407,7 @@ namespace osu.Game.Screens.Play
                                 Origin = Anchor.TopCentre,
                                 AutoSizeAxes = Axes.Both,
                                 Margin = new MarginPadding { Top = 20 },
-                                Current = beatmap.Mods
+                                Current = { Value = mods }
                             }
                         },
                     }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -301,7 +301,7 @@ namespace osu.Game.Screens.Play
             }
 
             private readonly WorkingBeatmap beatmap;
-            private readonly IEnumerable<Mod> mods;
+            private readonly IReadOnlyList<Mod> mods;
             private LoadingAnimation loading;
             private Sprite backgroundSprite;
             private ModDisplay modDisplay;
@@ -323,7 +323,7 @@ namespace osu.Game.Screens.Play
                 }
             }
 
-            public BeatmapMetadataDisplay(WorkingBeatmap beatmap, IEnumerable<Mod> mods)
+            public BeatmapMetadataDisplay(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
             {
                 this.beatmap = beatmap;
                 this.mods = mods;

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -310,12 +310,12 @@ namespace osu.Game.Screens.Select
                     try
                     {
                         // Try to get the beatmap with the user's ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(ruleset, Enumerable.Empty<Mod>());
+                        playableBeatmap = beatmap.GetPlayableBeatmap(ruleset, Array.Empty<Mod>());
                     }
                     catch (BeatmapInvalidForRulesetException)
                     {
                         // Can't be converted to the user's ruleset, so use the beatmap's own ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset, Enumerable.Empty<Mod>());
+                        playableBeatmap = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset, Array.Empty<Mod>());
                     }
 
                     labels.AddRange(playableBeatmap.GetStatistics().Select(s => new InfoLabel(s)));

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -25,6 +25,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Screens.Select
@@ -309,12 +310,12 @@ namespace osu.Game.Screens.Select
                     try
                     {
                         // Try to get the beatmap with the user's ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(ruleset);
+                        playableBeatmap = beatmap.GetPlayableBeatmap(ruleset, Enumerable.Empty<Mod>());
                     }
                     catch (BeatmapInvalidForRulesetException)
                     {
                         // Can't be converted to the user's ruleset, so use the beatmap's own ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset);
+                        playableBeatmap = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset, Enumerable.Empty<Mod>());
                     }
 
                     labels.AddRange(playableBeatmap.GetStatistics().Select(s => new InfoLabel(s)));

--- a/osu.Game/Screens/Select/MatchSongSelect.cs
+++ b/osu.Game/Screens/Select/MatchSongSelect.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
 using osu.Framework.Allocation;
@@ -25,9 +24,6 @@ namespace osu.Game.Screens.Select
 
         [Resolved(typeof(Room))]
         protected Bindable<PlaylistItem> CurrentItem { get; private set; }
-
-        [Resolved]
-        private Bindable<IEnumerable<Mod>> selectedMods { get; set; }
 
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
@@ -65,7 +61,7 @@ namespace osu.Game.Screens.Select
             {
                 Ruleset.Value = CurrentItem.Value.Ruleset;
                 Beatmap.Value = beatmaps.GetWorkingBeatmap(CurrentItem.Value.Beatmap);
-                Beatmap.Value.Mods.Value = selectedMods.Value = CurrentItem.Value.RequiredMods ?? Enumerable.Empty<Mod>();
+                SelectedMods.Value = CurrentItem.Value.RequiredMods ?? Enumerable.Empty<Mod>();
             }
 
             Beatmap.Disabled = true;

--- a/osu.Game/Screens/Select/MatchSongSelect.cs
+++ b/osu.Game/Screens/Select/MatchSongSelect.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Screens.Select
                 RulesetID = Ruleset.Value.ID ?? 0
             };
 
-            item.RequiredMods.AddRange(SelectedMods.Value);
+            item.RequiredMods.AddRange(Mods.Value);
 
             Selected?.Invoke(item);
 
@@ -61,12 +61,12 @@ namespace osu.Game.Screens.Select
             {
                 Ruleset.Value = CurrentItem.Value.Ruleset;
                 Beatmap.Value = beatmaps.GetWorkingBeatmap(CurrentItem.Value.Beatmap);
-                SelectedMods.Value = CurrentItem.Value.RequiredMods ?? Enumerable.Empty<Mod>();
+                Mods.Value = CurrentItem.Value.RequiredMods ?? Enumerable.Empty<Mod>();
             }
 
             Beatmap.Disabled = true;
             Ruleset.Disabled = true;
-            SelectedMods.Disabled = true;
+            Mods.Disabled = true;
 
             return false;
         }
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Select
 
             Beatmap.Disabled = false;
             Ruleset.Disabled = false;
-            SelectedMods.Disabled = false;
+            Mods.Disabled = false;
         }
     }
 }

--- a/osu.Game/Screens/Select/MatchSongSelect.cs
+++ b/osu.Game/Screens/Select/MatchSongSelect.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -61,7 +60,7 @@ namespace osu.Game.Screens.Select
             {
                 Ruleset.Value = CurrentItem.Value.Ruleset;
                 Beatmap.Value = beatmaps.GetWorkingBeatmap(CurrentItem.Value.Beatmap);
-                Mods.Value = CurrentItem.Value.RequiredMods ?? Enumerable.Empty<Mod>();
+                Mods.Value = CurrentItem.Value.RequiredMods?.ToArray() ?? Array.Empty<Mod>();
             }
 
             Beatmap.Disabled = true;

--- a/osu.Game/Screens/Select/MatchSongSelect.cs
+++ b/osu.Game/Screens/Select/MatchSongSelect.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Screens.Select
 
             Beatmap.Disabled = true;
             Ruleset.Disabled = true;
+            SelectedMods.Disabled = true;
 
             return false;
         }
@@ -76,6 +77,7 @@ namespace osu.Game.Screens.Select
 
             Beatmap.Disabled = false;
             Ruleset.Disabled = false;
+            SelectedMods.Disabled = false;
         }
     }
 }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -52,10 +52,10 @@ namespace osu.Game.Screens.Select
                 var auto = Ruleset.Value.CreateInstance().GetAutoplayMod();
                 var autoType = auto.GetType();
 
-                var mods = SelectedMods.Value;
+                var mods = Mods.Value;
                 if (mods.All(m => m.GetType() != autoType))
                 {
-                    SelectedMods.Value = mods.Append(auto);
+                    Mods.Value = mods.Append(auto);
                     removeAutoModOnResume = true;
                 }
             }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Select
                 var mods = Mods.Value;
                 if (mods.All(m => m.GetType() != autoType))
                 {
-                    Mods.Value = mods.Append(auto);
+                    Mods.Value = mods.Append(auto).ToArray();
                     removeAutoModOnResume = true;
                 }
             }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Select
 
         [Cached]
         [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> selectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>()); // Bound to the game's mods, but is not reset on exiting
+        private readonly Bindable<IEnumerable<Mod>> mods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>()); // Bound to the game's mods, but is not reset on exiting
 
         protected SongSelect()
         {
@@ -219,7 +219,7 @@ namespace osu.Game.Screens.Select
         [BackgroundDependencyLoader(true)]
         private void load(BeatmapManager beatmaps, AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins)
         {
-            selectedMods.BindTo(SelectedMods);
+            mods.BindTo(Mods);
 
             if (Footer != null)
             {
@@ -394,7 +394,7 @@ namespace osu.Game.Screens.Select
                 {
                     Logger.Log($"ruleset changed from \"{decoupledRuleset.Value}\" to \"{ruleset}\"");
 
-                    selectedMods.Value = Enumerable.Empty<Mod>();
+                    mods.Value = Enumerable.Empty<Mod>();
                     decoupledRuleset.Value = ruleset;
 
                     // force a filter before attempting to change the beatmap.
@@ -529,8 +529,8 @@ namespace osu.Game.Screens.Select
             if (Beatmap.Value.Track != null)
                 Beatmap.Value.Track.Looping = false;
 
-            selectedMods.UnbindAll();
-            SelectedMods.Value = Enumerable.Empty<Mod>();
+            mods.UnbindAll();
+            Mods.Value = Enumerable.Empty<Mod>();
 
             return false;
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -84,8 +84,8 @@ namespace osu.Game.Screens.Select
         private readonly Bindable<RulesetInfo> decoupledRuleset = new Bindable<RulesetInfo>();
 
         [Cached]
-        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        private readonly Bindable<IEnumerable<Mod>> mods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>()); // Bound to the game's mods, but is not reset on exiting
+        [Cached(Type = typeof(IBindable<IReadOnlyList<Mod>>))]
+        private readonly Bindable<IReadOnlyList<Mod>> mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>()); // Bound to the game's mods, but is not reset on exiting
 
         protected SongSelect()
         {
@@ -394,7 +394,7 @@ namespace osu.Game.Screens.Select
                 {
                     Logger.Log($"ruleset changed from \"{decoupledRuleset.Value}\" to \"{ruleset}\"");
 
-                    mods.Value = Enumerable.Empty<Mod>();
+                    mods.Value = Array.Empty<Mod>();
                     decoupledRuleset.Value = ruleset;
 
                     // force a filter before attempting to change the beatmap.
@@ -530,7 +530,7 @@ namespace osu.Game.Screens.Select
                 Beatmap.Value.Track.Looping = false;
 
             mods.UnbindAll();
-            Mods.Value = Enumerable.Empty<Mod>();
+            Mods.Value = Array.Empty<Mod>();
 
             return false;
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -394,7 +394,7 @@ namespace osu.Game.Screens.Select
                 {
                     Logger.Log($"ruleset changed from \"{decoupledRuleset.Value}\" to \"{ruleset}\"");
 
-                    Beatmap.Value.Mods.Value = Enumerable.Empty<Mod>();
+                    SelectedMods.Value = Enumerable.Empty<Mod>();
                     decoupledRuleset.Value = ruleset;
 
                     // force a filter before attempting to change the beatmap.
@@ -530,7 +530,7 @@ namespace osu.Game.Screens.Select
                 Beatmap.Value.Track.Looping = false;
 
             SelectedMods.UnbindAll();
-            Beatmap.Value.Mods.Value = new Mod[] { };
+            base.SelectedMods.Value = Enumerable.Empty<Mod>();
 
             return false;
         }
@@ -557,8 +557,6 @@ namespace osu.Game.Screens.Select
         /// <param name="beatmap">The working beatmap.</param>
         protected virtual void UpdateBeatmap(WorkingBeatmap beatmap)
         {
-            beatmap.Mods.BindTo(SelectedMods);
-
             Logger.Log($"working beatmap updated to {beatmap}");
 
             if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -83,7 +83,9 @@ namespace osu.Game.Screens.Select
 
         private readonly Bindable<RulesetInfo> decoupledRuleset = new Bindable<RulesetInfo>();
 
-        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
+        [Cached]
+        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
+        private readonly Bindable<IEnumerable<Mod>> selectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>()); // Bound to the game's mods, but is not reset on exiting
 
         protected SongSelect()
         {
@@ -217,6 +219,8 @@ namespace osu.Game.Screens.Select
         [BackgroundDependencyLoader(true)]
         private void load(BeatmapManager beatmaps, AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins)
         {
+            selectedMods.BindTo(SelectedMods);
+
             if (Footer != null)
             {
                 Footer.AddButton(@"mods", colours.Yellow, ModSelect, Key.F1);
@@ -264,11 +268,6 @@ namespace osu.Game.Screens.Select
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-
-            SelectedMods.BindTo(base.SelectedMods);
-
-            dependencies.CacheAs(SelectedMods);
-            dependencies.CacheAs<IBindable<IEnumerable<Mod>>>(SelectedMods);
 
             dependencies.CacheAs(this);
             dependencies.CacheAs(decoupledRuleset);
@@ -395,7 +394,7 @@ namespace osu.Game.Screens.Select
                 {
                     Logger.Log($"ruleset changed from \"{decoupledRuleset.Value}\" to \"{ruleset}\"");
 
-                    SelectedMods.Value = Enumerable.Empty<Mod>();
+                    selectedMods.Value = Enumerable.Empty<Mod>();
                     decoupledRuleset.Value = ruleset;
 
                     // force a filter before attempting to change the beatmap.
@@ -530,8 +529,8 @@ namespace osu.Game.Screens.Select
             if (Beatmap.Value.Track != null)
                 Beatmap.Value.Track.Looping = false;
 
-            SelectedMods.UnbindAll();
-            base.SelectedMods.Value = Enumerable.Empty<Mod>();
+            selectedMods.UnbindAll();
+            SelectedMods.Value = Enumerable.Empty<Mod>();
 
             return false;
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -83,9 +83,7 @@ namespace osu.Game.Screens.Select
 
         private readonly Bindable<RulesetInfo> decoupledRuleset = new Bindable<RulesetInfo>();
 
-        [Cached]
-        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(new Mod[] { });
+        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
 
         protected SongSelect()
         {
@@ -217,11 +215,8 @@ namespace osu.Game.Screens.Select
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(BeatmapManager beatmaps, AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, Bindable<IEnumerable<Mod>> selectedMods)
+        private void load(BeatmapManager beatmaps, AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins)
         {
-            if (selectedMods != null)
-                SelectedMods.BindTo(selectedMods);
-
             if (Footer != null)
             {
                 Footer.AddButton(@"mods", colours.Yellow, ModSelect, Key.F1);
@@ -269,6 +264,12 @@ namespace osu.Game.Screens.Select
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            SelectedMods.BindTo(base.SelectedMods);
+
+            dependencies.CacheAs(SelectedMods);
+            dependencies.CacheAs<IBindable<IEnumerable<Mod>>>(SelectedMods);
+
             dependencies.CacheAs(this);
             dependencies.CacheAs(decoupledRuleset);
             dependencies.CacheAs<IBindable<RulesetInfo>>(decoupledRuleset);

--- a/osu.Game/Tests/Visual/AllPlayersTestCase.cs
+++ b/osu.Game/Tests/Visual/AllPlayersTestCase.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual
             var working = CreateWorkingBeatmap(beatmap, Clock);
 
             Beatmap.Value = working;
-            SelectedMods.Value = new[] { r.GetAllMods().First(m => m is ModNoFail) };
+            Mods.Value = new[] { r.GetAllMods().First(m => m is ModNoFail) };
 
             Player?.Exit();
             Player = null;

--- a/osu.Game/Tests/Visual/AllPlayersTestCase.cs
+++ b/osu.Game/Tests/Visual/AllPlayersTestCase.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual
             var working = CreateWorkingBeatmap(beatmap, Clock);
 
             Beatmap.Value = working;
-            Beatmap.Value.Mods.Value = new[] { r.GetAllMods().First(m => m is ModNoFail) };
+            SelectedMods.Value = new[] { r.GetAllMods().First(m => m is ModNoFail) };
 
             Player?.Exit();
             Player = null;

--- a/osu.Game/Tests/Visual/OsuTestCase.cs
+++ b/osu.Game/Tests/Visual/OsuTestCase.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Visual
 
         [Cached]
         [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>();
+        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
 
         protected DependencyContainer Dependencies { get; private set; }
 
@@ -38,12 +38,10 @@ namespace osu.Game.Tests.Visual
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
-            Dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-
             // This is the earliest we can get OsuGameBase, which is used by the dummy working beatmap to find textures
-            beatmap.Default = new DummyWorkingBeatmap(Dependencies.Get<OsuGameBase>());
+            beatmap.Default = new DummyWorkingBeatmap(parent.Get<OsuGameBase>());
 
-            return Dependencies;
+            return Dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
         }
 
         protected OsuTestCase()

--- a/osu.Game/Tests/Visual/OsuTestCase.cs
+++ b/osu.Game/Tests/Visual/OsuTestCase.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -10,15 +11,25 @@ using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Tests.Visual
 {
     public abstract class OsuTestCase : TestCase
     {
+        [Cached(typeof(Bindable<WorkingBeatmap>))]
+        [Cached(typeof(IBindable<WorkingBeatmap>))]
         private readonly OsuTestBeatmap beatmap = new OsuTestBeatmap(new DummyWorkingBeatmap());
+
         protected BindableBeatmap Beatmap => beatmap;
 
+        [Cached]
+        [Cached(typeof(IBindable<RulesetInfo>))]
         protected readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
+
+        [Cached]
+        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
+        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>();
 
         protected DependencyContainer Dependencies { get; private set; }
 
@@ -31,12 +42,6 @@ namespace osu.Game.Tests.Visual
 
             // This is the earliest we can get OsuGameBase, which is used by the dummy working beatmap to find textures
             beatmap.Default = new DummyWorkingBeatmap(Dependencies.Get<OsuGameBase>());
-
-            Dependencies.CacheAs<Bindable<WorkingBeatmap>>(beatmap);
-            Dependencies.CacheAs<IBindable<WorkingBeatmap>>(beatmap);
-
-            Dependencies.CacheAs(Ruleset);
-            Dependencies.CacheAs<IBindable<RulesetInfo>>(Ruleset);
 
             return Dependencies;
         }

--- a/osu.Game/Tests/Visual/OsuTestCase.cs
+++ b/osu.Game/Tests/Visual/OsuTestCase.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Visual
 
         [Cached]
         [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        protected readonly Bindable<IEnumerable<Mod>> SelectedMods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
+        protected readonly Bindable<IEnumerable<Mod>> Mods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
 
         protected DependencyContainer Dependencies { get; private set; }
 

--- a/osu.Game/Tests/Visual/OsuTestCase.cs
+++ b/osu.Game/Tests/Visual/OsuTestCase.cs
@@ -28,8 +28,8 @@ namespace osu.Game.Tests.Visual
         protected readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
 
         [Cached]
-        [Cached(Type = typeof(IBindable<IEnumerable<Mod>>))]
-        protected readonly Bindable<IEnumerable<Mod>> Mods = new Bindable<IEnumerable<Mod>>(Enumerable.Empty<Mod>());
+        [Cached(Type = typeof(IBindable<IReadOnlyList<Mod>>))]
+        protected readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         protected DependencyContainer Dependencies { get; private set; }
 

--- a/osu.Game/Tests/Visual/PlayerTestCase.cs
+++ b/osu.Game/Tests/Visual/PlayerTestCase.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual
             Beatmap.Value = new TestWorkingBeatmap(beatmap, Clock);
 
             if (!AllowFail)
-                Beatmap.Value.Mods.Value = new[] { ruleset.GetAllMods().First(m => m is ModNoFail) };
+                SelectedMods.Value = new[] { ruleset.GetAllMods().First(m => m is ModNoFail) };
 
             Player = CreatePlayer(ruleset);
             LoadScreen(Player);

--- a/osu.Game/Tests/Visual/PlayerTestCase.cs
+++ b/osu.Game/Tests/Visual/PlayerTestCase.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual
             Beatmap.Value = new TestWorkingBeatmap(beatmap, Clock);
 
             if (!AllowFail)
-                SelectedMods.Value = new[] { ruleset.GetAllMods().First(m => m is ModNoFail) };
+                Mods.Value = new[] { ruleset.GetAllMods().First(m => m is ModNoFail) };
 
             Player = CreatePlayer(ruleset);
             LoadScreen(Player);


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/4610

1. `OsuScreen` now has a `SelectedMods` bindable, similar to beatmap and ruleset.
2. Mods now have to be provided to `WorkingBeatmap.GetPlayableBeatmap()` and `DrawableRuleset()`.
3. Track adjustments are applied at music controlled right now, because that's the component which handles music playing right now. I think eventually we may want to move it into `SongSelect`, but I kept the changes simple for now.
4. Due to (3), `MatchSubScreen` now plays the modded track, which may be expected functionality?