### PR TITLE
Isolate alpha usage in OsuCheckbox

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Graphics.UserInterface
 
             Current.DisabledChanged += disabled =>
             {
-                Alpha = disabled ? 0.3f : 1;
+                labelSpriteText.Alpha = Nub.Alpha = disabled ? 0.3f : 1;
             };
         }
 


### PR DESCRIPTION
Should not be setting one's own alpha value.