### PR TITLE
Allow RulesetConfigCache to return null configs

### DIFF
--- a/osu.Game/Rulesets/RulesetConfigCache.cs
+++ b/osu.Game/Rulesets/RulesetConfigCache.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets
         public IRulesetConfigManager GetConfigFor(Ruleset ruleset)
         {
             if (ruleset.RulesetInfo.ID == null)
-                throw new InvalidOperationException("The provided ruleset doesn't have a valid id.");
+                return null;
 
             return configCache.GetOrAdd(ruleset.RulesetInfo.ID.Value, _ => ruleset.CreateConfig(settingsStore));
         }


### PR DESCRIPTION
Every use case handles null already... Seems like a saner default which can be used to test arbitrary rulesets, as I'm doing.