### PR TITLE
Fix overlay activation mode not being set for intro

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -794,20 +794,20 @@ namespace osu.Game
 
         protected virtual void ScreenChanged(IScreen current, IScreen newScreen)
         {
-            switch (newScreen)
-            {
-                case Intro intro:
-                    introScreen = intro;
-                    break;
-
-                case MainMenu menu:
-                    menuScreen = menu;
-                    break;
-            }
-
             if (newScreen is IOsuScreen newOsuScreen)
             {
                 OverlayActivationMode.Value = newOsuScreen.InitialOverlayActivationMode;
+
+                switch (newOsuScreen)
+                {
+                    case Intro intro:
+                        introScreen = intro;
+                        break;
+
+                    case MainMenu menu:
+                        menuScreen = menu;
+                        break;
+                }
 
                 if (newOsuScreen.HideOverlaysOnEnter)
                     CloseAllOverlays();


### PR DESCRIPTION
Currently, the `OverlayActivationMode` is never set for `Intro`, even though it has an `InitialOverlayActivationMode`. 

This means if a disclaimer is shown, the `OverlayActivationMode` during the `Intro` is `Disabled`, but otherwise it'll remain `All`.