### PR TITLE
Add fallback option for badly-headered beatmap files

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -494,5 +494,39 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.DoesNotThrow(() => decoder.Decode(badStream));
             }
         }
+
+        [Test]
+        public void TestDecodeBeatmapWithCorruptedHeader()
+        {
+            Decoder<Beatmap> decoder = null;
+            Beatmap beatmap = null;
+
+            using (var resStream = TestResources.OpenResource("corrupted-header.osu"))
+            using (var stream = new StreamReader(resStream))
+            {
+                Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
+                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                Assert.DoesNotThrow(() => beatmap = decoder.Decode(stream));
+                Assert.AreEqual("Beatmap with corrupted header", beatmap.Metadata.Title);
+                Assert.AreEqual("Evil Hacker", beatmap.Metadata.AuthorString);
+            }
+        }
+
+        [Test]
+        public void TestDecodeBeatmapWithMissingHeader()
+        {
+            Decoder<Beatmap> decoder = null;
+            Beatmap beatmap = null;
+
+            using (var resStream = TestResources.OpenResource("missing-header.osu"))
+            using (var stream = new StreamReader(resStream))
+            {
+                Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
+                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+                Assert.DoesNotThrow(() => beatmap = decoder.Decode(stream));
+                Assert.AreEqual("Beatmap with no header", beatmap.Metadata.Title);
+                Assert.AreEqual("Incredibly Evil Hacker", beatmap.Metadata.AuthorString);
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Resources/corrupted-header.osu
+++ b/osu.Game.Tests/Resources/corrupted-header.osu
@@ -1,0 +1,5 @@
+﻿ow computerosu file format v14
+
+[Metadata]
+Title: Beatmap with corrupted header
+Creator: Evil Hacker

--- a/osu.Game.Tests/Resources/missing-header.osu
+++ b/osu.Game.Tests/Resources/missing-header.osu
@@ -1,0 +1,3 @@
+﻿[Metadata]
+Title: Beatmap with no header
+Creator: Incredibly Evil Hacker

--- a/osu.Game.Tests/osu.Game.Tests.csproj
+++ b/osu.Game.Tests/osu.Game.Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.TestProject.props" />
+  <ItemGroup>
+    <None Remove="Resources\corrupted-header.osu" />
+    <None Remove="Resources\missing-header.osu" />
+  </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="DeepEqual" Version="2.0.0" />

--- a/osu.Game/Beatmaps/Formats/Decoder.cs
+++ b/osu.Game/Beatmaps/Formats/Decoder.cs
@@ -12,16 +12,23 @@ namespace osu.Game.Beatmaps.Formats
         where TOutput : new()
     {
         protected virtual TOutput CreateTemplateObject() => new TOutput();
+        protected TOutput Output => output.Value;
+
+        private readonly Lazy<TOutput> output;
+
+        protected Decoder()
+        {
+            output = new Lazy<TOutput>(CreateTemplateObject);
+        }
 
         public TOutput Decode(StreamReader primaryStream, params StreamReader[] otherStreams)
         {
-            var output = CreateTemplateObject();
             foreach (StreamReader stream in otherStreams.Prepend(primaryStream))
-                ParseStreamInto(stream, output);
-            return output;
+                ParseStream(stream);
+            return Output;
         }
 
-        protected abstract void ParseStreamInto(StreamReader stream, TOutput output);
+        protected abstract void ParseStream(StreamReader stream);
     }
 
     public abstract class Decoder

--- a/osu.Game/Beatmaps/Formats/JsonBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/JsonBeatmapDecoder.cs
@@ -13,15 +13,15 @@ namespace osu.Game.Beatmaps.Formats
             AddDecoder<Beatmap>("{", m => new JsonBeatmapDecoder());
         }
 
-        protected override void ParseStreamInto(StreamReader stream, Beatmap output)
+        protected override void ParseStream(StreamReader stream)
         {
             stream.BaseStream.Position = 0;
             stream.DiscardBufferedData();
 
-            stream.ReadToEnd().DeserializeInto(output);
+            stream.ReadToEnd().DeserializeInto(Output);
 
-            foreach (var hitObject in output.HitObjects)
-                hitObject.ApplyDefaults(output.ControlPointInfo, output.BeatmapInfo.BaseDifficulty);
+            foreach (var hitObject in Output.HitObjects)
+                hitObject.ApplyDefaults(Output.ControlPointInfo, Output.BeatmapInfo.BaseDifficulty);
         }
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -23,6 +23,13 @@ namespace osu.Game.Beatmaps.Formats
         public static void Register()
         {
             AddDecoder<Beatmap>(@"osu file format v", m => new LegacyBeatmapDecoder(Parsing.ParseInt(m.Split('v').Last())));
+            SetFallbackDecoder<Beatmap>(line =>
+            {
+                var decoder = new LegacyBeatmapDecoder();
+                // it's possible that the first line was a section header - make sure it is parsed
+                decoder.ParseLine(line);
+                return decoder;
+            });
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -60,11 +60,11 @@ namespace osu.Game.Beatmaps.Formats
 
         protected override bool ShouldSkipLine(string line) => base.ShouldSkipLine(line) || line.StartsWith(" ", StringComparison.Ordinal) || line.StartsWith("_", StringComparison.Ordinal);
 
-        protected override void ParseLine(Beatmap beatmap, Section section, string line)
+        protected override void ParseSectionLine(Beatmap beatmap, string line)
         {
             var strippedLine = StripComments(line);
 
-            switch (section)
+            switch (ConfigSection)
             {
                 case Section.General:
                     handleGeneral(strippedLine);
@@ -95,7 +95,7 @@ namespace osu.Game.Beatmaps.Formats
                     return;
             }
 
-            base.ParseLine(beatmap, section, line);
+            base.ParseSectionLine(beatmap, line);
         }
 
         private void handleGeneral(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -24,8 +24,6 @@ namespace osu.Game.Beatmaps.Formats
 
         protected override void ParseStream(StreamReader stream)
         {
-            configSection = Section.None;
-
             string line;
 
             while ((line = stream.ReadLine()) != null)
@@ -81,7 +79,7 @@ namespace osu.Game.Beatmaps.Formats
             return line;
         }
 
-        private Section configSection;
+        private Section configSection = Section.None;
         private bool hasComboColours;
 
         private void handleColours(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -22,17 +22,17 @@ namespace osu.Game.Beatmaps.Formats
             FormatVersion = version;
         }
 
-        protected override void ParseStreamInto(StreamReader stream, T output)
+        protected override void ParseStream(StreamReader stream)
         {
             configSection = Section.None;
 
             string line;
 
             while ((line = stream.ReadLine()) != null)
-                ParseLine(output, line);
+                ParseLine(line);
         }
 
-        protected void ParseLine(T output, string line)
+        protected void ParseLine(string line)
         {
             if (ShouldSkipLine(line))
                 return;
@@ -42,7 +42,7 @@ namespace osu.Game.Beatmaps.Formats
                 if (Enum.TryParse(line.Substring(1, line.Length - 2), out configSection))
                     return;
 
-                Logger.Log($"Unknown section \"{line}\" in \"{output}\"");
+                Logger.Log($"Unknown section \"{line}\" in \"{Output}\"");
                 configSection = Section.None;
 
                 return;
@@ -50,24 +50,24 @@ namespace osu.Game.Beatmaps.Formats
 
             try
             {
-                ParseSectionLine(output, line);
+                ParseSectionLine(line);
             }
             catch (Exception e)
             {
-                Logger.Log($"Failed to process line \"{line}\" into \"{output}\": {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
+                Logger.Log($"Failed to process line \"{line}\" into \"{Output}\": {e.Message}", LoggingTarget.Runtime, LogLevel.Important);
             }
         }
 
         protected virtual bool ShouldSkipLine(string line) => string.IsNullOrWhiteSpace(line) || line.AsSpan().TrimStart().StartsWith("//".AsSpan(), StringComparison.Ordinal);
 
-        protected virtual void ParseSectionLine(T output, string line)
+        protected virtual void ParseSectionLine(string line)
         {
             line = StripComments(line);
 
             switch (ConfigSection)
             {
                 case Section.Colours:
-                    handleColours(output, line);
+                    handleColours(line);
                     return;
             }
         }
@@ -84,7 +84,7 @@ namespace osu.Game.Beatmaps.Formats
         private Section configSection;
         private bool hasComboColours;
 
-        private void handleColours(T output, string line)
+        private void handleColours(string line)
         {
             var pair = SplitKeyVal(line);
 
@@ -108,7 +108,7 @@ namespace osu.Game.Beatmaps.Formats
 
             if (isCombo)
             {
-                if (!(output is IHasComboColours tHasComboColours)) return;
+                if (!(Output is IHasComboColours tHasComboColours)) return;
 
                 if (!hasComboColours)
                 {
@@ -121,7 +121,7 @@ namespace osu.Game.Beatmaps.Formats
             }
             else
             {
-                if (!(output is IHasCustomColours tHasCustomColours)) return;
+                if (!(Output is IHasCustomColours tHasCustomColours)) return;
 
                 tHasCustomColours.CustomColours[pair.Key] = colour;
             }

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -45,11 +45,11 @@ namespace osu.Game.Beatmaps.Formats
                 layer.Elements = layer.Elements.OrderBy(h => h.StartTime).ToList();
         }
 
-        protected override void ParseLine(Storyboard storyboard, Section section, string line)
+        protected override void ParseSectionLine(Storyboard storyboard, string line)
         {
             line = StripComments(line);
 
-            switch (section)
+            switch (ConfigSection)
             {
                 case Section.Events:
                     handleEvents(line);
@@ -60,7 +60,7 @@ namespace osu.Game.Beatmaps.Formats
                     return;
             }
 
-            base.ParseLine(storyboard, section, line);
+            base.ParseSectionLine(storyboard, line);
         }
 
         private void handleEvents(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -31,6 +31,13 @@ namespace osu.Game.Beatmaps.Formats
             // note that this isn't completely correct
             AddDecoder<Storyboard>(@"osu file format v", m => new LegacyStoryboardDecoder());
             AddDecoder<Storyboard>(@"[Events]", m => new LegacyStoryboardDecoder());
+            SetFallbackDecoder<Storyboard>(line =>
+            {
+                var decoder = new LegacyStoryboardDecoder();
+                // it's possible that the first line was a section header - make sure it is parsed
+                decoder.ParseLine(line);
+                return decoder;
+            });
         }
 
         protected override void ParseStream(StreamReader stream)

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -19,8 +19,6 @@ namespace osu.Game.Beatmaps.Formats
         private StoryboardSprite storyboardSprite;
         private CommandTimelineGroup timelineGroup;
 
-        private Storyboard storyboard;
-
         private readonly Dictionary<string, string> variables = new Dictionary<string, string>();
 
         public LegacyStoryboardDecoder()
@@ -35,17 +33,16 @@ namespace osu.Game.Beatmaps.Formats
             AddDecoder<Storyboard>(@"[Events]", m => new LegacyStoryboardDecoder());
         }
 
-        protected override void ParseStreamInto(StreamReader stream, Storyboard storyboard)
+        protected override void ParseStream(StreamReader stream)
         {
-            this.storyboard = storyboard;
-            base.ParseStreamInto(stream, storyboard);
+            base.ParseStream(stream);
 
             // OrderBy is used to guarantee that the parsing order of elements with equal start times is maintained (stably-sorted)
-            foreach (StoryboardLayer layer in storyboard.Layers)
+            foreach (StoryboardLayer layer in Output.Layers)
                 layer.Elements = layer.Elements.OrderBy(h => h.StartTime).ToList();
         }
 
-        protected override void ParseSectionLine(Storyboard storyboard, string line)
+        protected override void ParseSectionLine(string line)
         {
             line = StripComments(line);
 
@@ -60,7 +57,7 @@ namespace osu.Game.Beatmaps.Formats
                     return;
             }
 
-            base.ParseSectionLine(storyboard, line);
+            base.ParseSectionLine(line);
         }
 
         private void handleEvents(string line)
@@ -96,7 +93,7 @@ namespace osu.Game.Beatmaps.Formats
                         var x = float.Parse(split[4], NumberFormatInfo.InvariantInfo);
                         var y = float.Parse(split[5], NumberFormatInfo.InvariantInfo);
                         storyboardSprite = new StoryboardSprite(path, origin, new Vector2(x, y));
-                        storyboard.GetLayer(layer).Add(storyboardSprite);
+                        Output.GetLayer(layer).Add(storyboardSprite);
                         break;
                     }
 
@@ -111,7 +108,7 @@ namespace osu.Game.Beatmaps.Formats
                         var frameDelay = double.Parse(split[7], NumberFormatInfo.InvariantInfo);
                         var loopType = split.Length > 8 ? (AnimationLoopType)Enum.Parse(typeof(AnimationLoopType), split[8]) : AnimationLoopType.LoopForever;
                         storyboardSprite = new StoryboardAnimation(path, origin, new Vector2(x, y), frameCount, frameDelay, loopType);
-                        storyboard.GetLayer(layer).Add(storyboardSprite);
+                        Output.GetLayer(layer).Add(storyboardSprite);
                         break;
                     }
 
@@ -121,7 +118,7 @@ namespace osu.Game.Beatmaps.Formats
                         var layer = parseLayer(split[2]);
                         var path = cleanFilename(split[3]);
                         var volume = split.Length > 4 ? float.Parse(split[4], CultureInfo.InvariantCulture) : 100;
-                        storyboard.GetLayer(layer).Add(new StoryboardSampleInfo(path, time, (int)volume));
+                        Output.GetLayer(layer).Add(new StoryboardSampleInfo(path, time, (int)volume));
                         break;
                     }
                 }

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Skinning
         {
         }
 
