### PR TITLE
Disable Hidden mod for osu!taiko (until it is implemented)

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -9,5 +9,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
     {
         public override string Description => @"Beats fade out before you hit them!";
         public override double ScoreMultiplier => 1.06;
+        public override bool HasImplementation => false;
     }
 }


### PR DESCRIPTION
I wanted to do that one as well as it seemed simple but everything there is unexpectedly vastly different and built more confusing than the other game modes.
I need more time wrapping my head around this so I thought disabling it (like it should) would be less disappointing to players.