### PR TITLE
Pause via inactive activates hold-for-menu button directly

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestCasePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCasePause.cs
@@ -196,9 +196,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             public bool PauseOverlayVisible => PauseOverlay.State == Visibility.Visible;
 
-            public PausePlayer()
+            protected override void LoadComplete()
             {
-                PauseOnFocusLost = false;
+                base.LoadComplete();
+                HUDOverlay.HoldToQuit.PauseOnFocusLost = false;
             }
         }
     }

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -144,8 +144,13 @@ namespace osu.Game.Screens.Play.HUD
 
                 bind();
 
-                gameActive.BindValueChanged(_ => updateActive());
                 gameActive.BindTo(game.IsActive);
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                gameActive.BindValueChanged(_ => updateActive(), true);
             }
 
             private void bind()
@@ -195,7 +200,7 @@ namespace osu.Game.Screens.Play.HUD
                 base.OnHoverLost(e);
             }
 
-            private bool pauseOnFocusLost;
+            private bool pauseOnFocusLost = true;
 
             public bool PauseOnFocusLost
             {
@@ -205,7 +210,8 @@ namespace osu.Game.Screens.Play.HUD
                         return;
 
                     pauseOnFocusLost = value;
-                    updateActive();
+                    if (IsLoaded)
+                        updateActive();
                 }
             }
 

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -70,6 +70,11 @@ namespace osu.Game.Screens.Play.HUD
             return base.OnMouseMove(e);
         }
 
+        public bool GameInactive
+        {
+            set => button.GameInactive = value;
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -182,6 +187,25 @@ namespace osu.Game.Screens.Play.HUD
             {
                 HoverLost?.Invoke();
                 base.OnHoverLost(e);
+            }
+
+            private bool gameInactive;
+
+            public bool GameInactive
+            {
+                get => gameInactive;
+                set
+                {
+                    if (gameInactive == value)
+                        return;
+
+                    gameInactive = value;
+
+                    if (gameInactive)
+                        BeginConfirm();
+                    else
+                        AbortConfirm();
+                }
             }
 
             public bool OnPressed(GlobalAction action)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -393,8 +393,8 @@ namespace osu.Game.Screens.Play
             base.Update();
 
             // eagerly pause when we lose window focus (if we are locally playing).
-            if (PauseOnFocusLost && !Game.IsActive.Value)
-                Pause();
+            if (PauseOnFocusLost)
+                HUDOverlay.HoldToQuit.GameInactive = !Game.IsActive.Value;
         }
 
         public void Pause()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -44,8 +44,6 @@ namespace osu.Game.Screens.Play
 
         public bool HasFailed { get; private set; }
 
-        public bool PauseOnFocusLost { get; set; } = true;
-
         private Bindable<bool> mouseWheelDisabled;
 
         private readonly Bindable<bool> storyboardReplacesBackground = new Bindable<bool>();
@@ -387,15 +385,6 @@ namespace osu.Game.Screens.Play
             && !HasFailed
             // already resuming
             && !IsResuming;
-
-        protected override void Update()
-        {
-            base.Update();
-
-            // eagerly pause when we lose window focus (if we are locally playing).
-            if (PauseOnFocusLost)
-                HUDOverlay.HoldToQuit.GameInactive = !Game.IsActive.Value;
-        }
 
         public void Pause()
         {


### PR DESCRIPTION
Resolves #4685 and moves more logic out of `Player`.