### PR TITLE
Access WindowModes via IBindableList

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private Bindable<ScalingMode> scalingMode;
         private Bindable<Size> sizeFullscreen;
-        private readonly BindableList<WindowMode> windowModes = new BindableList<WindowMode>();
+        private readonly IBindableList<WindowMode> windowModes = new BindableList<WindowMode>();
 
         private OsuGameBase game;
         private SettingsDropdown<Size> resolutionDropdown;


### PR DESCRIPTION
With the `IWindow` refactor in https://github.com/ppy/osu-framework/pull/2504, `WindowModes` is now exposed as an `IBindableList`, so we must bind in a similar fashion.

Required for the next framework update, but can be merged independently.