### PR TITLE
Add toggle for hiding "great" judgement in osu

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
             Set(OsuRulesetSetting.SnakingInSliders, true);
             Set(OsuRulesetSetting.SnakingOutSliders, true);
             Set(OsuRulesetSetting.ShowCursorTrail, true);
+            Set(OsuRulesetSetting.ShowGreatJudgement, true);
         }
     }
 
@@ -26,6 +27,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
     {
         SnakingInSliders,
         SnakingOutSliders,
-        ShowCursorTrail
+        ShowCursorTrail,
+        ShowGreatJudgement
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -4,6 +4,8 @@
 using osuTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -12,6 +14,8 @@ using osu.Game.Rulesets.UI;
 using System.Linq;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.UI.Cursor;
+using osu.Game.Rulesets.Osu.Configuration;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -48,6 +52,14 @@ namespace osu.Game.Rulesets.Osu.UI
             };
         }
 
+        private Bindable<bool> showGreatJudgement;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuRulesetConfigManager config)
+        {
+            showGreatJudgement = config.GetBindable<bool>(OsuRulesetSetting.ShowGreatJudgement);
+        }
+
         public override void Add(DrawableHitObject h)
         {
             h.OnNewResult += onNewResult;
@@ -80,6 +92,9 @@ namespace osu.Game.Rulesets.Osu.UI
         private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
         {
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
+                return;
+
+            if (!showGreatJudgement.Value && result.Type == HitResult.Great)
                 return;
 
             DrawableOsuJudgement explosion = new DrawableOsuJudgement(result, judgedObject)

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Rulesets.Osu.UI
                     LabelText = "Cursor trail",
                     Bindable = config.GetBindable<bool>(OsuRulesetSetting.ShowCursorTrail)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Show \"great\" hit result",
+                    Bindable = config.GetBindable<bool>(OsuRulesetSetting.ShowGreatJudgement)
+                }
             };
         }
     }


### PR DESCRIPTION
As a player the "great" text showing after each hit is annoying.
In legacy we get around this with skinning hacks, but those hacks don't always work in the legacy skins here. This also allows to hide it in the default skin too.
Open to discussions on whether this is the right way to procede.

I'm not sure if this is a thing in other Rulesets too, i made it for osu only as it's what i play.

Also first contribution ༼ つ ◕_◕ ༽つ