### PR TITLE
Implement S+ and SS+ Grading

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -42,10 +42,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             scoreProcessor.Health.ValueChanged += health => { blinds.AnimateClosedness((float)health.NewValue); };
         }
 
-        public ScoreRank AdjustRank(ScoreRank rank)
-        {
-            return rank;
-        }
+        public ScoreRank AdjustRank(ScoreRank rank) => rank;
 
         /// <summary>
         /// Element for the Blinds mod drawing 2 black boxes covering the whole screen which resize inside a restricted area with some leniency.

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
 using osuTK;
 using osuTK.Graphics;
 
@@ -39,6 +40,11 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {
             scoreProcessor.Health.ValueChanged += health => { blinds.AnimateClosedness((float)health.NewValue); };
+        }
+
+        public ScoreRank AdjustRank(ScoreRank rank)
+        {
+            return rank;
         }
 
         /// <summary>

--- a/osu.Game.Tests/Visual/Gameplay/TestCasePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCasePlayerLoader.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
 using osu.Game.Screens;
 using osu.Game.Screens.Play;
 
@@ -109,6 +110,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
             {
                 Applied = true;
+            }
+
+            public ScoreRank AdjustRank(ScoreRank rank)
+            {
+                return rank;
             }
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestCasePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCasePlayerLoader.cs
@@ -112,10 +112,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Applied = true;
             }
 
-            public ScoreRank AdjustRank(ScoreRank rank)
-            {
-                return rank;
-            }
+            public ScoreRank AdjustRank(ScoreRank rank) => rank;
         }
 
         private class TestPlayer : Player

--- a/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
@@ -12,6 +12,10 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableToScoreProcessor : IApplicableMod
     {
         void ApplyToScoreProcessor(ScoreProcessor scoreProcessor);
+        
+        /// <summary>
+        /// Adjusts rank on specific mods, mostly used for S and SS to be S+ and SS+ 
+        /// </summary>
         ScoreRank AdjustRank(ScoreRank rank);
     }
 }

--- a/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
         void ApplyToScoreProcessor(ScoreProcessor scoreProcessor);
 
         /// <summary>
-        /// Adjusts rank on specific mods, mostly used for S and SS to be S+ and SS+ 
+        /// Adjusts rank on specific mods, mostly used for S and SS to be S+ and SS+
         /// </summary>
         ScoreRank AdjustRank(ScoreRank rank);
     }

--- a/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
@@ -11,5 +11,6 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableToScoreProcessor : IApplicableMod
     {
         void ApplyToScoreProcessor(ScoreProcessor scoreProcessor);
+        ScoreRank AdjustRank(ScoreRank rank);
     }
 }

--- a/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableToScoreProcessor : IApplicableMod
     {
         void ApplyToScoreProcessor(ScoreProcessor scoreProcessor);
-        
+
         /// <summary>
         /// Adjusts rank on specific mods, mostly used for S and SS to be S+ and SS+ 
         /// </summary>

--- a/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToScoreProcessor.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -16,6 +16,7 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
 using osuTK;
 using osuTK.Graphics;
 
@@ -45,6 +46,8 @@ namespace osu.Game.Rulesets.Mods
         {
             Combo.BindTo(scoreProcessor.Combo);
         }
+
+        public ScoreRank
 
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -47,10 +47,7 @@ namespace osu.Game.Rulesets.Mods
             Combo.BindTo(scoreProcessor.Combo);
         }
 
-        public ScoreRank AdjustRank(ScoreRank rank)
-        {
-            return rank;
-        }
+        public ScoreRank AdjustRank(ScoreRank rank) => rank;
 
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -47,7 +47,10 @@ namespace osu.Game.Rulesets.Mods
             Combo.BindTo(scoreProcessor.Combo);
         }
 
-        public ScoreRank
+        public ScoreRank AdjustRank(ScoreRank rank)
+        {
+            return rank;
+        }
 
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -11,7 +11,7 @@ using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModHidden : Mod, IReadFromConfig, IApplicableToDrawableHitObjects
+    public abstract class ModHidden : Mod, IReadFromConfig, IApplicableToDrawableHitObjects, IApplicableToScoreProcessor
     {
         public override string Name => "Hidden";
         public override string Acronym => "HD";
@@ -20,6 +20,23 @@ namespace osu.Game.Rulesets.Mods
         public override bool Ranked => true;
 
         protected Bindable<bool> IncreaseFirstObjectVisibility = new Bindable<bool>();
+
+        public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        {
+        }
+
+        public ScoreRank AdjustRank(ScoreRank rank)
+        {
+            switch (rank)
+            {
+                case ScoreRank.X:
+                    return ScoreRank.XH;
+                case ScoreRank.S:
+                    return ScoreRank.SH;
+                default:
+                    return rank;
+            }
+        }
 
         public void ReadFromConfig(OsuConfigManager config)
         {

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Scoring;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -25,10 +25,7 @@ namespace osu.Game.Rulesets.Mods
             scoreProcessor.FailConditions += FailCondition;
         }
 
-        public ScoreRank AdjustRank(ScoreRank rank)
-        {
-            return rank;
-        }
+        public ScoreRank AdjustRank(ScoreRank rank) => rank;
 
         protected virtual bool FailCondition(ScoreProcessor scoreProcessor) => scoreProcessor.Combo.Value == 0;
     }

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -23,7 +24,7 @@ namespace osu.Game.Rulesets.Mods
         {
             scoreProcessor.FailConditions += FailCondition;
         }
-        
+
         public ScoreRank AdjustRank(ScoreRank rank)
         {
             return rank;

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -23,6 +23,11 @@ namespace osu.Game.Rulesets.Mods
         {
             scoreProcessor.FailConditions += FailCondition;
         }
+        
+        public ScoreRank AdjustRank(ScoreRank rank)
+        {
+            return rank;
+        }
 
         protected virtual bool FailCondition(ScoreProcessor scoreProcessor) => scoreProcessor.Combo.Value == 0;
     }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -251,6 +251,9 @@ namespace osu.Game.Screens.Play
             if (ScoreProcessor.HasFailed || onCompletionEvent != null)
                 return;
 
+            foreach (var mod in Mods.Value.OfType<IApplicableToScoreProcessor>())
+                ScoreProcessor.Rank.Value = mod.AdjustRank(ScoreProcessor.Rank.Value);
+
             ValidForResume = false;
 
             if (!showResults) return;


### PR DESCRIPTION
### Implement SH and XH (S+ and SS+) grades when playing locally.
NOTE: I've discovered an issue in this pull request, the value of the grade is automatically changed if the accuracy was changed in ScoreProcessor, and it's bound to the break's grade value, so that'll cause an issue of displaying the grade not adjusted in a break period.
![Preview](https://user-images.githubusercontent.com/22781491/56362674-1c39ad80-61f3-11e9-8515-c4885bc5b43c.png)
