### PR TITLE
Fix order of nested hitobjects on 2B Catch maps

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -57,33 +57,20 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             CatchHitObject lastObject = null;
 
-            foreach (var hitObject in beatmap.HitObjects.OfType<CatchHitObject>())
+            // In 2B beatmaps, it is possible that a normal Fruit is placed in the middle of a JuiceStream.
+            foreach (var hitObject in beatmap.HitObjects
+                                             .SelectMany(obj => obj is JuiceStream stream ? stream.NestedHitObjects : new[] { obj })
+                                             .OfType<CatchHitObject>()
+                                             .OrderBy(x => x.StartTime))
             {
-                if (lastObject == null)
-                {
-                    lastObject = hitObject;
+                // We want to only consider fruits that contribute to the combo.
+                if (hitObject is BananaShower || hitObject is TinyDroplet)
                     continue;
-                }
 
-                switch (hitObject)
-                {
-                    // We want to only consider fruits that contribute to the combo. Droplets are addressed as accuracy and spinners are not relevant for "skill" calculations.
-                    case Fruit fruit:
-                        yield return new CatchDifficultyHitObject(fruit, lastObject, clockRate, halfCatchWidth);
+                if (lastObject != null)
+                    yield return new CatchDifficultyHitObject(hitObject, lastObject, clockRate, halfCatchWidth);
 
-                        lastObject = hitObject;
-                        break;
-
-                    case JuiceStream _:
-                        foreach (var nested in hitObject.NestedHitObjects.OfType<CatchHitObject>().Where(o => !(o is TinyDroplet)))
-                        {
-                            yield return new CatchDifficultyHitObject(nested, lastObject, clockRate, halfCatchWidth);
-
-                            lastObject = nested;
-                        }
-
-                        break;
-                }
+                lastObject = hitObject;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             // In 2B beatmaps, it is possible that a normal Fruit is placed in the middle of a JuiceStream.
             foreach (var hitObject in beatmap.HitObjects
                                              .SelectMany(obj => obj is JuiceStream stream ? stream.NestedHitObjects : new[] { obj })
-                                             .OfType<CatchHitObject>()
+                                             .Cast<CatchHitObject>()
                                              .OrderBy(x => x.StartTime))
             {
                 // We want to only consider fruits that contribute to the combo.


### PR DESCRIPTION
Fixes massive difficulty values in 2B Catch the Beat maps.

---

This PR fixes the massive difficulty values seen in #4622. These were caused by invalid strain decay calculations when a normal fruit appeared in a juice stream (slider). If this was the case, the lastHitobject (and so DeltaTime and StreamDecay) values were incorrect and could cause errors.