### PR TITLE
Reduce Triangle drawnode overhead by ~90%

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -63,6 +63,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.702.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.717.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.719.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -192,12 +192,11 @@ namespace osu.Game.Graphics.Backgrounds
             private readonly List<TriangleParticle> parts = new List<TriangleParticle>();
             private Vector2 size;
 
-            private readonly LinearBatch<TexturedVertex2D> vertexBatch;
+            private LinearBatch<TexturedVertex2D> vertexBatch;
 
             public TrianglesDrawNode(Triangles source)
                 : base(source)
             {
-                vertexBatch = new LinearBatch<TexturedVertex2D>(source.AimCount * 3, 2, PrimitiveType.Triangles);
             }
 
             public override void ApplyState()
@@ -214,6 +213,9 @@ namespace osu.Game.Graphics.Backgrounds
 
             public override void Draw(Action<TexturedVertex2D> vertexAction)
             {
+                if (vertexBatch == null && Source.AimCount > 0)
+                    vertexBatch = new LinearBatch<TexturedVertex2D>(Source.AimCount * 3, 2, PrimitiveType.Triangles);
+
                 base.Draw(vertexAction);
 
                 shader.Bind();

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -8,7 +8,6 @@ using osuTK.Graphics;
 using System;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
-using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Allocation;
@@ -192,7 +191,7 @@ namespace osu.Game.Graphics.Backgrounds
             private readonly List<TriangleParticle> parts = new List<TriangleParticle>();
             private Vector2 size;
 
-            private LinearBatch<TexturedVertex2D> vertexBatch;
+            private TriangleBatch<TexturedVertex2D> vertexBatch;
 
             public TrianglesDrawNode(Triangles source)
                 : base(source)
@@ -215,10 +214,10 @@ namespace osu.Game.Graphics.Backgrounds
             {
                 base.Draw(vertexAction);
 
-                if (vertexBatch == null || vertexBatch.Size != Source.AimCount * 6)
+                if (vertexBatch == null || vertexBatch.Size != Source.AimCount)
                 {
                     vertexBatch?.Dispose();
-                    vertexBatch = new LinearBatch<TexturedVertex2D>(Source.AimCount * 6, 1, PrimitiveType.Triangles);
+                    vertexBatch = new TriangleBatch<TexturedVertex2D>(Source.AimCount, 1);
                 }
 
                 shader.Bind();

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -137,11 +137,13 @@ namespace osu.Game.Graphics.Backgrounds
             }
         }
 
+        protected int AimCount;
+
         private void addTriangles(bool randomY)
         {
-            int aimTriangleCount = (int)(DrawWidth * DrawHeight * 0.002f / (triangleScale * triangleScale) * SpawnRatio);
+            AimCount = (int)(DrawWidth * DrawHeight * 0.002f / (triangleScale * triangleScale) * SpawnRatio);
 
-            for (int i = 0; i < aimTriangleCount - parts.Count; i++)
+            for (int i = 0; i < AimCount - parts.Count; i++)
                 parts.Add(createTriangle(randomY));
         }
 
@@ -190,11 +192,12 @@ namespace osu.Game.Graphics.Backgrounds
             private readonly List<TriangleParticle> parts = new List<TriangleParticle>();
             private Vector2 size;
 
-            private readonly LinearBatch<TexturedVertex2D> vertexBatch = new LinearBatch<TexturedVertex2D>(100 * 3, 10, PrimitiveType.Triangles);
+            private readonly LinearBatch<TexturedVertex2D> vertexBatch;
 
             public TrianglesDrawNode(Triangles source)
                 : base(source)
             {
+                vertexBatch = new LinearBatch<TexturedVertex2D>(source.AimCount * 3, 2, PrimitiveType.Triangles);
             }
 
             public override void ApplyState()

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -249,7 +249,7 @@ namespace osu.Game.Graphics.Backgrounds
             {
                 base.Dispose(isDisposing);
 
-                vertexBatch.Dispose();
+                vertexBatch?.Dispose();
             }
         }
 

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -213,10 +213,13 @@ namespace osu.Game.Graphics.Backgrounds
 
             public override void Draw(Action<TexturedVertex2D> vertexAction)
             {
-                if (vertexBatch == null && Source.AimCount > 0)
-                    vertexBatch = new LinearBatch<TexturedVertex2D>(Source.AimCount * 3, 2, PrimitiveType.Triangles);
-
                 base.Draw(vertexAction);
+
+                if (vertexBatch == null || vertexBatch.Size != Source.AimCount * 6)
+                {
+                    vertexBatch?.Dispose();
+                    vertexBatch = new LinearBatch<TexturedVertex2D>(Source.AimCount * 6, 1, PrimitiveType.Triangles);
+                }
 
                 shader.Bind();
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.702.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.717.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.719.0" />
     <PackageReference Include="SharpCompress" Version="0.23.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -105,8 +105,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.702.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.717.1" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.717.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.719.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.719.0" />
     <PackageReference Include="SharpCompress" Version="0.22.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
This was never batching, ever. Pointless memory overhead.

Before:

![image](https://user-images.githubusercontent.com/191335/61472616-c62a0100-a9bf-11e9-90bc-4446d3f96fe8.png)

After:

![image](https://user-images.githubusercontent.com/191335/61472584-b4485e00-a9bf-11e9-9a94-d4464fbb1b9c.png)

Note that workloads above are not 1:1 equal so only relative % is relevant (the fact that `TriangleDrawNode` is no longer in the top list, or anywhere close to it). Also, memory savings are double (unmanaged reduced by equal amount).