### PR TITLE
Add tooltip for DifficultyIcon

### DIFF
--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
@@ -16,7 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    public class DifficultyIcon : DifficultyColouredContainer
+    public class DifficultyIcon : DifficultyColouredContainer, IHasTooltip
     {
         private readonly RulesetInfo ruleset;
 
@@ -27,9 +28,12 @@ namespace osu.Game.Beatmaps.Drawables
                 throw new ArgumentNullException(nameof(beatmap));
 
             this.ruleset = ruleset ?? beatmap.Ruleset;
+            TooltipText = beatmap.StarDifficulty.ToString("Star Difficulty 0.##");
 
             Size = new Vector2(20);
         }
+
+        public string TooltipText { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -174,7 +174,6 @@ namespace osu.Game.Overlays.BeatmapSet
 
             public readonly BeatmapInfo Beatmap;
 
-            public Action<BeatmapInfo> OnHovered;
             public Action<BeatmapInfo> OnClicked;
             public event Action<DifficultySelectorState> StateChanged;
 
@@ -229,7 +228,6 @@ namespace osu.Game.Overlays.BeatmapSet
             protected override bool OnHover(HoverEvent e)
             {
                 fadeIn();
-                OnHovered?.Invoke(Beatmap);
                 return base.OnHover(e);
             }
 

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -57,12 +57,6 @@ namespace osu.Game.Overlays.BeatmapSet
                 difficulties.ChildrenEnumerable = BeatmapSet.Beatmaps.OrderBy(beatmap => beatmap.StarDifficulty).Select(b => new DifficultySelectorButton(b)
                 {
                     State = DifficultySelectorState.NotSelected,
-                    OnHovered = beatmap =>
-                    {
-                        showBeatmap(beatmap);
-                        starRating.Text = beatmap.StarDifficulty.ToString("Star Difficulty 0.##");
-                        starRating.FadeIn(100);
-                    },
                     OnClicked = beatmap => { Beatmap.Value = beatmap; },
                 });
             }

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private const float tile_spacing = 2;
 
         private readonly DifficultiesContainer difficulties;
-        private readonly OsuSpriteText version, starRating;
+        private readonly OsuSpriteText version;
         private readonly Statistic plays, favourites;
 
         public readonly Bindable<BeatmapInfo> Beatmap = new Bindable<BeatmapInfo>();
@@ -61,7 +61,6 @@ namespace osu.Game.Overlays.BeatmapSet
                 });
             }
 
-            starRating.FadeOut(100);
             Beatmap.Value = BeatmapSet?.Beatmaps.FirstOrDefault();
             plays.Value = BeatmapSet?.OnlineInfo.PlayCount ?? 0;
             favourites.Value = BeatmapSet?.OnlineInfo.FavouriteCount ?? 0;
@@ -90,7 +89,6 @@ namespace osu.Game.Overlays.BeatmapSet
                             OnLostHover = () =>
                             {
                                 showBeatmap(Beatmap.Value);
-                                starRating.FadeOut(100);
                             },
                         },
                         new FillFlowContainer
@@ -105,15 +103,6 @@ namespace osu.Game.Overlays.BeatmapSet
                                     Anchor = Anchor.BottomLeft,
                                     Origin = Anchor.BottomLeft,
                                     Font = OsuFont.GetFont(size: 20, weight: FontWeight.Bold)
-                                },
-                                starRating = new OsuSpriteText
-                                {
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                    Font = OsuFont.GetFont(size: 13, weight: FontWeight.Bold),
-                                    Text = "Star Difficulty",
-                                    Alpha = 0,
-                                    Margin = new MarginPadding { Bottom = 1 },
                                 },
                             },
                         },
@@ -143,7 +132,6 @@ namespace osu.Game.Overlays.BeatmapSet
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            starRating.Colour = colours.Yellow;
             updateDisplay();
         }
 


### PR DESCRIPTION
Adds a tooltip to the DifficulyIcon drawable. It can be really helpful when browsing osu!direct or when looking through multiplayer lobbies. Seems to work perfectly fine, but I am still not sure if I did this correctly.
Also removes the difficulty hover text in BeatmapPicker, because it isn't needed with the tooltip.
 
<details><summary>Screenshots</summary>

![Screenshot3](https://user-images.githubusercontent.com/5059753/57719682-95a4ae80-7680-11e9-918a-4d380db3bcbf.png)
![Screenshot4](https://user-images.githubusercontent.com/5059753/57719683-95a4ae80-7680-11e9-9181-06fcfe263af2.png)
![Screenshot1](https://user-images.githubusercontent.com/5059753/57719684-95a4ae80-7680-11e9-8615-90c99f0987a0.png)
![Screenshot2](https://user-images.githubusercontent.com/5059753/57719685-95a4ae80-7680-11e9-994c-c34c55eb4ff4.png)


</details>

Any opinions?