### PR TITLE
Add OsuNumberBox

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNumberBox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNumberBox.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    [TestFixture]
+    public class TestSceneNumberBox : OsuTestScene
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(OsuNumberBox),
+        };
+
+        private OsuNumberBox numberBox;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.X,
+                Padding = new MarginPadding { Horizontal = 250 },
+                Child = numberBox = new OsuNumberBox
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.X,
+                    PlaceholderText = "Insert numbers here"
+                }
+            };
+
+            clearInput();
+            AddStep("enter numbers", () => numberBox.Text = "987654321");
+            expectedValue("987654321");
+            clearInput();
+            AddStep("enter text + single number", () => numberBox.Text = "1 hello 2 world 3");
+            expectedValue("123");
+            clearInput();
+        }
+
+        private void clearInput() => AddStep("clear input", () => numberBox.Text = null);
+
+        private void expectedValue(string value) => AddAssert("expect number", () => numberBox.Text == value);
+    }
+}

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -183,7 +183,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 AutoSizeAxes = Axes.Both,
                                 Children = new Drawable[]
                                 {
-                                    new SettingsTextBox
+                                    new SettingsNumberBox
                                     {
                                         LabelText = "Beatmap ID",
                                         RelativeSizeAxes = Axes.None,

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -231,7 +231,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 AutoSizeAxes = Axes.Both,
                                 Children = new Drawable[]
                                 {
-                                    new SettingsTextBox
+                                    new SettingsNumberBox
                                     {
                                         LabelText = "User ID",
                                         RelativeSizeAxes = Axes.None,

--- a/osu.Game/Graphics/UserInterface/OsuNumberBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuNumberBox.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public class OsuNumberBox : OsuTextBox
+    {
+        protected override bool CanAddCharacter(char character) => char.IsNumber(character);
+    }
+}

--- a/osu.Game/Overlays/Settings/SettingsNumberBox.cs
+++ b/osu.Game/Overlays/Settings/SettingsNumberBox.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Overlays.Settings
+{
+    public class SettingsNumberBox : SettingsItem<string>
+    {
+        protected override Drawable CreateControl() => new OsuNumberBox
+        {
+            Margin = new MarginPadding { Top = 5 },
+            RelativeSizeAxes = Axes.X,
+        };
+    }
+}


### PR DESCRIPTION
Adds a simple textbox that only allows numbers and is used for the ID fields in tournament tools.

closes https://github.com/ppy/osu/issues/5105