### PR TITLE
Fix long skip performance

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestCaseFrameStabilityContainer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseFrameStabilityContainer.cs
@@ -74,6 +74,26 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestInitialSeekWithGameplayStart()
+        {
+            seekManualTo(1000);
+            createStabilityContainer(30000);
+
+            confirmSeek(1000);
+            checkFrameCount(0);
+
+            seekManualTo(10000);
+            confirmSeek(10000);
+
+            checkFrameCount(1);
+
+            seekManualTo(130000);
+            confirmSeek(130000);
+
+            checkFrameCount(6002);
+        }
+
+        [Test]
         public void TestInitialSeek()
         {
             seekManualTo(100000);

--- a/osu.Game.Tests/Visual/Gameplay/TestCaseFrameStabilityContainer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestCaseFrameStabilityContainer.cs
@@ -103,7 +103,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             checkFrameCount(0);
         }
 
-        private void createStabilityContainer() => AddStep("create container", () => mainContainer.Child = new FrameStabilityContainer().WithChild(consumer = new ClockConsumingChild()));
+        private const int max_frames_catchup = 50;
+
+        private void createStabilityContainer(double gameplayStartTime = double.MinValue) => AddStep("create container", () =>
+            mainContainer.Child = new FrameStabilityContainer(gameplayStartTime) { MaxCatchUpFrames = max_frames_catchup }
+                .WithChild(consumer = new ClockConsumingChild()));
 
         private void seekManualTo(double time) => AddStep($"seek manual clock to {time}", () => manualClock.CurrentTime = time);
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.UI
         {
             InternalChildren = new Drawable[]
             {
-                frameStabilityContainer = new FrameStabilityContainer
+                frameStabilityContainer = new FrameStabilityContainer(GameplayStartTime)
                 {
                     Child = KeyBindingInputManager
                         .WithChild(CreatePlayfieldAdjustmentContainer()

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -17,10 +17,14 @@ namespace osu.Game.Rulesets.UI
     /// </summary>
     public class FrameStabilityContainer : Container, IHasReplayHandler
     {
-        public FrameStabilityContainer()
+        private readonly double gameplayStartTime;
+
+        public FrameStabilityContainer(double gameplayStartTime = double.MinValue)
         {
             RelativeSizeAxes = Axes.Both;
             gameplayClock = new GameplayClock(framedClock = new FramedClock(manualClock = new ManualClock()));
+
+            this.gameplayStartTime = gameplayStartTime;
         }
 
         private readonly ManualClock manualClock;
@@ -116,6 +120,8 @@ namespace osu.Game.Rulesets.UI
 
                     firstConsumption = false;
                 }
+                else if (manualClock.CurrentTime < gameplayStartTime)
+                    manualClock.CurrentTime = newProposedTime = Math.Min(gameplayStartTime, newProposedTime);
                 else if (Math.Abs(manualClock.CurrentTime - newProposedTime) > sixty_frame_time * 1.2f)
                 {
                     newProposedTime = newProposedTime > manualClock.CurrentTime

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -19,6 +19,11 @@ namespace osu.Game.Rulesets.UI
     {
         private readonly double gameplayStartTime;
 
+        /// <summary>
+        /// The number of frames (per parent frame) which can be run in an attempt to catch-up to real-time.
+        /// </summary>
+        public int MaxCatchUpFrames { get; set; } = 5;
+
         public FrameStabilityContainer(double gameplayStartTime = double.MinValue)
         {
             RelativeSizeAxes = Axes.Both;
@@ -68,8 +73,6 @@ namespace osu.Game.Rulesets.UI
 
         private bool isAttached => ReplayInputHandler != null;
 
-        private const int max_catch_up_updates_per_frame = 50;
-
         private const double sixty_frame_time = 1000.0 / 60;
 
         private bool firstConsumption = true;
@@ -81,7 +84,7 @@ namespace osu.Game.Rulesets.UI
 
             int loops = 0;
 
-            while (validState && requireMoreUpdateLoops && loops++ < max_catch_up_updates_per_frame)
+            while (validState && requireMoreUpdateLoops && loops++ < MaxCatchUpFrames)
             {
                 updateClock();
 


### PR DESCRIPTION
Lead-in time was still being performed under the confines of `FrameStability`, even though not required. On taiko, which hasn't been optimised yet, this was especially noticeable.

- Closes #4740.
- Reduces the max skip frames to avoid frame drops during skip.