### PR TITLE
Randomise beatmap playback order on startup

### DIFF
--- a/osu.Game/Overlays/Music/PlaylistList.cs
+++ b/osu.Game/Overlays/Music/PlaylistList.cs
@@ -87,25 +87,24 @@ namespace osu.Game.Overlays.Music
                 beatmapBacking.ValueChanged += _ => updateSelectedSet();
             }
 
-            private void addBeatmapSet(BeatmapSetInfo obj) => Schedule(() =>
-            {
-                if (obj == draggedItem?.BeatmapSetInfo)
-                {
-                    draggedItem = null;
-                    return;
-                }
-
-                items.Insert(items.Count - 1, new PlaylistItem(obj) { OnSelect = set => Selected?.Invoke(set) });
-            });
-
-            private void removeBeatmapSet(BeatmapSetInfo obj) => Schedule(() =>
+            private void addBeatmapSet(BeatmapSetInfo obj)
             {
                 if (obj == draggedItem?.BeatmapSetInfo) return;
 
-                var itemToRemove = items.FirstOrDefault(i => i.BeatmapSetInfo.ID == obj.ID);
-                if (itemToRemove != null)
-                    items.Remove(itemToRemove);
-            });
+                Schedule(() => items.Insert(items.Count - 1, new PlaylistItem(obj) { OnSelect = set => Selected?.Invoke(set) }));
+            }
+
+            private void removeBeatmapSet(BeatmapSetInfo obj)
+            {
+                if (obj == draggedItem?.BeatmapSetInfo) return;
+
+                Schedule(() =>
+                {
+                    var itemToRemove = items.FirstOrDefault(i => i.BeatmapSetInfo.ID == obj.ID);
+                    if (itemToRemove != null)
+                        items.Remove(itemToRemove);
+                });
+            }
 
             private void updateSelectedSet()
             {
@@ -146,19 +145,16 @@ namespace osu.Game.Overlays.Music
             {
                 nativeDragPosition = e.ScreenSpaceMousePosition;
 
-                if (draggedItem != null)
-                {
-                    if (dragDestination != null)
-                    {
-                        // draggedItem is nulled when the BindableList's add event is received so we can quietly ignore the callbacks.
-                        musicController.ChangeBeatmapSetPosition(draggedItem.BeatmapSetInfo, dragDestination.Value);
-                        dragDestination = null;
-                    }
+                if (draggedItem == null)
+                    return base.OnDragEnd(e);
 
-                    return true;
-                }
+                if (dragDestination != null)
+                    musicController.ChangeBeatmapSetPosition(draggedItem.BeatmapSetInfo, dragDestination.Value);
 
-                return base.OnDragEnd(e);
+                draggedItem = null;
+                dragDestination = null;
+
+                return true;
             }
 
             protected override void Update()

--- a/osu.Game/Overlays/Music/PlaylistList.cs
+++ b/osu.Game/Overlays/Music/PlaylistList.cs
@@ -43,8 +43,6 @@ namespace osu.Game.Overlays.Music
 
         private class ItemsScrollContainer : OsuScrollContainer
         {
-            private IBindableList<BeatmapSetInfo> beatmaps;
-
             public Action<BeatmapSetInfo> Selected;
 
             private readonly SearchContainer search;
@@ -52,7 +50,10 @@ namespace osu.Game.Overlays.Music
 
             private readonly IBindable<WorkingBeatmap> beatmapBacking = new Bindable<WorkingBeatmap>();
 
-            private MusicController musicController;
+            private IBindableList<BeatmapSetInfo> beatmaps;
+
+            [Resolved]
+            private MusicController musicController { get; set; }
 
             public ItemsScrollContainer()
             {
@@ -75,12 +76,9 @@ namespace osu.Game.Overlays.Music
             }
 
             [BackgroundDependencyLoader]
-            private void load(MusicController musicController, IBindable<WorkingBeatmap> beatmap)
+            private void load(IBindable<WorkingBeatmap> beatmap)
             {
-                this.musicController = musicController;
-
                 beatmaps = musicController.BeatmapSets.GetBoundCopy();
-
                 beatmaps.ItemsAdded += i => i.ForEach(addBeatmapSet);
                 beatmaps.ItemsRemoved += i => i.ForEach(removeBeatmapSet);
                 beatmaps.ForEach(addBeatmapSet);

--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -21,12 +20,6 @@ namespace osu.Game.Overlays.Music
     {
         private const float transition_duration = 600;
         private const float playlist_height = 510;
-
-        /// <summary>
-        /// Invoked when the order of an item in the list has changed.
-        /// The second parameter indicates the new index of the item.
-        /// </summary>
-        public Action<BeatmapSetInfo, int> OrderChanged;
 
         private readonly Bindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
         private BeatmapManager beatmaps;
@@ -65,7 +58,6 @@ namespace osu.Game.Overlays.Music
                             RelativeSizeAxes = Axes.Both,
                             Padding = new MarginPadding { Top = 95, Bottom = 10, Right = 10 },
                             Selected = itemSelected,
-                            OrderChanged = (s, i) => OrderChanged?.Invoke(s, i)
                         },
                         filter = new FilterControl
                         {

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -25,7 +25,9 @@ namespace osu.Game.Overlays
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
 
-        public readonly BindableList<BeatmapSetInfo> BeatmapSets = new BindableList<BeatmapSetInfo>();
+        public IBindableList<BeatmapSetInfo> BeatmapSets => beatmapSets;
+
+        private readonly BindableList<BeatmapSetInfo> beatmapSets = new BindableList<BeatmapSetInfo>();
 
         public bool IsUserPaused { get; private set; }
 
@@ -47,7 +49,7 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load()
         {
-            BeatmapSets.AddRange(beatmaps.GetAllUsableBeatmapSets().OrderBy(_ => RNG.Next()));
+            beatmapSets.AddRange(beatmaps.GetAllUsableBeatmapSets().OrderBy(_ => RNG.Next()));
             beatmaps.ItemAdded += handleBeatmapAdded;
             beatmaps.ItemRemoved += handleBeatmapRemoved;
         }
@@ -66,8 +68,8 @@ namespace osu.Game.Overlays
         /// <param name="index">The new position.</param>
         public void ChangeBeatmapSetPosition(BeatmapSetInfo beatmapSetInfo, int index)
         {
-            BeatmapSets.Remove(beatmapSetInfo);
-            BeatmapSets.Insert(index, beatmapSetInfo);
+            beatmapSets.Remove(beatmapSetInfo);
+            beatmapSets.Insert(index, beatmapSetInfo);
         }
 
         /// <summary>
@@ -76,10 +78,10 @@ namespace osu.Game.Overlays
         public bool IsPlaying => beatmap.Value.Track.IsRunning;
 
         private void handleBeatmapAdded(BeatmapSetInfo set) =>
-            Schedule(() => BeatmapSets.Add(set));
+            Schedule(() => beatmapSets.Add(set));
 
         private void handleBeatmapRemoved(BeatmapSetInfo set) =>
-            Schedule(() => BeatmapSets.RemoveAll(s => s.ID == set.ID));
+            Schedule(() => beatmapSets.RemoveAll(s => s.ID == set.ID));
 
         private ScheduledDelegate seekDelegate;
 

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -81,7 +81,6 @@ namespace osu.Game.Overlays
                         {
                             RelativeSizeAxes = Axes.X,
                             Y = player_height + 10,
-                            OrderChanged = musicController.ChangeBeatmapSetPosition
                         },
                         playerContainer = new Container
                         {


### PR DESCRIPTION
Closes #6135.

Note that due to limitations of `BindableList`, newly imported beatmaps are always added at the end. This doesn't seem like much of an issue, though.