### PR TITLE
Fix OsuHoverContainer not updating visual hover state when enabled mid-hover

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
@@ -4,11 +4,8 @@
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 
@@ -18,8 +15,7 @@ namespace osu.Game.Tests.Visual.UserInterface
     public class TestSceneOsuHoverContainer : ManualInputManagerTestScene
     {
         private OsuHoverTestContainer hoverContainer;
-        private OsuSpriteText textContainer;
-        private ColourInfo currentColour => textContainer.DrawColourInfo.Colour;
+        private Box colourContainer;
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -28,19 +24,11 @@ namespace osu.Game.Tests.Visual.UserInterface
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                AutoSizeAxes = Axes.Both,
-                Child = new FillFlowContainer<SpriteText>
+                Size = new Vector2(100),
+                Child = colourContainer = new Box
                 {
-                    AutoSizeAxes = Axes.Both,
-                    Children = new[]
-                    {
-                        textContainer = new OsuSpriteText
-                        {
-                            Text = "Test",
-                            Font = OsuFont.GetFont(weight: FontWeight.Medium, size: 20),
-                        },
-                    }
-                }
+                    RelativeSizeAxes = Axes.Both,
+                },
             };
         });
 
@@ -191,6 +179,8 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private void waitUntilColourIs(ColourInfo expectedColour)
             => AddUntilStep($"Wait until hover colour is {expectedColour}", () => currentColour.Equals(expectedColour));
+
+        private ColourInfo currentColour => colourContainer.DrawColourInfo.Colour;
 
         /// <summary>
         ///     Moves the cursor to top left corner of the screen

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
@@ -55,8 +55,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             moveOut();
             checkNotHovered();
-
-            ReturnUserInput();
         }
 
         [Test]
@@ -78,8 +76,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             moveOut();
             waitUntilColourIs(OsuHoverTestContainer.IDLE_COLOUR);
-
-            ReturnUserInput();
         }
 
         [Test]
@@ -101,8 +97,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             moveOut();
             checkColour(OsuHoverTestContainer.IDLE_COLOUR);
-
-            ReturnUserInput();
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             Child = hoverContainer = new OsuHoverTestContainer
             {
+                Enabled = { Value = true },
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(100),
@@ -30,6 +31,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                     RelativeSizeAxes = Axes.Both,
                 },
             };
+
+            doMoveOut();
         });
 
         [Description("Checks IsHovered property value on a container when it is hovered/unhovered.")]
@@ -37,7 +40,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [TestCase(false, TestName = "Disabled_Check_IsHovered")]
         public void TestIsHoveredHasProperValue(bool isEnabled)
         {
-            moveOut();
             setContainerEnabledTo(isEnabled);
 
             checkNotHovered();
@@ -61,7 +63,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Description("Checks colour fading on an enabled container when it is hovered/unhovered.")]
         public void TestTransitionWhileEnabled()
         {
-            moveOut();
             enableContainer();
 
             checkColour(OsuHoverTestContainer.IDLE_COLOUR);
@@ -85,7 +86,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Description("Checks colour fading on a disabled container when it is hovered/unhovered.")]
         public void TestNoTransitionWhileDisabled()
         {
-            moveOut();
             disableContainer();
 
             checkColour(OsuHoverTestContainer.IDLE_COLOUR);
@@ -109,7 +109,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Description("Checks that when a disabled & hovered container gets enabled, colour fading happens")]
         public void TestBecomesEnabledTransition()
         {
-            moveOut();
             disableContainer();
             checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
@@ -124,7 +123,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Description("Checks that when an enabled & hovered container gets disabled, colour fading happens")]
         public void TestBecomesDisabledTransition()
         {
-            moveOut();
             enableContainer();
             checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
@@ -139,7 +137,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Description("Checks that when a hovered container gets enabled and disabled multiple times, colour fading happens")]
         public void TestDisabledChangesMultipleTimes()
         {
-            moveOut();
             enableContainer();
             checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
@@ -20,18 +20,9 @@ namespace osu.Game.Tests.Visual.UserInterface
         private OsuHoverTestContainer hoverContainer;
         private OsuSpriteText textContainer;
         private ColourInfo currentColour => textContainer.DrawColourInfo.Colour;
-        private ColourInfo idleColour => hoverContainer.IdleColourPublic;
-        private ColourInfo hoverColour => hoverContainer.HoverColourPublic;
-
-        public TestSceneOsuHoverContainer()
-        {
-            setupUI();
-        }
 
         [SetUp]
-        public void TestSceneOsuHoverContainer_SetUp() => Schedule(() => setupUI());
-
-        private void setupUI()
+        public void SetUp() => Schedule(() =>
         {
             Child = hoverContainer = new OsuHoverTestContainer
             {
@@ -51,12 +42,12 @@ namespace osu.Game.Tests.Visual.UserInterface
                     }
                 }
             };
-        }
+        });
 
         [Description("Checks IsHovered property value on a container when it is hovered/unhovered.")]
         [TestCase(true, TestName = "Enabled_Check_IsHovered")]
         [TestCase(false, TestName = "Disabled_Check_IsHovered")]
