### PR TITLE
Standardise health adjustment process across all rulesets

### DIFF
--- a/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
                 default:
                     return 0;
                 case HitResult.Perfect:
-                    return 0.08;
+                    return 0.008;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
                 default:
                     return 0;
                 case HitResult.Perfect:
-                    return 8;
+                    return 0.08;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Rulesets.Catch.Judgements
             switch (result)
             {
                 default:
-                    return 0;
+                    return base.HealthIncreaseFor(result);
                 case HitResult.Perfect:
-                    return 7;
+                    return 0.07;
             }
         }
     }

--- a/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
                 default:
                     return base.HealthIncreaseFor(result);
                 case HitResult.Perfect:
-                    return 0.07;
+                    return 0.007;
             }
         }
     }

--- a/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
@@ -27,9 +27,9 @@ namespace osu.Game.Rulesets.Catch.Judgements
             switch (result)
             {
                 default:
-                    return 0;
+                    return -0.02;
                 case HitResult.Perfect:
-                    return 10.2;
+                    return 0.01;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
                 default:
                     return 0;
                 case HitResult.Perfect:
-                    return 4;
+                    return 0.004;
             }
         }
     }

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Catch.Scoring
             hpDrainRate = beatmap.BeatmapInfo.BaseDifficulty.DrainRate;
         }
 
-        protected override double HpFactorFor(JudgementResult result)
+        protected override double HealthAdjustmentFactorFor(JudgementResult result)
         {
             switch (result.Type)
             {

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -26,12 +26,10 @@ namespace osu.Game.Rulesets.Catch.Scoring
             hpDrainRate = beatmap.BeatmapInfo.BaseDifficulty.DrainRate;
         }
 
-        protected override double HpFactorFor(Judgement judgement, HitResult result)
+        protected override double HpFactorFor(JudgementResult result)
         {
-            switch (result)
+            switch (result.Type)
             {
-                case HitResult.Miss when judgement.IsBonus:
-                    return 0;
                 case HitResult.Miss:
                     return hpDrainRate;
                 default:

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Judgements;
@@ -27,20 +26,17 @@ namespace osu.Game.Rulesets.Catch.Scoring
             hpDrainRate = beatmap.BeatmapInfo.BaseDifficulty.DrainRate;
         }
 
-        private const double harshness = 0.01;
-
-        protected override void ApplyResult(JudgementResult result)
+        protected override double HpFactorFor(Judgement judgement, HitResult result)
         {
-            base.ApplyResult(result);
-
-            if (result.Type == HitResult.Miss)
+            switch (result)
             {
-                if (!result.Judgement.IsBonus)
-                    Health.Value -= hpDrainRate * (harshness * 2);
-                return;
+                case HitResult.Miss when judgement.IsBonus:
+                    return 0;
+                case HitResult.Miss:
+                    return hpDrainRate;
+                default:
+                    return 10 - hpDrainRate; // Award less HP as drain rate is increased
             }
-
-            Health.Value += Math.Max(result.Judgement.HealthIncreaseFor(result) - hpDrainRate, 0) * harshness;
         }
 
         public override HitWindows CreateHitWindows() => new CatchHitWindows();

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Catch.Scoring
                 case HitResult.Miss:
                     return hpDrainRate;
                 default:
-                    return 10 - hpDrainRate; // Award less HP as drain rate is increased
+                    return 10.2 - hpDrainRate; // Award less HP as drain rate is increased
             }
         }
 

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
@@ -10,5 +10,16 @@ namespace osu.Game.Rulesets.Mania.Judgements
         public override bool AffectsCombo => false;
 
         protected override int NumericResultFor(HitResult result) => 20;
+
+        protected override double HealthIncreaseFor(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Miss:
+                    return 0;
+                default:
+                    return 0.040;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -25,5 +25,26 @@ namespace osu.Game.Rulesets.Mania.Judgements
                     return 300;
             }
         }
