### PR TITLE
Fix random failures on BeatmapCarousel filter test

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -239,6 +239,18 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("Selection is non-null", () => currentSelection != null);
 
             setSelected(1, 3);
+        }
+
+        [Test]
+        public void TestFilterRange()
+        {
+            loadBeatmaps();
+
+            // buffer the selection
+            setSelected(3, 2);
+
+            setSelected(1, 3);
+
             AddStep("Apply a range filter", () => carousel.Filter(new FilterCriteria
             {
                 SearchText = "#3",
@@ -249,9 +261,9 @@ namespace osu.Game.Tests.Visual.SongSelect
                     IsLowerInclusive = true
                 }
             }, false));
-            waitForSelection(3, 2);
 
-            AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
+            // should reselect the buffered selection.
+            waitForSelection(3, 2);
         }
 
         /// <summary>


### PR DESCRIPTION
The "un-filter" step causes a `SelectNextRandom` invocation. If this happens to select a difficulty in set 3 other than the previously buffered difficulty #2, the subsequent test would fail.

I've split this test out to remove the random element, but added a new assert to ensure buffered (previously visited?) difficulty is re-selected on return to the same set.