### PR TITLE
Fix LegacySkin not checking for @2x hitcircle when deciding sizing

### DIFF
--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Skinning
             Samples = audioManager.GetSampleStore(storage);
             Textures = new TextureStore(new TextureLoaderStore(storage));
 
-            using (var testStream = storage.GetStream("hitcircle"))
+            using (var testStream = storage.GetStream("hitcircle@2x") ?? storage.GetStream("hitcircle"))
                 hasHitCircle |= testStream != null;
 
             if (hasHitCircle)


### PR DESCRIPTION
Regressed tests (and potentially skins with no @2x hitcircle element).