### PR TITLE
Move system user colour assignment to ensure consistency

### DIFF
--- a/osu.Game/Online/Chat/ErrorMessage.cs
+++ b/osu.Game/Online/Chat/ErrorMessage.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Online.Chat
         public ErrorMessage(string message)
             : base(message)
         {
-            Sender.Colour = @"ff0000";
+            // todo: this should likely be styled differently in the future.
         }
     }
 }

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -187,6 +187,7 @@ namespace osu.Game.Users
         public static readonly User SYSTEM_USER = new User
         {
             Username = "system",
+            Colour = @"9c0101",
             Id = 0
         };
 


### PR DESCRIPTION
The colour was being changed in `ErrorMessage` but his would persist to other (non-error) usages.

Leaving `ErrorMessage` class for future implementation.