### PR TITLE
Make OsuButton non-abstract again

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -17,11 +17,11 @@ namespace osu.Game.Graphics.UserInterface
     /// <summary>
     /// A button with added default sound effects.
     /// </summary>
-    public abstract class OsuButton : Button
+    public class OsuButton : Button
     {
         private Box hover;
 
-        protected OsuButton()
+        public OsuButton()
         {
             Height = 40;
 


### PR DESCRIPTION
This class is actually usable as-is, and preferred for admin-level controls. Used in tournament tools to reduce screen movement (we use remote desktop to control these tools so this is important).