### PR TITLE
Implement grouped difficulty icons

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Direct;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Osu;
 using osu.Game.Users;
 using osuTK;
 
@@ -24,7 +23,7 @@ namespace osu.Game.Tests.Visual.Online
             typeof(IconPill)
         };
 
-        private BeatmapSetInfo getUndownloadableBeatmapSet(RulesetInfo ruleset) => new BeatmapSetInfo
+        private BeatmapSetInfo getUndownloadableBeatmapSet() => new BeatmapSetInfo
         {
             OnlineBeatmapSetID = 123,
             Metadata = new BeatmapMetadata
@@ -56,23 +55,62 @@ namespace osu.Game.Tests.Visual.Online
             {
                 new BeatmapInfo
                 {
-                    Ruleset = ruleset,
+                    Ruleset = Ruleset.Value,
                     Version = "Test",
                     StarDifficulty = 6.42,
                 }
             }
         };
 
-        [BackgroundDependencyLoader]
-        private void load()
+        private BeatmapSetInfo getManyDifficultiesBeatmapSet(RulesetStore rulesets)
         {
-            var ruleset = new OsuRuleset().RulesetInfo;
+            var beatmaps = new List<BeatmapInfo>();
 
-            var normal = CreateWorkingBeatmap(ruleset).BeatmapSetInfo;
+            for (int i = 0; i < 100; i++)
+            {
+                beatmaps.Add(new BeatmapInfo
+                {
+                    Ruleset = rulesets.GetRuleset(i % 4),
+                    StarDifficulty = 2 + i % 4 * 2,
+                    BaseDifficulty = new BeatmapDifficulty
+                    {
+                        OverallDifficulty = 3.5f,
+                    }
+                });
+            }
+
+            return new BeatmapSetInfo
+            {
+                OnlineBeatmapSetID = 1,
+                Metadata = new BeatmapMetadata
+                {
+                    Title = "many difficulties beatmap",
+                    Artist = "test",
+                    Author = new User
+                    {
+                        Username = "BanchoBot",
+                        Id = 3,
+                    }
+                },
+                OnlineInfo = new BeatmapSetOnlineInfo
+                {
+                    HasVideo = true,
+                    HasStoryboard = true,
+                    Covers = new BeatmapSetOnlineCovers(),
+                },
+                Beatmaps = beatmaps,
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(RulesetStore rulesets)
+        {
+            var normal = CreateWorkingBeatmap(Ruleset.Value).BeatmapSetInfo;
             normal.OnlineInfo.HasVideo = true;
             normal.OnlineInfo.HasStoryboard = true;
 
-            var undownloadable = getUndownloadableBeatmapSet(ruleset);
+            var undownloadable = getUndownloadableBeatmapSet();
+            var manyDifficulties = getManyDifficultiesBeatmapSet(rulesets);
 
             Child = new BasicScrollContainer
             {
@@ -81,15 +119,17 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
+                    Direction = FillDirection.Full,
                     Padding = new MarginPadding(20),
-                    Spacing = new Vector2(0, 20),
+                    Spacing = new Vector2(5, 20),
                     Children = new Drawable[]
                     {
                         new DirectGridPanel(normal),
-                        new DirectListPanel(normal),
                         new DirectGridPanel(undownloadable),
+                        new DirectGridPanel(manyDifficulties),
+                        new DirectListPanel(normal),
                         new DirectListPanel(undownloadable),
+                        new DirectListPanel(manyDifficulties),
                     },
                 },
             };

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -516,6 +516,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     OnlineBeatmapID = b * 10,
                     Path = $"extra{b}.osu",
                     Version = $"Extra {b}",
+                    Ruleset = rulesets.GetRuleset((b - 1) % 4),
                     StarDifficulty = 2,
                     BaseDifficulty = new BeatmapDifficulty
                     {

--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -21,10 +22,22 @@ namespace osu.Game.Beatmaps.Drawables
 {
     public class DifficultyIcon : CompositeDrawable, IHasCustomTooltip
     {
-        private readonly BeatmapInfo beatmap;
-        private readonly RulesetInfo ruleset;
+        private BeatmapInfo beatmap;
 
         private readonly Container iconContainer;
+        private readonly Box iconBg;
+
+        protected BeatmapInfo Beatmap
+        {
+            get => beatmap;
+            set
+            {
+                beatmap = value;
+
+                if (IsLoaded)
+                    updateIconColour();
+            }
+        }
 
         /// <summary>
         /// Size of this difficulty icon.
@@ -37,15 +50,46 @@ namespace osu.Game.Beatmaps.Drawables
 
         public DifficultyIcon(BeatmapInfo beatmap, RulesetInfo ruleset = null, bool shouldShowTooltip = true)
         {
-            this.beatmap = beatmap ?? throw new ArgumentNullException(nameof(beatmap));
+            this.beatmap = beatmap;
 
-            this.ruleset = ruleset ?? beatmap.Ruleset;
             if (shouldShowTooltip)
                 TooltipContent = beatmap;
 
             AutoSizeAxes = Axes.Both;
 
-            InternalChild = iconContainer = new Container { Size = new Vector2(20f) };
+            InternalChild = iconContainer = new Container
+            {
+                Size = new Vector2(20f),
+                Children = new Drawable[]
+                {
+                    new CircularContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Scale = new Vector2(0.84f),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Masking = true,
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Colour = Color4.Black.Opacity(0.08f),
+                            Type = EdgeEffectType.Shadow,
+                            Radius = 5,
+                        },
+                        Child = iconBg = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                    },
+                    new ConstrainedIconContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        // the null coalesce here is only present to make unit tests work (ruleset dlls aren't copied correctly for testing at the moment)
+                        Icon = (ruleset ?? beatmap?.Ruleset)?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.Regular.QuestionCircle }
+                    }
+                }
+            };
         }
 
         public string TooltipText { get; set; }
@@ -54,40 +98,17 @@ namespace osu.Game.Beatmaps.Drawables
 
         public object TooltipContent { get; set; }
 
+        private OsuColour colours;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            iconContainer.Children = new Drawable[]
-            {
-                new CircularContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Scale = new Vector2(0.84f),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Masking = true,
-                    EdgeEffect = new EdgeEffectParameters
-                    {
-                        Colour = Color4.Black.Opacity(0.08f),
-                        Type = EdgeEffectType.Shadow,
-                        Radius = 5,
-                    },
-                    Child = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colours.ForDifficultyRating(beatmap.DifficultyRating),
-                    },
-                },
-                new ConstrainedIconContainer
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    // the null coalesce here is only present to make unit tests work (ruleset dlls aren't copied correctly for testing at the moment)
-                    Icon = ruleset?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.Regular.QuestionCircle }
-                }
-            };
+            this.colours = colours;
+
+            updateIconColour();
         }
