### PR TITLE
Change beatmap intro skip to match stable

### DIFF
--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -87,30 +87,26 @@ namespace osu.Game.Screens.Play
             };
         }
 
-        private const double skip_required_cutoff = 3000;
         private const double fade_time = 300;
 
-        private double beginFadeTime => startTime - skip_required_cutoff - fade_time;
+        private double beginFadeTime => startTime - fade_time;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            if (startTime < skip_required_cutoff)
+            if (startTime + 2000 > 1000)
             {
-                Alpha = 0;
+                this.FadeInFromZero(fade_time);
+                using (BeginAbsoluteSequence(beginFadeTime))
+                {
+                    this.FadeOut(fade_time);
+                }
+                button.Action = () => RequestSeek?.Invoke(startTime - fade_time);
+                displayTime = Time.Current;
                 Expire();
                 return;
             }
-
-            this.FadeInFromZero(fade_time);
-            using (BeginAbsoluteSequence(beginFadeTime))
-                this.FadeOut(fade_time);
-
-            button.Action = () => RequestSeek?.Invoke(startTime - skip_required_cutoff - fade_time);
-
-            displayTime = Time.Current;
-
+            Alpha = 0;
             Expire();
         }
 

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -88,6 +88,13 @@ namespace osu.Game.Screens.Play
         }
 
         private const double fade_time = 300;
+
+        /// <summary>
+        /// Represents minimum of secs required for gameplay start time in order to run skip overlay.
+        /// Since gameplay start time is 2 secs before beatmap's first object start time, in order to
+        /// use skip overlay if intro delay is >= 1 sec, we must substract 2 secs from 1, which is -1.
+        /// See "<see cref="osu.Game.Rulesets.UI.DrawableRuleset.GameplayStartTime"/>".
+        /// </summary>
         private const int skip_required_time = -1000;
 
         private double beginFadeTime => startTime - fade_time;
@@ -95,7 +102,8 @@ namespace osu.Game.Screens.Play
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            if (startTime < skip_required_time)
+
+            if(startTime < skip_required_time)
             {
                 Alpha = 0;
                 Expire();
@@ -103,10 +111,9 @@ namespace osu.Game.Screens.Play
             }
 
             this.FadeInFromZero(fade_time);
-            using (BeginAbsoluteSequence(beginFadeTime))
-            {
+
+            using(BeginAbsoluteSequence(beginFadeTime))
                 this.FadeOut(fade_time);
-            }
 
             button.Action = () => RequestSeek?.Invoke(startTime - fade_time);
             displayTime = Time.Current;

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -101,11 +101,13 @@ namespace osu.Game.Screens.Play
                 {
                     this.FadeOut(fade_time);
                 }
+
                 button.Action = () => RequestSeek?.Invoke(startTime - fade_time);
                 displayTime = Time.Current;
                 Expire();
                 return;
             }
+
             Alpha = 0;
             Expire();
         }

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -88,27 +88,28 @@ namespace osu.Game.Screens.Play
         }
 
         private const double fade_time = 300;
+        private const int skip_required_time = -1000;
 
         private double beginFadeTime => startTime - fade_time;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            if (startTime + 2000 > 1000)
+            if (startTime < skip_required_time)
             {
-                this.FadeInFromZero(fade_time);
-                using (BeginAbsoluteSequence(beginFadeTime))
-                {
-                    this.FadeOut(fade_time);
-                }
-
-                button.Action = () => RequestSeek?.Invoke(startTime - fade_time);
-                displayTime = Time.Current;
+                Alpha = 0;
                 Expire();
                 return;
             }
 
-            Alpha = 0;
+            this.FadeInFromZero(fade_time);
+            using (BeginAbsoluteSequence(beginFadeTime))
+            {
+                this.FadeOut(fade_time);
+            }
+
+            button.Action = () => RequestSeek?.Invoke(startTime - fade_time);
+            displayTime = Time.Current;
             Expire();
         }
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/4676.

Since without any beatmap intro delay, the timer starts at ~ -3 secs I considered these modifications:
- removed `skip_required_cutoff`, the timer after skipping becoming ~ -3 secs, like in a no-delay beatmap
- used `if (startTime + 2000 > 1000)`, which means, use the `skip` feature when the beatmap intro delay is bigger than 1 sec, aka no blink if delay is too small