### PR TITLE
Fix keybindings being offset incorrectly

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -95,9 +95,6 @@ namespace osu.Game.Input.Bindings
         [Description("Quick retry (hold)")]
         QuickRetry,
 
-        [Description("Quick exit (Hold)")]
-        QuickExit,
-
         [Description("Take screenshot")]
         TakeScreenshot,
 
@@ -115,5 +112,8 @@ namespace osu.Game.Input.Bindings
 
         [Description("Select")]
         Select,
+
+        [Description("Quick exit (Hold)")]
+        QuickExit,
     }
 }


### PR DESCRIPTION
I thoguht we were already using strings for keys, but turns out that's only the case for settings