### PR TITLE
Remove DrawableHitObject legacy state update function

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
@@ -200,10 +200,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                         break;
                 }
             }
-
-            protected override void UpdateState(ArmedState state)
-            {
-            }
         }
 
         private class TestDrawableHitObject : DrawableHitObject<HitObject>
@@ -215,10 +211,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                 AutoSizeAxes = Axes.Both;
 
                 AddInternal(new Box { Size = new Vector2(75) });
-            }
-
-            protected override void UpdateState(ArmedState state)
-            {
             }
         }
     }


### PR DESCRIPTION
Removes legacy `UpdateState()` function and `UseTransformStateManagement` property in `DrawableHitObject`.
- [x] Depends on #5841 