### PR TITLE
Update game code inline with TestSuite introduction

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimContainer.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimContainer.cs
@@ -35,7 +35,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Background
 {
-    [TestFixture]
     public class TestSceneUserDimContainer : ManualInputManagerTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -11,7 +11,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Components
 {
-    [TestFixture]
     public class TestSceneIdleTracker : ManualInputManagerTestScene
     {
         private IdleTrackingBox box1;

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorCompose.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorCompose.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit.Compose;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneEditorCompose : EditorClockTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(ComposeScreen) };

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeRadioButtons.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeRadioButtons.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Edit.Components.RadioButtons;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneEditorComposeRadioButtons : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(DrawableRadioButton) };

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -19,7 +18,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneEditorComposeTimeline : EditorClockTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorMenuBar.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -12,7 +11,6 @@ using osu.Game.Screens.Edit.Components.Menus;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneEditorMenuBar : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(EditorMenuBar), typeof(ScreenSelectionTabControl) };

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorSeekSnapping.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorSeekSnapping.cs
@@ -15,7 +15,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneEditorSeekSnapping : EditorClockTestScene
     {
         public TestSceneEditorSeekSnapping()

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorSummaryTimeline.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorSummaryTimeline.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Osu;
@@ -12,7 +11,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneEditorSummaryTimeline : EditorClockTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(SummaryTimeline) };

