### PR TITLE
Allow for difficulty icon to have content added near the icon

### DIFF
--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -19,23 +19,33 @@ using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
-    public class DifficultyIcon : Container, IHasCustomTooltip
+    public class DifficultyIcon : CompositeDrawable, IHasCustomTooltip
     {
         private readonly BeatmapInfo beatmap;
         private readonly RulesetInfo ruleset;
 
+        private readonly Container iconContainer;
+
+        /// <summary>
+        /// Size of this difficulty icon.
+        /// </summary>
+        public new Vector2 Size
+        {
+            get => iconContainer.Size;
+            set => iconContainer.Size = value;
+        }
+
         public DifficultyIcon(BeatmapInfo beatmap, RulesetInfo ruleset = null, bool shouldShowTooltip = true)
         {
-            if (beatmap == null)
-                throw new ArgumentNullException(nameof(beatmap));
-
-            this.beatmap = beatmap;
+            this.beatmap = beatmap ?? throw new ArgumentNullException(nameof(beatmap));
 
             this.ruleset = ruleset ?? beatmap.Ruleset;
             if (shouldShowTooltip)
                 TooltipContent = beatmap;
 
-            Size = new Vector2(20);
+            AutoSizeAxes = Axes.Both;
+
+            InternalChild = iconContainer = new Container { Size = new Vector2(20f) };
         }
 
         public string TooltipText { get; set; }
@@ -47,7 +57,7 @@ namespace osu.Game.Beatmaps.Drawables
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            Children = new Drawable[]
+            iconContainer.Children = new Drawable[]
             {
                 new CircularContainer
                 {


### PR DESCRIPTION
- Moves the icon inside a container such that it can be inherited to other types of difficulty icons and add content to it (e.g. `GroupedDifficultyIcon` adding a counter near the icon)