### PR TITLE
Update menu backgrounds

### DIFF
--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Backgrounds
         private Background background;
 
         private int currentDisplay;
-        private const int background_count = 5;
+        private const int background_count = 7;
 
         private string backgroundName => $@"Menu/menu-background-{currentDisplay % background_count + 1}";
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.701.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.702.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2019.702.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -104,7 +104,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.701.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.702.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2019.702.0" />
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.702.0" />
     <PackageReference Include="SharpCompress" Version="0.22.0" />


### PR DESCRIPTION
Also reduces pinned (LOH) memory usage by 13mb via trimming of wav files.

We may want to consider using a non-lossless format in the future, but I've left it for now to prioritise low latency playback (even though they are just menu sounds).