### PR TITLE
Fix filtered grouped difficulty items in DrawableCarouselBeatmapSet aren't hidden on first load

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -223,11 +223,9 @@ namespace osu.Game.Screens.Select.Carousel
             public FilterableGroupedDifficultyIcon(List<CarouselBeatmap> items, RulesetInfo ruleset)
                 : base(items.Select(i => i.Beatmap).ToList(), ruleset, Color4.White)
             {
-                items.ForEach(item => item.Filtered.ValueChanged += _ =>
-                {
-                    // for now, fade the whole group based on the ratio of hidden items.
-                    this.FadeTo(1 - 0.9f * ((float)items.Count(i => i.Filtered.Value) / items.Count), 100);
-                });
+                // for now, fade the whole group based on the ratio of hidden items.
+                items.ForEach(item => item.Filtered.BindValueChanged(_
+                    => this.FadeTo(1 - 0.9f * ((float)items.Count(i => i.Filtered.Value) / items.Count), 100), true));
             }
         }
     }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -220,12 +220,23 @@ namespace osu.Game.Screens.Select.Carousel
 
         public class FilterableGroupedDifficultyIcon : GroupedDifficultyIcon
         {
+            private readonly List<CarouselBeatmap> items;
+
             public FilterableGroupedDifficultyIcon(List<CarouselBeatmap> items, RulesetInfo ruleset)
                 : base(items.Select(i => i.Beatmap).ToList(), ruleset, Color4.White)
             {
+                this.items = items;
+
+                foreach (var item in items)
+                    item.Filtered.BindValueChanged(_ => Scheduler.AddOnce(updateFilteredDisplay));
+
+                updateFilteredDisplay();
+            }
+
+            private void updateFilteredDisplay()
+            {
                 // for now, fade the whole group based on the ratio of hidden items.
-                items.ForEach(item => item.Filtered.BindValueChanged(_ =>
-                    this.FadeTo(1 - 0.9f * ((float)items.Count(i => i.Filtered.Value) / items.Count), 100), true));
+                this.FadeTo(1 - 0.9f * ((float)items.Count(i => i.Filtered.Value) / items.Count), 100);
             }
         }
     }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -224,8 +224,8 @@ namespace osu.Game.Screens.Select.Carousel
                 : base(items.Select(i => i.Beatmap).ToList(), ruleset, Color4.White)
             {
                 // for now, fade the whole group based on the ratio of hidden items.
-                items.ForEach(item => item.Filtered.BindValueChanged(_
-                    => this.FadeTo(1 - 0.9f * ((float)items.Count(i => i.Filtered.Value) / items.Count), 100), true));
+                items.ForEach(item => item.Filtered.BindValueChanged(_ =>
+                    this.FadeTo(1 - 0.9f * ((float)items.Count(i => i.Filtered.Value) / items.Count), 100), true));
             }
         }
     }


### PR DESCRIPTION
Expected behavior
![Screenshot_5](https://user-images.githubusercontent.com/22874522/63687168-8222eb00-c80c-11e9-895b-5d9b60038e8c.png)
Current behavior
![Screenshot_3](https://user-images.githubusercontent.com/22874522/63687184-89e28f80-c80c-11e9-907a-6c9352bf4e1e.png)
