### PR TITLE
Unbind from previous bindable when rebinding a SettingsItem

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -63,6 +63,9 @@ namespace osu.Game.Overlays.Settings
 
             set
             {
+                if (bindable != null)
+                    controlWithCurrent?.Current.UnbindFrom(bindable);
+
                 bindable = value;
                 controlWithCurrent?.Current.BindTo(bindable);
 


### PR DESCRIPTION
Local fix similar to https://github.com/ppy/osu-framework/pull/2547.