### PR TITLE
Adjust testcase to avoid random failures

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestCaseUpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestCaseUpdateableBeatmapBackgroundSprite.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             var loadedBackgrounds = backgrounds.Where(b => b.ContentLoaded);
 
-            AddUntilStep("some loaded", () => (initialLoadCount = loadedBackgrounds.Count()) > 0);
+            AddUntilStep("some loaded", () => loadedBackgrounds.Any());
             AddStep("scroll to bottom", () => scrollContainer.ScrollToEnd());
             AddUntilStep("all unloaded", () => !loadedBackgrounds.Any());
         }

--- a/osu.Game.Tests/Visual/UserInterface/TestCaseUpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestCaseUpdateableBeatmapBackgroundSprite.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                         AutoSizeAxes = Axes.Y,
                         Direction = FillDirection.Vertical,
                         Spacing = new Vector2(10),
-                        Padding = new MarginPadding { Bottom = 250 }
+                        Padding = new MarginPadding { Bottom = 550 }
                     }
                 };
 
@@ -136,7 +136,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddUntilStep("some loaded", () => (initialLoadCount = loadedBackgrounds.Count()) > 0);
             AddStep("scroll to bottom", () => scrollContainer.ScrollToEnd());
-            AddUntilStep("some unloaded", () => loadedBackgrounds.Count() < initialLoadCount);
+            AddUntilStep("all unloaded", () => !loadedBackgrounds.Any());
         }
 
         private class TestUpdateableBeatmapBackgroundSprite : UpdateableBeatmapBackgroundSprite

--- a/osu.Game.Tests/Visual/UserInterface/TestCaseUpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestCaseUpdateableBeatmapBackgroundSprite.cs
@@ -132,8 +132,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             var loadedBackgrounds = backgrounds.Where(b => b.ContentLoaded);
 
-            int initialLoadCount = 0;
-
             AddUntilStep("some loaded", () => (initialLoadCount = loadedBackgrounds.Count()) > 0);
             AddStep("scroll to bottom", () => scrollContainer.ScrollToEnd());
             AddUntilStep("all unloaded", () => !loadedBackgrounds.Any());


### PR DESCRIPTION
Fixes https://ci.appveyor.com/project/peppy/osu/builds/24395011/tests

Which could fail if only one background was loaded in the first until step.