### PR TITLE
Move placement blueprint movement logic to a higher level

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Graphics;
-using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Mania.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Mania.Objects;
 using osuTK;
@@ -49,13 +48,13 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
         private double originalStartTime;
 
-        protected override bool OnMouseMove(MouseMoveEvent e)
+        public override void UpdatePosition(Vector2 screenSpacePosition)
         {
-            base.OnMouseMove(e);
+            base.UpdatePosition(screenSpacePosition);
 
             if (PlacementBegun)
             {
-                var endTime = TimeAt(e.ScreenSpaceMousePosition);
+                var endTime = TimeAt(screenSpacePosition);
 
                 HitObject.StartTime = endTime < originalStartTime ? endTime : originalStartTime;
                 HitObject.Duration = Math.Abs(endTime - originalStartTime);
@@ -65,10 +64,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
                 headPiece.Width = tailPiece.Width = SnappedWidth;
                 headPiece.X = tailPiece.X = SnappedMousePosition.X;
 
-                originalStartTime = HitObject.StartTime = TimeAt(e.ScreenSpaceMousePosition);
+                originalStartTime = HitObject.StartTime = TimeAt(screenSpacePosition);
             }
-
-            return true;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -62,19 +62,18 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
             return base.OnMouseUp(e);
         }
 
-        protected override bool OnMouseMove(MouseMoveEvent e)
+        public override void UpdatePosition(Vector2 screenSpacePosition)
         {
             if (!PlacementBegun)
-                Column = ColumnAt(e.ScreenSpaceMousePosition);
+                Column = ColumnAt(screenSpacePosition);
 
-            if (Column == null) return false;
+            if (Column == null) return;
 
             SnappedWidth = Column.DrawWidth;
 
             // Snap to the column
             var parentPos = Parent.ToLocalSpace(Column.ToScreenSpace(new Vector2(Column.DrawWidth / 2, 0)));
-            SnappedMousePosition = new Vector2(parentPos.X, e.MousePosition.Y);
-            return true;
+            SnappedMousePosition = new Vector2(parentPos.X, Parent.ToLocalSpace(screenSpacePosition).Y);
         }
 
         protected double TimeAt(Vector2 screenSpacePosition)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -19,14 +19,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
             InternalChild = new HitCirclePiece(HitObject);
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame
-            HitObject.Position = Parent?.ToLocalSpace(GetContainingInputManager().CurrentState.Mouse.Position) ?? Vector2.Zero;
-        }
-
         protected override bool OnClick(ClickEvent e)
         {
             HitObject.StartTime = EditorClock.CurrentTime;
@@ -34,10 +26,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
             return true;
         }
 
-        protected override bool OnMouseMove(MouseMoveEvent e)
+        public override void UpdatePosition(Vector2 screenSpacePosition)
         {
-            HitObject.Position = e.MousePosition;
-            return true;
+            HitObject.Position = ToLocalSpace(screenSpacePosition);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -47,28 +47,18 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             setState(PlacementState.Initial);
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame
-            HitObject.Position = Parent?.ToLocalSpace(GetContainingInputManager().CurrentState.Mouse.Position) ?? Vector2.Zero;
-        }
-
-        protected override bool OnMouseMove(MouseMoveEvent e)
+        public override void UpdatePosition(Vector2 screenSpacePosition)
         {
             switch (state)
             {
                 case PlacementState.Initial:
-                    HitObject.Position = e.MousePosition;
-                    return true;
+                    HitObject.Position = ToLocalSpace(screenSpacePosition);
+                    break;
 
                 case PlacementState.Body:
-                    cursor = e.MousePosition - HitObject.Position;
-                    return true;
+                    cursor = ToLocalSpace(screenSpacePosition) - HitObject.Position;
+                    break;
             }
-
-            return false;
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
 {
@@ -42,6 +43,10 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
             }
 
             return true;
+        }
+
+        public override void UpdatePosition(Vector2 screenSpacePosition)
+        {
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -109,6 +109,12 @@ namespace osu.Game.Rulesets.Edit
         }
 
         /// <summary>
