### PR TITLE
Fix possible exit from non-current screen

### DIFF
--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -276,7 +276,7 @@ namespace osu.Game.Screens.Multi
 
             updatePollingRate(isIdle.Value);
 
-            if (screenStack.CurrentScreen == null)
+            if (screenStack.CurrentScreen == null && this.IsCurrentScreen())
                 this.Exit();
         }
 


### PR DESCRIPTION
It's possible to exit the child screen after the main multiplayer screen has exited, just due to the ordering of events here.