### PR TITLE
Simplify exit logic of screens with textboxes using back button receptor

### DIFF
--- a/osu.Game/Graphics/UserInterface/BackButton.cs
+++ b/osu.Game/Graphics/UserInterface/BackButton.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Graphics.UserInterface
 
         public BackButton(Receptor receptor)
         {
-            receptor.OnBackPressed = () => Action?.Invoke();
+            receptor.OnBackPressed = () => button.Click();
 
             Size = TwoLayerButton.SIZE_EXTENDED;
 

--- a/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Graphics.UserInterface
             if (!HasFocus) return false;
 
             if (e.Key == Key.Escape)
-                return false; // disable the framework-level handling of escape key for confority (we use GlobalAction.Back).
+                return false; // disable the framework-level handling of escape key for conformity (we use GlobalAction.Back).
 
             return base.OnKeyDown(e);
         }

--- a/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/FocusedTextBox.cs
@@ -2,22 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osuTK.Graphics;
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Input.Events;
 using osu.Framework.Platform;
 using osu.Game.Input.Bindings;
 using osuTK.Input;
+using osu.Framework.Input.Bindings;
 
 namespace osu.Game.Graphics.UserInterface
 {
     /// <summary>
     /// A textbox which holds focus eagerly.
     /// </summary>
-    public class FocusedTextBox : OsuTextBox
+    public class FocusedTextBox : OsuTextBox, IKeyBindingHandler<GlobalAction>
     {
-        public Action Exit;
-
         private bool focus;
 
         private bool allowImmediateFocus => host?.OnScreenKeyboardOverlapsGameWindow != true;
@@ -68,7 +66,7 @@ namespace osu.Game.Graphics.UserInterface
             return base.OnKeyDown(e);
         }
 
-        public override bool OnPressed(GlobalAction action)
+        public bool OnPressed(GlobalAction action)
         {
             if (action == GlobalAction.Back)
             {
@@ -79,14 +77,10 @@ namespace osu.Game.Graphics.UserInterface
                 }
             }
 
-            return base.OnPressed(action);
+            return false;
         }
 
-        protected override void KillFocus()
-        {
-            base.KillFocus();
-            Exit?.Invoke();
-        }
+        public bool OnReleased(GlobalAction action) => false;
 
         public override bool RequestsFocus => HoldFocus;
     }

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -8,13 +8,11 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
 using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Input.Bindings;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class OsuTextBox : TextBox, IKeyBindingHandler<GlobalAction>
+    public class OsuTextBox : TextBox
     {
         protected override float LeftRightPadding => 10;
 
@@ -57,18 +55,5 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         protected override Drawable GetDrawableCharacter(char c) => new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: CalculatedTextSize) };
-
-        public virtual bool OnPressed(GlobalAction action)
-        {
-            if (action == GlobalAction.Back)
-            {
-                KillFocus();
-                return true;
-            }
-
-            return false;
-        }
-
-        public bool OnReleased(GlobalAction action) => false;
     }
 }

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Online.Chat
     {
         public readonly Bindable<Channel> Channel = new Bindable<Channel>();
 
-        public Action Exit;
-
         private readonly FocusedTextBox textbox;
 
         protected ChannelManager ChannelManager;
@@ -66,8 +64,6 @@ namespace osu.Game.Online.Chat
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                 });
-
-                textbox.Exit += () => Exit?.Invoke();
             }
 
             Channel.BindValueChanged(channelChanged);

--- a/osu.Game/Overlays/Chat/Selection/ChannelSelectionOverlay.cs
+++ b/osu.Game/Overlays/Chat/Selection/ChannelSelectionOverlay.cs
@@ -119,7 +119,6 @@ namespace osu.Game.Overlays.Chat.Selection
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     PlaceholderText = @"Search",
-                                    Exit = Hide,
                                 },
                             },
                         },

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -138,7 +138,6 @@ namespace osu.Game.Overlays
                                             RelativeSizeAxes = Axes.Both,
                                             Height = 1,
                                             PlaceholderText = "type your message",
-                                            Exit = Hide,
                                             OnCommit = postMessage,
                                             ReleaseFocusOnCommit = false,
                                             HoldFocus = true,

