### PR TITLE
HoverClickSounds should handle click event instead of MouseUp

### DIFF
--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -34,12 +34,12 @@ namespace osu.Game.Graphics.UserInterface
             this.buttons = buttons ?? new[] { MouseButton.Left };
         }
 
-        protected override bool OnMouseUp(MouseUpEvent e)
+        protected override bool OnClick(ClickEvent e)
         {
             if (buttons.Contains(e.Button) && Contains(e.ScreenSpaceMousePosition))
                 sampleClick?.Play();
 
-            return base.OnMouseUp(e);
+            return base.OnClick(e);
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Fixes #5982

If we actually want to make right mouse button click sounds work, we should be changing right mouse button to be allowed to trigger clicks (can be easily done but requires regression testing as we are currently not checking which button is used for clicks in many other places).