### PR TITLE
Remove text shadow in chat

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -85,6 +85,7 @@ namespace osu.Game.Overlays.Chat
 
             Drawable effectedUsername = username = new OsuSpriteText
             {
+                Shadow = false,
                 Colour = hasBackground ? customUsernameColour : username_colours[message.Sender.Id % username_colours.Length],
                 Font = OsuFont.GetFont(size: TextSize, weight: FontWeight.Bold, italics: true)
             };
@@ -133,6 +134,7 @@ namespace osu.Game.Overlays.Chat
                     {
                         timestamp = new OsuSpriteText
                         {
+                            Shadow = false,
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                             Font = OsuFont.GetFont(size: TextSize * 0.75f, weight: FontWeight.SemiBold, fixedWidth: true)
@@ -155,6 +157,8 @@ namespace osu.Game.Overlays.Chat
                     {
                         contentFlow = new LinkFlowContainer(t =>
                         {
+                            t.Shadow = false;
+
                             if (Message.IsAction)
                             {
                                 t.Font = OsuFont.GetFont(italics: true);


### PR DESCRIPTION
Was hardly visible anyway. ~30% performance gain with fullscreen chat (under best-case circumstances).