### PR TITLE
Add cancellation support to storyboard/hitobject loading

### DIFF
--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
@@ -140,7 +141,7 @@ namespace osu.Game.Rulesets.UI
         public virtual PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new PlayfieldAdjustmentContainer();
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, CancellationToken cancellationToken)
         {
             InternalChildren = new Drawable[]
             {
@@ -163,16 +164,24 @@ namespace osu.Game.Rulesets.UI
 
             applyRulesetMods(mods, config);
 
-            loadObjects();
+            loadObjects(cancellationToken);
         }
 
         /// <summary>
         /// Creates and adds drawable representations of hit objects to the play field.
         /// </summary>
-        private void loadObjects()
+        private void loadObjects(CancellationToken cancellationToken)
         {
             foreach (TObject h in Beatmap.HitObjects)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
                 addHitObject(h);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+                return;
 
             Playfield.PostProcess();
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -57,7 +58,7 @@ namespace osu.Game.Storyboards.Drawables
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(FileStore fileStore, GameplayClock clock)
+        private void load(FileStore fileStore, GameplayClock clock, CancellationToken cancellationToken)
         {
             if (clock != null)
                 Clock = clock;
@@ -65,7 +66,12 @@ namespace osu.Game.Storyboards.Drawables
             dependencies.Cache(new TextureStore(new TextureLoaderStore(fileStore.Store), false, scaleAdjust: 1));
 
             foreach (var layer in Storyboard.Layers)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
                 Add(layer.CreateDrawable());
+            }
         }
 
         private void updateLayerVisibility()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardLayer.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardLayer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -24,10 +25,13 @@ namespace osu.Game.Storyboards.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(CancellationToken cancellationToken)
         {
             foreach (var element in Layer.Elements)
             {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
                 if (element.IsDrawable)
                     AddInternal(element.CreateDrawable());
             }

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -5,11 +5,10 @@ using osu.Game.Beatmaps;
 using osu.Game.Storyboards.Drawables;
 using System.Collections.Generic;
 using System.Linq;
-using System;
 
 namespace osu.Game.Storyboards
 {
-    public class Storyboard : IDisposable
+    public class Storyboard
     {
         private readonly Dictionary<string, StoryboardLayer> layers = new Dictionary<string, StoryboardLayer>();
         public IEnumerable<StoryboardLayer> Layers => layers.Values;
@@ -56,30 +55,5 @@ namespace osu.Game.Storyboards
             drawable.Width = drawable.Height * (BeatmapInfo.WidescreenStoryboard ? 16 / 9f : 4 / 3f);
             return drawable;
         }
-
-        #region Disposal
-
-        ~Storyboard()
-        {
-            Dispose(false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        private bool isDisposed;
-
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (isDisposed)
-                return;
-
-            isDisposed = true;
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
Testable on maps with long storyboards (e.g. https://osu.ppy.sh/beatmapsets/470977#osu/1006822) and marathons (e.g. https://osu.ppy.sh/beatmapsets/121591#osu/311269)