### PR TITLE
Fix paginated layouts only showing one column even if enough space is available for more

### DIFF
--- a/osu.Game/Overlays/Profile/Sections/PaginatedContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedContainer.cs
@@ -49,7 +49,6 @@ namespace osu.Game.Overlays.Profile.Sections
                 {
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
-                    Direction = FillDirection.Vertical,
                     Spacing = new Vector2(0, 2),
                 },
                 MoreButton = new ShowMoreButton


### PR DESCRIPTION
Regressed in #4875.

- Closes #4939