### PR TITLE
Split OsuGameDesktop into three platform specific classes

### DIFF
--- a/osu.Desktop/GameDesktop.cs
+++ b/osu.Desktop/GameDesktop.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Desktop.Platform.Linux;
+using osu.Desktop.Platform.MacOS;
+using osu.Desktop.Platform.Windows;
+using osu.Framework;
+
+namespace osu.Desktop
+{
+    public static class GameDesktop
+    {
+        internal static OsuGameDesktop GetSuitableDesktopGame(string[] args = null)
+        {
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.MacOsx:
+                    return new MacOSOsuGameDesktop(args);
+
+                case RuntimeInfo.Platform.Linux:
+                    return new LinuxOsuGameDesktop(args);
+
+                case RuntimeInfo.Platform.Windows:
+                    return new WindowsOsuGameDesktop(args);
+
+                default:
+                    throw new InvalidOperationException(
+                        $"Could not find a suitable {nameof(OsuGameDesktop)} for the selected operating system ({Enum.GetName(typeof(RuntimeInfo.Platform), RuntimeInfo.OS)}).");
+            }
+        }
+    }
+}

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -11,40 +10,22 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
 using osu.Game;
 using osuTK.Input;
-using Microsoft.Win32;
 using osu.Desktop.Updater;
 using osu.Framework;
-using osu.Framework.Logging;
-using osu.Framework.Platform.Windows;
 using osu.Framework.Screens;
 using osu.Game.Screens.Menu;
 
 namespace osu.Desktop
 {
-    internal class OsuGameDesktop : OsuGame
+    internal abstract class OsuGameDesktop : OsuGame
     {
         private readonly bool noVersionOverlay;
         private VersionManager versionManager;
 
-        public OsuGameDesktop(string[] args = null)
+        protected OsuGameDesktop(string[] args = null)
             : base(args)
         {
             noVersionOverlay = args?.Any(a => a == "--no-version-overlay") ?? false;
-        }
-
-        public override Storage GetStorageForStableInstall()
-        {
-            try
-            {
-                if (Host is DesktopGameHost desktopHost)
-                    return new StableStorage(desktopHost);
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e, "Error while searching for stable install");
-            }
-
-            return null;
         }
 
         protected override void LoadComplete()
@@ -93,7 +74,7 @@ namespace osu.Desktop
             {
                 desktopWindow.CursorState |= CursorState.Hidden;
 
-                desktopWindow.SetIconFromStream(Assembly.GetExecutingAssembly().GetManifestResourceStream(GetType(), "lazer.ico"));
+                desktopWindow.SetIconFromStream(Assembly.GetExecutingAssembly().GetManifestResourceStream(typeof(OsuGameDesktop), "lazer.ico"));
                 desktopWindow.Title = Name;
 
                 desktopWindow.FileDrop += fileDrop;
@@ -109,46 +90,6 @@ namespace osu.Desktop
             if (filePaths.Any(f => Path.GetExtension(f) != firstExtension)) return;
 
             Task.Factory.StartNew(() => Import(filePaths), TaskCreationOptions.LongRunning);
-        }
-
-        /// <summary>
-        /// A method of accessing an osu-stable install in a controlled fashion.
-        /// </summary>
-        private class StableStorage : WindowsStorage
-        {
-            protected override string LocateBasePath()
-            {
-                bool checkExists(string p) => Directory.Exists(Path.Combine(p, "Songs"));
-
-                string stableInstallPath;
-
-                try
-                {
-                    using (RegistryKey key = Registry.ClassesRoot.OpenSubKey("osu"))
-                        stableInstallPath = key?.OpenSubKey(@"shell\open\command")?.GetValue(String.Empty).ToString().Split('"')[1].Replace("osu!.exe", "");
-
-                    if (checkExists(stableInstallPath))
-                        return stableInstallPath;
-                }
-                catch
-                {
-                }
-
-                stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"osu!");
-                if (checkExists(stableInstallPath))
-                    return stableInstallPath;
-
-                stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".osu");
-                if (checkExists(stableInstallPath))
-                    return stableInstallPath;
-
-                return null;
-            }
-
-            public StableStorage(DesktopGameHost host)
-                : base(string.Empty, host)
-            {
-            }
         }
     }
 }

--- a/osu.Desktop/Platform/Linux/LinuxOsuGameDesktop.cs
+++ b/osu.Desktop/Platform/Linux/LinuxOsuGameDesktop.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Desktop.Platform.Linux
+{
+    internal class LinuxOsuGameDesktop : OsuGameDesktop
+    {
+        public LinuxOsuGameDesktop(string[] args = null)
+            : base(args)
+        {
+        }
+    }
+}

--- a/osu.Desktop/Platform/MacOS/MacOSOsuGameDesktop.cs
+++ b/osu.Desktop/Platform/MacOS/MacOSOsuGameDesktop.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Desktop.Platform.MacOS
+{
+    internal class MacOSOsuGameDesktop : OsuGameDesktop
+    {
+        public MacOSOsuGameDesktop(string[] args = null)
+            : base(args)
+        {
+        }
+    }
+}

--- a/osu.Desktop/Platform/Windows/WindowsOsuGameDesktop.cs
+++ b/osu.Desktop/Platform/Windows/WindowsOsuGameDesktop.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using Microsoft.Win32;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Platform.Windows;
+
+namespace osu.Desktop.Platform.Windows
+{
+    internal class WindowsOsuGameDesktop : OsuGameDesktop
+    {
+        public WindowsOsuGameDesktop(string[] args = null)
+            : base(args)
+        {
+        }
+
+        public override Storage GetStorageForStableInstall()
+        {
+            try
+            {
+                if (Host is DesktopGameHost desktopHost)
+                    return new StableStorage(desktopHost);
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Error while searching for stable install");
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// A method of accessing an osu-stable install in a controlled fashion.
+        /// </summary>
+        private class StableStorage : WindowsStorage
+        {
+            protected override string LocateBasePath()
+            {
+                bool checkExists(string p) => Directory.Exists(Path.Combine(p, "Songs"));
+
+                string stableInstallPath;
+
+                try
+                {
+                    using (RegistryKey key = Registry.ClassesRoot.OpenSubKey("osu"))
+                        stableInstallPath = key?.OpenSubKey(@"shell\open\command")?.GetValue(string.Empty).ToString().Split('"')[1].Replace("osu!.exe", "");
+
+                    if (checkExists(stableInstallPath))
+                        return stableInstallPath;
+                }
+                catch
+                {
+                }
+
+                stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"osu!");
+                if (checkExists(stableInstallPath))
+                    return stableInstallPath;
+
+                stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".osu");
+                if (checkExists(stableInstallPath))
+                    return stableInstallPath;
+
+                return null;
+            }
+
+            public StableStorage(DesktopGameHost host)
+                : base(string.Empty, host)
+            {
+            }
+        }
+    }
+}

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -44,7 +44,7 @@ namespace osu.Desktop
                     switch (args.FirstOrDefault() ?? string.Empty)
                     {
                         default:
-                            host.Run(new OsuGameDesktop(args));
+                            host.Run(GameDesktop.GetSuitableDesktopGame(args));
                             break;
                     }
                 }


### PR DESCRIPTION
Motivation:
As far as I remember, osu! stable is available only on Windows. Hence, having stable-related stuff in the class which is used for running the game on Linux is not correct. Also, having Registry-related code which is specific to Windows is not correct too.