### PR TITLE
Fix layout of profile top header to match web

### DIFF
--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -119,10 +119,11 @@ namespace osu.Game.Overlays.Profile.Header
                                             Margin = new MarginPadding { Top = 10 },
                                             Colour = colours.GreySeafoamLighter,
                                         },
-                                        new Container
+                                        new FillFlowContainer
                                         {
                                             AutoSizeAxes = Axes.Both,
                                             Margin = new MarginPadding { Top = 5 },
+                                            Direction = FillDirection.Horizontal,
                                             Children = new Drawable[]
                                             {
                                                 userFlag = new UpdateableFlag
@@ -133,7 +134,7 @@ namespace osu.Game.Overlays.Profile.Header
                                                 userCountryText = new OsuSpriteText
                                                 {
                                                     Font = OsuFont.GetFont(size: 17.5f, weight: FontWeight.Regular),
-                                                    Margin = new MarginPadding { Left = 40 },
+                                                    Margin = new MarginPadding { Left = 10 },
                                                     Origin = Anchor.CentreLeft,
                                                     Anchor = Anchor.CentreLeft,
                                                     Colour = colours.GreySeafoamLighter,

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -72,18 +72,30 @@ namespace osu.Game.Overlays.Profile.Header
                                 new FillFlowContainer
                                 {
                                     AutoSizeAxes = Axes.Both,
-                                    Direction = FillDirection.Horizontal,
+                                    Direction = FillDirection.Vertical,
                                     Children = new Drawable[]
                                     {
-                                        usernameText = new OsuSpriteText
+                                        new FillFlowContainer
                                         {
-                                            Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Horizontal,
+                                            Children = new Drawable[]
+                                            {
+                                                usernameText = new OsuSpriteText
+                                                {
+                                                    Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
+                                                },
+                                                openUserExternally = new ExternalLinkButton
+                                                {
+                                                    Margin = new MarginPadding { Left = 5 },
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                },
+                                            }
                                         },
-                                        openUserExternally = new ExternalLinkButton
+                                        titleText = new OsuSpriteText
                                         {
-                                            Margin = new MarginPadding { Left = 5 },
-                                            Anchor = Anchor.CentreLeft,
-                                            Origin = Anchor.CentreLeft,
+                                            Font = OsuFont.GetFont(size: 18, weight: FontWeight.Regular)
                                         },
                                     }
                                 },
@@ -95,10 +107,6 @@ namespace osu.Game.Overlays.Profile.Header
                                     AutoSizeAxes = Axes.Both,
                                     Children = new Drawable[]
                                     {
-                                        titleText = new OsuSpriteText
-                                        {
-                                            Font = OsuFont.GetFont(size: 18, weight: FontWeight.Regular)
-                                        },
                                         supporterTag = new SupporterIcon
                                         {
                                             Height = 20,


### PR DESCRIPTION
Before:
![osu_2019-07-02_10-46-07](https://user-images.githubusercontent.com/35318437/60535145-4eb65b00-9cb8-11e9-8a6f-8b2149d40d5e.png)

After:
![osu_2019-07-02_10-42-42](https://user-images.githubusercontent.com/35318437/60535141-4b22d400-9cb8-11e9-9ec2-c512be9c6a14.png)