### PR TITLE
Decouple online retrieval from import process

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -21,14 +21,14 @@ namespace osu.Game.Tests.Beatmaps.IO
     public class ImportBeatmapTest
     {
         [Test]
-        public void TestImportWhenClosed()
+        public async Task TestImportWhenClosed()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportWhenClosed"))
             {
                 try
                 {
-                    LoadOszIntoOsu(loadOsu(host));
+                    await LoadOszIntoOsu(loadOsu(host));
                 }
                 finally
                 {
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
-        public void TestImportThenDelete()
+        public async Task TestImportThenDelete()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenDelete"))
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 {
                     var osu = loadOsu(host);
 
-                    var imported = LoadOszIntoOsu(osu);
+                    var imported = await LoadOszIntoOsu(osu);
 
                     deleteBeatmapSet(imported, osu);
                 }
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
-        public void TestImportThenImport()
+        public async Task TestImportThenImport()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenImport"))
@@ -68,8 +68,8 @@ namespace osu.Game.Tests.Beatmaps.IO
                 {
                     var osu = loadOsu(host);
 
-                    var imported = LoadOszIntoOsu(osu);
-                    var importedSecondTime = LoadOszIntoOsu(osu);
+                    var imported = await LoadOszIntoOsu(osu);
+                    var importedSecondTime = await LoadOszIntoOsu(osu);
 
                     // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
                     Assert.IsTrue(imported.ID == importedSecondTime.ID);
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
-        public void TestRollbackOnFailure()
+        public async Task TestRollbackOnFailure()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestRollbackOnFailure"))
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     manager.ItemAdded += (_, __) => fireCount++;
                     manager.ItemRemoved += _ => fireCount++;
 
-                    var imported = LoadOszIntoOsu(osu);
+                    var imported = await LoadOszIntoOsu(osu);
 
                     Assert.AreEqual(0, fireCount -= 1);
 
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     Assert.AreEqual(12, manager.QueryBeatmaps(_ => true).ToList().Count);
 
                     // this will trigger purging of the existing beatmap (online set id match) but should rollback due to broken osu.
-                    manager.Import(breakTemp);
+                    await manager.Import(breakTemp);
 
                     // no events should be fired in the case of a rollback.
                     Assert.AreEqual(0, fireCount);
@@ -149,7 +149,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
-        public void TestImportThenImportDifferentHash()
+        public async Task TestImportThenImportDifferentHash()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenImportDifferentHash"))
@@ -159,12 +159,12 @@ namespace osu.Game.Tests.Beatmaps.IO
                     var osu = loadOsu(host);
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
-                    var imported = LoadOszIntoOsu(osu);
+                    var imported = await LoadOszIntoOsu(osu);
 
                     imported.Hash += "-changed";
                     manager.Update(imported);
 
-                    var importedSecondTime = LoadOszIntoOsu(osu);
+                    var importedSecondTime = await LoadOszIntoOsu(osu);
 
                     Assert.IsTrue(imported.ID != importedSecondTime.ID);
                     Assert.IsTrue(imported.Beatmaps.First().ID < importedSecondTime.Beatmaps.First().ID);
@@ -181,7 +181,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
-        public void TestImportThenDeleteThenImport()
+        public async Task TestImportThenDeleteThenImport()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportThenDeleteThenImport"))
@@ -190,11 +190,11 @@ namespace osu.Game.Tests.Beatmaps.IO
                 {
                     var osu = loadOsu(host);
 
-                    var imported = LoadOszIntoOsu(osu);
+                    var imported = await LoadOszIntoOsu(osu);
 
                     deleteBeatmapSet(imported, osu);
 
-                    var importedSecondTime = LoadOszIntoOsu(osu);
+                    var importedSecondTime = await LoadOszIntoOsu(osu);
 
                     // check the newly "imported" beatmap is actually just the restored previous import. since it matches hash.
                     Assert.IsTrue(imported.ID == importedSecondTime.ID);
@@ -209,7 +209,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
         [TestCase(true)]
         [TestCase(false)]
-        public void TestImportThenDeleteThenImportWithOnlineIDMismatch(bool set)
+        public async Task TestImportThenDeleteThenImportWithOnlineIDMismatch(bool set)
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost($"TestImportThenDeleteThenImport-{set}"))
@@ -218,7 +218,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 {
                     var osu = loadOsu(host);
 
-                    var imported = LoadOszIntoOsu(osu);
+                    var imported = await LoadOszIntoOsu(osu);
 
                     if (set)
                         imported.OnlineBeatmapSetID = 1234;
@@ -229,7 +229,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                     deleteBeatmapSet(imported, osu);
 
-                    var importedSecondTime = LoadOszIntoOsu(osu);
+                    var importedSecondTime = await LoadOszIntoOsu(osu);
 
                     // check the newly "imported" beatmap has been reimported due to mismatch (even though hashes matched)
                     Assert.IsTrue(imported.ID != importedSecondTime.ID);
@@ -243,7 +243,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
-        public void TestImportWithDuplicateBeatmapIDs()
+        public async Task TestImportWithDuplicateBeatmapIDs()
         {
             //unfortunately for the time being we need to reference osu.Framework.Desktop for a game host here.
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportWithDuplicateBeatmapID"))
@@ -284,7 +284,7 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
-                    var imported = manager.Import(toImport);
+                    var imported = await manager.Import(toImport);
 
                     Assert.NotNull(imported);
                     Assert.AreEqual(null, imported.Beatmaps[0].OnlineBeatmapID);
@@ -330,7 +330,7 @@ namespace osu.Game.Tests.Beatmaps.IO
         }
 
         [Test]
-        public void TestImportWhenFileOpen()
+        public async Task TestImportWhenFileOpen()
         {
             using (HeadlessGameHost host = new CleanRunHeadlessGameHost("TestImportWhenFileOpen"))
             {
@@ -339,7 +339,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     var osu = loadOsu(host);
                     var temp = TestResources.GetTestBeatmapForImport();
                     using (File.OpenRead(temp))
-                        osu.Dependencies.Get<BeatmapManager>().Import(temp);
+                        await osu.Dependencies.Get<BeatmapManager>().Import(temp);
                     ensureLoaded(osu);
                     File.Delete(temp);
                     Assert.IsFalse(File.Exists(temp), "We likely held a read lock on the file when we shouldn't");
@@ -351,13 +351,13 @@ namespace osu.Game.Tests.Beatmaps.IO
             }
         }
 
-        public static BeatmapSetInfo LoadOszIntoOsu(OsuGameBase osu, string path = null)
+        public static async Task<BeatmapSetInfo> LoadOszIntoOsu(OsuGameBase osu, string path = null)
         {
             var temp = path ?? TestResources.GetTestBeatmapForImport();
 
             var manager = osu.Dependencies.Get<BeatmapManager>();
 
-            manager.Import(temp);
+            await manager.Import(temp);
 
             var imported = manager.GetAllUsableBeatmapSets();
 

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -135,14 +135,14 @@ namespace osu.Game.Tests.Beatmaps.IO
                         zip.SaveTo(outStream, SharpCompress.Common.CompressionType.Deflate);
                     }
 
-                    Assert.AreEqual(1, manager.GetAllUsableBeatmapSets().Count);
-                    Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
-                    Assert.AreEqual(12, manager.QueryBeatmaps(_ => true).ToList().Count);
-
-                    Assert.AreEqual(18, files.QueryFiles(_ => true).Count());
-
                     // this will trigger purging of the existing beatmap (online set id match) but should rollback due to broken osu.
-                    await manager.Import(breakTemp);
+                    try
+                    {
+                        await manager.Import(breakTemp);
+                    }
+                    catch
+                    {
+                    }
 
                     // no events should be fired in the case of a rollback.
                     Assert.AreEqual(0, fireCount);

--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -12,6 +12,7 @@ using osu.Framework.Platform;
 using osu.Game.IPC;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
+using osu.Game.IO;
 using osu.Game.Tests.Resources;
 using SharpCompress.Archives.Zip;
 
@@ -97,6 +98,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                 {
                     var osu = loadOsu(host);
                     var manager = osu.Dependencies.Get<BeatmapManager>();
+                    var files = osu.Dependencies.Get<FileStore>();
 
                     int fireCount = 0;
 
@@ -112,6 +114,12 @@ namespace osu.Game.Tests.Beatmaps.IO
                     manager.Update(imported);
 
                     Assert.AreEqual(0, fireCount -= 2);
+
+                    Assert.AreEqual(1, manager.GetAllUsableBeatmapSets().Count);
+                    Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
+                    Assert.AreEqual(12, manager.QueryBeatmaps(_ => true).ToList().Count);
+
+                    Assert.AreEqual(18, files.QueryFiles(_ => true).Count());
 
                     var breakTemp = TestResources.GetTestBeatmapForImport();
 
@@ -131,6 +139,8 @@ namespace osu.Game.Tests.Beatmaps.IO
                     Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
                     Assert.AreEqual(12, manager.QueryBeatmaps(_ => true).ToList().Count);
 
+                    Assert.AreEqual(18, files.QueryFiles(_ => true).Count());
+
                     // this will trigger purging of the existing beatmap (online set id match) but should rollback due to broken osu.
                     await manager.Import(breakTemp);
 
@@ -140,6 +150,9 @@ namespace osu.Game.Tests.Beatmaps.IO
                     Assert.AreEqual(1, manager.GetAllUsableBeatmapSets().Count);
                     Assert.AreEqual(1, manager.QueryBeatmapSets(_ => true).ToList().Count);
                     Assert.AreEqual(12, manager.QueryBeatmaps(_ => true).ToList().Count);
+
+                    Assert.AreEqual(18, files.QueryFiles(_ => true).Count());
+                    Assert.AreEqual(18, files.QueryFiles(f => f.ReferenceCount == 1).Count());
                 }
                 finally
                 {

--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenBeatmap.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenBeatmap.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Tests.Visual.Background
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, factory, rulesets, null, audio, host, Beatmap.Default));
             Dependencies.Cache(new OsuConfigManager(LocalStorage));
 
-            manager.Import(TestResources.GetTestBeatmapForImport());
+            manager.Import(TestResources.GetTestBeatmapForImport()).Wait();
 
             Beatmap.SetDefault();
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -210,7 +210,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("start not requested", () => !startRequested);
         }
 
-        private void importForRuleset(int id) => AddStep($"import test map for ruleset {id}", () => manager.Import(createTestBeatmapSet(getImportId(), rulesets.AvailableRulesets.Where(r => r.ID == id).ToArray())));
+        private void importForRuleset(int id) => AddStep($"import test map for ruleset {id}", () => manager.Import(createTestBeatmapSet(getImportId(), rulesets.AvailableRulesets.Where(r => r.ID == id).ToArray())).Wait());
 
         private static int importId;
         private int getImportId() => ++importId;
@@ -232,7 +232,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 var usableRulesets = rulesets.AvailableRulesets.Where(r => r.ID != 2).ToArray();
 
                 for (int i = 0; i < 100; i += 10)
-                    manager.Import(createTestBeatmapSet(i, usableRulesets));
+                    manager.Import(createTestBeatmapSet(i, usableRulesets)).Wait();
             });
         }
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             this.api = api;
             this.rulesets = rulesets;
 
