### PR TITLE
Allow fallback decoder overwrite

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -591,5 +591,27 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.Throws<IOException>(() => Decoder.GetDecoder<Beatmap>(stream));
             }
         }
+
+        [Test]
+        public void TestAllowFallbackDecoderOverwrite()
+        {
+            Decoder<Beatmap> decoder = null;
+
+            using (var resStream = TestResources.OpenResource("corrupted-header.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
+                Assert.IsInstanceOf<LegacyBeatmapDecoder>(decoder);
+            }
+
+            Assert.DoesNotThrow(LegacyDifficultyCalculatorBeatmapDecoder.Register);
+
+            using (var resStream = TestResources.OpenResource("corrupted-header.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                Assert.DoesNotThrow(() => decoder = Decoder.GetDecoder<Beatmap>(stream));
+                Assert.IsInstanceOf<LegacyDifficultyCalculatorBeatmapDecoder>(decoder);
+            }
+        }
     }
 }

--- a/osu.Game/Beatmaps/Formats/Decoder.cs
+++ b/osu.Game/Beatmaps/Formats/Decoder.cs
@@ -93,14 +93,12 @@ namespace osu.Game.Beatmaps.Formats
         /// <summary>
         /// Registers a fallback decoder instantiation function.
         /// The fallback will be returned if the first non-empty line of the decoded stream does not match any known magic.
+        /// Calling this method will overwrite any existing global fallback registration for type <see cref="T"/> - use with caution.
         /// </summary>
         /// <typeparam name="T">Type of object being decoded.</typeparam>
         /// <param name="constructor">A function that constructs the fallback<see cref="Decoder"/>.</param>
         protected static void SetFallbackDecoder<T>(Func<Decoder> constructor)
         {
-            if (fallback_decoders.ContainsKey(typeof(T)))
-                throw new InvalidOperationException($"A fallback decoder was already added for type {typeof(T)}.");
-
             fallback_decoders[typeof(T)] = constructor;
         }
     }


### PR DESCRIPTION
Follow-up to #6117. Resolves crashes on start-up in the difficulty calculator.

# Summary

`LegacyDifficultyCalculatorBeatmapDecoder` was registered as a fallback decoder in commit ffde389 for future use in the server-side difficulty calculation components. Due to the pre-existing fallback registrations this caused a runtime crash when the diffcalc components were started.

Add a test reproducing this scenario to prevent the issue from resurfacing in the future and remove the check for pre-existing fallback registration along with the exception. The xmldoc for the registration function has been extended to make users aware of possible consequences of calling it.

Sorry for not catching this in time in the original PR, saw that change slightly too late.