### PR TITLE
Allow exiting Editor again

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -24,11 +24,13 @@ using osu.Game.Screens.Edit.Design;
 using osuTK.Input;
 using System.Collections.Generic;
 using osu.Framework;
+using osu.Framework.Input.Bindings;
+using osu.Game.Input.Bindings;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Edit
 {
-    public class Editor : OsuScreen
+    public class Editor : OsuScreen, IKeyBindingHandler<GlobalAction>
     {
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenCustom(@"Backgrounds/bg4");
 
@@ -205,6 +207,19 @@ namespace osu.Game.Screens.Edit
 
             return true;
         }
+
+        public bool OnPressed(GlobalAction action)
+        {
+            if (action == GlobalAction.Back)
+            {
+                this.Exit();
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool OnReleased(GlobalAction action) => action == GlobalAction.Back;
 
         public override void OnResuming(IScreen last)
         {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -212,6 +212,7 @@ namespace osu.Game.Screens.Edit
         {
             if (action == GlobalAction.Back)
             {
+                // as we don't want to display the back button, manual handling of exit action is required.
                 this.Exit();
                 return true;
             }


### PR DESCRIPTION
https://github.com/ppy/osu/pull/5149 made it impossible to leave the Editor as I trapped myself there today.

This will allow exiting the Editor again, although I think the design needs to be updated to properly make place for the back button here. Otherwise you still can't leave without a keyboard.