+
+        protected override double HealthIncreaseFor(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Miss:
+                    return -0.125;
+                case HitResult.Meh:
+                    return 0.005;
+                case HitResult.Ok:
+                    return 0.010;
+                case HitResult.Good:
+                    return 0.035;
+                case HitResult.Great:
+                    return 0.055;
+                case HitResult.Perfect:
+                    return 0.065;
+                default:
+                    return 0;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -3,7 +3,6 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
@@ -29,36 +28,6 @@ namespace osu.Game.Rulesets.Mania.Scoring
         private const double hp_multiplier_max = 1;
 
         /// <summary>
-        /// The default BAD hit HP increase.
-        /// </summary>
-        private const double hp_increase_bad = 0.005;
-
-        /// <summary>
-        /// The default OK hit HP increase.
-        /// </summary>
-        private const double hp_increase_ok = 0.010;
-
-        /// <summary>
-        /// The default GOOD hit HP increase.
-        /// </summary>
-        private const double hp_increase_good = 0.035;
-
-        /// <summary>
-        /// The default tick hit HP increase.
-        /// </summary>
-        private const double hp_increase_tick = 0.040;
-
-        /// <summary>
-        /// The default GREAT hit HP increase.
-        /// </summary>
-        private const double hp_increase_great = 0.055;
-
-        /// <summary>
-        /// The default PERFECT hit HP increase.
-        /// </summary>
-        private const double hp_increase_perfect = 0.065;
-
-        /// <summary>
         /// The MISS HP multiplier at OD = 0.
         /// </summary>
         private const double hp_multiplier_miss_min = 0.5;
@@ -74,11 +43,6 @@ namespace osu.Game.Rulesets.Mania.Scoring
         private const double hp_multiplier_miss_max = 1;
 
         /// <summary>
-        /// The default MISS HP increase.
-        /// </summary>
-        private const double hp_increase_miss = -0.125;
-
-        /// <summary>
         /// The MISS HP multiplier. This is multiplied to the miss hp increase.
         /// </summary>
         private double hpMissMultiplier = 1;
@@ -87,10 +51,6 @@ namespace osu.Game.Rulesets.Mania.Scoring
         /// The HIT HP multiplier. This is multiplied to hit hp increases.
         /// </summary>
         private double hpMultiplier = 1;
-
-        public ManiaScoreProcessor()
-        {
-        }
 
         public ManiaScoreProcessor(DrawableRuleset<ManiaHitObject> drawableRuleset)
             : base(drawableRuleset)
@@ -122,8 +82,8 @@ namespace osu.Game.Rulesets.Mania.Scoring
             }
         }
 
-        protected override double HpFactorFor(Judgement judgement, HitResult result)
-            => result == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
+        protected override double HpFactorFor(JudgementResult result)
+            => result.Type == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
 
         public override HitWindows CreateHitWindows() => new ManiaHitWindows();
     }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -122,42 +122,8 @@ namespace osu.Game.Rulesets.Mania.Scoring
             }
         }
 
-        protected override void ApplyResult(JudgementResult result)
-        {
-            base.ApplyResult(result);
-
-            bool isTick = result.Judgement is HoldNoteTickJudgement;
-
-            if (isTick)
-            {
-                if (result.IsHit)
-                    Health.Value += hpMultiplier * hp_increase_tick;
-            }
-            else
-            {
-                switch (result.Type)
-                {
-                    case HitResult.Miss:
-                        Health.Value += hpMissMultiplier * hp_increase_miss;
-                        break;
-                    case HitResult.Meh:
-                        Health.Value += hpMultiplier * hp_increase_bad;
-                        break;
-                    case HitResult.Ok:
-                        Health.Value += hpMultiplier * hp_increase_ok;
-                        break;
-                    case HitResult.Good:
-                        Health.Value += hpMultiplier * hp_increase_good;
-                        break;
-                    case HitResult.Great:
-                        Health.Value += hpMultiplier * hp_increase_great;
-                        break;
-                    case HitResult.Perfect:
-                        Health.Value += hpMultiplier * hp_increase_perfect;
-                        break;
-                }
-            }
-        }
+        protected override double HpFactorFor(Judgement judgement, HitResult result)
+            => result == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
 
         public override HitWindows CreateHitWindows() => new ManiaHitWindows();
     }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Mania.Scoring
             }
         }
 
-        protected override double HpFactorFor(JudgementResult result)
+        protected override double HealthAdjustmentFactorFor(JudgementResult result)
             => result.Type == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
 
         public override HitWindows CreateHitWindows() => new ManiaHitWindows();

--- a/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
@@ -24,5 +24,20 @@ namespace osu.Game.Rulesets.Osu.Judgements
                     return 300;
             }
         }
+
+        protected override double HealthIncreaseFor(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Miss:
+                    return -0.02;
+                case HitResult.Meh:
+                case HitResult.Good:
+                case HitResult.Great:
+                    return 0.01;
+                default:
+                    return 0;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 comboResultCounts[osuResult.ComboType] = comboResultCounts.GetOrDefault(osuResult.ComboType) + 1;
         }
 
