### PR TITLE
Clear avatar before updating it

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -114,6 +114,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         {
             set
             {
+                avatar.ClearUser();
                 avatar.User = value.User;
                 flag.Country = value.User.Country;
                 date.Text = $@"achieved {value.Date.Humanize()}";

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -152,6 +152,7 @@ namespace osu.Game.Overlays.Profile.Header
 
         private void updateUser(User user)
         {
+            avatar.ClearUser();
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
             openUserExternally.Link = $@"https://osu.ppy.sh/users/{user?.Id ?? 0}";

--- a/osu.Game/Users/UpdateableAvatar.cs
+++ b/osu.Game/Users/UpdateableAvatar.cs
@@ -47,6 +47,15 @@ namespace osu.Game.Users
             updateAvatar();
         }
 
+        /// <summary>
+        /// Clears the user instantly
+        /// </summary>
+        public void ClearUser()
+        {
+            user = null;
+            displayedAvatar?.FadeOut().Expire();
+        }
+
         private void updateAvatar()
         {
             displayedAvatar?.FadeOut(300);


### PR DESCRIPTION
Instantly fades out the avatars in the BeatmapSetOverlay when setting new ones.

Closes #5029