### PR TITLE
Inline commands in chat

### DIFF
--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -60,5 +60,7 @@ namespace osu.Game.Beatmaps
     public class Beatmap : Beatmap<HitObject>
     {
         public new Beatmap Clone() => (Beatmap)base.Clone();
+
+        public override string ToString() => BeatmapInfo?.ToString() ?? base.ToString();
     }
 }

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -60,7 +60,5 @@ namespace osu.Game.Beatmaps
     public class Beatmap : Beatmap<HitObject>
     {
         public new Beatmap Clone() => (Beatmap)base.Clone();
-
-        public override string ToString() => BeatmapInfo?.ToString() ?? base.ToString();
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Beatmaps.Formats
                 {
                     if (!Enum.TryParse(line.Substring(1, line.Length - 2), out section))
                     {
-                        Logger.Log($"Unknown section \"{line}\" in {output}");
+                        Logger.Log($"Unknown section \"{line}\" in \"{output}\"");
                         section = Section.None;
                     }
 
@@ -49,7 +49,7 @@ namespace osu.Game.Beatmaps.Formats
                 }
                 catch (Exception e)
                 {
-                    Logger.Log($"Failed to process line \"{line}\" into {output}: {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                    Logger.Log($"Failed to process line \"{line}\" into \"{output}\": {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
                 }
             }
         }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Beatmaps.Formats
                 {
                     if (!Enum.TryParse(line.Substring(1, line.Length - 2), out section))
                     {
-                        Logger.Log($"Unknown section \"{line}\" in \"{output}\"");
+                        Logger.Log($"Unknown section \"{line}\" in {output}");
                         section = Section.None;
                     }
 
@@ -49,7 +49,7 @@ namespace osu.Game.Beatmaps.Formats
                 }
                 catch (Exception e)
                 {
-                    Logger.Log($"Failed to process line \"{line}\" into \"{output}\": {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                    Logger.Log($"Failed to process line \"{line}\" into {output}: {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
                 }
             }
         }

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -4,12 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
-using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Chat.Tabs;
@@ -34,7 +32,6 @@ namespace osu.Game.Online.Chat
 
         private readonly BindableList<Channel> availableChannels = new BindableList<Channel>();
         private readonly BindableList<Channel> joinedChannels = new BindableList<Channel>();
-        private readonly Bindable<WorkingBeatmap> currentBeatmap = new Bindable<WorkingBeatmap>();
 
         /// <summary>
         /// The currently opened channel
@@ -62,12 +59,12 @@ namespace osu.Game.Online.Chat
             HighPollRate.BindValueChanged(enabled => TimeBetweenPolls = enabled.NewValue ? 1000 : 6000, true);
         }
 
-            /// <summary>
-            /// Opens a channel or switches to the channel if already opened.
-            /// </summary>
-            /// <exception cref="ChannelNotFoundException">If the name of the specifed channel was not found this exception will be thrown.</exception>
-            /// <param name="name"></param>
-            public void OpenChannel(string name)
+        /// <summary>
+        /// Opens a channel or switches to the channel if already opened.
+        /// </summary>
+        /// <exception cref="ChannelNotFoundException">If the name of the specifed channel was not found this exception will be thrown.</exception>
+        /// <param name="name"></param>
+        public void OpenChannel(string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -101,25 +98,6 @@ namespace osu.Game.Online.Chat
         /// Ensure we run post actions in sequence, once at a time.
         /// </summary>
         private readonly Queue<Action> postQueue = new Queue<Action>();
-
-        public string ProcessInlineCommands(string text) {
-
-            return Regex.Replace(text, @"\$[a-zA-Z0-9]+", delegate(Match match) {
-                string cmd = match.Value.Substring(1, match.Value.Length - 1);
-                switch (cmd) {
-                    case "np":
-                        BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
-                        return String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
-
-                    case "pp":
-                        if(api.LocalUser != null)
-                            return api.LocalUser.Value.Statistics.PP.ToString();
-                        return text;
-                    default:
-                        return match.Value;
-                }
-            });
-        }
 
         /// <summary>
         /// Posts a message to the currently opened channel.
@@ -256,12 +234,6 @@ namespace osu.Game.Online.Chat
 
                 case "help":
                     target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel]"));
