### PR TITLE
Update textbox usages in line with TabbableContentContainer changes

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Graphics.UserInterface
 
         public OsuPasswordTextBox()
         {
-            Add(warning = new CapsWarning
+            AddInternal(warning = new CapsWarning
             {
                 Size = new Vector2(20),
                 Origin = Anchor.CentreRight,

--- a/osu.Game/Graphics/UserInterface/SearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/SearchTextBox.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Graphics.UserInterface
         public SearchTextBox()
         {
             Height = 35;
-            AddRange(new Drawable[]
+            AddRangeInternal(new Drawable[]
             {
                 new SpriteIcon
                 {

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -47,81 +47,82 @@ namespace osu.Game.Overlays.AccountCreation
             this.api = api;
             this.host = host;
 
-            InternalChildren = new Drawable[]
+            InternalChild = new TabbableContentContainer
             {
-                new FillFlowContainer
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    Padding = new MarginPadding(20),
-                    Spacing = new Vector2(0, 10),
-                    Children = new Drawable[]
+                    new FillFlowContainer
                     {
-                        new OsuSpriteText
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Padding = new MarginPadding(20),
+                        Spacing = new Vector2(0, 10),
+                        Children = new Drawable[]
                         {
-                            Margin = new MarginPadding { Vertical = 10 },
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            Font = OsuFont.GetFont(size: 20),
-                            Text = "Let's create an account!",
-                        },
-                        usernameTextBox = new OsuTextBox
-                        {
-                            PlaceholderText = "username",
-                            RelativeSizeAxes = Axes.X,
-                            TabbableContentContainer = this
-                        },
-                        usernameDescription = new ErrorTextFlowContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y
-                        },
-                        emailTextBox = new OsuTextBox
-                        {
-                            PlaceholderText = "email address",
-                            RelativeSizeAxes = Axes.X,
-                            TabbableContentContainer = this
-                        },
-                        emailAddressDescription = new ErrorTextFlowContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y
-                        },
-                        passwordTextBox = new OsuPasswordTextBox
-                        {
-                            PlaceholderText = "password",
-                            RelativeSizeAxes = Axes.X,
-                            TabbableContentContainer = this,
-                        },
-                        passwordDescription = new ErrorTextFlowContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Children = new Drawable[]
+                            new OsuSpriteText
                             {
-                                registerShake = new ShakeContainer
+                                Margin = new MarginPadding { Vertical = 10 },
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                Font = OsuFont.GetFont(size: 20),
+                                Text = "Let's create an account!",
+                            },
+                            usernameTextBox = new OsuTextBox
+                            {
+                                PlaceholderText = "username",
+                                RelativeSizeAxes = Axes.X,
+                            },
+                            usernameDescription = new ErrorTextFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y
+                            },
+                            emailTextBox = new OsuTextBox
+                            {
+                                PlaceholderText = "email address",
+                                RelativeSizeAxes = Axes.X,
+                            },
+                            emailAddressDescription = new ErrorTextFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y
+                            },
+                            passwordTextBox = new OsuPasswordTextBox
+                            {
+                                PlaceholderText = "password",
+                                RelativeSizeAxes = Axes.X,
+                            },
+                            passwordDescription = new ErrorTextFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Children = new Drawable[]
                                 {
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                    Child = new SettingsButton
+                                    registerShake = new ShakeContainer
                                     {
-                                        Text = "Register",
-                                        Margin = new MarginPadding { Vertical = 20 },
-                                        Action = performRegistration
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Child = new SettingsButton
+                                        {
+                                            Text = "Register",
+                                            Margin = new MarginPadding { Vertical = 20 },
+                                            Action = performRegistration
+                                        }
                                     }
                                 }
-                            }
+                            },
                         },
                     },
-                },
-                processingOverlay = new ProcessingOverlay { Alpha = 0 }
+                    processingOverlay = new ProcessingOverlay { Alpha = 0 }
+                }
             };
 
             textboxes = new[] { usernameTextBox, emailTextBox, passwordTextBox };
