### PR TITLE
Use correct type for value of text transforms

### DIFF
--- a/osu.Game/Graphics/Sprites/OsuSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/OsuSpriteText.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.Sprites
 {
@@ -22,7 +23,7 @@ namespace osu.Game.Graphics.Sprites
         /// Sets <see cref="OsuSpriteText.Text"/> to a new value after a duration.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformTextTo<T>(this T spriteText, string newText, double duration = 0, Easing easing = Easing.None)
+        public static TransformSequence<T> TransformTextTo<T>(this T spriteText, LocalisedString newText, double duration = 0, Easing easing = Easing.None)
             where T : OsuSpriteText
             => spriteText.TransformTo(nameof(OsuSpriteText.Text), newText, duration, easing);
 
@@ -30,7 +31,7 @@ namespace osu.Game.Graphics.Sprites
         /// Sets <see cref="OsuSpriteText.Text"/> to a new value after a duration.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformTextTo<T>(this TransformSequence<T> t, string newText, double duration = 0, Easing easing = Easing.None)
+        public static TransformSequence<T> TransformTextTo<T>(this TransformSequence<T> t, LocalisedString newText, double duration = 0, Easing easing = Easing.None)
             where T : OsuSpriteText
             => t.Append(o => o.TransformTextTo(newText, duration, easing));
     }


### PR DESCRIPTION
- Fixes text transforms throwing invalid operation exception.
- [ ] Depends on ppy/osu-framework#2783