### PR TITLE
Set "Title" as the default grouping/sorting modes in song select

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -120,7 +120,8 @@ namespace osu.Game.Screens.Select
                                     RelativeSizeAxes = Axes.X,
                                     Height = 24,
                                     Width = 0.5f,
-                                    AutoSort = true
+                                    AutoSort = true,
+                                    Current = { Value = GroupMode.Title }
                                 },
                                 //spriteText = new OsuSpriteText
                                 //{
@@ -139,6 +140,7 @@ namespace osu.Game.Screens.Select
                                     Width = 0.5f,
                                     Height = 24,
                                     AutoSort = true,
+                                    Current = { Value = SortMode.Title }
                                 }
                             }
                         },


### PR DESCRIPTION
I guess this was a regression but it was kinda intentional, since tabcontrol now selects the first visible tab rather than relying on some arbitrary sorting order of the internal fill flow.