### PR TITLE
Fix cursor trail appearing glitched when pausing immediately after entering gameplay

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -54,7 +54,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
             for (int i = 0; i < max_sprites; i++)
             {
-                // InvalidationID 1 forces an update of each part of the cursor trail the first time ApplyState is ran on the draw node
+                // InvalidationID 1 forces an update of each part of the cursor trail the first time ApplyState is run on the draw node
+                // This is to prevent garbage data from being sent to the vertex shader, resulting in visual issues on some platforms
                 parts[i].InvalidationID = 1;
                 parts[i].WasUpdated = true;
             }

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -54,7 +54,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
             for (int i = 0; i < max_sprites; i++)
             {
-                parts[i].InvalidationID = 0;
+                // InvalidationID 1 forces an update of each part of the cursor trail the first time ApplyState is ran on the draw node
+                parts[i].InvalidationID = 1;
                 parts[i].WasUpdated = true;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/4605

Previously, stopping the GameplayClockContainer immediately after entering player blocks the `LoadComplete` for the `CursorTrail` (since it hasn't been updated yet). The draw node would never get updated with the Drawable cursor trails until `LoadComplete`, which bumps the invalidation ID and forces an invalidation. 

To resolve this, we initialize InvalidationID to 1, which immediately forces the draw node's cursor parts to match the drawable's when `ApplyState` is called.

This was tested using the first step of `TestScenePause`, which creates a player and then immediately pauses it.

This issue was only visible on windows.