### PR TITLE
Fix UpdateableBeatmapBackgroundSprite displaying extra backgrounds

### DIFF
--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Beatmaps.Drawables
         protected virtual double UnloadDelay => 10000;
 
         private BeatmapInfo lastModel;
+        private bool firstLoad = true;
 
         protected override DelayedLoadWrapper CreateDelayedLoadWrapper(Drawable content, double timeBeforeLoad)
         {
@@ -39,11 +40,12 @@ namespace osu.Game.Beatmaps.Drawables
             {
                 // If DelayedLoadUnloadWrapper is attempting to RELOAD the same content (Beatmap), that means that it was
                 // previously UNLOADED and thus its children have been disposed of, so we need to recreate them here.
-                if (lastModel != null && lastModel == Beatmap.Value)
+                if (!firstLoad && lastModel == Beatmap.Value)
                     return CreateDrawable(Beatmap.Value);
 
                 // If the model has changed since the previous unload (or if there was no load), then we can safely use the given content
                 lastModel = Beatmap.Value;
+                firstLoad = false;
                 return content;
             }, timeBeforeLoad, UnloadDelay);
         }

--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Beatmaps.Drawables
             {
                 // If DelayedLoadUnloadWrapper is attempting to RELOAD the same content (Beatmap), that means that it was
                 // previously UNLOADED and thus its children have been disposed of, so we need to recreate them here.
-                if (lastModel == Beatmap.Value)
+                if (lastModel != null && lastModel == Beatmap.Value)
                     return CreateDrawable(Beatmap.Value);
 
                 // If the model has changed since the previous unload (or if there was no load), then we can safely use the given content


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1329837/58232273-23188a80-7d74-11e9-8efa-fc2fa8270ed5.png)

`CreateDrawable()` would be called, which passes its content into our `CreateDelayedLoadWrapper()`, which then re-creates the content instead of re-using the perfectly valid one passed in.