### PR TITLE
Don't return DefaultSkin on beatmap skin parsing failure

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -138,19 +138,15 @@ namespace osu.Game.Beatmaps
 
             protected override Skin GetSkin()
             {
-                Skin skin;
-
                 try
                 {
-                    skin = new LegacyBeatmapSkin(BeatmapInfo, store, AudioManager);
+                    return new LegacyBeatmapSkin(BeatmapInfo, store, AudioManager);
                 }
                 catch (Exception e)
                 {
                     Logger.Error(e, "Skin failed to load");
-                    skin = new DefaultSkin();
+                    return null;
                 }
-
-                return skin;
             }
         }
     }


### PR DESCRIPTION
This would bypass any user skin setting if it ever occurred.