### PR TITLE
Fix bracket editor crash when no round description is present

### DIFF
--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentRound.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentRound.cs
@@ -51,8 +51,8 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             name = round.Name.GetBoundCopy();
             name.BindValueChanged(n => textName.Text = ((losers ? "Losers " : "") + round.Name).ToUpper(), true);
 
-            description = round.Name.GetBoundCopy();
-            description.BindValueChanged(n => textDescription.Text = round.Description.Value.ToUpper(), true);
+            description = round.Description.GetBoundCopy();
+            description.BindValueChanged(n => textDescription.Text = round.Description.Value?.ToUpper(), true);
         }
     }
 }


### PR DESCRIPTION
We now use the correct bindable for the description and don't crash with a NullReference if there's no description present.

If someone wants to reproduce for fun:
1) Set up a round as you wish without touching the description field (I usually save changes as well)
2) Right click in bracket editor to add a match
3) Click on match and change the round in the settings on the right