### PR TITLE
Remove local implementation of bindable in OsuCheckbox

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
@@ -15,17 +14,6 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class OsuCheckbox : Checkbox
     {
-        private Bindable<bool> bindable;
-
-        public Bindable<bool> Bindable
-        {
-            set
-            {
-                bindable = value;
-                Current.BindTo(bindable);
-            }
-        }
-
         public Color4 CheckedColor { get; set; } = Color4.Cyan;
         public Color4 UncheckedColor { get; set; } = Color4.White;
         public int FadeDuration { get; set; }

--- a/osu.Game/Screens/Play/PlayerSettings/DiscussionSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/DiscussionSettings.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 new PlayerCheckbox
                 {
                     LabelText = "Show floating comments",
-                    Bindable = config.GetBindable<bool>(OsuSetting.FloatingComments)
+                    Current = config.GetBindable<bool>(OsuSetting.FloatingComments)
                 },
                 new FocusedTextBox
                 {

--- a/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
@@ -25,6 +25,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config) => mouseButtonsCheckbox.Bindable = config.GetBindable<bool>(OsuSetting.MouseDisableButtons);
+        private void load(OsuConfigManager config) => mouseButtonsCheckbox.Current = config.GetBindable<bool>(OsuSetting.MouseDisableButtons);
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -47,9 +47,9 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             dimSliderBar.Bindable = config.GetBindable<double>(OsuSetting.DimLevel);
             blurSliderBar.Bindable = config.GetBindable<double>(OsuSetting.BlurLevel);
-            showStoryboardToggle.Bindable = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
-            beatmapSkinsToggle.Bindable = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
-            beatmapHitsoundsToggle.Bindable = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
+            showStoryboardToggle.Current = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
+            beatmapSkinsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
+            beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
         }
     }
 }


### PR DESCRIPTION
Sloppy, incorrect and unnecessary after framework Current logic is fixed via ppy/osu-framework#2547.

- [x] Depends on ppy/osu-framework#2547.