### PR TITLE
Add dynamically sized visualiser bars on osu! logo

### DIFF
--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Menu
         private const float bar_length_const = 600;
 
         /// <summary>
-        /// The calculated max length of each bar in the visualiser from the audio value
+        /// The calculated max length of each bar in the osu!logo visualizer (calculated from the audio value)
         /// </summary>
         private static float bar_length => Convert.ToSingle(bar_length_const * (audio == null ? 1 : audio.Volume.Value));
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The calculated max length of each bar in the osu!logo visualizer (calculated from the audio value)
         /// </summary>
-        private static float barLength => Convert.ToSingle(bar_length_const * (audio == null ? 1 : audio.Volume.Value));
+        private static float barLength => Convert.ToSingle(bar_length_const * audio.Volume.Value);
 
         /// <summary>
         /// The number of bars in one rotation of the visualiser.
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The minimum amplitude to show a bar.
         /// </summary>
-        private static float amplitude_dead_zone = 1f / bar_length_const;
+        private const float amplitude_dead_zone = 1f / bar_length_const;
 
         private int indexOffset;
 
@@ -80,6 +80,7 @@ namespace osu.Game.Screens.Menu
         private Bindable<Skin> skin;
 
         private static AudioManager audio;
+
         public LogoVisualisation()
         {
             texture = Texture.WhitePixel;

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -35,7 +35,12 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The maximum length of each bar in the visualiser. Will be reduced when kiai is not activated.
         /// </summary>
-        private static float bar_length => Convert.ToSingle(650 * (audio == null ? 1 : audio.Volume.Value));
+        private const float bar_length_const = 600;
+
+        /// <summary>
+        /// The calculated max length of each bar in the visualiser from the audio value
+        /// </summary>
+        private static float bar_length => Convert.ToSingle(bar_length_const * (audio == null ? 1 : audio.Volume.Value));
 
         /// <summary>
         /// The number of bars in one rotation of the visualiser.
@@ -60,7 +65,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The minimum amplitude to show a bar.
         /// </summary>
-        private static float amplitude_dead_zone = 1f / bar_length;
+        private static float amplitude_dead_zone = 1f / bar_length_const;
 
         private int indexOffset;
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -19,6 +19,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Audio;
 
 namespace osu.Game.Screens.Menu
 {
@@ -34,7 +35,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The maximum length of each bar in the visualiser. Will be reduced when kiai is not activated.
         /// </summary>
-        private const float bar_length = 600;
+        private static float bar_length => Convert.ToSingle(650 * (audio == null ? 1 : audio.Volume.Value));
 
         /// <summary>
         /// The number of bars in one rotation of the visualiser.
@@ -59,7 +60,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The minimum amplitude to show a bar.
         /// </summary>
-        private const float amplitude_dead_zone = 1f / bar_length;
+        private static float amplitude_dead_zone = 1f / bar_length;
 
         private int indexOffset;
 
@@ -73,6 +74,7 @@ namespace osu.Game.Screens.Menu
         private Bindable<User> user;
         private Bindable<Skin> skin;
 
+        private static AudioManager audio;
         public LogoVisualisation()
         {
             texture = Texture.WhitePixel;
@@ -80,12 +82,13 @@ namespace osu.Game.Screens.Menu
         }
 
         [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, IAPIProvider api, SkinManager skinManager)
+        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, IAPIProvider api, SkinManager skinManager, AudioManager Audio)
         {
             this.beatmap.BindTo(beatmap);
             shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
             user = api.LocalUser.GetBoundCopy();
             skin = skinManager.CurrentSkin.GetBoundCopy();
+            audio = Audio;
 
             user.ValueChanged += _ => updateColour();
             skin.BindValueChanged(_ => updateColour(), true);

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Menu
         /// <summary>
         /// The calculated max length of each bar in the osu!logo visualizer (calculated from the audio value)
         /// </summary>
-        private static float bar_length => Convert.ToSingle(bar_length_const * (audio == null ? 1 : audio.Volume.Value));
+        private static float barLength => Convert.ToSingle(bar_length_const * (audio == null ? 1 : audio.Volume.Value));
 
         /// <summary>
         /// The number of bars in one rotation of the visualiser.
@@ -87,13 +87,13 @@ namespace osu.Game.Screens.Menu
         }
 
         [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, IAPIProvider api, SkinManager skinManager, AudioManager Audio)
+        private void load(ShaderManager shaders, IBindable<WorkingBeatmap> beatmap, IAPIProvider api, SkinManager skinManager, AudioManager audioManager)
         {
             this.beatmap.BindTo(beatmap);
             shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
             user = api.LocalUser.GetBoundCopy();
             skin = skinManager.CurrentSkin.GetBoundCopy();
-            audio = Audio;
+            audio = audioManager;
 
             user.ValueChanged += _ => updateColour();
             skin.BindValueChanged(_ => updateColour(), true);
@@ -219,7 +219,7 @@ namespace osu.Game.Screens.Menu
                             //taking the cos and sin to the 0..1 range
                             var barPosition = new Vector2(rotationCos / 2 + 0.5f, rotationSin / 2 + 0.5f) * size;
 
-                            var barSize = new Vector2(size * (float)Math.Sqrt(2 * (1 - Math.Cos(MathHelper.DegreesToRadians(360f / bars_per_visualiser)))) / 2f, bar_length * audioData[i]);
+                            var barSize = new Vector2(size * (float)Math.Sqrt(2 * (1 - Math.Cos(MathHelper.DegreesToRadians(360f / bars_per_visualiser)))) / 2f, barLength * audioData[i]);
                             //The distance between the position and the sides of the bar.
                             var bottomOffset = new Vector2(-rotationSin * barSize.X / 2, rotationCos * barSize.X / 2);
                             //The distance between the bottom side of the bar and the top side.


### PR DESCRIPTION
This is in response to #4807 - the bars around the osu! logo will size depending on the master volume. It also keeps the in-game timeseeker at the bottom functional, as the first commit broke it and turned it into a solid block.