@@ -135,7 +136,11 @@ namespace osu.Game.Overlays.AccountCreation
             characterCheckText = passwordDescription.AddText("8 characters long");
             passwordDescription.AddText(". Choose something long but also something you will remember, like a line from your favourite song.");
 
-            passwordTextBox.Current.ValueChanged += password => { characterCheckText.ForEach(s => s.Colour = password.NewValue.Length == 0 ? Color4.White : Interpolation.ValueAt(password.NewValue.Length, Color4.OrangeRed, Color4.YellowGreen, 0, 8, Easing.In)); };
+            passwordTextBox.Current.ValueChanged += password =>
+            {
+                characterCheckText.ForEach(s =>
+                    s.Colour = password.NewValue.Length == 0 ? Color4.White : Interpolation.ValueAt(password.NewValue.Length, Color4.OrangeRed, Color4.YellowGreen, 0, 8, Easing.In));
+            };
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/LoginOverlay.cs
+++ b/osu.Game/Overlays/LoginOverlay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays
                             Colour = Color4.Black,
                             Alpha = 0.6f,
                         },
-                        new Container
+                        new TabbableContentContainer
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -225,13 +225,11 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         PlaceholderText = "email address",
                         RelativeSizeAxes = Axes.X,
                         Text = api?.ProvidedUsername ?? string.Empty,
-                        TabbableContentContainer = this
                     },
                     password = new OsuPasswordTextBox
                     {
                         PlaceholderText = "password",
                         RelativeSizeAxes = Axes.X,
-                        TabbableContentContainer = this,
                         OnCommit = (sender, newText) => performLogin()
                     },
                     new SettingsCheckbox

--- a/osu.Game/Screens/Edit/Setup/Components/LabelledComponents/LabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/Components/LabelledComponents/LabelledTextBox.cs
@@ -98,13 +98,12 @@ namespace osu.Game.Screens.Edit.Setup.Components.LabelledComponents
                                     Colour = Color4.White,
                                     Font = OsuFont.GetFont(size: default_label_text_size, weight: FontWeight.Bold),
                                 },
-                                textBox = new OsuTextBox
+                                textBox = new RoundedTextBox
                                 {
                                     Anchor = Anchor.TopLeft,
                                     Origin = Anchor.TopLeft,
                                     RelativeSizeAxes = Axes.Both,
                                     Height = 1,
-                                    CornerRadius = corner_radius,
                                 },
                             },
                         },
@@ -120,10 +119,18 @@ namespace osu.Game.Screens.Edit.Setup.Components.LabelledComponents
             textBox.OnCommit += OnCommit;
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private class RoundedTextBox : OsuTextBox
         {
-            textBox.BorderColour = colours.Blue;
+            public RoundedTextBox()
+            {
+                CornerRadius = corner_radius;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                BorderColour = colours.Blue;
+            }
         }
     }
 }

--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                                     RelativeSizeAxes = Axes.Both,
                                     Children = new[]
                                     {
-                                        new Container
+                                        new TabbableContentContainer
                                         {
                                             Padding = new MarginPadding { Horizontal = SearchableListOverlay.WIDTH_PADDING },
                                             RelativeSizeAxes = Axes.X,
@@ -119,7 +119,6 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                             Child = NameField = new SettingsTextBox
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
-                                                                TabbableContentContainer = this,
                                                                 OnCommit = (sender, text) => apply(),
                                                             },
                                                         },
@@ -170,7 +169,6 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                             Child = MaxParticipantsField = new SettingsNumberTextBox
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
-                                                                TabbableContentContainer = this,
                                                                 ReadOnly = true,
                                                                 OnCommit = (sender, text) => apply()
                                                             },
@@ -201,7 +199,6 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                             Child = new SettingsPasswordTextBox
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
-                                                                TabbableContentContainer = this,
                                                                 ReadOnly = true,
                                                                 OnCommit = (sender, text) => apply()
                                                             },


### PR DESCRIPTION
 - [ ] Depends on https://github.com/ppy/osu-framework/pull/2757

osu-side PR to adjust for the changes to `TextBox`, which is now a `CompositeDrawable`.