### PR TITLE
Fix dimmed screen when closing child SettingsPanel via home button

### DIFF
--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -44,6 +44,11 @@ namespace osu.Game.Overlays
 
         public override bool AcceptsFocus => keyBindingPanel.State != Visibility.Visible;
 
+        /// <summary>
+        /// <see cref="SettingsOverlay"/> is a special case that should dim the main content.
+        /// </summary>
+        protected override bool DimMainContent => true;
+
         private void keyBindingPanelStateChanged(Visibility visibility)
         {
             switch (visibility)

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -57,6 +57,11 @@ namespace osu.Game.Overlays
             AutoSizeAxes = Axes.X;
         }
 
+        /// <summary>
+        /// Individual <see cref="SettingsPanel"/>s should not dim the main content.
+        /// </summary>
+        protected override bool DimMainContent => false;
+
         protected virtual IEnumerable<SettingsSection> CreateSections() => null;
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Fixes an issue where closing the key configuration panel by pressing the home button would not undim the screen.  Caused due to `SettingsPanel` registering itself as a blocking overlay but not being removed since the settings overlay does not close subpanels automatically.

Changes:
* `SettingsPanel` overrides `DimMainContent` to return false so that it no longer registers itself as a blocking overlay, but it still blocks screenwide mouse as expected via `BlockScreenWideMouse`.  We assume that the main content will already be dimmed.
* `SettingsOverlay` re-overrides `DimMainContent` to return true again so that it will register itself as a blocking overlay and dim the main content as expected.

Another solution would be to simply close all child `SettingsPanel`s when the home button is pressed, but I was unsure as to whether this was desired behaviour.  Currently when the settings button is pressed again, it will return to the key configuration panel.