### PR TITLE
Fix catch catcher lookups

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -60,7 +60,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.903.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.903.1" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2019.830.1" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Catch/CatchSkinComponent.cs
+++ b/osu.Game.Rulesets.Catch/CatchSkinComponent.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Catch
         {
         }
 
-        protected override string RulesetPrefix => CatchRuleset.SHORT_NAME;
+        protected override string RulesetPrefix => "catch"; // todo: use CatchRuleset.SHORT_NAME;
 
         protected override string ComponentName => Component.ToString().ToLower();
     }

--- a/osu.Game.Rulesets.Catch/CatchSkinComponents.cs
+++ b/osu.Game.Rulesets.Catch/CatchSkinComponents.cs
@@ -5,6 +5,5 @@ namespace osu.Game.Rulesets.Catch
 {
     public enum CatchSkinComponents
     {
-        Catcher
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherSprite.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherSprite.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Catch.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = new SkinnableSprite(new CatchSkinComponent(CatchSkinComponents.Catcher))
+            InternalChild = new SkinnableSprite("Gameplay/catch/fruit-catcher-idle")
             {
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.TopCentre,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ApproachCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ApproachCircle.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         private class SkinnableApproachCircle : SkinnableSprite
         {
             public SkinnableApproachCircle()
-                : base(new OsuSkinComponent(OsuSkinComponents.ApproachCircle))
+                : base("Gameplay/osu/approachcircle")
             {
             }
 

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -19,11 +19,23 @@ namespace osu.Game.Skinning
         [Resolved]
         private TextureStore textures { get; set; }
 
-        public SkinnableSprite(ISkinComponent component, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.ScaleDownToFit)
-            : base(component, allowFallback, confineMode)
+        public SkinnableSprite(string textureName, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.ScaleDownToFit)
+            : base(new SpriteComponent(textureName), allowFallback, confineMode)
         {
         }
 
         protected override Drawable CreateDefault(ISkinComponent component) => new Sprite { Texture = textures.Get(component.LookupName) };
+
+        private class SpriteComponent : ISkinComponent
+        {
+            private readonly string textureName;
+
+            public SpriteComponent(string textureName)
+            {
+                this.textureName = textureName;
+            }
+
+            public string LookupName => textureName;
+        }
     }
 }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.903.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.903.1" />
     <PackageReference Include="ppy.osu.Framework" Version="2019.830.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -117,7 +117,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.903.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2019.903.1" />
     <PackageReference Include="ppy.osu.Framework" Version="2019.830.1" />
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.830.1" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />


### PR DESCRIPTION
Reverts `SkinnableSprite` lookups to old behaviour.

- [x] Depends on https://github.com/ppy/osu-resources/pull/75
- [x] Depends on `osu-resources` bump.