### PR TITLE
Remove manual Y adjustment for ModIcon

### DIFF
--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -49,7 +49,6 @@ namespace osu.Game.Rulesets.UI
                     Anchor = Anchor.Centre,
                     Size = new Vector2(size),
                     Icon = OsuIcon.ModBg,
-                    Y = -6.5f,
                     Shadow = true,
                 },
                 modIcon = new SpriteIcon


### PR DESCRIPTION
* [ ] Depends on https://github.com/ppy/osu-framework/pull/2427
* Fixes https://github.com/ppy/osu/issues/4825

This seems to be the only scenario that I can see was severely affected by the change. I've tried looking through as many components as I can, but everything else I've checked looks either good or the same as before.

Certain SpriteText scenarios need further verification, such as for https://github.com/ppy/osu/issues/4803