### PR TITLE
Migrate beatmap carousel test to AddUntilStep

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("ensure prev random fetch worked", () => selectedSets.Peek() == carousel.SelectedBeatmapSet);
 
         private void checkSelected(int set, int? diff = null) =>
-            AddAssert($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
+            AddUntilStep($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
             {
                 if (diff != null)
                     return carousel.SelectedBeatmap == carousel.BeatmapSets.Skip(set - 1).First().Beatmaps.Skip(diff.Value - 1).First();

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         private void ensureRandomFetchSuccess() =>
             AddAssert("ensure prev random fetch worked", () => selectedSets.Peek() == carousel.SelectedBeatmapSet);
 
-        private void checkSelected(int set, int? diff = null) =>
+        private void waitForSelection(int set, int? diff = null) =>
             AddUntilStep($"selected is set{set}{(diff.HasValue ? $" diff{diff.Value}" : "")}", () =>
             {
                 if (diff != null)
@@ -168,24 +168,24 @@ namespace osu.Game.Tests.Visual.SongSelect
             loadBeatmaps();
 
             advanceSelection(direction: 1, diff: false);
-            checkSelected(1, 1);
+            waitForSelection(1, 1);
 
             advanceSelection(direction: 1, diff: true);
-            checkSelected(1, 2);
+            waitForSelection(1, 2);
 
             advanceSelection(direction: -1, diff: false);
-            checkSelected(set_count, 1);
+            waitForSelection(set_count, 1);
 
             advanceSelection(direction: -1, diff: true);
-            checkSelected(set_count - 1, 3);
+            waitForSelection(set_count - 1, 3);
 
             advanceSelection(diff: false);
             advanceSelection(diff: false);
-            checkSelected(1, 2);
+            waitForSelection(1, 2);
 
             advanceSelection(direction: -1, diff: true);
             advanceSelection(direction: -1, diff: true);
-            checkSelected(set_count, 3);
+            waitForSelection(set_count, 3);
         }
 
         /// <summary>
@@ -203,10 +203,10 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("Filter", () => carousel.Filter(new FilterCriteria { SearchText = "set #3!" }, false));
             checkVisibleItemCount(diff: false, count: 1);
             checkVisibleItemCount(diff: true, count: 3);
-            checkSelected(3, 1);
+            waitForSelection(3, 1);
 
             advanceSelection(diff: true, count: 4);
-            checkSelected(3, 2);
+            waitForSelection(3, 2);
 
             AddStep("Un-filter (debounce)", () => carousel.Filter(new FilterCriteria()));
             AddUntilStep("Wait for debounce", () => !carousel.PendingFilterTask);
@@ -217,10 +217,10 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             setSelected(1, 2);
             AddStep("Filter some difficulties", () => carousel.Filter(new FilterCriteria { SearchText = "Normal" }, false));
-            checkSelected(1, 1);
+            waitForSelection(1, 1);
 
             AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
-            checkSelected(1, 1);
+            waitForSelection(1, 1);
 
             AddStep("Filter all", () => carousel.Filter(new FilterCriteria { SearchText = "Dingo" }, false));
 
@@ -249,7 +249,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     IsLowerInclusive = true
                 }
             }, false));
-            checkSelected(3, 2);
+            waitForSelection(3, 2);
 
             AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
         }
@@ -317,7 +317,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             checkVisibleItemCount(false, set_count);
 
-            checkSelected(set_count);
+            waitForSelection(set_count);
         }
 
         /// <summary>
@@ -343,11 +343,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("Selection is non-null", () => currentSelection != null);
 
             AddStep("Remove selected", () => carousel.RemoveBeatmapSet(carousel.SelectedBeatmapSet));
-            checkSelected(2);
+            waitForSelection(2);
 
             AddStep("Remove first", () => carousel.RemoveBeatmapSet(carousel.BeatmapSets.First()));
             AddStep("Remove first", () => carousel.RemoveBeatmapSet(carousel.BeatmapSets.First()));
-            checkSelected(1);
+            waitForSelection(1);
 
             AddUntilStep("Remove all", () =>
             {
@@ -390,17 +390,17 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             checkVisibleItemCount(true, 2);
             advanceSelection(true);
-            checkSelected(1, 3);
+            waitForSelection(1, 3);
 
             setHidden(3);
-            checkSelected(1, 1);
+            waitForSelection(1, 1);
 
             setHidden(2, false);
             advanceSelection(true);
-            checkSelected(1, 2);
+            waitForSelection(1, 2);
 
             setHidden(1);
-            checkSelected(1, 2);
+            waitForSelection(1, 2);
 
             setHidden(2);
             checkNoSelection();


### PR DESCRIPTION
Attempts to resolve `osu.Game.Tests.Visual.SongSelect.TestSceneBeatmapCarousel.TestFiltering` visual test non-deterministically failing builds.

# Summary

Due to non-deterministic test failures in `TestSceneBeatmapCarousel`, migrate the `checkSelected` helper step from `AddAssert` to `AddUntilStep`. This adds more leniency for performance-related issues while still checking the desired behaviour.

# Remarks

I am moderately certain that the root cause is the step progression racing with the filtering logic, which this sort of change would resolve, but I'm not sure how to convincingly prove that this fix succeeds, other than by saying the following:
* The test failure sometimes reproduced locally, usually at the first couple of test runs after opening Visual Studio.
* I never got that symptom again after applying the fix, I restarted VS like 5-6 times doing that.
* I ran five AppVeyor builds with the fix on my fork, here's a summary:

| Build | Test result | Build result |
|-|:-:|:-:|
| [fix-test-races-9](https://ci.appveyor.com/project/bdach/osu/builds/27737496/tests) | pass | pass |
| [fix-test-races-10](https://ci.appveyor.com/project/bdach/osu/builds/27737621/tests) | pass | pass |
| [fix-test-races-11](https://ci.appveyor.com/project/bdach/osu/builds/27737744/tests) | pass | pass |
| [fix-test-races-12](https://ci.appveyor.com/project/bdach/osu/builds/27737861/tests) | pass | fail |
| [fix-test-races-13](https://ci.appveyor.com/project/bdach/osu/builds/27737942/tests) | pass | pass |

The one failure comes from `osu.Game.Tests.Visual.Menus.TestSceneScreenNavigation`. I've also seen that fail sometimes, along with other tests, but after looking at them I did not have any idea of a fix that I'd be willing to PR.

Sorry for introducing this in the first place, I will bear the possibility of this sort of issue in mind in the future.