### PR TITLE
Apply safe area insets for overlays

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -457,10 +457,17 @@ namespace osu.Game
                         logoContainer = new Container { RelativeSizeAxes = Axes.Both },
                     }
                 },
-                overlayContent = new Container { RelativeSizeAxes = Axes.Both },
-                rightFloatingOverlayContent = new Container { RelativeSizeAxes = Axes.Both },
-                leftFloatingOverlayContent = new Container { RelativeSizeAxes = Axes.Both },
-                topMostOverlayContent = new Container { RelativeSizeAxes = Axes.Both },
+                new SafeAreaContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        overlayContent = new Container { RelativeSizeAxes = Axes.Both },
+                        rightFloatingOverlayContent = new Container { RelativeSizeAxes = Axes.Both },
+                        leftFloatingOverlayContent = new Container { RelativeSizeAxes = Axes.Both },
+                        topMostOverlayContent = new Container { RelativeSizeAxes = Axes.Both },
+                    }
+                },
                 idleTracker
             });
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -106,6 +106,8 @@ namespace osu.Game
 
         private readonly List<OverlayContainer> visibleBlockingOverlays = new List<OverlayContainer>();
 
+        private SafeAreaContainer overlaySafeAreaContainer;
+
         public OsuGame(string[] args = null)
         {
             this.args = args;
@@ -457,7 +459,7 @@ namespace osu.Game
                         logoContainer = new Container { RelativeSizeAxes = Axes.Both },
                     }
                 },