-        protected override double HpFactorFor(JudgementResult result)
+        protected override double HealthAdjustmentFactorFor(JudgementResult result)
         {
             switch (result.Type)
             {

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -47,28 +47,29 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
             if (result.Type != HitResult.None)
                 comboResultCounts[osuResult.ComboType] = comboResultCounts.GetOrDefault(osuResult.ComboType) + 1;
+        }
 
-            switch (result.Type)
+        protected override double HpFactorFor(Judgement judgement, HitResult result)
+        {
+            switch (result)
             {
                 case HitResult.Great:
-                    Health.Value += (10.2 - hpDrainRate) * harshness;
-                    break;
+                    return 10.2 - hpDrainRate;
 
                 case HitResult.Good:
-                    Health.Value += (8 - hpDrainRate) * harshness;
-                    break;
+                    return 8 - hpDrainRate;
 
                 case HitResult.Meh:
-                    Health.Value += (4 - hpDrainRate) * harshness;
-                    break;
+                    return 4 - hpDrainRate;
 
-                /*case HitResult.SliderTick:
-                    Health.Value += Math.Max(7 - hpDrainRate, 0) * 0.01;
-                    break;*/
+                // case HitResult.SliderTick:
+                //     return Math.Max(7 - hpDrainRate, 0) * 0.01;
 
                 case HitResult.Miss:
-                    Health.Value -= hpDrainRate * (harshness * 2);
-                    break;
+                    return hpDrainRate;
+
+                default:
+                    return 0;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Rulesets.Osu.Scoring
             comboResultCounts.Clear();
         }
 
-        private const double harshness = 0.01;
-
         protected override void ApplyResult(JudgementResult result)
         {
             base.ApplyResult(result);
@@ -49,9 +47,9 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 comboResultCounts[osuResult.ComboType] = comboResultCounts.GetOrDefault(osuResult.ComboType) + 1;
         }
 
-        protected override double HpFactorFor(Judgement judgement, HitResult result)
+        protected override double HpFactorFor(JudgementResult result)
         {
-            switch (result)
+            switch (result.Type)
             {
                 case HitResult.Great:
                     return 10.2 - hpDrainRate;

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -46,8 +46,8 @@ namespace osu.Game.Rulesets.Taiko.Scoring
             hpMissMultiplier = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.DrainRate, 0.0018, 0.0075, 0.0120);
         }
 
-        protected override double HpFactorFor(Judgement judgement, HitResult result)
-            => result == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
+        protected override double HpFactorFor(JudgementResult result)
+            => result.Type == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
 
         protected override void Reset(bool storeResults)
         {

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -46,19 +46,8 @@ namespace osu.Game.Rulesets.Taiko.Scoring
             hpMissMultiplier = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.DrainRate, 0.0018, 0.0075, 0.0120);
         }
 
-        protected override void ApplyResult(JudgementResult result)
-        {
-            base.ApplyResult(result);
-
-            double hpIncrease = result.Judgement.HealthIncreaseFor(result);
-
-            if (result.Type == HitResult.Miss)
-                hpIncrease *= hpMissMultiplier;
-            else
-                hpIncrease *= hpMultiplier;
-
-            Health.Value += hpIncrease;
-        }
+        protected override double HpFactorFor(Judgement judgement, HitResult result)
+            => result == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
 
         protected override void Reset(bool storeResults)
         {

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Taiko.Scoring
             hpMissMultiplier = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.DrainRate, 0.0018, 0.0075, 0.0120);
         }
 
-        protected override double HpFactorFor(JudgementResult result)
+        protected override double HealthAdjustmentFactorFor(JudgementResult result)
             => result.Type == HitResult.Miss ? hpMissMultiplier : hpMultiplier;
 
         protected override void Reset(bool storeResults)

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -32,6 +32,11 @@ namespace osu.Game.Rulesets.Judgements
         public int MaxNumericResult => NumericResultFor(MaxResult);
 
         /// <summary>
+        /// The health increase for the maximum achievable result.
+        /// </summary>
+        public double MaxHealthIncrease => HealthIncreaseFor(MaxResult);
+
+        /// <summary>
         /// Retrieves the numeric score representation of a <see cref="HitResult"/>.
         /// </summary>
         /// <param name="result">The <see cref="HitResult"/> to find the numeric score representation for.</param>

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -38,6 +38,11 @@ namespace osu.Game.Rulesets.Judgements
         public int HighestComboAtJudgement { get; internal set; }
 
         /// <summary>
+        /// The health prior to this <see cref="JudgementResult"/> occurring.
+        /// </summary>
+        public double HealthAtJudgement { get; internal set; }
+
+        /// <summary>
         /// Whether a miss or hit occurred.
         /// </summary>
         public bool HasResult => Type > HitResult.None;

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -206,9 +206,6 @@ namespace osu.Game.Rulesets.Scoring
         private double baseScore;
         private double bonusScore;
 
-        private double rollingHp;
-        private double rollingMaxHp;
-
         protected ScoreProcessor()
         {
         }
@@ -304,6 +301,7 @@ namespace osu.Game.Rulesets.Scoring
         {
             result.ComboAtJudgement = Combo.Value;
             result.HighestComboAtJudgement = HighestCombo.Value;
+            result.HealthAtJudgement = Health.Value;
 
             JudgedHits++;
 
@@ -336,8 +334,7 @@ namespace osu.Game.Rulesets.Scoring
                 rollingMaxBaseScore += result.Judgement.MaxNumericResult;
             }
 
