### PR TITLE
Fix ChangeLog crash.

### DIFF
--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Overlays.Changelog
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            if(Build.ChangelogEntries == null)
+            if (Build.ChangelogEntries == null)
                 return;
 
             foreach (var categoryEntries in Build.ChangelogEntries.GroupBy(b => b.Category).OrderBy(c => c.Key))

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Overlays.Changelog
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
+            if(Build.ChangelogEntries == null)
+                return;
+
             foreach (var categoryEntries in Build.ChangelogEntries.GroupBy(b => b.Category).OrderBy(c => c.Key))
             {
                 ChangelogEntries.Add(new OsuSpriteText


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9100368/59480211-58575a80-8e92-11e9-8615-f8c6791d0a03.png)

After pressing previous stable feedback button two or three times, null ` Build.ChangelogEntries` will cause game crash.