### PR TITLE
Fix memory leaks from download buttons

### DIFF
--- a/osu.Game/Online/DownloadTrackingComposite.cs
+++ b/osu.Game/Online/DownloadTrackingComposite.cs
@@ -48,20 +48,22 @@ namespace osu.Game.Online
                     attachDownload(manager.GetExistingDownload(modelInfo.NewValue));
             }, true);
 
-            manager.DownloadBegan += download =>
-            {
-                if (download.Model.Equals(Model.Value))
-                    attachDownload(download);
-            };
-
-            manager.DownloadFailed += download =>
-            {
-                if (download.Model.Equals(Model.Value))
-                    attachDownload(null);
-            };
-
+            manager.DownloadBegan += downloadBegan;
+            manager.DownloadFailed += downloadFailed;
             manager.ItemAdded += itemAdded;
             manager.ItemRemoved += itemRemoved;
+        }
+
+        private void downloadBegan(ArchiveDownloadRequest<TModel> request)
+        {
+            if (request.Model.Equals(Model.Value))
+                attachDownload(request);
+        }
+
+        private void downloadFailed(ArchiveDownloadRequest<TModel> request)
+        {
+            if (request.Model.Equals(Model.Value))
+                attachDownload(null);
         }
 
         private ArchiveDownloadRequest<TModel> attachedRequest;
@@ -126,8 +128,10 @@ namespace osu.Game.Online
 
             if (manager != null)
             {
-                manager.DownloadBegan -= attachDownload;
+                manager.DownloadBegan -= downloadBegan;
+                manager.DownloadFailed -= downloadFailed;
                 manager.ItemAdded -= itemAdded;
+                manager.ItemRemoved -= itemRemoved;
             }
 
             State.UnbindAll();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1329837/62452219-b4f83700-b7aa-11e9-8c4b-cecca681eab3.png)

ScoreManager keeping reference to download buttons (in this case, from the results screen) via the delegate, which keeps an upwards reference to song select via dependencies because SS caches itself.