### PR TITLE
Improve vertical flexibility of BeatmapSetOverlay's header

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -97,7 +97,13 @@ namespace osu.Game.Overlays.BeatmapSet
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Padding = new MarginPadding { Top = 20, Bottom = 30, Horizontal = BeatmapSetOverlay.X_PADDING },
+                            Padding = new MarginPadding
+                            {
+                                Top = 20,
+                                Bottom = 30,
+                                Left = BeatmapSetOverlay.X_PADDING,
+                                Right = BeatmapSetOverlay.X_PADDING + BeatmapSetOverlay.RIGHT_WIDTH,
+                            },
                             Child = new FillFlowContainer
                             {
                                 RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Overlays.BeatmapSet
             ExternalLinkButton externalLink;
 
             RelativeSizeAxes = Axes.X;
-            Height = 400;
+            AutoSizeAxes = Axes.Y;
             Masking = true;
 
             EdgeEffect = new EdgeEffectParameters
@@ -72,7 +72,8 @@ namespace osu.Game.Overlays.BeatmapSet
                 },
                 new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding { Top = tabs_height },
                     Children = new Drawable[]
                     {
@@ -94,18 +95,20 @@ namespace osu.Game.Overlays.BeatmapSet
                         },
                         new Container
                         {
-                            RelativeSizeAxes = Axes.Both,
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
                             Padding = new MarginPadding { Top = 20, Bottom = 30, Horizontal = BeatmapSetOverlay.X_PADDING },
                             Child = new FillFlowContainer
                             {
-                                RelativeSizeAxes = Axes.Both,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
                                 Direction = FillDirection.Vertical,
                                 Children = new Drawable[]
                                 {
                                     new Container
                                     {
                                         RelativeSizeAxes = Axes.X,
-                                        Height = 113,
+                                        AutoSizeAxes = Axes.Y,
                                         Child = Picker = new BeatmapPicker(),
                                     },
                                     new FillFlowContainer
@@ -158,7 +161,7 @@ namespace osu.Game.Overlays.BeatmapSet
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.BottomRight,
                             AutoSizeAxes = Axes.Both,
-                            Margin = new MarginPadding { Right = BeatmapSetOverlay.X_PADDING },
+                            Margin = new MarginPadding { Top = BeatmapSetOverlay.TOP_PADDING, Right = BeatmapSetOverlay.X_PADDING },
                             Direction = FillDirection.Vertical,
                             Spacing = new Vector2(10),
                             Children = new Drawable[]

--- a/osu.Game/Overlays/BeatmapSetOverlay.cs
+++ b/osu.Game/Overlays/BeatmapSetOverlay.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Overlays
         private const int fade_duration = 300;
 
         public const float X_PADDING = 40;
+        public const float TOP_PADDING = 25;
         public const float RIGHT_WIDTH = 275;
 
         private readonly Header header;


### PR DESCRIPTION
- Avoid overlapping between beatmap info and details
- Make header expandable (mostly for beatmap availability box and beatmaps with many difficulties)