-        public void Check_IsHovered_HasProperValue(bool isEnabled)
+        public void TestIsHoveredHasProperValue(bool isEnabled)
         {
             moveOut();
             setContainerEnabledTo(isEnabled);
@@ -80,101 +71,101 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         [Test]
         [Description("Checks colour fading on an enabled container when it is hovered/unhovered.")]
-        public void WhenEnabled_Fades()
+        public void TestTransitionWhileEnabled()
         {
             moveOut();
             enableContainer();
 
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveToText();
-            waitUntilColourIs(hoverColour);
+            waitUntilColourIs(OsuHoverTestContainer.HOVER_COLOUR);
 
             moveOut();
-            waitUntilColourIs(idleColour);
+            waitUntilColourIs(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveToText();
-            waitUntilColourIs(hoverColour);
+            waitUntilColourIs(OsuHoverTestContainer.HOVER_COLOUR);
 
             moveOut();
-            waitUntilColourIs(idleColour);
+            waitUntilColourIs(OsuHoverTestContainer.IDLE_COLOUR);
 
             ReturnUserInput();
         }
 
         [Test]
         [Description("Checks colour fading on a disabled container when it is hovered/unhovered.")]
-        public void WhenDisabled_DoesNotFade()
+        public void TestNoTransitionWhileDisabled()
         {
             moveOut();
             disableContainer();
 
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveToText();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveOut();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveToText();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveOut();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             ReturnUserInput();
         }
 
         [Test]
         [Description("Checks that when a disabled & hovered container gets enabled, colour fading happens")]
-        public void WhileHovering_WhenGetsEnabled_Fades()
+        public void TestBecomesEnabledTransition()
         {
             moveOut();
             disableContainer();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveToText();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             enableContainer();
-            waitUntilColourIs(hoverColour);
+            waitUntilColourIs(OsuHoverTestContainer.HOVER_COLOUR);
         }
 
         [Test]
         [Description("Checks that when an enabled & hovered container gets disabled, colour fading happens")]
-        public void WhileHovering_WhenGetsDisabled_Fades()
+        public void TestBecomesDisabledTransition()
         {
             moveOut();
             enableContainer();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveToText();
-            waitUntilColourIs(hoverColour);
+            waitUntilColourIs(OsuHoverTestContainer.HOVER_COLOUR);
 
             disableContainer();
-            waitUntilColourIs(idleColour);
+            waitUntilColourIs(OsuHoverTestContainer.IDLE_COLOUR);
         }
 
         [Test]
         [Description("Checks that when a hovered container gets enabled and disabled multiple times, colour fading happens")]
-        public void WhileHovering_WhenEnabledChangesMultipleTimes_Fades()
+        public void TestDisabledChangesMultipleTimes()
         {
             moveOut();
             enableContainer();
-            checkColour(idleColour);
+            checkColour(OsuHoverTestContainer.IDLE_COLOUR);
 
             moveToText();
-            waitUntilColourIs(hoverColour);
+            waitUntilColourIs(OsuHoverTestContainer.HOVER_COLOUR);
 
             disableContainer();
-            waitUntilColourIs(idleColour);
+            waitUntilColourIs(OsuHoverTestContainer.IDLE_COLOUR);
 
             enableContainer();
-            waitUntilColourIs(hoverColour);
+            waitUntilColourIs(OsuHoverTestContainer.HOVER_COLOUR);
 
             disableContainer();
-            waitUntilColourIs(idleColour);
+            waitUntilColourIs(OsuHoverTestContainer.IDLE_COLOUR);
         }
 
         private void enableContainer() => setContainerEnabledTo(true);
@@ -209,8 +200,14 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private sealed class OsuHoverTestContainer : OsuHoverContainer
         {
-            public Color4 HoverColourPublic => HoverColour;
-            public Color4 IdleColourPublic => IdleColour;
+            public static readonly Color4 HOVER_COLOUR = Color4.Red;
+            public static readonly Color4 IDLE_COLOUR = Color4.Green;
+
+            public OsuHoverTestContainer()
+            {
+                HoverColour = HOVER_COLOUR;
+                IdleColour = IDLE_COLOUR;
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
@@ -1,0 +1,216 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    [TestFixture]
+    public class TestSceneOsuHoverContainer : ManualInputManagerTestScene
+    {
+        private OsuHoverTestContainer hoverContainer;
+        private OsuSpriteText textContainer;
+        private ColourInfo currentColour => textContainer.DrawColourInfo.Colour;
+        private ColourInfo idleColour => hoverContainer.IdleColourPublic;
+        private ColourInfo hoverColour => hoverContainer.HoverColourPublic;
+
+        public TestSceneOsuHoverContainer()
+        {
+            setupUI();
+        }
+
+        [SetUp]
+        public void TestSceneOsuHoverContainer_SetUp() => Schedule(() => setupUI());
+
+        private void setupUI()
+        {
+            Child = hoverContainer = new OsuHoverTestContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                Child = new FillFlowContainer<SpriteText>
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Children = new[]
+                    {
+                        textContainer = new OsuSpriteText
+                        {
+                            Text = "Test",
+                            Font = OsuFont.GetFont(weight: FontWeight.Medium, size: 20),
+                        },
+                    }
+                }
+            };
+        }
+
+        [Description("Checks IsHovered property value on a container when it is hovered/unhovered.")]
+        [TestCase(true, TestName = "Enabled_Check_IsHovered")]
+        [TestCase(false, TestName = "Disabled_Check_IsHovered")]
+        public void Check_IsHovered_HasProperValue(bool isEnabled)
+        {
+            moveOut();
+            setContainerEnabledTo(isEnabled);
+
+            checkNotHovered();
+
+            moveToText();
+            checkHovered();
+
+            moveOut();
+            checkNotHovered();
+
+            moveToText();
+            checkHovered();
+
+            moveOut();
+            checkNotHovered();
+
+            ReturnUserInput();
+        }
+
+        [Test]
+        [Description("Checks colour fading on an enabled container when it is hovered/unhovered.")]
+        public void WhenEnabled_Fades()
+        {
+            moveOut();
+            enableContainer();
+
+            checkColour(idleColour);
+
+            moveToText();
+            waitUntilColourIs(hoverColour);
+
+            moveOut();
+            waitUntilColourIs(idleColour);
+
+            moveToText();
+            waitUntilColourIs(hoverColour);
+
+            moveOut();
+            waitUntilColourIs(idleColour);
+
+            ReturnUserInput();
+        }
+
+        [Test]
+        [Description("Checks colour fading on a disabled container when it is hovered/unhovered.")]
+        public void WhenDisabled_DoesNotFade()
+        {
+            moveOut();
+            disableContainer();
+
+            checkColour(idleColour);
+
+            moveToText();
+            checkColour(idleColour);
+
+            moveOut();
+            checkColour(idleColour);
+
+            moveToText();
+            checkColour(idleColour);
+
+            moveOut();
+            checkColour(idleColour);
+
+            ReturnUserInput();
+        }
+
+        [Test]
+        [Description("Checks that when a disabled & hovered container gets enabled, colour fading happens")]
+        public void WhileHovering_WhenGetsEnabled_Fades()
+        {
+            moveOut();
+            disableContainer();
+            checkColour(idleColour);
+
+            moveToText();
+            checkColour(idleColour);
+
+            enableContainer();
+            waitUntilColourIs(hoverColour);
+        }
+
+        [Test]
+        [Description("Checks that when an enabled & hovered container gets disabled, colour fading happens")]
+        public void WhileHovering_WhenGetsDisabled_Fades()
+        {
+            moveOut();
+            enableContainer();
+            checkColour(idleColour);
+
+            moveToText();
+            waitUntilColourIs(hoverColour);
+
+            disableContainer();
+            waitUntilColourIs(idleColour);
+        }
+
+        [Test]
+        [Description("Checks that when a hovered container gets enabled and disabled multiple times, colour fading happens")]
+        public void WhileHovering_WhenEnabledChangesMultipleTimes_Fades()
+        {
+            moveOut();
+            enableContainer();
+            checkColour(idleColour);
+
+            moveToText();
+            waitUntilColourIs(hoverColour);
+
+            disableContainer();
+            waitUntilColourIs(idleColour);
+
+            enableContainer();
+            waitUntilColourIs(hoverColour);
+
+            disableContainer();
+            waitUntilColourIs(idleColour);
+        }
+
+        private void enableContainer() => setContainerEnabledTo(true);
+
+        private void disableContainer() => setContainerEnabledTo(false);
+
+        private void setContainerEnabledTo(bool newValue)
+        {
+            string word = newValue ? "Enable" : "Disable";
+            AddStep($"{word} container", () => hoverContainer.Enabled.Value = newValue);
+        }
+
+        private void moveToText() => AddStep("Move mouse to text", () => InputManager.MoveMouseTo(hoverContainer));
+
+        private void moveOut() => AddStep("Move out", doMoveOut);
+
+        private void checkHovered() => AddAssert("Check hovered", () => hoverContainer.IsHovered);
+
+        private void checkNotHovered() => AddAssert("Check not hovered", () => !hoverContainer.IsHovered);
+
+        private void checkColour(ColourInfo expectedColour)
+            => AddAssert($"Check colour to be '{expectedColour}'", () => currentColour.Equals(expectedColour));
+
+        private void waitUntilColourIs(ColourInfo expectedColour)
+            => AddUntilStep($"Wait until hover colour is {expectedColour}", () => currentColour.Equals(expectedColour));
+
+        /// <summary>
+        ///     Moves the cursor to top left corner of the screen
+        /// </summary>
+        private void doMoveOut()
+            => InputManager.MoveMouseTo(new Vector2(InputManager.ScreenSpaceDrawQuad.TopLeft.X, InputManager.ScreenSpaceDrawQuad.TopLeft.Y));
+
+        private sealed class OsuHoverTestContainer : OsuHoverContainer
+        {
+            public Color4 HoverColourPublic => HoverColour;
+            public Color4 IdleColourPublic => IdleColour;
+        }
+    }
+}

--- a/osu.Game/Graphics/Containers/OsuHoverContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuHoverContainer.cs
@@ -24,11 +24,13 @@ namespace osu.Game.Graphics.Containers
         {
             Enabled.ValueChanged += e =>
             {
-                if (e.NewValue && isHovered)
-                    fadeIn();
-
-                if (!e.NewValue)
-                    unhover();
+                if (isHovered)
+                {
+                    if (e.NewValue)
+                        fadeIn();
+                    else
+                        fadeOut();
+                }
             };
         }
 
@@ -36,6 +38,9 @@ namespace osu.Game.Graphics.Containers
 
         protected override bool OnHover(HoverEvent e)
         {
+            if (isHovered)
+                return false;
+
             isHovered = true;
 
             if (!Enabled.Value)
@@ -48,17 +53,13 @@ namespace osu.Game.Graphics.Containers
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            unhover();
-            base.OnHoverLost(e);
-        }
-
-        private void unhover()
-        {
             if (!isHovered)
                 return;
 
             isHovered = false;
-            EffectTargets.ForEach(d => d.FadeColour(IdleColour, FADE_DURATION, Easing.OutQuint));
+            fadeOut();
+
+            base.OnHoverLost(e);
         }
 
         [BackgroundDependencyLoader]
@@ -77,6 +78,11 @@ namespace osu.Game.Graphics.Containers
         private void fadeIn()
         {
             EffectTargets.ForEach(d => d.FadeColour(HoverColour, FADE_DURATION, Easing.OutQuint));
+        }
+
+        private void fadeOut()
+        {
+            EffectTargets.ForEach(d => d.FadeColour(IdleColour, FADE_DURATION, Easing.OutQuint));
         }
     }
 }

