### PR TITLE
Add abstract implementation for editor screens which display a timeline

### DIFF
--- a/osu.Game.Tests/Visual/Editor/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneComposeScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Osu;
@@ -11,10 +9,8 @@ using osu.Game.Screens.Edit.Compose;
 namespace osu.Game.Tests.Visual.Editor
 {
     [TestFixture]
-    public class TestSceneEditorCompose : EditorClockTestScene
+    public class TestSceneComposeScreen : EditorClockTestScene
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(ComposeScreen) };
-
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -1,112 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
-using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Framework.Logging;
-using osu.Game.Screens.Edit.Compose.Components;
-using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Skinning;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose
 {
-    public class ComposeScreen : EditorScreen
+    public class ComposeScreen : EditorScreenWithTimeline
     {
-        private const float vertical_margins = 10;
-        private const float horizontal_margins = 20;
-
-        private readonly BindableBeatDivisor beatDivisor = new BindableBeatDivisor();
-
-        [BackgroundDependencyLoader(true)]
-        private void load([CanBeNull] BindableBeatDivisor beatDivisor)
+        protected override Drawable CreateMainContent()
         {
-            if (beatDivisor != null)
-                this.beatDivisor.BindTo(beatDivisor);
-
-            Container composerContainer;
-
-            Children = new Drawable[]
-            {
-                new GridContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Content = new[]
-                    {
-                        new Drawable[]
-                        {
-                            new Container
-                            {
-                                Name = "Timeline",
-                                RelativeSizeAxes = Axes.Both,
-                                Children = new Drawable[]
-                                {
-                                    new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.Black.Opacity(0.5f)
-                                    },
-                                    new Container
-                                    {
-                                        Name = "Timeline content",
-                                        RelativeSizeAxes = Axes.Both,
-                                        Padding = new MarginPadding { Horizontal = horizontal_margins, Vertical = vertical_margins },
-                                        Child = new GridContainer
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Content = new[]
-                                            {
-                                                new Drawable[]
-                                                {
-                                                    new Container
-                                                    {
-                                                        RelativeSizeAxes = Axes.Both,
-                                                        Padding = new MarginPadding { Right = 5 },
-                                                        Child = new TimelineArea { RelativeSizeAxes = Axes.Both }
-                                                    },
-                                                    new BeatDivisorControl(beatDivisor) { RelativeSizeAxes = Axes.Both }
-                                                },
-                                            },
-                                            ColumnDimensions = new[]
-                                            {
-                                                new Dimension(),
-                                                new Dimension(GridSizeMode.Absolute, 90),
-                                            }
-                                        },
-                                    }
-                                }
-                            }
-                        },
-                        new Drawable[]
-                        {
-                            composerContainer = new Container
-                            {
-                                Name = "Composer content",
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding { Horizontal = horizontal_margins, Vertical = vertical_margins },
-                            }
-                        }
-                    },
-                    RowDimensions = new[] { new Dimension(GridSizeMode.Absolute, 110) }
-                },
-            };
-
             var ruleset = Beatmap.Value.BeatmapInfo.Ruleset?.CreateInstance();
 
-            if (ruleset == null)
-            {
-                Logger.Log("Beatmap doesn't have a ruleset assigned.");
-                // ExitRequested?.Invoke();
-                return;
-            }
-
-            var composer = ruleset.CreateHitObjectComposer();
-
-            Drawable content;
+            var composer = ruleset?.CreateHitObjectComposer();
 
             if (composer != null)
             {
@@ -118,18 +25,10 @@ namespace osu.Game.Screens.Edit.Compose
 
                 // load the skinning hierarchy first.
                 // this is intentionally done in two stages to ensure things are in a loaded state before exposing the ruleset to skin sources.
-                content = beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(ruleset.CreateHitObjectComposer()));
-            }
-            else
-            {
-                content = new ScreenWhiteBox.UnderConstructionMessage($"{ruleset.Description}'s composer");
+                return beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(ruleset.CreateHitObjectComposer()));
             }
 
-            LoadComponentAsync(content, _ =>
-            {
-                composerContainer.Add(content);
-                content.FadeInFromZero(300, Easing.OutQuint);
-            });
+            return new ScreenWhiteBox.UnderConstructionMessage($"{ruleset.Description}'s composer");
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Edit.Compose
                 return beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(ruleset.CreateHitObjectComposer()));
             }
 
