### PR TITLE
Resize BeatmapCarousel and confine its PositionalInput

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -53,6 +53,8 @@ namespace osu.Game.Screens.Select
         public override bool HandleNonPositionalInput => AllowSelection;
         public override bool HandlePositionalInput => AllowSelection;
 
+        protected override bool ConfinePositionalInput => true;
+
         /// <summary>
         /// Whether carousel items have completed asynchronously loaded.
         /// </summary>

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -434,7 +434,7 @@ namespace osu.Game.Screens.Select
             return true;
         }
 
-        protected override bool ReceiveSubTreePositionalInputAt(Vector2 screenSpacePos) => ReceivePositionalInputAt(screenSpacePos);
+        protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => ReceivePositionalInputAt(screenSpacePos);
 
         protected override void Update()
         {

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -342,13 +342,13 @@ namespace osu.Game.Screens.Select
         public bool AllowSelection = true;
 
         /// <summary>
-        /// The total height of the displayable portion of the Beatmap Carousel.
+        /// Half the height of the visible content.
         /// <remarks>
-        /// This is different from <see cref="ScrollContainer{T}.displayableContent"/>, since
+        /// This is different from the height of <see cref="ScrollContainer{T}.displayableContent"/>, since
         /// the beatmap carousel bleeds into the <see cref="FilterControl"/> and the <see cref="Footer"/>
         /// </remarks>
         /// </summary>
-        private float visibleHeight => DrawHeight + bleed_bottom + bleed_top;
+        private float visibleHalfHeight => (DrawHeight + bleed_bottom + bleed_top) / 2;
 
         /// <summary>
         /// The position of the lower visible bound with respect to the current scroll position.
@@ -508,9 +508,8 @@ namespace osu.Game.Screens.Select
 
             // Update externally controlled state of currently visible items
             // (e.g. x-offset and opacity).
-            float halfHeight = visibleHeight / 2;
             foreach (DrawableCarouselItem p in scrollableContent.Children)
-                updateItem(p, halfHeight);
+                updateItem(p);
         }
 
         protected override void Dispose(bool isDisposing)
@@ -564,7 +563,7 @@ namespace osu.Game.Screens.Select
 
             yPositions.Clear();
 
-            float currentY = visibleHeight / 2;
+            float currentY = visibleHalfHeight;
             DrawableCarouselBeatmapSet lastSet = null;
 
             scrollTarget = null;
@@ -617,7 +616,7 @@ namespace osu.Game.Screens.Select
                     currentY += d.DrawHeight + 5;
             }
 
-            currentY += visibleHeight / 2;
+            currentY += visibleHalfHeight;
             scrollableContent.Height = currentY;
 
             if (BeatmapSetsLoaded && (selectedBeatmapSet == null || selectedBeatmap == null || selectedBeatmapSet.State.Value != CarouselItemState.Selected))
@@ -658,16 +657,15 @@ namespace osu.Game.Screens.Select
         /// the current scroll position.
         /// </summary>
         /// <param name="p">The item to be updated.</param>
