### PR TITLE
Close beatmap options when suspending

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -505,6 +505,8 @@ namespace osu.Game.Screens.Select
         {
             ModSelect.Hide();
 
+            BeatmapOptions.Hide();
+
             this.ScaleTo(1.1f, 250, Easing.InSine);
 
             this.FadeOut(250);


### PR DESCRIPTION
Does the other half of closed PR #4352. It didn't feel right that the options were still visible after finishing map.

---