### PR TITLE
Load beatmap content asynchronously in the background

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -231,7 +231,7 @@ namespace osu.Game.Beatmaps
         {
             // recycling logic is not here for the time being, as components which use
             // retrieved objects from WorkingBeatmap may not hold a reference to the WorkingBeatmap itself.
-            // this should be fine as each retrieved comopnent do have their own finalizers.
+            // this should be fine as each retrieved component do have their own finalizers.
 
             // cancelling the beatmap load is safe for now since the retrieval is a synchronous
             // operation. if we add an async retrieval method this may need to be reconsidered.

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -157,7 +157,20 @@ namespace osu.Game.Beatmaps
             return b;
         }, beatmapCancellation.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default)));
 
-        public IBeatmap Beatmap => LoadBeatmapAsync().Result;
+        public IBeatmap Beatmap
+        {
+            get
+            {
+                try
+                {
+                    return LoadBeatmapAsync().Result;
+                }
+                catch (TaskCanceledException)
+                {
+                    return null;
+                }
+            }
+        }
 
         private readonly CancellationTokenSource beatmapCancellation = new CancellationTokenSource();
         protected abstract IBeatmap GetBeatmap();

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Beatmaps
 
         public Task<IBeatmap> LoadBeatmapAsync() => (beatmapLoadTask ?? (beatmapLoadTask = Task.Factory.StartNew(() =>
         {
+            // Todo: Handle cancellation during beatmap parsing
             var b = GetBeatmap() ?? new Beatmap();
 
             // The original beatmap version needs to be preserved as the database doesn't contain it

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -46,11 +46,6 @@ namespace osu.Game.Beatmaps
             skin = new RecyclableLazy<Skin>(GetSkin);
         }
 
-        ~WorkingBeatmap()
-        {
-            Dispose(false);
-        }
-
         protected virtual Track GetVirtualTrack()
         {
             const double excess_length = 1000;
@@ -227,6 +222,11 @@ namespace osu.Game.Beatmaps
             // cancelling the beatmap load is safe for now since the retrieval is a synchronous
             // operation. if we add an async retrieval method this may need to be reconsidered.
             beatmapCancellation.Cancel();
+        }
+
+        ~WorkingBeatmap()
+        {
+            Dispose(false);
         }
 
         #endregion

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -51,11 +51,6 @@ namespace osu.Game.Beatmaps
             total_count.Value++;
         }
 
-        ~WorkingBeatmap()
-        {
-            Dispose(false);
-        }
-
         protected virtual Track GetVirtualTrack()
         {
             const double excess_length = 1000;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -296,6 +296,8 @@ namespace osu.Game
             if (nextBeatmap?.Track != null)
                 nextBeatmap.Track.Completed += currentTrackCompleted;
 
+            beatmap.OldValue?.Dispose();
+
             nextBeatmap?.LoadBeatmapAsync();
         }
 


### PR DESCRIPTION
Now that the `MusicController` is not always present, there were cases (such as the menu buttons) that were no longer obtaining a beatmap as they only requested it in a passive way (first checking `working.BeatmapLoadded`).

We generally always want the beatmap to be loaded when a `WorkingBeatmap` is constructed, so this change moves that process to an implicit asynchronous load.

Closes #5215.