### PR TITLE
Fix transforming mods not working properly

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -147,12 +147,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
             if (State.Value == newState && !force)
                 return;
 
-            // apply any custom state overrides
-            ApplyCustomUpdateState?.Invoke(this, newState);
-
-            if (newState == ArmedState.Hit)
-                PlaySamples();
-
             if (UseTransformStateManagement)
             {
                 double transformTime = HitObject.StartTime - InitialLifetimeOffset;
@@ -177,6 +171,12 @@ namespace osu.Game.Rulesets.Objects.Drawables
                 state.Value = newState;
 
             UpdateState(newState);
+
+            // apply any custom state overrides
+            ApplyCustomUpdateState?.Invoke(this, newState);
+
+            if (newState == ArmedState.Hit)
+                PlaySamples();
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #5478 

The `ApplyCustomUpdateState` event was invoked before the normal update states which caused them to clear the custom transformations `base.ClearTransformsAfter(transformTime, true);`