### PR TITLE
Fix stacked objects shaking on rewind

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestNoJudgementsOnRewind()
         {
+            AddUntilStep("wait for track to start running", () => track.IsRunning);
             addSeekStep(3000);
             AddAssert("all judged", () => player.DrawableRuleset.Playfield.AllHitObjects.All(h => h.Judged));
             AddStep("clear results", () => player.AppliedResults.Clear());

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
@@ -49,8 +49,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep($"seek to {time}", () => player.GameplayClockContainer.Seek(time));
 
-            // Allow 2 frames of lenience
-            AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, player.DrawableRuleset.FrameStableClock.CurrentTime, 32));
+            // Allow a few frames of lenience
+            AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, player.DrawableRuleset.FrameStableClock.CurrentTime, 100));
         }
 
         protected override Player CreatePlayer(Ruleset ruleset)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
 using osu.Framework.MathUtils;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
@@ -31,8 +32,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
         }
 
+        private Track track;
+
         protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap)
-            => new ClockBackedTestWorkingBeatmap(beatmap, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+        {
+            var working = new ClockBackedTestWorkingBeatmap(beatmap, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+            track = working.Track;
+            return working;
+        }
 
         [Test]
         public void TestNotJudgementsOnRewind()
@@ -47,7 +54,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void addSeekStep(double time)
         {
-            AddStep($"seek to {time}", () => player.GameplayClockContainer.Seek(time));
+            AddStep($"seek to {time}", () => track.Seek(time));
 
             // Allow a few frames of lenience
             AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, player.DrawableRuleset.FrameStableClock.CurrentTime, 100));

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.MathUtils;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public class TestSceneGameplayRewinding : PlayerTestScene
+    {
+        private RulesetExposingPlayer player => (RulesetExposingPlayer)Player;
+
+        [Resolved]
+        private AudioManager audioManager { get; set; }
+
+        public TestSceneGameplayRewinding()
+            : base(new OsuRuleset())
+        {
+        }
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap)
+            => new ClockBackedTestWorkingBeatmap(beatmap, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
+
+        [Test]
+        public void TestNotJudgementsOnRewind()
+        {
+            addSeekStep(3000);
+            AddAssert("all judged", () => player.DrawableRuleset.Playfield.AllHitObjects.All(h => h.Judged));
+            AddStep("clear results", () => player.AppliedResults.Clear());
+            addSeekStep(0);
+            AddAssert("none judged", () => player.DrawableRuleset.Playfield.AllHitObjects.All(h => !h.Judged));
+            AddAssert("no results triggered", () => player.AppliedResults.Count == 0);
+        }
+
+        private void addSeekStep(double time)
+        {
+            AddStep($"seek to {time}", () => player.GameplayClockContainer.Seek(time));
+
+            // Allow 2 frames of lenience
+            AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, player.DrawableRuleset.FrameStableClock.CurrentTime, 32));
+        }
+
+        protected override Player CreatePlayer(Ruleset ruleset)
+        {
+            Mods.Value = Mods.Value.Concat(new[] { ruleset.GetAutoplayMod() }).ToArray();
+            return new RulesetExposingPlayer();
+        }
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
+        {
+            var beatmap = new Beatmap
+            {
+                BeatmapInfo = { BaseDifficulty = { ApproachRate = 9 } },
+            };
+
+            for (int i = 0; i < 15; i++)
+            {
+                beatmap.HitObjects.Add(new HitCircle
+                {
+                    Position = new Vector2(256, 192),
+                    StartTime = 1000 + 30 * i
+                });
+            }
+
+            return beatmap;
+        }
+
+        private class RulesetExposingPlayer : Player
+        {
+            public readonly List<JudgementResult> AppliedResults = new List<JudgementResult>();
+
+            public new GameplayClockContainer GameplayClockContainer => base.GameplayClockContainer;
+
+            public new DrawableRuleset DrawableRuleset => base.DrawableRuleset;
+
+            public RulesetExposingPlayer()
+                : base(false, false)
+            {
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                ScoreProcessor.NewJudgement += r => AppliedResults.Add(r);
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayRewinding.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestNotJudgementsOnRewind()
+        public void TestNoJudgementsOnRewind()
         {
             addSeekStep(3000);
             AddAssert("all judged", () => player.DrawableRuleset.Playfield.AllHitObjects.All(h => h.Judged));

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -243,6 +243,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <returns>Whether a scoring result has occurred from this <see cref="DrawableHitObject"/> or any nested <see cref="DrawableHitObject"/>.</returns>
         protected bool UpdateResult(bool userTriggered)
         {
+            // It's possible for input to get into a bad state when rewinding gameplay, so results should not be processed
+            if (Time.Elapsed < 0)
+                return false;
+
             judgementOccurred = false;
 
             if (AllJudged)


### PR DESCRIPTION
Fixes #4602

Does not fix some hitobject states not being correctly reverted - approach circles remaining at their most contracted state for example. Will make a separate issue for that one.