### PR TITLE
Fix settings subpanels dimming main content

### DIFF
--- a/osu.Game/Overlays/SettingsSubPanel.cs
+++ b/osu.Game/Overlays/SettingsSubPanel.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Overlays
             });
         }
 
+        protected override bool DimMainContent => false; // dimming is handled by main overlay
+
         private class BackButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>
         {
             private AspectContainer aspect;


### PR DESCRIPTION
Supersedes #4857, using new `SettingsSubPanel` class instead.

Was easier to make a new PR than bring the other one up-to-date.