### PR TITLE
Fix incorrect DI usage of IAPIProvider in many tests

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneDisclaimer.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneDisclaimer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Game.Online.API;
 using osu.Game.Screens.Menu;
 using osu.Game.Users;
 
@@ -11,17 +10,17 @@ namespace osu.Game.Tests.Visual.Menus
     public class TestSceneDisclaimer : ScreenTestScene
     {
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api)
+        private void load()
         {
             AddStep("load disclaimer", () => LoadScreen(new Disclaimer()));
 
             AddStep("toggle support", () =>
             {
-                api.LocalUser.Value = new User
+                API.LocalUser.Value = new User
                 {
-                    Username = api.LocalUser.Value.Username,
-                    Id = api.LocalUser.Value.Id,
-                    IsSupporter = !api.LocalUser.Value.IsSupporter,
+                    Username = API.LocalUser.Value.Username,
+                    Id = API.LocalUser.Value.Id,
+                    IsSupporter = !API.LocalUser.Value.IsSupporter,
                 };
             });
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchLeaderboard.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMatchLeaderboard : MultiplayerTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         public TestSceneMatchLeaderboard()
         {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
     [TestFixture]
     public class TestSceneMultiScreen : ScreenTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneAccountCreationOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneAccountCreationOverlay.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Overlays.AccountCreation;
 using osu.Game.Users;
@@ -26,6 +26,8 @@ namespace osu.Game.Tests.Visual.Online
         };
 
         private readonly Container userPanelArea;
+
+        private Bindable<User> localUser;
 
         public TestSceneAccountCreationOverlay()
         {
@@ -47,12 +49,14 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [BackgroundDependencyLoader]
-        private void load(IAPIProvider api)
+        private void load()
         {
-            api.Logout();
-            api.LocalUser.BindValueChanged(user => { userPanelArea.Child = new UserPanel(user.NewValue) { Width = 200 }; }, true);
+            API.Logout();
 
-            AddStep("logout", api.Logout);
+            localUser = API.LocalUser.GetBoundCopy();
+            localUser.BindValueChanged(user => { userPanelArea.Child = new UserPanel(user.NewValue) { Width = 200 }; }, true);
+
+            AddStep("logout", API.Logout);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual.Online
             typeof(BeatmapAvailability),
         };
 
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         private RulesetInfo taikoRuleset;
         private RulesetInfo maniaRuleset;

--- a/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.Online
             typeof(Comments),
         };
 
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneDirectOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectOverlay.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Tests.Visual.Online
     {
         private DirectOverlay direct;
 
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public class TestSceneHistoricalSection : OsuTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneSocialOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneSocialOverlay.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public class TestSceneSocialOverlay : OsuTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.Visual.Online
 {
     public class TestSceneUserProfileHeader : OsuTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public class TestSceneUserProfileOverlay : OsuTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         private readonly TestUserProfileOverlay profile;
 

--- a/osu.Game.Tests/Visual/Online/TestSceneUserRanks.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserRanks.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public class TestSceneUserRanks : OsuTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(DrawableProfileScore), typeof(RanksSection) };
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 {
     public class TestSceneUpdateableBeatmapBackgroundSprite : OsuTestScene
     {
-        protected override bool RequiresAPIAccess => true;
+        protected override bool UseOnlineAPI => true;
 
         private BeatmapSetInfo testBeatmap;
         private IAPIProvider api;
@@ -32,7 +32,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [BackgroundDependencyLoader]
         private void load(OsuGameBase osu, IAPIProvider api, RulesetStore rulesets)
         {
-            this.api = api;
             this.rulesets = rulesets;
 
             testBeatmap = ImportBeatmapTest.LoadOszIntoOsu(osu).Result;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneUpdateableBeatmapBackgroundSprite.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [BackgroundDependencyLoader]
         private void load(OsuGameBase osu, IAPIProvider api, RulesetStore rulesets)
         {
+            this.api = api;
             this.rulesets = rulesets;
 
             testBeatmap = ImportBeatmapTest.LoadOszIntoOsu(osu).Result;

--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Overlays
                 var tcs = new TaskCompletionSource<bool>();
 
                 var req = new GetChangelogRequest();
-                req.Success += res =>
+                req.Success += res => Schedule(() =>
                 {
                     // remap streams to builds to ensure model equality
                     res.Builds.ForEach(b => b.UpdateStream = res.Streams.Find(s => s.Id == b.UpdateStream.Id));
@@ -182,7 +182,7 @@ namespace osu.Game.Overlays
                     header.Streams.Populate(res.Streams);
 
                     tcs.SetResult(true);
-                };
+                });
                 req.Failure += _ => initialFetchTask = null;
                 req.Perform(API);
 

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Visual
             get
             {
                 if (UseOnlineAPI)
-                    throw new Exception("Using the OsuTestScene dummy API is not supported when UseOnlineAPI is true");
+                    throw new Exception($"Using the {nameof(OsuTestScene)} dummy API is not supported when {nameof(UseOnlineAPI)} is true");
 
                 return dummyAPI;
             }
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual
 
         /// <summary>
         /// Whether this test scene requires real-world API access.
-        /// If true, this will bypass the local <see cref="dummyAPI"/> and use the <see cref="OsuGameBase"/> provided one.
+        /// If true, this will bypass the local <see cref="DummyAPIAccess"/> and use the <see cref="OsuGameBase"/> provided one.
         /// </summary>
         protected virtual bool UseOnlineAPI => false;
 

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -46,13 +46,27 @@ namespace osu.Game.Tests.Visual
         protected Storage LocalStorage => localStorage.Value;
 
         private readonly Lazy<DatabaseContextFactory> contextFactory;
+
+        protected IAPIProvider API
+        {
+            get
+            {
+                if (UseOnlineAPI)
+                    throw new Exception("Using the OsuTestScene dummy API is not supported when UseOnlineAPI is true");
+
+                return dummyAPI;
+            }
+        }
+
+        private DummyAPIAccess dummyAPI;
+
         protected DatabaseContextFactory ContextFactory => contextFactory.Value;
 
         /// <summary>
-        /// Whether this test scene requires API access
-        /// Setting this will cache an actual <see cref="APIAccess"/>.
+        /// Whether this test scene requires real-world API access.
+        /// If true, this will bypass the local <see cref="dummyAPI"/> and use the <see cref="OsuGameBase"/> provided one.
         /// </summary>
-        protected virtual bool RequiresAPIAccess => false;
+        protected virtual bool UseOnlineAPI => false;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -66,10 +80,9 @@ namespace osu.Game.Tests.Visual
 
             Dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
-            if (!RequiresAPIAccess)
+            if (!UseOnlineAPI)
             {
-                var dummyAPI = new DummyAPIAccess();
-
+                dummyAPI = new DummyAPIAccess();
                 Dependencies.CacheAs<IAPIProvider>(dummyAPI);
                 Add(dummyAPI);
             }

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Visual
             get
             {
                 if (UseOnlineAPI)
-                    throw new Exception($"Using the {nameof(OsuTestScene)} dummy API is not supported when {nameof(UseOnlineAPI)} is true");
+                    throw new InvalidOperationException($"Using the {nameof(OsuTestScene)} dummy API is not supported when {nameof(UseOnlineAPI)} is true");
 
                 return dummyAPI;
             }


### PR DESCRIPTION
`OsuTestScene` was caching its dummy API and many tests were trying to access it in `BackgrounDependencyLoader`. It would get the parent API.

- Fixes `TestSceneAccountCreation` incorrectly binding (and never unbinding) from a bindable.
- Fixes (hopefully) randomly getting logged out after running tests.