--- a/osu.Game.Tests/Visual/Editor/TestSceneHitObjectComposer.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneHitObjectComposer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
@@ -21,7 +20,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneHitObjectComposer : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Editor/TestScenePlaybackControl.cs
+++ b/osu.Game.Tests/Visual/Editor/TestScenePlaybackControl.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
@@ -11,7 +10,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestScenePlaybackControl : OsuTestScene
     {
         [BackgroundDependencyLoader]

--- a/osu.Game.Tests/Visual/Editor/TestSceneWaveContainer.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneWaveContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -14,7 +13,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneWaveContainer : OsuTestScene
     {
         [BackgroundDependencyLoader]

--- a/osu.Game.Tests/Visual/Editor/TestSceneWaveform.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneWaveform.cs
@@ -16,7 +16,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Editor
 {
-    [TestFixture]
     public class TestSceneWaveform : OsuTestScene
     {
         private WorkingBeatmap waveformBeatmap;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakOverlay.cs
@@ -11,7 +11,6 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneBreakOverlay : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.MathUtils;
 using osu.Game.Screens.Play;
@@ -12,7 +11,6 @@ using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneKeyCounter : ManualInputManagerTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneMedalOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneMedalOverlay.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Game.Overlays;
 using osu.Game.Overlays.MedalSplash;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneMedalOverlay : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Online;
 using osu.Game.Online.API.Requests.Responses;
@@ -15,7 +14,6 @@ using System.Collections.Generic;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneReplayDownloadButton : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplaySettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplaySettingsOverlay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Play.HUD;
@@ -9,7 +8,6 @@ using osu.Game.Screens.Play.PlayerSettings;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneReplaySettingsOverlay : OsuTestScene
     {
         public TestSceneReplaySettingsOverlay()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneResults.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneResults.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
@@ -15,7 +14,6 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneResults : ScreenTestScene
     {
         private BeatmapManager beatmaps;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoreCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoreCounter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.MathUtils;
@@ -12,7 +11,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneScoreCounter : OsuTestScene
     {
         public TestSceneScoreCounter()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
@@ -20,7 +19,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneScrollingHitObjects : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(Playfield) };

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -12,7 +12,6 @@ using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneSkipOverlay : ManualInputManagerTestScene
     {
         private SkipOverlay skip;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.MathUtils;
@@ -12,7 +11,6 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneSongProgress : OsuTestScene
     {
         private readonly SongProgress progress;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -15,7 +14,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    [TestFixture]
     public class TestSceneStoryboard : OsuTestScene
     {
         private readonly Container<DrawableStoryboard> storyboardContainer;

--- a/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
+++ b/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -15,7 +14,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Menus
 {
-    [TestFixture]
     public abstract class IntroTestScene : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroCircles.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroCircles.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Screens;
 using osu.Game.Screens.Menu;
 
 namespace osu.Game.Tests.Visual.Menus
 {
-    [TestFixture]
     public class TestSceneIntroCircles : IntroTestScene
     {
         protected override IScreen CreateScreen() => new IntroCircles();

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroTriangles.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroTriangles.cs
@@ -1,13 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Screens;
 using osu.Game.Screens.Menu;
 
 namespace osu.Game.Tests.Visual.Menus
 {
-    [TestFixture]
     public class TestSceneIntroTriangles : IntroTestScene
     {
         protected override IScreen CreateScreen() => new IntroTriangles();

--- a/osu.Game.Tests/Visual/Menus/TestSceneLoaderAnimation.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneLoaderAnimation.cs
@@ -13,7 +13,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Menus
 {
-    [TestFixture]
     public class TestSceneLoaderAnimation : ScreenTestScene
     {
         private TestLoader loader;

--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays.Toolbar;
 
 namespace osu.Game.Tests.Visual.Menus
 {
-    [TestFixture]
     public class TestSceneToolbar : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchInfo.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
@@ -13,7 +12,6 @@ using osu.Game.Screens.Multi.Match.Components;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    [TestFixture]
     public class TestSceneMatchInfo : MultiplayerTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchParticipants.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchParticipants.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Multi.Match.Components;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    [TestFixture]
     public class TestSceneMatchParticipants : MultiplayerTestScene
     {
         public TestSceneMatchParticipants()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiHeader.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiHeader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Game.Screens;
@@ -9,7 +8,6 @@ using osu.Game.Screens.Multi;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    [TestFixture]
     public class TestSceneMultiHeader : OsuTestScene
     {
         public TestSceneMultiHeader()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Game.Screens.Multi.Lounge;
 using osu.Game.Screens.Multi.Lounge.Components;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    [TestFixture]
     public class TestSceneMultiScreen : ScreenTestScene
     {
         protected override bool UseOnlineAPI => true;

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapAvailability.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapAvailability.cs
@@ -7,7 +7,6 @@ using osu.Game.Overlays.BeatmapSet;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneBeatmapAvailability : OsuTestScene
     {
         private readonly BeatmapAvailability container;

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -16,7 +16,6 @@ using System.Linq;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneBeatmapSetOverlay : OsuTestScene
     {
         private readonly TestBeatmapSetOverlay overlay;

--- a/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Changelog;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneChangelogOverlay : OsuTestScene
     {
         private ChangelogOverlay changelog;

--- a/osu.Game.Tests/Visual/Online/TestSceneChatLineTruncation.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLineTruncation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,7 +13,6 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneChatLineTruncation : OsuTestScene
     {
         private readonly TestChatLineContainer textContainer;

--- a/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -20,7 +19,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneChatLink : OsuTestScene
     {
         private readonly TestChatLineContainer textContainer;

--- a/osu.Game.Tests/Visual/Online/TestSceneDirectOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectOverlay.cs
@@ -2,13 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneDirectOverlay : OsuTestScene
     {
         private DirectOverlay direct;

--- a/osu.Game.Tests/Visual/Online/TestSceneFullscreenOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFullscreenOverlay.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Overlays;
@@ -9,7 +8,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneFullscreenOverlay : OsuTestScene
     {
         private FullscreenOverlay overlay;

--- a/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
@@ -2,14 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneGraph : OsuTestScene
     {
         public TestSceneGraph()

--- a/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
@@ -14,7 +13,6 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneHistoricalSection : OsuTestScene
     {
         protected override bool UseOnlineAPI => true;

--- a/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -15,7 +14,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneRankGraph : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Online/TestSceneSocialOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneSocialOverlay.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Social;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneSocialOverlay : OsuTestScene
     {
         protected override bool UseOnlineAPI => true;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -10,7 +10,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneUserPanel : OsuTestScene
     {
         private readonly UserPanel peppy;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -16,7 +15,6 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneUserProfileOverlay : OsuTestScene
     {
         protected override bool UseOnlineAPI => true;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfilePreviousUsernames.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfilePreviousUsernames.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -14,7 +13,6 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneUserProfilePreviousUsernames : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileRecentSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileRecentSection.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -17,7 +16,6 @@ using osu.Game.Overlays.Profile.Sections.Recent;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneUserProfileRecentSection : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/Online/TestSceneUserRanks.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserRanks.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -15,7 +14,6 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneUserRanks : OsuTestScene
     {
         protected override bool UseOnlineAPI => true;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserRequest.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
@@ -17,7 +16,6 @@ using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    [TestFixture]
     public class TestSceneUserRequest : OsuTestScene
     {
         [Resolved]

--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Game.Overlays;
 using osu.Game.Overlays.KeyBinding;
 
 namespace osu.Game.Tests.Visual.Settings
 {
-    [TestFixture]
     public class TestSceneKeyBindingPanel : OsuTestScene
     {
         private readonly KeyBindingPanel panel;

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsPanel.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
@@ -11,7 +10,6 @@ using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Tests.Visual.Settings
 {
-    [TestFixture]
     public class TestSceneSettingsPanel : OsuTestScene
     {
         private readonly SettingsPanel settings;

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -19,7 +19,6 @@ using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
-    [TestFixture]
     public class TestSceneBeatmapCarousel : OsuTestScene
     {
         private TestBeatmapCarousel carousel;

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetailArea.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetailArea.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
@@ -14,7 +13,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
-    [TestFixture]
     [System.ComponentModel.Description("PlaySongSelect leaderboard/details area")]
     public class TestSceneBeatmapDetailArea : OsuTestScene
     {

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -21,7 +21,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
-    [TestFixture]
     public class TestSceneBeatmapInfoWedge : OsuTestScene
     {
         private RulesetStore rulesets;

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -27,7 +27,6 @@ using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
-    [TestFixture]
     public class TestScenePlaySongSelect : ScreenTestScene
     {
         private BeatmapManager manager;

--- a/osu.Game.Tests/Visual/TestSceneOsuGame.cs
+++ b/osu.Game.Tests/Visual/TestSceneOsuGame.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -31,7 +30,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual
 {
-    [TestFixture]
     public class TestSceneOsuGame : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/TestSceneOsuScreenStack.cs
+++ b/osu.Game.Tests/Visual/TestSceneOsuScreenStack.cs
@@ -13,7 +13,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual
 {
-    [TestFixture]
     public class TestSceneOsuScreenStack : OsuTestScene
     {
         private TestOsuScreenStack stack;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
@@ -21,7 +20,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneBeatSyncedContainer : OsuTestScene
     {
         private readonly NowPlayingOverlay np;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbs.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBreadcrumbs.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
@@ -9,7 +8,6 @@ using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneBreadcrumbs : OsuTestScene
     {
         private readonly BreadcrumbControl<BreadcrumbTab> breadcrumbs;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneButtonSystem.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneButtonSystem.cs
@@ -14,7 +14,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneButtonSystem : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -14,7 +13,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneContextMenu : OsuTestScene
     {
         private const int start_time = 0;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneCursors.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneCursors.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -16,7 +15,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneCursors : ManualInputManagerTestScene
     {
         private readonly MenuCursorContainer menuCursorContainer;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDialogOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDialogOverlay.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneDialogOverlay : OsuTestScene
     {
         public TestSceneDialogOverlay()

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneIconButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneIconButton.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -13,7 +12,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneIconButton : OsuTestScene
     {
         public TestSceneIconButton()

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledTextBox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledTextBox.cs
@@ -12,7 +12,6 @@ using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneLabelledTextBox : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -15,7 +15,6 @@ using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneNotificationOverlay : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNowPlayingOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNowPlayingOverlay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
@@ -9,7 +8,6 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneNowPlayingOverlay : OsuTestScene
     {
         [Cached]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNumberBox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNumberBox.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -11,7 +10,6 @@ using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneNumberBox : OsuTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
@@ -11,7 +10,6 @@ using osu.Game.Overlays.OSD;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneOnScreenDisplay : OsuTestScene
     {
         [BackgroundDependencyLoader]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
@@ -11,7 +11,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneOsuHoverContainer : ManualInputManagerTestScene
     {
         private OsuHoverTestContainer hoverContainer;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuIcon.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Reflection;
-using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -16,7 +15,6 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneOsuIcon : OsuTestScene
     {
         public TestSceneOsuIcon()

--- a/osu.Game.Tests/Visual/UserInterface/TestScenePopupDialog.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestScenePopupDialog.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays.Dialog;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestScenePopupDialog : OsuTestScene
     {
         public TestScenePopupDialog()

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneScreenBreadcrumbControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneScreenBreadcrumbControl.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -15,7 +14,6 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [TestFixture]
     public class TestSceneScreenBreadcrumbControl : OsuTestScene
     {
         private readonly ScreenBreadcrumbControl breadcrumbs;

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -8,21 +8,21 @@ namespace osu.Game.Tournament.Tests
 {
     public abstract class TournamentTestScene : OsuTestScene
     {
-        protected override ITestSceneTestRunner CreateRunner() => new TournamentTestSceneTestRunner();
+        protected override ITestSuiteTestRunner CreateRunner() => new TournamentTestSceneTestRunner();
 
-        public class TournamentTestSceneTestRunner : TournamentGameBase, ITestSceneTestRunner
+        public class TournamentTestSceneTestRunner : TournamentGameBase, ITestSuiteTestRunner
         {
-            private TestSceneTestRunner.TestRunner runner;
+            private TestSuiteTestRunner.TestRunner runner;
 
             protected override void LoadAsyncComplete()
             {
                 // this has to be run here rather than LoadComplete because
                 // TestScene.cs is checking the IsLoaded state (on another thread) and expects
                 // the runner to be loaded at that point.
-                Add(runner = new TestSceneTestRunner.TestRunner());
+                Add(runner = new TestSuiteTestRunner.TestRunner());
             }
 
-            public void RunTestBlocking(TestScene test) => runner.RunTestBlocking(test);
+            public void RunTestBlocking(TestSuite test) => runner.RunTestBlocking(test);
         }
     }
 }

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -24,7 +24,11 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual
 {
-    public abstract class OsuTestScene : TestScene
+    public abstract class OsuTestScene : OsuTestScene<EmptyTestScene>
+    {
+    }
+
+    public abstract class OsuTestScene<T> : TestSuite<T> where T : TestScene, new()
     {
         [Cached(typeof(Bindable<WorkingBeatmap>))]
         [Cached(typeof(IBindable<WorkingBeatmap>))]
@@ -146,7 +150,7 @@ namespace osu.Game.Tests.Visual
             }
         }
 
-        protected override ITestSceneTestRunner CreateRunner() => new OsuTestSceneTestRunner();
+        protected override ITestSuiteTestRunner CreateRunner() => new OsuTestSceneTestRunner();
 
         public class ClockBackedTestWorkingBeatmap : TestWorkingBeatmap
         {
@@ -210,7 +214,7 @@ namespace osu.Game.Tests.Visual
 
                 public IEnumerable<string> GetAvailableResources() => throw new NotImplementedException();
 
-                public Track GetVirtual(double length = Double.PositiveInfinity)
+                public Track GetVirtual(double length = double.PositiveInfinity)
                 {
                     var track = new TrackVirtualManual(referenceClock) { Length = length };
                     AddItem(track);
@@ -306,19 +310,19 @@ namespace osu.Game.Tests.Visual
             }
         }
 
-        public class OsuTestSceneTestRunner : OsuGameBase, ITestSceneTestRunner
+        public class OsuTestSceneTestRunner : OsuGameBase, ITestSuiteTestRunner
         {
-            private TestSceneTestRunner.TestRunner runner;
+            private TestSuiteTestRunner.TestRunner runner;
 
             protected override void LoadAsyncComplete()
             {
                 // this has to be run here rather than LoadComplete because
                 // TestScene.cs is checking the IsLoaded state (on another thread) and expects
                 // the runner to be loaded at that point.
-                Add(runner = new TestSceneTestRunner.TestRunner());
+                Add(runner = new TestSuiteTestRunner.TestRunner());
             }
 
-            public void RunTestBlocking(TestScene test) => runner.RunTestBlocking(test);
+            public void RunTestBlocking(TestSuite test) => runner.RunTestBlocking(test);
         }
     }
 }


### PR DESCRIPTION
Update game code to make things work after [this](https://github.com/ppy/osu-framework/pull/2872) framework change.
This PR was made in order to demonstrate impact on framework consumers.
Note that game test code still violates SRP and needs refactoring. But it can be done later.