### PR TITLE
Use float types for user visual levels

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimContainer.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimContainer.cs
@@ -295,8 +295,8 @@ namespace osu.Game.Tests.Visual.Background
             }
 
             public readonly Bindable<bool> DimEnabled = new Bindable<bool>();
-            public readonly Bindable<double> DimLevel = new Bindable<double>();
-            public readonly Bindable<double> BlurLevel = new Bindable<double>();
+            public readonly Bindable<float> DimLevel = new Bindable<float>();
+            public readonly Bindable<float> BlurLevel = new Bindable<float>();
 
             public new BeatmapCarousel Carousel => base.Carousel;
 
@@ -307,11 +307,11 @@ namespace osu.Game.Tests.Visual.Background
                 config.BindWith(OsuSetting.BlurLevel, BlurLevel);
             }
 
-            public bool IsBackgroundDimmed() => ((FadeAccessibleBackground)Background).CurrentColour == OsuColour.Gray(1 - (float)DimLevel.Value);
+            public bool IsBackgroundDimmed() => ((FadeAccessibleBackground)Background).CurrentColour == OsuColour.Gray(1f - DimLevel.Value);
 
             public bool IsBackgroundUndimmed() => ((FadeAccessibleBackground)Background).CurrentColour == Color4.White;
 
-            public bool IsUserBlurApplied() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2((float)BlurLevel.Value * BackgroundScreenBeatmap.USER_BLUR_FACTOR);
+            public bool IsUserBlurApplied() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BlurLevel.Value * BackgroundScreenBeatmap.USER_BLUR_FACTOR);
 
             public bool IsUserBlurDisabled() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(0);
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -77,8 +77,8 @@ namespace osu.Game.Configuration
             Set(OsuSetting.MenuParallax, true);
 
             // Gameplay
-            Set(OsuSetting.DimLevel, 0.3, 0, 1, 0.01);
-            Set(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
+            Set(OsuSetting.DimLevel, 0.3f, 0f, 1f, 0.01f);
+            Set(OsuSetting.BlurLevel, 0f, 0f, 1f, 0.01f);
 
             Set(OsuSetting.ShowInterface, true);
             Set(OsuSetting.ShowHealthDisplayWhenCantFail, true);

--- a/osu.Game/Graphics/Containers/UserDimContainer.cs
+++ b/osu.Game/Graphics/Containers/UserDimContainer.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Graphics.Containers
             ContentDisplayed = ShowDimContent;
 
             dimContent.FadeTo(ContentDisplayed ? 1 : 0, BACKGROUND_FADE_DURATION, Easing.OutQuint);
-            dimContent.FadeColour(OsuColour.Gray(1 - (float)DimLevel), BACKGROUND_FADE_DURATION, Easing.OutQuint);
+            dimContent.FadeColour(OsuColour.Gray(1f - DimLevel), BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }
     }
 }

--- a/osu.Game/Graphics/Containers/UserDimContainer.cs
+++ b/osu.Game/Graphics/Containers/UserDimContainer.cs
@@ -31,11 +31,11 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         public bool ContentDisplayed { get; private set; }
 
-        protected Bindable<double> UserDimLevel { get; private set; }
+        protected Bindable<float> UserDimLevel { get; private set; }
 
         protected Bindable<bool> ShowStoryboard { get; private set; }
 
-        protected double DimLevel => EnableUserDim.Value ? UserDimLevel.Value : 0;
+        protected float DimLevel => EnableUserDim.Value ? UserDimLevel.Value : 0f;
 
         protected override Container<Drawable> Content => dimContent;
 
@@ -52,7 +52,7 @@ namespace osu.Game.Graphics.Containers
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            UserDimLevel = config.GetBindable<double>(OsuSetting.DimLevel);
+            UserDimLevel = config.GetBindable<float>(OsuSetting.DimLevel);
             ShowStoryboard = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
 
             EnableUserDim.ValueChanged += _ => UpdateVisuals();

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -17,16 +17,16 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
         {
             Children = new Drawable[]
             {
-                new SettingsSlider<double>
+                new SettingsSlider<float>
                 {
                     LabelText = "Background dim",
-                    Bindable = config.GetBindable<double>(OsuSetting.DimLevel),
+                    Bindable = config.GetBindable<float>(OsuSetting.DimLevel),
                     KeyboardStep = 0.01f
                 },
-                new SettingsSlider<double>
+                new SettingsSlider<float>
                 {
                     LabelText = "Background blur",
-                    Bindable = config.GetBindable<double>(OsuSetting.BlurLevel),
+                    Bindable = config.GetBindable<float>(OsuSetting.BlurLevel),
                     KeyboardStep = 0.01f
                 },
                 new SettingsCheckbox

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Screens.Backgrounds
                 }
             }
 
