### PR TITLE
Poll only when network available

### DIFF
--- a/osu.Game/Online/PollingComponent.cs
+++ b/osu.Game/Online/PollingComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using osu.Framework.Graphics;
+using osu.Framework.IO.Network;
 using osu.Framework.Threading;
 
 namespace osu.Game.Online
@@ -83,7 +84,11 @@ namespace osu.Game.Online
         {
             scheduledPoll = null;
             pollingActive = true;
-            Poll().ContinueWith(_ => pollComplete());
+
+            if (NetworkHelper.NetworkAvailable)
+                Poll().ContinueWith(_ => pollComplete());
+            else
+                pollComplete();
         }
 
         /// <summary>


### PR DESCRIPTION
Perform polling when network is not available is pointless. Hence, we should not do it.

depends on https://github.com/ppy/osu-framework/pull/2556