### PR TITLE
Isolate "No beatmaps available" from DummyWorkingBeatmap

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -97,9 +97,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestDummy()
         {
             createSongSelect();
-            AddAssert("dummy selected", () => songSelect.CurrentBeatmap == defaultBeatmap);
+            AddAssert("no beatmaps selected", () => songSelect.CurrentBeatmap == defaultBeatmap);
 
-            AddUntilStep("dummy shown on wedge", () => songSelect.CurrentBeatmapDetailsBeatmap == defaultBeatmap);
+            AddUntilStep("no beatmaps shown on wedge", () => songSelect.CurrentBeatmapDetailsBeatmap == defaultBeatmap);
 
             addManyTestMaps();
             AddWaitStep("wait for select", 3);

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -19,14 +19,13 @@ namespace osu.Game.Beatmaps
     {
         private readonly TextureStore textures;
 
+        protected virtual string Name => "dummy beatmap";
+        protected virtual string Description => "";
+
         public DummyWorkingBeatmap(AudioManager audio, TextureStore textures)
             : base(new BeatmapInfo
             {
-                Metadata = new BeatmapMetadata
-                {
-                    Artist = "please load a beatmap!",
-                    Title = "no beatmaps available!"
-                },
+                Metadata = new BeatmapMetadata(),
                 BeatmapSet = new BeatmapSetInfo(),
                 BaseDifficulty = new BeatmapDifficulty
                 {
@@ -37,6 +36,9 @@ namespace osu.Game.Beatmaps
                 Ruleset = new DummyRulesetInfo()
             }, audio)
         {
+            Metadata.Title = Name;
+            Metadata.Artist = Description;
+
             this.textures = textures;
         }
 

--- a/osu.Game/Beatmaps/NoBeatmapsAvailable.cs
+++ b/osu.Game/Beatmaps/NoBeatmapsAvailable.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Game.Beatmaps
+{
+    public class NoBeatmapsAvailableWorkingBeatmap : DummyWorkingBeatmap
+    {
+        protected override string Name => "no beatmaps available!";
+        protected override string Description => "please load a beatmap!";
+
+        public NoBeatmapsAvailableWorkingBeatmap(AudioManager audio, TextureStore textures)
+            : base(audio, textures)
+        {
+        }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -165,7 +165,7 @@ namespace osu.Game
 
             dependencies.CacheAs<IAPIProvider>(API);
 
-            var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
+            var defaultBeatmap = new NoBeatmapsAvailableWorkingBeatmap(Audio, Textures);
 
             dependencies.Cache(RulesetStore = new RulesetStore(contextFactory));
             dependencies.Cache(FileStore = new FileStore(contextFactory, Host.Storage));

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Visual
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
             // This is the earliest we can get OsuGameBase, which is used by the dummy working beatmap to find textures
-            var working = new DummyWorkingBeatmap(parent.Get<AudioManager>(), parent.Get<TextureStore>());
+            var working = new NoBeatmapsAvailableWorkingBeatmap(parent.Get<AudioManager>(), parent.Get<TextureStore>());
 
             beatmap = new OsuTestBeatmap(working)
             {


### PR DESCRIPTION
- Allows for checking if `no beatmaps available!` is the current beatmap and also for creating other types-of `DummyWorkingBeatmap` like `NoBeatmapsFound` for example.