### PR TITLE
Remove redundant ScreenshotManager.Update override

### DIFF
--- a/osu.Game/Graphics/ScreenshotManager.cs
+++ b/osu.Game/Graphics/ScreenshotManager.cs
@@ -92,7 +92,8 @@ namespace osu.Game.Graphics
 
             using (var image = await host.TakeScreenshotAsync())
             {
-                Interlocked.Decrement(ref screenShotTasks);
+                if (Interlocked.Decrement(ref screenShotTasks) == 0 && cursorVisibility.Value == false)
+                    cursorVisibility.Value = true;
 
                 var fileName = getFileName();
                 if (fileName == null) return;
@@ -124,14 +125,6 @@ namespace osu.Game.Graphics
                 });
             }
         });
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (cursorVisibility.Value == false && Interlocked.CompareExchange(ref screenShotTasks, 0, 0) == 0)
-                cursorVisibility.Value = true;
-        }
 
         private string getFileName()
         {


### PR DESCRIPTION
Since `screenShotTasks` is decrementing only in one place, I guess it is ok to perform `cursorVisibility` check on the spot. Also, for the same reason I guess it is redundant to perform this check on every update loop iteration.