### PR TITLE
Fix TriangleDrawNode crash when required triangles is zero

### DIFF
--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -214,7 +214,7 @@ namespace osu.Game.Graphics.Backgrounds
             {
                 base.Draw(vertexAction);
 
-                if (vertexBatch == null || vertexBatch.Size != Source.AimCount && Source.AimCount > 0)
+                if (Source.AimCount > 0 && (vertexBatch == null || vertexBatch.Size != Source.AimCount))
                 {
                     vertexBatch?.Dispose();
                     vertexBatch = new TriangleBatch<TexturedVertex2D>(Source.AimCount, 1);

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -214,7 +214,7 @@ namespace osu.Game.Graphics.Backgrounds
             {
                 base.Draw(vertexAction);
 
-                if (vertexBatch == null || vertexBatch.Size != Source.AimCount)
+                if (vertexBatch == null || vertexBatch.Size != Source.AimCount && Source.AimCount > 0)
                 {
                     vertexBatch?.Dispose();
                     vertexBatch = new TriangleBatch<TexturedVertex2D>(Source.AimCount, 1);


### PR DESCRIPTION
Had this fix previously but forgot to push it before the PR got merged.