### PR TITLE
Fix Multiplayer crash if attempting to exit with no screens in inner screen stack

### DIFF
--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -212,7 +212,7 @@ namespace osu.Game.Screens.Multi
 
         public override bool OnExiting(IScreen next)
         {
-            if (!(screenStack.CurrentScreen is LoungeSubScreen))
+            if (screenStack.CurrentScreen != null && !(screenStack.CurrentScreen is LoungeSubScreen))
             {
                 screenStack.Exit();
                 return true;


### PR DESCRIPTION
Currently, there is logic in place in `subScreenChanged` in `Multiplayer` that invokes `Multiplayer.Exit` if and only if the`CurrentScreen` is `null`. This will throw an exception as the multiplayer `ScreenStack` will then attempt to exit from a null screen.

Either this check needs to exist or we need to delete that logic inside `subScreenChanged`, or we need to make it so `LoungeSubScreen` doesn't exit itself if the `FilterControl` gets exited via https://github.com/ppy/osu/blob/05eb8ecd9896b24d83cb55573d4575ab83727b28/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs#L73.