### PR TITLE
Don't count last section in difficulty calculation

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Catch.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Catch";
 
-        [TestCase(4.2058561036909863d, "diffcalc-test")]
+        [TestCase(4.2019052105105601d, "diffcalc-test")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
 

--- a/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Mania.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Mania";
 
-        [TestCase(2.3683365342338796d, "diffcalc-test")]
+        [TestCase(2.3031617269438298d, "diffcalc-test")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
 

--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Osu";
 
-        [TestCase(6.931145117263422, "diffcalc-test")]
+        [TestCase(6.931145116016932, "diffcalc-test")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
 

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
-        [TestCase(2.9811338051242915d, "diffcalc-test")]
-        [TestCase(2.9811338051242915d, "diffcalc-test-strong")]
+        [TestCase(2.9811336589467095d, "diffcalc-test")]
+        [TestCase(2.9811336589467095d, "diffcalc-test-strong")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
 

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -93,9 +93,7 @@ namespace osu.Game.Rulesets.Difficulty
                     s.Process(h);
             }
 
-            // The peak strain will not be saved for the last section in the above loop
-            foreach (Skill s in skills)
-                s.SaveCurrentPeak();
+            // The peak strain is not saved for the last section in stable (bug compatibility)
 
             return CreateDifficultyAttributes(beatmap, mods, skills, clockRate);
         }


### PR DESCRIPTION
In order to be [bug-for-bug compatible](https://en.wikipedia.org/wiki/Bug_compatibility) with stable's diffcalc, the last strain section should not be counted. This solves several cases in #4622 where stable reports a way lower value than lazer. This affects all gamemodes.

This is technically incorrect behavior, but IMO it's better to just follow stable until it is deprecated. Naturally, another course of action would be to update stable.

### osu!
| beatmap       | lazer old       | stable | lazer new       |
| ------------- | --------------- | ------ | --------------- |
| diffcalc-test | 6.9311451172634 | N/A    | 6.9311451160169 |

I'm testing using an outdated stable build which doesn't contain the most recent balancing updates.

### Taiko
| beatmap                | lazer old    | stable       | lazer new    |
| ---------------------- | ------------ | ------------ | ------------ |
| diffcalc-test(-strong) | 2.9811338051 | 2.9811336589 | 2.9811336589 |

Unit test matches stable perfectly now!

### Mania
| beatmap       | lazer old | stable  | lazer new |
| ------------- | --------- | ------- | --------- |
| diffcalc-test | 2.36834   | 2.27048 | 2.30316   |

### Catch
| beatmap       | lazer old | stable  | lazer new |
| ------------- | --------- | ------- | --------- |
| 1463571       | 51.0636   | 12.9724 | 13.2875   |
| 1578040       | 57.2904   | 1.62373 | 3.21903   |
| 448918        | 40.2829   | 1.20154 | 1.18474   |
| 628771        | 45.2952   | 1.97616 | 1.97592   |
| diffcalc-test | 4.20586   | 4.20191 | 4.20191   |
| 977762        | 1.77877   | 1.78872 | 1.77877   |
| 2057725       | 3.45302   | 3.44780 | 3.44947   |
| 2020384       | 6.72952   | 6.72932 | 6.72952   |
| 1533958       | 4.16960   | 4.15895 | 4.16960   |
