### PR TITLE
Always update drawable hitobject state on skin change

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -163,9 +163,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private float sliderPathRadius;
 
-        protected override void SkinChanged(ISkinSource skin, bool allowFallback)
+        protected override void ApplySkin(ISkinSource skin, bool allowFallback)
         {
-            base.SkinChanged(skin, allowFallback);
+            base.ApplySkin(skin, allowFallback);
 
             Body.BorderSize = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderBorderSize)?.Value ?? SliderBody.DEFAULT_BORDER_SIZE;
             sliderPathRadius = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderPathRadius)?.Value ?? OsuHitObject.OBJECT_RADIUS;

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         #endregion
 
-        protected override void SkinChanged(ISkinSource skin, bool allowFallback)
+        protected sealed override void SkinChanged(ISkinSource skin, bool allowFallback)
         {
             base.SkinChanged(skin, allowFallback);
 
@@ -250,6 +250,19 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
                 AccentColour.Value = comboColours?.Count > 0 ? comboColours[combo.ComboIndex % comboColours.Count] : Color4.White;
             }
+
+            ApplySkin(skin, allowFallback);
+
+            updateState(State.Value, true);
+        }
+
+        /// <summary>
+        /// Called when a change is made to the skin.
+        /// </summary>
+        /// <param name="skin">The new skin.</param>
+        /// <param name="allowFallback">Whether fallback to default skin should be allowed if the custom skin is missing this resource.</param>
+        protected virtual void ApplySkin(ISkinSource skin, bool allowFallback)
+        {
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -253,7 +253,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             ApplySkin(skin, allowFallback);
 
-            updateState(State.Value, true);
+            if (IsLoaded)
+                updateState(State.Value, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Allows mods to apply changes, and state to potentially be more correctly restored after skin-specific changes.