-            rollingHp += HpFactorFor(result.Judgement, result.Type) * result.Judgement.HealthIncreaseFor(result);
-            rollingMaxHp += HpFactorFor(result.Judgement, result.Judgement.MaxResult) * result.Judgement.MaxHealthIncrease;
+            Health.Value += HpFactorFor(result) * result.Judgement.HealthIncreaseFor(result);
         }
 
         /// <summary>
@@ -349,6 +346,7 @@ namespace osu.Game.Rulesets.Scoring
         {
             Combo.Value = result.ComboAtJudgement;
             HighestCombo.Value = result.HighestComboAtJudgement;
+            Health.Value = result.HealthAtJudgement;
 
             JudgedHits--;
 
@@ -362,12 +360,9 @@ namespace osu.Game.Rulesets.Scoring
                 baseScore -= result.Judgement.NumericResultFor(result);
                 rollingMaxBaseScore -= result.Judgement.MaxNumericResult;
             }
-
-            rollingHp -= HpFactorFor(result.Judgement, result.Type) * result.Judgement.HealthIncreaseFor(result);
-            rollingMaxHp -= HpFactorFor(result.Judgement, result.Judgement.MaxResult) * result.Judgement.MaxHealthIncrease;
         }
 
-        protected virtual double HpFactorFor(Judgement judgement, HitResult result) => 1;
+        protected virtual double HpFactorFor(JudgementResult result) => 1;
 
         private void updateScore()
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -334,7 +334,7 @@ namespace osu.Game.Rulesets.Scoring
                 rollingMaxBaseScore += result.Judgement.MaxNumericResult;
             }
 
-            Health.Value += HpFactorFor(result) * result.Judgement.HealthIncreaseFor(result);
+            Health.Value += HealthAdjustmentFactorFor(result) * result.Judgement.HealthIncreaseFor(result);
         }
 
         /// <summary>
@@ -362,7 +362,12 @@ namespace osu.Game.Rulesets.Scoring
             }
         }
 
-        protected virtual double HpFactorFor(JudgementResult result) => 1;
+        /// <summary>
+        /// An adjustment factor which is multiplied into the health increase provided by a <see cref="JudgementResult"/>.
+        /// </summary>
+        /// <param name="result">The <see cref="JudgementResult"/> for which the adjustment should apply.</param>
+        /// <returns>The adjustment factor.</returns>
+        protected virtual double HealthAdjustmentFactorFor(JudgementResult result) => 1;
 
         private void updateScore()
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -206,6 +206,9 @@ namespace osu.Game.Rulesets.Scoring
         private double baseScore;
         private double bonusScore;
 
+        private double rollingHp;
+        private double rollingMaxHp;
+
         protected ScoreProcessor()
         {
         }
@@ -332,6 +335,9 @@ namespace osu.Game.Rulesets.Scoring
                 baseScore += result.Judgement.NumericResultFor(result);
                 rollingMaxBaseScore += result.Judgement.MaxNumericResult;
             }
+
+            rollingHp += HpFactorFor(result.Judgement, result.Type) * result.Judgement.HealthIncreaseFor(result);
+            rollingMaxHp += HpFactorFor(result.Judgement, result.Judgement.MaxResult) * result.Judgement.MaxHealthIncrease;
         }
 
         /// <summary>
@@ -356,7 +362,12 @@ namespace osu.Game.Rulesets.Scoring
                 baseScore -= result.Judgement.NumericResultFor(result);
                 rollingMaxBaseScore -= result.Judgement.MaxNumericResult;
             }
+
+            rollingHp -= HpFactorFor(result.Judgement, result.Type) * result.Judgement.HealthIncreaseFor(result);
+            rollingMaxHp -= HpFactorFor(result.Judgement, result.Judgement.MaxResult) * result.Judgement.MaxHealthIncrease;
         }
+
+        protected virtual double HpFactorFor(Judgement judgement, HitResult result) => 1;
 
         private void updateScore()
         {


### PR DESCRIPTION
Brings us a little bit closer to having fully standardised health, still needs a little bit more work (standardisation of increase values, drain rate (maybe?), standardisation of adjustment factors), but I think this is fine for an initial implementation.

I've tried to preserve existing functionality, but catch differs slightly because it baked in some form of pseudo-drain into its calculations. If we do implement this again in the future it should be standardised across all rulesets.

* Fixes HP rewinding not working.
* Fixes slider input errors in https://ci.appveyor.com/project/peppy/osu/builds/24010341/tests (although there is likely a deeper issue causing the clock to rewind).