### PR TITLE
Remove unnecessary AndroidNativeLibrary specification

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -49,7 +49,6 @@
     <None Include="$(MSBuildThisFileDirectory)\osu.licenseheader">
       <Link>osu.licenseheader</Link>
     </None>
-    <AndroidNativeLibrary Include="$(OutputPath)\**\*.so" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Is depended on https://github.com/ppy/osu-framework/pull/2824.

This pr removes a workaround