### PR TITLE
Update lazer default combo colours to match stable

### DIFF
--- a/osu.Game/Skinning/DefaultSkinConfiguration.cs
+++ b/osu.Game/Skinning/DefaultSkinConfiguration.cs
@@ -14,10 +14,10 @@ namespace osu.Game.Skinning
         {
             ComboColours.AddRange(new[]
             {
-                new Color4(17, 136, 170, 255),
-                new Color4(102, 136, 0, 255),
-                new Color4(204, 102, 0, 255),
-                new Color4(121, 9, 13, 255)
+                new Color4(255, 192, 0, 255),
+                new Color4(0, 202, 0, 255),
+                new Color4(18, 124, 255, 255),
+                new Color4(242, 24, 57, 255),
             });
         }
     }


### PR DESCRIPTION
Previous lazer defaults were out-of-order and also too dark for most usage scenarios.

- Closes #6356.