-            private Bindable<double> userBlurLevel { get; set; }
+            private Bindable<float> userBlurLevel { get; set; }
 
             private Background background;
 
@@ -161,13 +161,13 @@ namespace osu.Game.Screens.Backgrounds
             /// As an optimisation, we add the two blur portions to be applied rather than actually applying two separate blurs.
             /// </summary>
             private Vector2 blurTarget => EnableUserDim.Value
-                ? new Vector2(BlurAmount.Value + (float)userBlurLevel.Value * USER_BLUR_FACTOR)
+                ? new Vector2(BlurAmount.Value + userBlurLevel.Value * USER_BLUR_FACTOR)
                 : new Vector2(BlurAmount.Value);
 
             [BackgroundDependencyLoader]
             private void load(OsuConfigManager config)
             {
-                userBlurLevel = config.GetBindable<double>(OsuSetting.BlurLevel);
+                userBlurLevel = config.GetBindable<float>(OsuSetting.BlurLevel);
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
     {
         protected override string Title => "Visual settings";
 
-        private readonly PlayerSliderBar<double> dimSliderBar;
-        private readonly PlayerSliderBar<double> blurSliderBar;
+        private readonly PlayerSliderBar<float> dimSliderBar;
+        private readonly PlayerSliderBar<float> blurSliderBar;
         private readonly PlayerCheckbox showStoryboardToggle;
         private readonly PlayerCheckbox beatmapSkinsToggle;
         private readonly PlayerCheckbox beatmapHitsoundsToggle;
@@ -26,12 +26,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 {
                     Text = "Background dim:"
                 },
-                dimSliderBar = new PlayerSliderBar<double>(),
+                dimSliderBar = new PlayerSliderBar<float>(),
                 new OsuSpriteText
                 {
                     Text = "Background blur:"
                 },
-                blurSliderBar = new PlayerSliderBar<double>(),
+                blurSliderBar = new PlayerSliderBar<float>(),
                 new OsuSpriteText
                 {
                     Text = "Toggles:"
@@ -45,8 +45,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            dimSliderBar.Bindable = config.GetBindable<double>(OsuSetting.DimLevel);
-            blurSliderBar.Bindable = config.GetBindable<double>(OsuSetting.BlurLevel);
+            dimSliderBar.Bindable = config.GetBindable<float>(OsuSetting.DimLevel);
+            blurSliderBar.Bindable = config.GetBindable<float>(OsuSetting.BlurLevel);
             showStoryboardToggle.Current = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
             beatmapSkinsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
             beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);

--- a/osu.Game/Tests/Visual/AllPlayersTestScene.cs
+++ b/osu.Game/Tests/Visual/AllPlayersTestScene.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual
 
             OsuConfigManager manager;
             Dependencies.Cache(manager = new OsuConfigManager(LocalStorage));
-            manager.GetBindable<double>(OsuSetting.DimLevel).Value = 1.0;
+            manager.GetBindable<float>(OsuSetting.DimLevel).Value = 1.0f;
         }
 
         protected abstract void AddCheckSteps();

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Visual
         private void load()
         {
             Dependencies.Cache(LocalConfig = new OsuConfigManager(LocalStorage));
-            LocalConfig.GetBindable<double>(OsuSetting.DimLevel).Value = 1.0;
+            LocalConfig.GetBindable<float>(OsuSetting.DimLevel).Value = 1.0f;
         }
 
         [SetUpSteps]


### PR DESCRIPTION
- Uses `float` type for user visual levels (`BlurLevel` and `DimLevel`) as it should've been.
- [x] Depends on ppy/osu-framework#2816