### PR TITLE
Add support for legacy skins' circle explode animation

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -170,21 +170,38 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     ApproachCircle.FadeOut(50);
 
                     const double flash_in = 40;
+                    const double flash_out = 100;
+
                     flash.FadeTo(0.8f, flash_in)
                          .Then()
-                         .FadeOut(100);
+                         .FadeOut(flash_out);
 
                     explode.FadeIn(flash_in);
 
                     using (BeginDelayedSequence(flash_in, true))
                     {
-                        //after the flash, we can hide some elements that were behind it
-                        ring.FadeOut();
-                        circle.FadeOut();
-                        number.FadeOut();
+                        if (flash.HasImplementation)
+                        {
+                            //after the flash, we can hide some elements that were behind it
+                            ring.FadeOut();
+                            circle.FadeOut();
+                            number.FadeOut();
+                        }
 
-                        this.FadeOut(800);
-                        explodeContainer.ScaleTo(1.5f, 400, Easing.OutQuad);
+                        if (explode.HasImplementation)
+                        {
+                            const double fade_duration = 400;
+
+                            this.FadeOut(fade_duration);
+                            explodeContainer.ScaleTo(1.5f, fade_duration, Easing.OutQuad);
+                        }
+                        else
+                        {
+                            const double legacy_fade_duration = 240;
+
+                            this.FadeOut(legacy_fade_duration, Easing.Out);
+                            explodeContainer.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
+                        }
                     }
 
                     Expire();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 ShakeDuration = 30,
                 RelativeSizeAxes = Axes.Both
             });
+
             Alpha = 0;
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ExplodePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ExplodePiece.cs
@@ -27,5 +27,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 Alpha = 0.2f,
             }, s => s.GetTexture("Play/osu/hitcircle") == null);
         }
+
+        public bool HasImplementation => ((SkinnableDrawable)Child).HasImplementation;
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/FlashPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/FlashPiece.cs
@@ -31,5 +31,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 }
             }, s => s.GetTexture("Play/osu/hitcircle") == null);
         }
+
+        public bool HasImplementation => ((SkinnableDrawable)Child).HasImplementation;
     }
 }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -138,6 +138,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
             State.TriggerChange();
         }
 
+        protected override void SkinChanged(ISkinSource skin, bool allowFallback)
+        {
+            base.SkinChanged(skin, allowFallback);
+            if (IsLoaded)
+                State.TriggerChange();
+        }
+
         protected abstract void UpdateState(ArmedState state);
 
         /// <summary>

--- a/osu.Game/Skinning/SkinnableDrawable.cs
+++ b/osu.Game/Skinning/SkinnableDrawable.cs
@@ -92,5 +92,7 @@ namespace osu.Game.Skinning
             else
                 ClearInternal();
         }
+
+        public bool HasImplementation => Drawable != null;
     }
 }


### PR DESCRIPTION
Turned out to work better as an implementation at `DrawableHitCircle` for now. Just trying to keep things simple rather than over-engineering.

@smoogipoo interested in your thoughts on this. Whether `HasImplementation` makes sense, and how we should standardise it (`IHasSkinAvailability` or a better named interface for intermediary classes that potentially have skinnable children, to pass the messaging on).
