### PR TITLE
Add base class for startup screens

### DIFF
--- a/osu.Game/Screens/Loader.cs
+++ b/osu.Game/Screens/Loader.cs
@@ -9,21 +9,12 @@ using osu.Framework.Graphics.Shaders;
 using osu.Game.Screens.Menu;
 using osuTK;
 using osu.Framework.Screens;
-using osu.Game.Overlays;
 
 namespace osu.Game.Screens
 {
-    public class Loader : OsuScreen
+    public class Loader : StartupScreen
     {
         private bool showDisclaimer;
-
-        public override bool HideOverlaysOnEnter => true;
-
-        public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
-
-        public override bool CursorVisible => false;
-
-        public override bool AllowBackButton => false;
 
         public Loader()
         {

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -15,25 +15,17 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
 using osuTK;
 using osuTK.Graphics;
-using osu.Game.Overlays;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Menu
 {
-    public class Disclaimer : OsuScreen
+    public class Disclaimer : StartupScreen
     {
         private Intro intro;
         private SpriteIcon icon;
         private Color4 iconColour;
         private LinkFlowContainer textFlow;
         private LinkFlowContainer supportFlow;
-
-        public override bool HideOverlaysOnEnter => true;
-        public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
-
-        public override bool AllowBackButton => false;
-
-        public override bool CursorVisible => false;
 
         private Drawable heart;
 

--- a/osu.Game/Screens/Menu/Intro.cs
+++ b/osu.Game/Screens/Menu/Intro.cs
@@ -15,11 +15,10 @@ using osu.Game.IO.Archives;
 using osu.Game.Screens.Backgrounds;
 using osuTK;
 using osuTK.Graphics;
-using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Menu
 {
-    public class Intro : OsuScreen
+    public class Intro : StartupScreen
     {
         private const string menu_music_beatmap_hash = "3c8b1fcc9434dbb29e2fb613d3b9eada9d7bb6c125ceb32396c3b53437280c83";
 
@@ -31,13 +30,6 @@ namespace osu.Game.Screens.Menu
         private MainMenu mainMenu;
         private SampleChannel welcome;
         private SampleChannel seeya;
-
-        public override bool AllowBackButton => false;
-
-        public override bool HideOverlaysOnEnter => true;
-        public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
-
-        public override bool CursorVisible => false;
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenBlack();
 

--- a/osu.Game/Screens/StartupScreen.cs
+++ b/osu.Game/Screens/StartupScreen.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens
+{
+    /// <summary>
+    /// A screen which is shown once as part of the startup procedure.
+    /// </summary>
+    public abstract class StartupScreen : OsuScreen
+    {
+        public override bool AllowBackButton => false;
+
+        public override bool HideOverlaysOnEnter => true;
+
+        public override bool CursorVisible => false;
+
+        public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
+    }
+}


### PR DESCRIPTION
Avoids missing adding changes to screens like Disclaimer, which may not be shown in debug builds.