### PR TITLE
Fix drawable channels remaining in memory after being closed

### DIFF
--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -256,6 +256,9 @@ namespace osu.Game.Overlays
                 loadedChannels.Add(loaded);
                 LoadComponentAsync(loaded, l =>
                 {
+                    if (currentChannel.Value != e.NewValue)
+                        return;
+
                     loading.Hide();
 
                     currentChannelContainer.Clear(false);
@@ -381,7 +384,18 @@ namespace osu.Game.Overlays
             foreach (Channel channel in channels)
             {
                 ChannelTabControl.RemoveChannel(channel);
-                loadedChannels.Remove(loadedChannels.Find(c => c.Channel == channel));
+
+                var loaded = loadedChannels.Find(c => c.Channel == channel);
+
+                if (loaded != null)
+                {
+                    loadedChannels.Remove(loaded);
+
+                    // Because the container is only cleared in the async load callback of a new channel, it is forcefully cleared
+                    // to ensure that the previous channel doesn't get updated after it's disposed
+                    currentChannelContainer.Remove(loaded);
+                    loaded.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
In combination with https://github.com/ppy/osu-framework/pull/2722, reduces memory leaks due to removed drawable channels.

One caveat to this is that the current channel content disappears immediately when it's closed, bypassing the whole fade-out thing of the container during the async load of the next channel. I see this as fine for now because it is very subtle and this entire component needs a huge refactoring to resolve other threading-related issues.