### PR TITLE
Refactor HitObjectComposer for readability

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mania.Edit
     [Cached(Type = typeof(IManiaHitObjectComposer))]
     public class ManiaHitObjectComposer : HitObjectComposer<ManiaHitObject>, IManiaHitObjectComposer
     {
-        protected new DrawableManiaEditRuleset DrawableRuleset { get; private set; }
+        private DrawableManiaEditRuleset drawableRuleset;
 
         public ManiaHitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -33,23 +33,23 @@ namespace osu.Game.Rulesets.Mania.Edit
         /// </summary>
         /// <param name="screenSpacePosition">The screen-space position.</param>
         /// <returns>The column which intersects with <paramref name="screenSpacePosition"/>.</returns>
-        public Column ColumnAt(Vector2 screenSpacePosition) => DrawableRuleset.GetColumnByPosition(screenSpacePosition);
+        public Column ColumnAt(Vector2 screenSpacePosition) => drawableRuleset.GetColumnByPosition(screenSpacePosition);
 
         private DependencyContainer dependencies;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-        public int TotalColumns => ((ManiaPlayfield)DrawableRuleset.Playfield).TotalColumns;
+        public int TotalColumns => ((ManiaPlayfield)drawableRuleset.Playfield).TotalColumns;
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods)
         {
-            DrawableRuleset = new DrawableManiaEditRuleset(ruleset, beatmap, mods);
+            drawableRuleset = new DrawableManiaEditRuleset(ruleset, beatmap, mods);
 
             // This is the earliest we can cache the scrolling info to ourselves, before masks are added to the hierarchy and inject it
-            dependencies.CacheAs(DrawableRuleset.ScrollingInfo);
+            dependencies.CacheAs(drawableRuleset.ScrollingInfo);
 
-            return DrawableRuleset;
+            return drawableRuleset;
         }
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]

--- a/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRuleset.cs
@@ -11,27 +11,10 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Edit
 {
-    public abstract class DrawableEditRuleset : CompositeDrawable
-    {
-        /// <summary>
-        /// The <see cref="Playfield"/> contained by this <see cref="DrawableEditRuleset"/>.
-        /// </summary>
-        public abstract Playfield Playfield { get; }
-
-        public abstract PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer();
-
-        internal DrawableEditRuleset()
-        {
-            RelativeSizeAxes = Axes.Both;
-        }
-    }
-
-    public class DrawableEditRuleset<TObject> : DrawableEditRuleset
+    public class DrawableEditRuleset<TObject> : CompositeDrawable
         where TObject : HitObject
     {
-        public override Playfield Playfield => drawableRuleset.Playfield;
-
-        public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => drawableRuleset.CreatePlayfieldAdjustmentContainer();
+        public Playfield Playfield => drawableRuleset.Playfield;
 
         private readonly DrawableRuleset<TObject> drawableRuleset;
 
@@ -41,6 +24,8 @@ namespace osu.Game.Rulesets.Edit
         public DrawableEditRuleset(DrawableRuleset<TObject> drawableRuleset)
         {
             this.drawableRuleset = drawableRuleset;
+
+            RelativeSizeAxes = Axes.Both;
 
             InternalChild = drawableRuleset;
         }
@@ -75,6 +60,8 @@ namespace osu.Game.Rulesets.Edit
             drawableRuleset.Playfield.Remove(drawableObject);
             drawableRuleset.Playfield.PostProcess();
         }
+
+        public PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => drawableRuleset.CreatePlayfieldAdjustmentContainer();
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
@@ -11,7 +11,10 @@ using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Edit
 {
-    public class DrawableEditRuleset<TObject> : CompositeDrawable
+    /// <summary>
+    /// A wrapper for a <see cref="DrawableRuleset{TObject}"/>. Handles adding visual representations of <see cref="HitObject"/>s to the underlying <see cref="DrawableRuleset{TObject}"/>.
+    /// </summary>
+    internal class DrawableEditRulesetWrapper<TObject> : CompositeDrawable
         where TObject : HitObject
     {
         public Playfield Playfield => drawableRuleset.Playfield;
@@ -21,7 +24,7 @@ namespace osu.Game.Rulesets.Edit
         [Resolved]
         private IEditorBeatmap<TObject> beatmap { get; set; }
 
-        public DrawableEditRuleset(DrawableRuleset<TObject> drawableRuleset)
+        public DrawableEditRulesetWrapper(DrawableRuleset<TObject> drawableRuleset)
         {
             this.drawableRuleset = drawableRuleset;
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Edit
         where TObject : HitObject
     {
         protected IRulesetConfigManager Config { get; private set; }
-        protected DrawableEditRuleset DrawableRuleset { get; private set; }
 
         protected readonly Ruleset Ruleset;
 
@@ -39,6 +38,7 @@ namespace osu.Game.Rulesets.Edit
         private EditorBeatmap<TObject> editorBeatmap;
         private IBeatmapProcessor beatmapProcessor;
 
+        private DrawableEditRuleset<TObject> drawableRuleset;
         private BlueprintContainer blueprintContainer;
         private readonly List<Container> layerContainers = new List<Container>();
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Edit
         {
             try
             {
-                DrawableRuleset = new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, workingBeatmap.Value, Array.Empty<Mod>()))
+                drawableRuleset = new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, workingBeatmap.Value, Array.Empty<Mod>()))
                 {
                     Clock = framedClock
                 };
@@ -66,10 +66,10 @@ namespace osu.Game.Rulesets.Edit
                 return;
             }
 
-            var layerBelowRuleset = DrawableRuleset.CreatePlayfieldAdjustmentContainer();
+            var layerBelowRuleset = drawableRuleset.CreatePlayfieldAdjustmentContainer();
             layerBelowRuleset.Child = new EditorPlayfieldBorder { RelativeSizeAxes = Axes.Both };
 
-            var layerAboveRuleset = DrawableRuleset.CreatePlayfieldAdjustmentContainer();
+            var layerAboveRuleset = drawableRuleset.CreatePlayfieldAdjustmentContainer();
             layerAboveRuleset.Child = blueprintContainer = new BlueprintContainer();
 
             layerContainers.Add(layerBelowRuleset);
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Edit
                             Children = new Drawable[]
                             {
                                 layerBelowRuleset,
-                                DrawableRuleset,
+                                drawableRuleset,
                                 layerAboveRuleset
                             }
                         }
@@ -153,10 +153,10 @@ namespace osu.Game.Rulesets.Edit
 
             layerContainers.ForEach(l =>
             {
-                l.Anchor = DrawableRuleset.Playfield.Anchor;
-                l.Origin = DrawableRuleset.Playfield.Origin;
-                l.Position = DrawableRuleset.Playfield.Position;
-                l.Size = DrawableRuleset.Playfield.Size;
+                l.Anchor = drawableRuleset.Playfield.Anchor;
+                l.Origin = drawableRuleset.Playfield.Origin;
+                l.Position = drawableRuleset.Playfield.Position;
+                l.Size = drawableRuleset.Playfield.Size;
             });
         }
 
