### PR TITLE
Add a base class for all future labelled components

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledComponent.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledComponent.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Screens.Edit.Setup.Components.LabelledComponents;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneLabelledComponent : OsuTestScene
+    {
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestPadded(bool hasDescription) => createPaddedComponent(hasDescription);
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestNonPadded(bool hasDescription) => createPaddedComponent(hasDescription, false);
+
+        private void createPaddedComponent(bool hasDescription = false, bool padded = true)
+        {
+            AddStep("create component", () =>
+            {
+                LabelledComponent component;
+
+                Child = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 500,
+                    AutoSizeAxes = Axes.Y,
+                    Child = component = padded ? (LabelledComponent)new PaddedLabelledComponent() : new NonPaddedLabelledComponent(),
+                };
+
+                component.Label = "a sample component";
+                component.Description = hasDescription ? "this text describes the component" : string.Empty;
+            });
+        }
+
+        private class PaddedLabelledComponent : LabelledComponent
+        {
+            public PaddedLabelledComponent()
+                : base(true)
+            {
+            }
+
+            protected override Drawable CreateComponent() => new OsuSpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Colour = Color4.Red,
+                Text = @"(( Component ))"
+            };
+        }
+
+        private class NonPaddedLabelledComponent : LabelledComponent
+        {
+            public NonPaddedLabelledComponent()
+                : base(false)
+            {
+            }
+
+            protected override Drawable CreateComponent() => new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 40,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.SlateGray
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Colour = Color4.Red,
+                        Text = @"(( Component ))"
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/Components/LabelledComponents/LabelledComponent.cs
+++ b/osu.Game/Screens/Edit/Setup/Components/LabelledComponents/LabelledComponent.cs
@@ -1,0 +1,121 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Setup.Components.LabelledComponents
+{
+    public abstract class LabelledComponent : CompositeDrawable
+    {
+        protected const float CONTENT_PADDING_VERTICAL = 10;
+        protected const float CONTENT_PADDING_HORIZONTAL = 15;
+        protected const float CORNER_RADIUS = 15;
+
+        protected readonly Drawable Component;
+
+        private readonly OsuTextFlowContainer labelText;
+        private readonly OsuTextFlowContainer descriptionText;
+
+        protected LabelledComponent(bool padded)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            CornerRadius = CORNER_RADIUS;
+            Masking = true;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = OsuColour.FromHex("1c2125"),
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Padding = padded
+                        ? new MarginPadding { Horizontal = CONTENT_PADDING_HORIZONTAL, Vertical = CONTENT_PADDING_VERTICAL }
+                        : new MarginPadding { Left = CONTENT_PADDING_HORIZONTAL },
+                    Spacing = new Vector2(0, 12),
+                    Children = new Drawable[]
+                    {
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Content = new[]
+                            {
+                                new Drawable[]
+                                {
+                                    labelText = new OsuTextFlowContainer(s => s.Font = OsuFont.GetFont(weight: FontWeight.Bold))
+                                    {
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        AutoSizeAxes = Axes.Both,
+                                        Padding = new MarginPadding { Right = 20 }
+                                    },
+                                    new Container
+                                    {
+                                        Anchor = Anchor.CentreRight,
+                                        Origin = Anchor.CentreRight,
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Child = Component = CreateComponent().With(d =>
+                                        {
+                                            d.Anchor = Anchor.CentreRight;
+                                            d.Origin = Anchor.CentreRight;
+                                        })
+                                    }
+                                },
+                            },
+                            RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                            ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
+                        },
+                        descriptionText = new OsuTextFlowContainer(s => s.Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold, italics: true))
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Padding = new MarginPadding { Bottom = padded ? 0 : CONTENT_PADDING_VERTICAL },
+                            Alpha = 0,
+                        }
+                    }
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour osuColour)
+        {
+            descriptionText.Colour = osuColour.Yellow;
+        }
+
+        public string Label
+        {
+            set => labelText.Text = value;
+        }
+
+        public string Description
+        {
+            set
+            {
+                descriptionText.Text = value;
+
+                if (!string.IsNullOrEmpty(value))
+                    descriptionText.Show();
+                else
+                    descriptionText.Hide();
+            }
+        }
+
+        protected abstract Drawable CreateComponent();
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/Components/LabelledComponents/LabelledComponent.cs
+++ b/osu.Game/Screens/Edit/Setup/Components/LabelledComponents/LabelledComponent.cs
@@ -17,11 +17,18 @@ namespace osu.Game.Screens.Edit.Setup.Components.LabelledComponents
         protected const float CONTENT_PADDING_HORIZONTAL = 15;
         protected const float CORNER_RADIUS = 15;
 
+        /// <summary>
+        /// The component that is being displayed.
+        /// </summary>
         protected readonly Drawable Component;
 
         private readonly OsuTextFlowContainer labelText;
         private readonly OsuTextFlowContainer descriptionText;
 
+        /// <summary>
+        /// Creates a new <see cref="LabelledComponent"/>.
+        /// </summary>
+        /// <param name="padded">Whether the component should be padded or should be expanded to the bounds of this <see cref="LabelledComponent"/>.</param>
         protected LabelledComponent(bool padded)
         {
             RelativeSizeAxes = Axes.X;
@@ -116,6 +123,10 @@ namespace osu.Game.Screens.Edit.Setup.Components.LabelledComponents
             }
         }
 
+        /// <summary>
+        /// Creates the component that should be displayed.
+        /// </summary>
+        /// <returns>The component.</returns>
         protected abstract Drawable CreateComponent();
     }
 }


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/3085

Has two modes:

Padded:

![image](https://user-images.githubusercontent.com/1329837/65317951-c620ca00-dbd7-11e9-973e-e6dd0d969265.png)

Non-padded:

![image](https://user-images.githubusercontent.com/1329837/65318102-04b68480-dbd8-11e9-802d-d4cade2692d9.png)

Some of the code is definitely going to change in the future since the designs require specific alignment, but I think this is fine for now?