### PR TITLE
Make OverlayContainers with no blocking input VisibilityContainers

### DIFF
--- a/osu.Desktop/Overlays/VersionManager.cs
+++ b/osu.Desktop/Overlays/VersionManager.cs
@@ -15,7 +15,7 @@ using osuTK.Graphics;
 
 namespace osu.Desktop.Overlays
 {
-    public class VersionManager : OverlayContainer
+    public class VersionManager : VisibilityContainer
     {
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, TextureStore textures, OsuGameBase game)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -102,7 +102,7 @@ namespace osu.Game
 
         private readonly List<OverlayContainer> overlays = new List<OverlayContainer>();
 
-        private readonly List<OverlayContainer> toolbarElements = new List<OverlayContainer>();
+        private readonly List<VisibilityContainer> toolbarElements = new List<VisibilityContainer>();
 
         private readonly List<OverlayContainer> visibleBlockingOverlays = new List<OverlayContainer>();
 

--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -16,7 +16,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Music
 {
-    public class PlaylistOverlay : OverlayContainer
+    public class PlaylistOverlay : VisibilityContainer
     {
         private const float transition_duration = 600;
         private const float playlist_height = 510;

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -16,7 +16,7 @@ using osu.Game.Rulesets;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    public class Toolbar : OverlayContainer
+    public class Toolbar : VisibilityContainer
     {
         public const float HEIGHT = 40;
         public const float TOOLTIP_HEIGHT = 30;
@@ -25,8 +25,6 @@ namespace osu.Game.Overlays.Toolbar
 
         private ToolbarUserButton userButton;
         private ToolbarRulesetSelector rulesetSelector;
-
-        protected override bool BlockPositionalInput => false;
 
         private const double transition_time = 500;
 

--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -19,7 +19,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Overlays
 {
-    public class VolumeOverlay : OverlayContainer
+    public class VolumeOverlay : VisibilityContainer
     {
         private const float offset = 10;
 
@@ -27,8 +27,6 @@ namespace osu.Game.Overlays
         private VolumeMeter volumeMeterEffect;
         private VolumeMeter volumeMeterMusic;
         private MuteButton muteButton;
-
-        protected override bool BlockPositionalInput => false;
 
         private readonly BindableDouble muteAdjustment = new BindableDouble();
 

--- a/osu.Game/Screens/Play/ResumeOverlay.cs
+++ b/osu.Game/Screens/Play/ResumeOverlay.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Play
     /// <summary>
     /// An overlay which can be used to require further user actions before gameplay is resumed.
     /// </summary>
-    public abstract class ResumeOverlay : OverlayContainer
+    public abstract class ResumeOverlay : VisibilityContainer
     {
         public CursorContainer GameplayCursor { get; set; }
 
@@ -28,8 +28,6 @@ namespace osu.Game.Screens.Play
         public virtual CursorContainer LocalCursor => null;
 
         protected const float TRANSITION_TIME = 500;
-
-        protected override bool BlockPositionalInput => false;
 
         protected abstract string Message { get; }
 

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -23,7 +23,7 @@ using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Play
 {
-    public class SkipOverlay : OverlayContainer, IKeyBindingHandler<GlobalAction>
+    public class SkipOverlay : VisibilityContainer, IKeyBindingHandler<GlobalAction>
     {
         private readonly double startTime;
 
@@ -36,7 +36,6 @@ namespace osu.Game.Screens.Play
         private double displayTime;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
-        protected override bool BlockPositionalInput => false;
 
         /// <summary>
         /// Displays a skip overlay, giving the user the ability to skip forward.

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -29,7 +29,7 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Screens.Select
 {
-    public class BeatmapInfoWedge : OverlayContainer
+    public class BeatmapInfoWedge : VisibilityContainer
     {
         private const float shear_width = 36.75f;
 
@@ -61,8 +61,6 @@ namespace osu.Game.Screens.Select
             ruleset.BindTo(parentRuleset);
             ruleset.ValueChanged += _ => updateDisplay();
         }
-
-        protected override bool BlockPositionalInput => false;
 
         protected override void PopIn()
         {


### PR DESCRIPTION
- `OverlayContainer`s with only `BlockPositionalInput` overridden to false are changed to `VisibilityContainer`s.
- `VersionManager` shouldn't block input in the first place, and thus changed.
- `PlaylistOverlay` is a child to `NowPlayingOverlay`, and thus changed.