### PR TITLE
Fix beatmap carousel overlapping beatmap info wedge

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -89,8 +89,6 @@ namespace osu.Game.Screens.Select
 
         protected SongSelect()
         {
-            const float carousel_width = 640;
-
             AddRangeInternal(new Drawable[]
             {
                 new ParallaxContainer
@@ -103,7 +101,8 @@ namespace osu.Game.Screens.Select
                         new WedgeBackground
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Right = carousel_width * 0.76f },
+                            Padding = new MarginPadding { Right = -150 },
+                            Size = new Vector2(wedged_container_size.X, 1),
                         }
                     }
                 },
@@ -144,8 +143,8 @@ namespace osu.Game.Screens.Select
                             Carousel = new BeatmapCarousel
                             {
                                 Masking = false,
-                                RelativeSizeAxes = Axes.Y,
-                                Size = new Vector2(carousel_width, 1),
+                                RelativeSizeAxes = Axes.Both,
+                                Size = new Vector2(wedged_container_size.X, 1),
                                 Anchor = Anchor.CentreRight,
                                 Origin = Anchor.CentreRight,
                                 SelectionChanged = updateSelectedBeatmap,

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Screens.Select
     public abstract class SongSelect : OsuScreen
     {
         private static readonly Vector2 wedged_container_size = new Vector2(0.5f, 245);
+
         protected const float BACKGROUND_BLUR = 20;
         private const float left_area_padding = 20;
 
@@ -144,7 +145,7 @@ namespace osu.Game.Screens.Select
                             {
                                 Masking = false,
                                 RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(wedged_container_size.X, 1),
+                                Size = new Vector2(1 - wedged_container_size.X, 1),
                                 Anchor = Anchor.CentreRight,
                                 Origin = Anchor.CentreRight,
                                 SelectionChanged = updateSelectedBeatmap,


### PR DESCRIPTION
Fixes #3974. I think the best way of resolving this was not overlapping them in the first place. Replaces the fixed width of beatmap carousel. Now dependent on 50% windows size.

---