-                    break;
-
-                case "np":
-                    BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
-                    string beatmapLink = String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
-                    target.AddNewMessages(new InfoMessage(String.Format("Now playing command :) {0}", beatmapLink)));
                     break;
 
                 default:
@@ -474,10 +446,9 @@ namespace osu.Game.Online.Chat
         }
 
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api, Bindable<WorkingBeatmap> beatmap)
+        private void load(IAPIProvider api)
         {
             this.api = api;
-            this.currentBeatmap.BindTo(beatmap);
         }
     }
 

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Chat.Tabs;
@@ -32,6 +34,7 @@ namespace osu.Game.Online.Chat
 
         private readonly BindableList<Channel> availableChannels = new BindableList<Channel>();
         private readonly BindableList<Channel> joinedChannels = new BindableList<Channel>();
+        private readonly Bindable<WorkingBeatmap> currentBeatmap = new Bindable<WorkingBeatmap>();
 
         /// <summary>
         /// The currently opened channel
@@ -59,12 +62,12 @@ namespace osu.Game.Online.Chat
             HighPollRate.BindValueChanged(enabled => TimeBetweenPolls = enabled.NewValue ? 1000 : 6000, true);
         }
 
-        /// <summary>
-        /// Opens a channel or switches to the channel if already opened.
-        /// </summary>
-        /// <exception cref="ChannelNotFoundException">If the name of the specifed channel was not found this exception will be thrown.</exception>
-        /// <param name="name"></param>
-        public void OpenChannel(string name)
+            /// <summary>
+            /// Opens a channel or switches to the channel if already opened.
+            /// </summary>
+            /// <exception cref="ChannelNotFoundException">If the name of the specifed channel was not found this exception will be thrown.</exception>
+            /// <param name="name"></param>
+            public void OpenChannel(string name)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
@@ -98,6 +101,25 @@ namespace osu.Game.Online.Chat
         /// Ensure we run post actions in sequence, once at a time.
         /// </summary>
         private readonly Queue<Action> postQueue = new Queue<Action>();
+
+        public string ProcessInlineCommands(string text) {
+
+            return Regex.Replace(text, @"\$[a-zA-Z0-9]+", delegate(Match match) {
+                string cmd = match.Value.Substring(1, match.Value.Length - 1);
+                switch (cmd) {
+                    case "np":
+                        BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
+                        return String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
+
+                    case "pp":
+                        if(api.LocalUser != null)
+                            return api.LocalUser.Value.Statistics.PP.ToString();
+                        return text;
+                    default:
+                        return match.Value;
+                }
+            });
+        }
 
         /// <summary>
         /// Posts a message to the currently opened channel.
@@ -234,6 +256,12 @@ namespace osu.Game.Online.Chat
 
                 case "help":
                     target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel]"));
+                    break;
+
+                case "np":
+                    BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
+                    string beatmapLink = String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
+                    target.AddNewMessages(new InfoMessage(String.Format("Now playing command :) {0}", beatmapLink)));
                     break;
 
                 default:
@@ -446,9 +474,10 @@ namespace osu.Game.Online.Chat
         }
 
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api)
+        private void load(IAPIProvider api, Bindable<WorkingBeatmap> beatmap)
         {
             this.api = api;
+            this.currentBeatmap.BindTo(beatmap);
         }
     }
 

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -34,7 +33,7 @@ namespace osu.Game.Online.Chat
 
         private readonly BindableList<Channel> availableChannels = new BindableList<Channel>();
         private readonly BindableList<Channel> joinedChannels = new BindableList<Channel>();
-        private readonly Bindable<WorkingBeatmap> currentBeatmap = new Bindable<WorkingBeatmap>();
+        private readonly IBindable<WorkingBeatmap> currentBeatmap = new Bindable<WorkingBeatmap>();
 
         /// <summary>
         /// The currently opened channel
