### PR TITLE
Fix username overlap timestamp in match chatroom

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -32,6 +32,12 @@ namespace osu.Game.Tests.Visual.Online
             Id = 4,
         };
 
+        private readonly User longUsernameUser = new User
+        {
+            Username = "Very Long Long Username",
+            Id = 5,
+        };
+
         [Cached]
         private ChannelManager channelManager = new ChannelManager();
 
@@ -98,6 +104,12 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Sender = admin,
                 Content = "Okay okay, calm down guys. Let's do this!"
+            }));
+
+            AddStep("message from long username", () => testChannel.AddNewMessages(new Message(sequence++)
+            {
+                Sender = longUsernameUser,
+                Content = "Hi guys, my new username is lit!"
             }));
         }
     }

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -146,6 +146,7 @@ namespace osu.Game.Online.Chat
 
             protected override float HorizontalPadding => 10;
             protected override float MessagePadding => 120;
+            protected override float TimestampPadding => 130;
 
             public StandAloneMessage(Message message)
                 : base(message)

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Online.Chat
 
             protected override float HorizontalPadding => 10;
             protected override float MessagePadding => 120;
-            protected override float TimestampPadding => 130;
+            protected override float TimestampPadding => 50;
 
             public StandAloneMessage(Message message)
                 : base(message)

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Overlays.Chat
                 Font = OsuFont.GetFont(size: TextSize, weight: FontWeight.Bold, italics: true),
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
-                MaxWidth = default_message_padding - TimestampPadding
+                MaxWidth = MessagePadding - TimestampPadding
             };
 
             if (hasBackground)
@@ -151,7 +151,6 @@ namespace osu.Game.Overlays.Chat
                         new MessageSender(message.Sender)
                         {
                             AutoSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Left = TimestampPadding },
                             Origin = Anchor.TopRight,
                             Anchor = Anchor.TopRight,
                             Child = effectedUsername,

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -31,7 +31,9 @@ namespace osu.Game.Overlays.Chat
 
         protected virtual float MessagePadding => default_message_padding;
 
-        private const float timestamp_padding = 65;
+        private const float default_timestamp_padding = 65;
+
+        protected virtual float TimestampPadding => default_timestamp_padding;
 
         private const float default_horizontal_padding = 15;
 
@@ -94,7 +96,7 @@ namespace osu.Game.Overlays.Chat
                 Font = OsuFont.GetFont(size: TextSize, weight: FontWeight.Bold, italics: true),
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
-                MaxWidth = default_message_padding - timestamp_padding
+                MaxWidth = default_message_padding - TimestampPadding
             };
 
             if (hasBackground)
@@ -149,7 +151,7 @@ namespace osu.Game.Overlays.Chat
                         new MessageSender(message.Sender)
                         {
                             AutoSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Left = timestamp_padding },
+                            Padding = new MarginPadding { Left = TimestampPadding },
                             Origin = Anchor.TopRight,
                             Anchor = Anchor.TopRight,
                             Child = effectedUsername,


### PR DESCRIPTION
Fix #6061 

| This PR | Master Branch  |
| ------------- | ------------- |
| <img width="600" alt="Screen Shot 2019-10-01 at 20 45 00" src="https://user-images.githubusercontent.com/6506864/65968293-2263d380-e48d-11e9-9478-c00f737dafa8.png"> | <img width="600" alt="Screen Shot 2019-10-01 at 20 44 11" src="https://user-images.githubusercontent.com/6506864/65968294-2263d380-e48d-11e9-9e43-65327b0347e6.png">
<img width="800" alt="Screen Shot 2019-10-01 at 20 22 30" src="https://user-images.githubusercontent.com/6506864/65968296-22fc6a00-e48d-11e9-951b-c38b5cb6b3e3.png"> |  <img width="800" alt="Screen Shot 2019-10-01 at 20 23 17" src="https://user-images.githubusercontent.com/6506864/65968297-22fc6a00-e48d-11e9-995e-b75ff72ca302.png">

I just give a shot to fix this, but still not sure this is the correct way to solve it. Also `TimestampPadding` is obtained from trial and error so not sure this is pixel perfect.
