### PR TITLE
Add ability to watch replays of leaderboard scores

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayPlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayPlayerLoader.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             playerLoader = null;
         });
 
-
         [Test]
         public void TestWaitForDownload()
         {
@@ -53,14 +52,15 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             private readonly ScoreInfo score;
 
-            public DownloadReplayRequest DownloadRequest = null;
+            public DownloadReplayRequest DownloadRequest;
 
-            public TestReplayPlayerLoader(ScoreInfo score, Func<Score, Player> createPlayer) : base(score, createPlayer)
+            public TestReplayPlayerLoader(ScoreInfo score, Func<Score, Player> createPlayer)
+                : base(score, createPlayer)
             {
                 this.score = score;
             }
 
-            Action<Player> onPlayerLoad;
+            private Action<Player> onPlayerLoad;
 
             protected override Task CreatePlayerLoadTask(Action<Player> onLoad)
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayPlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayPlayerLoader.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Screens;
+using osu.Game.Online.API.Requests;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Scoring;
+using osu.Game.Screens;
+using osu.Game.Screens.Play;
+using System;
+using System.Threading.Tasks;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public class TestSceneReplayPlayerLoader : OsuTestScene
+    {
+        private TestReplayPlayerLoader playerLoader;
+        private OsuScreenStack stack;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Child = stack = new OsuScreenStack { RelativeSizeAxes = Axes.Both };
+            Beatmap.Value = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
+            playerLoader = null;
+        });
+
+
+        [Test]
+        public void TestWaitForDownload()
+        {
+            ScoreInfo score = new ScoreInfo
+            {
+                Ruleset = Ruleset.Value,
+                OnlineScoreID = -66,
+            };
+
+            TestPlayer player = null;
+
+            AddStep("create new loader", () => stack.Push(playerLoader = new TestReplayPlayerLoader(score, _ => player = new TestPlayer(false, false))));
+            AddUntilStep("wait for current screen", () => playerLoader.IsCurrentScreen());
+            AddAssert("player is still null", () => player == null);
+            AddAssert("download request created", () => playerLoader.DownloadRequest != null);
+            AddStep("trigger download success", () => playerLoader.TriggerDownloadSuccess());
+            AddAssert("player has been created", () => player != null);
+            AddStep("remove player reference", () => player = null);
+        }
+
+        private class TestReplayPlayerLoader : ReplayPlayerLoader
+        {
+            private readonly ScoreInfo score;
+
+            public DownloadReplayRequest DownloadRequest = null;
+
+            public TestReplayPlayerLoader(ScoreInfo score, Func<Score, Player> createPlayer) : base(score, createPlayer)
+            {
+                this.score = score;
+            }
+
+            Action<Player> onPlayerLoad;
+
+            protected override Task CreatePlayerLoadTask(Action<Player> onLoad)
+            {
+                onPlayerLoad = onLoad;
+
+                return Task.Run(() =>
+                {
+                    DownloadRequest = new DownloadReplayRequest(score);
+                });
+            }
+
+            public void TriggerDownloadSuccess()
+            {
+                LoadReplay(string.Empty, onPlayerLoad);
+            }
+
+            protected override Score CreateReplayScore(string _)
+            {
+                return Ruleset.Value.CreateInstance().GetAutoplayMod().CreateReplayScore(Beatmap.Value.GetPlayableBeatmap(Ruleset.Value, Array.Empty<Mod>()));
+            }
+        }
+    }
+}

