### PR TITLE
Encapsulate editor hitobject additions/removals

### DIFF
--- a/osu.Game.Tests/Visual/Editor/TestSceneHitObjectComposer.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneHitObjectComposer.cs
@@ -16,15 +16,13 @@ using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Screens.Edit.Compose;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Editor
 {
     [TestFixture]
-    [Cached(Type = typeof(IPlacementHandler))]
-    public class TestSceneHitObjectComposer : OsuTestScene, IPlacementHandler
+    public class TestSceneHitObjectComposer : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
@@ -38,8 +36,6 @@ namespace osu.Game.Tests.Visual.Editor
             typeof(HitCircleSelectionBlueprint),
             typeof(HitCirclePlacementBlueprint),
         };
-
-        private HitObjectComposer composer;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -67,15 +63,7 @@ namespace osu.Game.Tests.Visual.Editor
             Dependencies.CacheAs<IAdjustableClock>(clock);
             Dependencies.CacheAs<IFrameBasedClock>(clock);
 
-            Child = composer = new OsuHitObjectComposer(new OsuRuleset());
+            Child = new OsuHitObjectComposer(new OsuRuleset());
         }
-
-        public void BeginPlacement(HitObject hitObject)
-        {
-        }
-
-        public void EndPlacement(HitObject hitObject) => composer.Add(hitObject);
-
-        public void Delete(HitObject hitObject) => composer.Remove(hitObject);
     }
 }

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Beatmaps
     /// <summary>
     /// A Beatmap containing converted HitObjects.
     /// </summary>
-    public class Beatmap<T> : IBeatmap
+    public class Beatmap<T> : IBeatmap<T>
         where T : HitObject
     {
         public BeatmapInfo BeatmapInfo { get; set; } = new BeatmapInfo
@@ -36,17 +36,13 @@ namespace osu.Game.Beatmaps
 
         public List<BreakPeriod> Breaks { get; set; } = new List<BreakPeriod>();
 
-        /// <summary>
-        /// Total amount of break time in the beatmap.
-        /// </summary>
         [JsonIgnore]
         public double TotalBreakTime => Breaks.Sum(b => b.Duration);
 
-        /// <summary>
-        /// The HitObjects this Beatmap contains.
-        /// </summary>
         [JsonConverter(typeof(TypedListConverter<HitObject>))]
-        public List<T> HitObjects = new List<T>();
+        public List<T> HitObjects { get; set; } = new List<T>();
+
+        IReadOnlyList<T> IBeatmap<T>.HitObjects => HitObjects;
 
         IReadOnlyList<HitObject> IBeatmap.HitObjects => HitObjects;
 

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -53,4 +53,13 @@ namespace osu.Game.Beatmaps
         /// <returns>The shallow-cloned beatmap.</returns>
         IBeatmap Clone();
     }
+
+    public interface IBeatmap<out T> : IBeatmap
+        where T : HitObject
+    {
+        /// <summary>
+        /// The hitobjects contained by this beatmap.
+        /// </summary>
+        new IReadOnlyList<T> HitObjects { get; }
+    }
 }

--- a/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Edit
         private readonly DrawableRuleset<TObject> drawableRuleset;
 
         [Resolved]
-        private EditorBeatmap<TObject> beatmap { get; set; }
+        private IEditorBeatmap<TObject> beatmap { get; set; }
 
         public DrawableEditRuleset(DrawableRuleset<TObject> drawableRuleset)
         {

--- a/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
@@ -75,5 +75,16 @@ namespace osu.Game.Rulesets.Edit
             drawableRuleset.Playfield.Remove(drawableObject);
             drawableRuleset.Playfield.PostProcess();
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (beatmap != null)
+            {
+                beatmap.HitObjectAdded -= addHitObject;
+                beatmap.HitObjectRemoved -= removeHitObject;
+            }
+        }
     }
 }

