### PR TITLE
Disallow adding bonus judgements to statistics

### DIFF
--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -325,9 +325,6 @@ namespace osu.Game.Rulesets.Scoring
 
             JudgedHits++;
 
-            if (result.Type != HitResult.None)
-                scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) + 1;
-
             if (result.Judgement.AffectsCombo)
             {
                 switch (result.Type)
@@ -352,6 +349,9 @@ namespace osu.Game.Rulesets.Scoring
             }
             else
             {
+                if (result.HasResult)
+                    scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) + 1;
+
                 baseScore += result.Judgement.NumericResultFor(result);
                 rollingMaxBaseScore += result.Judgement.MaxNumericResult;
             }
@@ -371,9 +371,6 @@ namespace osu.Game.Rulesets.Scoring
 
             JudgedHits--;
 
-            if (result.Type != HitResult.None)
-                scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) - 1;
-
             if (result.Judgement.IsBonus)
             {
                 if (result.IsHit)
@@ -381,6 +378,9 @@ namespace osu.Game.Rulesets.Scoring
             }
             else
             {
+                if (result.HasResult)
+                    scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) - 1;
+
                 baseScore -= result.Judgement.NumericResultFor(result);
                 rollingMaxBaseScore -= result.Judgement.MaxNumericResult;
             }


### PR DESCRIPTION
Matching stable behavior, bonus results should not count as they don't affect combo.