### PR TITLE
Fix lead-in time being too short

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Input;
@@ -61,7 +62,7 @@ namespace osu.Game.Rulesets.Osu.UI
             get
             {
                 var first = (OsuHitObject)Objects.First();
-                return first.StartTime - first.TimePreempt;
+                return first.StartTime - Math.Max(2000, first.TimePreempt);
             }
         }
     }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -95,8 +95,7 @@ namespace osu.Game.Screens.Play
 
             UserPlaybackRate.ValueChanged += _ => updateRate();
 
-            Seek(Math.Min(0, gameplayStartTime - beatmap.BeatmapInfo.AudioLeadIn));
-            adjustableClock.ProcessFrame();
+            Seek(Math.Min(-beatmap.BeatmapInfo.AudioLeadIn, gameplayStartTime));
         }
 
         public void Restart()

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -136,6 +136,9 @@ namespace osu.Game.Screens.Play
             // remove the offset component here because most of the time we want the seek to be aligned to gameplay, not the audio track.
             // we may want to consider reversing the application of offsets in the future as it may feel more correct.
             adjustableClock.Seek(time - totalOffset);
+
+            // manually process frame to ensure GameplayClock is correctly updated after a seek.
+            userOffsetClock.ProcessFrame();
         }
 
         public void Stop()

--- a/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osuTK;
 
 namespace osu.Game.Tests.Beatmaps
 {
@@ -67,9 +68,10 @@ namespace osu.Game.Tests.Beatmaps
 
             public override bool Seek(double seek)
             {
-                offset = Math.Min(seek, Length);
+                offset = MathHelper.Clamp(seek, 0, Length);
                 lastReferenceTime = null;
-                return true;
+
+                return offset == seek;
             }
 
             public override void Start()


### PR DESCRIPTION
Didn't really regress, but the fact it felt okay until now hinged on a transition/schedule value which was removed.

- [x] Depends on #4673
- Fixes userOffsetClock being incorrect after a Seek call.
- Fixes beatmap legacy setting `AudioLeadIn` being consumed incorrectly (referenced against osu-stable Player.cs#1313 and Player.cs#1294).
- Resolves #4670.