-            testBeatmap = ImportBeatmapTest.LoadOszIntoOsu(osu);
+            testBeatmap = ImportBeatmapTest.LoadOszIntoOsu(osu).Result;
         }
 
         [Test]

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -18,4 +18,9 @@
     <ProjectReference Include="..\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj" />
     <ProjectReference Include="..\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\..\..\..\usr\local\share\dotnet\sdk\NuGetFallbackFolder\microsoft.win32.registry\4.5.0\ref\netstandard2.0\Microsoft.Win32.Registry.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -18,9 +18,4 @@
     <ProjectReference Include="..\osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj" />
     <ProjectReference Include="..\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\..\..\..\usr\local\share\dotnet\sdk\NuGetFallbackFolder\microsoft.win32.registry\4.5.0\ref\netstandard2.0\Microsoft.Win32.Registry.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 </Project>

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         public List<ScoreInfo> Scores { get; set; }
 
-        public override string ToString() => $"{Metadata} [{Version}]";
+        public override string ToString() => $"{Metadata} [{Version}]".Trim();
 
         public bool Equals(BeatmapInfo other)
         {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -424,7 +424,9 @@ namespace osu.Game.Beatmaps
         {
             private readonly IAPIProvider api;
 
-            private readonly ThreadedTaskScheduler updateScheduler = new ThreadedTaskScheduler(4);
+            private const int update_queue_request_concurrency = 4;
+
+            private readonly ThreadedTaskScheduler updateScheduler = new ThreadedTaskScheduler(update_queue_request_concurrency);
 
             public BeatmapUpdateQueue(IAPIProvider api)
             {
@@ -455,10 +457,7 @@ namespace osu.Game.Beatmaps
                     beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
                 };
 
-                req.Failure += e =>
-                {
-                    Logger.Log($"Failed ({e})", LoggingTarget.Database);
-                };
+                req.Failure += e => { Logger.Log($"Failed ({e})", LoggingTarget.Database); };
 
                 // intentionally blocking to limit web request concurrency
                 req.Perform(api);

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Beatmaps
 
             validateOnlineIds(beatmapSet);
 
-            await updateQueue.Perform(beatmapSet, cancellationToken);
+            await updateQueue.UpdateAsync(beatmapSet, cancellationToken);
         }
 
         protected override void PreImport(BeatmapSetInfo beatmapSet)
@@ -433,20 +433,20 @@ namespace osu.Game.Beatmaps
                 this.api = api;
             }
 
