### PR TITLE
Don't report delta patch failures to sentry

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -27,6 +27,8 @@ namespace osu.Desktop.Updater
 
         public Task PrepareUpdateAsync() => UpdateManager.RestartAppWhenExited();
 
+        private static readonly Logger logger = Logger.GetLogger("updater");
+
         [BackgroundDependencyLoader]
         private void load(NotificationOverlay notification, OsuGameBase game)
         {
@@ -77,7 +79,7 @@ namespace osu.Desktop.Updater
                 {
                     if (useDeltaPatching)
                     {
-                        Logger.Error(e, @"delta patching failed!");
+                        logger.Add(@"delta patching failed; will attempt full download!");
 
                         //could fail if deltas are unavailable for full update path (https://github.com/Squirrel/Squirrel.Windows/issues/959)
                         //try again without deltas.
@@ -163,15 +165,10 @@ namespace osu.Desktop.Updater
         {
             public LogLevel Level { get; set; } = LogLevel.Info;
 
-            private Logger logger;
-
             public void Write(string message, LogLevel logLevel)
             {
                 if (logLevel < Level)
                     return;
-
-                if (logger == null)
-                    logger = Logger.GetLogger("updater");
 
                 logger.Add(message);
             }


### PR DESCRIPTION
It is quite a common occurrence that delta patching fails due to a shortage of deltas (if a user has not updated for a while). It gracefully falls back to a full download, but also reports this to sentry which can get quite noisy.

- Closes https://github.com/ppy/osu/issues/5505.