### PR TITLE
Fix dialog going off-screen when UI scaling is applied

### DIFF
--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -134,9 +134,9 @@ namespace osu.Game.Overlays.Dialog
                             Origin = Anchor.BottomCentre,
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Position = new Vector2(0f, 60f),
+                            Position = new Vector2(0f, -40f),
                             Direction = FillDirection.Vertical,
-                            Spacing = new Vector2(0f, 10f),
+                            Spacing = new Vector2(0f, 5f),
                             Children = new Drawable[]
                             {
                                 new Container
@@ -146,7 +146,7 @@ namespace osu.Game.Overlays.Dialog
                                     Size = ringSize,
                                     Margin = new MarginPadding
                                     {
-                                        Bottom = 30,
+                                        Bottom = 0,
                                     },
                                     Children = new Drawable[]
                                     {
@@ -181,14 +181,17 @@ namespace osu.Game.Overlays.Dialog
                                     Anchor = Anchor.TopCentre,
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Padding = new MarginPadding(15),
+                                    Padding = new MarginPadding(5),
                                     TextAnchor = Anchor.TopCentre,
                                 },
                                 body = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 18))
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Padding = new MarginPadding(15),
+                                    Padding = new MarginPadding {
+                                        Top = 5,
+                                        Bottom = -20,
+                                    },
                                     TextAnchor = Anchor.TopCentre,
                                 },
                             },

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -134,9 +134,9 @@ namespace osu.Game.Overlays.Dialog
                             Origin = Anchor.BottomCentre,
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Position = new Vector2(0f, -40f),
                             Direction = FillDirection.Vertical,
-                            Spacing = new Vector2(0f, 5f),
+                            Spacing = new Vector2(0f, 10f),
+                            Padding = new MarginPadding { Bottom = 10 },
                             Children = new Drawable[]
                             {
                                 new Container
@@ -144,10 +144,6 @@ namespace osu.Game.Overlays.Dialog
                                     Origin = Anchor.TopCentre,
                                     Anchor = Anchor.TopCentre,
                                     Size = ringSize,
-                                    Margin = new MarginPadding
-                                    {
-                                        Bottom = 0,
-                                    },
                                     Children = new Drawable[]
                                     {
                                         ring = new CircularContainer
@@ -181,18 +177,15 @@ namespace osu.Game.Overlays.Dialog
                                     Anchor = Anchor.TopCentre,
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Padding = new MarginPadding(5),
                                     TextAnchor = Anchor.TopCentre,
                                 },
                                 body = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 18))
                                 {
+                                    Origin = Anchor.TopCentre,
+                                    Anchor = Anchor.TopCentre,
+                                    TextAnchor = Anchor.TopCentre,
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Padding = new MarginPadding {
-                                        Top = 5,
-                                        Bottom = -20,
-                                    },
-                                    TextAnchor = Anchor.TopCentre,
                                 },
                             },
                         },

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Overlays.Dialog
                             Origin = Anchor.BottomCentre,
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Position = new Vector2(0f, -50f),
+                            Position = new Vector2(0f, 60f),
                             Direction = FillDirection.Vertical,
                             Spacing = new Vector2(0f, 10f),
                             Children = new Drawable[]


### PR DESCRIPTION
Regarding https://github.com/ppy/osu/issues/5040

New here, i never really programmed on a big project like this. It looks kinda makeshift / too easy and i hope it doesn't cause any other issues but i've seen nothing wrong and it fixed the issue for me. It was all dialog boxes that got cut off at the top (so also deleting all beatmaps etc.)