+
+        private void updateIconColour() => iconBg.Colour = colours.ForDifficultyRating(beatmap.DifficultyRating);
 
         private class DifficultyIconTooltip : VisibilityContainer, ITooltip
         {

--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/osu.Game/Beatmaps/Drawables/GroupedDifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/GroupedDifficultyIcon.cs
@@ -11,6 +11,12 @@ using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables
 {
+    /// <summary>
+    /// A difficulty icon that contains a counter on the right-side of it.
+    /// </summary>
+    /// <remarks>
+    /// Used in cases when there are too many difficulty icons to show.
+    /// </remarks>
     public class GroupedDifficultyIcon : DifficultyIcon
     {
         private readonly OsuSpriteText counter;

--- a/osu.Game/Beatmaps/Drawables/GroupedDifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/GroupedDifficultyIcon.cs
@@ -19,46 +19,19 @@ namespace osu.Game.Beatmaps.Drawables
     /// </remarks>
     public class GroupedDifficultyIcon : DifficultyIcon
     {
-        private readonly OsuSpriteText counter;
-
-        private List<BeatmapInfo> beatmaps;
-
-        protected List<BeatmapInfo> Beatmaps
-        {
-            get => beatmaps;
-            set
-            {
-                beatmaps = value;
-
-                updateDisplay();
-            }
-        }
-
         public GroupedDifficultyIcon(List<BeatmapInfo> beatmaps, RulesetInfo ruleset, Color4 counterColour)
-            : base(null, ruleset, false)
+            : base(beatmaps.OrderBy(b => b.StarDifficulty).Last(), ruleset, false)
         {
-            this.beatmaps = beatmaps;
-
-            AddInternal(counter = new OsuSpriteText
+            AddInternal(new OsuSpriteText
             {
                 Anchor = Anchor.CentreRight,
                 Origin = Anchor.CentreRight,
                 Padding = new MarginPadding { Left = Size.X },
                 Margin = new MarginPadding { Left = 2, Right = 5 },
                 Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                Text = beatmaps.Count.ToString(),
                 Colour = counterColour,
             });
-
-            updateDisplay();
-        }
-
-        private void updateDisplay()
-        {
-            if (beatmaps == null || beatmaps.Count == 0)
-                return;
-
-            Beatmap = beatmaps.OrderBy(b => b.StarDifficulty).Last();
-            counter.Text = beatmaps.Count.ToString();
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/GroupedDifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/GroupedDifficultyIcon.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
+using osuTK.Graphics;
+
+namespace osu.Game.Beatmaps.Drawables
+{
+    public class GroupedDifficultyIcon : DifficultyIcon
+    {
+        private readonly OsuSpriteText counter;
+
+        private List<BeatmapInfo> beatmaps;
+
+        protected List<BeatmapInfo> Beatmaps
+        {
+            get => beatmaps;
+            set
+            {
+                beatmaps = value;
+
+                updateDisplay();
+            }
+        }
+
+        public GroupedDifficultyIcon(List<BeatmapInfo> beatmaps, RulesetInfo ruleset, Color4 counterColour)
+            : base(null, ruleset, false)
+        {
+            this.beatmaps = beatmaps;
+
+            AddInternal(counter = new OsuSpriteText
+            {
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight,
+                Padding = new MarginPadding { Left = Size.X },
+                Margin = new MarginPadding { Left = 2, Right = 5 },
+                Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                Colour = counterColour,
+            });
+
+            updateDisplay();
+        }
+
+        private void updateDisplay()
+        {
+            if (beatmaps == null || beatmaps.Count == 0)
+                return;
+
+            Beatmap = beatmaps.OrderBy(b => b.StarDifficulty).Last();
+            counter.Text = beatmaps.Count.ToString();
+        }
+    }
+}

--- a/osu.Game/Overlays/Direct/DirectGridPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectGridPanel.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Overlays.Direct
                                             AutoSizeAxes = Axes.X,
                                             Height = 20,
                                             Margin = new MarginPadding { Top = vertical_padding, Bottom = vertical_padding },
-                                            Children = GetDifficultyIcons(),
+                                            Children = GetDifficultyIcons(colours),
                                         },
                                     },
                                 },

--- a/osu.Game/Overlays/Direct/DirectListPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectListPanel.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.Direct
                                                     AutoSizeAxes = Axes.X,
                                                     Height = 20,
                                                     Margin = new MarginPadding { Top = vertical_padding, Bottom = vertical_padding },
-                                                    Children = GetDifficultyIcons(),
+                                                    Children = GetDifficultyIcons(colours),
                                                 },
                                             },
                                         },

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -18,7 +18,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Rulesets;
 using osuTK;
 using osuTK.Graphics;
 

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Overlays.Direct
         private Container content;
 
         private BeatmapSetOverlay beatmapSetOverlay;
