### PR TITLE
Load results pages asynchronously

### DIFF
--- a/osu.Game/Screens/Ranking/Results.cs
+++ b/osu.Game/Screens/Ranking/Results.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Screens.Ranking
                 currentPage = page.NewValue?.CreatePage();
 
                 if (currentPage != null)
-                    circleInner.Add(currentPage);
+                    LoadComponentAsync(currentPage, circleInner.Add);
             }, true);
         }
 


### PR DESCRIPTION
Reduces performance burden when first displaying pages. Closes #4977.