### PR TITLE
Fix incorrect texture name usage for some rank icons

### DIFF
--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -204,7 +204,6 @@ namespace osu.Game.Overlays.Profile.Header
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = 30,
-                            FillMode = FillMode.Fit
                         },
                         rankCount = new OsuSpriteText
                         {

--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -4,14 +4,12 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Scoring;
 using osu.Game.Users;
@@ -185,8 +183,6 @@ namespace osu.Game.Overlays.Profile.Header
 
         private class ScoreRankInfo : CompositeDrawable
         {
-            private readonly ScoreRank rank;
-            private readonly Sprite rankSprite;
             private readonly OsuSpriteText rankCount;
 
             public int RankCount
@@ -196,8 +192,6 @@ namespace osu.Game.Overlays.Profile.Header
 
             public ScoreRankInfo(ScoreRank rank)
             {
-                this.rank = rank;
-
                 AutoSizeAxes = Axes.Both;
                 InternalChild = new FillFlowContainer
                 {
@@ -206,9 +200,10 @@ namespace osu.Game.Overlays.Profile.Header
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        rankSprite = new Sprite
+                        new DrawableRank(rank)
                         {
-                            RelativeSizeAxes = Axes.Both,
+                            RelativeSizeAxes = Axes.X,
+                            Height = 30,
                             FillMode = FillMode.Fit
                         },
                         rankCount = new OsuSpriteText
@@ -219,12 +214,6 @@ namespace osu.Game.Overlays.Profile.Header
                         }
                     }
                 };
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
-            {
-                rankSprite.Texture = textures.Get($"Grades/{rank.GetDescription()}");
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/4732

29 is the exact height, close enough - doesn't need to be exact. This is required because using the previous `RelativeSizeAxes` + `Fit` combo would give the `DrawableRank` a size of 56x56, whereas the sprite previously received the intended size using this same combo due to having a texture.