### PR TITLE
Change song select initialisation to promote database context sharing

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -11,7 +11,6 @@ using osu.Game.Configuration;
 using osuTK.Input;
 using osu.Framework.MathUtils;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
@@ -64,35 +63,29 @@ namespace osu.Game.Screens.Select
         public IEnumerable<BeatmapSetInfo> BeatmapSets
         {
             get => beatmapSets.Select(g => g.BeatmapSet);
-            set => loadBeatmapSets(() => value);
+            set => loadBeatmapSets(value);
         }
 
-        public void LoadBeatmapSetsFromManager(BeatmapManager manager) => loadBeatmapSets(manager.GetAllUsableBeatmapSetsEnumerable);
-
-        private void loadBeatmapSets(Func<IEnumerable<BeatmapSetInfo>> beatmapSets)
+        private void loadBeatmapSets(IEnumerable<BeatmapSetInfo> beatmapSets)
         {
             CarouselRoot newRoot = new CarouselRoot(this);
 
-            Task.Run(() =>
-            {
-                beatmapSets().Select(createCarouselSet).Where(g => g != null).ForEach(newRoot.AddChild);
-                newRoot.Filter(activeCriteria);
+            beatmapSets.Select(createCarouselSet).Where(g => g != null).ForEach(newRoot.AddChild);
+            newRoot.Filter(activeCriteria);
 
-                // preload drawables as the ctor overhead is quite high currently.
-                var _ = newRoot.Drawables;
-            }).ContinueWith(_ => Schedule(() =>
-            {
-                root = newRoot;
-                scrollableContent.Clear(false);
-                itemsCache.Invalidate();
-                scrollPositionCache.Invalidate();
+            // preload drawables as the ctor overhead is quite high currently.
+            var _ = newRoot.Drawables;
 
-                Schedule(() =>
-                {
-                    BeatmapSetsChanged?.Invoke();
-                    BeatmapSetsLoaded = true;
-                });
-            }));
+            root = newRoot;
+            scrollableContent.Clear(false);
+            itemsCache.Invalidate();
+            scrollPositionCache.Invalidate();
+
+            Schedule(() =>
+            {
+                BeatmapSetsChanged?.Invoke();
+                BeatmapSetsLoaded = true;
+            });
         }
 
         private readonly List<float> yPositions = new List<float>();
@@ -125,13 +118,15 @@ namespace osu.Game.Screens.Select
         }
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, BeatmapManager beatmaps)
         {
             config.BindWith(OsuSetting.RandomSelectAlgorithm, RandomAlgorithm);
             config.BindWith(OsuSetting.SongSelectRightMouseScroll, RightClickScrollingEnabled);
 
             RightClickScrollingEnabled.ValueChanged += enabled => RightMouseScrollbar = enabled.NewValue;
             RightClickScrollingEnabled.TriggerChange();
+
+            loadBeatmapSets(beatmaps.GetAllUsableBeatmapSetsEnumerable());
         }
 
         public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -244,8 +244,6 @@ namespace osu.Game.Screens.Select
             sampleChangeBeatmap = audio.Samples.Get(@"SongSelect/select-expand");
             SampleConfirm = audio.Samples.Get(@"SongSelect/confirm-selection");
 
-            Carousel.LoadBeatmapSetsFromManager(this.beatmaps);
-
             if (dialogOverlay != null)
             {
                 Schedule(() =>


### PR DESCRIPTION
This alone almost plugs a memory leak caused by entering song select many times over. The database contexts used to be created on `ThreadPool` threads, and as we enforce one-context-per-thread there was a new one created every song select entry.

This does not seem to affect `SongSelect` load performance or transition in an adverse way.

I'm working towards a solution which reduces database contexts down further (by sharing over all threads, likely) but this should be considered a hotfix to reduce runaway scenarios.