-        private RulesetStore rulesets;
 
         public PreviewTrack Preview => PlayButton.Preview;
         public Bindable<bool> PreviewPlaying => PlayButton.Playing;
@@ -70,10 +69,9 @@ namespace osu.Game.Overlays.Direct
         };
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(BeatmapManager beatmaps, OsuColour colours, BeatmapSetOverlay beatmapSetOverlay, RulesetStore rulesets)
+        private void load(BeatmapManager beatmaps, OsuColour colours, BeatmapSetOverlay beatmapSetOverlay)
         {
             this.beatmapSetOverlay = beatmapSetOverlay;
-            this.rulesets = rulesets;
 
             AddInternal(content = new Container
             {
@@ -148,12 +146,8 @@ namespace osu.Game.Overlays.Direct
 
             if (SetInfo.Beatmaps.Count > maximum_difficulty_icons)
             {
-                foreach (var ruleset in rulesets.AvailableRulesets)
-                {
-                    List<BeatmapInfo> list;
-                    if ((list = SetInfo.Beatmaps.FindAll(b => b.Ruleset.Equals(ruleset))).Count > 0)
-                        icons.Add(new GroupedDifficultyIcon(list, ruleset, this is DirectListPanel ? Color4.White : Color4.Black));
-                }
+                foreach (var ruleset in SetInfo.Beatmaps.Select(b => b.Ruleset).Distinct())
+                    icons.Add(new GroupedDifficultyIcon(SetInfo.Beatmaps.FindAll(b => b.Ruleset.Equals(ruleset)), ruleset, this is DirectListPanel ? Color4.White : Color4.Black));
             }
             else
                 foreach (var b in SetInfo.Beatmaps.OrderBy(beatmap => beatmap.StarDifficulty))

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -139,14 +139,14 @@ namespace osu.Game.Overlays.Direct
             };
         }
 
-        protected List<DifficultyIcon> GetDifficultyIcons()
+        protected List<DifficultyIcon> GetDifficultyIcons(OsuColour colours)
         {
             var icons = new List<DifficultyIcon>();
 
             if (SetInfo.Beatmaps.Count > maximum_difficulty_icons)
             {
                 foreach (var ruleset in SetInfo.Beatmaps.Select(b => b.Ruleset).Distinct())
-                    icons.Add(new GroupedDifficultyIcon(SetInfo.Beatmaps.FindAll(b => b.Ruleset.Equals(ruleset)), ruleset, this is DirectListPanel ? Color4.White : Color4.Black));
+                    icons.Add(new GroupedDifficultyIcon(SetInfo.Beatmaps.FindAll(b => b.Ruleset.Equals(ruleset)), ruleset, this is DirectListPanel ? Color4.White : colours.Gray5));
             }
             else
                 foreach (var b in SetInfo.Beatmaps.OrderBy(beatmap => beatmap.StarDifficulty))

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Select.Carousel
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(BeatmapManager manager, BeatmapSetOverlay beatmapOverlay, DialogOverlay overlay, RulesetStore rulesets)
+        private void load(BeatmapManager manager, BeatmapSetOverlay beatmapOverlay, DialogOverlay overlay)
         {
             restoreHiddenRequested = s => s.Beatmaps.ForEach(manager.Restore);
             dialogOverlay = overlay;
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Select.Carousel
                                 {
                                     AutoSizeAxes = Axes.Both,
                                     Spacing = new Vector2(3),
-                                    Children = getDifficultyIcons(rulesets),
+                                    Children = getDifficultyIcons(),
                                 },
                             }
                         }
@@ -111,19 +111,15 @@ namespace osu.Game.Screens.Select.Carousel
 
         private const int maximum_difficulty_icons = 18;
 
-        private List<DifficultyIcon> getDifficultyIcons(RulesetStore rulesets)
+        private List<DifficultyIcon> getDifficultyIcons()
         {
             var beatmaps = ((CarouselBeatmapSet)Item).Beatmaps.ToList();
             var icons = new List<DifficultyIcon>();
 
             if (beatmaps.Count > maximum_difficulty_icons)
             {
-                foreach (var ruleset in rulesets.AvailableRulesets.OrderBy(r => r.ID))
-                {
-                    List<CarouselBeatmap> list;
-                    if ((list = beatmaps.FindAll(b => b.Beatmap.Ruleset.Equals(ruleset))).Count > 0)
-                        icons.Add(new FilterableGroupedDifficultyIcon(list, ruleset));
-                }
+                foreach (var ruleset in beatmaps.Select(b => b.Beatmap.Ruleset).Distinct())
+                    icons.Add(new FilterableGroupedDifficultyIcon(beatmaps.FindAll(b => b.Beatmap.Ruleset.Equals(ruleset)), ruleset));
             }
             else beatmaps.ForEach(b => icons.Add(new FilterableDifficultyIcon(b)));
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -118,8 +118,8 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (beatmaps.Count > maximum_difficulty_icons)
             {
-                foreach (var ruleset in beatmaps.Select(b => b.Beatmap.Ruleset).Distinct())
-                    icons.Add(new FilterableGroupedDifficultyIcon(beatmaps.FindAll(b => b.Beatmap.Ruleset.Equals(ruleset)), ruleset));
+                foreach (var group in beatmaps.GroupBy(b => b.Beatmap.Ruleset))
+                    icons.Add(new FilterableGroupedDifficultyIcon(group.ToList(), group.Key));
             }
             else beatmaps.ForEach(b => icons.Add(new FilterableDifficultyIcon(b)));
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Select.Carousel
                                 {
                                     AutoSizeAxes = Axes.Both,
                                     Spacing = new Vector2(3),
-                                    Children = getDifficultyIcons(),
+                                    ChildrenEnumerable = getDifficultyIcons(),
                                 },
                             }
                         }
