### PR TITLE
Fix osu! hitcircle font textures being incorrectly sized

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -86,9 +86,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
                         ? null
                         : new LegacySpriteText(source, font)
                         {
-                            // Spacing value was reverse-engineered from the ratio of the rendered sprite size in the visual inspector vs the actual texture size
-                            Scale = new Vector2(0.96f),
-                            Spacing = new Vector2(-overlap * 0.89f, 0)
+                            // stable applies a blanket 0.8x scale to hitcircle fonts
+                            Scale = new Vector2(0.8f),
+                            Spacing = new Vector2(-overlap, 0)
                         };
             }
 

--- a/osu.Game/Skinning/LegacySpriteText.cs
+++ b/osu.Game/Skinning/LegacySpriteText.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Text;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Skinning
@@ -18,7 +17,7 @@ namespace osu.Game.Skinning
             Shadow = false;
             UseFullGlyphHeight = false;
 
-            Font = new FontUsage(font, OsuFont.DEFAULT_FONT_SIZE);
+            Font = new FontUsage(font, 1);
             glyphStore = new LegacyGlyphStore(skin);
         }
 
@@ -36,10 +35,6 @@ namespace osu.Game.Skinning
             public ITexturedCharacterGlyph Get(string fontName, char character)
             {
                 var texture = skin.GetTexture($"{fontName}-{character}");
-
-                if (texture != null)
-                    // Approximate value that brings character sizing roughly in-line with stable
-                    texture.ScaleAdjust *= 18;
 
                 if (texture == null)
                     return null;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/5996.

Removes magic ratios and still matches pixel perfect. Tested scaling and custom overlaps.

![compare](https://user-images.githubusercontent.com/191335/64668806-fb237300-d499-11e9-906f-d703c05b76ad.gif)

