### PR TITLE
Fix results screen pushed at the beginning of a gameplay

### DIFF
--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The current health.
         /// </summary>
-        public readonly BindableDouble Health = new BindableDouble { MinValue = 0, MaxValue = 1 };
+        public readonly BindableDouble Health = new BindableDouble(1) { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
         /// The current combo.

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -269,6 +269,8 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="beatmap">The <see cref="Beatmap{TObject}"/> to simulate.</param>
         protected virtual void SimulateAutoplay(Beatmap<TObject> beatmap)
         {
+            Reset(false);
+
             foreach (var obj in beatmap.HitObjects)
                 simulate(obj);
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -233,6 +233,8 @@ namespace osu.Game.Rulesets.Scoring
             drawableRuleset.OnRevertResult += revertResult;
 
             ApplyBeatmap(drawableRuleset.Beatmap);
+
+            Reset(false);
             SimulateAutoplay(drawableRuleset.Beatmap);
             Reset(true);
 
@@ -269,8 +271,6 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="beatmap">The <see cref="Beatmap{TObject}"/> to simulate.</param>
         protected virtual void SimulateAutoplay(Beatmap<TObject> beatmap)
         {
-            Reset(false);
-
             foreach (var obj in beatmap.HitObjects)
                 simulate(obj);
 


### PR DESCRIPTION
Due to autoplay simulation failing if the first judgement doesn't increase health.