@@ -101,28 +100,6 @@ namespace osu.Game.Online.Chat
         /// Ensure we run post actions in sequence, once at a time.
         /// </summary>
         private readonly Queue<Action> postQueue = new Queue<Action>();
-
-        /// <summary>
-        /// Scans for inline commands of the form $cmd and returns the newly processed text
-        /// </summary>
-        public string ProcessInlineCommands(string text) {
-
-            return Regex.Replace(text, @"\$[a-zA-Z0-9]+", delegate(Match match) {
-                string cmd = match.Value.Substring(1, match.Value.Length - 1);
-                switch (cmd) {
-                    case "np":
-                        BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
-                        return String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
-
-                    case "pp":
-                        if(api.LocalUser != null)
-                            return api.LocalUser.Value.Statistics.PP.ToString();
-                        return text;
-                    default:
-                        return match.Value;
-                }
-            });
-        }
 
         /// <summary>
         /// Posts a message to the currently opened channel.
@@ -263,8 +240,7 @@ namespace osu.Game.Online.Chat
 
                 case "np":
                     BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
-                    string beatmapLink = String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
-                    target.AddNewMessages(new InfoMessage(String.Format("Now playing command :) {0}", beatmapLink)));
+                    PostMessage($"is playing [https://osu.ppy.sh/b/{beatmapInfo.OnlineBeatmapID} {beatmapInfo.ToString()}]");
                     break;
 
                 default:

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Chat.Tabs;
@@ -32,6 +34,7 @@ namespace osu.Game.Online.Chat
 
         private readonly BindableList<Channel> availableChannels = new BindableList<Channel>();
         private readonly BindableList<Channel> joinedChannels = new BindableList<Channel>();
+        private readonly Bindable<WorkingBeatmap> currentBeatmap = new Bindable<WorkingBeatmap>();
 
         /// <summary>
         /// The currently opened channel
@@ -98,6 +101,28 @@ namespace osu.Game.Online.Chat
         /// Ensure we run post actions in sequence, once at a time.
         /// </summary>
         private readonly Queue<Action> postQueue = new Queue<Action>();
+
+        /// <summary>
+        /// Scans for inline commands of the form $cmd and returns the newly processed text
+        /// </summary>
+        public string ProcessInlineCommands(string text) {
+
+            return Regex.Replace(text, @"\$[a-zA-Z0-9]+", delegate(Match match) {
+                string cmd = match.Value.Substring(1, match.Value.Length - 1);
+                switch (cmd) {
+                    case "np":
+                        BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
+                        return String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
+
+                    case "pp":
+                        if(api.LocalUser != null)
+                            return api.LocalUser.Value.Statistics.PP.ToString();
+                        return text;
+                    default:
+                        return match.Value;
+                }
+            });
+        }
 
         /// <summary>
         /// Posts a message to the currently opened channel.
@@ -234,6 +259,12 @@ namespace osu.Game.Online.Chat
 
                 case "help":
                     target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel]"));
+                    break;
+
+                case "np":
+                    BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
+                    string beatmapLink = String.Format("({0} - {1} mapped by {2})[https://osu.ppy.sh/b/{3}]", beatmapInfo.Metadata.Artist, beatmapInfo.Metadata.Title, beatmapInfo.Metadata.Author, beatmapInfo.OnlineBeatmapID);
+                    target.AddNewMessages(new InfoMessage(String.Format("Now playing command :) {0}", beatmapLink)));
                     break;
 
                 default:
@@ -446,9 +477,10 @@ namespace osu.Game.Online.Chat
         }
 
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api)
+        private void load(IAPIProvider api, Bindable<WorkingBeatmap> beatmap)
         {
             this.api = api;
+            this.currentBeatmap.BindTo(beatmap);
         }
     }
 