+        /// Updates the position of this <see cref="PlacementBlueprint"/> to a new screen-space position.
+        /// </summary>
+        /// <param name="screenSpacePosition">The screen-space position.</param>
+        public abstract void UpdatePosition(Vector2 screenSpacePosition);
+
+        /// <summary>
         /// Invokes <see cref="Objects.HitObject.ApplyDefaults(ControlPointInfo,BeatmapDifficulty)"/>,
         /// refreshing <see cref="Objects.HitObject.NestedHitObjects"/> and parameters for the <see cref="HitObject"/>.
         /// </summary>
@@ -125,7 +131,7 @@ namespace osu.Game.Rulesets.Edit
                 case ScrollEvent _:
                     return false;
 
-                case MouseEvent _:
+                case MouseButtonEvent _:
                     return true;
 
                 default:

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Game.Rulesets.Edit;
@@ -22,8 +23,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private Container<PlacementBlueprint> placementBlueprintContainer;
         private PlacementBlueprint currentPlacement;
-
         private SelectionHandler selectionHandler;
+        private InputManager inputManager;
 
         private IEnumerable<SelectionBlueprint> selections => selectionBlueprints.Children.Where(c => c.IsAlive);
 
@@ -66,6 +67,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             beatmap.HitObjectAdded += addBlueprintFor;
             beatmap.HitObjectRemoved += removeBlueprintFor;
+
+            inputManager = GetContainingInputManager();
         }
 
         private HitObjectCompositionTool currentTool;
@@ -136,6 +139,17 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return true;
         }
 
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            if (currentPlacement != null)
+            {
+                currentPlacement.UpdatePosition(e.ScreenSpaceMousePosition);
+                return true;
+            }
+
+            return base.OnMouseMove(e);
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -158,8 +172,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
             currentPlacement = null;
 
             var blueprint = CurrentTool?.CreatePlacementBlueprint();
+
             if (blueprint != null)
+            {
                 placementBlueprintContainer.Child = currentPlacement = blueprint;
+
+                // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame
+                blueprint.UpdatePosition(inputManager.CurrentState.Mouse.Position);
+            }
         }
 
         /// <summary>

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -4,6 +4,8 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
 using osu.Framework.Timing;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
@@ -18,16 +20,17 @@ namespace osu.Game.Tests.Visual
         protected Container HitObjectContainer;
         private PlacementBlueprint currentBlueprint;
 
+        private InputManager inputManager;
+
         protected PlacementBlueprintTestScene()
         {
-            Add(HitObjectContainer = CreateHitObjectContainer());
+            Add(HitObjectContainer = CreateHitObjectContainer().With(c => c.Clock = new FramedClock(new StopwatchClock())));
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
             Beatmap.Value.BeatmapInfo.BaseDifficulty.CircleSize = 2;
-            Add(currentBlueprint = CreateBlueprint());
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -36,6 +39,14 @@ namespace osu.Game.Tests.Visual
             dependencies.CacheAs<IAdjustableClock>(new StopwatchClock());
 
             return dependencies;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inputManager = GetContainingInputManager();
+            Add(currentBlueprint = CreateBlueprint());
         }
 
         public void BeginPlacement(HitObject hitObject)
@@ -54,9 +65,26 @@ namespace osu.Game.Tests.Visual
         {
         }
 
-        protected virtual Container CreateHitObjectContainer() => new Container { RelativeSizeAxes = Axes.Both };
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            currentBlueprint.UpdatePosition(e.ScreenSpaceMousePosition);
+            return true;
+        }
+
+        public override void Add(Drawable drawable)
+        {
+            base.Add(drawable);
+
+            if (drawable is PlacementBlueprint blueprint)
+            {
+                blueprint.Show();
+                blueprint.UpdatePosition(inputManager.CurrentState.Mouse.Position);
+            }
+        }
 
         protected virtual void AddHitObject(DrawableHitObject hitObject) => HitObjectContainer.Add(hitObject);
+
+        protected virtual Container CreateHitObjectContainer() => new Container { RelativeSizeAxes = Axes.Both };
 
         protected abstract DrawableHitObject CreateHitObject(HitObject hitObject);
         protected abstract PlacementBlueprint CreateBlueprint();


### PR DESCRIPTION
Moved to `BlueprintContainer`, which will eventually handle querying the snapped position / etc.

Everything now goes through the `PlacementBlueprint.UpdatePosition()` method. In the process I've also fixed the placement blueprint tests not working (mania one is broken but will be fixed in an upcoming PR).