### PR TITLE
Add more detail to log output when beatmap parsing errors occur

### DIFF
--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -60,5 +60,7 @@ namespace osu.Game.Beatmaps
     public class Beatmap : Beatmap<HitObject>
     {
         public new Beatmap Clone() => (Beatmap)base.Clone();
+
+        public override string ToString() => BeatmapInfo?.ToString();
     }
 }

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -61,6 +61,6 @@ namespace osu.Game.Beatmaps
     {
         public new Beatmap Clone() => (Beatmap)base.Clone();
 
-        public override string ToString() => BeatmapInfo?.ToString();
+        public override string ToString() => BeatmapInfo?.ToString() ?? base.ToString();
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Beatmaps.Formats
                 {
                     if (!Enum.TryParse(line.Substring(1, line.Length - 2), out section))
                     {
-                        Logger.Log($"Unknown section \"{line}\" in {output}");
+                        Logger.Log($"Unknown section \"{line}\" in \"{output}\"");
                         section = Section.None;
                     }
 
@@ -49,7 +49,7 @@ namespace osu.Game.Beatmaps.Formats
                 }
                 catch (Exception e)
                 {
-                    Logger.Log($"Failed to process line \"{line}\" into {output}: {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                    Logger.Log($"Failed to process line \"{line}\" into \"{output}\": {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
                 }
             }
         }


### PR DESCRIPTION
Closes #5679

Changes
```
Failed to process line "-1,1E+90,4,1,0,20,1,0" into osu.Game.Beatmaps.Beatmap: Value is too high
Failed to process line "40570,1E+90,4,1,0,20,1,0" into osu.Game.Beatmaps.Beatmap: Value is too high
Failed to process line "131950,-1E+90,1,2,70,10,1,0" into osu.Game.Beatmaps.Beatmap: Value is too low
```
to
```
Failed to process line "-1,1E+90,4,1,0,20,1,0" into LeaF - Aleph-0 (Pikaquim) [Omega + 1]: Value is too high
Failed to process line "40570,1E+90,4,1,0,20,1,0" into LeaF - Aleph-0 (Pikaquim) [Omega + 1]: Value is too high
Failed to process line "131950,-1E+90,1,2,70,10,1,0" into LeaF - Aleph-0 (Pikaquim) [Omega + 1]: Value is too low
```