### PR TITLE
Unuse the gameplay clock in KeyCounter

### DIFF
--- a/osu.Game/Screens/Play/KeyCounter.cs
+++ b/osu.Game/Screens/Play/KeyCounter.cs
@@ -75,9 +75,6 @@ namespace osu.Game.Screens.Play
         [BackgroundDependencyLoader(true)]
         private void load(TextureStore textures, GameplayClock clock)
         {
-            if (clock != null)
-                Clock = clock;
-
             Children = new Drawable[]
             {
                 buttonSprite = new Sprite

--- a/osu.Game/Screens/Play/KeyCounter.cs
+++ b/osu.Game/Screens/Play/KeyCounter.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(TextureStore textures, GameplayClock clock)
+        private void load(TextureStore textures)
         {
             Children = new Drawable[]
             {


### PR DESCRIPTION
Using the gameplay clock causes the key counter to slow down due to the rate slowing down on failing state, unusing it should be better.

Closes #4993 