### PR TITLE
Prevent non-combo affecting judgements from triggering sudden death

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
@@ -22,7 +22,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         protected override bool AllowFail => true;
 
-        protected override Player CreatePlayer(Ruleset ruleset) => new ScoreAccessiblePlayer();
+        protected override Player CreatePlayer(Ruleset ruleset)
+        {
+            Mods.Value = Mods.Value.Concat(new[] { new TaikoModSuddenDeath() }).ToArray();
+            return new ScoreAccessiblePlayer();
+        }
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) =>
             new TaikoBeatmap
@@ -45,7 +49,6 @@ namespace osu.Game.Rulesets.Taiko.Tests
             AddStep("Setup judgements", () =>
             {
                 judged = false;
-                Mods.Value = Mods.Value.Concat(new[] { new TaikoModSuddenDeath() }).ToArray();
                 ((ScoreAccessiblePlayer)Player).ScoreProcessor.NewJudgement += b => judged = true;
             });
             AddUntilStep("swell judged", () => judged);

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Beatmaps;
+using osu.Game.Rulesets.Taiko.Mods;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TestSceneTaikoSuddenDeath : PlayerTestScene
+    {
+        public TestSceneTaikoSuddenDeath()
+            : base(new TaikoRuleset())
+        {
+        }
+
+        protected override bool AllowFail => true;
+
+        protected override Player CreatePlayer(Ruleset ruleset) => new ScoreAccessiblePlayer();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) =>
+            new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new Swell { StartTime = 1500 },
+                    new Hit { StartTime = 100000 },
+                },
+                BeatmapInfo =
+                {
+                    Ruleset = new TaikoRuleset().RulesetInfo
+                }
+            };
+
+        [Test]
+        public void TestSpinnerDoesNotFail()
+        {
+            bool judged = false;
+            AddStep("Setup judgements", () =>
+            {
+                judged = false;
+                Mods.Value = Mods.Value.Concat(new[] { new TaikoModSuddenDeath() }).ToArray();
+                ((ScoreAccessiblePlayer)Player).ScoreProcessor.NewJudgement += b => judged = true;
+            });
+            AddUntilStep("swell judged", () => judged);
+            AddAssert("not failed", () => !Player.HasFailed);
+        }
+
+        private class ScoreAccessiblePlayer : TestPlayer
+        {
+            public ScoreAccessiblePlayer()
+                : base(false, false)
+            {
+            }
+
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                ScoreProcessor.FailConditions += _ => true;
+                ScoreProcessor.FailConditions += (_, __) => true;
             }
         }
     }

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mods
@@ -14,6 +15,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage Icon => OsuIcon.ModPerfect;
         public override string Description => "SS or quit.";
 
-        protected override bool FailCondition(ScoreProcessor scoreProcessor) => scoreProcessor.Accuracy.Value != 1;
+        protected override bool FailCondition(ScoreProcessor scoreProcessor, JudgementResult result) => scoreProcessor.Accuracy.Value != 1;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -27,6 +28,6 @@ namespace osu.Game.Rulesets.Mods
 
         public ScoreRank AdjustRank(ScoreRank rank, double accuracy) => rank;
 
-        protected virtual bool FailCondition(ScoreProcessor scoreProcessor) => scoreProcessor.Combo.Value == 0;
+        protected virtual bool FailCondition(ScoreProcessor scoreProcessor, JudgementResult result) => scoreProcessor.Combo.Value == 0 && result.Judgement.AffectsCombo;
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Additional conditions on top of <see cref="DefaultFailCondition"/> that cause a failing state.
         /// </summary>
-        public event Func<ScoreProcessor, bool> FailConditions;
+        public event Func<ScoreProcessor, JudgementResult, bool> FailConditions;
 
         /// <summary>
         /// The current total score.
@@ -151,12 +151,12 @@ namespace osu.Game.Rulesets.Scoring
         /// This can only ever notify subscribers once.
         /// </para>
         /// </summary>
-        protected void UpdateFailed()
+        protected void UpdateFailed(JudgementResult result)
         {
             if (HasFailed)
                 return;
 
-            if (!DefaultFailCondition && FailConditions?.Invoke(this) != true)
+            if (!DefaultFailCondition && FailConditions?.Invoke(this, result) != true)
                 return;
 
             if (Failed?.Invoke() != false)
@@ -287,7 +287,7 @@ namespace osu.Game.Rulesets.Scoring
             ApplyResult(result);
             updateScore();
 
-            UpdateFailed();
+            UpdateFailed(result);
             NotifyNewJudgement(result);
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/5011

This required exposing the `Judgement` that triggered the score update to the `FailConditions`, which should be fine considering the fail state was only being updated on `applyResult` anyway.