### PR TITLE
Improve performance when entering gameplay by delaying hitobject updates

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 ShakeDuration = 30,
                 RelativeSizeAxes = Axes.Both
             });
+
             Alpha = 0;
         }
 
@@ -37,6 +38,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void AddInternal(Drawable drawable) => shakeContainer.Add(drawable);
         protected override void ClearInternal(bool disposeChildren = true) => shakeContainer.Clear(disposeChildren);
         protected override bool RemoveInternal(Drawable drawable) => shakeContainer.Remove(drawable);
+
+        protected sealed override double InitialLifetimeOffset => HitObject.TimePreempt;
 
         protected sealed override void UpdateState(ArmedState state)
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -179,6 +179,38 @@ namespace osu.Game.Rulesets.Objects.Drawables
             UpdateResult(false);
         }
 
+        private double? lifetimeStart;
+
+        public override double LifetimeStart
+        {
+            get => lifetimeStart ?? (HitObject.StartTime - InitialLifetimeOffset);
+            set
+            {
+                base.LifetimeStart = value;
+                lifetimeStart = value;
+            }
+        }
+
+        /// <summary>
+        /// A safe offset prior to the start time of <see cref="HitObject"/> at which this <see cref="DrawableHitObject"/> may begin displaying contents.
+        /// By default, <see cref="DrawableHitObject"/>s are assumed to display their contents within 10 seconds prior to the start time of <see cref="HitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is only used as an optimisation to delay the initial update of this <see cref="DrawableHitObject"/> and may be tuned more aggressively if required.
+        /// A more accurate <see cref="LifetimeStart"/> should be set inside <see cref="UpdateState"/> for an <see cref="ArmedState.Idle"/> state.
+        /// </remarks>
+        protected virtual double InitialLifetimeOffset => 10000;
+
+        /// <summary>
+        /// Will called at least once after the <see cref="Drawable.LifetimeEnd"/> of this <see cref="DrawableHitObject"/> has been passed.
+        /// </summary>
+        internal void OnLifetimeEnd()
+        {
+            foreach (var nested in NestedHitObjects)
+                nested.OnLifetimeEnd();
+            UpdateResult(false);
+        }
+
         protected virtual void AddNested(DrawableHitObject h)
         {
             h.OnNewResult += (d, r) => OnNewResult?.Invoke(d, r);
@@ -221,16 +253,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             OnNewResult?.Invoke(this, Result);
-        }
-
-        /// <summary>
-        /// Will called at least once after the <see cref="Drawable.LifetimeEnd"/> of this <see cref="DrawableHitObject"/> has been passed.
-        /// </summary>
-        internal void OnLifetimeEnd()
-        {
-            foreach (var nested in NestedHitObjects)
-                nested.OnLifetimeEnd();
-            UpdateResult(false);
         }
 
         /// <summary>


### PR DESCRIPTION
In combination with https://github.com/ppy/osu-framework/pull/2650, I now get only a single short stutter on https://osu.ppy.sh/beatmapsets/121591#osu/311269