-            public async Task Perform(BeatmapSetInfo beatmapSet, CancellationToken cancellationToken)
+            public async Task UpdateAsync(BeatmapSetInfo beatmapSet, CancellationToken cancellationToken)
             {
                 if (api?.State != APIState.Online)
                     return;
 
                 LogForModel(beatmapSet, "Performing online lookups...");
-                await Task.WhenAll(beatmapSet.Beatmaps.Select(b => Perform(beatmapSet, b, cancellationToken)).ToArray());
+                await Task.WhenAll(beatmapSet.Beatmaps.Select(b => UpdateAsync(beatmapSet, b, cancellationToken)).ToArray());
             }
 
             // todo: expose this when we need to do individual difficulty lookups.
-            protected Task Perform(BeatmapSetInfo beatmapSet, BeatmapInfo beatmap, CancellationToken cancellationToken)
-                => Task.Factory.StartNew(() => perform(beatmapSet, beatmap), cancellationToken, TaskCreationOptions.HideScheduler, updateScheduler);
+            protected Task UpdateAsync(BeatmapSetInfo beatmapSet, BeatmapInfo beatmap, CancellationToken cancellationToken)
+                => Task.Factory.StartNew(() => update(beatmapSet, beatmap), cancellationToken, TaskCreationOptions.HideScheduler, updateScheduler);
 
