### PR TITLE
Remove unnecessary local item storage in SettingsDropdown

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 
         private class AudioDeviceSettingsDropdown : SettingsDropdown<string>
         {
-            protected override OsuDropdown<string> CreateDropdown() => new AudioDeviceDropdownControl { Items = Items };
+            protected override OsuDropdown<string> CreateDropdown() => new AudioDeviceDropdownControl();
 
             private class AudioDeviceDropdownControl : DropdownControl
             {

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private class ResolutionSettingsDropdown : SettingsDropdown<Size>
         {
-            protected override OsuDropdown<Size> CreateDropdown() => new ResolutionDropdownControl { Items = Items };
+            protected override OsuDropdown<Size> CreateDropdown() => new ResolutionDropdownControl();
 
             private class ResolutionDropdownControl : DropdownControl
             {

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private class SkinSettingsDropdown : SettingsDropdown<SkinInfo>
         {
-            protected override OsuDropdown<SkinInfo> CreateDropdown() => new SkinDropdownControl { Items = Items };
+            protected override OsuDropdown<SkinInfo> CreateDropdown() => new SkinDropdownControl();
 
             private class SkinDropdownControl : DropdownControl
             {

--- a/osu.Game/Overlays/Settings/SettingsDropdown.cs
+++ b/osu.Game/Overlays/Settings/SettingsDropdown.cs
@@ -13,39 +13,23 @@ namespace osu.Game.Overlays.Settings
     {
         protected new OsuDropdown<T> Control => (OsuDropdown<T>)base.Control;
 
-        private IEnumerable<T> items = Enumerable.Empty<T>();
-
         public IEnumerable<T> Items
         {
-            get => items;
-            set
-            {
-                items = value;
-
-                if (Control != null)
-                    Control.Items = value;
-            }
+            get => Control.Items;
+            set => Control.Items = value;
         }
-
-        private IBindableList<T> itemSource;
 
         public IBindableList<T> ItemSource
         {
-            get => itemSource;
-            set
-            {
-                itemSource = value;
-
-                if (Control != null)
-                    Control.ItemSource = value;
-            }
+            get => Control.ItemSource;
+            set => Control.ItemSource = value;
         }
 
         public override IEnumerable<string> FilterTerms => base.FilterTerms.Concat(Control.Items.Select(i => i.ToString()));
 
         protected sealed override Drawable CreateControl() => CreateDropdown();
 
-        protected virtual OsuDropdown<T> CreateDropdown() => new DropdownControl { Items = Items, ItemSource = ItemSource };
+        protected virtual OsuDropdown<T> CreateDropdown() => new DropdownControl();
 
         protected class DropdownControl : OsuDropdown<T>
         {


### PR DESCRIPTION
Resolves #5025

Doesn't seem like there's a reason for it - the control is always initialised in the ctor so it can't be null.