### PR TITLE
Block gameplay input while in failing state

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -77,9 +77,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         private bool judgementOccurred;
 
-        public bool Interactive = true;
-        public override bool HandleNonPositionalInput => Interactive;
-        public override bool HandlePositionalInput => Interactive;
+        public override bool PropagateNonPositionalInputSubTree => !HasFailed.Value;
+        public override bool PropagatePositionalInputSubTree => !HasFailed.Value;
 
         public override bool RemoveWhenNotAlive => false;
         public override bool RemoveCompletedTransforms => false;


### PR DESCRIPTION
 - Override correct booleans ~~`HandleNonPositionalInput`~~ `PropagateNonPositionalInputSubTree`

- [ ] Depends on #5085

Closes #5086 