### PR TITLE
Store databased settings based on string keys rather than ints

### DIFF
--- a/osu.Game/Configuration/DatabasedSetting.cs
+++ b/osu.Game/Configuration/DatabasedSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel.DataAnnotations.Schema;
@@ -16,11 +16,7 @@ namespace osu.Game.Configuration
         public int? Variant { get; set; }
 
         [Column("Key")]
-        public int IntKey
-        {
-            get => (int)Key;
-            private set => Key = value;
-        }
+        public string Key { get; set; }
 
         [Column("Value")]
         public string StringValue
@@ -29,10 +25,9 @@ namespace osu.Game.Configuration
             set => Value = value;
         }
 
-        public object Key;
         public object Value;
 
-        public DatabasedSetting(object key, object value)
+        public DatabasedSetting(string key, object value)
         {
             Key = key;
             Value = value;

--- a/osu.Game/Configuration/SettingsStore.cs
+++ b/osu.Game/Configuration/SettingsStore.cs
@@ -37,5 +37,11 @@ namespace osu.Game.Configuration
 
             SettingChanged?.Invoke();
         }
+
+        public void Delete(DatabasedSetting setting)
+        {
+            using (var usage = ContextFactory.GetForWrite())
+                usage.Context.Remove(setting);
+        }
     }
 }

--- a/osu.Game/Migrations/20180125143340_Settings.cs
+++ b/osu.Game/Migrations/20180125143340_Settings.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Migrations
                 {
                     ID = table.Column<int>(type: "INTEGER", nullable: false)
                         .Annotation("Sqlite:Autoincrement", true),
-                    Key = table.Column<int>(type: "INTEGER", nullable: false),
+                    Key = table.Column<int>(type: "TEXT", nullable: false),
                     RulesetID = table.Column<int>(type: "INTEGER", nullable: true),
                     Value = table.Column<string>(type: "TEXT", nullable: true),
                     Variant = table.Column<int>(type: "INTEGER", nullable: true)

--- a/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
+++ b/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.1-servicing-10028");
+                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
 
             modelBuilder.Entity("osu.Game.Beatmaps.BeatmapDifficulty", b =>
                 {
@@ -198,7 +198,7 @@ namespace osu.Game.Migrations
                     b.Property<int>("ID")
                         .ValueGeneratedOnAdd();
 
-                    b.Property<int>("IntKey")
+                    b.Property<string>("Key")
                         .HasColumnName("Key");
 
                     b.Property<int?>("RulesetID");


### PR DESCRIPTION
Allows for rearranging/removal from enums without consequence.

Does not have a migration as sqlite does not support this. Luckily sqlite isn't so strict about data types so this will not break on existing databases.