### PR TITLE
Revert iOS import changes causing crash

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -14,8 +14,6 @@
 	<string>0.1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<true/>
 	<key>MinimumOSVersion</key>
 	<string>10.0</string>
 	<key>UIDeviceFamily</key>


### PR DESCRIPTION
Temporary fix to #5545.

Just ignore ITMS-90737. It's a new feature in iOS11.

Finding a better way to deal with it.