### PR TITLE
Disallow failing for replay players

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
@@ -17,9 +17,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected override Player CreatePlayer(Ruleset ruleset)
         {
             Mods.Value = Array.Empty<Mod>();
-
-            var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, Array.Empty<Mod>());
-            return new FailPlayer(ruleset.GetAutoplayMod().CreateReplayScore(beatmap));
+            return new FailPlayer();
         }
 
         protected override void AddCheckSteps()
@@ -29,16 +27,12 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("total judgements == 1", () => ((FailPlayer)Player).ScoreProcessor.JudgedHits == 1);
         }
 
-        private class FailPlayer : ReplayPlayer
+        private class FailPlayer : TestPlayer
         {
-            public new DrawableRuleset DrawableRuleset => base.DrawableRuleset;
-
             public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
 
-            protected override bool PauseOnFocusLost => false;
-
-            public FailPlayer(Score score)
-                : base(score, false, false)
+            public FailPlayer()
+                : base(false, false)
             {
             }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI;
-using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual.Gameplay

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
@@ -26,12 +26,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddUntilStep("score above zero", () => ((ScoreAccessibleReplayPlayer)Player).ScoreProcessor.TotalScore.Value > 0);
             AddUntilStep("key counter counted keys", () => ((ScoreAccessibleReplayPlayer)Player).HUDOverlay.KeyCounter.Children.Any(kc => kc.CountPresses > 0));
+            AddAssert("cannot fail", () => ((ScoreAccessibleReplayPlayer)Player).BypassFail);
         }
 
         private class ScoreAccessibleReplayPlayer : ReplayPlayer
         {
             public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
             public new HUDOverlay HUDOverlay => base.HUDOverlay;
+            public new bool BypassFail => base.BypassFail;
 
             protected override bool PauseOnFocusLost => false;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
@@ -26,14 +26,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddUntilStep("score above zero", () => ((ScoreAccessibleReplayPlayer)Player).ScoreProcessor.TotalScore.Value > 0);
             AddUntilStep("key counter counted keys", () => ((ScoreAccessibleReplayPlayer)Player).HUDOverlay.KeyCounter.Children.Any(kc => kc.CountPresses > 0));
-            AddAssert("cannot fail", () => ((ScoreAccessibleReplayPlayer)Player).BypassFail);
+            AddAssert("cannot fail", () => !((ScoreAccessibleReplayPlayer)Player).AllowFail);
         }
 
         private class ScoreAccessibleReplayPlayer : ReplayPlayer
         {
             public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
             public new HUDOverlay HUDOverlay => base.HUDOverlay;
-            public new bool BypassFail => base.BypassFail;
+            public new bool AllowFail => base.AllowFail;
 
             protected override bool PauseOnFocusLost => false;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -87,9 +87,11 @@ namespace osu.Game.Screens.Play
         protected new readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         /// <summary>
-        /// Whether to block the player from failing.
+        /// Whether failing should be allowed.
+        ///
+        /// By default, this checks whether any selected mod disallows failing.
         /// </summary>
-        protected virtual bool BypassFail => false;
+        protected virtual bool AllowFail => !Mods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail);
 
         private readonly bool allowPause;
         private readonly bool showResults;
@@ -365,7 +367,7 @@ namespace osu.Game.Screens.Play
 
         private bool onFail()
         {
-            if (Mods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail) || BypassFail)
+            if (!AllowFail)
                 return false;
 
             HasFailed = true;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -86,6 +86,11 @@ namespace osu.Game.Screens.Play
         [Cached(Type = typeof(IBindable<IReadOnlyList<Mod>>))]
         protected new readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
+        /// <summary>
+        /// Whether to block the player from failing.
+        /// </summary>
+        protected virtual bool BypassFail => false;
+
         private readonly bool allowPause;
         private readonly bool showResults;
 
@@ -360,7 +365,7 @@ namespace osu.Game.Screens.Play
 
         private bool onFail()
         {
-            if (Mods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail))
+            if (Mods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail) || BypassFail)
                 return false;
 
             HasFailed = true;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -89,9 +89,9 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Whether failing should be allowed.
         ///
-        /// By default, this checks whether any selected mod disallows failing.
+        /// By default, this checks whether all selected mods allow failing.
         /// </summary>
-        protected virtual bool AllowFail => !Mods.Value.OfType<IApplicableFailOverride>().Any(m => !m.AllowFail);
+        protected virtual bool AllowFail => Mods.Value.OfType<IApplicableFailOverride>().All(m => m.AllowFail);
 
         private readonly bool allowPause;
         private readonly bool showResults;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -88,7 +88,6 @@ namespace osu.Game.Screens.Play
 
         /// <summary>
         /// Whether failing should be allowed.
-        ///
         /// By default, this checks whether all selected mods allow failing.
         /// </summary>
         protected virtual bool AllowFail => Mods.Value.OfType<IApplicableFailOverride>().All(m => m.AllowFail);

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -9,8 +9,8 @@ namespace osu.Game.Screens.Play
     {
         private readonly Score score;
 
-        // Block replays from failing. (see https://github.com/ppy/osu/issues/6108)
-        protected override bool BypassFail => true;
+        // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
+        protected override bool AllowFail => false;
 
         public ReplayPlayer(Score score, bool allowPause = true, bool showResults = true)
             : base(allowPause, showResults)

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -9,6 +9,9 @@ namespace osu.Game.Screens.Play
     {
         private readonly Score score;
 
+        // Block replays from failing. (see https://github.com/ppy/osu/issues/6108)
+        protected override bool BypassFail => true;
+
         public ReplayPlayer(Score score, bool allowPause = true, bool showResults = true)
             : base(allowPause, showResults)
         {


### PR DESCRIPTION
- Disallows failing for replay players as a temporary fix for judgement conflicts between stable's slider and lazer's.

Closes #6108 