### PR TITLE
Fix escaped html strings not being unescaped in changelog entries.

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
@@ -68,6 +68,34 @@ namespace osu.Game.Tests.Visual.Online
                 changelog.ShowListing();
                 changelog.Show();
             });
+
+            AddStep(@"Ensure HTML string unescaping", () =>
+            {
+                changelog.ShowBuild(new APIChangelogBuild
+                {
+                    Version = "2019.920.0",
+                    DisplayVersion = "2019.920.0",
+                    UpdateStream = new APIUpdateStream
+                    {
+                        Name = "Test",
+                        DisplayName = "Test"
+                    },
+                    ChangelogEntries = new List<APIChangelogEntry>
+                    {
+                        new APIChangelogEntry
+                        {
+                            Category = "Testing HTML strings unescaping",
+                            Title = "Ensuring HTML strings are being unescaped",
+                            MessageHtml = "&quot;&quot;&quot;This text should appear triple-quoted&quot;&quot;&quot;    &gt;_&lt;",
+                            GithubUser = new APIChangelogUser
+                            {
+                                DisplayName = "Dummy",
+                                OsuUsername = "Dummy",
+                            }
+                        },
+                    }
+                });
+            });
         }
     }
 }

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Users;
 using osuTK.Graphics;
 using osu.Framework.Allocation;
+using System.Net;
 
 namespace osu.Game.Overlays.Changelog
 {
@@ -149,7 +150,7 @@ namespace osu.Game.Overlays.Changelog
                         };
 
                         // todo: use markdown parsing once API returns markdown
-                        message.AddText(Regex.Replace(entry.MessageHtml, @"<(.|\n)*?>", string.Empty), t =>
+                        message.AddText(WebUtility.HtmlDecode(Regex.Replace(entry.MessageHtml, @"<(.|\n)*?>", string.Empty)), t =>
                         {
                             t.Font = fontSmall;
                             t.Colour = new Color4(235, 184, 254, 255);


### PR DESCRIPTION
Fixes #6174 

![image](https://user-images.githubusercontent.com/20256717/65269699-015cc380-db1a-11e9-9fbc-ddd9755a8ec4.png)
