### PR TITLE
Fix mod equality checks not working as intended

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIMod.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIMod.cs
@@ -8,5 +8,7 @@ namespace osu.Game.Online.API.Requests.Responses
     public class APIMod : IMod
     {
         public string Acronym { get; set; }
+
+        public bool Equals(IMod other) => Acronym == other?.Acronym;
     }
 }

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using Newtonsoft.Json;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public interface IMod
+    public interface IMod : IEquatable<IMod>
     {
         /// <summary>
         /// The shortened name of this mod.

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -70,5 +70,7 @@ namespace osu.Game.Rulesets.Mods
         /// Creates a copy of this <see cref="Mod"/> initialised to a default state.
         /// </summary>
         public virtual Mod CreateCopy() => (Mod)Activator.CreateInstance(GetType());
+
+        public bool Equals(IMod other) => GetType() == other?.GetType();
     }
 }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -177,6 +177,8 @@ namespace osu.Game.Scoring
         protected class DeserializedMod : IMod
         {
             public string Acronym { get; set; }
+
+            public bool Equals(IMod other) => Acronym == other?.Acronym;
         }
 
         public override string ToString() => $"{User} playing {Beatmap}";

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.Multi.Play
             if (ruleset.Value.ID != playlistItem.Ruleset.ID)
                 throw new InvalidOperationException("Current Ruleset does not match PlaylistItem's Ruleset");
 
-            if (!playlistItem.RequiredMods.All(m => Mods.Value.Contains(m)))
+            if (!playlistItem.RequiredMods.All(m => Mods.Value.Any(m.Equals)))
                 throw new InvalidOperationException("Current Mods do not match PlaylistItem's RequiredMods");
 
             var req = new CreateRoomScoreRequest(roomId.Value ?? 0, playlistItem.ID);


### PR DESCRIPTION
Any multiplayer game with mods currently crashes as a result. Likely due to the changes to mod instantiation.