-            private void perform(BeatmapSetInfo set, BeatmapInfo beatmap)
+            private void update(BeatmapSetInfo set, BeatmapInfo beatmap)
             {
                 if (api?.State != APIState.Online)
                     return;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -426,7 +426,7 @@ namespace osu.Game.Beatmaps
 
             private const int update_queue_request_concurrency = 4;
 
-            private readonly ThreadedTaskScheduler updateScheduler = new ThreadedTaskScheduler(update_queue_request_concurrency);
+            private readonly ThreadedTaskScheduler updateScheduler = new ThreadedTaskScheduler(update_queue_request_concurrency, nameof(BeatmapUpdateQueue));
 
             public BeatmapUpdateQueue(IAPIProvider api)
             {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using osu.Framework.Audio;
@@ -14,6 +16,7 @@ using osu.Framework.Extensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Framework.Threading;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Database;
 using osu.Game.IO.Archives;
@@ -72,6 +75,8 @@ namespace osu.Game.Beatmaps
 
         private readonly List<DownloadBeatmapSetRequest> currentDownloads = new List<DownloadBeatmapSetRequest>();
 
+        private readonly BeatmapUpdateQueue updateQueue;
+
         public BeatmapManager(Storage storage, IDatabaseContextFactory contextFactory, RulesetStore rulesets, IAPIProvider api, AudioManager audioManager, GameHost host = null,
                               WorkingBeatmap defaultBeatmap = null)
             : base(storage, contextFactory, new BeatmapStore(contextFactory), host)
@@ -86,9 +91,11 @@ namespace osu.Game.Beatmaps
             beatmaps = (BeatmapStore)ModelStore;
             beatmaps.BeatmapHidden += b => BeatmapHidden?.Invoke(b);
             beatmaps.BeatmapRestored += b => BeatmapRestored?.Invoke(b);
+
+            updateQueue = new BeatmapUpdateQueue(api);
         }
 
-        protected override void Populate(BeatmapSetInfo beatmapSet, ArchiveReader archive)
+        protected override async Task Populate(BeatmapSetInfo beatmapSet, ArchiveReader archive, CancellationToken cancellationToken = default)
         {
             if (archive != null)
                 beatmapSet.Beatmaps = createBeatmapDifficulties(archive);
@@ -104,8 +111,7 @@ namespace osu.Game.Beatmaps
 
             validateOnlineIds(beatmapSet);
 
-            foreach (BeatmapInfo b in beatmapSet.Beatmaps)
-                fetchAndPopulateOnlineValues(b);
+            await Task.WhenAll(beatmapSet.Beatmaps.Select(b => updateQueue.Enqueue(new UpdateItem(b, cancellationToken)).Task).ToArray());
         }
 
         protected override void PreImport(BeatmapSetInfo beatmapSet)
@@ -181,10 +187,10 @@ namespace osu.Game.Beatmaps
 
             request.Success += filename =>
             {
-                Task.Factory.StartNew(() =>
+                Task.Factory.StartNew(async () =>
                 {
                     // This gets scheduled back to the update thread, but we want the import to run in the background.
-                    Import(downloadNotification, filename);
+                    await Import(downloadNotification, filename);
                     currentDownloads.Remove(request);
                 }, TaskCreationOptions.LongRunning);
             };
@@ -382,47 +388,6 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Query the API to populate missing values like OnlineBeatmapID / OnlineBeatmapSetID or (Rank-)Status.
-        /// </summary>
-        /// <param name="beatmap">The beatmap to populate.</param>
-        /// <param name="force">Whether to re-query if the provided beatmap already has populated values.</param>
-        /// <returns>True if population was successful.</returns>
-        private bool fetchAndPopulateOnlineValues(BeatmapInfo beatmap, bool force = false)
-        {
-            if (api?.State != APIState.Online)
-                return false;
-
-            if (!force && beatmap.OnlineBeatmapID != null && beatmap.BeatmapSet.OnlineBeatmapSetID != null
-                && beatmap.Status != BeatmapSetOnlineStatus.None && beatmap.BeatmapSet.Status != BeatmapSetOnlineStatus.None)
-                return true;
-
-            Logger.Log("Attempting online lookup for the missing values...", LoggingTarget.Database);
-
-            try
-            {
-                var req = new GetBeatmapRequest(beatmap);
-
-                req.Perform(api);
-
-                var res = req.Result;
-
-                Logger.Log($"Successfully mapped to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.", LoggingTarget.Database);
-
-                beatmap.Status = res.Status;
-                beatmap.BeatmapSet.Status = res.BeatmapSet.Status;
-                beatmap.BeatmapSet.OnlineBeatmapSetID = res.OnlineBeatmapSetID;
-                beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
-
-                return true;
-            }
-            catch (Exception e)
-            {
-                Logger.Log($"Failed ({e})", LoggingTarget.Database);
-                return false;
-            }
-        }
-
-        /// <summary>
         /// A dummy WorkingBeatmap for the purpose of retrieving a beatmap for star difficulty calculation.
         /// </summary>
         private class DummyConversionBeatmap : WorkingBeatmap
@@ -453,6 +418,112 @@ namespace osu.Game.Beatmaps
             private class SilencedProgressCompletionNotification : ProgressCompletionNotification
             {
                 public override bool IsImportant => false;
+            }
+        }
+
+        private class BeatmapUpdateQueue
+        {
+            private readonly IAPIProvider api;
+            private readonly Queue<UpdateItem> queue = new Queue<UpdateItem>();
+
+            private int activeThreads;
+
+            public BeatmapUpdateQueue(IAPIProvider api)
+            {
+                this.api = api;
+            }
+
+            public UpdateItem Enqueue(UpdateItem item)
+            {
+                lock (queue)
+                {
+                    queue.Enqueue(item);
+
+                    if (activeThreads >= 16)
+                        return item;
+
+                    new Thread(runWork) { IsBackground = true }.Start();
+                    activeThreads++;
+                }
+
+                return item;
+            }
+
+            private void runWork()
+            {
+                while (true)
+                {
+                    UpdateItem toProcess;
+
+                    lock (queue)
+                    {
+                        if (queue.Count == 0)
+                            break;
+
+                        toProcess = queue.Dequeue();
+                    }
+
+                    toProcess.PerformUpdate(api);
+                }
+
+                lock (queue)
+                    activeThreads--;
+            }
+        }
+
+        private class UpdateItem
+        {
+            public Task Task => tcs.Task;
+
+            private readonly BeatmapInfo beatmap;
+            private readonly CancellationToken cancellationToken;
+
+            private readonly TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
+
+            public UpdateItem(BeatmapInfo beatmap, CancellationToken cancellationToken)
+            {
+                this.beatmap = beatmap;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public void PerformUpdate(IAPIProvider api)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    tcs.SetCanceled();
+                    return;
+                }
+
+                if (api?.State != APIState.Online)
+                {
+                    tcs.SetResult(false);
+                    return;
+                }
+
+                Logger.Log("Attempting online lookup for the missing values...", LoggingTarget.Database);
+
+                var req = new GetBeatmapRequest(beatmap);
+
+                req.Success += res =>
+                {
+                    Logger.Log($"Successfully mapped to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.", LoggingTarget.Database);
+
+                    beatmap.Status = res.Status;
+                    beatmap.BeatmapSet.Status = res.BeatmapSet.Status;
+                    beatmap.BeatmapSet.OnlineBeatmapSetID = res.OnlineBeatmapSetID;
+                    beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
+
+                    tcs.SetResult(true);
+                };
+
+                req.Failure += e =>
+                {
+                    Logger.Log($"Failed ({e})", LoggingTarget.Database);
+
+                    tcs.SetResult(false);
+                };
+
+                req.Perform(api);
             }
         }
     }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Beatmaps
             updateQueue = new BeatmapUpdateQueue(api);
         }
 
