### PR TITLE
Add ScreenTitleIcon class to allow code reuse of overlay header icons

### DIFF
--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Graphics.UserInterface
     {
         public const float ICON_WIDTH = ICON_SIZE + icon_spacing;
 
-        protected const float ICON_SIZE = 25;
+        public const float ICON_SIZE = 25;
 
         private SpriteIcon iconSprite;
         private readonly OsuSpriteText titleText, pageText;

--- a/osu.Game/Graphics/UserInterface/ScreenTitleIcon.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitleIcon.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Allocation;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Game/Graphics/UserInterface/ScreenTitleIcon.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitleIcon.cs
@@ -1,0 +1,61 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    /// <summary>
+    /// A custom icon class for use with <see cref="ScreenTitle.CreateIcon()"/>
+    /// </summary>
+    public class ScreenTitleIcon : CompositeDrawable
+    {
+        private const float circle_allowance = 0.8f;
+
+        private string icon;
+
+        public ScreenTitleIcon(string icon)
+        {
+            this.icon = icon;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures, OsuColour colours)
+        {
+            Size = new Vector2(ScreenTitle.ICON_SIZE / circle_allowance);
+
+            InternalChildren = new Drawable[]
+            {
+                new CircularContainer
+                {
+                    Masking = true,
+                    BorderColour = colours.Violet,
+                    BorderThickness = 3,
+                    MaskingSmoothness = 1,
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Sprite
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Texture = textures.Get(icon),
+                            Size = new Vector2(circle_allowance),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colours.Violet,
+                            Alpha = 0,
+                            AlwaysPresent = true,
+                        },
+                    }
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ScreenTitleIcon.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitleIcon.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Graphics.UserInterface
     {
         private const float circle_allowance = 0.8f;
 
-        private string icon;
+        private readonly string icon;
 
         public ScreenTitleIcon(string icon)
         {

--- a/osu.Game/Graphics/UserInterface/ScreenTitleTextureIcon.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitleTextureIcon.cs
@@ -12,17 +12,17 @@ using osuTK;
 namespace osu.Game.Graphics.UserInterface
 {
     /// <summary>
-    /// A custom icon class for use with <see cref="ScreenTitle.CreateIcon()"/>
+    /// A custom icon class for use with <see cref="ScreenTitle.CreateIcon()"/> based off a texture resource.
     /// </summary>
-    public class ScreenTitleIcon : CompositeDrawable
+    public class ScreenTitleTextureIcon : CompositeDrawable
     {
         private const float circle_allowance = 0.8f;
 
-        private readonly string icon;
+        private readonly string textureName;
 
-        public ScreenTitleIcon(string icon)
+        public ScreenTitleTextureIcon(string textureName)
         {
-            this.icon = icon;
+            this.textureName = textureName;
         }
 
         [BackgroundDependencyLoader]
@@ -44,7 +44,7 @@ namespace osu.Game.Graphics.UserInterface
                         new Sprite
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Texture = textures.Get(icon),
+                            Texture = textures.Get(textureName),
                             Size = new Vector2(circle_allowance),
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Overlays.Changelog
                 AccentColour = colours.Violet;
             }
 
-            protected override Drawable CreateIcon() => new ScreenTitleIcon(@"Icons/changelog");
+            protected override Drawable CreateIcon() => new ScreenTitleTextureIcon(@"Icons/changelog");
         }
     }
 }

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -7,13 +7,11 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
-using osuTK;
 
 namespace osu.Game.Overlays.Changelog
 {
@@ -123,48 +121,7 @@ namespace osu.Game.Overlays.Changelog
                 AccentColour = colours.Violet;
             }
 
-            protected override Drawable CreateIcon() => new ChangelogIcon();
-
-            internal class ChangelogIcon : CompositeDrawable
-            {
-                private const float circle_allowance = 0.8f;
-
-                [BackgroundDependencyLoader]
-                private void load(TextureStore textures, OsuColour colours)
-                {
-                    Size = new Vector2(ICON_SIZE / circle_allowance);
-
-                    InternalChildren = new Drawable[]
-                    {
-                        new CircularContainer
-                        {
-                            Masking = true,
-                            BorderColour = colours.Violet,
-                            BorderThickness = 3,
-                            MaskingSmoothness = 1,
-                            RelativeSizeAxes = Axes.Both,
-                            Children = new Drawable[]
-                            {
-                                new Sprite
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Texture = textures.Get(@"Icons/changelog"),
-                                    Size = new Vector2(circle_allowance),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                },
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = colours.Violet,
-                                    Alpha = 0,
-                                    AlwaysPresent = true,
-                                },
-                            }
-                        },
-                    };
-                }
-            }
+            protected override Drawable CreateIcon() => new ScreenTitleIcon(@"Icons/changelog");
         }
     }
 }


### PR DESCRIPTION
Mostly a change to reuse existing code for custom icons on overlay headers and avoid code duplication.

Needed for News overlay implementation coming soon.