@@ -111,19 +111,13 @@ namespace osu.Game.Screens.Select.Carousel
 
         private const int maximum_difficulty_icons = 18;
 
-        private List<DifficultyIcon> getDifficultyIcons()
+        private IEnumerable<DifficultyIcon> getDifficultyIcons()
         {
             var beatmaps = ((CarouselBeatmapSet)Item).Beatmaps.ToList();
-            var icons = new List<DifficultyIcon>();
 
-            if (beatmaps.Count > maximum_difficulty_icons)
-            {
-                foreach (var group in beatmaps.GroupBy(b => b.Beatmap.Ruleset))
-                    icons.Add(new FilterableGroupedDifficultyIcon(group.ToList(), group.Key));
-            }
-            else beatmaps.ForEach(b => icons.Add(new FilterableDifficultyIcon(b)));
-
-            return icons;
+            return beatmaps.Count > maximum_difficulty_icons
+                ? (IEnumerable<DifficultyIcon>)beatmaps.GroupBy(b => b.Beatmap.Ruleset).Select(group => new FilterableGroupedDifficultyIcon(group.ToList(), group.Key))
+                : beatmaps.Select(b => new FilterableDifficultyIcon(b));
         }
 
         public MenuItem[] ContextMenuItems

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -231,11 +231,8 @@ namespace osu.Game.Screens.Select.Carousel
             {
                 items.ForEach(item => item.Filtered.ValueChanged += _ =>
                 {
-                    var hiddenItems = items.FindAll(i => !i.Filtered.Value);
-                    var hasHidden = hiddenItems.Count > 0;
-
-                    this.FadeTo(hasHidden ? 1 : 0.1f, 100);
-                    Beatmaps = (hasHidden ? hiddenItems : items).Select(i => i.Beatmap).ToList();
+                    // for now, fade the whole group based on the ratio of hidden items.
+                    this.FadeTo(1 - 0.9f * ((float)items.Count(i => i.Filtered.Value) / items.Count), 100);
                 });
             }
         }


### PR DESCRIPTION
- This fixes direct panels having out-of-bounds difficulties by replacing them with counters for each ruleset, Matching the web for now (same for carousel).
- [x] Depends on #5822

Fixes panel part of #4929 