-        protected override void ParseSectionLine(DefaultSkinConfiguration skin, string line)
+        protected override void ParseSectionLine(string line)
         {
             if (ConfigSection != Section.Colours)
             {
@@ -26,11 +26,11 @@ namespace osu.Game.Skinning
                         switch (pair.Key)
                         {
                             case @"Name":
-                                skin.SkinInfo.Name = pair.Value;
+                                Output.SkinInfo.Name = pair.Value;
                                 return;
 
                             case @"Author":
-                                skin.SkinInfo.Creator = pair.Value;
+                                Output.SkinInfo.Creator = pair.Value;
                                 return;
                         }
 
@@ -38,10 +38,10 @@ namespace osu.Game.Skinning
                 }
 
                 if (!string.IsNullOrEmpty(pair.Key))
-                    skin.ConfigDictionary[pair.Key] = pair.Value;
+                    Output.ConfigDictionary[pair.Key] = pair.Value;
             }
 
-            base.ParseSectionLine(skin, line);
+            base.ParseSectionLine(line);
         }
     }
 }

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -12,15 +12,15 @@ namespace osu.Game.Skinning
         {
         }
 
-        protected override void ParseLine(DefaultSkinConfiguration skin, Section section, string line)
+        protected override void ParseSectionLine(DefaultSkinConfiguration skin, string line)
         {
-            if (section != Section.Colours)
+            if (ConfigSection != Section.Colours)
             {
                 line = StripComments(line);
 
                 var pair = SplitKeyVal(line);
 
-                switch (section)
+                switch (ConfigSection)
                 {
                     case Section.General:
                         switch (pair.Key)
@@ -41,7 +41,7 @@ namespace osu.Game.Skinning
                     skin.ConfigDictionary[pair.Key] = pair.Value;
             }
 
-            base.ParseLine(skin, section, line);
+            base.ParseSectionLine(skin, line);
         }
     }
 }


