### PR TITLE
Reduce memory allocation of ContextMenuItems property

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -222,15 +222,14 @@ namespace osu.Game.Overlays.Chat
             {
                 get
                 {
-                    List<MenuItem> items = new List<MenuItem>
-                    {
-                        new OsuMenuItem("View Profile", MenuItemType.Highlighted, Action)
-                    };
+                    bool isOtherPlayer = sender.Id != api.LocalUser.Value.Id;
+                    MenuItem[] items = new MenuItem[isOtherPlayer ? 2 : 1];
+                    items[0] = new OsuMenuItem("View Profile", MenuItemType.Highlighted, Action);
 
-                    if (sender.Id != api.LocalUser.Value.Id)
-                        items.Add(new OsuMenuItem("Start Chat", MenuItemType.Standard, startChatAction));
+                    if (isOtherPlayer)
+                        items[1] = new OsuMenuItem("Start Chat", MenuItemType.Standard, startChatAction);
 
-                    return items.ToArray();
+                    return items;
                 }
             }
         }


### PR DESCRIPTION
I saw PR #4900 and I was wondering if you are open to optimizations like I just did here.

**Explanation**
The `List<T>.ToArray` method creates a new array which it will return. After returning, at some point the GC will have to clean up the list (internal array + private variables). I changed the logic to another implementation which does not use a List, hence it is more lightweight in terms of memory allocation.

It does not have high impact or anything but I thought if we could improve the code a bit, why not.

Let me see what do you think about it, and whether are you open for fixes like these.