### PR TITLE
Don't redraw certain buffered containers on scale change

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -61,6 +61,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.904.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.830.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.905.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Graphics/Backgrounds/Background.cs
+++ b/osu.Game/Graphics/Backgrounds/Background.cs
@@ -57,8 +57,9 @@ namespace osu.Game.Graphics.Backgrounds
 
                 AddInternal(bufferedContainer = new BufferedContainer
                 {
-                    CacheDrawnFrameBuffer = true,
                     RelativeSizeAxes = Axes.Both,
+                    CacheDrawnFrameBuffer = true,
+                    RedrawOnScale = false,
                     Child = Sprite
                 });
             }

--- a/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
@@ -12,6 +12,7 @@ namespace osu.Game.Graphics.Sprites
     public class GlowingSpriteText : Container, IHasText
     {
         private readonly OsuSpriteText spriteText, blurredText;
+        private readonly BufferedContainer buffer;
 
         public string Text
         {
@@ -43,13 +44,19 @@ namespace osu.Game.Graphics.Sprites
             set => blurredText.Colour = value;
         }
 
+        public bool RedrawOnScale
+        {
+            get => buffer.RedrawOnScale;
+            set => buffer.RedrawOnScale = value;
+        }
+
         public GlowingSpriteText()
         {
             AutoSizeAxes = Axes.Both;
 
             Children = new Drawable[]
             {
-                new BufferedContainer
+                buffer = new BufferedContainer
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
@@ -12,7 +12,6 @@ namespace osu.Game.Graphics.Sprites
     public class GlowingSpriteText : Container, IHasText
     {
         private readonly OsuSpriteText spriteText, blurredText;
-        private readonly BufferedContainer buffer;
 
         public string Text
         {
@@ -44,24 +43,19 @@ namespace osu.Game.Graphics.Sprites
             set => blurredText.Colour = value;
         }
 
-        public bool RedrawOnScale
-        {
-            get => buffer.RedrawOnScale;
-            set => buffer.RedrawOnScale = value;
-        }
-
         public GlowingSpriteText()
         {
             AutoSizeAxes = Axes.Both;
 
             Children = new Drawable[]
             {
-                buffer = new BufferedContainer
+                new BufferedContainer
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     BlurSigma = new Vector2(4),
                     CacheDrawnFrameBuffer = true,
+                    RedrawOnScale = false,
                     RelativeSizeAxes = Axes.Both,
                     Blending = BlendingParameters.Additive,
                     Size = new Vector2(3f),

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -193,7 +193,6 @@ namespace osu.Game.Online.Leaderboards
                                             GlowColour = OsuColour.FromHex(@"83ccfa"),
                                             Text = score.TotalScore.ToString(@"N0"),
                                             Font = OsuFont.Numeric.With(size: 23),
-                                            RedrawOnScale = false,
                                         },
                                         RankContainer = new Container
                                         {
@@ -339,7 +338,6 @@ namespace osu.Game.Online.Leaderboards
                             GlowColour = OsuColour.FromHex(@"83ccfa"),
                             Text = statistic.Value,
                             Font = OsuFont.GetFont(size: 17, weight: FontWeight.Bold),
-                            RedrawOnScale = false
                         },
                     },
                 };

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -193,6 +193,7 @@ namespace osu.Game.Online.Leaderboards
                                             GlowColour = OsuColour.FromHex(@"83ccfa"),
                                             Text = score.TotalScore.ToString(@"N0"),
                                             Font = OsuFont.Numeric.With(size: 23),
+                                            RedrawOnScale = false,
                                         },
                                         RankContainer = new Container
                                         {
@@ -338,6 +339,7 @@ namespace osu.Game.Online.Leaderboards
                             GlowColour = OsuColour.FromHex(@"83ccfa"),
                             Text = statistic.Value,
                             Font = OsuFont.GetFont(size: 17, weight: FontWeight.Bold),
+                            RedrawOnScale = false
                         },
                     },
                 };

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -351,7 +351,6 @@ namespace osu.Game.Overlays
                 RelativeSizeAxes = Axes.Both;
 
                 CacheDrawnFrameBuffer = true;
-                RedrawOnScale = false;
 
                 Children = new Drawable[]
                 {

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -346,9 +346,12 @@ namespace osu.Game.Overlays
             public Background(WorkingBeatmap beatmap = null)
             {
                 this.beatmap = beatmap;
-                CacheDrawnFrameBuffer = true;
+
                 Depth = float.MaxValue;
                 RelativeSizeAxes = Axes.Both;
+
+                CacheDrawnFrameBuffer = true;
+                RedrawOnScale = false;
 
                 Children = new Drawable[]
                 {

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -103,6 +103,7 @@ namespace osu.Game.Screens.Play
             var newColumns = new BufferedContainer<Column>
             {
                 CacheDrawnFrameBuffer = true,
+                RedrawOnScale = false,
                 RelativeSizeAxes = Axes.Both,
             };
 

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -154,6 +154,8 @@ namespace osu.Game.Screens.Select
                 var metadata = beatmapInfo.Metadata ?? beatmap.BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
 
                 CacheDrawnFrameBuffer = true;
+                RedrawOnScale = false;
+
                 RelativeSizeAxes = Axes.Both;
 
                 titleBinding = localisation.GetLocalisedString(new LocalisedString((metadata.TitleUnicode, metadata.Title)));

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -146,6 +146,7 @@ namespace osu.Game.Screens.Select.Carousel
             public PanelBackground(WorkingBeatmap working)
             {
                 CacheDrawnFrameBuffer = true;
+                RedrawOnScale = false;
 
                 Children = new Drawable[]
                 {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.904.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.830.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.905.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -118,8 +118,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.904.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.830.1" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.830.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.905.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.905.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/2820

Reduces me from ~110MPixels to ~80MPixel when entering player from song select. There's still a lot going on but I have tested to make sure it's not these particular buffered containers.