### PR TITLE
Shortcut checking for whether directories are files

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Beatmaps
                 }
             }
 
-            private string getPathForFile(string filename) => BeatmapSetInfo.Files.First(f => string.Equals(f.Filename, filename, StringComparison.InvariantCultureIgnoreCase)).FileInfo.StoragePath;
+            private string getPathForFile(string filename) => BeatmapSetInfo.Files.FirstOrDefault(f => string.Equals(f.Filename, filename, StringComparison.InvariantCultureIgnoreCase))?.FileInfo.StoragePath;
 
             private TextureStore textureStore;
 

--- a/osu.Game/Utils/ZipUtils.cs
+++ b/osu.Game/Utils/ZipUtils.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 using SharpCompress.Archives.Zip;
 
 namespace osu.Game.Utils
@@ -10,6 +11,9 @@ namespace osu.Game.Utils
     {
         public static bool IsZipArchive(string path)
         {
+            if (!File.Exists(path))
+                return false;
+
             try
             {
                 using (var arc = ZipArchive.Open(path))


### PR DESCRIPTION
Very slight debugger-performance change. Previously `ZipArchive` would throw if the path was a directory since it does a `File.Exits()` check internally, and would be caught below. This has huge consequences during debugging on macOS (https://github.com/dotnet/coreclr/issues/24626).