### PR TITLE
Add more asserts to pause test in an attempt to track down intermittent test failures

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestCasePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCasePause.cs
@@ -157,6 +157,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void confirmPaused()
         {
             confirmClockRunning(false);
+            AddAssert("player not exited", () => Player.IsCurrentScreen());
+            AddAssert("player not failed", () => !Player.HasFailed);
             AddAssert("pause overlay shown", () => Player.PauseOverlayVisible);
         }
 


### PR DESCRIPTION
I left tests running continuously overnight and could not repro https://ci.appveyor.com/project/peppy/osu/builds/24410383/tests

I'm guessing it's due to one of the conditions added in the asserts here, but can't immediately see why it would happen.