### PR TITLE
Fix IconButtons not being scaled correctly

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneIconButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneIconButton.cs
@@ -26,8 +26,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 {
                     new NamedIconButton("No change", new IconButton()),
                     new NamedIconButton("Background colours", new ColouredIconButton()),
-                    new NamedIconButton("Full-width", new IconButton { ButtonSize = new Vector2(200, 30) }),
-                    new NamedIconButton("Unchanging size", new IconButton(), false),
+                    new NamedIconButton("Full-width", new IconButton { Size = new Vector2(200, 30) }),
                     new NamedIconButton("Icon colours", new IconButton
                     {
                         IconColour = Color4.Green,
@@ -48,7 +47,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private class NamedIconButton : Container
         {
-            public NamedIconButton(string name, IconButton button, bool allowSizeChange = true)
+            public NamedIconButton(string name, IconButton button)
             {
                 AutoSizeAxes = Axes.Y;
                 Width = 200;
@@ -101,13 +100,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     }
                 };
 
-                if (allowSizeChange)
-                    iconContainer.AutoSizeAxes = Axes.Both;
-                else
-                {
-                    iconContainer.RelativeSizeAxes = Axes.X;
-                    iconContainer.Height = 30;
-                }
+                iconContainer.AutoSizeAxes = Axes.Both;
 
                 button.Anchor = Anchor.Centre;
                 button.Origin = Anchor.Centre;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneMusicController.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneMusicController.cs
@@ -3,7 +3,6 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Timing;
 using osu.Game.Overlays;
 
@@ -23,9 +22,9 @@ namespace osu.Game.Tests.Visual.UserInterface
             };
             Add(mc);
 
-            AddToggleStep(@"toggle visibility", state => mc.State.Value = state ? Visibility.Visible : Visibility.Hidden);
             AddStep(@"show", () => mc.Show());
             AddToggleStep(@"toggle beatmap lock", state => Beatmap.Disabled = state);
+            AddStep(@"show", () => mc.Hide());
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/IconButton.cs
+++ b/osu.Game/Graphics/UserInterface/IconButton.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class IconButton : OsuAnimatedButton
     {
-        public const float BUTTON_SIZE = 30;
+        public const float DEFAULT_BUTTON_SIZE = 30;
 
         private Color4? iconColour;
 
@@ -57,26 +57,11 @@ namespace osu.Game.Graphics.UserInterface
             set => icon.Scale = value;
         }
 
-        /// <summary>
-        /// The size of the <see cref="IconButton"/> while it is not being pressed.
-        /// </summary>
-        public Vector2 ButtonSize
-        {
-            get => Content.Size;
-            set
-            {
-                Content.RelativeSizeAxes = Axes.None;
-                Content.AutoSizeAxes = Axes.None;
-                Content.Size = value;
-            }
-        }
-
         private readonly SpriteIcon icon;
 
         public IconButton()
         {
-            AutoSizeAxes = Axes.Both;
-            ButtonSize = new Vector2(BUTTON_SIZE);
+            Size = new Vector2(DEFAULT_BUTTON_SIZE);
 
             Add(icon = new SpriteIcon
             {

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -464,11 +464,25 @@ namespace osu.Game.Overlays
 
         private class MusicIconButton : IconButton
         {
+            public MusicIconButton()
+            {
+                AutoSizeAxes = Axes.Both;
+            }
+
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
                 HoverColour = colours.YellowDark.Opacity(0.6f);
                 FlashColour = colours.Yellow;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                // works with AutoSizeAxes above to make buttons autosize with the scale animation.
+                Content.AutoSizeAxes = Axes.None;
+                Content.Size = new Vector2(DEFAULT_BUTTON_SIZE);
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 // Small offset to look a bit better centered along with the divisor text
                 Y = 1;
 
-                ButtonSize = new Vector2(20);
+                Size = new Vector2(20);
                 IconScale = new Vector2(0.6f);
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineButton.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineButton.cs
@@ -31,14 +31,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             InternalChild = button = new TimelineIconButton { Action = () => Action?.Invoke() };
 
             button.Enabled.BindTo(Enabled);
-            Width = button.ButtonSize.X;
+            Width = button.Width;
         }
 
         protected override void Update()
         {
             base.Update();
 
-            button.ButtonSize = new Vector2(button.ButtonSize.X, DrawHeight);
+            button.Size = new Vector2(button.Width, DrawHeight);
         }
 
         private class TimelineIconButton : IconButton


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/4898 for cases where autosize was being used.

The default behaviour now is that `IconButton`s / `OsuAnimatedButton`s will not be autosize. A local implementation which makes them autosize (with the shrink  animation) is added back only in `MusicController`.