--- a/osu.Game/Overlays/Music/FilterControl.cs
+++ b/osu.Game/Overlays/Music/FilterControl.cs
@@ -31,7 +31,6 @@ namespace osu.Game.Overlays.Music
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = 40,
-                            Exit = () => ExitRequested?.Invoke(),
                         },
                         new CollectionsDropdown<PlaylistCollection>
                         {
@@ -46,8 +45,6 @@ namespace osu.Game.Overlays.Music
         }
 
         private void current_ValueChanged(ValueChangedEvent<string> e) => FilterChanged?.Invoke(e.NewValue);
-
-        public Action ExitRequested;
 
         public Action<string> FilterChanged;
 

--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -63,7 +63,6 @@ namespace osu.Game.Overlays.Music
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            ExitRequested = Hide,
                             FilterChanged = search => list.Filter(search),
                             Padding = new MarginPadding(10),
                         },

--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -88,8 +88,6 @@ namespace osu.Game.Overlays.SearchableList
                     },
                 },
             };
-
-            Filter.Search.Exit = Hide;
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -91,7 +91,6 @@ namespace osu.Game.Overlays
                                 Top = 20,
                                 Bottom = 20
                             },
-                            Exit = Hide,
                         },
                         Footer = CreateFooter()
                     },

--- a/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
@@ -69,8 +69,6 @@ namespace osu.Game.Screens.Multi.Lounge
                     },
                 },
             };
-
-            Filter.Search.Exit += this.Exit;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Screens.Multi.Match
         [BackgroundDependencyLoader]
         private void load()
         {
-            MatchChatDisplay chat;
             Components.Header header;
             Info info;
             GridContainer bottomRow;
@@ -122,7 +121,7 @@ namespace osu.Game.Screens.Multi.Match
                                                 Vertical = 10,
                                             },
                                             RelativeSizeAxes = Axes.Both,
-                                            Child = chat = new MatchChatDisplay
+                                            Child = new MatchChatDisplay
                                             {
                                                 RelativeSizeAxes = Axes.Both
                                             }
@@ -158,12 +157,6 @@ namespace osu.Game.Screens.Multi.Match
                 info.FadeTo(settingsDisplayed ? 0 : 1, fade_duration, Easing.OutQuint);
                 bottomRow.FadeTo(settingsDisplayed ? 0 : 1, fade_duration, Easing.OutQuint);
             }, true);
-
-            chat.Exit += () =>
-            {
-                if (this.IsCurrentScreen())
-                    this.Exit();
-            };
 
             beatmapManager.ItemAdded += beatmapAdded;
         }

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -49,8 +49,6 @@ namespace osu.Game.Screens.Select
             return criteria;
         }
 
-        public Action Exit;
-
         private readonly SearchTextBox searchTextBox;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
@@ -75,11 +73,7 @@ namespace osu.Game.Screens.Select
                     Origin = Anchor.TopRight,
                     Children = new Drawable[]
                     {
-                        searchTextBox = new SearchTextBox
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Exit = () => Exit?.Invoke(),
-                        },
+                        searchTextBox = new SearchTextBox { RelativeSizeAxes = Axes.X },
                         new Box
                         {
                             RelativeSizeAxes = Axes.X,

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -171,11 +171,6 @@ namespace osu.Game.Screens.Select
                                 Height = FilterControl.HEIGHT,
                                 FilterChanged = c => Carousel.Filter(c),
                                 Background = { Width = 2 },
-                                Exit = () =>
-                                {
-                                    if (this.IsCurrentScreen())
-                                        this.Exit();
-                                },
                             },
                         }
                     },


### PR DESCRIPTION
Initially I just wanted to do the second commit, but it wasn't working with every screen as `Exit()` was happening on textboxes.

Since back button receptor is now the last `GlobalAction` when pressing escape, it won't interfere with the `GlobalAction`s of textboxes, etc.

`OnPressed` of `OsuTextBox` is already done [framework level](https://github.com/ppy/osu-framework/blob/master/osu.Framework/Graphics/UserInterface/TextBox.cs#L708) using `OnKeyDown`. Using breakpoints, it was never executed.