### PR TITLE
Remove unnecessary osu! endpoint from changelog builds

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIChangelogBuild.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIChangelogBuild.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("versions")]
         public VersionNavigation Versions { get; set; }
 
-        public string Url => $"https://osu.ppy.sh/home/changelog/{UpdateStream.Name}/{Version}";
+        public string Url => $"/home/changelog/{UpdateStream.Name}/{Version}";
 
         public class VersionNavigation
         {


### PR DESCRIPTION
URL is already fed the API endpoint on `OsuGame.OpenUrlExternally()`.