### PR TITLE
Prevent PlayerLoader from tracking the logo after it has been exited.

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -163,7 +163,11 @@ namespace osu.Game.Screens.Play
             logo.ScaleTo(new Vector2(0.15f), duration, Easing.In);
             logo.FadeIn(350);
 
-            Scheduler.AddDelayed(() => { content.StartTracking(logo, resuming ? 0 : 500, Easing.InOutExpo); }, resuming ? 0 : 500);
+            Scheduler.AddDelayed(() =>
+            {
+                if (this.IsCurrentScreen())
+                    content.StartTracking(logo, resuming ? 0 : 500, Easing.InOutExpo);
+            }, resuming ? 0 : 500);
         }
 
         protected override void LogoExiting(OsuLogo logo)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/4671

Not sure if there could be better testing for this or if there is a more catch-all solution for screens attempting to track a logo when it is no longer current, but since `pushWhenLoaded` has a similar current screen check I'm thinking this fix is okay.