### PR TITLE
Fix judgement disposals causing huge LOH pressure

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.UI;
 using System.Linq;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.UI.Cursor;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -39,7 +40,13 @@ namespace osu.Game.Rulesets.Osu.UI
                     RelativeSizeAxes = Axes.Both,
                     Depth = 1,
                 },
-                HitObjectContainer,
+                // Todo: This should not exist, but currently helps to reduce LOH allocations due to unbinding skin source events on judgement disposal
+                // Todo: Remove when hitobjects are properly pooled
+                new LocalSkinOverrideContainer(null)
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = HitObjectContainer,
+                },
                 approachCircles = new ApproachCircleProxyContainer
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Skinning/LocalSkinOverrideContainer.cs
+++ b/osu.Game/Skinning/LocalSkinOverrideContainer.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Skinning
         public Drawable GetDrawableComponent(string componentName)
         {
             Drawable sourceDrawable;
-            if (beatmapSkins.Value && (sourceDrawable = skin.GetDrawableComponent(componentName)) != null)
+            if (beatmapSkins.Value && (sourceDrawable = skin?.GetDrawableComponent(componentName)) != null)
                 return sourceDrawable;
 
             return fallbackSource?.GetDrawableComponent(componentName);
@@ -43,7 +43,7 @@ namespace osu.Game.Skinning
         public Texture GetTexture(string componentName)
         {
             Texture sourceTexture;
-            if (beatmapSkins.Value && (sourceTexture = skin.GetTexture(componentName)) != null)
+            if (beatmapSkins.Value && (sourceTexture = skin?.GetTexture(componentName)) != null)
                 return sourceTexture;
 
             return fallbackSource.GetTexture(componentName);
@@ -52,7 +52,7 @@ namespace osu.Game.Skinning
         public SampleChannel GetSample(string sampleName)
         {
             SampleChannel sourceChannel;
-            if (beatmapHitsounds.Value && (sourceChannel = skin.GetSample(sampleName)) != null)
+            if (beatmapHitsounds.Value && (sourceChannel = skin?.GetSample(sampleName)) != null)
                 return sourceChannel;
 
             return fallbackSource?.GetSample(sampleName);


### PR DESCRIPTION
As we discovered previously, unbinding from events has huge performance implications. One of which is a [complete re-allocation of the delegate list](https://source.dot.net/#System.Private.CoreLib/src/System/MulticastDelegate.cs,c2a5d5528659658f).

This only happens in gameplay due to hitobjects, which are always present within the hitobject container.