-            return new ScreenWhiteBox.UnderConstructionMessage($"{ruleset.Description}'s composer");
+            return new ScreenWhiteBox.UnderConstructionMessage(ruleset == null ? "This beatmap" : $"{ruleset.Description}'s composer");
         }
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -19,13 +19,13 @@ using osu.Framework.Timing;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Edit.Components.Menus;
-using osu.Game.Screens.Edit.Compose;
 using osu.Game.Screens.Edit.Design;
 using osuTK.Input;
 using System.Collections.Generic;
 using osu.Framework;
 using osu.Framework.Input.Bindings;
 using osu.Game.Input.Bindings;
+using osu.Game.Screens.Edit.Compose;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Edit.Timing;
 using osu.Game.Users;
@@ -274,10 +274,6 @@ namespace osu.Game.Screens.Edit
 
                 case EditorScreenMode.Timing:
                     currentScreen = new TimingScreen();
-                    break;
-
-                default:
-                    currentScreen = new EditorScreen();
                     break;
             }
 

--- a/osu.Game/Screens/Edit/EditorScreen.cs
+++ b/osu.Game/Screens/Edit/EditorScreen.cs
@@ -10,28 +10,23 @@ using osu.Game.Beatmaps;
 namespace osu.Game.Screens.Edit
 {
     /// <summary>
-    /// TODO: eventually make this inherit Screen and add a local scren stack inside the Editor.
+    /// TODO: eventually make this inherit Screen and add a local screen stack inside the Editor.
     /// </summary>
-    public class EditorScreen : Container
+    public abstract class EditorScreen : Container
     {
-        protected readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
+        [Resolved]
+        protected IBindable<WorkingBeatmap> Beatmap { get; private set; }
 
         protected override Container<Drawable> Content => content;
         private readonly Container content;
 
-        public EditorScreen()
+        protected EditorScreen()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;
 
             InternalChild = content = new Container { RelativeSizeAxes = Axes.Both };
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap)
-        {
-            Beatmap.BindTo(beatmap);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -1,0 +1,107 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Screens.Edit.Compose.Components;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Edit
+{
+    public abstract class EditorScreenWithTimeline : EditorScreen
+    {
+        private const float vertical_margins = 10;
+        private const float horizontal_margins = 20;
+
+        private readonly BindableBeatDivisor beatDivisor = new BindableBeatDivisor();
+
+        [BackgroundDependencyLoader(true)]
+        private void load([CanBeNull] BindableBeatDivisor beatDivisor)
+        {
+            if (beatDivisor != null)
+                this.beatDivisor.BindTo(beatDivisor);
+
+            Container mainContent;
+
+            Children = new Drawable[]
+            {
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new Container
+                            {
+                                Name = "Timeline",
+                                RelativeSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = Color4.Black.Opacity(0.5f)
+                                    },
+                                    new Container
+                                    {
+                                        Name = "Timeline content",
+                                        RelativeSizeAxes = Axes.Both,
+                                        Padding = new MarginPadding { Horizontal = horizontal_margins, Vertical = vertical_margins },
+                                        Child = new GridContainer
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Content = new[]
+                                            {
+                                                new Drawable[]
+                                                {
+                                                    new Container
+                                                    {
+                                                        RelativeSizeAxes = Axes.Both,
+                                                        Padding = new MarginPadding { Right = 5 },
+                                                        Child = CreateTimeline()
+                                                    },
+                                                    new BeatDivisorControl(beatDivisor) { RelativeSizeAxes = Axes.Both }
+                                                },
+                                            },
+                                            ColumnDimensions = new[]
+                                            {
+                                                new Dimension(),
+                                                new Dimension(GridSizeMode.Absolute, 90),
+                                            }
+                                        },
+                                    }
+                                }
+                            }
+                        },
+                        new Drawable[]
+                        {
+                            mainContent = new Container
+                            {
+                                Name = "Main content",
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding { Horizontal = horizontal_margins, Vertical = vertical_margins },
+                            }
+                        }
+                    },
+                    RowDimensions = new[] { new Dimension(GridSizeMode.Absolute, 110) }
+                },
+            };
+
+            LoadComponentAsync(CreateMainContent(), content =>
+            {
+                mainContent.Add(content);
+                content.FadeInFromZero(300, Easing.OutQuint);
+            });
+        }
+
+        protected abstract Drawable CreateMainContent();
+
+        protected virtual Drawable CreateTimeline() => new TimelineArea { RelativeSizeAxes = Axes.Both };
+    }
+}


### PR DESCRIPTION
To be used by compose/design/timing screens. Transition isn't perfect, but will do for now. Note that going forward each of these screens are going to require slightly different implementations of the timeline display, which is why I opted to do it this way (rather than moving the timeline to a higher level).