### PR TITLE
Fix bracket and parenthesis handling in existing link formats

### DIFF
--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -120,6 +120,53 @@ namespace osu.Game.Tests.Chat
         }
 
         [Test]
+        public void TestOldFormatLinkWithBalancedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a (tricky (one))[https://osu.ppy.sh]!" });
+
+            Assert.AreEqual("This is a tricky (one)!", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(12, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestOldFormatLinkWithEscapedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is (another loose bracket \\))[https://osu.ppy.sh]." });
+
+            Assert.AreEqual("This is another loose bracket ).", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(8, result.Links[0].Index);
+            Assert.AreEqual(23, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestOldFormatWithBackslashes()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This link (should end with a backslash \\)[https://osu.ppy.sh]." });
+            Assert.AreEqual("This link should end with a backslash \\.", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(29, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestOldFormatLinkWithEscapedAndBalancedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a (\\)super\\(\\( tricky (one))[https://osu.ppy.sh]!" });
+
+            Assert.AreEqual("This is a )super(( tricky (one)!", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(21, result.Links[0].Length);
+        }
+
+        [Test]
         public void TestNewFormatLink()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh simple test]." });

--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -180,6 +180,53 @@ namespace osu.Game.Tests.Chat
         }
 
         [Test]
+        public void TestMarkdownFormatLinkWithBalancedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [tricky [one]](https://osu.ppy.sh)!" });
+
+            Assert.AreEqual("This is a tricky [one]!", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(12, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestMarkdownFormatLinkWithEscapedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is [another loose bracket \\]](https://osu.ppy.sh)." });
+
+            Assert.AreEqual("This is another loose bracket ].", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(8, result.Links[0].Index);
+            Assert.AreEqual(23, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestMarkdownFormatWithBackslashes()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This link [should end with a backslash \\](https://osu.ppy.sh)." });
+            Assert.AreEqual("This link should end with a backslash \\.", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(29, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestMarkdownFormatLinkWithEscapedAndBalancedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [\\]super\\[\\[ tricky [one]](https://osu.ppy.sh)!" });
+
+            Assert.AreEqual("This is a ]super[[ tricky [one]!", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(21, result.Links[0].Length);
+        }
+
+        [Test]
         public void TestChannelLink()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is an #english and #japanese." });

--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -132,6 +132,42 @@ namespace osu.Game.Tests.Chat
         }
 
         [Test]
+        public void TestNewFormatLinkWithEscapedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh nasty link with escaped brackets: \\] and \\[]" });
+
+            Assert.AreEqual("This is a nasty link with escaped brackets: ] and [", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(41, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestNewFormatLinkWithBackslashesInside()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh link \\ with \\ backslashes \\]" });
+
+            Assert.AreEqual("This is a link \\ with \\ backslashes \\", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(27, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestNewFormatLinkWithEscapedAndBalancedBrackets()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [https://osu.ppy.sh [link [with \\] too many brackets \\[ ]]]" });
+
+            Assert.AreEqual("This is a [link [with ] too many brackets [ ]]", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(10, result.Links[0].Index);
+            Assert.AreEqual(36, result.Links[0].Length);
+        }
+
+        [Test]
         public void TestMarkdownFormatLink()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a [simple test](https://osu.ppy.sh)." });

--- a/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
@@ -128,6 +128,7 @@ namespace osu.Game.Tests.Visual.Online
             addMessageWithChecks("Let's (try)[https://osu.ppy.sh/home] [https://osu.ppy.sh/b/252238 multiple links] https://osu.ppy.sh/home", 3,
                 expectedActions: new[] { LinkAction.External, LinkAction.OpenBeatmap, LinkAction.External });
             addMessageWithChecks("[https://osu.ppy.sh/home New link format with escaped [and \\[ paired] braces]", expectedActions: LinkAction.External);
+            addMessageWithChecks("[Markdown link format with escaped [and \\[ paired] braces](https://osu.ppy.sh/home)", expectedActions: LinkAction.External);
             // note that there's 0 links here (they get removed if a channel is not found)
             addMessageWithChecks("#lobby or #osu would be blue (and work) in the ChatDisplay test (when a proper ChatOverlay is present).");
             addMessageWithChecks("I am important!", 0, false, true);

--- a/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
@@ -127,8 +127,9 @@ namespace osu.Game.Tests.Visual.Online
             addMessageWithChecks("is now playing [https://osu.ppy.sh/b/252238 IMAGE -MATERIAL- <Version 0>]", 1, true, expectedActions: LinkAction.OpenBeatmap);
             addMessageWithChecks("Let's (try)[https://osu.ppy.sh/home] [https://osu.ppy.sh/b/252238 multiple links] https://osu.ppy.sh/home", 3,
                 expectedActions: new[] { LinkAction.External, LinkAction.OpenBeatmap, LinkAction.External });
-            addMessageWithChecks("[https://osu.ppy.sh/home New link format with escaped [and \\[ paired] braces]", expectedActions: LinkAction.External);
-            addMessageWithChecks("[Markdown link format with escaped [and \\[ paired] braces](https://osu.ppy.sh/home)", expectedActions: LinkAction.External);
+            addMessageWithChecks("[https://osu.ppy.sh/home New link format with escaped [and \\[ paired] braces]", 1, expectedActions: LinkAction.External);
+            addMessageWithChecks("[Markdown link format with escaped [and \\[ paired] braces](https://osu.ppy.sh/home)", 1, expectedActions: LinkAction.External);
+            addMessageWithChecks("(Old link format with escaped (and \\( paired) parentheses)[https://osu.ppy.sh/home] and [[also a rogue wiki link]]", 2, expectedActions: new[] { LinkAction.External, LinkAction.External });
             // note that there's 0 links here (they get removed if a channel is not found)
             addMessageWithChecks("#lobby or #osu would be blue (and work) in the ChatDisplay test (when a proper ChatOverlay is present).");
             addMessageWithChecks("I am important!", 0, false, true);

--- a/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
@@ -127,6 +127,7 @@ namespace osu.Game.Tests.Visual.Online
             addMessageWithChecks("is now playing [https://osu.ppy.sh/b/252238 IMAGE -MATERIAL- <Version 0>]", 1, true, expectedActions: LinkAction.OpenBeatmap);
             addMessageWithChecks("Let's (try)[https://osu.ppy.sh/home] [https://osu.ppy.sh/b/252238 multiple links] https://osu.ppy.sh/home", 3,
                 expectedActions: new[] { LinkAction.External, LinkAction.OpenBeatmap, LinkAction.External });
+            addMessageWithChecks("[https://osu.ppy.sh/home New link format with escaped [and \\[ paired] braces]", expectedActions: LinkAction.External);
             // note that there's 0 links here (they get removed if a channel is not found)
             addMessageWithChecks("#lobby or #osu would be blue (and work) in the ChatDisplay test (when a proper ChatOverlay is present).");
             addMessageWithChecks("I am important!", 0, false, true);

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Online.Chat
         private static readonly Regex wiki_regex = new Regex(@"\[\[(?<text>[^\]]+)\]\]");
 
         // (test)[https://osu.ppy.sh/b/1234] -> test (https://osu.ppy.sh/b/1234)
-        private static readonly Regex old_link_regex = new Regex(@"\((?<text>[^\)]*)\)\[(?<url>[a-z]+://[^ ]+)\]");
+        private static readonly Regex old_link_regex = new Regex(@"\((?<text>(((?<=\\)[\(\)])|[^\(\)])*(((?<open>\()(((?<=\\)[\(\)])|[^\(\)])*)+((?<close-open>\))(((?<=\\)[\(\)])|[^\(\)])*)+)*(?(open)(?!)))\)\[(?<url>[a-z]+://[^ ]+)\]");
 
         // [https://osu.ppy.sh/b/1234 Beatmap [Hard] (poop)] -> Beatmap [hard] (poop) (https://osu.ppy.sh/b/1234)
         private static readonly Regex new_link_regex = new Regex(@"\[(?<url>[a-z]+://[^ ]+) (?<text>(((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]");
@@ -194,7 +194,7 @@ namespace osu.Game.Online.Chat
             handleMatches(markdown_link_regex, "{1}", "{2}", result, startIndex, escapeChars: new[] { '[', ']' });
 
             // handle the ()[] link format
-            handleMatches(old_link_regex, "{1}", "{2}", result, startIndex);
+            handleMatches(old_link_regex, "{1}", "{2}", result, startIndex, escapeChars: new[] { '(', ')' });
 
             // handle wiki links
             handleMatches(wiki_regex, "{1}", "https://osu.ppy.sh/wiki/{1}", result, startIndex);

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -11,16 +11,16 @@ namespace osu.Game.Online.Chat
     public static class MessageFormatter
     {
         // [[Performance Points]] -> wiki:Performance Points (https://osu.ppy.sh/wiki/Performance_Points)
-        private static readonly Regex wiki_regex = new Regex(@"\[\[([^\]]+)\]\]");
+        private static readonly Regex wiki_regex = new Regex(@"\[\[(?<text>[^\]]+)\]\]");
 
         // (test)[https://osu.ppy.sh/b/1234] -> test (https://osu.ppy.sh/b/1234)
-        private static readonly Regex old_link_regex = new Regex(@"\(([^\)]*)\)\[([a-z]+://[^ ]+)\]");
+        private static readonly Regex old_link_regex = new Regex(@"\((?<text>[^\)]*)\)\[(?<url>[a-z]+://[^ ]+)\]");
 
         // [https://osu.ppy.sh/b/1234 Beatmap [Hard] (poop)] -> Beatmap [hard] (poop) (https://osu.ppy.sh/b/1234)
-        private static readonly Regex new_link_regex = new Regex(@"\[([a-z]+://[^ ]+) ((((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]");
+        private static readonly Regex new_link_regex = new Regex(@"\[(?<url>[a-z]+://[^ ]+) (?<text>(((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]");
 
         // [test](https://osu.ppy.sh/b/1234) -> test (https://osu.ppy.sh/b/1234) aka correct markdown format
-        private static readonly Regex markdown_link_regex = new Regex(@"\[([^\]]*)\]\(([a-z]+://[^ ]+)\)");
+        private static readonly Regex markdown_link_regex = new Regex(@"\[(?<text>[^\]]*)\]\((?<url>[a-z]+://[^ ]+)\)");
 
         // advanced, RFC-compatible regular expression that matches any possible URL, *but* allows certain invalid characters that are widely used
         // This is in the format (<required>, [optional]):
@@ -59,13 +59,13 @@ namespace osu.Game.Online.Chat
 
                 var displayText = string.Format(display,
                     m.Groups[0],
-                    m.Groups.Count > 1 ? m.Groups[1].Value : "",
-                    m.Groups.Count > 2 ? m.Groups[2].Value : "").Trim();
+                    m.Groups["text"].Value,
+                    m.Groups["url"].Value).Trim();
 
                 var linkText = string.Format(link,
                     m.Groups[0],
-                    m.Groups.Count > 1 ? m.Groups[1].Value : "",
-                    m.Groups.Count > 2 ? m.Groups[2].Value : "").Trim();
+                    m.Groups["text"].Value,
+                    m.Groups["url"].Value).Trim();
 
                 if (displayText.Length == 0 || linkText.Length == 0) continue;
 
@@ -188,7 +188,7 @@ namespace osu.Game.Online.Chat
             var result = new MessageFormatterResult(toFormat);
 
             // handle the [link display] format
-            handleMatches(new_link_regex, "{2}", "{1}", result, startIndex, escapeChars: new[] { '[', ']' });
+            handleMatches(new_link_regex, "{1}", "{2}", result, startIndex, escapeChars: new[] { '[', ']' });
 
             // handle the standard markdown []() format
             handleMatches(markdown_link_regex, "{1}", "{2}", result, startIndex);

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Online.Chat
         private static readonly Regex new_link_regex = new Regex(@"\[(?<url>[a-z]+://[^ ]+) (?<text>(((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]");
 
         // [test](https://osu.ppy.sh/b/1234) -> test (https://osu.ppy.sh/b/1234) aka correct markdown format
-        private static readonly Regex markdown_link_regex = new Regex(@"\[(?<text>[^\]]*)\]\((?<url>[a-z]+://[^ ]+)\)");
+        private static readonly Regex markdown_link_regex = new Regex(@"\[(?<text>(((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]\((?<url>[a-z]+://[^ ]+)\)");
 
         // advanced, RFC-compatible regular expression that matches any possible URL, *but* allows certain invalid characters that are widely used
         // This is in the format (<required>, [optional]):
@@ -191,7 +191,7 @@ namespace osu.Game.Online.Chat
             handleMatches(new_link_regex, "{1}", "{2}", result, startIndex, escapeChars: new[] { '[', ']' });
 
             // handle the standard markdown []() format
-            handleMatches(markdown_link_regex, "{1}", "{2}", result, startIndex);
+            handleMatches(markdown_link_regex, "{1}", "{2}", result, startIndex, escapeChars: new[] { '[', ']' });
 
             // handle the ()[] link format
             handleMatches(old_link_regex, "{1}", "{2}", result, startIndex);


### PR DESCRIPTION
Resolves #5772 (at least partially, see *Potential issues* for the asterisk on that).

# Description

For users to be able to add square brackets inside of links using the new format, the regular expression used for parsing those links contained a balancing group, which can be used for matching pairs of tokens (in this case, opening and closing brackets, in that order). However, this means that users could not post links with unmatched brackets inside of them (ie. ones that contain single brackets, or a closing bracket and then an opening one). Allow for escaping opening and closing brackets using the backslash character.

The change substitutes this old fragment of the regex in the display text group:

    [^\[\]]*        // any character other than closing/opening bracket, zero or more times

for this one: 

    (((?<=\\)[\[\]])|[^\[\]])*

The second pattern in the alternative remains the same; the first one performs the escaping, as follows:

    (
        (?<=\\)     // positive lookbehind expression:
                    // this match will succeed, if the next expression
                    // is preceded by a single backslash
        [\[\]]      // either an opening or closing brace
    )

Since the entire display group is matched and then passed down to actually format the link, unfortunately the lookbehind expression does not actually strip the backslashes, so they are manually stripped in `handleMatches`.

As demonstrated in the unit tests attached, this also allows balanced brackets to be mixed with escaped ones.

Analogous changes were made to Markdown and old-style link formats.

For the sake of readability, consistency and to make further changes easier, named groups `(?<text>)` and `(?<url>)` were also introduced to all link parsing regexes which have parts containing the desired link text and (optionally) URL.

The introduction of the named groups additionally simplifies `handleMatches()` and makes all calls to it consistent.

# Potential issues

* I'm not entirely sure about that escape replace part; entirely willing to swap that `Aggregate()` out for some `StringBuilding`.
* Open question: should I add the same handling to wiki links?
* Follow-up: to fully resolve #5772 in the original case of stray brackets in the link display text, it might also be required to escape all brackets in link texts in the kudosu list view, but that seems kind of out-of-scope for this PR. But it might be less painful for everyone involved if I just include it here.
* Documentation - I pulled this PR's description almost entirely from commit messages, but maybe some inline comments would also do?
* Readability - I could extract that magic `(((?<=\\)[\[\]])|[^\[\]])*` part to a variable and string together the regexes with that.
* Testing - I think I covered the obvious test cases, but suggestions for more are very welcome.