### PR TITLE
Add option to increase visibility of first object with grow mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
@@ -28,16 +28,16 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override double ScoreMultiplier => 1;
 
-        protected Bindable<bool> IncreaseFirstObjectGrowVisibility = new Bindable<bool>();
+        protected Bindable<bool> IncreaseFirstObjectVisibility = new Bindable<bool>();
 
         public void ReadFromConfig(OsuConfigManager config)
         {
-            IncreaseFirstObjectGrowVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectGrowVisibility);
+            IncreaseFirstObjectVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility);
         }
 
         public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
         {
-            foreach (var drawable in drawables.Skip(IncreaseFirstObjectGrowVisibility.Value ? 1 : 0))
+            foreach (var drawable in drawables.Skip(IncreaseFirstObjectVisibility.Value ? 1 : 0))
             {
                 switch (drawable)
                 {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
@@ -2,8 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -11,7 +14,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModGrow : Mod, IApplicableToDrawableHitObjects
+    internal class OsuModGrow : Mod, IReadFromConfig, IApplicableToDrawableHitObjects
     {
         public override string Name => "Grow";
 
@@ -25,9 +28,16 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override double ScoreMultiplier => 1;
 
+        protected Bindable<bool> IncreaseFirstObjectGrowVisibility = new Bindable<bool>();
+
+        public void ReadFromConfig(OsuConfigManager config)
+        {
+            IncreaseFirstObjectGrowVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectGrowVisibility);
+        }
+
         public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
         {
-            foreach (var drawable in drawables)
+            foreach (var drawable in drawables.Skip(IncreaseFirstObjectGrowVisibility.Value ? 1 : 0))
             {
                 switch (drawable)
                 {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModGrow.cs
@@ -28,16 +28,16 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override double ScoreMultiplier => 1;
 
-        protected Bindable<bool> IncreaseFirstObjectVisibility = new Bindable<bool>();
+        private Bindable<bool> increaseFirstObjectVisibility = new Bindable<bool>();
 
         public void ReadFromConfig(OsuConfigManager config)
         {
-            IncreaseFirstObjectVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility);
+            increaseFirstObjectVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility);
         }
 
         public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
         {
-            foreach (var drawable in drawables.Skip(IncreaseFirstObjectVisibility.Value ? 1 : 0))
+            foreach (var drawable in drawables.Skip(increaseFirstObjectVisibility.Value ? 1 : 0))
             {
                 switch (drawable)
                 {

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -85,8 +85,6 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.IncreaseFirstObjectVisibility, true);
 
-            Set(OsuSetting.IncreaseFirstObjectGrowVisibility, true);
-
             // Update
             Set(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
 
@@ -160,7 +158,6 @@ namespace osu.Game.Configuration
         BeatmapSkins,
         BeatmapHitsounds,
         IncreaseFirstObjectVisibility,
-        IncreaseFirstObjectGrowVisibility,
         ScoreDisplayMode,
         ExternalLinkWarning,
         Scaling,

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.IncreaseFirstObjectVisibility, true);
 
+            Set(OsuSetting.IncreaseFirstObjectGrowVisibility, true);
+
             // Update
             Set(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
 
@@ -158,6 +160,7 @@ namespace osu.Game.Configuration
         BeatmapSkins,
         BeatmapHitsounds,
         IncreaseFirstObjectVisibility,
+        IncreaseFirstObjectGrowVisibility,
         ScoreDisplayMode,
         ExternalLinkWarning,
         Scaling,

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
             {
                 new SettingsCheckbox
                 {
-                    LabelText = "Increase visibility of first object with \"Hidden\" mod",
+                    LabelText = "Increase visibility of first object when visual impairment mods are enabled",
                     Bindable = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility)
                 },
             };

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
@@ -20,11 +20,6 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = "Increase visibility of first object with \"Hidden\" mod",
                     Bindable = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility)
                 },
-                new SettingsCheckbox
-                {
-                    LabelText = "Increase visibility of first object with \"Grow\" mod",
-                    Bindable = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectGrowVisibility)
-                },
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = "Increase visibility of first object with \"Hidden\" mod",
                     Bindable = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Increase visibility of first object with \"Grow\" mod",
+                    Bindable = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectGrowVisibility)
+                },
             };
         }
     }


### PR DESCRIPTION
Since it's hide the approach circle like hidden mod, it make sense to add option like hidden mod to keep the approach circle visible on first object.

Demo: https://youtu.be/ab9TRcr3w7k

- [x] Depends on #4970.