### PR TITLE
Fix pause tests and cursor visibility

### DIFF
--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -68,7 +68,12 @@ namespace osu.Game.Rulesets.UI
         {
             Cursor = CreateCursor();
             if (Cursor != null)
+            {
+                // initial showing of the cursor will be handed by MenuCursorContainer (via DrawableRuleset's IProvideCursor implementation).
+                Cursor.Hide();
+
                 AddInternal(Cursor);
+            }
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -110,11 +110,8 @@ namespace osu.Game.Screens.Play
                     adjustableClock.ChangeSource(sourceClock);
                     updateRate();
 
-                    this.Delay(750).Schedule(() =>
-                    {
-                        if (!IsPaused.Value)
-                            Start();
-                    });
+                    if (!IsPaused.Value)
+                        Start();
                 });
             });
         }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Screens.Play
         {
             // Seeking the decoupled clock to its current time ensures that its source clock will be seeked to the same time
             // This accounts for the audio clock source potentially taking time to enter a completely stopped state
-            adjustableClock.Seek(GameplayClock.CurrentTime);
+            Seek(GameplayClock.CurrentTime);
             adjustableClock.Start();
             IsPaused.Value = false;
         }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Play
         {
             // Seeking the decoupled clock to its current time ensures that its source clock will be seeked to the same time
             // This accounts for the audio clock source potentially taking time to enter a completely stopped state
-            adjustableClock.Seek(adjustableClock.CurrentTime);
+            adjustableClock.Seek(GameplayClock.CurrentTime);
             adjustableClock.Start();
             IsPaused.Value = false;
         }


### PR DESCRIPTION
- Fixes pause tests failing under nUnit (due to incorrect clock seek).
- Removes arbitrary delay on entering player (to make new cursor hide logic look better by ensuring the `GameplayClock` is running)