### PR TITLE
Fix newlines being considered in user profile content

### DIFF
--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -138,6 +138,9 @@ namespace osu.Game.Overlays.Profile.Header
 
         private void tryAddInfo(IconUsage icon, string content, string link = null)
         {
+            // newlines could be contained in API returned user content.
+            content = content?.Replace("\n", " ");
+
             if (string.IsNullOrEmpty(content)) return;
 
             bottomLinkContainer.AddIcon(icon, text =>

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -138,10 +138,10 @@ namespace osu.Game.Overlays.Profile.Header
 
         private void tryAddInfo(IconUsage icon, string content, string link = null)
         {
-            // newlines could be contained in API returned user content.
-            content = content?.Replace("\n", " ");
-
             if (string.IsNullOrEmpty(content)) return;
+
+            // newlines could be contained in API returned user content.
+            content = content.Replace("\n", " ");
 
             bottomLinkContainer.AddIcon(icon, text =>
             {


### PR DESCRIPTION
Applying a local fix for now. May change in the future as we decide how to better strip these server-side.