-        protected override async Task Populate(BeatmapSetInfo beatmapSet, ArchiveReader archive, CancellationToken cancellationToken = default)
+        protected override Task Populate(BeatmapSetInfo beatmapSet, ArchiveReader archive, CancellationToken cancellationToken = default)
         {
             if (archive != null)
                 beatmapSet.Beatmaps = createBeatmapDifficulties(archive);
@@ -110,7 +110,7 @@ namespace osu.Game.Beatmaps
 
             validateOnlineIds(beatmapSet);
 
-            await updateQueue.UpdateAsync(beatmapSet, cancellationToken);
+            return updateQueue.UpdateAsync(beatmapSet, cancellationToken);
         }
 
         protected override void PreImport(BeatmapSetInfo beatmapSet)
@@ -433,13 +433,13 @@ namespace osu.Game.Beatmaps
                 this.api = api;
             }
 
-            public async Task UpdateAsync(BeatmapSetInfo beatmapSet, CancellationToken cancellationToken)
+            public Task UpdateAsync(BeatmapSetInfo beatmapSet, CancellationToken cancellationToken)
             {
                 if (api?.State != APIState.Online)
-                    return;
+                    return Task.CompletedTask;
 
                 LogForModel(beatmapSet, "Performing online lookups...");
-                await Task.WhenAll(beatmapSet.Beatmaps.Select(b => UpdateAsync(beatmapSet, b, cancellationToken)).ToArray());
+                return Task.WhenAll(beatmapSet.Beatmaps.Select(b => UpdateAsync(beatmapSet, b, cancellationToken)).ToArray());
             }
 
             // todo: expose this when we need to do individual difficulty lookups.

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -436,8 +436,7 @@ namespace osu.Game.Beatmaps
 
             private void perform(BeatmapInfo beatmap, CancellationToken cancellation)
             {
-                if (cancellation.IsCancellationRequested)
-                    return;
+                cancellation.ThrowIfCancellationRequested();
 
                 if (api?.State != APIState.Online)
                     return;

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -172,8 +172,7 @@ namespace osu.Game.Database
                 }
                 else
                 {
-                    var e = t.Exception.InnerException ?? t.Exception;
-                    Logger.Error(e, $@"Could not import ({Path.GetFileName(path)})");
+                    Logger.Error(t.Exception, $@"Could not import ({Path.GetFileName(path)})");
                 }
             }, TaskContinuationOptions.NotOnCanceled)));
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -630,7 +630,15 @@ namespace osu.Game.Database
 
     public abstract class ArchiveModelManager
     {
-        // allow sharing static across all generic types
-        protected static readonly ThreadedTaskScheduler IMPORT_SCHEDULER = new ThreadedTaskScheduler(1);
+        private const int import_queue_request_concurrency = 1;
+
+        /// <summary>
+        /// A singleton scheduler shared by all <see cref="ArchiveModelManager{TModel,TFileModel}"/>.
+        /// </summary>
+        /// <remarks>
+        /// This scheduler generally performs IO and CPU intensive work so concurrency is limited harshly.
+        /// It is mainly being used as a queue mechanism for large imports.
+        /// </remarks>
+        protected static readonly ThreadedTaskScheduler IMPORT_SCHEDULER = new ThreadedTaskScheduler(import_queue_request_concurrency);
     }
 }

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -361,6 +361,10 @@ namespace osu.Game.Database
 
                 Logger.Log($"Import of {item} successfully completed!", LoggingTarget.Database);
             }