--- a/osu.Game/Online/Chat/MessagePreprocessor.cs
+++ b/osu.Game/Online/Chat/MessagePreprocessor.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text.RegularExpressions;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game/Online/Chat/MessagePreprocessor.cs
+++ b/osu.Game/Online/Chat/MessagePreprocessor.cs
@@ -1,0 +1,41 @@
+﻿
+using System.Text.RegularExpressions;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Online.Chat
+{
+    public class MessagePreprocessor: Component
+    {
+        private readonly IBindable<WorkingBeatmap> currentBeatmap = new Bindable<WorkingBeatmap>();
+
+        public string PreProcess(string text)
+        {
+            if (!text.Contains("$"))
+                return text;
+
+            return Regex.Replace(text, @"\$[a-zA-Z0-9]+", delegate (Match match)
+            {
+                string cmd = match.Value.Substring(1, match.Value.Length - 1);
+
+                switch (cmd)
+                {
+                    case "np":
+                        BeatmapInfo beatmapInfo = currentBeatmap.Value.Beatmap.BeatmapInfo;
+                        return $"[https://osu.ppy.sh/b/{beatmapInfo.OnlineBeatmapID} {beatmapInfo.ToString()}]";
+
+                    default:
+                        return match.Value;
+                }
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(Bindable<WorkingBeatmap> beatmap)
+        {
+            this.currentBeatmap.BindTo(beatmap);
+        }
+    }
+}

--- a/osu.Game/Online/Chat/MessagePreprocessor.cs
+++ b/osu.Game/Online/Chat/MessagePreprocessor.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Chat;
 using osuTK.Graphics;
@@ -22,13 +21,13 @@ namespace osu.Game.Online.Chat
     {
         public readonly Bindable<Channel> Channel = new Bindable<Channel>();
 
-        private Bindable<WorkingBeatmap> current_beatmap = new Bindable<WorkingBeatmap>();
-
         public Action Exit;
 
         private readonly FocusedTextBox textbox;
 
         protected ChannelManager ChannelManager;
+
+        private MessagePreprocessor messagePreprocessor;
 
         private DrawableChannel drawableChannel;
 
@@ -77,9 +76,9 @@ namespace osu.Game.Online.Chat
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(ChannelManager manager, Bindable<WorkingBeatmap> beatmap)
+        private void load(ChannelManager manager, MessagePreprocessor messagePreprocessor)
         {
-            current_beatmap = beatmap;
+            this.messagePreprocessor = messagePreprocessor;
             if (ChannelManager == null)
                 ChannelManager = manager;
         }
@@ -93,10 +92,9 @@ namespace osu.Game.Online.Chat
 
             if (text[0] == '/')
                 ChannelManager?.PostCommand(text.Substring(1), Channel.Value);
-            else {
-                text = ChannelManager?.ProcessInlineCommands(text);
-                ChannelManager?.PostMessage(text, target: Channel.Value);
-            }
+            else
+                ChannelManager?.PostMessage(messagePreprocessor?.PreProcess(text), target: Channel.Value);
+
             textbox.Text = string.Empty;
         }
 

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Chat;
 using osuTK.Graphics;
@@ -21,8 +20,6 @@ namespace osu.Game.Online.Chat
     public class StandAloneChatDisplay : CompositeDrawable
     {
         public readonly Bindable<Channel> Channel = new Bindable<Channel>();
-
-        private Bindable<WorkingBeatmap> current_beatmap = new Bindable<WorkingBeatmap>();
 
         public Action Exit;
 
@@ -77,9 +74,8 @@ namespace osu.Game.Online.Chat
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(ChannelManager manager, Bindable<WorkingBeatmap> beatmap)
+        private void load(ChannelManager manager)
         {
-            current_beatmap = beatmap;
             if (ChannelManager == null)
                 ChannelManager = manager;
         }
@@ -93,10 +89,9 @@ namespace osu.Game.Online.Chat
 
             if (text[0] == '/')
                 ChannelManager?.PostCommand(text.Substring(1), Channel.Value);
-            else {
-                text = ChannelManager?.ProcessInlineCommands(text);
+            else
                 ChannelManager?.PostMessage(text, target: Channel.Value);
-            }
+
             textbox.Text = string.Empty;
         }
 

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Chat;
 using osuTK.Graphics;
@@ -20,6 +21,8 @@ namespace osu.Game.Online.Chat
     public class StandAloneChatDisplay : CompositeDrawable
     {
         public readonly Bindable<Channel> Channel = new Bindable<Channel>();
+
+        private Bindable<WorkingBeatmap> current_beatmap = new Bindable<WorkingBeatmap>();
 
         public Action Exit;
 
@@ -74,8 +77,9 @@ namespace osu.Game.Online.Chat
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(ChannelManager manager)
+        private void load(ChannelManager manager, Bindable<WorkingBeatmap> beatmap)
         {
+            current_beatmap = beatmap;
             if (ChannelManager == null)
                 ChannelManager = manager;
         }
@@ -89,9 +93,10 @@ namespace osu.Game.Online.Chat
 
             if (text[0] == '/')
                 ChannelManager?.PostCommand(text.Substring(1), Channel.Value);
-            else
+            else {
+                text = ChannelManager?.ProcessInlineCommands(text);
                 ChannelManager?.PostMessage(text, target: Channel.Value);
-
+            }
             textbox.Text = string.Empty;
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -58,6 +58,8 @@ namespace osu.Game
 
         private ChannelManager channelManager;
 
+        private MessagePreprocessor messagePreprocessor;
+
         private NotificationOverlay notifications;
 
         private DirectOverlay direct;
@@ -482,6 +484,7 @@ namespace osu.Game
             loadComponentSingleFile(direct = new DirectOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(social = new SocialOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(channelManager = new ChannelManager(), AddInternal, true);
+            loadComponentSingleFile(messagePreprocessor = new MessagePreprocessor(), AddInternal, true);
             loadComponentSingleFile(chatOverlay = new ChatOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(settings = new SettingsOverlay { GetToolbarHeight = () => ToolbarOffset }, leftFloatingOverlayContent.Add, true);
             var changelogOverlay = loadComponentSingleFile(new ChangelogOverlay(), overlayContent.Add, true);

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Overlays
 
         private FocusedTextBox textbox;
 
+        private MessagePreprocessor messagePreprocessor;
+
         private const int transition_length = 500;
 
         public const float DEFAULT_HEIGHT = 0.4f;
@@ -71,8 +73,9 @@ namespace osu.Game.Overlays
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, OsuColour colours, ChannelManager channelManager)
+        private void load(OsuConfigManager config, OsuColour colours, ChannelManager channelManager, MessagePreprocessor messagePreprocessor)
         {
+            this.messagePreprocessor = messagePreprocessor;
             const float padding = 5;
 
             Children = new Drawable[]
@@ -425,10 +428,9 @@ namespace osu.Game.Overlays
 
             if (text[0] == '/')
                 channelManager.PostCommand(text.Substring(1));
-            else {
-                text = channelManager.ProcessInlineCommands(text);
-                channelManager.PostMessage(text);
-            }
+            else
+                channelManager.PostMessage(messagePreprocessor.PreProcess(text));
+
             textbox.Text = string.Empty;
         }
 

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -425,9 +425,10 @@ namespace osu.Game.Overlays
 
             if (text[0] == '/')
                 channelManager.PostCommand(text.Substring(1));
-            else
+            else {
+                text = channelManager.ProcessInlineCommands(text);
                 channelManager.PostMessage(text);
-
+            }
             textbox.Text = string.Empty;
         }
 

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -425,10 +425,9 @@ namespace osu.Game.Overlays
 
             if (text[0] == '/')
                 channelManager.PostCommand(text.Substring(1));
-            else {
-                text = channelManager.ProcessInlineCommands(text);
+            else
                 channelManager.PostMessage(text);
-            }
+
             textbox.Text = string.Empty;
         }
 


### PR DESCRIPTION
From the following issue : https://github.com/ppy/osu/issues/5675

Commands can be written in chat with a leading "$" and they are processed inline. Below an example with the functionality of the /np command inline and a new command $pp that gives your current pp's. Also I implemented the old /np command

![Untitled](https://user-images.githubusercontent.com/8768822/62838407-50dee280-bc84-11e9-9a4c-6a1b346e6f03.png)