@@ -173,8 +173,8 @@ namespace osu.Game.Rulesets.Edit
             beatmapProcessor?.PostProcess();
         }
 
-        public override IEnumerable<DrawableHitObject> HitObjects => DrawableRuleset.Playfield.AllHitObjects;
-        public override bool CursorInPlacementArea => DrawableRuleset.Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
+        public override IEnumerable<DrawableHitObject> HitObjects => drawableRuleset.Playfield.AllHitObjects;
+        public override bool CursorInPlacementArea => drawableRuleset.Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
 
         protected abstract IReadOnlyList<HitObjectCompositionTool> CompositionTools { get; }
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -25,40 +25,40 @@ using osu.Game.Screens.Edit.Compose.Components;
 
 namespace osu.Game.Rulesets.Edit
 {
-    public abstract class HitObjectComposer : CompositeDrawable
+    [Cached(Type = typeof(IPlacementHandler))]
+    public abstract class HitObjectComposer<TObject> : HitObjectComposer, IPlacementHandler
+        where TObject : HitObject
     {
-        public IEnumerable<DrawableHitObject> HitObjects => DrawableRuleset.Playfield.AllHitObjects;
+        protected IRulesetConfigManager Config { get; private set; }
+        protected DrawableEditRuleset DrawableRuleset { get; private set; }
 
         protected readonly Ruleset Ruleset;
 
-        protected readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
-
-        protected IRulesetConfigManager Config { get; private set; }
-
-        private readonly List<Container> layerContainers = new List<Container>();
-
-        protected DrawableEditRuleset DrawableRuleset { get; private set; }
+        private IBindable<WorkingBeatmap> workingBeatmap;
+        private Beatmap<TObject> playableBeatmap;
+        private EditorBeatmap<TObject> editorBeatmap;
+        private IBeatmapProcessor beatmapProcessor;
 
         private BlueprintContainer blueprintContainer;
+        private readonly List<Container> layerContainers = new List<Container>();
 
         private InputManager inputManager;
 
-        internal HitObjectComposer(Ruleset ruleset)
+        protected HitObjectComposer(Ruleset ruleset)
         {
             Ruleset = ruleset;
-
             RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap, IFrameBasedClock framedClock)
+        private void load(IFrameBasedClock framedClock)
         {
-            Beatmap.BindTo(beatmap);
-
             try
             {
-                DrawableRuleset = CreateDrawableRuleset();
-                DrawableRuleset.Clock = framedClock;
+                DrawableRuleset = new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, workingBeatmap.Value, Array.Empty<Mod>()))
+                {
+                    Clock = framedClock
+                };
             }
             catch (Exception e)
             {
@@ -120,21 +120,31 @@ namespace osu.Game.Rulesets.Edit
             toolboxCollection.Items[0].Select();
         }
 
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            workingBeatmap = parent.Get<IBindable<WorkingBeatmap>>().GetBoundCopy();
+            playableBeatmap = (Beatmap<TObject>)workingBeatmap.Value.GetPlayableBeatmap(Ruleset.RulesetInfo, Array.Empty<Mod>());
+
+            beatmapProcessor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
+
+            editorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
+            editorBeatmap.HitObjectAdded += addHitObject;
+            editorBeatmap.HitObjectRemoved += removeHitObject;
+
+            var dependencies = new DependencyContainer(parent);
+            dependencies.CacheAs<IEditorBeatmap>(editorBeatmap);
+            dependencies.CacheAs<IEditorBeatmap<TObject>>(editorBeatmap);
+
+            Config = dependencies.Get<RulesetConfigCache>().GetConfigFor(Ruleset);
+
+            return base.CreateChildDependencies(dependencies);
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
             inputManager = GetContainingInputManager();
-        }
-
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-        {
-            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-
-            dependencies.CacheAs(this);
-            Config = dependencies.Get<RulesetConfigCache>().GetConfigFor(Ruleset);
-
-            return dependencies;
         }
 
         protected override void UpdateAfterChildren()
