### PR TITLE
Add hit lighting

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -1,22 +1,66 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Configuration;
 using osuTK;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableOsuJudgement : DrawableJudgement
     {
+        private SkinnableSprite lighting;
+        private Bindable<Color4> lightingColour;
+
         public DrawableOsuJudgement(JudgementResult result, DrawableHitObject judgedObject)
             : base(result, judgedObject)
         {
         }
 
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            if (config.Get<bool>(OsuSetting.HitLighting) && Result.Type != HitResult.Miss)
+            {
+                AddInternal(lighting = new SkinnableSprite("lighting")
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Blending = BlendingParameters.Additive,
+                    Depth = float.MaxValue
+                });
+
+                if (JudgedObject != null)
+                {
+                    lightingColour = JudgedObject.AccentColour.GetBoundCopy();
+                    lightingColour.BindValueChanged(colour => lighting.Colour = colour.NewValue, true);
+                }
+                else
+                {
+                    lighting.Colour = Color4.White;
+                }
+            }
+        }
+
+        protected override double FadeOutDelay => lighting == null ? base.FadeOutDelay : 1400;
+
         protected override void ApplyHitAnimations()
         {
+            if (lighting != null)
+            {
+                JudgementBody.Delay(FadeInDuration).FadeOut(400);
+
+                lighting.ScaleTo(0.8f).ScaleTo(1.2f, 600, Easing.Out);
+                lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);
+            }
+
             JudgementText?.TransformSpacingTo(new Vector2(14, 0), 1800, Easing.OutQuint);
             base.ApplyHitAnimations();
         }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -81,6 +81,8 @@ namespace osu.Game.Configuration
             Set(OsuSetting.DimLevel, 0.3, 0, 1, 0.01);
             Set(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
 
+            Set(OsuSetting.HitLighting, true);
+
             Set(OsuSetting.ShowInterface, true);
             Set(OsuSetting.ShowHealthDisplayWhenCantFail, true);
             Set(OsuSetting.KeyOverlay, false);
@@ -180,6 +182,7 @@ namespace osu.Game.Configuration
         ScalingSizeX,
         ScalingSizeY,
         UIScale,
-        IntroSequence
+        IntroSequence,
+        HitLighting
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Graphics/DetailSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/DetailSettings.cs
@@ -28,6 +28,11 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = "Hit Lighting",
+                    Bindable = config.GetBindable<bool>(OsuSetting.HitLighting)
+                },
+                new SettingsCheckbox
+                {
                     LabelText = "Rotate cursor when dragging",
                     Bindable = config.GetBindable<bool>(OsuSetting.CursorRotation)
                 },

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -34,9 +34,13 @@ namespace osu.Game.Rulesets.Judgements
 
         /// <summary>
         /// Duration of initial fade in.
-        /// Default fade out will start immediately after this duration.
         /// </summary>
         protected virtual double FadeInDuration => 100;
+
+        /// <summary>
+        /// Duration to wait until fade out begins. Defaults to <see cref="FadeInDuration"/>.
+        /// </summary>
+        protected virtual double FadeOutDelay => FadeInDuration;
 
         /// <summary>
         /// Creates a drawable which visualises a <see cref="Judgements.Judgement"/>.
@@ -76,7 +80,7 @@ namespace osu.Game.Rulesets.Judgements
             JudgementBody.ScaleTo(0.9f);
             JudgementBody.ScaleTo(1, 500, Easing.OutElastic);
 
-            this.Delay(FadeInDuration).FadeOut(400);
+            this.Delay(FadeOutDelay).FadeOut(400);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
For now this is only implemented in osu! ruleset. Going forward it should be supported (in some way) by all rulesets.