### PR TITLE
Increase loader animation wait time

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestCaseLoaderAnimation.cs
+++ b/osu.Game.Tests/Visual/Menus/TestCaseLoaderAnimation.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.Menus
             bool logoVisible = false;
 
             AddStep("begin loading", () => LoadScreen(loader = new TestLoader()));
-            AddWaitStep("wait", 2);
+            AddWaitStep("wait", 3);
             AddStep("finish loading", () =>
             {
                 logoVisible = loader.Logo?.Alpha > 0;


### PR DESCRIPTION
Pretty sure nothing regressed this, and it's just a random failure related to time between tests vs 500ms delay of the logo...

https://ci.appveyor.com/project/peppy/osu/builds/24526570/tests