### PR TITLE
Highlight major changes on the changelog overlay

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIChangelogEntry.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIChangelogEntry.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public string MessageHtml { get; set; }
 
         [JsonProperty("major")]
-        public bool? Major { get; set; }
+        public bool Major { get; set; }
 
         [JsonProperty("created_at")]
         public DateTimeOffset? CreatedAt { get; set; }

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Overlays.Changelog
                         Margin = new MarginPadding { Vertical = 5 },
                     };
 
-                    var entryColour = entry.Major != null && (bool)entry.Major ? colours.YellowLight : Color4.White;
+                    var entryColour = entry.Major ? colours.YellowLight : Color4.White;
 
                     title.AddIcon(FontAwesome.Solid.Check, t =>
                     {

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -13,6 +13,7 @@ using System.Text.RegularExpressions;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Users;
 using osuTK.Graphics;
+using osu.Framework.Allocation;
 
 namespace osu.Game.Overlays.Changelog
 {
@@ -45,8 +46,12 @@ namespace osu.Game.Overlays.Changelog
                     Direction = FillDirection.Vertical,
                 },
             };
+        }
 
-            foreach (var categoryEntries in build.ChangelogEntries.GroupBy(b => b.Category).OrderBy(c => c.Key))
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            foreach (var categoryEntries in Build.ChangelogEntries.GroupBy(b => b.Category).OrderBy(c => c.Key))
             {
                 ChangelogEntries.Add(new OsuSpriteText
                 {
@@ -69,19 +74,19 @@ namespace osu.Game.Overlays.Changelog
                         Margin = new MarginPadding { Vertical = 5 },
                     };
 
-                    var entryColor = entry.Major != null && (bool)entry.Major ? OsuColour.FromHex("#fd5") : Color4.White;
+                    var entryColour = entry.Major != null && (bool)entry.Major ? colours.YellowLight : Color4.White;
 
                     title.AddIcon(FontAwesome.Solid.Check, t =>
                     {
                         t.Font = fontSmall;
-                        t.Colour = entryColor;
+                        t.Colour = entryColour;
                         t.Padding = new MarginPadding { Left = -17, Right = 5 };
                     });
 
                     title.AddText(entry.Title, t =>
                     {
                         t.Font = fontLarge;
-                        t.Colour = entryColor;
+                        t.Colour = entryColour;
                     });
 
                     if (!string.IsNullOrEmpty(entry.Repository))
@@ -89,25 +94,25 @@ namespace osu.Game.Overlays.Changelog
                         title.AddText(" (", t =>
                         {
                             t.Font = fontLarge;
-                            t.Colour = entryColor;
+                            t.Colour = entryColour;
                         });
                         title.AddLink($"{entry.Repository.Replace("ppy/", "")}#{entry.GithubPullRequestId}", entry.GithubUrl, Online.Chat.LinkAction.External,
                             creationParameters: t =>
                             {
                                 t.Font = fontLarge;
-                                t.Colour = entryColor;
+                                t.Colour = entryColour;
                             });
                         title.AddText(")", t =>
                         {
                             t.Font = fontLarge;
-                            t.Colour = entryColor;
+                            t.Colour = entryColour;
                         });
                     }
 
                     title.AddText(" by ", t =>
                     {
                         t.Font = fontMedium;
-                        t.Colour = entryColor;
+                        t.Colour = entryColour;
                     });
 
                     if (entry.GithubUser.UserId != null)
@@ -118,19 +123,19 @@ namespace osu.Game.Overlays.Changelog
                         }, t =>
                         {
                             t.Font = fontMedium;
-                            t.Colour = entryColor;
+                            t.Colour = entryColour;
                         });
                     else if (entry.GithubUser.GithubUrl != null)
                         title.AddLink(entry.GithubUser.DisplayName, entry.GithubUser.GithubUrl, Online.Chat.LinkAction.External, null, null, t =>
                         {
                             t.Font = fontMedium;
-                            t.Colour = entryColor;
+                            t.Colour = entryColour;
                         });
                     else
                         title.AddText(entry.GithubUser.DisplayName, t =>
                         {
                             t.Font = fontSmall;
-                            t.Colour = entryColor;
+                            t.Colour = entryColour;
                         });
 
                     ChangelogEntries.Add(title);

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -69,34 +69,69 @@ namespace osu.Game.Overlays.Changelog
                         Margin = new MarginPadding { Vertical = 5 },
                     };
 
+                    var entryColor = entry.Major != null && (bool)entry.Major ? OsuColour.FromHex("#fd5") : Color4.White;
+
                     title.AddIcon(FontAwesome.Solid.Check, t =>
                     {
                         t.Font = fontSmall;
+                        t.Colour = entryColor;
                         t.Padding = new MarginPadding { Left = -17, Right = 5 };
                     });
 
-                    title.AddText(entry.Title, t => { t.Font = fontLarge; });
+                    title.AddText(entry.Title, t =>
+                    {
+                        t.Font = fontLarge;
+                        t.Colour = entryColor;
+                    });
 
                     if (!string.IsNullOrEmpty(entry.Repository))
                     {
-                        title.AddText(" (", t => t.Font = fontLarge);
+                        title.AddText(" (", t =>
+                        {
+                            t.Font = fontLarge;
+                            t.Colour = entryColor;
+                        });
                         title.AddLink($"{entry.Repository.Replace("ppy/", "")}#{entry.GithubPullRequestId}", entry.GithubUrl, Online.Chat.LinkAction.External,
-                            creationParameters: t => { t.Font = fontLarge; });
-                        title.AddText(")", t => t.Font = fontLarge);
+                            creationParameters: t =>
+                            {
+                                t.Font = fontLarge;
+                                t.Colour = entryColor;
+                            });
+                        title.AddText(")", t =>
+                        {
+                            t.Font = fontLarge;
+                            t.Colour = entryColor;
+                        });
                     }
 
-                    title.AddText(" by ", t => t.Font = fontMedium);
+                    title.AddText(" by ", t =>
+                    {
+                        t.Font = fontMedium;
+                        t.Colour = entryColor;
+                    });
 
                     if (entry.GithubUser.UserId != null)
                         title.AddUserLink(new User
                         {
                             Username = entry.GithubUser.OsuUsername,
                             Id = entry.GithubUser.UserId.Value
-                        }, t => t.Font = fontMedium);
+                        }, t =>
+                        {
+                            t.Font = fontMedium;
+                            t.Colour = entryColor;
+                        });
                     else if (entry.GithubUser.GithubUrl != null)
-                        title.AddLink(entry.GithubUser.DisplayName, entry.GithubUser.GithubUrl, Online.Chat.LinkAction.External, null, null, t => t.Font = fontMedium);
+                        title.AddLink(entry.GithubUser.DisplayName, entry.GithubUser.GithubUrl, Online.Chat.LinkAction.External, null, null, t =>
+                        {
+                            t.Font = fontMedium;
+                            t.Colour = entryColor;
+                        });
                     else
-                        title.AddText(entry.GithubUser.DisplayName, t => t.Font = fontSmall);
+                        title.AddText(entry.GithubUser.DisplayName, t =>
+                        {
+                            t.Font = fontSmall;
+                            t.Colour = entryColor;
+                        });
 
                     ChangelogEntries.Add(title);
 


### PR DESCRIPTION
Resolves #4942 
Major changes in changelog entries are now highlighted on the changelog overlay (with the same color as on web)
![image](https://user-images.githubusercontent.com/20256717/59120691-5a7f5d80-8956-11e9-842a-56f1749436d0.png)
