### PR TITLE
Fix vertical alignment of hit error display ticks

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -238,7 +238,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             {
                 Y = getRelativeJudgementPosition(judgement.TimeOffset),
                 Anchor = alignment == Anchor.x2 ? Anchor.x0 : Anchor.x2,
-                Origin = alignment == Anchor.x2 ? Anchor.x0 : Anchor.x2,
+                Origin = Anchor.y1 | (alignment == Anchor.x2 ? Anchor.x0 : Anchor.x2),
             });
 
             arrow.MoveToY(


### PR DESCRIPTION
Wasn't correctly centered before.

Before:
![](https://puu.sh/EbDO6/86decfe47c.gif)

After:
![](https://puu.sh/EbDNn/603a982cd6.gif)