### PR TITLE
Move NotificationSection strings to constructor

### DIFF
--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -58,16 +58,12 @@ namespace osu.Game.Overlays
                             RelativeSizeAxes = Axes.X,
                             Children = new[]
                             {
-                                new NotificationSection
+                                new NotificationSection(@"Notifications", @"Clear All")
                                 {
-                                    Title = @"Notifications",
-                                    ClearText = @"Clear All",
                                     AcceptTypes = new[] { typeof(SimpleNotification) }
                                 },
-                                new NotificationSection
+                                new NotificationSection(@"Running Tasks", @"Cancel All")
                                 {
-                                    Title = @"Running Tasks",
-                                    ClearText = @"Cancel All",
                                     AcceptTypes = new[] { typeof(ProgressNotification) }
                                 }
                             }

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -17,10 +17,7 @@ namespace osu.Game.Overlays.Notifications
 {
     public class NotificationSection : AlwaysUpdateFillFlowContainer<Drawable>
     {
-        private OsuSpriteText titleText;
-        private OsuSpriteText countText;
-
-        private ClearAllButton clearButton;
+        private OsuSpriteText countDrawable;
 
         private FlowContainer<Notification> notifications;
 
@@ -35,28 +32,14 @@ namespace osu.Game.Overlays.Notifications
 
         public IEnumerable<Type> AcceptTypes;
 
-        private string clearText;
+        private readonly string clearButtonText;
 
-        public string ClearText
+        private readonly string titleText;
+
+        public NotificationSection(string title, string clearButtonText)
         {
-            get => clearText;
-            set
-            {
-                clearText = value;
-                if (clearButton != null) clearButton.Text = clearText;
-            }
-        }
-
-        private string title;
-
-        public string Title
-        {
-            get => title;
-            set
-            {
-                title = value;
-                if (titleText != null) titleText.Text = title.ToUpperInvariant();
-            }
+            this.clearButtonText = clearButtonText;
+            titleText = title;
         }
 
         [BackgroundDependencyLoader]
@@ -82,9 +65,9 @@ namespace osu.Game.Overlays.Notifications
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        clearButton = new ClearAllButton
+                        new ClearAllButton
                         {
-                            Text = clearText,
+                            Text = clearButtonText,
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
                             Action = clearAll
@@ -99,12 +82,12 @@ namespace osu.Game.Overlays.Notifications
                             AutoSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                titleText = new OsuSpriteText
+                                new OsuSpriteText
                                 {
-                                    Text = title.ToUpperInvariant(),
+                                    Text = titleText.ToUpperInvariant(),
                                     Font = OsuFont.GetFont(weight: FontWeight.Black)
                                 },
-                                countText = new OsuSpriteText
+                                countDrawable = new OsuSpriteText
                                 {
                                     Text = "3",
                                     Colour = colours.Yellow,
@@ -134,7 +117,7 @@ namespace osu.Game.Overlays.Notifications
         {
             base.Update();
 
-            countText.Text = notifications.Children.Count(c => c.Alpha > 0.99f).ToString();
+            countDrawable.Text = notifications.Children.Count(c => c.Alpha > 0.99f).ToString();
         }
 
         private class ClearAllButton : OsuClickableContainer


### PR DESCRIPTION
Found this while debugging performance issues. While this alone doesn't really solve the large problem (`NotificationOverlay` is `AlwaysPresent`) it felt like a nice clean-up step, as these strings should never change.