### PR TITLE
Fix flashlight potentially not correctly blocking vision

### DIFF
--- a/osu.Game/Graphics/OpenGL/Vertices/PositionAndColourVertex.cs
+++ b/osu.Game/Graphics/OpenGL/Vertices/PositionAndColourVertex.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.OpenGL.Vertices;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Graphics.ES30;
+
+namespace osu.Game.Graphics.OpenGL.Vertices
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct PositionAndColourVertex : IEquatable<PositionAndColourVertex>, IVertex
+    {
+        [VertexMember(2, VertexAttribPointerType.Float)]
+        public Vector2 Position;
+
+        [VertexMember(4, VertexAttribPointerType.Float)]
+        public Color4 Colour;
+
+        public bool Equals(PositionAndColourVertex other)
+            => Position.Equals(other.Position)
+               && Colour.Equals(other.Colour);
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
@@ -13,6 +14,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Graphics;
+using osu.Game.Graphics.OpenGL.Vertices;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
@@ -153,9 +155,17 @@ namespace osu.Game.Rulesets.Mods
                 private Vector2 flashlightSize;
                 private float flashlightDim;
 
+                private readonly VertexBatch<PositionAndColourVertex> quadBatch = new QuadBatch<PositionAndColourVertex>(1, 1);
+                private readonly Action<TexturedVertex2D> addAction;
+
                 public FlashlightDrawNode(Flashlight source)
                     : base(source)
                 {
+                    addAction = v => quadBatch.Add(new PositionAndColourVertex
+                    {
+                        Position = v.Position,
+                        Colour = v.Colour
+                    });
                 }
 
                 public override void ApplyState()
@@ -179,7 +189,7 @@ namespace osu.Game.Rulesets.Mods
                     shader.GetUniform<Vector2>("flashlightSize").UpdateValue(ref flashlightSize);
                     shader.GetUniform<float>("flashlightDim").UpdateValue(ref flashlightDim);
 
-                    DrawQuad(Texture.WhitePixel, screenSpaceDrawQuad, DrawColourInfo.Colour, vertexAction: vertexAction);
+                    DrawQuad(Texture.WhitePixel, screenSpaceDrawQuad, DrawColourInfo.Colour, vertexAction: addAction);
 
                     shader.Unbind();
                 }


### PR DESCRIPTION
Resolves #5234

Size of struct (`TexturedVertex2D`) was larger than the size of the attributes in the shader (position + colour only).

This resulted in the `TexturePosition` value from `TexturedVertex2D` to get written to the shader's depth attribute... Will look into ways of mitigating this framework-side, but osu! should be using a custom vertex here in any case.