--- a/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
@@ -5,10 +5,9 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -25,20 +24,6 @@ namespace osu.Game.Rulesets.Edit
         {
             RelativeSizeAxes = Axes.Both;
         }
-
-        /// <summary>
-        /// Adds a <see cref="HitObject"/> to the <see cref="Beatmap"/> and displays a visual representation of it.
-        /// </summary>
-        /// <param name="hitObject">The <see cref="HitObject"/> to add.</param>
-        /// <returns>The visual representation of <paramref name="hitObject"/>.</returns>
-        internal abstract DrawableHitObject Add(HitObject hitObject);
-
-        /// <summary>
-        /// Removes a <see cref="HitObject"/> from the <see cref="Beatmap"/> and the display.
-        /// </summary>
-        /// <param name="hitObject">The <see cref="HitObject"/> to remove.</param>
-        /// <returns>The visual representation of the removed <paramref name="hitObject"/>.</returns>
-        internal abstract DrawableHitObject Remove(HitObject hitObject);
     }
 
     public class DrawableEditRuleset<TObject> : DrawableEditRuleset
@@ -48,10 +33,10 @@ namespace osu.Game.Rulesets.Edit
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => drawableRuleset.CreatePlayfieldAdjustmentContainer();
 
-        private Ruleset ruleset => drawableRuleset.Ruleset;
-        private Beatmap<TObject> beatmap => drawableRuleset.Beatmap;
-
         private readonly DrawableRuleset<TObject> drawableRuleset;
+
+        [Resolved]
+        private EditorBeatmap<TObject> beatmap { get; set; }
 
         public DrawableEditRuleset(DrawableRuleset<TObject> drawableRuleset)
         {
@@ -67,50 +52,28 @@ namespace osu.Game.Rulesets.Edit
             Playfield.DisplayJudgements.Value = false;
         }
 
-        internal override DrawableHitObject Add(HitObject hitObject)
+        protected override void LoadComplete()
         {
-            var tObject = (TObject)hitObject;
+            base.LoadComplete();
 
-            // Add to beatmap, preserving sorting order
-            var insertionIndex = beatmap.HitObjects.FindLastIndex(h => h.StartTime <= hitObject.StartTime);
-            beatmap.HitObjects.Insert(insertionIndex + 1, tObject);
+            beatmap.HitObjectAdded += addHitObject;
+            beatmap.HitObjectRemoved += removeHitObject;
+        }
 
-            // Process object
-            var processor = ruleset.CreateBeatmapProcessor(beatmap);
-
-            processor?.PreProcess();
-            tObject.ApplyDefaults(beatmap.ControlPointInfo, beatmap.BeatmapInfo.BaseDifficulty);
-            processor?.PostProcess();
-
-            // Add visual representation
-            var drawableObject = drawableRuleset.CreateDrawableRepresentation(tObject);
+        private void addHitObject(HitObject hitObject)
+        {
+            var drawableObject = drawableRuleset.CreateDrawableRepresentation((TObject)hitObject);
 
             drawableRuleset.Playfield.Add(drawableObject);
             drawableRuleset.Playfield.PostProcess();
-
-            return drawableObject;
         }
 
