### PR TITLE
Catch autoplay improvements

### DIFF
--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -46,8 +46,8 @@ namespace osu.Game.Rulesets.Catch.Replays
                 //So we can either make it there without a dash or not.
                 double speedRequired = positionChange == 0 ? 0 : positionChange / timeAvailable;
 
-                bool dashRequired = speedRequired > movement_speed && h.StartTime != 0;
-                bool impossibleJump = speedRequired > movement_speed * 2 && h.StartTime != 0;
+                bool dashRequired = speedRequired > movement_speed;
+                bool impossibleJump = speedRequired > movement_speed * 2;
 
                 // todo: get correct catcher size, based on difficulty CS.
                 const float catcher_width_half = CatcherArea.CATCHER_SIZE / CatchPlayfield.BASE_WIDTH * 0.3f * 0.5f;

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                 double timeAvailable = h.StartTime - lastTime;
 
                 //So we can either make it there without a dash or not.
-                double speedRequired = positionChange / timeAvailable;
+                double speedRequired = positionChange == 0 ? 0 : positionChange / timeAvailable;
 
                 bool dashRequired = speedRequired > movement_speed && h.StartTime != 0;
                 bool impossibleJump = speedRequired > movement_speed * 2 && h.StartTime != 0;

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -44,7 +44,8 @@ namespace osu.Game.Rulesets.Catch.Replays
                 double timeAvailable = h.StartTime - lastTime;
 
                 // So we can either make it there without a dash or not.
-                // If positionChange is 0, we don't need to move so speedRequired should also be 0 (could be NaN if timeAvailable is 0 too)
+                // If positionChange is 0, we don't need to move, so speedRequired should also be 0 (could be NaN if timeAvailable is 0 too)
+                // The case where positionChange > 0 and timeAvailable == 0 results in PositiveInfinity which provides expected beheaviour.
                 double speedRequired = positionChange == 0 ? 0 : positionChange / timeAvailable;
 
                 bool dashRequired = speedRequired > movement_speed;

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -43,7 +43,8 @@ namespace osu.Game.Rulesets.Catch.Replays
                 float positionChange = Math.Abs(lastPosition - h.X);
                 double timeAvailable = h.StartTime - lastTime;
 
-                //So we can either make it there without a dash or not.
+                // So we can either make it there without a dash or not.
+                // If positionChange is 0, we don't need to move so speedRequired should also be 0 (could be NaN if timeAvailable is 0 too)
                 double speedRequired = positionChange == 0 ? 0 : positionChange / timeAvailable;
 
                 bool dashRequired = speedRequired > movement_speed;

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -60,9 +60,8 @@ namespace osu.Game.Rulesets.Catch.Replays
                     return;
                 }
 
-                if (h is Banana || impossibleJump)
+                if (impossibleJump)
                 {
-                    // auto bananas unrealistically warp to catch 100% combo.
                     Replay.Frames.Add(new CatchReplayFrame(h.StartTime, h.X));
                 }
                 else if (h.HyperDash)

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -47,6 +47,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                 double speedRequired = positionChange / timeAvailable;
 
                 bool dashRequired = speedRequired > movement_speed && h.StartTime != 0;
+                bool impossibleJump = speedRequired > movement_speed * 2 && h.StartTime != 0;
 
                 // todo: get correct catcher size, based on difficulty CS.
                 const float catcher_width_half = CatcherArea.CATCHER_SIZE / CatchPlayfield.BASE_WIDTH * 0.3f * 0.5f;
@@ -59,7 +60,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                     return;
                 }
 
-                if (h is Banana)
+                if (h is Banana || impossibleJump)
                 {
                     // auto bananas unrealistically warp to catch 100% combo.
                     Replay.Frames.Add(new CatchReplayFrame(h.StartTime, h.X));


### PR DESCRIPTION
- Fixes crash with 2B hitobjects, which caused a -Infinity Catcher x position
- Use normal instead of interpolated movement for bananas when possible
- Ensure speedRequired is not NaN to prevent bugs in the future.