### PR TITLE
Add key binding to restart current track

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -63,7 +63,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.TrackNext, GlobalAction.MusicNext),
             new KeyBinding(InputKey.F5, GlobalAction.MusicNext),
             new KeyBinding(InputKey.PlayPause, GlobalAction.MusicPlay),
-            new KeyBinding(InputKey.F3, GlobalAction.MusicPlay)
+            new KeyBinding(InputKey.F3, GlobalAction.MusicPlay),
+            new KeyBinding(InputKey.F2, GlobalAction.MusicRestart)
         };
 
         protected override IEnumerable<Drawable> KeyBindingInputQueue =>
@@ -136,5 +137,8 @@ namespace osu.Game.Input.Bindings
 
         [Description("Play / pause")]
         MusicPlay,
+
+        [Description("Restart track")]
+        MusicRestart,
     }
 }

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -46,8 +46,6 @@ namespace osu.Game.Overlays
         [Resolved(canBeNull: true)]
         private OnScreenDisplay onScreenDisplay { get; set; }
 
-        private bool isRestart;
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -183,12 +181,14 @@ namespace osu.Game.Overlays
             return false;
         }
 
-        private bool restartTrack()
+        private bool restartTrack(out bool isRestart)
         {
             var track = current?.Track;
 
             if (track == null)
             {
+                isRestart = false;
+
                 if (beatmap.Disabled)
                     return false;
 
@@ -297,7 +297,7 @@ namespace osu.Game.Overlays
                     return true;
 
                 case GlobalAction.MusicRestart:
-                    if (restartTrack())
+                    if (restartTrack(out bool isRestart))
                         onScreenDisplay?.Display(new MusicControllerToast(isRestart ? "Restart track" : "Play track"));
 
                     return true;

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Overlays
         [Resolved(canBeNull: true)]
         private OnScreenDisplay onScreenDisplay { get; set; }
 
+        private bool isRestart;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -181,6 +183,35 @@ namespace osu.Game.Overlays
             return false;
         }
 
+        private bool restartTrack()
+        {
+            var track = current?.Track;
+
+            if (track == null)
+            {
+                if (beatmap.Disabled)
+                    return false;
+
+                next(true);
+                return true;
+            }
+
+            if (track.IsRunning)
+            {
+                SeekTo(0);
+                isRestart = true;
+            }
+            else
+            {
+                track.Start();
+
+                IsUserPaused = false;
+                isRestart = false;
+            }
+
+            return true;
+        }
+
         private WorkingBeatmap current;
 
         private TrackChangeDirection? queuedDirection;
@@ -262,6 +293,12 @@ namespace osu.Game.Overlays
                 case GlobalAction.MusicPrev:
                     if (PrevTrack())
                         onScreenDisplay?.Display(new MusicControllerToast("Previous track"));
+
+                    return true;
+
+                case GlobalAction.MusicRestart:
+                    if (restartTrack())
+                        onScreenDisplay?.Display(new MusicControllerToast(isRestart ? "Restart track" : "Play track"));
 
                     return true;
             }

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -181,14 +181,12 @@ namespace osu.Game.Overlays
             return false;
         }
 
-        private bool restartTrack(out bool isRestart)
+        private bool restartTrack()
         {
             var track = current?.Track;
 
             if (track == null)
             {
-                isRestart = false;
-
                 if (beatmap.Disabled)
                     return false;
 
@@ -197,16 +195,11 @@ namespace osu.Game.Overlays
             }
 
             if (track.IsRunning)
-            {
                 SeekTo(0);
-                isRestart = true;
-            }
             else
             {
                 track.Start();
-
                 IsUserPaused = false;
-                isRestart = false;
             }
 
             return true;
@@ -297,8 +290,9 @@ namespace osu.Game.Overlays
                     return true;
 
                 case GlobalAction.MusicRestart:
-                    if (restartTrack(out bool isRestart))
-                        onScreenDisplay?.Display(new MusicControllerToast(isRestart ? "Restart track" : "Play track"));
+                    var wasPlaying = IsPlaying;
+                    if (restartTrack())
+                        onScreenDisplay?.Display(new MusicControllerToast(wasPlaying ? "Restart track" : "Play track"));
 
                     return true;
             }


### PR DESCRIPTION
Fix #6335 

**Proof of concept:** https://streamable.com/u208i

**Description:** Matching up the behaviour with stable. When track is running it'll restart the current track, when track is paused it'll resume the current track. For now it showing "Restart Track" and "Play Track" (stable only showing "Play")