### PR TITLE
Fix scores importing with deleted beatmap sets

### DIFF
--- a/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
+++ b/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
@@ -144,8 +144,8 @@ namespace osu.Game.Tests.Scores.IO
                     beatmapManager.Delete(beatmapManager.QueryBeatmapSet(s => s.Beatmaps.Any(b => b.ID == imported.Beatmap.ID)));
                     Assert.That(scoreManager.Query(s => s.ID == imported.ID).DeletePending, Is.EqualTo(true));
 
-                    await scoreManager.Import(imported);
-                    Assert.That(scoreManager.Query(s => s.ID == imported.ID).DeletePending, Is.EqualTo(true));
+                    var secondImport = await loadIntoOsu(osu, imported);
+                    Assert.That(secondImport, Is.Null);
                 }
                 finally
                 {
@@ -158,11 +158,16 @@ namespace osu.Game.Tests.Scores.IO
         {
             var beatmapManager = osu.Dependencies.Get<BeatmapManager>();
 
-            score.Beatmap = beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps.First();
-            score.Ruleset = new OsuRuleset().RulesetInfo;
+            if (score.Beatmap == null)
+                score.Beatmap = beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps.First();
+
+            if (score.Ruleset == null)
+                score.Ruleset = new OsuRuleset().RulesetInfo;
 
             var scoreManager = osu.Dependencies.Get<ScoreManager>();
-            return await scoreManager.Import(score);
+            await scoreManager.Import(score);
+
+            return scoreManager.GetAllUsableScores().FirstOrDefault();
         }
 
         private async Task<OsuGameBase> loadOsu(GameHost host)

--- a/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
+++ b/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Tests.Scores.IO
                     var beatmapManager = osu.Dependencies.Get<BeatmapManager>();
                     var scoreManager = osu.Dependencies.Get<ScoreManager>();
 
-                    beatmapManager.Delete(imported.Beatmap.BeatmapSet);
+                    beatmapManager.Delete(beatmapManager.QueryBeatmapSet(s => s.Beatmaps.Any(b => b.ID == imported.Beatmap.ID)));
                     Assert.That(scoreManager.Query(s => s.ID == imported.ID).DeletePending, Is.EqualTo(true));
 
                     await scoreManager.Import(imported);

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -590,7 +590,7 @@ namespace osu.Game.Database
         /// </summary>
         /// <param name="existing">The existing model.</param>
         /// <param name="import">The newly imported model.</param>
-        /// <returns>Whether the existing model should be restored and used. Returning false will delete the existing a force a re-import.</returns>
+        /// <returns>Whether the existing model should be restored and used. Returning false will delete the existing and force a re-import.</returns>
         protected virtual bool CanUndelete(TModel existing, TModel import) => true;
 
         private DbSet<TModel> queryModel() => ContextFactory.Get().Set<TModel>();

--- a/osu.Game/Scoring/Legacy/DatabasedLegacyScoreParser.cs
+++ b/osu.Game/Scoring/Legacy/DatabasedLegacyScoreParser.cs
@@ -22,6 +22,6 @@ namespace osu.Game.Scoring.Legacy
         }
 
         protected override Ruleset GetRuleset(int rulesetId) => rulesets.GetRuleset(rulesetId).CreateInstance();
-        protected override WorkingBeatmap GetBeatmap(string md5Hash) => beatmaps.GetWorkingBeatmap(beatmaps.QueryBeatmap(b => b.MD5Hash == md5Hash));
+        protected override WorkingBeatmap GetBeatmap(string md5Hash) => beatmaps.GetWorkingBeatmap(beatmaps.QueryBeatmap(b => !b.BeatmapSet.DeletePending && b.MD5Hash == md5Hash));
     }
 }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Scoring
             }
         }
 
+        protected override bool CanUndelete(ScoreInfo existing, ScoreInfo import) => false;
+
         protected override IEnumerable<string> GetStableImportPaths(Storage stableStorage)
             => stableStorage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.InvariantCultureIgnoreCase) ?? false));
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -56,8 +56,6 @@ namespace osu.Game.Scoring
             }
         }
 
-        protected override bool CanUndelete(ScoreInfo existing, ScoreInfo import) => false;
-
         protected override IEnumerable<string> GetStableImportPaths(Storage stableStorage)
             => stableStorage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.InvariantCultureIgnoreCase) ?? false));
 


### PR DESCRIPTION
Fixes #6109

I've added a test which _should_ fail on master, but doesn't. Haven't yet determined the cause of this, but it seems that in this particular unit test EFCore is not detecting changes to `DeletePending`, even though the line is being hit.