-        /// <param name="halfHeight">Half the draw height of the carousel container's parent.</param>
-        private void updateItem(DrawableCarouselItem p, float halfHeight)
+        private void updateItem(DrawableCarouselItem p)
         {
             float itemDrawY = p.Position.Y - visibleUpperBound + p.DrawHeight / 2;
-            float dist = Math.Abs(1f - itemDrawY / halfHeight);
+            float dist = Math.Abs(1f - itemDrawY / visibleHalfHeight);
 
             // Setting the origin position serves as an additive position on top of potential
             // local transformation we may want to apply (e.g. when a item gets selected, we
             // may want to smoothly transform it leftwards.)
-            p.OriginPosition = new Vector2(-offsetX(dist, halfHeight), 0);
+            p.OriginPosition = new Vector2(-offsetX(dist, visibleHalfHeight), 0);
 
             // We are applying a multiplicative alpha (which is internally done by nesting an
             // additional container and setting that container's alpha) such that we can

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -108,10 +108,12 @@ namespace osu.Game.Screens.Select
             root = new CarouselRoot(this);
             Child = new OsuContextMenuContainer
             {
+                Masking = false,
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Child = scrollableContent = new Container<DrawableCarouselItem>
                 {
+                    Masking = false,
                     RelativeSizeAxes = Axes.X,
                 }
             };
@@ -424,7 +426,9 @@ namespace osu.Game.Screens.Select
             if (!scrollPositionCache.IsValid)
                 updateScrollPosition();
 
-            float drawHeight = DrawHeight;
+            // The draw positions of individual sets extend beyond the size of the carousel and into its parent
+            // As a result, this should use the Parent's draw height instead.
+            float drawHeight = Parent.DrawHeight;
 
             // Remove all items that should no longer be on-screen
             scrollableContent.RemoveAll(p => p.Y < Current - p.DrawHeight || p.Y > Current + drawHeight || !p.IsPresent);
@@ -432,9 +436,9 @@ namespace osu.Game.Screens.Select
             // Find index range of all items that should be on-screen
             Trace.Assert(Items.Count == yPositions.Count);
 
-            int firstIndex = yPositions.BinarySearch(Current - DrawableCarouselItem.MAX_HEIGHT);
+            int firstIndex = yPositions.BinarySearch(Current - DrawableCarouselItem.MAX_HEIGHT - Parent.Padding.Top);
             if (firstIndex < 0) firstIndex = ~firstIndex;
-            int lastIndex = yPositions.BinarySearch(Current + drawHeight);
+            int lastIndex = yPositions.BinarySearch(Current + drawHeight + Parent.Padding.Bottom);
             if (lastIndex < 0) lastIndex = ~lastIndex;
 
             int notVisibleCount = 0;
@@ -637,18 +641,19 @@ namespace osu.Game.Screens.Select
         /// the current scroll position.
         /// </summary>
         /// <param name="p">The item to be updated.</param>
-        /// <param name="halfHeight">Half the draw height of the carousel container.</param>
-        private void updateItem(DrawableCarouselItem p, float halfHeight)
+        /// <param name="parentHalfHeight">Half the draw height of the carousel container's parent.</param>
+        private void updateItem(DrawableCarouselItem p, float parentHalfHeight)
         {
             var height = p.IsPresent ? p.DrawHeight : 0;
 
-            float itemDrawY = p.Position.Y - Current + height / 2;
-            float dist = Math.Abs(1f - itemDrawY / halfHeight);
+            // The actual Y position of the item needs to be offset by any potential padding set by the container's parent.
+            float itemDrawY = p.Position.Y - Current + Parent.Padding.Top + height / 2;
+            float dist = Math.Abs(1f - itemDrawY / parentHalfHeight);
 
             // Setting the origin position serves as an additive position on top of potential
             // local transformation we may want to apply (e.g. when a item gets selected, we
             // may want to smoothly transform it leftwards.)
-            p.OriginPosition = new Vector2(-offsetX(dist, halfHeight), 0);
+            p.OriginPosition = new Vector2(-offsetX(dist, parentHalfHeight), 0);
 
             // We are applying a multiplicative alpha (which is internally done by nesting an
             // additional container and setting that container's alpha) such that we can

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -187,11 +187,5 @@ namespace osu.Game.Screens.Select
         }
 
         private void updateCriteria() => FilterChanged?.Invoke(CreateCriteria());
-
-        protected override bool OnMouseDown(MouseDownEvent e) => true;
-
-        protected override bool OnMouseMove(MouseMoveEvent e) => true;
-
-        protected override bool OnClick(ClickEvent e) => true;
     }
 }

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Screens.Select
 {
     public class FilterControl : Container
     {
+        public const float HEIGHT = 100;
+
         public Action<FilterCriteria> FilterChanged;
 
         private readonly OsuTabControl<SortMode> sortTabs;

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -14,7 +14,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Select.Filter;
 using Container = osu.Framework.Graphics.Containers.Container;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Input.Events;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
 

--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -62,6 +62,10 @@ namespace osu.Game.Screens.Select
 
         public Footer()
         {
+            RelativeSizeAxes = Axes.X;
+            Height = HEIGHT;
+            Anchor = Anchor.BottomCentre;
+            Origin = Anchor.BottomCentre;
             Children = new Drawable[]
             {
                 new Box

--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -62,10 +62,6 @@ namespace osu.Game.Screens.Select
 
         public Footer()
         {
-            RelativeSizeAxes = Axes.X;
-            Height = HEIGHT;
-            Anchor = Anchor.BottomCentre;
-            Origin = Anchor.BottomCentre;
             Children = new Drawable[]
             {
                 new Box

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Screens.Select
     public abstract class SongSelect : OsuScreen, IKeyBindingHandler<GlobalAction>
     {
         private static readonly Vector2 wedged_container_size = new Vector2(0.5f, 245);
-        
+
         protected const float BACKGROUND_BLUR = 20;
         private const float left_area_padding = 20;
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -42,9 +42,7 @@ namespace osu.Game.Screens.Select
     public abstract class SongSelect : OsuScreen, IKeyBindingHandler<GlobalAction>
     {
         private static readonly Vector2 wedged_container_size = new Vector2(0.5f, 245);
-
-        public const float FILTER_CONTROL_HEIGHT = 100;
-        public const float FOOTER_HEIGHT = 50;
+        
         protected const float BACKGROUND_BLUR = 20;
         private const float left_area_padding = 20;
 
@@ -123,7 +121,7 @@ namespace osu.Game.Screens.Select
                     Size = new Vector2(wedged_container_size.X, 1),
                     Padding = new MarginPadding
                     {
-                        Bottom = FOOTER_HEIGHT,
+                        Bottom = Footer.HEIGHT,
                         Top = wedged_container_size.Y + left_area_padding,
                         Left = left_area_padding,
                         Right = left_area_padding * 2,
@@ -154,8 +152,8 @@ namespace osu.Game.Screens.Select
                                 RelativeSizeAxes = Axes.Both,
                                 Padding = new MarginPadding
                                 {
-                                    Top = FILTER_CONTROL_HEIGHT,
-                                    Bottom = FOOTER_HEIGHT
+                                    Top = FilterControl.HEIGHT,
+                                    Bottom = Footer.HEIGHT
                                 },
                                 Child = Carousel = new BeatmapCarousel
                                 {
@@ -171,7 +169,7 @@ namespace osu.Game.Screens.Select
                             FilterControl = new FilterControl
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Height = FILTER_CONTROL_HEIGHT,
+                                Height = FilterControl.HEIGHT,
                                 FilterChanged = c => Carousel.Filter(c),
                                 Background = { Width = 2 },
                                 Exit = () =>
@@ -210,7 +208,7 @@ namespace osu.Game.Screens.Select
                         Origin = Anchor.BottomLeft,
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Margin = new MarginPadding { Bottom = FOOTER_HEIGHT },
+                        Margin = new MarginPadding { Bottom = Footer.HEIGHT },
                         Children = new Drawable[]
                         {
                             BeatmapOptions = new BeatmapOptionsOverlay(),
@@ -222,13 +220,7 @@ namespace osu.Game.Screens.Select
                             }
                         }
                     },
-                    Footer = new Footer
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Height = FOOTER_HEIGHT,
-                        Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.BottomCentre,
-                    }
+                    Footer = new Footer()
                 });
             }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Screens.Select
 
         protected const float BACKGROUND_BLUR = 20;
         private const float left_area_padding = 20;
+        private const float filter_control_height = 100;
 
         public readonly FilterControl FilterControl;
 
@@ -121,7 +122,7 @@ namespace osu.Game.Screens.Select
                     Size = new Vector2(wedged_container_size.X, 1),
                     Padding = new MarginPadding
                     {
-                        Bottom = 50,
+                        Bottom = Footer.HEIGHT,
                         Top = wedged_container_size.Y + left_area_padding,
                         Left = left_area_padding,
                         Right = left_area_padding * 2,
@@ -147,20 +148,29 @@ namespace osu.Game.Screens.Select
                         Width = 0.5f,
                         Children = new Drawable[]
                         {
-                            Carousel = new BeatmapCarousel
+                            new Container
                             {
-                                Masking = false,
                                 RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(1 - wedged_container_size.X, 1),
-                                Anchor = Anchor.CentreRight,
-                                Origin = Anchor.CentreRight,
-                                SelectionChanged = updateSelectedBeatmap,
-                                BeatmapSetsChanged = carouselBeatmapsLoaded,
+                                Padding = new MarginPadding
+                                {
+                                    Top = filter_control_height,
+                                    Bottom = Footer.HEIGHT
+                                },
+                                Child = Carousel = new BeatmapCarousel
+                                {
+                                    Masking = false,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(1 - wedged_container_size.X, 1),
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    SelectionChanged = updateSelectedBeatmap,
+                                    BeatmapSetsChanged = carouselBeatmapsLoaded,
+                                },
                             },
                             FilterControl = new FilterControl
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Height = 100,
+                                Height = filter_control_height,
                                 FilterChanged = c => Carousel.Filter(c),
                                 Background = { Width = 2 },
                                 Exit = () =>

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -43,9 +43,10 @@ namespace osu.Game.Screens.Select
     {
         private static readonly Vector2 wedged_container_size = new Vector2(0.5f, 245);
 
+        public const float FILTER_CONTROL_HEIGHT = 100;
+        public const float FOOTER_HEIGHT = 50;
         protected const float BACKGROUND_BLUR = 20;
         private const float left_area_padding = 20;
-        private const float filter_control_height = 100;
 
         public readonly FilterControl FilterControl;
 
@@ -122,7 +123,7 @@ namespace osu.Game.Screens.Select
                     Size = new Vector2(wedged_container_size.X, 1),
                     Padding = new MarginPadding
                     {
-                        Bottom = Footer.HEIGHT,
+                        Bottom = FOOTER_HEIGHT,
                         Top = wedged_container_size.Y + left_area_padding,
                         Left = left_area_padding,
                         Right = left_area_padding * 2,
@@ -153,8 +154,8 @@ namespace osu.Game.Screens.Select
                                 RelativeSizeAxes = Axes.Both,
                                 Padding = new MarginPadding
                                 {
-                                    Top = filter_control_height,
-                                    Bottom = Footer.HEIGHT
+                                    Top = FILTER_CONTROL_HEIGHT,
+                                    Bottom = FOOTER_HEIGHT
                                 },
                                 Child = Carousel = new BeatmapCarousel
                                 {
@@ -170,7 +171,7 @@ namespace osu.Game.Screens.Select
                             FilterControl = new FilterControl
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Height = filter_control_height,
+                                Height = FILTER_CONTROL_HEIGHT,
                                 FilterChanged = c => Carousel.Filter(c),
                                 Background = { Width = 2 },
                                 Exit = () =>
@@ -209,7 +210,7 @@ namespace osu.Game.Screens.Select
                         Origin = Anchor.BottomLeft,
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Margin = new MarginPadding { Bottom = Footer.HEIGHT },
+                        Margin = new MarginPadding { Bottom = FOOTER_HEIGHT },
                         Children = new Drawable[]
                         {
                             BeatmapOptions = new BeatmapOptionsOverlay(),
@@ -221,7 +222,13 @@ namespace osu.Game.Screens.Select
                             }
                         }
                     },
-                    Footer = new Footer()
+                    Footer = new Footer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = FOOTER_HEIGHT,
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                    }
                 });
             }
 


### PR DESCRIPTION
* Fixes https://github.com/ppy/osu/issues/5452
* [x] Depends on https://github.com/ppy/osu-framework/pull/2694

Also makes `FilterControl` not block input (similar to the footer).