### PR TITLE
Fix taiko swell tick judgements having non-zero time offsets

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneSwellJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneSwellJudgements.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Judgements;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TestSceneSwellJudgements : PlayerTestScene
+    {
+        protected new TestPlayer Player => (TestPlayer)base.Player;
+
+        public TestSceneSwellJudgements()
+            : base(new TaikoRuleset())
+        {
+        }
+
+        [Test]
+        public void TestZeroTickTimeOffsets()
+        {
+            AddUntilStep("gameplay finished", () => Player.ScoreProcessor.HasCompleted);
+            AddAssert("all tick offsets are 0", () => Player.Results.Where(r => r.Judgement is TaikoSwellTickJudgement).All(r => r.TimeOffset == 0));
+        }
+
+        protected override bool Autoplay => true;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
+        {
+            var beatmap = new Beatmap<TaikoHitObject>
+            {
+                BeatmapInfo = { Ruleset = new TaikoRuleset().RulesetInfo },
+                HitObjects =
+                {
+                    new Swell
+                    {
+                        StartTime = 1000,
+                        Duration = 1000,
+                    }
+                }
+            };
+
+            return beatmap;
+        }
+
+        protected override Player CreatePlayer(Ruleset ruleset) => new TestPlayer();
+
+        protected class TestPlayer : Player
+        {
+            public readonly List<JudgementResult> Results = new List<JudgementResult>();
+
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            public TestPlayer()
+                : base(false, false)
+            {
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                ScoreProcessor.NewJudgement += r => Results.Add(r);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -14,7 +14,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
         }
 
-        public void TriggerResult(HitResult type) => ApplyResult(r => r.Type = type);
+        public void TriggerResult(HitResult type)
+        {
+            HitObject.StartTime = Time.Current;
+            ApplyResult(r => r.Type = type);
+        }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Whether all <see cref="Judgement"/>s have been processed.
         /// </summary>
-        protected virtual bool HasCompleted => false;
+        public virtual bool HasCompleted => false;
 
         /// <summary>
         /// Whether this ScoreProcessor has already triggered the failed state.
@@ -205,7 +205,7 @@ namespace osu.Game.Rulesets.Scoring
         private const double combo_portion = 0.7;
         private const double max_score = 1000000;
 
-        protected sealed override bool HasCompleted => JudgedHits == MaxHits;
+        public sealed override bool HasCompleted => JudgedHits == MaxHits;
 
         protected int MaxHits { get; private set; }
         protected int JudgedHits { get; private set; }

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
@@ -40,6 +41,8 @@ namespace osu.Game.Tests.Visual
 
         protected virtual bool AllowFail => false;
 
+        protected virtual bool Autoplay => false;
+
         private void loadPlayer()
         {
             var beatmap = CreateBeatmap(ruleset.RulesetInfo);
@@ -53,6 +56,16 @@ namespace osu.Game.Tests.Visual
             LoadScreen(Player);
         }
 
-        protected virtual Player CreatePlayer(Ruleset ruleset) => new TestPlayer(false, false);
+        protected virtual Player CreatePlayer(Ruleset ruleset)
+        {
+            if (Autoplay)
+            {
+                var mod = ruleset.GetAutoplayMod();
+                if (mod != null)
+                    Mods.Value = Mods.Value.Concat(mod.Yield()).ToArray();
+            }
+
+            return new TestPlayer(false, false);
+        }
     }
 }

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -52,12 +52,6 @@ namespace osu.Game.Tests.Visual
             if (!AllowFail)
                 Mods.Value = new[] { ruleset.GetAllMods().First(m => m is ModNoFail) };
 
-            Player = CreatePlayer(ruleset);
-            LoadScreen(Player);
-        }
-
-        protected virtual Player CreatePlayer(Ruleset ruleset)
-        {
             if (Autoplay)
             {
                 var mod = ruleset.GetAutoplayMod();
@@ -65,7 +59,10 @@ namespace osu.Game.Tests.Visual
                     Mods.Value = Mods.Value.Concat(mod.Yield()).ToArray();
             }
 
-            return new TestPlayer(false, false);
+            Player = CreatePlayer(ruleset);
+            LoadScreen(Player);
         }
+
+        protected virtual Player CreatePlayer(Ruleset ruleset) => new TestPlayer(false, false);
     }
 }


### PR DESCRIPTION
Resolves part of #5912