### PR TITLE
Fix key counters appearing negative on intense beatmaps

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Rulesets.UI
                         return;
                     }
 
-                    manualClock.CurrentTime = newTime.Value;
+                    newProposedTime = newTime.Value;
                 }
 
                 requireMoreUpdateLoops = manualClock.CurrentTime != parentGameplayClock.CurrentTime;

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -115,17 +115,16 @@ namespace osu.Game.Rulesets.UI
                 setClock(); // LoadComplete may not be run yet, but we still want the clock.
 
             validState = true;
+            requireMoreUpdateLoops = false;
 
             var newProposedTime = parentGameplayClock.CurrentTime;
 
             try
             {
                 if (!FrameStablePlayback)
-                {
-                    requireMoreUpdateLoops = false;
                     return;
-                }
-                else if (firstConsumption)
+
+                if (firstConsumption)
                 {
                     // On the first update, frame-stability seeking would result in unexpected/unwanted behaviour.
                     // Instead we perform an initial seek to the proposed time.
@@ -159,8 +158,6 @@ namespace osu.Game.Rulesets.UI
 
                     newProposedTime = newTime.Value;
                 }
-
-                requireMoreUpdateLoops = manualClock.CurrentTime != parentGameplayClock.CurrentTime;
             }
             finally
             {
@@ -170,6 +167,8 @@ namespace osu.Game.Rulesets.UI
                 manualClock.CurrentTime = newProposedTime;
                 manualClock.Rate = Math.Abs(parentGameplayClock.Rate) * direction;
                 manualClock.IsRunning = parentGameplayClock.IsRunning;
+
+                requireMoreUpdateLoops |= manualClock.CurrentTime != parentGameplayClock.CurrentTime;
 
                 // The manual clock time has changed in the above code. The framed clock now needs to be updated
                 // to ensure that the its time is valid for our children before input is processed

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -137,9 +137,9 @@ namespace osu.Game.Rulesets.UI
             {
             }
 
-            public bool OnPressed(T action) => Target.Children.OfType<KeyCounterAction<T>>().Any(c => c.OnPressed(action, Clock.ElapsedFrameTime > 0));
+            public bool OnPressed(T action) => Target.Children.OfType<KeyCounterAction<T>>().Any(c => c.OnPressed(action, Clock.Rate >= 0));
 
-            public bool OnReleased(T action) => Target.Children.OfType<KeyCounterAction<T>>().Any(c => c.OnReleased(action, Clock.ElapsedFrameTime > 0));
+            public bool OnReleased(T action) => Target.Children.OfType<KeyCounterAction<T>>().Any(c => c.OnReleased(action, Clock.Rate >= 0));
         }
 
         #endregion


### PR DESCRIPTION
When `FrameStabilityContainer` decides it needs multiple updates on the same frame, it ends up with an elapsed time of zero. This was interacting badly with the condition used in `RulesetInputManager` to govern playback direction.

I have changed this to use `Rate` as exposed by the frame stable clock.

- Closes #6198.