### PR TITLE
Cache DrawableHitObject for skinnables to access

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -17,6 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Objects.Drawables
 {
+    [Cached(typeof(DrawableHitObject))]
     public abstract class DrawableHitObject : SkinReloadableDrawable
     {
         public readonly HitObject HitObject;


### PR DESCRIPTION
Allows backwards lookups on DrawableHitObejcts by their skinnable components, keeping with our goal of no-skinning-knowledge in the base ruleset implementation.