-        internal override DrawableHitObject Remove(HitObject hitObject)
+        private void removeHitObject(HitObject hitObject)
         {
-            var tObject = (TObject)hitObject;
-
-            // Remove from beatmap
-            beatmap.HitObjects.Remove(tObject);
-
-            // Process the beatmap
-            var processor = ruleset.CreateBeatmapProcessor(beatmap);
-
-            processor?.PreProcess();
-            processor?.PostProcess();
-
-            // Remove visual representation
             var drawableObject = Playfield.AllHitObjects.Single(d => d.HitObject == hitObject);
 
             drawableRuleset.Playfield.Remove(drawableObject);
             drawableRuleset.Playfield.PostProcess();
-
-            return drawableObject;
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -177,6 +177,7 @@ namespace osu.Game.Rulesets.Edit
     {
         private Beatmap<TObject> playableBeatmap;
         private EditorBeatmap<TObject> editorBeatmap;
+        private IBeatmapProcessor beatmapProcessor;
 
         protected HitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -187,6 +188,8 @@ namespace osu.Game.Rulesets.Edit
         {
             var workingBeatmap = parent.Get<IBindable<WorkingBeatmap>>();
             playableBeatmap = (Beatmap<TObject>)workingBeatmap.Value.GetPlayableBeatmap(Ruleset.RulesetInfo, Array.Empty<Mod>());
+
+            beatmapProcessor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
 
             editorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
             editorBeatmap.HitObjectAdded += addHitObject;
@@ -201,19 +204,15 @@ namespace osu.Game.Rulesets.Edit
 
         private void addHitObject(HitObject hitObject)
         {
-            var processor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
-
-            processor?.PreProcess();
+            beatmapProcessor?.PreProcess();
             hitObject.ApplyDefaults(playableBeatmap.ControlPointInfo, playableBeatmap.BeatmapInfo.BaseDifficulty);
-            processor?.PostProcess();
+            beatmapProcessor?.PostProcess();
         }
 
         private void removeHitObject(HitObject hitObject)
         {
-            var processor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
-
-            processor?.PreProcess();
-            processor?.PostProcess();
+            beatmapProcessor?.PreProcess();
+            beatmapProcessor?.PostProcess();
         }
 
         internal override DrawableEditRuleset CreateDrawableRuleset()

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -176,9 +176,6 @@ namespace osu.Game.Rulesets.Edit
         where TObject : HitObject
     {
         private Beatmap<TObject> playableBeatmap;
-
-        [Cached]
-        [Cached(typeof(IEditorBeatmap))]
         private EditorBeatmap<TObject> editorBeatmap;
 
         protected HitObjectComposer(Ruleset ruleset)
@@ -195,7 +192,11 @@ namespace osu.Game.Rulesets.Edit
             editorBeatmap.HitObjectAdded += addHitObject;
             editorBeatmap.HitObjectRemoved += removeHitObject;
 
-            return base.CreateChildDependencies(parent);
+            var dependencies = new DependencyContainer(parent);
+            dependencies.CacheAs<IEditorBeatmap>(editorBeatmap);
+            dependencies.CacheAs<IEditorBeatmap<TObject>>(editorBeatmap);
+
+            return base.CreateChildDependencies(dependencies);
         }
 
         private void addHitObject(HitObject hitObject)

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.RadioButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 
@@ -183,6 +184,19 @@ namespace osu.Game.Rulesets.Edit
         protected HitObjectComposer(Ruleset ruleset)
             : base(ruleset)
         {
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var workingBeatmap = parent.Get<IBindable<WorkingBeatmap>>();
+            var playableBeatmap = (Beatmap<TObject>)workingBeatmap.Value.GetPlayableBeatmap(Ruleset.RulesetInfo, Array.Empty<Mod>());
+            var editorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
+
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            dependencies.CacheAs(editorBeatmap);
+            dependencies.CacheAs<IEditorBeatmap>(editorBeatmap);
+
+            return dependencies;
         }
 
         internal override DrawableEditRuleset CreateDrawableRuleset()

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -201,7 +201,6 @@ namespace osu.Game.Rulesets.Edit
 
         private void addHitObject(HitObject hitObject)
         {
-            // Process object
             var processor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
 
             processor?.PreProcess();

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -9,15 +9,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Logging;
 using osu.Game.Rulesets.Edit;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose
 {
-    [Cached(Type = typeof(IPlacementHandler))]
-    public class ComposeScreen : EditorScreen, IPlacementHandler
+    public class ComposeScreen : EditorScreen
     {
         private const float vertical_margins = 10;
         private const float horizontal_margins = 20;
@@ -119,13 +117,5 @@ namespace osu.Game.Screens.Edit.Compose
 
             composerContainer.Child = composer;
         }
-
-        public void BeginPlacement(HitObject hitObject)
-        {
-        }
-
-        public void EndPlacement(HitObject hitObject) => composer.Add(hitObject);
-
-        public void Delete(HitObject hitObject) => composer.Remove(hitObject);
     }
 }

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Screens.Edit
+{
+    public class EditorBeatmap<T> : IBeatmap<T>, IEditorBeatmap
+        where T : HitObject
+    {
+        public event Action<T> HitObjectRemoved;
+        public event Action<T> HitObjectAdded;
+
+        event Action<HitObject> IEditorBeatmap.HitObjectAdded
+        {
+            add => HitObjectAdded += value;
+            remove => HitObjectAdded -= value;
+        }
+
+        event Action<HitObject> IEditorBeatmap.HitObjectRemoved
+        {
+            add => HitObjectRemoved += value;
+            remove => HitObjectRemoved -= value;
+        }
+
+        private readonly Beatmap<T> beatmap;
+
+        public EditorBeatmap(Beatmap<T> beatmap)
+        {
+            this.beatmap = beatmap;
+        }
+
+        public BeatmapInfo BeatmapInfo
+        {
+            get => beatmap.BeatmapInfo;
+            set => beatmap.BeatmapInfo = value;
+        }
+
+        public BeatmapMetadata Metadata => beatmap.Metadata;
+
+        public ControlPointInfo ControlPointInfo => beatmap.ControlPointInfo;
+
+        public List<BreakPeriod> Breaks => beatmap.Breaks;
+
+        public double TotalBreakTime => beatmap.TotalBreakTime;
+
+        IReadOnlyList<T> IBeatmap<T>.HitObjects => beatmap.HitObjects;
+
+        IReadOnlyList<HitObject> IBeatmap.HitObjects => beatmap.HitObjects;
+
+        public IEnumerable<BeatmapStatistic> GetStatistics() => beatmap.GetStatistics();
+
+        public IBeatmap Clone() => (EditorBeatmap<T>)MemberwiseClone();
+
+        public void Add(T hitObject)
+        {
+            // Preserve existing sorting order in the beatmap
+            var insertionIndex = beatmap.HitObjects.FindLastIndex(h => h.StartTime <= hitObject.StartTime);
+            beatmap.HitObjects.Insert(insertionIndex + 1, hitObject);
+
+            HitObjectAdded?.Invoke(hitObject);
+        }
+
+        public void Remove(T hitObject)
+        {
+            if (beatmap.HitObjects.Remove(hitObject))
+                HitObjectRemoved?.Invoke(hitObject);
+        }
+
+        public void Add(HitObject hitObject) => Add((T)hitObject);
+
+        public void Remove(HitObject hitObject) => Remove((T)hitObject);
+    }
+}

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Screens.Edit
 {
-    public class EditorBeatmap<T> : IBeatmap<T>, IEditorBeatmap
+    public class EditorBeatmap<T> : IEditorBeatmap<T>
         where T : HitObject
     {
         public event Action<HitObject> HitObjectAdded;

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -13,20 +13,8 @@ namespace osu.Game.Screens.Edit
     public class EditorBeatmap<T> : IBeatmap<T>, IEditorBeatmap
         where T : HitObject
     {
-        public event Action<T> HitObjectRemoved;
-        public event Action<T> HitObjectAdded;
-
-        event Action<HitObject> IEditorBeatmap.HitObjectAdded
-        {
-            add => HitObjectAdded += value;
-            remove => HitObjectAdded -= value;
-        }
-
-        event Action<HitObject> IEditorBeatmap.HitObjectRemoved
-        {
-            add => HitObjectRemoved += value;
-            remove => HitObjectRemoved -= value;
-        }
+        public event Action<HitObject> HitObjectAdded;
+        public event Action<HitObject> HitObjectRemoved;
 
         private readonly Beatmap<T> beatmap;
 

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -45,6 +45,10 @@ namespace osu.Game.Screens.Edit
 
         public IBeatmap Clone() => (EditorBeatmap<T>)MemberwiseClone();
 
+        /// <summary>
+        /// Adds a <see cref="HitObject"/> to this <see cref="EditorBeatmap{T}"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to add.</param>
         public void Add(T hitObject)
         {
             // Preserve existing sorting order in the beatmap
@@ -54,14 +58,26 @@ namespace osu.Game.Screens.Edit
             HitObjectAdded?.Invoke(hitObject);
         }
 
+        /// <summary>
+        /// Removes a <see cref="HitObject"/> from this <see cref="EditorBeatmap{T}"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to add.</param>
         public void Remove(T hitObject)
         {
             if (beatmap.HitObjects.Remove(hitObject))
                 HitObjectRemoved?.Invoke(hitObject);
         }
 
+        /// <summary>
+        /// Adds a <see cref="HitObject"/> to this <see cref="EditorBeatmap{T}"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to add.</param>
         public void Add(HitObject hitObject) => Add((T)hitObject);
 
+        /// <summary>
+        /// Removes a <see cref="HitObject"/> from this <see cref="EditorBeatmap{T}"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to add.</param>
         public void Remove(HitObject hitObject) => Remove((T)hitObject);
     }
 }

--- a/osu.Game/Screens/Edit/IEditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/IEditorBeatmap.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Screens.Edit
+{
+    public interface IEditorBeatmap
+    {
+        event Action<HitObject> HitObjectAdded;
+        event Action<HitObject> HitObjectRemoved;
+
+        void Add(HitObject hitObject);
+        void Remove(HitObject hitObject);
+    }
+}

--- a/osu.Game/Screens/Edit/IEditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/IEditorBeatmap.cs
@@ -2,16 +2,35 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Screens.Edit
 {
-    public interface IEditorBeatmap
+    /// <summary>
+    /// Interface for the <see cref="IBeatmap"/> contained by the see <see cref="HitObjectComposer"/>.
+    /// Children of <see cref="HitObjectComposer"/> may resolve the beatmap via <see cref="IEditorBeatmap"/> or <see cref="IEditorBeatmap{T}"/>.
+    /// </summary>
+    public interface IEditorBeatmap : IBeatmap
     {
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> is added to this <see cref="IEditorBeatmap"/>.
+        /// </summary>
         event Action<HitObject> HitObjectAdded;
-        event Action<HitObject> HitObjectRemoved;
 
-        void Add(HitObject hitObject);
-        void Remove(HitObject hitObject);
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> is removed from this <see cref="IEditorBeatmap"/>.
+        /// </summary>
+        event Action<HitObject> HitObjectRemoved;
+    }
+
+    /// <summary>
+    /// Interface for the <see cref="IBeatmap"/> contained by the see <see cref="HitObjectComposer"/>.
+    /// Children of <see cref="HitObjectComposer"/> may resolve the beatmap via <see cref="IEditorBeatmap"/> or <see cref="IEditorBeatmap{T}"/>.
+    /// </summary>
+    public interface IEditorBeatmap<out T> : IEditorBeatmap, IBeatmap<T>
+        where T : HitObject
+    {
     }
 }


### PR DESCRIPTION
Want to encapsulate the logic surrounding additions/removals so that there's a specific flow - `HitObjectComposer` handles adding to/removing from the beatmap and processing it, `BlueprintContainer` reads from the events and adds/removes blueprints, `DrawableEditRuleset` reads from the events and adds/removes drawable visualisations.

Eventually, the grid layers will also read from the beatmap to perform their hitobject lookups.

Next PR is going to be a refactoring of the editor, in much the similar way that `DrawableRuleset` was refactored (moving most things to generic versions).