@@ -150,58 +160,6 @@ namespace osu.Game.Rulesets.Edit
             });
         }
 
-        /// <summary>
-        /// Whether the user's cursor is currently in an area of the <see cref="HitObjectComposer"/> that is valid for placement.
-        /// </summary>
-        public virtual bool CursorInPlacementArea => DrawableRuleset.Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
-
-        internal abstract DrawableEditRuleset CreateDrawableRuleset();
-
-        protected abstract IReadOnlyList<HitObjectCompositionTool> CompositionTools { get; }
-
-        /// <summary>
-        /// Creates a <see cref="SelectionBlueprint"/> for a specific <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <param name="hitObject">The <see cref="DrawableHitObject"/> to create the overlay for.</param>
-        public virtual SelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject) => null;
-
-        /// <summary>
-        /// Creates a <see cref="SelectionHandler"/> which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.
-        /// </summary>
-        public virtual SelectionHandler CreateSelectionHandler() => new SelectionHandler();
-    }
-
-    [Cached(Type = typeof(IPlacementHandler))]
-    public abstract class HitObjectComposer<TObject> : HitObjectComposer, IPlacementHandler
-        where TObject : HitObject
-    {
-        private Beatmap<TObject> playableBeatmap;
-        private EditorBeatmap<TObject> editorBeatmap;
-        private IBeatmapProcessor beatmapProcessor;
-
-        protected HitObjectComposer(Ruleset ruleset)
-            : base(ruleset)
-        {
-        }
-
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-        {
-            var workingBeatmap = parent.Get<IBindable<WorkingBeatmap>>();
-            playableBeatmap = (Beatmap<TObject>)workingBeatmap.Value.GetPlayableBeatmap(Ruleset.RulesetInfo, Array.Empty<Mod>());
-
-            beatmapProcessor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
-
-            editorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
-            editorBeatmap.HitObjectAdded += addHitObject;
-            editorBeatmap.HitObjectRemoved += removeHitObject;
-
-            var dependencies = new DependencyContainer(parent);
-            dependencies.CacheAs<IEditorBeatmap>(editorBeatmap);
-            dependencies.CacheAs<IEditorBeatmap<TObject>>(editorBeatmap);
-
-            return base.CreateChildDependencies(dependencies);
-        }
-
         private void addHitObject(HitObject hitObject)
         {
             beatmapProcessor?.PreProcess();
@@ -215,8 +173,10 @@ namespace osu.Game.Rulesets.Edit
             beatmapProcessor?.PostProcess();
         }
 
-        internal override DrawableEditRuleset CreateDrawableRuleset()
-            => new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, Beatmap.Value, Array.Empty<Mod>()));
+        public override IEnumerable<DrawableHitObject> HitObjects => DrawableRuleset.Playfield.AllHitObjects;
+        public override bool CursorInPlacementArea => DrawableRuleset.Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
+
+        protected abstract IReadOnlyList<HitObjectCompositionTool> CompositionTools { get; }
 
         protected abstract DrawableRuleset<TObject> CreateDrawableRuleset(Ruleset ruleset, WorkingBeatmap beatmap, IReadOnlyList<Mod> mods);
 