--- a/osu.Game/Graphics/Containers/OsuHoverContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuHoverContainer.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Graphics.Containers
 
         private void fadeIn()
         {
-            EffectTargets.ForEach(d => d.FadeColour(Color4.Black, FADE_DURATION * 10, Easing.OutQuint));
+            EffectTargets.ForEach(d => d.FadeColour(HoverColour, FADE_DURATION, Easing.OutQuint));
         }
     }
 }

--- a/osu.Game/Graphics/Containers/OsuHoverContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuHoverContainer.cs
@@ -75,14 +75,8 @@ namespace osu.Game.Graphics.Containers
             EffectTargets.ForEach(d => d.FadeColour(IdleColour));
         }
 
-        private void fadeIn()
-        {
-            EffectTargets.ForEach(d => d.FadeColour(HoverColour, FADE_DURATION, Easing.OutQuint));
-        }
+        private void fadeIn() => EffectTargets.ForEach(d => d.FadeColour(HoverColour, FADE_DURATION, Easing.OutQuint));
 
-        private void fadeOut()
-        {
-            EffectTargets.ForEach(d => d.FadeColour(IdleColour, FADE_DURATION, Easing.OutQuint));
-        }
+        private void fadeOut() => EffectTargets.ForEach(d => d.FadeColour(IdleColour, FADE_DURATION, Easing.OutQuint));
     }
 }

