### PR TITLE
Avoid displaying previous user avatar when showing new beatmap overlay

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         Size = new Vector2(40),
                         FillMode = FillMode.Fit,
                     },
-                    avatar = new UpdateableAvatar
+                    avatar = new UpdateableAvatar(transformImmediately: true)
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -90,7 +90,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 Origin = Anchor.CentreLeft,
                                 Font = OsuFont.GetFont(size: 15, weight: FontWeight.Bold)
                             },
-                            flag = new UpdateableFlag
+                            flag = new UpdateableFlag(transformImmediately: true)
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
@@ -116,7 +116,6 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         {
             set
             {
-                avatar.Reset();
                 avatar.User = value.User;
                 flag.Country = value.User.Country;
                 date.Text = $@"achieved {value.Date.Humanize()}";

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -116,6 +116,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         {
             set
             {
+                avatar.Reset();
                 avatar.User = value.User;
                 flag.Country = value.User.Country;
                 date.Text = $@"achieved {value.Date.Humanize()}";

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreUserSection.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         Size = new Vector2(40),
                         FillMode = FillMode.Fit,
                     },
-                    avatar = new UpdateableAvatar(transformImmediately: true)
+                    avatar = new UpdateableAvatar(hideImmediately: true)
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -90,7 +90,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 Origin = Anchor.CentreLeft,
                                 Font = OsuFont.GetFont(size: 15, weight: FontWeight.Bold)
                             },
-                            flag = new UpdateableFlag(transformImmediately: true)
+                            flag = new UpdateableFlag(hideImmediately: true)
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -37,6 +37,10 @@ namespace osu.Game.Users.Drawables
             set => base.EdgeEffect = value;
         }
 
+        protected override bool TransformImmediately { get; }
+
+        protected override double TransformDuration { get; } = 1000;
+
         /// <summary>
         /// Whether to show a default guest representation on null user (as opposed to nothing).
         /// </summary>
@@ -47,23 +51,14 @@ namespace osu.Game.Users.Drawables
         /// </summary>
         public readonly BindableBool OpenOnClick = new BindableBool(true);
 
-        public UpdateableAvatar(User user = null)
+        public UpdateableAvatar(User user = null, bool transformImmediately = false)
         {
             User = user;
-        }
 
-        /// <summary>
-        /// Fades and expires the <see cref="ModelBackedDrawable{T}.DisplayedDrawable"/>, and sets the
-        /// <see cref="ModelBackedDrawable{T}.Model"/> to null.
-        /// </summary>
-        /// <remarks>
-        /// Can be used when the <see cref="ModelBackedDrawable{T}.DisplayedDrawable"/> needs to be removed instantly.
-        /// </remarks>
-        public void Reset()
-        {
-            DisplayedDrawable?.FadeOut().Expire();
-
-            User = null;
+            if (transformImmediately) {
+                TransformDuration = 0;
+                TransformImmediately = true;
+            }
         }
 
         protected override Drawable CreateDrawable(User user)

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -52,6 +52,20 @@ namespace osu.Game.Users.Drawables
             User = user;
         }
 
+        /// <summary>
+        /// Fades and expires the <see cref="ModelBackedDrawable{T}.DisplayedDrawable"/>, and sets the
+        /// <see cref="ModelBackedDrawable{T}.Model"/> to null.
+        /// </summary>
+        /// <remarks>
+        /// Can be used when the <see cref="ModelBackedDrawable{T}.DisplayedDrawable"/> needs to be removed instantly.
+        /// </remarks>
+        public void Reset()
+        {
+            DisplayedDrawable?.FadeOut().Expire();
+
+            User = null;
+        }
+
         protected override Drawable CreateDrawable(User user)
         {
             if (user == null && !ShowGuestOnNull)

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -55,7 +55,8 @@ namespace osu.Game.Users.Drawables
         {
             User = user;
 
-            if (transformImmediately) {
+            if (transformImmediately)
+            {
                 TransformDuration = 0;
                 TransformImmediately = true;
             }

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -40,8 +40,6 @@ namespace osu.Game.Users.Drawables
 
         protected override bool TransformImmediately { get; }
 
-        protected override double TransformDuration { get; } = 1000;
-
         /// <summary>
         /// Whether to show a default guest representation on null user (as opposed to nothing).
         /// </summary>

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -5,6 +5,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Transforms;
 
 namespace osu.Game.Users.Drawables
 {
@@ -51,16 +52,13 @@ namespace osu.Game.Users.Drawables
         /// </summary>
         public readonly BindableBool OpenOnClick = new BindableBool(true);
 
-        public UpdateableAvatar(User user = null, bool transformImmediately = false)
+        public UpdateableAvatar(User user = null, bool hideImmediately = false)
         {
+            TransformImmediately = hideImmediately;
             User = user;
-
-            if (transformImmediately)
-            {
-                TransformDuration = 0;
-                TransformImmediately = true;
-            }
         }
+
+        protected override TransformSequence<Drawable> ApplyHideTransforms(Drawable drawable) => TransformImmediately ? drawable?.FadeOut() : base.ApplyHideTransforms(drawable);
 
         protected override Drawable CreateDrawable(User user)
         {

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -14,14 +14,23 @@ namespace osu.Game.Users.Drawables
             set => Model = value;
         }
 
+        protected override bool TransformImmediately { get; }
+
+        protected override double TransformDuration { get; } = 1000;
+
         /// <summary>
         /// Whether to show a place holder on null country.
         /// </summary>
         public bool ShowPlaceholderOnNull = true;
 
-        public UpdateableFlag(Country country = null)
+        public UpdateableFlag(Country country = null, bool transformImmediately = false)
         {
             Country = country;
+
+            if (transformImmediately) {
+                TransformDuration = 0;
+                TransformImmediately = true;
+            }
         }
 
         protected override Drawable CreateDrawable(Country country)

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -27,7 +27,8 @@ namespace osu.Game.Users.Drawables
         {
             Country = country;
 
-            if (transformImmediately) {
+            if (transformImmediately)
+            {
                 TransformDuration = 0;
                 TransformImmediately = true;
             }

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Transforms;
 
 namespace osu.Game.Users.Drawables
 {
@@ -23,16 +24,13 @@ namespace osu.Game.Users.Drawables
         /// </summary>
         public bool ShowPlaceholderOnNull = true;
 
-        public UpdateableFlag(Country country = null, bool transformImmediately = false)
+        public UpdateableFlag(Country country = null, bool hideImmediately = false)
         {
+            TransformImmediately = hideImmediately;
             Country = country;
-
-            if (transformImmediately)
-            {
-                TransformDuration = 0;
-                TransformImmediately = true;
-            }
         }
+
+        protected override TransformSequence<Drawable> ApplyHideTransforms(Drawable drawable) => TransformImmediately ? drawable?.FadeOut() : base.ApplyHideTransforms(drawable);
 
         protected override Drawable CreateDrawable(Country country)
         {

--- a/osu.Game/Users/Drawables/UpdateableFlag.cs
+++ b/osu.Game/Users/Drawables/UpdateableFlag.cs
@@ -17,8 +17,6 @@ namespace osu.Game.Users.Drawables
 
         protected override bool TransformImmediately { get; }
 
-        protected override double TransformDuration { get; } = 1000;
-
         /// <summary>
         /// Whether to show a place holder on null country.
         /// </summary>


### PR DESCRIPTION
Instantly fades out the avatar in the top score of BeatmapSetOverlay when setting a new one.

Supersedes #5068
Closes #5029