### PR TITLE
Fix score deletion not considering ScoreManager ownership

### DIFF
--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -65,7 +65,6 @@ namespace osu.Game.Beatmaps
         protected override IQueryable<BeatmapSetInfo> AddIncludesForDeletion(IQueryable<BeatmapSetInfo> query) =>
             base.AddIncludesForDeletion(query)
                 .Include(s => s.Metadata)
-                .Include(s => s.Beatmaps).ThenInclude(b => b.Scores)
                 .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
                 .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata);
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -385,7 +385,7 @@ namespace osu.Game.Database
         /// Delete multiple items.
         /// This will post notifications tracking progress.
         /// </summary>
-        public void Delete(List<TModel> items)
+        public void Delete(List<TModel> items, bool silent = false)
         {
             if (items.Count == 0) return;
 
@@ -396,7 +396,8 @@ namespace osu.Game.Database
                 State = ProgressNotificationState.Active,
             };
 
-            PostNotification?.Invoke(notification);
+            if (!silent)
+                PostNotification?.Invoke(notification);
 
             int i = 0;
 
@@ -423,7 +424,7 @@ namespace osu.Game.Database
         /// Restore multiple items that were previously deleted.
         /// This will post notifications tracking progress.
         /// </summary>
-        public void Undelete(List<TModel> items)
+        public void Undelete(List<TModel> items, bool silent = false)
         {
             if (!items.Any()) return;
 
@@ -434,7 +435,8 @@ namespace osu.Game.Database
                 State = ProgressNotificationState.Active,
             };
 
-            PostNotification?.Invoke(notification);
+            if (!silent)
+                PostNotification?.Invoke(notification);
 
             int i = 0;
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -25,9 +25,9 @@ namespace osu.Game.Scoring
         protected override string ImportFromStablePath => "Replays";
 
         private readonly RulesetStore rulesets;
-        private readonly BeatmapManager beatmaps;
+        private readonly Func<BeatmapManager> beatmaps;
 
-        public ScoreManager(RulesetStore rulesets, BeatmapManager beatmaps, Storage storage, IDatabaseContextFactory contextFactory, IIpcHost importHost = null)
+        public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, IDatabaseContextFactory contextFactory, IIpcHost importHost = null)
             : base(storage, contextFactory, new ScoreStore(contextFactory, storage), importHost)
         {
             this.rulesets = rulesets;
@@ -43,7 +43,7 @@ namespace osu.Game.Scoring
             {
                 try
                 {
-                    return new DatabasedLegacyScoreParser(rulesets, beatmaps).Parse(stream).ScoreInfo;
+                    return new DatabasedLegacyScoreParser(rulesets, beatmaps()).Parse(stream).ScoreInfo;
                 }
                 catch (LegacyScoreParser.BeatmapNotFoundException e)
                 {
@@ -53,7 +53,7 @@ namespace osu.Game.Scoring
             }
         }
 
-        public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps, Files.Store);
+        public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);
 
         public List<ScoreInfo> GetAllUsableScores() => ModelStore.ConsumableItems.Where(s => !s.DeletePending).ToList();
 


### PR DESCRIPTION
When trying to delete all beatmaps, my game would no longer start. This is a pretty important one to get fixed.

Regressed when ScoreManager became a thing, as scores now have their own child entities in the database (`ScoreFileInfo`). This removes the deletion by include and instead passes the operation on to `ScoreManager` to be handled more correctly.

Can probably be written in a more generic way when this come up another time, but let's keep it simple for now.