--- a/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
@@ -5,9 +5,9 @@ using osu.Game.Scoring;
 
 namespace osu.Game.Online.API.Requests
 {
-    class DownloadReplayRequest : APIDownloadRequest
+    public class DownloadReplayRequest : APIDownloadRequest
     {
-        private ScoreInfo score;
+        private readonly ScoreInfo score;
 
         public DownloadReplayRequest(ScoreInfo score)
         {

--- a/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Scoring;
+using System;
+
+namespace osu.Game.Online.API.Requests
+{
+    class DownloadReplayRequest : APIDownloadRequest
+    {
+        private ScoreInfo score;
+
+        public DownloadReplayRequest(ScoreInfo score)
+        {
+            this.score = score;
+        }
+
+        protected override String Target => $@"scores/{score.Ruleset.ShortName}/{score.OnlineScoreID}/download";
+    }
+}

--- a/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Scoring;
-using System;
 
 namespace osu.Game.Online.API.Requests
 {
@@ -15,6 +14,6 @@ namespace osu.Game.Online.API.Requests
             this.score = score;
         }
 
-        protected override String Target => $@"scores/{score.Ruleset.ShortName}/{score.OnlineScoreID}/download";
+        protected override string Target => $@"scores/{score.Ruleset.ShortName}/{score.OnlineScoreID}/download";
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/APILegacyScoreInfo.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Online.API.Requests.Responses
             set => User = value;
         }
 
-        [JsonProperty(@"score_id")]
+        [JsonProperty(@"id")]
         private long onlineScoreID
         {
             set => OnlineScoreID = value;
@@ -49,6 +49,9 @@ namespace osu.Game.Online.API.Requests.Responses
         {
             set => Beatmap = value;
         }
+
+        [JsonProperty(@"replay")]
+        public bool Replay { get; set; }
 
         [JsonProperty(@"beatmapset")]
         private BeatmapMetadata metadata

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.Play
         {
             this.api = api;
 
-            Mods.Value = base.Mods.Value.Select(m => m.CreateCopy()).ToArray();
+            Mods.Value = PlayerMods;
 
             WorkingBeatmap working = loadBeatmap();
 
@@ -307,6 +307,8 @@ namespace osu.Game.Screens.Play
 
             return score;
         }
+
+        protected virtual IReadOnlyList<Mod> PlayerMods => base.Mods.Value.Select(m => m.CreateCopy()).ToArray();
 
         protected override bool OnScroll(ScrollEvent e) => mouseWheelDisabled.Value && !GameplayClockContainer.IsPaused.Value;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -269,7 +269,12 @@ namespace osu.Game.Screens.Play
 
             ValidForResume = false;
 
-            if (!showResults) return;
+            if (!showResults)
+            {
+                // If results shouldn't be shown on completion, just exit
+                this.Exit();
+                return;
+            }
 
             using (BeginDelayedSequence(1000))
             {

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.Play
                 RelativeSizeAxes = Axes.Both,
             }).WithChildren(new Drawable[]
             {
-                info = new BeatmapMetadataDisplay(Beatmap.Value, Mods.Value, content.LogoFacade)
+                info = new BeatmapMetadataDisplay(Beatmap.Value, DisplayMods, content.LogoFacade)
                 {
                     Alpha = 0,
                     Anchor = Anchor.Centre,
@@ -121,6 +121,8 @@ namespace osu.Game.Screens.Play
 
             this.Delay(400).Schedule(pushWhenLoaded);
         }
+
+        protected virtual IReadOnlyList<Mod> DisplayMods => Mods.Value;
 
         protected virtual Task CreatePlayerLoadTask(Action<Player> onLoad)
         {

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -94,7 +94,6 @@ namespace osu.Game.Screens.Play
             });
         }
 
-
         private void playerLoaded(Player player)
         {
             if (IsDisposed)

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Screens.Play
         // Here because IsHovered will not update unless we do so.
         public override bool HandlePositionalInput => true;
 
-        private bool readyForPush =>  player?.LoadState == LoadState.Ready && IsHovered && GetContainingInputManager()?.DraggedDrawable == null;
+        private bool readyForPush => player?.LoadState == LoadState.Ready && IsHovered && GetContainingInputManager()?.DraggedDrawable == null;
 
         private void pushWhenLoaded()
         {

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
+using System.Collections.Generic;
 
 namespace osu.Game.Screens.Play
 {
@@ -20,6 +22,8 @@ namespace osu.Game.Screens.Play
             base.LoadComplete();
             DrawableRuleset?.SetReplayScore(score);
         }
+
+        protected override IReadOnlyList<Mod> PlayerMods => score.ScoreInfo.Mods;
 
         protected override ScoreInfo CreateScore() => score.ScoreInfo;
     }

--- a/osu.Game/Screens/Play/ReplayPlayerLoader.cs
+++ b/osu.Game/Screens/Play/ReplayPlayerLoader.cs
@@ -18,13 +18,13 @@ using System.Threading.Tasks;
 
 namespace osu.Game.Screens.Play
 {
-    class ReplayPlayerLoader : PlayerLoader
+    public class ReplayPlayerLoader : PlayerLoader
     {
         private readonly ScoreInfo score;
 
-        private Score replayScore = null;
+        private Score replayScore;
 
-        private Func<Score, Player> createPlayerWithReplay;
+        private readonly Func<Score, Player> createPlayerWithReplay;
 
         [Resolved]
         private IAPIProvider api { get; set; }
@@ -35,7 +35,8 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
 
-        public ReplayPlayerLoader(ScoreInfo score, Func<Score, Player> createPlayerWithReplay) : base(null)
+        public ReplayPlayerLoader(ScoreInfo score, Func<Score, Player> createPlayerWithReplay)
+            : base(null)
         {
             this.score = score;
             this.createPlayerWithReplay = createPlayerWithReplay;
@@ -78,7 +79,7 @@ namespace osu.Game.Screens.Play
                 request.Failure += e =>
                 {
                     Logger.Error(e, @"Replay download failed!");
-                    Schedule(() => this.Exit());
+                    Schedule(this.Exit);
                 };
 
                 // TODO: check whether framework is supposed to throw when file not found for download (as it is doing now) or trigger failure
@@ -89,7 +90,7 @@ namespace osu.Game.Screens.Play
                 catch (Exception e)
                 {
                     Logger.Error(e, @"Replay download failed!");
-                    Schedule(() => this.Exit());
+                    Schedule(this.Exit);
                 }
             });
         }

--- a/osu.Game/Screens/Play/ReplayPlayerLoader.cs
+++ b/osu.Game/Screens/Play/ReplayPlayerLoader.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace osu.Game.Screens.Play
+{
+    class ReplayPlayerLoader : PlayerLoader
+    {
+        private readonly ScoreInfo score;
+
+        private Score replayScore = null;
+
+        private Func<Score, Player> createPlayerWithReplay;
+
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
+
+        public ReplayPlayerLoader(ScoreInfo score, Func<Score, Player> createPlayerWithReplay) : base(null)
+        {
+            this.score = score;
+            this.createPlayerWithReplay = createPlayerWithReplay;
+        }
+
+        protected override Task CreatePlayerLoadTask(Action<Player> onLoad)
+        {
+            return Task.Run(() =>
+            {
+                var request = new DownloadReplayRequest(score);
+
+                request.Success += filename =>
+                {
+                    using (var stream = new FileStream(filename, FileMode.Open))
+                    {
+                        replayScore = new Score
+                        {
+                            ScoreInfo = score,
+                            Replay = new DatabasedLegacyScoreParser(rulesets, beatmaps).Parse(stream).Replay,
+                        };
+
+                        var player = createPlayerWithReplay(replayScore);
+
+                        LoadComponentAsync(player, onLoad);
+                    }
+                };
+
+                request.Failure += e =>
+                {
+                    Logger.Error(e, @"Replay download failed!");
+                    Schedule(() => this.Exit());
+                };
+
+                // TODO: check whether framework is supposed to throw when file not found for download (as it is doing now) or trigger failure
+                try
+                {
+                    request.Perform(api);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, @"Replay download failed!");
+                    Schedule(() => this.Exit());
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Play/ReplayPlayerLoader.cs
+++ b/osu.Game/Screens/Play/ReplayPlayerLoader.cs
@@ -8,9 +8,11 @@ using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -59,6 +61,8 @@ namespace osu.Game.Screens.Play
 
             LoadComponentAsync(player, onLoad);
         }
+
+        protected override IReadOnlyList<Mod> DisplayMods => score.Mods;
 
         protected override Task CreatePlayerLoadTask(Action<Player> onLoad)
         {

--- a/osu.Game/Screens/Play/SoloResults.cs
+++ b/osu.Game/Screens/Play/SoloResults.cs
@@ -2,6 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Screens;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Ranking.Types;
@@ -10,9 +18,62 @@ namespace osu.Game.Screens.Play
 {
     public class SoloResults : Results
     {
+
+        private ScoreManager scores;
+
         public SoloResults(ScoreInfo score)
             : base(score)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, ScoreManager scores)
+        {
+            this.scores = scores;
+
+            if (scores.Query(s => s.ID == Score.ID) != null || hasOnlineReplay)
+            {
+                AddInternal(new TwoLayerButton
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    BackgroundColour = colours.Yellow,
+                    Icon = FontAwesome.Solid.PlayCircle,
+                    Text = @"Replay",
+                    HoverColour = colours.YellowDark,
+                    Action = onReplay,
+                });
+            }
+        }
+
+        private bool hasOnlineReplay => Score is APILegacyScoreInfo apiScore && apiScore.OnlineScoreID != null & apiScore.Replay;
+
+        private IReadOnlyList<Mod> previousMods;
+
+        private void onReplay()
+        {
+            // FIXME: why Mods.Disabled == true ?_?
+            Mods.Disabled = false;
+            previousMods = Mods.Value;
+            Mods.Value = Score.Mods;
+
+            if (Score is APILegacyScoreInfo score)
+            {
+                this.Push(new ReplayPlayerLoader(score, replayScore => createReplayPlayer(replayScore)));
+                return;
+            }
+
+            this.Push(new PlayerLoader(() => createReplayPlayer(scores.GetScore(Score))));
+        }
+
+        private ReplayPlayer createReplayPlayer(Score score) => new ReplayPlayer(score, true, false);
+
+        public override void OnResuming(IScreen last)
+        {
+            base.OnResuming(last);
+
+            Mods.Value = previousMods;
+            previousMods = null;
         }
 
         protected override IEnumerable<IResultPageInfo> CreateResultPages() => new IResultPageInfo[]

--- a/osu.Game/Screens/Play/SoloResults.cs
+++ b/osu.Game/Screens/Play/SoloResults.cs
@@ -9,7 +9,6 @@ using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Ranking.Types;
@@ -18,7 +17,6 @@ namespace osu.Game.Screens.Play
 {
     public class SoloResults : Results
     {
-
         private ScoreManager scores;
 
         public SoloResults(ScoreInfo score)
@@ -52,7 +50,7 @@ namespace osu.Game.Screens.Play
         {
             if (Score is APILegacyScoreInfo score)
             {
-                this.Push(new ReplayPlayerLoader(score, replayScore => createReplayPlayer(replayScore)));
+                this.Push(new ReplayPlayerLoader(score, createReplayPlayer));
                 return;
             }
 

--- a/osu.Game/Screens/Play/SoloResults.cs
+++ b/osu.Game/Screens/Play/SoloResults.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private bool hasOnlineReplay => Score is APILegacyScoreInfo apiScore && apiScore.OnlineScoreID != null & apiScore.Replay;
+        private bool hasOnlineReplay => Score is APILegacyScoreInfo apiScore && apiScore.OnlineScoreID != null && apiScore.Replay;
 
         private void onReplay()
         {

--- a/osu.Game/Screens/Play/SoloResults.cs
+++ b/osu.Game/Screens/Play/SoloResults.cs
@@ -48,15 +48,8 @@ namespace osu.Game.Screens.Play
 
         private bool hasOnlineReplay => Score is APILegacyScoreInfo apiScore && apiScore.OnlineScoreID != null & apiScore.Replay;
 
-        private IReadOnlyList<Mod> previousMods;
-
         private void onReplay()
         {
-            // FIXME: why Mods.Disabled == true ?_?
-            Mods.Disabled = false;
-            previousMods = Mods.Value;
-            Mods.Value = Score.Mods;
-
             if (Score is APILegacyScoreInfo score)
             {
                 this.Push(new ReplayPlayerLoader(score, replayScore => createReplayPlayer(replayScore)));
@@ -67,14 +60,6 @@ namespace osu.Game.Screens.Play
         }
 
         private ReplayPlayer createReplayPlayer(Score score) => new ReplayPlayer(score, true, false);
-
-        public override void OnResuming(IScreen last)
-        {
-            base.OnResuming(last);
-
-            Mods.Value = previousMods;
-            previousMods = null;
-        }
 
         protected override IEnumerable<IResultPageInfo> CreateResultPages() => new IResultPageInfo[]
         {

--- a/osu.sln
+++ b/osu.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Game", "osu.Game\osu.Game.csproj", "{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}"
 EndProject
@@ -35,6 +35,10 @@ Global
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/osu.sln
+++ b/osu.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Game", "osu.Game\osu.Game.csproj", "{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}"
 EndProject
@@ -35,10 +35,6 @@ Global
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D9A367C9-4C1A-489F-9B05-A0CEA2B53B58}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C92A607B-1FDD-4954-9F92-03FF547D9080}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Adds a "watch replay" button in the results screen of local leaderboard scores and online leaderboard scores which have `replay: true` in the API response.