-                new SafeAreaContainer
+                overlaySafeAreaContainer = new SafeAreaContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
@@ -830,7 +832,7 @@ namespace osu.Game
         {
             base.UpdateAfterChildren();
 
-            screenContainer.Padding = new MarginPadding { Top = ToolbarOffset };
+            screenContainer.Padding = new MarginPadding { Top = overlaySafeAreaContainer.Padding.Top + ToolbarOffset };
             overlayContent.Padding = new MarginPadding { Top = ToolbarOffset };
 
             MenuCursorContainer.CanShowCursor = (ScreenStack.CurrentScreen as IOsuScreen)?.CursorVisible ?? false;

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -37,11 +37,16 @@ namespace osu.Game.Overlays
 
             Children = new Drawable[]
             {
-                new Box
+                new SafeAreaContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Black,
-                    Alpha = 0.6f
+                    SafeAreaOverrideEdges = Edges.Right | Edges.Bottom,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.Black,
+                        Alpha = 0.6f
+                    },
                 },
                 new OsuScrollContainer
                 {

--- a/osu.Game/Overlays/Settings/Sidebar.cs
+++ b/osu.Game/Overlays/Settings/Sidebar.cs
@@ -31,10 +31,14 @@ namespace osu.Game.Overlays.Settings
             RelativeSizeAxes = Axes.Y;
             InternalChildren = new Drawable[]
             {
-                new Box
+                new SafeAreaContainer
                 {
-                    Colour = Color4.Black,
-                    RelativeSizeAxes = Axes.Both,
+                    SafeAreaOverrideEdges = Edges.Left,
+                    Child = new Box
+                    {
+                        Colour = Color4.Black,
+                        RelativeSizeAxes = Axes.Both,
+                    },
                 },
                 new SidebarScrollContainer
                 {

--- a/osu.Game/Overlays/Settings/Sidebar.cs
+++ b/osu.Game/Overlays/Settings/Sidebar.cs
@@ -33,7 +33,8 @@ namespace osu.Game.Overlays.Settings
             {
                 new SafeAreaContainer
                 {
-                    SafeAreaOverrideEdges = Edges.Left,
+                    RelativeSizeAxes = Axes.Both,
+                    SafeAreaOverrideEdges = Edges.Left | Edges.Bottom,
                     Child = new Box
                     {
                         Colour = Color4.Black,

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Overlays
 
         protected Box Background;
 
+        private SafeAreaContainer safeAreaContainer;
+
         protected SettingsPanel(bool showSidebar)
         {
             this.showSidebar = showSidebar;
@@ -60,46 +62,51 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = ContentContainer = new Container
+            InternalChild = safeAreaContainer = new SafeAreaContainer
             {
-                Width = WIDTH,
-                RelativeSizeAxes = Axes.Y,
-                Children = new Drawable[]
+                RelativeSizeAxes = Axes.Both,
+                SafeAreaOverrideEdges = Edges.Bottom,
+                Child = ContentContainer = new Container
                 {
-                    Background = new Box
+                    Width = WIDTH,
+                    RelativeSizeAxes = Axes.Y,
+                    Children = new Drawable[]
                     {
-                        Anchor = Anchor.TopRight,
-                        Origin = Anchor.TopRight,
-                        Scale = new Vector2(2, 1), // over-extend to the left for transitions
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.Black,
-                        Alpha = 0.6f,
-                    },
-                    SectionsContainer = new SettingsSectionsContainer
-                    {
-                        Masking = true,
-                        RelativeSizeAxes = Axes.Both,
-                        ExpandableHeader = CreateHeader(),
-                        FixedHeader = searchTextBox = new SearchTextBox
+                        Background = new Box
                         {
-                            RelativeSizeAxes = Axes.X,
-                            Origin = Anchor.TopCentre,
-                            Anchor = Anchor.TopCentre,
-                            Width = 0.95f,
-                            Margin = new MarginPadding
-                            {
-                                Top = 20,
-                                Bottom = 20
-                            },
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Scale = new Vector2(2, 1), // over-extend to the left for transitions
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Black,
+                            Alpha = 0.6f,
                         },
-                        Footer = CreateFooter()
-                    },
+                        SectionsContainer = new SettingsSectionsContainer
+                        {
+                            Masking = true,
+                            RelativeSizeAxes = Axes.Both,
+                            ExpandableHeader = CreateHeader(),
+                            FixedHeader = searchTextBox = new SearchTextBox
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Origin = Anchor.TopCentre,
+                                Anchor = Anchor.TopCentre,
+                                Width = 0.95f,
+                                Margin = new MarginPadding
+                                {
+                                    Top = 20,
+                                    Bottom = 20
+                                },
+                            },
+                            Footer = CreateFooter()
+                        },
+                    }
                 }
             };
 
             if (showSidebar)
             {
-                AddInternal(Sidebar = new Sidebar { Width = sidebar_width });
+                safeAreaContainer.Add(Sidebar = new Sidebar { Width = sidebar_width });
 
                 SectionsContainer.SelectedSection.ValueChanged += section =>
                 {

--- a/osu.Game/Overlays/SettingsSubPanel.cs
+++ b/osu.Game/Overlays/SettingsSubPanel.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -26,11 +27,15 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(new BackButton
+            AddInternal(new SafeAreaContainer
             {
-                Anchor = Anchor.BottomLeft,
-                Origin = Anchor.BottomLeft,
-                Action = Hide
+                RelativeSizeAxes = Axes.Both,
+                Child = new BackButton
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Action = Hide
+                }
             });
         }
 

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -34,6 +34,7 @@ namespace osu.Game.Overlays.Toolbar
         private const float alpha_normal = 0.6f;
 
         private readonly Bindable<OverlayActivation> overlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
+        private ToolbarBackground background;
 
         public Toolbar()
         {
@@ -46,7 +47,7 @@ namespace osu.Game.Overlays.Toolbar
         {
             Children = new Drawable[]
             {
-                new ToolbarBackground(),
+                background = new ToolbarBackground(),
                 new FillFlowContainer
                 {
                     Direction = FillDirection.Horizontal,
@@ -99,13 +100,14 @@ namespace osu.Game.Overlays.Toolbar
                 overlayActivationMode.BindTo(osuGame.OverlayActivationMode);
         }
 
-        public class ToolbarBackground : Container
+        public class ToolbarBackground : SafeAreaContainer
         {
             private readonly Box solidBackground;
             private readonly Box gradientBackground;
 
             public ToolbarBackground()
             {
+                SafeAreaOverrideEdges = Edges.Left | Edges.Top | Edges.Right;
                 RelativeSizeAxes = Axes.Both;
                 Children = new Drawable[]
                 {
@@ -151,7 +153,7 @@ namespace osu.Game.Overlays.Toolbar
         {
             userButton?.StateContainer.Hide();
 
-            this.MoveToY(-DrawSize.Y, transition_time, Easing.OutQuint);
+            this.MoveToY(background.Padding.Top - DrawSize.Y, transition_time, Easing.OutQuint);
             this.FadeOut(transition_time);
         }
     }

--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -43,11 +43,16 @@ namespace osu.Game.Overlays
 
             AddRange(new Drawable[]
             {
-                new Box
+                new SafeAreaContainer
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    Width = 300,
-                    Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.75f), Color4.Black.Opacity(0))
+                    RelativeSizeAxes = Axes.Both,
+                    SafeAreaOverrideEdges = Edges.All,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Y,
+                        Width = 300,
+                        Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.75f), Color4.Black.Opacity(0))
+                    },
                 },
                 new FillFlowContainer
                 {

--- a/osu.Game/Screens/OsuScreenStack.cs
+++ b/osu.Game/Screens/OsuScreenStack.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
 
@@ -30,10 +31,15 @@ namespace osu.Game.Screens
 
         private void initializeStack()
         {
-            InternalChild = parallaxContainer = new ParallaxContainer
+            InternalChild = new SafeAreaContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = backgroundScreenStack = new BackgroundScreenStack { RelativeSizeAxes = Axes.Both },
+                SafeAreaOverrideEdges = Edges.All,
+                Child = parallaxContainer = new ParallaxContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = backgroundScreenStack = new BackgroundScreenStack { RelativeSizeAxes = Axes.Both },
+                }
             };
 
             ScreenPushed += onScreenChange;


### PR DESCRIPTION
Applies the minimum required to implement safe area insets for overlays.

* The top level overlay containers are wrapped in a `SafeAreaContainer`.
* Some individual overlays have been tweaked to ensure that backgrounds run off the edge of the screen, etc.
* The screen stack takes into account the safe area when pushing it below the toolbar.

This is currently "opt-in", as individual screens will need to wrap their contents in a `SafeAreaContainer` on a per-case basis.  I thought this was a better solution than applying a blanket padding to the screen stack and risking regressions.

Supersedes #4856 
