### PR TITLE
Fix potential crash when displaying leaderbaords

### DIFF
--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -51,7 +51,6 @@ namespace osu.Game.Online.Leaderboards
 
                 loading.Hide();
 
-                // schedule because we may not be loaded yet (LoadComponentAsync complains).
                 showScoresDelegate?.Cancel();
                 showScoresCancellationSource?.Cancel();
 
@@ -61,28 +60,22 @@ namespace osu.Game.Online.Leaderboards
                 // ensure placeholder is hidden when displaying scores
                 PlaceholderState = PlaceholderState.Successful;
 
-                scrollFlow = CreateScoreFlow();
-                scrollFlow.ChildrenEnumerable = scores.Select((s, index) => CreateDrawableScore(s, index + 1));
+                var sf = CreateScoreFlow();
+                sf.ChildrenEnumerable = scores.Select((s, index) => CreateDrawableScore(s, index + 1));
 
-                if (!IsLoaded)
-                    showScoresDelegate = Schedule(showScores);
-                else
-                    showScores();
-
-                void showScores() => LoadComponentAsync(scrollFlow, _ =>
+                // schedule because we may not be loaded yet (LoadComponentAsync complains).
+                showScoresDelegate = Schedule(() => LoadComponentAsync(sf, _ =>
                 {
-                    scrollContainer.Add(scrollFlow);
+                    scrollContainer.Add(scrollFlow = sf);
 
                     int i = 0;
 
                     foreach (var s in scrollFlow.Children)
-                    {
                         using (s.BeginDelayedSequence(i++ * 50, true))
                             s.Show();
-                    }
 
                     scrollContainer.ScrollTo(0f, false);
-                }, (showScoresCancellationSource = new CancellationTokenSource()).Token);
+                }, (showScoresCancellationSource = new CancellationTokenSource()).Token));
             }
         }
 


### PR DESCRIPTION
```
Unhandled Exception: [runtime:error] 2019-07-17 08:23:52: An unhandled error has occurred.
[runtime:error] 2019-07-17 08:23:52: System.InvalidOperationException: May not query Value of an invalid Cached.
[runtime:error] 2019-07-17 08:23:52: at osu.Framework.Caching.Cached`1.get_Value() in C:\projects\osu-framework-a4n7e\osu.Framework\Caching\Cached.cs:line 23
[runtime:error] 2019-07-17 08:23:52: at osu.Framework.Graphics.Drawable.get_DrawInfo() in C:\projects\osu-framework-a4n7e\osu.Framework\Graphics\Drawable.cs:line 1543
[runtime:error] 2019-07-17 08:23:52: at osu.Framework.Graphics.Drawable.ToSpaceOfOtherDrawable(Vector2 input, IDrawable other) in C:\projects\osu-framework-a4n7e\osu.Framework\Graphics\Drawable.cs:line 1770
[runtime:error] 2019-07-17 08:23:52: at osu.Game.Online.Leaderboards.Leaderboard`2.UpdateAfterChildren() in /Users/dean/Projects/osu/osu.Game/Online/Leaderboards/Leaderboard.cs:line 299
```

Important part is the moving of the private field assignment to inside the `LoadComponentAsync` callback.