--- a/osu.Game/Graphics/Containers/OsuHoverContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuHoverContainer.cs
@@ -24,6 +24,9 @@ namespace osu.Game.Graphics.Containers
         {
             Enabled.ValueChanged += e =>
             {
+                if (e.NewValue && isHovered)
+                    fadeIn();
+
                 if (!e.NewValue)
                     unhover();
             };
@@ -33,11 +36,12 @@ namespace osu.Game.Graphics.Containers
 
         protected override bool OnHover(HoverEvent e)
         {
+            isHovered = true;
+
             if (!Enabled.Value)
                 return false;
 
-            EffectTargets.ForEach(d => d.FadeColour(HoverColour, FADE_DURATION, Easing.OutQuint));
-            isHovered = true;
+            fadeIn();
 
             return base.OnHover(e);
         }
@@ -68,6 +72,11 @@ namespace osu.Game.Graphics.Containers
         {
             base.LoadComplete();
             EffectTargets.ForEach(d => d.FadeColour(IdleColour));
+        }
+
+        private void fadeIn()
+        {
+            EffectTargets.ForEach(d => d.FadeColour(Color4.Black, FADE_DURATION * 10, Easing.OutQuint));
         }
     }
 }


### PR DESCRIPTION
Fixes #4904.

I would like to get some feedback on this, and some guidance for writing a test for this one.

Thanks in advance.

_Note:_
I have used this piece of code to manually test this functionality:
```csharp
if (!Enabled.Value)
{
    Task.Factory.StartNew(async () =>
    {
        await Task.Delay(1000);
        Enabled.Value = true;
    });
}
```
Just insert to the beginning of `OnHover` method, hover on a disabled item, wait for a second and it will start fading.