### PR TITLE
Do not close osu! when the back button is pressed on android.

### DIFF
--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -21,5 +21,12 @@ namespace osu.Android
             Window.AddFlags(WindowManagerFlags.Fullscreen);
             Window.AddFlags(WindowManagerFlags.KeepScreenOn);
         }
+
+        /// <summary>
+        /// Overriding this method avoids that osu! closes when the backbutton is pressed.
+        /// </summary>
+        public override void OnBackPressed()
+        {
+        }
     }
 }


### PR DESCRIPTION
Overiding this method prevents that the back button closes the app.

Resolves https://github.com/ppy/osu/issues/6325