+            catch (TaskCanceledException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 Logger.Error(e, $"Import of {item} failed and has been rolled back.", LoggingTarget.Database);

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -305,8 +305,7 @@ namespace osu.Game.Database
             {
                 Logger.Log($"Importing {item}...", LoggingTarget.Database);
 
-                if (archive != null)
-                    item.Files = createFileInfos(archive, Files);
+                item.Files = archive != null ? createFileInfos(archive, Files) : new List<TFileModel>();
 
                 var localItem = item;
 
@@ -314,7 +313,7 @@ namespace osu.Game.Database
                 {
                     await Populate(item, archive, cancellationToken);
                 }
-                finally
+                catch (Exception)
                 {
                     if (!Delete(localItem))
                         Files.Dereference(localItem.Files.Select(f => f.FileInfo).ToArray());

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -331,7 +331,7 @@ namespace osu.Game.Database
                             if (CanUndelete(existing, item))
                             {
                                 Undelete(existing);
-                                Logger.Log($"Found existing {typeof(TModel)} for {item} (ID {existing.ID}). Skipping import.", LoggingTarget.Database);
+                                Logger.Log($"Found existing {nameof(TModel)} for {item} (ID {existing.ID}). Skipping import.", LoggingTarget.Database);
                                 handleEvent(() => ItemAdded?.Invoke(existing, true));
                                 return existing;
                             }

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -577,7 +577,7 @@ namespace osu.Game.Database
         /// <param name="model">The model to populate.</param>
         /// <param name="archive">The archive to use as a reference for population. May be null.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        protected virtual async Task Populate(TModel model, [CanBeNull] ArchiveReader archive, CancellationToken cancellationToken = default) => await Task.CompletedTask;
+        protected virtual Task Populate(TModel model, [CanBeNull] ArchiveReader archive, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         /// <summary>
         /// Perform any final actions before the import to database executes.

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -161,8 +161,8 @@ namespace osu.Game.Database
                     lock (imported)
                     {
                         imported.Add(model);
+                        current++;
 
-                        Interlocked.Increment(ref current);
                         notification.Text = $"Imported {current} of {paths.Length} {humanisedModelName}s";
                         notification.Progress = (float)current / paths.Length;
                     }

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -162,6 +162,7 @@ namespace osu.Game.Database
                     {
                         imported.Add(model);
 
+                        Interlocked.Increment(ref current);
                         notification.Text = $"Imported {current} of {paths.Length} {humanisedModelName}s";
                         notification.Progress = (float)current / paths.Length;
                     }
@@ -173,10 +174,6 @@ namespace osu.Game.Database
                 catch (Exception e)
                 {
                     Logger.Error(e, $@"Could not import ({Path.GetFileName(path)})");
-                }
-                finally
-                {
-                    Interlocked.Increment(ref current);
                 }
             }));
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -644,6 +644,6 @@ namespace osu.Game.Database
         /// This scheduler generally performs IO and CPU intensive work so concurrency is limited harshly.
         /// It is mainly being used as a queue mechanism for large imports.
         /// </remarks>
-        protected static readonly ThreadedTaskScheduler IMPORT_SCHEDULER = new ThreadedTaskScheduler(import_queue_request_concurrency);
+        protected static readonly ThreadedTaskScheduler IMPORT_SCHEDULER = new ThreadedTaskScheduler(import_queue_request_concurrency, nameof(ArchiveModelManager));
     }
 }

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -132,13 +132,13 @@ namespace osu.Game.Database
         /// This will post notifications tracking progress.
         /// </summary>
         /// <param name="paths">One or more archive locations on disk.</param>