@@ -238,5 +198,35 @@ namespace osu.Game.Rulesets.Edit
                 editorBeatmap.HitObjectRemoved -= removeHitObject;
             }
         }
+    }
+
+    [Cached(typeof(HitObjectComposer))]
+    public abstract class HitObjectComposer : CompositeDrawable
+    {
+        internal HitObjectComposer()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        /// <summary>
+        /// All the <see cref="DrawableHitObject"/>s.
+        /// </summary>
+        public abstract IEnumerable<DrawableHitObject> HitObjects { get; }
+
+        /// <summary>
+        /// Whether the user's cursor is currently in an area of the <see cref="HitObjectComposer"/> that is valid for placement.
+        /// </summary>
+        public abstract bool CursorInPlacementArea { get; }
+
+        /// <summary>
+        /// Creates a <see cref="SelectionBlueprint"/> for a specific <see cref="DrawableHitObject"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="DrawableHitObject"/> to create the overlay for.</param>
+        public virtual SelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject) => null;
+
+        /// <summary>
+        /// Creates a <see cref="SelectionHandler"/> which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.
+        /// </summary>
+        public virtual SelectionHandler CreateSelectionHandler() => new SelectionHandler();
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Edit
         private EditorBeatmap<TObject> editorBeatmap;
         private IBeatmapProcessor beatmapProcessor;
 
-        private DrawableEditRuleset<TObject> drawableRuleset;
+        private DrawableEditRulesetWrapper<TObject> drawableRulesetWrapper;
         private BlueprintContainer blueprintContainer;
         private readonly List<Container> layerContainers = new List<Container>();
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Edit
         {
             try
             {
-                drawableRuleset = new DrawableEditRuleset<TObject>(CreateDrawableRuleset(Ruleset, workingBeatmap.Value, Array.Empty<Mod>()))
+                drawableRulesetWrapper = new DrawableEditRulesetWrapper<TObject>(CreateDrawableRuleset(Ruleset, workingBeatmap.Value, Array.Empty<Mod>()))
                 {
                     Clock = framedClock
                 };
@@ -66,10 +66,10 @@ namespace osu.Game.Rulesets.Edit
                 return;
             }
 
-            var layerBelowRuleset = drawableRuleset.CreatePlayfieldAdjustmentContainer();
+            var layerBelowRuleset = drawableRulesetWrapper.CreatePlayfieldAdjustmentContainer();
             layerBelowRuleset.Child = new EditorPlayfieldBorder { RelativeSizeAxes = Axes.Both };
 
-            var layerAboveRuleset = drawableRuleset.CreatePlayfieldAdjustmentContainer();
+            var layerAboveRuleset = drawableRulesetWrapper.CreatePlayfieldAdjustmentContainer();
             layerAboveRuleset.Child = blueprintContainer = new BlueprintContainer();
 
             layerContainers.Add(layerBelowRuleset);
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Edit
                             Children = new Drawable[]
                             {
                                 layerBelowRuleset,
-                                drawableRuleset,
+                                drawableRulesetWrapper,
                                 layerAboveRuleset
                             }
                         }
@@ -153,10 +153,10 @@ namespace osu.Game.Rulesets.Edit
 
             layerContainers.ForEach(l =>
             {
-                l.Anchor = drawableRuleset.Playfield.Anchor;
-                l.Origin = drawableRuleset.Playfield.Origin;
-                l.Position = drawableRuleset.Playfield.Position;
-                l.Size = drawableRuleset.Playfield.Size;
+                l.Anchor = drawableRulesetWrapper.Playfield.Anchor;
+                l.Origin = drawableRulesetWrapper.Playfield.Origin;
+                l.Position = drawableRulesetWrapper.Playfield.Position;
+                l.Size = drawableRulesetWrapper.Playfield.Size;
             });
         }
 
@@ -173,8 +173,8 @@ namespace osu.Game.Rulesets.Edit
             beatmapProcessor?.PostProcess();
         }
 
-        public override IEnumerable<DrawableHitObject> HitObjects => drawableRuleset.Playfield.AllHitObjects;
-        public override bool CursorInPlacementArea => drawableRuleset.Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
+        public override IEnumerable<DrawableHitObject> HitObjects => drawableRulesetWrapper.Playfield.AllHitObjects;
+        public override bool CursorInPlacementArea => drawableRulesetWrapper.Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
 
         protected abstract IReadOnlyList<HitObjectCompositionTool> CompositionTools { get; }
 


### PR DESCRIPTION
No logical changes in this one, just moving things around. The non-generic `HitObjectComposer` is now a very minimal class.