### PR TITLE
Avoid using a BufferedContainer for backgrounds unless required

### DIFF
--- a/osu.Game/Graphics/Backgrounds/Background.cs
+++ b/osu.Game/Graphics/Backgrounds/Background.cs
@@ -6,23 +6,28 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.Transforms;
+using osuTK;
 
 namespace osu.Game.Graphics.Backgrounds
 {
-    public class Background : BufferedContainer
+    /// <summary>
+    /// A background which offer blurring on demand.
+    /// </summary>
+    public class Background : CompositeDrawable
     {
         public Sprite Sprite;
 
         private readonly string textureName;
 
+        private BufferedContainer bufferedContainer;
+
         public Background(string textureName = @"")
         {
-            CacheDrawnFrameBuffer = true;
-
             this.textureName = textureName;
             RelativeSizeAxes = Axes.Both;
 
-            Add(Sprite = new Sprite
+            AddInternal(Sprite = new Sprite
             {
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
@@ -36,6 +41,29 @@ namespace osu.Game.Graphics.Backgrounds
         {
             if (!string.IsNullOrEmpty(textureName))
                 Sprite.Texture = textures.Get(textureName);
+        }
+
+        public Vector2 BlurSigma => bufferedContainer?.BlurSigma ?? Vector2.Zero;
+
+        /// <summary>
+        /// Smoothly adjusts <see cref="IBufferedContainer.BlurSigma"/> over time.
+        /// </summary>
+        /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+        public void BlurTo(Vector2 newBlurSigma, double duration = 0, Easing easing = Easing.None)
+        {
+            if (bufferedContainer == null)
+            {
+                RemoveInternal(Sprite);
+
+                AddInternal(bufferedContainer = new BufferedContainer
+                {
+                    CacheDrawnFrameBuffer = true,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = Sprite
+                });
+            }
+
+            bufferedContainer.BlurTo(newBlurSigma, duration, easing);
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/Background.cs
+++ b/osu.Game/Graphics/Backgrounds/Background.cs
@@ -12,7 +12,7 @@ using osuTK;
 namespace osu.Game.Graphics.Backgrounds
 {
     /// <summary>
-    /// A background which offer blurring on demand.
+    /// A background which offers blurring via a <see cref="BufferedContainer"/> on demand.
     /// </summary>
     public class Background : CompositeDrawable
     {


### PR DESCRIPTION
Mainly an optimisation for main menu, which doesn't blur yet currently buffers every background it displays.

Future extension could potentially support reverting away from `BufferedContainer` after blur transform completes and blur sigma is zero.

Reduces unmanaged memory by 3mb (on startup), plus an addition 3mb per `Background` not using blur.