### PR TITLE
Fix back button hover sounds playing in unclickable area

### DIFF
--- a/osu.Game/Graphics/UserInterface/BackButton.cs
+++ b/osu.Game/Graphics/UserInterface/BackButton.cs
@@ -22,8 +22,8 @@ namespace osu.Game.Graphics.UserInterface
 
             Child = button = new TwoLayerButton
             {
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopLeft,
                 Text = @"back",
                 Icon = OsuIcon.LeftCircle,
                 Action = () => Action?.Invoke()

--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -29,9 +29,9 @@ namespace osu.Game.Graphics.UserInterface
         private const int transform_time = 600;
         private const int pulse_length = 250;
 
-        private const float SHEAR_WIDTH = 5f;
+        private const float shear_width = 5f;
 
-        private static readonly Vector2 shearing = new Vector2(SHEAR_WIDTH / Footer.HEIGHT, 0);
+        private static readonly Vector2 shearing = new Vector2(shear_width / Footer.HEIGHT, 0);
 
         public static readonly Vector2 SIZE_EXTENDED = new Vector2(140, 50);
         public static readonly Vector2 SIZE_RETRACTED = new Vector2(100, 50);

--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private const float shear_width = 5f;
 
-        private static readonly Vector2 shearing = new Vector2(shear_width / Footer.HEIGHT, 0);
+        private static readonly Vector2 shear = new Vector2(shear_width / Footer.HEIGHT, 0);
 
         public static readonly Vector2 SIZE_EXTENDED = new Vector2(140, 50);
         public static readonly Vector2 SIZE_RETRACTED = new Vector2(100, 50);
@@ -59,7 +59,7 @@ namespace osu.Game.Graphics.UserInterface
                 c1.Origin = c1.Anchor = value.HasFlag(Anchor.x2) ? Anchor.TopLeft : Anchor.TopRight;
                 c2.Origin = c2.Anchor = value.HasFlag(Anchor.x2) ? Anchor.TopRight : Anchor.TopLeft;
 
-                X = value.HasFlag(Anchor.x2) ? SIZE_RETRACTED.X * shearing.X * 0.5f : 0;
+                X = value.HasFlag(Anchor.x2) ? SIZE_RETRACTED.X * shear.X * 0.5f : 0;
 
                 Remove(c1);
                 Remove(c2);
@@ -73,7 +73,7 @@ namespace osu.Game.Graphics.UserInterface
         public TwoLayerButton()
         {
             Size = SIZE_RETRACTED;
-            Shear = shearing;
+            Shear = shear;
 
             Children = new Drawable[]
             {
@@ -108,7 +108,7 @@ namespace osu.Game.Graphics.UserInterface
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Shear = -shearing,
+                            Shear = -shear,
                         },
                     }
                 },
@@ -147,7 +147,7 @@ namespace osu.Game.Graphics.UserInterface
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                            Shear = -shearing,
+                            Shear = -shear,
                         }
                     }
                 },

--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -15,6 +15,7 @@ using System;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.Screens.Select;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -28,7 +29,9 @@ namespace osu.Game.Graphics.UserInterface
         private const int transform_time = 600;
         private const int pulse_length = 250;
 
-        private const float shear = 0.1f;
+        private const float SHEAR_WIDTH = 5f;
+
+        private static readonly Vector2 shearing = new Vector2(SHEAR_WIDTH / Footer.HEIGHT, 0);
 
         public static readonly Vector2 SIZE_EXTENDED = new Vector2(140, 50);
         public static readonly Vector2 SIZE_RETRACTED = new Vector2(100, 50);
@@ -56,7 +59,7 @@ namespace osu.Game.Graphics.UserInterface
                 c1.Origin = c1.Anchor = value.HasFlag(Anchor.x2) ? Anchor.TopLeft : Anchor.TopRight;
                 c2.Origin = c2.Anchor = value.HasFlag(Anchor.x2) ? Anchor.TopRight : Anchor.TopLeft;
 
-                X = value.HasFlag(Anchor.x2) ? SIZE_RETRACTED.X * shear * 0.5f : 0;
+                X = value.HasFlag(Anchor.x2) ? SIZE_RETRACTED.X * shearing.X * 0.5f : 0;
 
                 Remove(c1);
                 Remove(c2);
@@ -70,6 +73,7 @@ namespace osu.Game.Graphics.UserInterface
         public TwoLayerButton()
         {
             Size = SIZE_RETRACTED;
+            Shear = shearing;
 
             Children = new Drawable[]
             {
@@ -82,7 +86,6 @@ namespace osu.Game.Graphics.UserInterface
                         new Container
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Shear = new Vector2(shear, 0),
                             Masking = true,
                             MaskingSmoothness = 2,
                             EdgeEffect = new EdgeEffectParameters
@@ -105,6 +108,7 @@ namespace osu.Game.Graphics.UserInterface
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
+                            Shear = -shearing,
                         },
                     }
                 },
@@ -119,7 +123,6 @@ namespace osu.Game.Graphics.UserInterface
                         new Container
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Shear = new Vector2(shear, 0),
                             Masking = true,
                             MaskingSmoothness = 2,
                             EdgeEffect = new EdgeEffectParameters
@@ -144,6 +147,7 @@ namespace osu.Game.Graphics.UserInterface
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
+                            Shear = -shearing,
                         }
                     }
                 },
@@ -188,7 +192,6 @@ namespace osu.Game.Graphics.UserInterface
             var flash = new Box
             {
                 RelativeSizeAxes = Axes.Both,
-                Shear = new Vector2(shear, 0),
                 Colour = Color4.White.Opacity(0.5f),
             };
             Add(flash);


### PR DESCRIPTION
Fixes part of #3348.

Visual changes (text is better aligned & right button fixed):

Before:

![osu_2019-08-05_20-14-14](https://user-images.githubusercontent.com/35318437/62509214-293cd580-b7bf-11e9-8527-824364b42ccd.jpg)

After:

![osu_2019-08-05_20-20-07](https://user-images.githubusercontent.com/35318437/62509180-0ca09d80-b7bf-11e9-91cf-84a8052f1f84.jpg)

---