-        public async Task Import(params string[] paths)
+        public Task Import(params string[] paths)
         {
             var notification = new ProgressNotification { State = ProgressNotificationState.Active };
 
             PostNotification?.Invoke(notification);
 
-            await Import(notification, paths);
+            return Import(notification, paths);
         }
 
         protected async Task Import(ProgressNotification notification, params string[] paths)
@@ -243,7 +243,7 @@ namespace osu.Game.Database
         /// </summary>
         /// <param name="archive">The archive to be imported.</param>
         /// <param name="cancellationToken">An optional cancellation token.</param>
-        public async Task<TModel> Import(ArchiveReader archive, CancellationToken cancellationToken = default)
+        public Task<TModel> Import(ArchiveReader archive, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -267,7 +267,7 @@ namespace osu.Game.Database
                 return null;
             }
 
-            return await Import(model, archive, cancellationToken);
+            return Import(model, archive, cancellationToken);
         }
 
         /// <summary>
@@ -548,24 +548,24 @@ namespace osu.Game.Database
         /// <summary>
         /// This is a temporary method and will likely be replaced by a full-fledged (and more correctly placed) migration process in the future.
         /// </summary>
-        public async Task ImportFromStableAsync()
+        public Task ImportFromStableAsync()
         {
             var stable = GetStableStorage?.Invoke();
 
             if (stable == null)
             {
                 Logger.Log("No osu!stable installation available!", LoggingTarget.Information, LogLevel.Error);
-                return;
+                return Task.CompletedTask;
             }
 
             if (!stable.ExistsDirectory(ImportFromStablePath))
             {
                 // This handles situations like when the user does not have a Skins folder
                 Logger.Log($"No {ImportFromStablePath} folder available in osu!stable installation", LoggingTarget.Information, LogLevel.Error);
-                return;
+                return Task.CompletedTask;
             }
 
-            await Task.Run(async () => await Import(stable.GetDirectories(ImportFromStablePath).Select(f => stable.GetFullPath(f)).ToArray()));
+            return Task.Run(async () => await Import(stable.GetDirectories(ImportFromStablePath).Select(f => stable.GetFullPath(f)).ToArray()));
         }
 
         #endregion

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -146,8 +146,6 @@ namespace osu.Game.Database
             notification.Progress = 0;
             notification.Text = "Import is initialising...";
 
-            var term = $"{typeof(TModel).Name.Replace("Info", "").ToLower()}";
-
             int current = 0;
 
             var imported = new List<TModel>();
@@ -164,7 +162,7 @@ namespace osu.Game.Database
                     {
                         imported.Add(model);
 
-                        notification.Text = $"Imported {current} of {paths.Length} {term}s";
+                        notification.Text = $"Imported {current} of {paths.Length} {humanisedModelName}s";
                         notification.Progress = (float)current / paths.Length;
                     }
                 }
