### PR TITLE
Regenerate slider ticks when modified in editor

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSelectionBlueprint.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Path = startPath
             };
 
-            applyDefaults();
+            slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = 2 });
 
             Add(drawableObject = new DrawableSlider(slider));
         }
@@ -65,8 +65,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 slider.Position = startPosition;
                 slider.Path = startPath;
-
-                applyDefaults();
             });
         }
 
@@ -86,19 +84,16 @@ namespace osu.Game.Rulesets.Osu.Tests
                     new Vector2(-150, -150),
                     new Vector2(300, 0)
                 });
-
-                applyDefaults();
             });
 
             AddAssert("Nested objects were regenerated", () => regenerated);
 
             AddStep("Move slider", () => slider.Position = new Vector2(192, 256));
 
-            // The blueprint needed to be regenerated as well, so this checks that the new blueprint tracks the new headcircle position.
+            // We should have only regenerated the ticks and nothing else, so check that the selection blueprint is still attached to the head circle.
+            AddAssert("Selection blueprint attatched to drawable", () => blueprint.HeadBlueprint.HitObject.HitObject == slider.HeadCircle);
             AddAssert("Slider head blueprint tracks object", () => blueprint.HeadBlueprint.Position == drawableObject.HeadCircle.Position);
         }
-
-        private void applyDefaults() => slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = 2 });
 
         protected override SelectionBlueprint CreateBlueprint() => blueprint = new TestSliderSelectionBlueprint(drawableObject);
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSelectionBlueprint.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep("Modify sliderpath", () =>
             {
                 regenerated = false;
-                slider.OnRegenerated += () => regenerated = true;
+                slider.OnTicksRegenerated += () => regenerated = true;
 
                 slider.Path = new SliderPath(PathType.Bezier, new[]
                 {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
@@ -24,6 +26,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         [Resolved]
         private OsuColour colours { get; set; }
+
+        protected IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
 
         public PathControlPointPiece(Slider slider, int index)
         {
@@ -49,6 +53,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     Child = new Box { RelativeSizeAxes = Axes.Both }
                 }
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IBindable<WorkingBeatmap> beatmap)
+        {
+            Beatmap.BindTo(beatmap);
         }
 
         protected override void Update()
@@ -97,6 +107,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 newControlPoints[index - 1] = newControlPoints[index];
 
             slider.Path = new SliderPath(slider.Path.Type, newControlPoints);
+
+            slider.ApplyDefaults(Beatmap.Value.Beatmap.ControlPointInfo, Beatmap.Value.BeatmapInfo.BaseDifficulty);
 
             return true;
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
@@ -85,8 +84,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         protected override bool OnDragStart(DragStartEvent e) => true;
 
-        private ScheduledDelegate sliderUpdateDebounce;
-
         protected override bool OnDrag(DragEvent e)
         {
             var newControlPoints = slider.Path.ControlPoints.ToArray();
@@ -110,9 +107,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 newControlPoints[index - 1] = newControlPoints[index];
 
             slider.Path = new SliderPath(slider.Path.Type, newControlPoints);
-
-            sliderUpdateDebounce?.Cancel();
-            sliderUpdateDebounce = Schedule(() => slider.ApplyDefaults(beatmap.Value.Beatmap.ControlPointInfo, beatmap.Value.BeatmapInfo.BaseDifficulty));
 
             return true;
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Threading;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -13,6 +14,17 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             : base(hitObject)
         {
             InternalChild = new SliderCirclePiece(slider, position);
+
+            ScheduledDelegate regenerationDebounce = null;
+
+            slider.OnRegenerated += () =>
+            {
+                regenerationDebounce?.Cancel();
+                regenerationDebounce = Schedule(() =>
+                {
+                    InternalChild = new SliderCirclePiece(slider, position);
+                });
+            };
 
             Select();
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Threading;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -14,17 +13,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             : base(hitObject)
         {
             InternalChild = new SliderCirclePiece(slider, position);
-
-            ScheduledDelegate regenerationDebounce = null;
-
-            slider.OnRegenerated += () =>
-            {
-                regenerationDebounce?.Cancel();
-                regenerationDebounce = Schedule(() =>
-                {
-                    InternalChild = new SliderCirclePiece(slider, position);
-                });
-            };
 
             Select();
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Threading;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -13,42 +11,19 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 {
     public class SliderSelectionBlueprint : OsuSelectionBlueprint
     {
-        protected SliderCircleSelectionBlueprint HeadBlueprint { get; private set; }
+        protected SliderCircleSelectionBlueprint HeadBlueprint { get; }
 
         public SliderSelectionBlueprint(DrawableSlider slider)
             : base(slider)
         {
-            Container sliderCircleContainer;
             var sliderObject = (Slider)slider.HitObject;
 
             InternalChildren = new Drawable[]
             {
                 new SliderBodyPiece(sliderObject),
-                sliderCircleContainer = new Container
-                {
-                    Children = new[]
-                    {
-                        HeadBlueprint = new SliderCircleSelectionBlueprint(slider.HeadCircle, sliderObject, SliderPosition.Start),
-                        new SliderCircleSelectionBlueprint(slider.TailCircle, sliderObject, SliderPosition.End),
-                    }
-                },
+                HeadBlueprint = new SliderCircleSelectionBlueprint(slider.HeadCircle, sliderObject, SliderPosition.Start),
+                new SliderCircleSelectionBlueprint(slider.TailCircle, sliderObject, SliderPosition.End),
                 new PathControlPointVisualiser(sliderObject),
-            };
-
-            ScheduledDelegate regenerationDebounce = null;
-
-            sliderObject.OnRegenerated += () =>
-            {
-                regenerationDebounce?.Cancel();
-                regenerationDebounce = Schedule(() =>
-                {
-                    sliderCircleContainer.Clear();
-                    sliderCircleContainer.AddRange(new[]
-                    {
-                        HeadBlueprint = new SliderCircleSelectionBlueprint(slider.HeadCircle, sliderObject, SliderPosition.Start),
-                        new SliderCircleSelectionBlueprint(slider.TailCircle, sliderObject, SliderPosition.End),
-                    });
-                });
             };
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Threading;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -11,22 +13,45 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 {
     public class SliderSelectionBlueprint : OsuSelectionBlueprint
     {
-        private readonly SliderCircleSelectionBlueprint headBlueprint;
+        protected SliderCircleSelectionBlueprint HeadBlueprint { get; private set; }
 
         public SliderSelectionBlueprint(DrawableSlider slider)
             : base(slider)
         {
+            Container sliderCircleContainer;
             var sliderObject = (Slider)slider.HitObject;
 
             InternalChildren = new Drawable[]
             {
                 new SliderBodyPiece(sliderObject),
-                headBlueprint = new SliderCircleSelectionBlueprint(slider.HeadCircle, sliderObject, SliderPosition.Start),
-                new SliderCircleSelectionBlueprint(slider.TailCircle, sliderObject, SliderPosition.End),
+                sliderCircleContainer = new Container
+                {
+                    Children = new[]
+                    {
+                        HeadBlueprint = new SliderCircleSelectionBlueprint(slider.HeadCircle, sliderObject, SliderPosition.Start),
+                        new SliderCircleSelectionBlueprint(slider.TailCircle, sliderObject, SliderPosition.End),
+                    }
+                },
                 new PathControlPointVisualiser(sliderObject),
+            };
+
+            ScheduledDelegate regenerationDebounce = null;
+
+            sliderObject.OnRegenerated += () =>
+            {
+                regenerationDebounce?.Cancel();
+                regenerationDebounce = Schedule(() =>
+                {
+                    sliderCircleContainer.Clear();
+                    sliderCircleContainer.AddRange(new[]
+                    {
+                        HeadBlueprint = new SliderCircleSelectionBlueprint(slider.HeadCircle, sliderObject, SliderPosition.Start),
+                        new SliderCircleSelectionBlueprint(slider.TailCircle, sliderObject, SliderPosition.End),
+                    });
+                });
             };
         }
 
-        public override Vector2 SelectionPoint => headBlueprint.SelectionPoint;
+        public override Vector2 SelectionPoint => HeadBlueprint.SelectionPoint;
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -219,12 +219,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private void generateDrawableTicks()
         {
-            foreach (var tick in ticks)
-            {
-                components.Remove(tick);
-                RemoveNested(tick);
-            }
-
+            components.RemoveAll(d => d is DrawableSliderTick);
+            RemoveAllFromNested(d => d is DrawableSliderTick);
             ticks.Clear();
 
             foreach (var tick in slider.NestedHitObjects.OfType<SliderTick>())

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             ScheduledDelegate tickGenerationDebounce = null;
 
-            slider.OnRegenerated += () =>
+            slider.OnTicksRegenerated += () =>
             {
                 tickGenerationDebounce?.Cancel();
                 tickGenerationDebounce = Schedule(generateDrawableTicks);
@@ -237,6 +237,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             foreach (var tick in slider.NestedHitObjects.OfType<SliderTick>())
             {
                 var drawableTick = new DrawableSliderTick(tick) { Position = tick.Position - slider.Position };
+
                 ticks.Add(drawableTick);
                 components.Add(drawableTick);
                 AddNested(drawableTick);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public readonly SnakingSliderBody Body;
         public readonly SliderBall Ball;
+        private readonly Container<DrawableSliderTick> ticks;
 
         private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
         private readonly IBindable<float> scaleBindable = new Bindable<float>();
@@ -43,7 +44,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             Position = s.StackedPosition;
 
-            Container<DrawableSliderTick> ticks;
             Container<DrawableRepeatPoint> repeatPoints;
 
             InternalChildren = new Drawable[]
@@ -74,14 +74,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             AddNested(TailCircle);
             components.Add(TailCircle);
 
-            foreach (var tick in s.NestedHitObjects.OfType<SliderTick>())
-            {
-                var drawableTick = new DrawableSliderTick(tick) { Position = tick.Position - s.Position };
-
-                ticks.Add(drawableTick);
-                components.Add(drawableTick);
-                AddNested(drawableTick);
-            }
+            generateDrawableTicks();
 
             foreach (var repeatPoint in s.NestedHitObjects.OfType<RepeatPoint>())
             {
@@ -90,6 +83,27 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 repeatPoints.Add(drawableRepeatPoint);
                 components.Add(drawableRepeatPoint);
                 AddNested(drawableRepeatPoint);
+            }
+
+            slider.OnTicksRegenerated += generateDrawableTicks;
+        }
+
+        private void generateDrawableTicks()
+        {
+            foreach (var tick in ticks)
+            {
+                components.Remove(tick);
+                RemoveNested(tick);
+            }
+
+            ticks.Clear();
+
+            foreach (var tick in slider.NestedHitObjects.OfType<SliderTick>())
+            {
+                var drawableTick = new DrawableSliderTick(tick) { Position = tick.Position - slider.Position };
+                ticks.Add(drawableTick);
+                components.Add(drawableTick);
+                AddNested(drawableTick);
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Threading;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Scoring;
@@ -86,13 +85,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 AddNested(drawableRepeatPoint);
             }
 
-            ScheduledDelegate tickGenerationDebounce = null;
-
-            slider.OnTicksRegenerated += () =>
-            {
-                tickGenerationDebounce?.Cancel();
-                tickGenerationDebounce = Schedule(generateDrawableTicks);
-            };
+            slider.OnTicksRegenerated += generateDrawableTicks;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osuTK;
 using osu.Game.Rulesets.Objects.Types;
 using System.Collections.Generic;
@@ -31,6 +32,8 @@ namespace osu.Game.Rulesets.Osu.Objects
         public override Vector2 EndPosition => endPositionCache.IsValid ? endPositionCache.Value : endPositionCache.Value = Position + this.CurvePositionAt(1);
 
         public Vector2 StackedPositionAt(double t) => StackedPosition + this.CurvePositionAt(t);
+
+        public Action OnTicksRegenerated;
 
         public override int ComboIndex
         {
@@ -223,6 +226,8 @@ namespace osu.Game.Rulesets.Osu.Objects
                         break;
                 }
             }
+
+            OnTicksRegenerated?.Invoke();
         }
 
         private List<HitSampleInfo> getNodeSamples(int nodeIndex) =>

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public Vector2 StackedPositionAt(double t) => StackedPosition + this.CurvePositionAt(t);
 
-        public Action OnTicksRegenerated;
+        public Action OnRegenerated;
 
         public override int ComboIndex
         {
@@ -227,7 +227,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                 }
             }
 
-            OnTicksRegenerated?.Invoke();
+            OnRegenerated?.Invoke();
         }
 
         private List<HitSampleInfo> getNodeSamples(int nodeIndex) =>

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -69,8 +69,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             {
                 PathBindable.Value = value;
 
-                foreach (var tick in NestedHitObjects.OfType<SliderTick>())
-                    RemoveNested(tick);
+                RemoveAllFromNested(d => d is SliderTick);
 
                 foreach (var e in
                     SliderEventGenerator.Generate(StartTime, SpanDuration, Velocity, TickDistance, Path.Distance, this.SpanCount(), LegacyLastTickOffset))

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -69,7 +69,8 @@ namespace osu.Game.Rulesets.Osu.Objects
             {
                 PathBindable.Value = value;
 
-                RemoveAllNested(d => d is SliderTick);
+                foreach (var tick in NestedHitObjects.OfType<SliderTick>())
+                    RemoveNested(tick);
 
                 foreach (var e in
                     SliderEventGenerator.Generate(StartTime, SpanDuration, Velocity, TickDistance, Path.Distance, this.SpanCount(), LegacyLastTickOffset))

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -71,8 +71,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
                 RemoveAllFromNested(d => d is SliderTick);
 
-                foreach (var e in
-                    SliderEventGenerator.Generate(StartTime, SpanDuration, Velocity, TickDistance, Path.Distance, this.SpanCount(), LegacyLastTickOffset))
+                foreach (var e in generateDescriptors())
                 {
                     if (e.Type == SliderEventType.Tick)
                         addNestedTick(e);
@@ -168,12 +167,14 @@ namespace osu.Game.Rulesets.Osu.Objects
             TickDistance = scoringDistance / difficulty.SliderTickRate * TickDistanceMultiplier;
         }
 
+        private IEnumerable<SliderEventDescriptor> generateDescriptors() =>
+            SliderEventGenerator.Generate(StartTime, SpanDuration, Velocity, TickDistance, Path.Distance, this.SpanCount(), LegacyLastTickOffset);
+
         protected override void CreateNestedHitObjects()
         {
             base.CreateNestedHitObjects();
 
-            foreach (var e in
-                SliderEventGenerator.Generate(StartTime, SpanDuration, Velocity, TickDistance, Path.Distance, this.SpanCount(), LegacyLastTickOffset))
+            foreach (var e in generateDescriptors())
             {
                 switch (e.Type)
                 {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -317,7 +317,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         }
 
         /// <summary>
-        /// Removes a <see cref="DrawableHitObject"/> from this object's <see cref="NestedHitObjects"/>.
+        /// Removes all <see cref="DrawableHitObject"/> from this object's <see cref="NestedHitObjects"/> that matches the predicate.
         /// </summary>
         /// <param name="predicate">The predicate the <see cref="DrawableHitObject"/> must match to be removed.</param>
         protected void RemoveAllFromNested(Predicate<DrawableHitObject> predicate) => nestedHitObjects.Value.RemoveAll(predicate);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -311,6 +311,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             nestedHitObjects.Value.Add(h);
         }
 
+        protected void RemoveNested(DrawableHitObject h) => nestedHitObjects.Value.Remove(h);
+
         /// <summary>
         /// Applies the <see cref="Result"/> of this <see cref="DrawableHitObject"/>, notifying responders such as
         /// the <see cref="ScoreProcessor"/> of the <see cref="JudgementResult"/>.

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -302,6 +302,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
             UpdateResult(false);
         }
 
+        /// <summary>
+        /// Adds a <see cref="DrawableHitObject"/> to this object's <see cref="NestedHitObjects"/>,
+        /// allowing events that affect this object to propagate to it.
+        /// </summary>
+        /// <param name="h">The <see cref="DrawableHitObject"/> to add.</param>
         protected virtual void AddNested(DrawableHitObject h)
         {
             h.OnNewResult += (d, r) => OnNewResult?.Invoke(d, r);
@@ -311,6 +316,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
             nestedHitObjects.Value.Add(h);
         }
 
+        /// <summary>
+        /// Removes a <see cref="DrawableHitObject"/> from this object's <see cref="NestedHitObjects"/>.
+        /// </summary>
+        /// <param name="h">The <see cref="DrawableHitObject"/> to remove.</param>
         protected void RemoveNested(DrawableHitObject h) => nestedHitObjects.Value.Remove(h);
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -319,8 +319,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <summary>
         /// Removes a <see cref="DrawableHitObject"/> from this object's <see cref="NestedHitObjects"/>.
         /// </summary>
-        /// <param name="h">The <see cref="DrawableHitObject"/> to remove.</param>
-        protected void RemoveNested(DrawableHitObject h) => nestedHitObjects.Value.Remove(h);
+        /// <param name="predicate">The predicate the <see cref="DrawableHitObject"/> must match to be removed.</param>
+        protected void RemoveAllFromNested(Predicate<DrawableHitObject> predicate) => nestedHitObjects.Value.RemoveAll(predicate);
 
         /// <summary>
         /// Applies the <see cref="Result"/> of this <see cref="DrawableHitObject"/>, notifying responders such as

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Audio;
@@ -102,6 +103,8 @@ namespace osu.Game.Rulesets.Objects
         }
 
         protected void AddNested(HitObject hitObject) => nestedHitObjects.Add(hitObject);
+
+        protected void RemoveAllNested(Predicate<HitObject> predicate) => nestedHitObjects.RemoveAll(predicate);
 
         /// <summary>
         /// Creates the <see cref="Judgement"/> that represents the scoring information for this <see cref="HitObject"/>.

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Framework.Lists;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -58,7 +59,8 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         public HitWindows HitWindows { get; set; }
 
-        private readonly List<HitObject> nestedHitObjects = new List<HitObject>();
+        private readonly SortedList<HitObject> nestedHitObjects
+            = new SortedList<HitObject>(new ComparisonComparer<HitObject>((a, b) => a.StartTime.CompareTo(b.StartTime)));
 
         [JsonIgnore]
         public IReadOnlyList<HitObject> NestedHitObjects => nestedHitObjects;
@@ -79,8 +81,6 @@ namespace osu.Game.Rulesets.Objects
 
             CreateNestedHitObjects();
 
-            nestedHitObjects.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
-
             foreach (var h in nestedHitObjects)
             {
                 h.HitWindows = HitWindows;
@@ -94,6 +94,7 @@ namespace osu.Game.Rulesets.Objects
 
             if (HitWindows == null)
                 HitWindows = CreateHitWindows();
+
             HitWindows?.SetDifficulty(difficulty.OverallDifficulty);
         }
 

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Audio;
@@ -110,8 +111,8 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// Removes a <see cref="HitObject"/>s from this object's <see cref="NestedHitObjects"/>.
         /// </summary>
-        /// <param name="hitObject">The <see cref="HitObject"/> to remove.</param>
-        protected void RemoveNested(HitObject hitObject) => nestedHitObjects.Remove(hitObject);
+        /// <param name="predicate">The predicate the <see cref="HitObject"/> must match to be removed.</param>
+        protected void RemoveAllFromNested(Predicate<HitObject> predicate) => nestedHitObjects.RemoveAll(predicate);
 
         /// <summary>
         /// Creates the <see cref="Judgement"/> that represents the scoring information for this <see cref="HitObject"/>.

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Objects
         protected void AddNested(HitObject hitObject) => nestedHitObjects.Add(hitObject);
 
         /// <summary>
-        /// Removes a <see cref="HitObject"/>s from this object's <see cref="NestedHitObjects"/>.
+        /// Removes all <see cref="HitObject"/>s from this object's <see cref="NestedHitObjects"/> that matches the predicate.
         /// </summary>
         /// <param name="predicate">The predicate the <see cref="HitObject"/> must match to be removed.</param>
         protected void RemoveAllFromNested(Predicate<HitObject> predicate) => nestedHitObjects.RemoveAll(predicate);

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using osu.Framework.Lists;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -59,8 +58,7 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         public HitWindows HitWindows { get; set; }
 
-        private readonly SortedList<HitObject> nestedHitObjects
-            = new SortedList<HitObject>(new ComparisonComparer<HitObject>((a, b) => a.StartTime.CompareTo(b.StartTime)));
+        private readonly List<HitObject> nestedHitObjects = new List<HitObject>();
 
         [JsonIgnore]
         public IReadOnlyList<HitObject> NestedHitObjects => nestedHitObjects;
@@ -81,6 +79,8 @@ namespace osu.Game.Rulesets.Objects
 
             CreateNestedHitObjects();
 
+            nestedHitObjects.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
+
             foreach (var h in nestedHitObjects)
             {
                 h.HitWindows = HitWindows;
@@ -94,7 +94,6 @@ namespace osu.Game.Rulesets.Objects
 
             if (HitWindows == null)
                 HitWindows = CreateHitWindows();
-
             HitWindows?.SetDifficulty(difficulty.OverallDifficulty);
         }
 

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Audio;
@@ -102,9 +101,17 @@ namespace osu.Game.Rulesets.Objects
         {
         }
 
+        /// <summary>
+        /// Adds a <see cref="HitObject"/>s to this object's <see cref="NestedHitObjects"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to add.</param>
         protected void AddNested(HitObject hitObject) => nestedHitObjects.Add(hitObject);
 
-        protected void RemoveAllNested(Predicate<HitObject> predicate) => nestedHitObjects.RemoveAll(predicate);
+        /// <summary>
+        /// Removes a <see cref="HitObject"/>s from this object's <see cref="NestedHitObjects"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to remove.</param>
+        protected void RemoveNested(HitObject hitObject) => nestedHitObjects.Remove(hitObject);
 
         /// <summary>
         /// Creates the <see cref="Judgement"/> that represents the scoring information for this <see cref="HitObject"/>.

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -84,6 +84,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             refreshTool();
 
             var blueprint = composer.CreateBlueprintFor(hitObject);
+
             if (blueprint == null)
                 return;
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/5181

Re-opening now that the change is isolated to `SliderTick`s.

This PR forces a regeneration for slider ticks and drawable slider ticks whenever the slider path is modified in editor. This should be fine for now, but eventually we'll want to cache everything.