### PR TITLE
Fix Relax mod not working with osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     {
         private readonly ShakeContainer shakeContainer;
 
+        // Must be set to update IsHovered as it's used in relax mdo to detect osu hit objects.
         public override bool HandlePositionalInput => true;
 
         protected DrawableOsuHitObject(OsuHitObject hitObject)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     {
         private readonly ShakeContainer shakeContainer;
 
+        public override bool HandlePositionalInput => true;
+
         protected DrawableOsuHitObject(OsuHitObject hitObject)
             : base(hitObject)
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -81,8 +81,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
         public override bool RemoveCompletedTransforms => false;
         protected override bool RequiresChildrenUpdate => true;
 
-        public override bool HandlePositionalInput => true;
-
         public override bool IsPresent => base.IsPresent || (State.Value == ArmedState.Idle && Clock?.CurrentTime >= LifetimeStart);
 
         public readonly Bindable<ArmedState> State = new Bindable<ArmedState>();

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         public override bool RemoveCompletedTransforms => false;
         protected override bool RequiresChildrenUpdate => true;
 
+        public override bool HandlePositionalInput => true;
+
         public override bool IsPresent => base.IsPresent || (State.Value == ArmedState.Idle && Clock?.CurrentTime >= LifetimeStart);
 
         public readonly Bindable<ArmedState> State = new Bindable<ArmedState>();


### PR DESCRIPTION
`IsHovered` doesn't get updated anymore due to `HandlePositionalInput` not set to true, which breaks Relax mod, in that line below. 
https://github.com/ppy/osu/blob/43d83b35d04c7f32e639e02e889a3e33df4953a1/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs#L43

The slider and spinner didn't break because slider uses the ball's hover, while the spinner doesn't require anything to be set
https://github.com/ppy/osu/blob/43d83b35d04c7f32e639e02e889a3e33df4953a1/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs#L44

Closes #5184