@@ -191,7 +189,7 @@ namespace osu.Game.Database
             {
                 notification.CompletionText = imported.Count == 1
                     ? $"Imported {imported.First()}!"
-                    : $"Imported {current} {term}s!";
+                    : $"Imported {current} {humanisedModelName}s!";
 
                 if (imported.Count > 0 && PresentImport != null)
                 {
@@ -339,7 +337,7 @@ namespace osu.Game.Database
                             if (CanUndelete(existing, item))
                             {
                                 Undelete(existing);
-                                Logger.Log($"Found existing {nameof(TModel)} for {item} (ID {existing.ID}). Skipping import.", LoggingTarget.Database);
+                                Logger.Log($"Found existing {humanisedModelName} for {item} (ID {existing.ID}). Skipping import.", LoggingTarget.Database);
                                 handleEvent(() => ItemAdded?.Invoke(existing, true));
 
                                 // existing item will be used; rollback new import and exit early.
@@ -609,6 +607,8 @@ namespace osu.Game.Database
         protected virtual bool CanUndelete(TModel existing, TModel import) => true;
 
         private DbSet<TModel> queryModel() => ContextFactory.Get().Set<TModel>();
+
+        private string humanisedModelName => $"{typeof(TModel).Name.Replace("Info", "").ToLower()}";
 
         /// <summary>
         /// Creates an <see cref="ArchiveReader"/> from a valid storage path.

--- a/osu.Game/Database/ICanAcceptFiles.cs
+++ b/osu.Game/Database/ICanAcceptFiles.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
+
 namespace osu.Game.Database
 {
     /// <summary>
@@ -12,7 +14,7 @@ namespace osu.Game.Database
         /// Import the specified paths.
         /// </summary>
         /// <param name="paths">The files which should be imported.</param>
-        void Import(params string[] paths);
+        Task Import(params string[] paths);
 
         /// <summary>
         /// An array of accepted file extensions (in the standard format of ".abc").

--- a/osu.Game/IO/FileStore.cs
+++ b/osu.Game/IO/FileStore.cs
@@ -2,8 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
@@ -26,6 +29,13 @@ namespace osu.Game.IO
         {
             Store = new StorageBackedResourceStore(Storage);
         }
+
+        /// <summary>
+        /// Perform a lookup query on available <see cref="FileInfo"/>s.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <returns>Results from the provided query.</returns>
+        public IEnumerable<FileInfo> QueryFiles(Expression<Func<FileInfo, bool>> query) => ContextFactory.Get().Set<FileInfo>().AsNoTracking().Where(f => f.ReferenceCount > 0).Where(query);
 
         public FileInfo Add(Stream data, bool reference = true)
         {

--- a/osu.Game/IPC/ArchiveImportIPCChannel.cs
+++ b/osu.Game/IPC/ArchiveImportIPCChannel.cs
@@ -38,7 +38,7 @@ namespace osu.Game.IPC
             }
 
             if (importer.HandledExtensions.Contains(Path.GetExtension(path)?.ToLowerInvariant()))
-                importer.Import(path);
+                await importer.Import(path);
         }
     }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -268,13 +269,13 @@ namespace osu.Game
 
         private readonly List<ICanAcceptFiles> fileImporters = new List<ICanAcceptFiles>();
 
-        public void Import(params string[] paths)
+        public async Task Import(params string[] paths)
         {
             var extension = Path.GetExtension(paths.First())?.ToLowerInvariant();
 
             foreach (var importer in fileImporters)
                 if (importer.HandledExtensions.Contains(extension))
-                    importer.Import(paths);
+                    await importer.Import(paths);
         }
 
         public string[] HandledExtensions => fileImporters.SelectMany(i => i.HandledExtensions).ToArray();

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -36,6 +37,10 @@ namespace osu.Game.Overlays.Notifications
             State = state;
         }
 
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        public CancellationToken CancellationToken => cancellationTokenSource.Token;
+
         public virtual ProgressNotificationState State
         {
             get => state;
@@ -62,6 +67,8 @@ namespace osu.Game.Overlays.Notifications
                                 break;
 
                             case ProgressNotificationState.Cancelled:
+                                cancellationTokenSource.Cancel();
+
                                 Light.Colour = colourCancelled;
                                 Light.Pulsate = false;
                                 progressBar.Active = false;

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Menu
                 if (setInfo == null)
                 {
                     // we need to import the default menu background beatmap
-                    setInfo = beatmaps.Import(new ZipArchiveReader(game.Resources.GetStream(@"Tracks/circles.osz"), "circles.osz"));
+                    setInfo = beatmaps.Import(new ZipArchiveReader(game.Resources.GetStream(@"Tracks/circles.osz"), "circles.osz")).Result;
 
                     setInfo.Protected = true;
                     beatmaps.Update(setInfo);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -279,7 +279,7 @@ namespace osu.Game.Screens.Play
 
                     var score = CreateScore();
                     if (DrawableRuleset.ReplayScore == null)
-                        scoreManager.Import(score);
+                        scoreManager.Import(score).Wait();
 
                     this.Push(CreateResults(score));
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -32,6 +32,7 @@ using osuTK.Input;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Screens.Select
@@ -256,8 +257,8 @@ namespace osu.Game.Screens.Select
                     if (!beatmaps.GetAllUsableBeatmapSets().Any() && beatmaps.StableInstallationAvailable)
                         dialogOverlay.Push(new ImportFromStablePopup(() =>
                         {
-                            beatmaps.ImportFromStableAsync();
-                            skins.ImportFromStableAsync();
+                            Task.Run(beatmaps.ImportFromStableAsync);
+                            Task.Run(skins.ImportFromStableAsync);
                         }));
                 });
             }

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -71,9 +73,9 @@ namespace osu.Game.Skinning
 
         protected override SkinInfo CreateModel(ArchiveReader archive) => new SkinInfo { Name = archive.Name };
 
-        protected override void Populate(SkinInfo model, ArchiveReader archive)
+        protected override async Task Populate(SkinInfo model, ArchiveReader archive, CancellationToken cancellationToken = default)
         {
-            base.Populate(model, archive);
+            await base.Populate(model, archive, cancellationToken);
 
             Skin reference = getSkin(model);
 


### PR DESCRIPTION
This uses async flow to allow locally intensive work to continue without blocking on potentially slow web requests. It also adds a specific concurrency to online lookups to improve the throughput of the many web requests that currently fire.

Future efforts would
- Reduce the number of requests required
- Completely decouple data lookup (when feasible, requires server-side format changes)

Closes #4498.