### PR TITLE
Add automatic resource mapping for rulesets to their own dll

### DIFF
--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
+using osu.Framework.IO.Stores;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Edit;
@@ -82,6 +83,8 @@ namespace osu.Game.Rulesets
         public virtual HitObjectComposer CreateHitObjectComposer() => null;
 
         public virtual Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.Solid.QuestionCircle };
+
+        public virtual IResourceStore<byte[]> CreateReourceStore() => new NamespacedResourceStore<byte[]>(new DllResourceStore(GetType().Assembly.Location), @"Resources");
 
         public abstract string Description { get; }
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -14,10 +14,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
+using osu.Framework.IO.Stores;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Input.Handlers;
@@ -50,6 +54,10 @@ namespace osu.Game.Rulesets.UI
         public override double GameplayStartTime => Objects.First().StartTime - 2000;
 
         private readonly Lazy<Playfield> playfield;
+
+        private TextureStore textureStore;
+
+        private ISampleStore sampleStore;
 
         /// <summary>
         /// The playfield.
@@ -141,6 +149,18 @@ namespace osu.Game.Rulesets.UI
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            var resources = Ruleset.CreateReourceStore();
+
+            if (resources != null)
+            {
+                textureStore = new TextureStore(new TextureLoaderStore(new NamespacedResourceStore<byte[]>(resources, "Textures")));
+                textureStore.AddStore(dependencies.Get<TextureStore>());
+                dependencies.Cache(textureStore);
+
+                sampleStore = dependencies.Get<AudioManager>().GetSampleStore(new NamespacedResourceStore<byte[]>(resources, "Samples"));
+                dependencies.CacheAs(sampleStore);
+            }
 
             onScreenDisplay = dependencies.Get<OnScreenDisplay>();
 

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Audio;
@@ -20,7 +21,7 @@ namespace osu.Game.Skinning
 
         private SampleChannel[] channels;
 
-        private AudioManager audio;
+        private ISampleStore samples;
 
         public SkinnableSound(IEnumerable<ISampleInfo> hitSamples)
         {
@@ -33,9 +34,9 @@ namespace osu.Game.Skinning
         }
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        private void load(ISampleStore samples)
         {
-            this.audio = audio;
+            this.samples = samples;
         }
 
         private bool looping;
@@ -81,7 +82,7 @@ namespace osu.Game.Skinning
 
                 if (ch == null && allowFallback)
                     foreach (var lookup in s.LookupNames)
-                        if ((ch = audio.Samples.Get($"Gameplay/{lookup}")) != null)
+                        if ((ch = samples.Get($"Gameplay/{lookup}")) != null)
                             break;
 
                 if (ch != null)
@@ -102,8 +103,9 @@ namespace osu.Game.Skinning
         {
             base.Dispose(isDisposing);
 
-            foreach (var c in channels)
-                c.Dispose();
+            if (channels != null)
+                foreach (var c in channels)
+                    c.Dispose();
         }
     }
 }


### PR DESCRIPTION
Until now, rulesets had a shocking task of trying to access their own resources.

This adds automatic access to Resources folder in the ruleset's DLL.