### PR TITLE
Fix track-adjusting mods not applying after resuming from another screen

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             beatmap.BindValueChanged(beatmapChanged, true);
-            mods.BindValueChanged(_ => updateAudioAdjustments(), true);
+            mods.BindValueChanged(_ => ResetTrackAdjustments(), true);
             base.LoadComplete();
         }
 
@@ -213,12 +213,12 @@ namespace osu.Game.Overlays
             current = beatmap.NewValue;
             TrackChanged?.Invoke(current, direction);
 
-            updateAudioAdjustments();
+            ResetTrackAdjustments();
 
             queuedDirection = null;
         }
 
-        private void updateAudioAdjustments()
+        public void ResetTrackAdjustments()
         {
             var track = current?.Track;
             if (track == null)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -490,6 +490,7 @@ namespace osu.Game.Screens.Select
             BeatmapDetails.Leaderboard.RefreshScores();
 
             Beatmap.Value.Track.Looping = true;
+            music?.ResetTrackAdjustments();
 
             if (Beatmap != null && !Beatmap.Value.BeatmapSetInfo.DeletePending)
             {


### PR DESCRIPTION
- Fixes track-adjusting mods not applying after resuming from another screen (`PlayerLoader` / `Player`) by reapplying adjustments `OnResuming()`

This issue happens because when starting a beatmap, the track is bind to the gameplay clock which means resetting speed adjustments of the gameplay clock applies the same for the track which results in the track being played with normal adjustments on resuming.

Closes #6298