### PR DESCRIPTION
Going to preempt this by saying that I don't like how this PR turned out at all, so posting as a draft and if you feel like this is too wrong I'm completely fine with this being closed.

Due to quite wide refactoring I recommend reading the diffs commit-by-commit instead of in bulk. If it's deemed necessary I can also split this out across multiple PRs.

# Description

This is an attempt to address #5522 while preserving the current public interface. Unfortunately, due to stream foibles the only way I could come up with something is by introducing state to the `Decoder`s. I dislike stateful objects, but I *really* tried to think of something else for like two days and I got nothing.

The reason for the refactor is, that when calling `Decoder<T>.GetDecoder()`, the method examines the first line of the stream being decoded for a magic string and uses it to return a correct decoder type. Because it operates on the stream directly, that first line is consumed - the actual decoder will read from the second line onwards.

It is however possible that this magic string will not be present in the first line of the file, and will instead actually be a part of the content to be decoded (most likely, a section header). In such a case
it is desired that this line is not discarded, and instead parsed the same way normal lines are. If it isn't, then the entire section will be discarded.

Rewinding the `StreamReader` is not correct due to encoding issues. If the file being parsed contains a byte sequence indicating encoding, like the UTF-8 byte-order mark, [it will be read with the first line after the rewind and break parsing](https://stackoverflow.com/a/31444226/6817321). There are workarounds floating around the Web that don't seek to offset 0, but instead use the methods of the `StreamReader` to get the preamble length. (I tested that, those methods don't actually *check* that the content has that preamble, so that hack is wrong when the BOM mark is *missing*.)

To bypass this roadblock, extract current configuration section to a protected field, and extract logic of parsing a single line to a protected method. This allows `GetDecoder()` to fall back to the normal line parsing path, when a file without a header is encountered.

Additionally, to be able to do something with that line, refactor base `Decoder` to contain an `Output` property with the decoded object instance, which is lazily constructed on-demand using the implementation of `CreateTemplateObject()`.

This allows to remove fields in `LegacyBeatmapDecoder` and `LegacyStoryboardDecoder` which functionally had the same usage.

Finally the fallback is implemented using a dictionary mapping types to fallback constructor delegates. I would have liked to not use a second collection, but `Dictionary` does not guarantee preserving order, and `OrderedDictionary` has a horrible untyped interface.

The main problem with this (besides introducing state), is that it makes instances of `Decoder` non-thread-safe. That's sort of easily fixable though, I guess, if unperformant.

# (Potential) To-do list

Of course this applies only if it even makes sense to continue in this manner.
* [ ] Right now even garbage files will get parsed; nothing valuable will be written to `Output`, but a still non-`null` object will be returned. It'd probably be better to fail out if nothing sensible ever gets read (will fix failing test: `osu.Game.Tests.Beatmaps.IO.ImportBeatmapTest.TestRollbackOnFailure()`)
* [ ] Make everything thread-safe (guard the `Lazy<TObject>` and `Decode()`)
* [ ] At current the API is sort of consumer-unsafe. That could be addressed by consolidating `GetDecoder()` and `Decode()` into one operation and hiding everything ugly with stricter access modifiers. Although there are tests now that rely on those two being separate (they call `GetDecoder()`, do some casting to set a property on the decoder, and only then call `Decode()`).