### PR TITLE
Change Taiko pp to be more consistent with stable

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 StarRating = skills.Single().DifficultyValue() * star_scaling_factor,
                 Mods = mods,
                 // Todo: This int cast is temporary to achieve 1:1 results with osu!stable, and should be removed in the future
-                GreatHitWindow = (int)(beatmap.HitObjects.First().HitWindows.Great / 2) / clockRate,
+                GreatHitWindow = ((int)(beatmap.HitObjects.First().HitWindows.Great / 2) - 0.5) / clockRate,
                 MaxCombo = beatmap.HitObjects.Count(h => h is Hit),
                 Skills = skills
             };

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -77,10 +77,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
             strainValue *= Math.Pow(0.985, countMiss);
 
-            // Combo scaling
-            if (Attributes.MaxCombo > 0)
-                strainValue *= Math.Min(Math.Pow(Score.MaxCombo, 0.5) / Math.Pow(Attributes.MaxCombo, 0.5), 1.0);
-
             if (mods.Any(m => m is ModHidden))
                 strainValue *= 1.025;
 


### PR DESCRIPTION
Fixes #4275

Currently, if you run `osu-tools` to calculate pp on a taiko score (especially one that's not an FC), the result would be wildly different than what we observe live.

This is due to these 2 factors addressed in this PR:
- `ppy/osu` has combo scaling. This is inconsistent with live pp, which doesn't care about your combo at all
- OD calculation off by 0.5ms (which made all scores a few pp too low). `ppy/osu` is using 50ms window for a 300 on OD0, but stable (for whatever reason) uses 49.5ms

However, some scores are still off by a couple pp. I think it might involve the star rating being slightly different on certain maps. ([example](https://osu.ppy.sh/beatmapsets/409025#taiko/888020) which is 4.20* on stable/web but 4.26* on lazer). This PR doesn't touch the star rating/strain at all.

Here's the output of `osu-tools` running `profile Cychloryn -r 1`:
On `master` (off by 185.7pp): https://pastebin.com/JWy3ZBHP
Proposed (off by 1.3pp): https://pastebin.com/haQ4bXdS