### PR TITLE
Reduce notification span during beatmap imports

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -386,7 +386,7 @@ namespace osu.Game.Beatmaps
                     beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
                 };
 
-                req.Failure += e => { LogForModel(set, $"Online retrieval failed for {beatmap}", e); };
+                req.Failure += e => { LogForModel(set, $"Online retrieval failed for {beatmap} ({e.Message})"); };
 
                 // intentionally blocking to limit web request concurrency
                 req.Perform(api);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -589,7 +589,7 @@ namespace osu.Game
         {
             int recentLogCount = 0;
 
-            const double debounce = 5000;
+            const double debounce = 60000;
 
             Logger.NewEntry += entry =>
             {


### PR DESCRIPTION
- Increases the debounce period (3 notifications per minute)
- Logs online retrieval failures at a lower level (we do not care about stack traces in these cases).
- Closes https://github.com/ppy/osu/issues/5428.

