### PR TITLE
Fix rulesets not matching in dictionary lookups due to missing GetHashCode implementation

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -248,7 +248,7 @@ namespace osu.Game
                 }
 
                 // Use first beatmap available for current ruleset, else switch ruleset.
-                var first = databasedSet.Beatmaps.Find(b => b.Ruleset == Ruleset.Value) ?? databasedSet.Beatmaps.First();
+                var first = databasedSet.Beatmaps.Find(b => b.Ruleset.Equals(Ruleset.Value)) ?? databasedSet.Beatmaps.First();
 
                 Ruleset.Value = first.Ruleset;
                 Beatmap.Value = BeatmapManager.GetWorkingBeatmap(first);

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Overlays.Toolbar
         {
             foreach (var tabItem in TabContainer)
             {
-                if (tabItem.Value == Current.Value)
+                if (tabItem.Value.Equals(Current.Value))
                 {
                     ModeButtonLine.MoveToX(tabItem.DrawPosition.X, !hasInitialPosition ? 0 : 200, Easing.OutQuint);
                     break;

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Rulesets
 
         public bool Equals(RulesetInfo other) => other != null && ID == other.ID && Available == other.Available && Name == other.Name && InstantiationInfo == other.InstantiationInfo;
 
+        public override bool Equals(object obj) => obj is RulesetInfo rulesetInfo && Equals(rulesetInfo);
+
         [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
         public override int GetHashCode()
         {

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace osu.Game.Rulesets
@@ -22,6 +23,19 @@ namespace osu.Game.Rulesets
         public virtual Ruleset CreateInstance() => (Ruleset)Activator.CreateInstance(Type.GetType(InstantiationInfo), this);
 
         public bool Equals(RulesetInfo other) => other != null && ID == other.ID && Available == other.Available && Name == other.Name && InstantiationInfo == other.InstantiationInfo;
+
+        [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = ID.HasValue ? ID.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ (InstantiationInfo != null ? InstantiationInfo.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Available.GetHashCode();
+                return hashCode;
+            }
+        }
 
         public override string ToString() => $"{Name} ({ShortName}) ID: {ID}";
     }

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets
         public RulesetStore(IDatabaseContextFactory factory)
             : base(factory)
         {
-            AddMissingRulesets();
+            addMissingRulesets();
         }
 
         /// <summary>
@@ -52,13 +52,13 @@ namespace osu.Game.Rulesets
         /// <summary>
         /// All available rulesets.
         /// </summary>
-        public IEnumerable<RulesetInfo> AvailableRulesets;
+        public IEnumerable<RulesetInfo> AvailableRulesets { get; private set; }
 
         private static Assembly currentDomain_AssemblyResolve(object sender, ResolveEventArgs args) => loaded_assemblies.Keys.FirstOrDefault(a => a.FullName == args.Name);
 
         private const string ruleset_library_prefix = "osu.Game.Rulesets";
 
-        protected void AddMissingRulesets()
+        private void addMissingRulesets()
         {
             using (var usage = ContextFactory.GetForWrite())
             {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -329,7 +329,7 @@ namespace osu.Game.Screens.Select
 
             if (this.IsCurrentScreen() && !Carousel.SelectBeatmap(e.NewValue?.BeatmapInfo, false))
                 // If selecting new beatmap without bypassing filters failed, there's possibly a ruleset mismatch
-                if (e.NewValue?.BeatmapInfo?.Ruleset != null && e.NewValue.BeatmapInfo.Ruleset != decoupledRuleset.Value)
+                if (e.NewValue?.BeatmapInfo?.Ruleset != null && !e.NewValue.BeatmapInfo.Ruleset.Equals(decoupledRuleset.Value))
                 {
                     Ruleset.Value = e.NewValue.BeatmapInfo.Ruleset;
                     Carousel.SelectBeatmap(e.NewValue.BeatmapInfo);


### PR DESCRIPTION
Hard crashes caused by ruleset selector if a ruleset change is requested by any other component which set the ruleset from a database-retrieved beatmap (`BeatmapManager.QueryBeatmap`'s return).

Example: Click the button to load an already downloaded beatmap from a user profile

```
System.Collections.Generic.KeyNotFoundException: The given key 'osu! (osu) ID: 0' was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at osu.Framework.Graphics.UserInterface.TabControl`1.<.ctor>b__24_2(ValueChangedEvent`1 newSelection) in C:\projects\osu-framework-a4n7e\osu.Framework\Graphics\UserInterface\TabControl.cs:line 130
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in C:\projects\osu-framework-a4n7e\osu.Framework\Bindables\Bindable.cs:line 254
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in C:\projects\osu-framework-a4n7e\osu.Framework\Bindables\Bindable.cs:line 244
   at osu.Framework.Bindables.Bindable`1.set_Value(T value) in C:\projects\osu-framework-a4n7e\osu.Framework\Bindables\Bindable.cs:line 93
   at osu.Game.OsuGame.<>c__DisplayClass41_0.<PresentBeatmap>b__2() in /Users/dean/Projects/osu/osu.Game/OsuGame.cs:line 253
   at osu.Game.OsuGame.performFromMainMenu(Action action, String taskName, Type targetScreen, Boolean bypassScreenAllowChecks) in /Users/dean/Projects/osu/osu.Game/OsuGame.cs:line 347
   at osu.Game.OsuGame.PresentBeatmap(BeatmapSetInfo beatmap) in /Users/dean/Projects/osu/osu.Game/OsuGame.cs:line 238
```