### PR TITLE
Prevent logo idle state from being updated incorrectly

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Screens.Menu
 
         private void updateIdleState(bool isIdle)
         {
-            if (isIdle && State != ButtonSystemState.Exit)
+            if (isIdle && State != ButtonSystemState.Exit && State != ButtonSystemState.EnteringMode)
                 State = ButtonSystemState.Initial;
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/4754

The issue was caused by the fact the idle state could be triggered from outside of MainMenu, causing `ButtonSystemState` to revert to initial, which makes the logo perform the track-over-duration animation instead of the instant track animation.

Adding a check for this fixes the problem.