### PR TITLE
Add "plus" type changelog entry

### DIFF
--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Changelog
                     {
                         t.Font = fontSmall;
                         t.Colour = entryColour;
-                        t.Padding = new MarginPadding { Left = -17, Right = 5, Top= -1 };
+                        t.Padding = new MarginPadding { Left = -17, Right = 5, Top = -1 };
                     });
 
                     title.AddText(entry.Title, t =>

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Changelog
                     {
                         t.Font = fontSmall;
                         t.Colour = entryColour;
-                        t.Padding = new MarginPadding { Left = -17, Right = 5 };
+                        t.Padding = new MarginPadding { Left = -17, Right = 5, Top= -1 };
                     });
 
                     title.AddText(entry.Title, t =>

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Overlays.Changelog
 
                     var entryColour = entry.Major ? colours.YellowLight : Color4.White;
 
-                    title.AddIcon(FontAwesome.Solid.Check, t =>
+                    title.AddIcon(entry.Type == "add" ? FontAwesome.Solid.Plus : FontAwesome.Solid.Check, t =>
                     {
                         t.Font = fontSmall;
                         t.Colour = entryColour;


### PR DESCRIPTION
* adds "+" icon to changelog entries
* changes vertical alignment slightly

before:
![before](https://user-images.githubusercontent.com/46070579/65256557-ff860680-daff-11e9-806f-033ea9641776.PNG)
after:
![after](https://user-images.githubusercontent.com/46070579/65256562-014fca00-db00-11e9-8371-6b6756126b94.PNG)
