### PR TITLE
Fix SkinChanged events triggering after disposal

### DIFF
--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -38,7 +38,8 @@ namespace osu.Game.Skinning
 
         private void onChange() =>
             // schedule required to avoid calls after disposed.
-            Schedule(() => SkinChanged(skin, allowDefaultFallback));
+            // note that this has the side-effect of components only performance a skin change when they are alive.
+            Scheduler.AddOnce(() => SkinChanged(skin, allowDefaultFallback));
 
         protected override void LoadAsyncComplete()
         {

--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -36,12 +36,14 @@ namespace osu.Game.Skinning
             skin.SourceChanged += onChange;
         }
 
-        private void onChange() => SkinChanged(skin, allowDefaultFallback);
+        private void onChange() =>
+            // schedule required to avoid calls after disposed.
+            Schedule(() => SkinChanged(skin, allowDefaultFallback));
 
         protected override void LoadAsyncComplete()
         {
             base.LoadAsyncComplete();
-            onChange();
+            SkinChanged(skin, allowDefaultFallback);
         }
 
         /// <summary>

--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Skinning
 
         private void onChange() =>
             // schedule required to avoid calls after disposed.
-            // note that this has the side-effect of components only performance a skin change when they are alive.
+            // note that this has the side-effect of components only performing a skin change when they are alive.
             Scheduler.AddOnce(() => SkinChanged(skin, allowDefaultFallback));
 
         protected override void LoadAsyncComplete()


### PR DESCRIPTION
As we are using events here (not bindables), there is a chance that the event could be triggered before it is unbound, causing consumers of the event to try operations like `LoadComponentAsync` (which will rightfully exception).

This has the side-effects of making skin changes near-instant, spreading the SkinChanged events over the whole play time (they would be executed only when a `DrawableHitObject` becomes alive). Not a bad thing.

We may change the `SkinChanged` to a bindable in the future, but that is not done here as in previous testing the bindable overhead incurred is non-negligible to consider until we pool `DrawableHitObjects`.