### PR TITLE
Song select filter improvements

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
     [TestFixture]
     public class FilterMatchingTest
     {
-        private readonly BeatmapInfo exampleBeatmapInfo = new BeatmapInfo
+        private BeatmapInfo getExampleBeatmap() => new BeatmapInfo
         {
             Ruleset = new RulesetInfo { ID = 5 },
             StarDifficulty = 4.0d,
@@ -25,10 +25,10 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Metadata = new BeatmapMetadata
             {
                 Artist = "The Artist",
-                ArtistUnicode = "The Artist",
+                ArtistUnicode = "check unicode too",
                 Title = "Title goes here",
                 TitleUnicode = "Title goes here",
-                AuthorString = "Author",
+                AuthorString = "The Author",
                 Source = "unit tests",
                 Tags = "look for tags too",
             },
@@ -42,6 +42,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestCriteriaMatchingNoRuleset()
         {
+            var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria();
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);
@@ -51,6 +52,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestCriteriaMatchingSpecificRuleset()
         {
+            var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
                 Ruleset = new RulesetInfo { ID = 6 }
@@ -63,6 +65,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestCriteriaMatchingConvertedBeatmaps()
         {
+            var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
                 Ruleset = new RulesetInfo { ID = 6 },
@@ -78,6 +81,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase(false)]
         public void TestCriteriaMatchingRangeMin(bool inclusive)
         {
+            var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
                 Ruleset = new RulesetInfo { ID = 6 },
@@ -98,6 +102,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase(false)]
         public void TestCriteriaMatchingRangeMax(bool inclusive)
         {
+            var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
                 Ruleset = new RulesetInfo { ID = 6 },
@@ -122,11 +127,71 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase("an auteur", true)]
         public void TestCriteriaMatchingTerms(string terms, bool filtered)
         {
+            var exampleBeatmapInfo = getExampleBeatmap();
             var criteria = new FilterCriteria
             {
                 Ruleset = new RulesetInfo { ID = 6 },
                 AllowConvertedBeatmaps = true,
                 SearchText = terms
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        [TestCase("", false)]
+        [TestCase("The", false)]
+        [TestCase("THE", false)]
+        [TestCase("author", false)]
+        [TestCase("the author", false)]
+        [TestCase("the author AND then something else", true)]
+        [TestCase("unknown", true)]
+        public void TestCriteriaMatchingCreator(string creatorName, bool filtered)
+        {
+            var exampleBeatmapInfo = getExampleBeatmap();
+            var criteria = new FilterCriteria
+            {
+                Creator = new FilterCriteria.OptionalTextFilter { SearchTerm = creatorName }
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        [TestCase("", false)]
+        [TestCase("The", false)]
+        [TestCase("THE", false)]
+        [TestCase("artist", false)]
+        [TestCase("the artist", false)]
+        [TestCase("the artist AND then something else", true)]
+        [TestCase("unicode too", false)]
+        [TestCase("unknown", true)]
+        public void TestCriteriaMatchingArtist(string artistName, bool filtered)
+        {
+            var exampleBeatmapInfo = getExampleBeatmap();
+            var criteria = new FilterCriteria
+            {
+                Artist = new FilterCriteria.OptionalTextFilter { SearchTerm = artistName }
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        [TestCase("", false)]
+        [TestCase("artist", false)]
+        [TestCase("unknown", true)]
+        public void TestCriteriaMatchingArtistWithNullUnicodeName(string artistName, bool filtered)
+        {
+            var exampleBeatmapInfo = getExampleBeatmap();
+            exampleBeatmapInfo.Metadata.ArtistUnicode = null;
+
+            var criteria = new FilterCriteria
+            {
+                Artist = new FilterCriteria.OptionalTextFilter { SearchTerm = artistName }
             };
             var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
             carouselItem.Filter(criteria);

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Carousel;
+
+namespace osu.Game.Tests.NonVisual.Filtering
+{
+    [TestFixture]
+    public class FilterMatchingTest
+    {
+        private readonly BeatmapInfo exampleBeatmapInfo = new BeatmapInfo
+        {
+            Ruleset = new RulesetInfo { ID = 5 },
+            StarDifficulty = 4.0d,
+            BaseDifficulty = new BeatmapDifficulty
+            {
+                ApproachRate = 5.0f,
+                DrainRate = 3.0f,
+                CircleSize = 2.0f,
+            },
+            Metadata = new BeatmapMetadata
+            {
+                Artist = "The Artist",
+                ArtistUnicode = "The Artist",
+                Title = "Title goes here",
+                TitleUnicode = "Title goes here",
+                AuthorString = "Author",
+                Source = "unit tests",
+                Tags = "look for tags too",
+            },
+            Version = "version as well",
+            Length = 2500,
+            BPM = 160,
+            BeatDivisor = 12,
+            Status = BeatmapSetOnlineStatus.Loved
+        };
+
+        [Test]
+        public void TestCriteriaMatchingNoRuleset()
+        {
+            var criteria = new FilterCriteria();
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.IsFalse(carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        public void TestCriteriaMatchingSpecificRuleset()
+        {
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ID = 6 }
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.IsTrue(carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        public void TestCriteriaMatchingConvertedBeatmaps()
+        {
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ID = 6 },
+                AllowConvertedBeatmaps = true
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.IsFalse(carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestCriteriaMatchingRangeMin(bool inclusive)
+        {
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ID = 6 },
+                AllowConvertedBeatmaps = true,
+                ApproachRate = new FilterCriteria.OptionalRange<float>
+                {
+                    IsLowerInclusive = inclusive,
+                    Min = 5.0f
+                }
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.AreEqual(!inclusive, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestCriteriaMatchingRangeMax(bool inclusive)
+        {
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ID = 6 },
+                AllowConvertedBeatmaps = true,
+                BPM = new FilterCriteria.OptionalRange<double>
+                {
+                    IsUpperInclusive = inclusive,
+                    Max = 160d
+                }
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.AreEqual(!inclusive, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        [TestCase("artist", false)]
+        [TestCase("artist title author", false)]
+        [TestCase("an artist", true)]
+        [TestCase("tags too", false)]
+        [TestCase("version", false)]
+        [TestCase("an auteur", true)]
+        public void TestCriteriaMatchingTerms(string terms, bool filtered)
+        {
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { ID = 6 },
+                AllowConvertedBeatmaps = true,
+                SearchText = terms
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+    }
+}

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -125,5 +125,49 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual(BeatmapSetOnlineStatus.Ranked, filterCriteria.OnlineStatus.Max);
             Assert.IsTrue(filterCriteria.OnlineStatus.IsUpperInclusive);
         }
+
+        [Test]
+        public void TestApplyCreatorQueries()
+        {
+            const string query = "beatmap specifically by creator=my_fav";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("beatmap specifically by", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual("my_fav", filterCriteria.Creator.SearchTerm);
+        }
+
+        [Test]
+        public void TestApplyArtistQueries()
+        {
+            const string query = "find me songs by artist=singer please";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("find me songs by  please", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual("singer", filterCriteria.Artist.SearchTerm);
+        }
+
+        [Test]
+        public void TestApplyArtistQueriesWithSpaces()
+        {
+            const string query = "really like artist=\"name with space\" yes";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("really like  yes", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual("name with space", filterCriteria.Artist.SearchTerm);
+        }
+
+        [Test]
+        public void TestApplyArtistQueriesOneDoubleQuote()
+        {
+            const string query = "weird artist=double\"quote";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("weird", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual("double\"quote", filterCriteria.Artist.SearchTerm);
+        }
     }
 }

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Select;
+
+namespace osu.Game.Tests.NonVisual.Filtering
+{
+    [TestFixture]
+    public class FilterQueryParserTest
+    {
+        [Test]
+        public void TestApplyQueriesBareWords()
+        {
+            const string query = "looking for a beatmap";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("looking for a beatmap", filterCriteria.SearchText);
+            Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
+        }
+
+        [Test]
+        public void TestApplyStarQueries()
+        {
+            const string query = "stars<4 easy";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("easy", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual(4.0f, filterCriteria.StarDifficulty.Max);
+            Assert.IsFalse(filterCriteria.StarDifficulty.IsUpperInclusive);
+            Assert.IsNull(filterCriteria.StarDifficulty.Min);
+        }
+
+        [Test]
+        public void TestApplyApproachRateQueries()
+        {
+            const string query = "ar>=9 difficult";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("difficult", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual(9.0f, filterCriteria.ApproachRate.Min);
+            Assert.IsTrue(filterCriteria.ApproachRate.IsLowerInclusive);
+            Assert.IsNull(filterCriteria.ApproachRate.Max);
+        }
+
+        [Test]
+        public void TestApplyDrainRateQueries()
+        {
+            const string query = "dr>2 quite specific dr<:6";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(2, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual(2.0f, filterCriteria.DrainRate.Min);
+            Assert.IsFalse(filterCriteria.DrainRate.IsLowerInclusive);
+            Assert.AreEqual(6.0f, filterCriteria.DrainRate.Max);
+            Assert.IsTrue(filterCriteria.DrainRate.IsUpperInclusive);
+        }
+
+        [Test]
+        public void TestApplyBPMQueries()
+        {
+            const string query = "bpm>:200 gotta go fast";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("gotta go fast", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual(200d, filterCriteria.BPM.Min);
+            Assert.IsTrue(filterCriteria.BPM.IsLowerInclusive);
+            Assert.IsNull(filterCriteria.BPM.Max);
+        }
+
+        private static object[] lengthQueryExamples =
+        {
+            new object[] { "6ms", TimeSpan.FromMilliseconds(6), TimeSpan.FromMilliseconds(1) },
+            new object[] { "23s", TimeSpan.FromSeconds(23), TimeSpan.FromSeconds(1) },
+            new object[] { "9m", TimeSpan.FromMinutes(9), TimeSpan.FromMinutes(1) },
+            new object[] { "0.25h", TimeSpan.FromHours(0.25), TimeSpan.FromHours(1) },
+            new object[] { "70", TimeSpan.FromSeconds(70), TimeSpan.FromSeconds(1) },
+        };
+
+        [Test]
+        [TestCaseSource(nameof(lengthQueryExamples))]
+        public void TestApplyLengthQueries(string lengthQuery, TimeSpan expectedLength, TimeSpan scale)
+        {
+            string query = $"length={lengthQuery} time";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("time", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual(expectedLength.TotalMilliseconds - scale.TotalMilliseconds / 2.0, filterCriteria.Length.Min);
+            Assert.IsTrue(filterCriteria.Length.IsLowerInclusive);
+            Assert.AreEqual(expectedLength.TotalMilliseconds + scale.TotalMilliseconds / 2.0, filterCriteria.Length.Max);
+            Assert.IsTrue(filterCriteria.Length.IsUpperInclusive);
+        }
+
+        [Test]
+        public void TestApplyDivisorQueries()
+        {
+            const string query = "that's a time signature alright! divisor:12";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("that's a time signature alright!", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual(12, filterCriteria.BeatDivisor.Min);
+            Assert.IsTrue(filterCriteria.BeatDivisor.IsLowerInclusive);
+            Assert.AreEqual(12, filterCriteria.BeatDivisor.Max);
+            Assert.IsTrue(filterCriteria.BeatDivisor.IsUpperInclusive);
+        }
+
+        [Test]
+        public void TestApplyStatusQueries()
+        {
+            const string query = "I want the pp status=ranked";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("I want the pp", filterCriteria.SearchText.Trim());
+            Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual(BeatmapSetOnlineStatus.Ranked, filterCriteria.OnlineStatus.Min);
+            Assert.IsTrue(filterCriteria.OnlineStatus.IsLowerInclusive);
+            Assert.AreEqual(BeatmapSetOnlineStatus.Ranked, filterCriteria.OnlineStatus.Max);
+            Assert.IsTrue(filterCriteria.OnlineStatus.IsUpperInclusive);
+        }
+    }
+}

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -21,6 +21,16 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
         }
 
+        /*
+         * The following tests have been written a bit strangely (they don't check exact
+         * bound equality with what the filter says).
+         * This is to account for floating-point arithmetic issues.
+         * For example, specifying a bpm<140 filter would previously match beatmaps with BPM
+         * of 139.99999, which would be displayed in the UI as 140.
+         * Due to this the tests check the last tick inside the range and the first tick
+         * outside of the range.
+         */
+
         [Test]
         public void TestApplyStarQueries()
         {
@@ -29,8 +39,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual("easy", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual(4.0f, filterCriteria.StarDifficulty.Max);
-            Assert.IsFalse(filterCriteria.StarDifficulty.IsUpperInclusive);
+            Assert.IsNotNull(filterCriteria.StarDifficulty.Max);
+            Assert.Greater(filterCriteria.StarDifficulty.Max, 3.99d);
+            Assert.Less(filterCriteria.StarDifficulty.Max, 4.00d);
             Assert.IsNull(filterCriteria.StarDifficulty.Min);
         }
 
@@ -42,8 +53,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual("difficult", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual(9.0f, filterCriteria.ApproachRate.Min);
-            Assert.IsTrue(filterCriteria.ApproachRate.IsLowerInclusive);
+            Assert.IsNotNull(filterCriteria.ApproachRate.Min);
+            Assert.Greater(filterCriteria.ApproachRate.Min, 8.9f);
+            Assert.Less(filterCriteria.ApproachRate.Min, 9.0f);
             Assert.IsNull(filterCriteria.ApproachRate.Max);
         }
 
@@ -55,10 +67,10 @@ namespace osu.Game.Tests.NonVisual.Filtering
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
             Assert.AreEqual(2, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual(2.0f, filterCriteria.DrainRate.Min);
-            Assert.IsFalse(filterCriteria.DrainRate.IsLowerInclusive);
-            Assert.AreEqual(6.0f, filterCriteria.DrainRate.Max);
-            Assert.IsTrue(filterCriteria.DrainRate.IsUpperInclusive);
+            Assert.Greater(filterCriteria.DrainRate.Min, 2.0f);
+            Assert.Less(filterCriteria.DrainRate.Min, 2.1f);
+            Assert.Greater(filterCriteria.DrainRate.Max, 6.0f);
+            Assert.Less(filterCriteria.DrainRate.Min, 6.1f);
         }
 
         [Test]
@@ -69,8 +81,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual("gotta go fast", filterCriteria.SearchText.Trim());
             Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
-            Assert.AreEqual(200d, filterCriteria.BPM.Min);
-            Assert.IsTrue(filterCriteria.BPM.IsLowerInclusive);
+            Assert.IsNotNull(filterCriteria.BPM.Min);
+            Assert.Greater(filterCriteria.BPM.Min, 199.99d);
+            Assert.Less(filterCriteria.BPM.Min, 200.00d);
             Assert.IsNull(filterCriteria.BPM.Max);
         }
 
@@ -93,9 +106,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("time", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
             Assert.AreEqual(expectedLength.TotalMilliseconds - scale.TotalMilliseconds / 2.0, filterCriteria.Length.Min);
-            Assert.IsTrue(filterCriteria.Length.IsLowerInclusive);
             Assert.AreEqual(expectedLength.TotalMilliseconds + scale.TotalMilliseconds / 2.0, filterCriteria.Length.Max);
-            Assert.IsTrue(filterCriteria.Length.IsUpperInclusive);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -242,6 +242,21 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
 
             AddAssert("Selection is non-null", () => currentSelection != null);
+
+            setSelected(1, 3);
+            AddStep("Apply a range filter", () => carousel.Filter(new FilterCriteria
+            {
+                SearchText = "#3",
+                StarDifficulty = new FilterCriteria.OptionalRange<double>
+                {
+                    Min = 2,
+                    Max = 5.5,
+                    IsLowerInclusive = true
+                }
+            }, false));
+            checkSelected(3, 2);
+
+            AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
         }
 
         /// <summary>

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -39,6 +39,10 @@ namespace osu.Game.Screens.Select.Carousel
             match &= criteria.BeatDivisor.IsInRange(Beatmap.BeatDivisor);
             match &= criteria.OnlineStatus.IsInRange(Beatmap.Status);
 
+            match &= criteria.Creator.Matches(Beatmap.Metadata.AuthorString);
+            match &= criteria.Artist.Matches(Beatmap.Metadata.Artist) ||
+                     criteria.Artist.Matches(Beatmap.Metadata.ArtistUnicode);
+
             if (match)
                 foreach (var criteriaTerm in criteria.SearchTerms)
                     match &=

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Select
                     if (comparison < 0)
                         return false;
 
-                    if (comparison == 0 && !IsInclusive)
+                    if (comparison == 0 && !IsLowerInclusive)
                         return false;
                 }
 
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Select
                     if (comparison > 0)
                         return false;
 
-                    if (comparison == 0 && !IsInclusive)
+                    if (comparison == 0 && !IsUpperInclusive)
                         return false;
                 }
 
@@ -73,12 +73,14 @@ namespace osu.Game.Screens.Select
 
             public T? Min;
             public T? Max;
-            public bool IsInclusive;
+            public bool IsLowerInclusive;
+            public bool IsUpperInclusive;
 
             public bool Equals(OptionalRange<T> other)
                 => Min.Equals(other.Min)
                    && Max.Equals(other.Max)
-                   && IsInclusive.Equals(other.IsInclusive);
+                   && IsLowerInclusive.Equals(other.IsLowerInclusive)
+                   && IsUpperInclusive.Equals(other.IsUpperInclusive);
         }
     }
 }

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Screens.Select
         public OptionalRange<double> BPM;
         public OptionalRange<int> BeatDivisor;
         public OptionalRange<BeatmapSetOnlineStatus> OnlineStatus;
+        public OptionalTextFilter Creator;
+        public OptionalTextFilter Artist;
 
         public string[] SearchTerms = Array.Empty<string>();
 
@@ -81,6 +83,25 @@ namespace osu.Game.Screens.Select
                    && Max.Equals(other.Max)
                    && IsLowerInclusive.Equals(other.IsLowerInclusive)
                    && IsUpperInclusive.Equals(other.IsUpperInclusive);
+        }
+
+        public struct OptionalTextFilter : IEquatable<OptionalTextFilter>
+        {
+            public bool Matches(string value)
+            {
+                if (string.IsNullOrEmpty(SearchTerm))
+                    return true;
+
+                // search term is guaranteed to be non-empty, so if the string we're comparing is empty, it's not matching
+                if (string.IsNullOrEmpty(value))
+                    return false;
+
+                return value.IndexOf(SearchTerm, StringComparison.InvariantCultureIgnoreCase) >= 0;
+            }
+
+            public string SearchTerm;
+
+            public bool Equals(OptionalTextFilter other) => SearchTerm?.Equals(other.SearchTerm) ?? true;
         }
     }
 }

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Screens.Select
     internal static class FilterQueryParser
     {
         private static readonly Regex query_syntax_regex = new Regex(
-            @"\b(?<key>stars|ar|dr|cs|divisor|length|objects|bpm|status)(?<op>[=:><]+)(?<value>\S*)",
+            @"\b(?<key>stars|ar|dr|cs|divisor|length|objects|bpm|status|creator|artist)(?<op>[=:><]+)(?<value>("".*"")|(\S*))",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         internal static void ApplyQueries(FilterCriteria criteria, string query)
@@ -61,6 +61,14 @@ namespace osu.Game.Screens.Select
                     case "status" when Enum.TryParse<BeatmapSetOnlineStatus>(value, true, out var statusValue):
                         updateCriteriaRange(ref criteria.OnlineStatus, op, statusValue);
                         break;
+
+                    case "creator":
+                        updateCriteriaText(ref criteria.Creator, op, value);
+                        break;
+
+                    case "artist":
+                        updateCriteriaText(ref criteria.Artist, op, value);
+                        break;
                 }
 
                 query = query.Replace(match.ToString(), "");
@@ -77,6 +85,17 @@ namespace osu.Game.Screens.Select
 
         private static bool parseInt(string value, out int result) =>
             int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
+
+        private static void updateCriteriaText(ref FilterCriteria.OptionalTextFilter textFilter, string op, string value)
+        {
+            switch (op)
+            {
+                case "=":
+                case ":":
+                    textFilter.SearchTerm = value.Trim('"');
+                    break;
+            }
+        }
 
         private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, string op, float value, float tolerance = 0.05f)
         {

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -106,30 +106,30 @@ namespace osu.Game.Screens.Select
 
                 case "=":
                 case ":":
-                    range.IsInclusive = true;
+                    range.IsLowerInclusive = range.IsUpperInclusive = true;
                     range.Min = value;
                     range.Max = value;
                     break;
 
                 case ">":
-                    range.IsInclusive = false;
+                    range.IsLowerInclusive = false;
                     range.Min = value;
                     break;
 
                 case ">=":
                 case ">:":
-                    range.IsInclusive = true;
+                    range.IsLowerInclusive = true;
                     range.Min = value;
                     break;
 
                 case "<":
-                    range.IsInclusive = false;
+                    range.IsUpperInclusive = false;
                     range.Max = value;
                     break;
 
                 case "<=":
                 case "<:":
-                    range.IsInclusive = true;
+                    range.IsUpperInclusive = true;
                     range.Max = value;
                     break;
             }

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using osu.Game.Beatmaps;
 
@@ -23,27 +24,27 @@ namespace osu.Game.Screens.Select
 
                 switch (key)
                 {
-                    case "stars" when float.TryParse(value, out var stars):
+                    case "stars" when parseFloatWithPoint(value, out var stars):
                         updateCriteriaRange(ref criteria.StarDifficulty, op, stars);
                         break;
 
-                    case "ar" when float.TryParse(value, out var ar):
+                    case "ar" when parseFloatWithPoint(value, out var ar):
                         updateCriteriaRange(ref criteria.ApproachRate, op, ar);
                         break;
 
-                    case "dr" when float.TryParse(value, out var dr):
+                    case "dr" when parseFloatWithPoint(value, out var dr):
                         updateCriteriaRange(ref criteria.DrainRate, op, dr);
                         break;
 
-                    case "cs" when float.TryParse(value, out var cs):
+                    case "cs" when parseFloatWithPoint(value, out var cs):
                         updateCriteriaRange(ref criteria.CircleSize, op, cs);
                         break;
 
-                    case "bpm" when double.TryParse(value, out var bpm):
+                    case "bpm" when parseDoubleWithPoint(value, out var bpm):
                         updateCriteriaRange(ref criteria.BPM, op, bpm);
                         break;
 
-                    case "length" when double.TryParse(value.TrimEnd('m', 's', 'h'), out var length):
+                    case "length" when parseDoubleWithPoint(value.TrimEnd('m', 's', 'h'), out var length):
                         var scale =
                             value.EndsWith("ms") ? 1 :
                             value.EndsWith("s") ? 1000 :
@@ -53,7 +54,7 @@ namespace osu.Game.Screens.Select
                         updateCriteriaRange(ref criteria.Length, op, length * scale, scale / 2.0);
                         break;
 
-                    case "divisor" when int.TryParse(value, out var divisor):
+                    case "divisor" when parseInt(value, out var divisor):
                         updateCriteriaRange(ref criteria.BeatDivisor, op, divisor);
                         break;
 
@@ -67,6 +68,15 @@ namespace osu.Game.Screens.Select
 
             criteria.SearchText = query;
         }
+
+        private static bool parseFloatWithPoint(string value, out float result) =>
+            float.TryParse(value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out result);
+
+        private static bool parseDoubleWithPoint(string value, out double result) =>
+            double.TryParse(value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out result);
+
+        private static bool parseInt(string value, out int result) =>
+            int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
 
         private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, string op, float value, float tolerance = 0.05f)
         {

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -22,60 +22,66 @@ namespace osu.Game.Screens.Select
                 var op = match.Groups["op"].Value;
                 var value = match.Groups["value"].Value;
 
-                switch (key)
-                {
-                    case "stars" when parseFloatWithPoint(value, out var stars):
-                        updateCriteriaRange(ref criteria.StarDifficulty, op, stars, 0.01f / 2);
-                        break;
-
-                    case "ar" when parseFloatWithPoint(value, out var ar):
-                        updateCriteriaRange(ref criteria.ApproachRate, op, ar, 0.1f / 2);
-                        break;
-
-                    case "dr" when parseFloatWithPoint(value, out var dr):
-                        updateCriteriaRange(ref criteria.DrainRate, op, dr, 0.1f / 2);
-                        break;
-
-                    case "cs" when parseFloatWithPoint(value, out var cs):
-                        updateCriteriaRange(ref criteria.CircleSize, op, cs, 0.1f / 2);
-                        break;
-
-                    case "bpm" when parseDoubleWithPoint(value, out var bpm):
-                        updateCriteriaRange(ref criteria.BPM, op, bpm, 0.01d / 2);
-                        break;
-
-                    case "length" when parseDoubleWithPoint(value.TrimEnd('m', 's', 'h'), out var length):
-                        var scale =
-                            value.EndsWith("ms") ? 1 :
-                            value.EndsWith("s") ? 1000 :
-                            value.EndsWith("m") ? 60000 :
-                            value.EndsWith("h") ? 3600000 : 1000;
-
-                        updateCriteriaRange(ref criteria.Length, op, length * scale, scale / 2.0);
-                        break;
-
-                    case "divisor" when parseInt(value, out var divisor):
-                        updateCriteriaRange(ref criteria.BeatDivisor, op, divisor);
-                        break;
-
-                    case "status" when Enum.TryParse<BeatmapSetOnlineStatus>(value, true, out var statusValue):
-                        updateCriteriaRange(ref criteria.OnlineStatus, op, statusValue);
-                        break;
-
-                    case "creator":
-                        updateCriteriaText(ref criteria.Creator, op, value);
-                        break;
-
-                    case "artist":
-                        updateCriteriaText(ref criteria.Artist, op, value);
-                        break;
-                }
+                parseKeywordCriteria(criteria, key, value, op);
 
                 query = query.Replace(match.ToString(), "");
             }
 
             criteria.SearchText = query;
         }
+
+        private static void parseKeywordCriteria(FilterCriteria criteria, string key, string value, string op)
+        {
+            switch (key)
+            {
+                case "stars" when parseFloatWithPoint(value, out var stars):
+                    updateCriteriaRange(ref criteria.StarDifficulty, op, stars, 0.01f / 2);
+                    break;
+
+                case "ar" when parseFloatWithPoint(value, out var ar):
+                    updateCriteriaRange(ref criteria.ApproachRate, op, ar, 0.1f / 2);
+                    break;
+
+                case "dr" when parseFloatWithPoint(value, out var dr):
+                    updateCriteriaRange(ref criteria.DrainRate, op, dr, 0.1f / 2);
+                    break;
+
+                case "cs" when parseFloatWithPoint(value, out var cs):
+                    updateCriteriaRange(ref criteria.CircleSize, op, cs, 0.1f / 2);
+                    break;
+
+                case "bpm" when parseDoubleWithPoint(value, out var bpm):
+                    updateCriteriaRange(ref criteria.BPM, op, bpm, 0.01d / 2);
+                    break;
+
+                case "length" when parseDoubleWithPoint(value.TrimEnd('m', 's', 'h'), out var length):
+                    var scale = getLengthScale(value);
+                    updateCriteriaRange(ref criteria.Length, op, length * scale, scale / 2.0);
+                    break;
+
+                case "divisor" when parseInt(value, out var divisor):
+                    updateCriteriaRange(ref criteria.BeatDivisor, op, divisor);
+                    break;
+
+                case "status" when Enum.TryParse<BeatmapSetOnlineStatus>(value, true, out var statusValue):
+                    updateCriteriaRange(ref criteria.OnlineStatus, op, statusValue);
+                    break;
+
+                case "creator":
+                    updateCriteriaText(ref criteria.Creator, op, value);
+                    break;
+
+                case "artist":
+                    updateCriteriaText(ref criteria.Artist, op, value);
+                    break;
+            }
+        }
+
+        private static int getLengthScale(string value) =>
+            value.EndsWith("ms") ? 1 :
+            value.EndsWith("s") ? 1000 :
+            value.EndsWith("m") ? 60000 :
+            value.EndsWith("h") ? 3600000 : 1000;
 
         private static bool parseFloatWithPoint(string value, out float result) =>
             float.TryParse(value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out result);

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -25,23 +25,23 @@ namespace osu.Game.Screens.Select
                 switch (key)
                 {
                     case "stars" when parseFloatWithPoint(value, out var stars):
-                        updateCriteriaRange(ref criteria.StarDifficulty, op, stars);
+                        updateCriteriaRange(ref criteria.StarDifficulty, op, stars, 0.01f / 2);
                         break;
 
                     case "ar" when parseFloatWithPoint(value, out var ar):
-                        updateCriteriaRange(ref criteria.ApproachRate, op, ar);
+                        updateCriteriaRange(ref criteria.ApproachRate, op, ar, 0.1f / 2);
                         break;
 
                     case "dr" when parseFloatWithPoint(value, out var dr):
-                        updateCriteriaRange(ref criteria.DrainRate, op, dr);
+                        updateCriteriaRange(ref criteria.DrainRate, op, dr, 0.1f / 2);
                         break;
 
                     case "cs" when parseFloatWithPoint(value, out var cs):
-                        updateCriteriaRange(ref criteria.CircleSize, op, cs);
+                        updateCriteriaRange(ref criteria.CircleSize, op, cs, 0.1f / 2);
                         break;
 
                     case "bpm" when parseDoubleWithPoint(value, out var bpm):
-                        updateCriteriaRange(ref criteria.BPM, op, bpm);
+                        updateCriteriaRange(ref criteria.BPM, op, bpm, 0.01d / 2);
                         break;
 
                     case "length" when parseDoubleWithPoint(value.TrimEnd('m', 's', 'h'), out var length):
@@ -99,13 +99,32 @@ namespace osu.Game.Screens.Select
 
         private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, string op, float value, float tolerance = 0.05f)
         {
-            updateCriteriaRange(ref range, op, value);
-
             switch (op)
             {
+                default:
+                    return;
+
                 case "=":
                 case ":":
                     range.Min = value - tolerance;
+                    range.Max = value + tolerance;
+                    break;
+
+                case ">":
+                    range.Min = value + tolerance;
+                    break;
+
+                case ">=":
+                case ">:":
+                    range.Min = value - tolerance;
+                    break;
+
+                case "<":
+                    range.Max = value - tolerance;
+                    break;
+
+                case "<=":
+                case "<:":
                     range.Max = value + tolerance;
                     break;
             }
@@ -113,13 +132,32 @@ namespace osu.Game.Screens.Select
 
         private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<double> range, string op, double value, double tolerance = 0.05)
         {
-            updateCriteriaRange(ref range, op, value);
-
             switch (op)
             {
+                default:
+                    return;
+
                 case "=":
                 case ":":
                     range.Min = value - tolerance;
+                    range.Max = value + tolerance;
+                    break;
+
+                case ">":
+                    range.Min = value + tolerance;
+                    break;
+
+                case ">=":
+                case ">:":
+                    range.Min = value - tolerance;
+                    break;
+
+                case "<":
+                    range.Max = value - tolerance;
+                    break;
+
+                case "<=":
+                case "<:":
                     range.Max = value + tolerance;
                     break;
             }

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Text.RegularExpressions;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Screens.Select
+{
+    internal static class FilterQueryParser
+    {
+        private static readonly Regex query_syntax_regex = new Regex(
+            @"\b(?<key>stars|ar|dr|cs|divisor|length|objects|bpm|status)(?<op>[=:><]+)(?<value>\S*)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        internal static void ApplyQueries(FilterCriteria criteria, string query)
+        {
+            foreach (Match match in query_syntax_regex.Matches(query))
+            {
+                var key = match.Groups["key"].Value.ToLower();
+                var op = match.Groups["op"].Value;
+                var value = match.Groups["value"].Value;
+
+                switch (key)
+                {
+                    case "stars" when float.TryParse(value, out var stars):
+                        updateCriteriaRange(ref criteria.StarDifficulty, op, stars);
+                        break;
+
+                    case "ar" when float.TryParse(value, out var ar):
+                        updateCriteriaRange(ref criteria.ApproachRate, op, ar);
+                        break;
+
+                    case "dr" when float.TryParse(value, out var dr):
+                        updateCriteriaRange(ref criteria.DrainRate, op, dr);
+                        break;
+
+                    case "cs" when float.TryParse(value, out var cs):
+                        updateCriteriaRange(ref criteria.CircleSize, op, cs);
+                        break;
+
+                    case "bpm" when double.TryParse(value, out var bpm):
+                        updateCriteriaRange(ref criteria.BPM, op, bpm);
+                        break;
+
+                    case "length" when double.TryParse(value.TrimEnd('m', 's', 'h'), out var length):
+                        var scale =
+                            value.EndsWith("ms") ? 1 :
+                            value.EndsWith("s") ? 1000 :
+                            value.EndsWith("m") ? 60000 :
+                            value.EndsWith("h") ? 3600000 : 1000;
+
+                        updateCriteriaRange(ref criteria.Length, op, length * scale, scale / 2.0);
+                        break;
+
+                    case "divisor" when int.TryParse(value, out var divisor):
+                        updateCriteriaRange(ref criteria.BeatDivisor, op, divisor);
+                        break;
+
+                    case "status" when Enum.TryParse<BeatmapSetOnlineStatus>(value, true, out var statusValue):
+                        updateCriteriaRange(ref criteria.OnlineStatus, op, statusValue);
+                        break;
+                }
+
+                query = query.Replace(match.ToString(), "");
+            }
+
+            criteria.SearchText = query;
+        }
+
+        private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, string op, float value, float tolerance = 0.05f)
+        {
+            updateCriteriaRange(ref range, op, value);
+
+            switch (op)
+            {
+                case "=":
+                case ":":
+                    range.Min = value - tolerance;
+                    range.Max = value + tolerance;
+                    break;
+            }
+        }
+
+        private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<double> range, string op, double value, double tolerance = 0.05)
+        {
+            updateCriteriaRange(ref range, op, value);
+
+            switch (op)
+            {
+                case "=":
+                case ":":
+                    range.Min = value - tolerance;
+                    range.Max = value + tolerance;
+                    break;
+            }
+        }
+
+        private static void updateCriteriaRange<T>(ref FilterCriteria.OptionalRange<T> range, string op, T value)
+            where T : struct, IComparable
+        {
+            switch (op)
+            {
+                default:
+                    return;
+
+                case "=":
+                case ":":
+                    range.IsInclusive = true;
+                    range.Min = value;
+                    range.Max = value;
+                    break;
+
+                case ">":
+                    range.IsInclusive = false;
+                    range.Min = value;
+                    break;
+
+                case ">=":
+                case ">:":
+                    range.IsInclusive = true;
+                    range.Min = value;
+                    break;
+
+                case "<":
+                    range.IsInclusive = false;
+                    range.Max = value;
+                    break;
+
+                case "<=":
+                case "<:":
+                    range.IsInclusive = true;
+                    range.Max = value;
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Adds `creator=` and `artist=` filters to resolve #6186.
* Adds support for half-open interval queries.
* Fixes culture variance when parsing filters with decimal points.
* Fixes handling of floating-point interval queries.
* Adds comprehensive filter unit test suite.

# Summary

This is quite a big one - I kind of just wanted to implement #6186, but as there were no tests, I started adding some and hitting some things that I wanted to improve, so this grew in scope quite a bit. And splitting this into multiple PRs felt like just creating noise for the sake of it.

I realise this might be hard to review. It might be a little easier going commit-by-commit, but this is quite large anyways. Feel free to merge this at your leisure.

## New filters

To match newest stable additions, add `creator=` and `artist=` filters to the beatmap carousel on song select screen. Contrary to stable, this implementation supports phrase queries with spaces within using double quotes.

The quote handling is not entirely correct (can't nest), but quotes should rarely happen within names, and it is an edge case of an edge case - leaving best-effort as is.

## Support for half-open intervals

A single `IsInclusive` field caused unexpected issues when trying to formulate a half-open interval query (last operator chosen won). Split out `IsInclusive` into two fields, `Is{Lower,Upper}Inclusive` and update usages accordingly.

## Culture variance fix

Culture was not taken into account when parsing filters, which meant that in cultures that use the comma (`,`) as a decimal delimiter, it would conflict with the comma used to delimit search criteria. To remove any ambiguity, introduce local helper functions that allow the decimal point to be utilised, using the invariant culture. This also matches stable behaviour.

The decision to not reuse `osu.Game.Beatmaps.Formats.Parsing` was deliberate due to differing semantics (it's not really sane to throw exceptions on receiving user-facing input, and catching them didn't feel right).

## Floating-point interval fix

Due to floating-point rounding and representation errors, filters could wrongly display results incongruous with the wedge display text (ie. a beatmap with the BPM of 139.99999 would be displayed as having 140 BPM and also pass the `bpm<140` filter).

Apply tolerance when parsing floating-point constraints. The tolerance chosen is half of what the UI displays for the particular values (so for example half of 0.1 for AR/DR/CS, 0.01 for stars, etc.)

Spotted this at the very end, so that kind of invalidated most of the `IsInclusive` changes (but not all of them).

## Testing

Lots of unit tests added, both for parsing and filter evaluation, with one end-to-end visual test modification. For testability I extracted the parsing logic out of its original place at the very start.