### PR TITLE
Use float types for cursor sizes

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private bool cursorExpand;
 
-        private Bindable<double> cursorScale;
+        private Bindable<float> cursorScale;
         private Bindable<bool> autoCursorScale;
         private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
 
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             this.beatmap.BindTo(beatmap);
             this.beatmap.ValueChanged += _ => calculateScale();
 
-            cursorScale = config.GetBindable<double>(OsuSetting.GameplayCursorSize);
+            cursorScale = config.GetBindable<float>(OsuSetting.GameplayCursorSize);
             cursorScale.ValueChanged += _ => calculateScale();
 
             autoCursorScale = config.GetBindable<bool>(OsuSetting.AutoCursorSize);
@@ -70,12 +70,12 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private void calculateScale()
         {
-            float scale = (float)cursorScale.Value;
+            float scale = cursorScale.Value;
 
             if (autoCursorScale.Value && beatmap.Value != null)
             {
                 // if we have a beatmap available, let's get its circle size to figure out an automatic cursor scale modifier.
-                scale *= (float)(1 - 0.7 * (1 + beatmap.Value.BeatmapInfo.BaseDifficulty.CircleSize - BeatmapDifficulty.DEFAULT_DIFFICULTY) / BeatmapDifficulty.DEFAULT_DIFFICULTY);
+                scale *= 1f - 0.7f * (1f + beatmap.Value.BeatmapInfo.BaseDifficulty.CircleSize - BeatmapDifficulty.DEFAULT_DIFFICULTY) / BeatmapDifficulty.DEFAULT_DIFFICULTY;
             }
 
             scaleTarget.Scale = new Vector2(scale);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -58,8 +58,8 @@ namespace osu.Game.Configuration
             Set(OsuSetting.AudioOffset, 0, -500.0, 500.0, 1);
 
             // Input
-            Set(OsuSetting.MenuCursorSize, 1.0, 0.5f, 2, 0.01);
-            Set(OsuSetting.GameplayCursorSize, 1.0, 0.1f, 2, 0.01);
+            Set(OsuSetting.MenuCursorSize, 1.0f, 0.5f, 2f, 0.01f);
+            Set(OsuSetting.GameplayCursorSize, 1.0f, 0.1f, 2f, 0.01f);
             Set(OsuSetting.AutoCursorSize, false);
 
             Set(OsuSetting.MouseDisableButtons, false);

--- a/osu.Game/Graphics/Cursor/MenuCursor.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursor.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Graphics.Cursor
         public class Cursor : Container
         {
             private Container cursorContainer;
-            private Bindable<double> cursorScale;
+            private Bindable<float> cursorScale;
             private const float base_scale = 0.15f;
 
             public Sprite AdditiveLayer;
@@ -159,9 +159,8 @@ namespace osu.Game.Graphics.Cursor
                     }
                 };
 
-                cursorScale = config.GetBindable<double>(OsuSetting.MenuCursorSize);
-                cursorScale.ValueChanged += scale => cursorContainer.Scale = new Vector2((float)scale.NewValue * base_scale);
-                cursorScale.TriggerChange();
+                cursorScale = config.GetBindable<float>(OsuSetting.MenuCursorSize);
+                cursorScale.BindValueChanged(scale => cursorContainer.Scale = new Vector2(scale.NewValue * base_scale), true);
             }
         }
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -35,16 +35,16 @@ namespace osu.Game.Overlays.Settings.Sections
             Children = new Drawable[]
             {
                 skinDropdown = new SkinSettingsDropdown(),
-                new SettingsSlider<double, SizeSlider>
+                new SettingsSlider<float, SizeSlider>
                 {
                     LabelText = "Menu cursor size",
-                    Bindable = config.GetBindable<double>(OsuSetting.MenuCursorSize),
+                    Bindable = config.GetBindable<float>(OsuSetting.MenuCursorSize),
                     KeyboardStep = 0.01f
                 },
-                new SettingsSlider<double, SizeSlider>
+                new SettingsSlider<float, SizeSlider>
                 {
                     LabelText = "Gameplay cursor size",
-                    Bindable = config.GetBindable<double>(OsuSetting.GameplayCursorSize),
+                    Bindable = config.GetBindable<float>(OsuSetting.GameplayCursorSize),
                     KeyboardStep = 0.01f
                 },
                 new SettingsCheckbox
@@ -95,7 +95,7 @@ namespace osu.Game.Overlays.Settings.Sections
             }
         }
 
-        private class SizeSlider : OsuSliderBar<double>
+        private class SizeSlider : OsuSliderBar<float>
         {
             public override string TooltipText => Current.Value.ToString(@"0.##x");
         }


### PR DESCRIPTION
- Uses `float` type for cursor sizes (`GameplayCursorSize` and `MenuCursorSize`) as it should've been.
- [x] Depends on ppy/osu-framework#2816