### PR TITLE
Fix footer button hover sounds playing in unclickable area

### DIFF
--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Screens.Select
                         buttons = new FillFlowContainer<FooterButton>
                         {
                             Direction = FillDirection.Horizontal,
-                            Spacing = new Vector2(0.2f, 0),
+                            Spacing = new Vector2(-FooterButton.SHEAR_WIDTH, 0),
                             AutoSizeAxes = Axes.Both,
                         }
                     }

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -17,7 +17,9 @@ namespace osu.Game.Screens.Select
 {
     public class FooterButton : OsuClickableContainer
     {
-        private static readonly Vector2 shearing = new Vector2(0.15f, 0);
+        public static readonly float SHEAR_WIDTH = 7.5f;
+
+        protected static readonly Vector2 SHEARING = new Vector2(SHEAR_WIDTH / Footer.HEIGHT, 0);
 
         public string Text
         {
@@ -59,16 +61,16 @@ namespace osu.Game.Screens.Select
         private readonly Box box;
         private readonly Box light;
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
-
         public FooterButton()
         {
             AutoSizeAxes = Axes.Both;
+            Shear = SHEARING;
             Children = new Drawable[]
             {
                 TextContainer = new Container
                 {
-                    Size = new Vector2(100, 50),
+                    Size = new Vector2(100 - SHEAR_WIDTH, 50),
+                    Shear = -SHEARING,
                     Child = SpriteText = new OsuSpriteText
                     {
                         Anchor = Anchor.Centre,
@@ -78,14 +80,12 @@ namespace osu.Game.Screens.Select
                 box = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Shear = shearing,
                     EdgeSmoothness = new Vector2(2, 0),
                     Colour = Color4.White,
                     Alpha = 0,
                 },
                 light = new Box
                 {
-                    Shear = shearing,
                     Height = 4,
                     EdgeSmoothness = new Vector2(2, 0),
                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.Select
     {
         public static readonly float SHEAR_WIDTH = 7.5f;
 
-        protected static readonly Vector2 SHEARING = new Vector2(SHEAR_WIDTH / Footer.HEIGHT, 0);
+        protected static readonly Vector2 SHEAR = new Vector2(SHEAR_WIDTH / Footer.HEIGHT, 0);
 
         public string Text
         {
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Select
         public FooterButton()
         {
             AutoSizeAxes = Axes.Both;
-            Shear = SHEARING;
+            Shear = SHEAR;
             Children = new Drawable[]
             {
                 box = new Box
@@ -83,7 +83,7 @@ namespace osu.Game.Screens.Select
                 TextContainer = new Container
                 {
                     Size = new Vector2(100 - SHEAR_WIDTH, 50),
-                    Shear = -SHEARING,
+                    Shear = -SHEAR,
                     Child = SpriteText = new OsuSpriteText
                     {
                         Anchor = Anchor.Centre,

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -67,16 +67,6 @@ namespace osu.Game.Screens.Select
             Shear = SHEARING;
             Children = new Drawable[]
             {
-                TextContainer = new Container
-                {
-                    Size = new Vector2(100 - SHEAR_WIDTH, 50),
-                    Shear = -SHEARING,
-                    Child = SpriteText = new OsuSpriteText
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                    }
-                },
                 box = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -89,6 +79,16 @@ namespace osu.Game.Screens.Select
                     Height = 4,
                     EdgeSmoothness = new Vector2(2, 0),
                     RelativeSizeAxes = Axes.X,
+                },
+                TextContainer = new Container
+                {
+                    Size = new Vector2(100 - SHEAR_WIDTH, 50),
+                    Shear = -SHEARING,
+                    Child = SpriteText = new OsuSpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
                 },
             };
         }

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.Select
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
-                Shear = -SHEARING,
+                Shear = -SHEAR,
                 Child = modDisplay = new FooterModDisplay
                 {
                     DisplayUnrankedText = false,

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Screens.Select
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
+                Shear = -SHEARING,
                 Child = modDisplay = new FooterModDisplay
                 {
                     DisplayUnrankedText = false,


### PR DESCRIPTION
Fixes part of #3348. Will need to do other sheared containers.

Also fixes alignment and depth of text.

Before:
![osu_2019-08-05_18-24-33](https://user-images.githubusercontent.com/35318437/62504737-b592cc80-b7ae-11e9-90d6-9cc32ac52f4b.jpg)

After:
![osu_2019-08-05_18-22-51](https://user-images.githubusercontent.com/35318437/62504741-b7f52680-b7ae-11e9-95b8-86e8cb7de128.jpg)


---