### PR TITLE
Reduce size of dropdown chevron

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -247,8 +247,8 @@ namespace osu.Game.Graphics.UserInterface
                         Icon = FontAwesome.Solid.ChevronDown,
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
-                        Margin = new MarginPadding { Right = 4 },
-                        Size = new Vector2(20),
+                        Margin = new MarginPadding { Right = 5 },
+                        Size = new Vector2(12),
                     },
                 };
 


### PR DESCRIPTION
It felt too big

Before:

![image](https://user-images.githubusercontent.com/191335/60091612-02cb5980-9780-11e9-9df3-c3a19ce9b08d.png)

After:

![image](https://user-images.githubusercontent.com/191335/60091650-15de2980-9780-11e9-955d-4dee95b3057e.png)
