### PR TITLE
Implement nested drawable hitobject reconstruction

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
@@ -25,10 +25,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             AddInternal(bananaContainer = new Container { RelativeSizeAxes = Axes.Both });
         }
 
-        protected override void AddNested(DrawableHitObject h)
+        protected override void AddNested(DrawableHitObject hitObject)
         {
-            base.AddNested(h);
-            bananaContainer.Add(h);
+            base.AddNested(hitObject);
+            bananaContainer.Add(hitObject);
         }
 
         protected override void ClearNested()

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
@@ -2,35 +2,50 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableBananaShower : DrawableCatchHitObject<BananaShower>
     {
+        private readonly Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation;
         private readonly Container bananaContainer;
 
         public DrawableBananaShower(BananaShower s, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation = null)
             : base(s)
         {
+            this.createDrawableRepresentation = createDrawableRepresentation;
             RelativeSizeAxes = Axes.X;
             Origin = Anchor.BottomLeft;
             X = 0;
 
             AddInternal(bananaContainer = new Container { RelativeSizeAxes = Axes.Both });
-
-            foreach (var b in s.NestedHitObjects.Cast<Banana>())
-                AddNested(createDrawableRepresentation?.Invoke(b));
         }
 
         protected override void AddNested(DrawableHitObject h)
         {
-            ((DrawableCatchHitObject)h).CheckPosition = o => CheckPosition?.Invoke(o) ?? false;
-            bananaContainer.Add(h);
             base.AddNested(h);
+            bananaContainer.Add(h);
+        }
+
+        protected override void ClearNested()
+        {
+            base.ClearNested();
+            bananaContainer.Clear();
+        }
+
+        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case Banana banana:
+                    return createDrawableRepresentation?.Invoke(banana)?.With(o => ((DrawableCatchHitObject)o).CheckPosition = p => CheckPosition?.Invoke(p) ?? false);
+            }
+
+            return base.CreateNested(hitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableBananaShower.cs
@@ -25,19 +25,19 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             AddInternal(bananaContainer = new Container { RelativeSizeAxes = Axes.Both });
         }
 
-        protected override void AddNested(DrawableHitObject hitObject)
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            base.AddNested(hitObject);
+            base.AddNestedHitObject(hitObject);
             bananaContainer.Add(hitObject);
         }
 
-        protected override void ClearNested()
+        protected override void ClearNestedHitObjects()
         {
-            base.ClearNested();
+            base.ClearNestedHitObjects();
             bananaContainer.Clear();
         }
 
-        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
                     return createDrawableRepresentation?.Invoke(banana)?.With(o => ((DrawableCatchHitObject)o).CheckPosition = p => CheckPosition?.Invoke(p) ?? false);
             }
 
-            return base.CreateNested(hitObject);
+            return base.CreateNestedHitObject(hitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
@@ -25,10 +25,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             AddInternal(dropletContainer = new Container { RelativeSizeAxes = Axes.Both, });
         }
 
-        protected override void AddNested(DrawableHitObject h)
+        protected override void AddNested(DrawableHitObject hitObject)
         {
-            base.AddNested(h);
-            dropletContainer.Add(h);
+            base.AddNested(hitObject);
+            dropletContainer.Add(hitObject);
         }
 
         protected override void ClearNested()

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
@@ -25,19 +25,19 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
             AddInternal(dropletContainer = new Container { RelativeSizeAxes = Axes.Both, });
         }
 
-        protected override void AddNested(DrawableHitObject hitObject)
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            base.AddNested(hitObject);
+            base.AddNestedHitObject(hitObject);
             dropletContainer.Add(hitObject);
         }
 
-        protected override void ClearNested()
+        protected override void ClearNestedHitObjects()
         {
-            base.ClearNested();
+            base.ClearNestedHitObjects();
             dropletContainer.Clear();
         }
 
-        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawable
                     return createDrawableRepresentation?.Invoke(catchObject)?.With(o => ((DrawableCatchHitObject)o).CheckPosition = p => CheckPosition?.Invoke(p) ?? false);
             }
 
-            return base.CreateNested(hitObject);
+            return base.CreateNestedHitObject(hitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawable/DrawableJuiceStream.cs
@@ -2,38 +2,50 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawable
 {
     public class DrawableJuiceStream : DrawableCatchHitObject<JuiceStream>
     {
+        private readonly Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation;
         private readonly Container dropletContainer;
 
         public DrawableJuiceStream(JuiceStream s, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation = null)
             : base(s)
         {
+            this.createDrawableRepresentation = createDrawableRepresentation;
             RelativeSizeAxes = Axes.Both;
             Origin = Anchor.BottomLeft;
             X = 0;
 
             AddInternal(dropletContainer = new Container { RelativeSizeAxes = Axes.Both, });
-
-            foreach (var o in s.NestedHitObjects.Cast<CatchHitObject>())
-                AddNested(createDrawableRepresentation?.Invoke(o));
         }
 
         protected override void AddNested(DrawableHitObject h)
         {
-            var catchObject = (DrawableCatchHitObject)h;
-
-            catchObject.CheckPosition = o => CheckPosition?.Invoke(o) ?? false;
-
-            dropletContainer.Add(h);
             base.AddNested(h);
+            dropletContainer.Add(h);
+        }
+
+        protected override void ClearNested()
+        {
+            base.ClearNested();
+            dropletContainer.Clear();
+        }
+
+        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case CatchHitObject catchObject:
+                    return createDrawableRepresentation?.Invoke(catchObject)?.With(o => ((DrawableCatchHitObject)o).CheckPosition = p => CheckPosition?.Invoke(p) ?? false);
+            }
+
+            return base.CreateNested(hitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNoteSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNoteSelectionBlueprint.cs
@@ -20,28 +20,34 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
 
-        private readonly BodyPiece body;
+        [Resolved]
+        private OsuColour colours { get; set; }
 
         public HoldNoteSelectionBlueprint(DrawableHoldNote hold)
             : base(hold)
         {
-            InternalChildren = new Drawable[]
-            {
-                new HoldNoteNoteSelectionBlueprint(hold.Head),
-                new HoldNoteNoteSelectionBlueprint(hold.Tail),
-                body = new BodyPiece
-                {
-                    AccentColour = Color4.Transparent
-                },
-            };
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, IScrollingInfo scrollingInfo)
+        private void load(IScrollingInfo scrollingInfo)
         {
-            body.BorderColour = colours.Yellow;
-
             direction.BindTo(scrollingInfo.Direction);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            InternalChildren = new Drawable[]
+            {
+                new HoldNoteNoteSelectionBlueprint(HitObject.Head),
+                new HoldNoteNoteSelectionBlueprint(HitObject.Tail),
+                new BodyPiece
+                {
+                    AccentColour = Color4.Transparent,
+                    BorderColour = colours.Yellow
+                },
+            };
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -59,9 +59,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             }, true);
         }
 
-        protected override void AddNested(DrawableHitObject hitObject)
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            base.AddNested(hitObject);
+            base.AddNestedHitObject(hitObject);
 
             switch (hitObject)
             {
@@ -79,15 +79,15 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             }
         }
 
-        protected override void ClearNested()
+        protected override void ClearNestedHitObjects()
         {
-            base.ClearNested();
+            base.ClearNestedHitObjects();
             headContainer.Clear();
             tailContainer.Clear();
             tickContainer.Clear();
         }
 
-        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     };
             }
 
-            return base.CreateNested(hitObject);
+            return base.CreateNestedHitObject(hitObject);
         }
 
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -59,11 +59,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             }, true);
         }
 
-        protected override void AddNested(DrawableHitObject h)
+        protected override void AddNested(DrawableHitObject hitObject)
         {
-            base.AddNested(h);
+            base.AddNested(hitObject);
 
-            switch (h)
+            switch (hitObject)
             {
                 case DrawableHeadNote head:
                     headContainer.Child = head;

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -2,13 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
-using System.Linq;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -22,8 +21,12 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     {
         public override bool DisplayResult => false;
 
-        public readonly DrawableNote Head;
-        public readonly DrawableNote Tail;
+        private readonly Container<DrawableHeadNote> headContainer;
+        private readonly Container<DrawableTailNote> tailContainer;
+        private readonly Container<DrawableHoldNoteTick> tickContainer;
+
+        public DrawableNote Head { get; private set; }
+        public DrawableNote Tail { get; private set; }
 
         private readonly BodyPiece bodyPiece;
 
@@ -40,48 +43,79 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         public DrawableHoldNote(HoldNote hitObject)
             : base(hitObject)
         {
-            Container<DrawableHoldNoteTick> tickContainer;
             RelativeSizeAxes = Axes.X;
 
             AddRangeInternal(new Drawable[]
             {
-                bodyPiece = new BodyPiece
-                {
-                    RelativeSizeAxes = Axes.X,
-                },
-                tickContainer = new Container<DrawableHoldNoteTick>
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    ChildrenEnumerable = HitObject.NestedHitObjects.OfType<HoldNoteTick>().Select(tick => new DrawableHoldNoteTick(tick)
-                    {
-                        HoldStartTime = () => holdStartTime
-                    })
-                },
-                Head = new DrawableHeadNote(this)
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre
-                },
-                Tail = new DrawableTailNote(this)
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre
-                }
+                bodyPiece = new BodyPiece { RelativeSizeAxes = Axes.X },
+                tickContainer = new Container<DrawableHoldNoteTick> { RelativeSizeAxes = Axes.Both },
+                headContainer = new Container<DrawableHeadNote> { RelativeSizeAxes = Axes.Both },
+                tailContainer = new Container<DrawableTailNote> { RelativeSizeAxes = Axes.Both },
             });
-
-            foreach (var tick in tickContainer)
-                AddNested(tick);
-
-            AddNested(Head);
-            AddNested(Tail);
 
             AccentColour.BindValueChanged(colour =>
             {
                 bodyPiece.AccentColour = colour.NewValue;
-                Head.AccentColour.Value = colour.NewValue;
-                Tail.AccentColour.Value = colour.NewValue;
-                tickContainer.ForEach(t => t.AccentColour.Value = colour.NewValue);
             }, true);
+        }
+
+        protected override void AddNested(DrawableHitObject h)
+        {
+            base.AddNested(h);
+
+            switch (h)
+            {
+                case DrawableHeadNote head:
+                    headContainer.Child = head;
+                    break;
+
+                case DrawableTailNote tail:
+                    tailContainer.Child = tail;
+                    break;
+
+                case DrawableHoldNoteTick tick:
+                    tickContainer.Add(tick);
+                    break;
+            }
+        }
+
+        protected override void ClearNested()
+        {
+            base.ClearNested();
+            headContainer.Clear();
+            tailContainer.Clear();
+            tickContainer.Clear();
+        }
+
+        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case TailNote _:
+                    return Tail = new DrawableTailNote(this)
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        AccentColour = { BindTarget = AccentColour }
+                    };
+
+                case Note _:
+                    return Head = new DrawableHeadNote(this)
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        AccentColour = { BindTarget = AccentColour }
+                    };
+
+                case HoldNoteTick tick:
+                    return new DrawableHoldNoteTick(tick)
+                    {
+                        HoldStartTime = () => holdStartTime,
+                        AccentColour = { BindTarget = AccentColour }
+                    };
+            }
+
+            return base.CreateNested(hitObject);
         }
 
         protected override void OnDirectionChanged(ValueChangedEvent<ScrollingDirection> e)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -21,12 +21,12 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     {
         public override bool DisplayResult => false;
 
+        public DrawableNote Head => headContainer.Child;
+        public DrawableNote Tail => tailContainer.Child;
+
         private readonly Container<DrawableHeadNote> headContainer;
         private readonly Container<DrawableTailNote> tailContainer;
         private readonly Container<DrawableHoldNoteTick> tickContainer;
-
-        public DrawableNote Head { get; private set; }
-        public DrawableNote Tail { get; private set; }
 
         private readonly BodyPiece bodyPiece;
 
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             switch (hitObject)
             {
                 case TailNote _:
-                    return Tail = new DrawableTailNote(this)
+                    return new DrawableTailNote(this)
                     {
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     };
 
                 case Note _:
-                    return Head = new DrawableHeadNote(this)
+                    return new DrawableHeadNote(this)
                     {
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -94,13 +94,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        protected override void UpdateInitialTransforms()
-        {
-            base.UpdateInitialTransforms();
-
-            Body.FadeInFromZero(HitObject.TimeFadeIn);
-        }
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -127,6 +120,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 foreach (var drawableHitObject in NestedHitObjects)
                     drawableHitObject.AccentColour.Value = colour.NewValue;
             }, true);
+        }
+
+        protected override void UpdateInitialTransforms()
+        {
+            base.UpdateInitialTransforms();
+
+            Body.FadeInFromZero(HitObject.TimeFadeIn);
         }
 
         public readonly Bindable<bool> Tracking = new Bindable<bool>();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -258,7 +258,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        public Drawable ProxiedLayer => new Container(); // Todo:
+        public Drawable ProxiedLayer => HeadCircle.ProxiedLayer;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Body.ReceivePositionalInputAt(screenSpacePos);
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -20,8 +20,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSlider : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
-        public DrawableSliderHead HeadCircle { get; private set; }
-        public DrawableSliderTail TailCircle { get; private set; }
+        public DrawableSliderHead HeadCircle => headContainer.Child;
+        public DrawableSliderTail TailCircle => tailContainer.Child;
 
         public readonly SnakingSliderBody Body;
         public readonly SliderBall Ball;
@@ -100,11 +100,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             switch (hitObject)
             {
                 case DrawableSliderHead head:
-                    headContainer.Child = HeadCircle = head;
+                    headContainer.Child = head;
                     break;
 
                 case DrawableSliderTail tail:
-                    tailContainer.Child = TailCircle = tail;
+                    tailContainer.Child = tail;
                     break;
 
                 case DrawableSliderTick tick:

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -93,9 +93,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }, true);
         }
 
-        protected override void AddNested(DrawableHitObject hitObject)
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            base.AddNested(hitObject);
+            base.AddNestedHitObject(hitObject);
 
             switch (hitObject)
             {
@@ -117,9 +117,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        protected override void ClearNested()
+        protected override void ClearNestedHitObjects()
         {
-            base.ClearNested();
+            base.ClearNestedHitObjects();
 
             headContainer.Clear();
             tailContainer.Clear();
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             tickContainer.Clear();
         }
 
-        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
@@ -144,7 +144,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     return new DrawableRepeatPoint(repeat, this) { Position = repeat.Position - slider.Position };
             }
 
-            return base.CreateNested(hitObject);
+            return base.CreateNestedHitObject(hitObject);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -5,7 +5,6 @@ using osuTK;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -21,14 +20,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSlider : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
-        private readonly Slider slider;
-        private readonly List<Drawable> components = new List<Drawable>();
-
-        public readonly DrawableHitCircle HeadCircle;
-        public readonly DrawableSliderTail TailCircle;
+        public DrawableSliderHead HeadCircle { get; private set; }
+        public DrawableSliderTail TailCircle { get; private set; }
 
         public readonly SnakingSliderBody Body;
         public readonly SliderBall Ball;
+
+        private readonly Container<DrawableSliderHead> headContainer;
+        private readonly Container<DrawableSliderTail> tailContainer;
+        private readonly Container<DrawableSliderTick> tickContainer;
+        private readonly Container<DrawableRepeatPoint> repeatContainer;
+
+        private readonly Slider slider;
 
         private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
         private readonly IBindable<float> scaleBindable = new Bindable<float>();
@@ -44,14 +47,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             Position = s.StackedPosition;
 
-            Container<DrawableSliderTick> ticks;
-            Container<DrawableRepeatPoint> repeatPoints;
-
             InternalChildren = new Drawable[]
             {
                 Body = new SnakingSliderBody(s),
-                ticks = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
-                repeatPoints = new Container<DrawableRepeatPoint> { RelativeSizeAxes = Axes.Both },
+                tickContainer = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
+                repeatContainer = new Container<DrawableRepeatPoint> { RelativeSizeAxes = Axes.Both },
                 Ball = new SliderBall(s, this)
                 {
                     GetInitialHitAction = () => HeadCircle.HitAction,
@@ -60,38 +60,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     AlwaysPresent = true,
                     Alpha = 0
                 },
-                HeadCircle = new DrawableSliderHead(s, s.HeadCircle)
-                {
-                    OnShake = Shake
-                },
-                TailCircle = new DrawableSliderTail(s, s.TailCircle)
+                headContainer = new Container<DrawableSliderHead> { RelativeSizeAxes = Axes.Both },
+                tailContainer = new Container<DrawableSliderTail> { RelativeSizeAxes = Axes.Both },
             };
-
-            components.Add(Body);
-            components.Add(Ball);
-
-            AddNested(HeadCircle);
-
-            AddNested(TailCircle);
-            components.Add(TailCircle);
-
-            foreach (var tick in s.NestedHitObjects.OfType<SliderTick>())
-            {
-                var drawableTick = new DrawableSliderTick(tick) { Position = tick.Position - s.Position };
-
-                ticks.Add(drawableTick);
-                components.Add(drawableTick);
-                AddNested(drawableTick);
-            }
-
-            foreach (var repeatPoint in s.NestedHitObjects.OfType<RepeatPoint>())
-            {
-                var drawableRepeatPoint = new DrawableRepeatPoint(repeatPoint, this) { Position = repeatPoint.Position - s.Position };
-
-                repeatPoints.Add(drawableRepeatPoint);
-                components.Add(drawableRepeatPoint);
-                AddNested(drawableRepeatPoint);
-            }
         }
 
         [BackgroundDependencyLoader]
@@ -122,6 +93,60 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }, true);
         }
 
+        protected override void AddNested(DrawableHitObject h)
+        {
+            base.AddNested(h);
+
+            switch (h)
+            {
+                case DrawableSliderHead head:
+                    headContainer.Child = HeadCircle = head;
+                    break;
+
+                case DrawableSliderTail tail:
+                    tailContainer.Child = TailCircle = tail;
+                    break;
+
+                case DrawableSliderTick tick:
+                    tickContainer.Add(tick);
+                    break;
+
+                case DrawableRepeatPoint repeat:
+                    repeatContainer.Add(repeat);
+                    break;
+            }
+        }
+
+        protected override void ClearNested()
+        {
+            base.ClearNested();
+
+            headContainer.Clear();
+            tailContainer.Clear();
+            repeatContainer.Clear();
+            tickContainer.Clear();
+        }
+
+        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case SliderTailCircle tail:
+                    return new DrawableSliderTail(slider, tail);
+
+                case HitCircle head:
+                    return new DrawableSliderHead(slider, head) { OnShake = Shake };
+
+                case SliderTick tick:
+                    return new DrawableSliderTick(tick) { Position = tick.Position - slider.Position };
+
+                case RepeatPoint repeat:
+                    return new DrawableRepeatPoint(repeat, this) { Position = repeat.Position - slider.Position };
+            }
+
+            return base.CreateNested(hitObject);
+        }
+
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
@@ -139,9 +164,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             double completionProgress = MathHelper.Clamp((Time.Current - slider.StartTime) / slider.Duration, 0, 1);
 
-            foreach (var c in components.OfType<ISliderProgress>()) c.UpdateProgress(completionProgress);
-            foreach (var c in components.OfType<ITrackSnaking>()) c.UpdateSnakingPosition(slider.Path.PositionAt(Body.SnakedStart ?? 0), slider.Path.PositionAt(Body.SnakedEnd ?? 0));
-            foreach (var t in components.OfType<IRequireTracking>()) t.Tracking = Ball.Tracking;
+            Ball.UpdateProgress(completionProgress);
+            Body.UpdateProgress(completionProgress);
+
+            foreach (DrawableHitObject hitObject in NestedHitObjects)
+            {
+                if (hitObject is ITrackSnaking s) s.UpdateSnakingPosition(slider.Path.PositionAt(Body.SnakedStart ?? 0), slider.Path.PositionAt(Body.SnakedEnd ?? 0));
+                if (hitObject is IRequireTracking t) t.Tracking = Ball.Tracking;
+            }
 
             Size = Body.Size;
             OriginPosition = Body.PathOffset;
@@ -187,7 +217,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             ApplyResult(r =>
             {
-                var judgementsCount = NestedHitObjects.Count();
+                var judgementsCount = NestedHitObjects.Count;
                 var judgementsHit = NestedHitObjects.Count(h => h.IsHit);
 
                 var hitFraction = (double)judgementsHit / judgementsCount;
@@ -228,7 +258,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        public Drawable ProxiedLayer => HeadCircle.ApproachCircle;
+        public Drawable ProxiedLayer => new Container(); // Todo:
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Body.ReceivePositionalInputAt(screenSpacePos);
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -93,11 +93,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }, true);
         }
 
-        protected override void AddNested(DrawableHitObject h)
+        protected override void AddNested(DrawableHitObject hitObject)
         {
-            base.AddNested(h);
+            base.AddNested(hitObject);
 
-            switch (h)
+            switch (hitObject)
             {
                 case DrawableSliderHead head:
                     headContainer.Child = HeadCircle = head;

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -57,20 +57,14 @@ namespace osu.Game.Rulesets.Osu.UI
         public override void Add(DrawableHitObject h)
         {
             h.OnNewResult += onNewResult;
-
-            if (h is IDrawableHitObjectWithProxiedApproach c)
+            h.OnLoadComplete += d =>
             {
-                var original = c.ProxiedLayer;
-
-                // Hitobjects only have lifetimes set on LoadComplete. For nested hitobjects (e.g. SliderHeads), this only happens when the parenting slider becomes visible.
-                // This delegation is required to make sure that the approach circles for those not-yet-loaded objects aren't added prematurely.
-                original.OnLoadComplete += addApproachCircleProxy;
-            }
+                if (d is IDrawableHitObjectWithProxiedApproach c)
+                    approachCircles.Add(c.ProxiedLayer.CreateProxy());
+            };
 
             base.Add(h);
         }
-
-        private void addApproachCircleProxy(Drawable d) => approachCircles.Add(d.CreateProxy());
 
         public override void PostProcess()
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -55,11 +55,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             OnNewResult += onNewResult;
         }
 
-        protected override void AddNested(DrawableHitObject h)
+        protected override void AddNested(DrawableHitObject hitObject)
         {
-            base.AddNested(h);
+            base.AddNested(hitObject);
 
-            switch (h)
+            switch (hitObject)
             {
                 case DrawableDrumRollTick tick:
                     tickContainer.Add(tick);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             OnNewResult += onNewResult;
         }
 
-        protected override void AddNested(DrawableHitObject hitObject)
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            base.AddNested(hitObject);
+            base.AddNestedHitObject(hitObject);
 
             switch (hitObject)
             {
@@ -67,13 +67,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             }
         }
 
-        protected override void ClearNested()
+        protected override void ClearNestedHitObjects()
         {
-            base.ClearNested();
+            base.ClearNestedHitObjects();
             tickContainer.Clear();
         }
 
-        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     return new DrawableDrumRollTick(tick);
             }
 
-            return base.CreateNested(hitObject);
+            return base.CreateNestedHitObject(hitObject);
         }
 
         protected override TaikoPiece CreateMainPiece() => new ElongatedCirclePiece();

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
@@ -28,30 +29,17 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// </summary>
         private int rollingHits;
 
+        private readonly Container<DrawableDrumRollTick> tickContainer;
+
+        private Color4 colourIdle;
+        private Color4 colourEngaged;
+
         public DrawableDrumRoll(DrumRoll drumRoll)
             : base(drumRoll)
         {
             RelativeSizeAxes = Axes.Y;
-
-            Container<DrawableDrumRollTick> tickContainer;
             MainPiece.Add(tickContainer = new Container<DrawableDrumRollTick> { RelativeSizeAxes = Axes.Both });
-
-            foreach (var tick in drumRoll.NestedHitObjects.OfType<DrumRollTick>())
-            {
-                var newTick = new DrawableDrumRollTick(tick);
-                newTick.OnNewResult += onNewTickResult;
-
-                AddNested(newTick);
-                tickContainer.Add(newTick);
-            }
         }
-
-        protected override TaikoPiece CreateMainPiece() => new ElongatedCirclePiece();
-
-        public override bool OnPressed(TaikoAction action) => false;
-
-        private Color4 colourIdle;
-        private Color4 colourEngaged;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -60,8 +48,51 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             colourEngaged = colours.YellowDarker;
         }
 
-        private void onNewTickResult(DrawableHitObject obj, JudgementResult result)
+        protected override void LoadComplete()
         {
+            base.LoadComplete();
+
+            OnNewResult += onNewResult;
+        }
+
+        protected override void AddNested(DrawableHitObject h)
+        {
+            base.AddNested(h);
+
+            switch (h)
+            {
+                case DrawableDrumRollTick tick:
+                    tickContainer.Add(tick);
+                    break;
+            }
+        }
+
+        protected override void ClearNested()
+        {
+            base.ClearNested();
+            tickContainer.Clear();
+        }
+
+        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case DrumRollTick tick:
+                    return new DrawableDrumRollTick(tick);
+            }
+
+            return base.CreateNested(hitObject);
+        }
+
+        protected override TaikoPiece CreateMainPiece() => new ElongatedCirclePiece();
+
+        public override bool OnPressed(TaikoAction action) => false;
+
+        private void onNewResult(DrawableHitObject obj, JudgementResult result)
+        {
+            if (!(obj is DrawableDrumRollTick))
+                return;
+
             if (result.Type > HitResult.Miss)
                 rollingHits++;
             else

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -128,11 +128,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             Width *= Parent.RelativeChildSize.X;
         }
 
-        protected override void AddNested(DrawableHitObject h)
+        protected override void AddNested(DrawableHitObject hitObject)
         {
-            base.AddNested(h);
+            base.AddNested(hitObject);
 
-            switch (h)
+            switch (hitObject)
             {
                 case DrawableSwellTick tick:
                     ticks.Add(tick);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -128,9 +128,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             Width *= Parent.RelativeChildSize.X;
         }
 
-        protected override void AddNested(DrawableHitObject hitObject)
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            base.AddNested(hitObject);
+            base.AddNestedHitObject(hitObject);
 
             switch (hitObject)
             {
@@ -140,13 +140,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             }
         }
 
-        protected override void ClearNested()
+        protected override void ClearNestedHitObjects()
         {
-            base.ClearNested();
+            base.ClearNestedHitObjects();
             ticks.Clear();
         }
 
-        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
@@ -154,7 +154,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     return new DrawableSwellTick(tick);
             }
 
-            return base.CreateNested(hitObject);
+            return base.CreateNestedHitObject(hitObject);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -14,6 +13,7 @@ using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
@@ -30,8 +30,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// </summary>
         private const double ring_appear_offset = 100;
 
-        private readonly List<DrawableSwellTick> ticks = new List<DrawableSwellTick>();
-
+        private readonly Container<DrawableSwellTick> ticks;
         private readonly Container bodyContainer;
         private readonly CircularContainer targetRing;
         private readonly CircularContainer expandingRing;
@@ -108,16 +107,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 }
             });
 
+            AddInternal(ticks = new Container<DrawableSwellTick> { RelativeSizeAxes = Axes.Both });
+
             MainPiece.Add(symbol = new SwellSymbolPiece());
-
-            foreach (var tick in HitObject.NestedHitObjects.OfType<SwellTick>())
-            {
-                var vis = new DrawableSwellTick(tick);
-
-                ticks.Add(vis);
-                AddInternal(vis);
-                AddNested(vis);
-            }
         }
 
         [BackgroundDependencyLoader]
@@ -136,11 +128,49 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             Width *= Parent.RelativeChildSize.X;
         }
 
+        protected override void AddNested(DrawableHitObject h)
+        {
+            base.AddNested(h);
+
+            switch (h)
+            {
+                case DrawableSwellTick tick:
+                    ticks.Add(tick);
+                    break;
+            }
+        }
+
+        protected override void ClearNested()
+        {
+            base.ClearNested();
+            ticks.Clear();
+        }
+
+        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case SwellTick tick:
+                    return new DrawableSwellTick(tick);
+            }
+
+            return base.CreateNested(hitObject);
+        }
+
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (userTriggered)
             {
-                var nextTick = ticks.Find(j => !j.IsHit);
+                DrawableSwellTick nextTick = null;
+
+                foreach (var t in ticks)
+                {
+                    if (!t.IsHit)
+                    {
+                        nextTick = t;
+                        break;
+                    }
+                }
 
                 nextTick?.TriggerResult(HitResult.Great);
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -11,6 +11,7 @@ using osu.Game.Audio;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -109,11 +110,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
     {
         public override Vector2 OriginPosition => new Vector2(DrawHeight / 2);
 
-        protected readonly Vector2 BaseSize;
+        public new TaikoHitType HitObject;
 
+        protected readonly Vector2 BaseSize;
         protected readonly TaikoPiece MainPiece;
 
-        public new TaikoHitType HitObject;
+        private readonly Container<DrawableStrongNestedHit> strongHitContainer;
 
         protected DrawableTaikoHitObject(TaikoHitType hitObject)
             : base(hitObject)
@@ -129,15 +131,36 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             Content.Add(MainPiece = CreateMainPiece());
             MainPiece.KiaiMode = HitObject.Kiai;
 
-            var strongObject = HitObject.NestedHitObjects.OfType<StrongHitObject>().FirstOrDefault();
+            AddInternal(strongHitContainer = new Container<DrawableStrongNestedHit>());
+        }
 
-            if (strongObject != null)
+        protected override void AddNested(DrawableHitObject h)
+        {
+            base.AddNested(h);
+
+            switch (h)
             {
-                var strongHit = CreateStrongHit(strongObject);
-
-                AddNested(strongHit);
-                AddInternal(strongHit);
+                case DrawableStrongNestedHit strong:
+                    strongHitContainer.Add(strong);
+                    break;
             }
+        }
+
+        protected override void ClearNested()
+        {
+            base.ClearNested();
+            strongHitContainer.Clear();
+        }
+
+        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case StrongHitObject strong:
+                    return CreateStrongHit(strong);
+            }
+
+            return base.CreateNested(hitObject);
         }
 
         // Normal and clap samples are handled by the drum

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -134,11 +134,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             AddInternal(strongHitContainer = new Container<DrawableStrongNestedHit>());
         }
 
-        protected override void AddNested(DrawableHitObject h)
+        protected override void AddNested(DrawableHitObject hitObject)
         {
-            base.AddNested(h);
+            base.AddNested(hitObject);
 
-            switch (h)
+            switch (hitObject)
             {
                 case DrawableStrongNestedHit strong:
                     strongHitContainer.Add(strong);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -134,9 +134,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             AddInternal(strongHitContainer = new Container<DrawableStrongNestedHit>());
         }
 
-        protected override void AddNested(DrawableHitObject hitObject)
+        protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            base.AddNested(hitObject);
+            base.AddNestedHitObject(hitObject);
 
             switch (hitObject)
             {
@@ -146,13 +146,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             }
         }
 
-        protected override void ClearNested()
+        protected override void ClearNestedHitObjects()
         {
-            base.ClearNested();
+            base.ClearNestedHitObjects();
             strongHitContainer.Clear();
         }
 
-        protected override DrawableHitObject CreateNested(HitObject hitObject)
+        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
@@ -160,7 +160,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     return CreateStrongHit(strong);
             }
 
-            return base.CreateNested(hitObject);
+            return base.CreateNestedHitObject(hitObject);
         }
 
         // Normal and clap samples are handled by the drum

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             base.LoadComplete();
 
-            Apply(HitObject);
+            apply(HitObject);
 
             if (HitObject is IHasComboInformation combo)
             {
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             updateState(ArmedState.Idle, true);
         }
 
-        protected void Apply(HitObject hitObject)
+        private void apply(HitObject hitObject)
         {
 #pragma warning disable 618 // can be removed 20200417
             if (GetType().GetMethod(nameof(AddNested), BindingFlags.NonPublic | BindingFlags.Instance)?.DeclaringType != typeof(DrawableHitObject))

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
@@ -138,34 +139,65 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         protected void Apply(HitObject hitObject)
         {
+#pragma warning disable 618 // can be removed 20200417
+            if (GetType().GetMethod(nameof(AddNested), BindingFlags.NonPublic | BindingFlags.Instance)?.DeclaringType != typeof(DrawableHitObject))
+                return;
+#pragma warning restore 618
+
             if (nestedHitObjects.IsValueCreated)
             {
                 nestedHitObjects.Value.Clear();
-                ClearNested();
+                ClearNestedHitObjects();
             }
 
             foreach (var h in hitObject.NestedHitObjects)
             {
-                var drawableNested = CreateNested(h) ?? throw new InvalidOperationException($"{nameof(CreateNested)} returned null for {h.GetType().ReadableName()}.");
+                var drawableNested = CreateNestedHitObject(h) ?? throw new InvalidOperationException($"{nameof(CreateNestedHitObject)} returned null for {h.GetType().ReadableName()}.");
 
                 drawableNested.OnNewResult += (d, r) => OnNewResult?.Invoke(d, r);
                 drawableNested.OnRevertResult += (d, r) => OnRevertResult?.Invoke(d, r);
                 drawableNested.ApplyCustomUpdateState += (d, j) => ApplyCustomUpdateState?.Invoke(d, j);
 
                 nestedHitObjects.Value.Add(drawableNested);
-                AddNested(drawableNested);
+                AddNestedHitObject(drawableNested);
             }
         }
 
-        protected virtual void AddNested(DrawableHitObject hitObject)
+        /// <summary>
+        /// Invoked by the base <see cref="DrawableHitObject"/> to add nested <see cref="DrawableHitObject"/>s to the hierarchy.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="DrawableHitObject"/> to be added.</param>
+        protected virtual void AddNestedHitObject(DrawableHitObject hitObject)
         {
         }
 
-        protected virtual void ClearNested()
+        /// <summary>
+        /// Adds a nested <see cref="DrawableHitObject"/>. This should not be used except for legacy nested <see cref="DrawableHitObject"/> usages.
+        /// </summary>
+        /// <param name="h"></param>
+        [Obsolete("Use AddNestedHitObject() / ClearNestedHitObjects() / CreateNestedHitObject() instead.")] // can be removed 20200417
+        protected virtual void AddNested(DrawableHitObject h)
+        {
+            h.OnNewResult += (d, r) => OnNewResult?.Invoke(d, r);
+            h.OnRevertResult += (d, r) => OnRevertResult?.Invoke(d, r);
+            h.ApplyCustomUpdateState += (d, j) => ApplyCustomUpdateState?.Invoke(d, j);
+
+            nestedHitObjects.Value.Add(h);
+        }
+
+        /// <summary>
+        /// Invoked by the base <see cref="DrawableHitObject"/> to remove all previously-added nested <see cref="DrawableHitObject"/>s.
+        /// </summary>
+        protected virtual void ClearNestedHitObjects()
         {
         }
 
-        protected virtual DrawableHitObject CreateNested(HitObject hitObject) => null;
+        /// <summary>
+        /// Creates the drawable representation for a nested <see cref="HitObject"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/>.</param>
+        /// <returns>The drawable representation for <paramref name="hitObject"/>.</returns>
+        protected virtual DrawableHitObject CreateNestedHitObject(HitObject hitObject) => null;
 
         #region State / Transform Management
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
         }
 
-        protected virtual void AddNested(DrawableHitObject h)
+        protected virtual void AddNested(DrawableHitObject hitObject)
         {
         }
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -154,11 +154,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             {
                 var drawableNested = CreateNestedHitObject(h) ?? throw new InvalidOperationException($"{nameof(CreateNestedHitObject)} returned null for {h.GetType().ReadableName()}.");
 
-                drawableNested.OnNewResult += (d, r) => OnNewResult?.Invoke(d, r);
-                drawableNested.OnRevertResult += (d, r) => OnRevertResult?.Invoke(d, r);
-                drawableNested.ApplyCustomUpdateState += (d, j) => ApplyCustomUpdateState?.Invoke(d, j);
-
-                nestedHitObjects.Value.Add(drawableNested);
+                addNested(drawableNested);
                 AddNestedHitObject(drawableNested);
             }
         }
@@ -176,14 +172,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </summary>
         /// <param name="h"></param>
         [Obsolete("Use AddNestedHitObject() / ClearNestedHitObjects() / CreateNestedHitObject() instead.")] // can be removed 20200417
-        protected virtual void AddNested(DrawableHitObject h)
-        {
-            h.OnNewResult += (d, r) => OnNewResult?.Invoke(d, r);
-            h.OnRevertResult += (d, r) => OnRevertResult?.Invoke(d, r);
-            h.ApplyCustomUpdateState += (d, j) => ApplyCustomUpdateState?.Invoke(d, j);
-
-            nestedHitObjects.Value.Add(h);
-        }
+        protected virtual void AddNested(DrawableHitObject h) => addNested(h);
 
         /// <summary>
         /// Invoked by the base <see cref="DrawableHitObject"/> to remove all previously-added nested <see cref="DrawableHitObject"/>s.
@@ -198,6 +187,17 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <param name="hitObject">The <see cref="HitObject"/>.</param>
         /// <returns>The drawable representation for <paramref name="hitObject"/>.</returns>
         protected virtual DrawableHitObject CreateNestedHitObject(HitObject hitObject) => null;
+
+        private void addNested(DrawableHitObject hitObject)
+        {
+            // Todo: Exists for legacy purposes, can be removed 20200417
+
+            hitObject.OnNewResult += (d, r) => OnNewResult?.Invoke(d, r);
+            hitObject.OnRevertResult += (d, r) => OnRevertResult?.Invoke(d, r);
+            hitObject.ApplyCustomUpdateState += (d, j) => ApplyCustomUpdateState?.Invoke(d, j);
+
+            nestedHitObjects.Value.Add(hitObject);
+        }
 
         #region State / Transform Management
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -123,12 +123,20 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (blueprint == null)
                 return;
 
-            blueprint.Selected += onBlueprintSelected;
-            blueprint.Deselected += onBlueprintDeselected;
-            blueprint.SelectionRequested += onSelectionRequested;
-            blueprint.DragRequested += onDragRequested;
+            if (hitObject.IsLoaded)
+                addBlueprint();
+            else
+                hitObject.OnLoadComplete += _ => addBlueprint();
 
-            selectionBlueprints.Add(blueprint);
+            void addBlueprint()
+            {
+                blueprint.Selected += onBlueprintSelected;
+                blueprint.Deselected += onBlueprintDeselected;
+                blueprint.SelectionRequested += onSelectionRequested;
+                blueprint.DragRequested += onDragRequested;
+
+                selectionBlueprints.Add(blueprint);
+            }
         }
 
         private void removeBlueprintFor(DrawableHitObject hitObject) => removeBlueprintFor(hitObject.HitObject);

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -123,20 +123,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (blueprint == null)
                 return;
 
-            if (hitObject.IsLoaded)
-                addBlueprint();
-            else
-                hitObject.OnLoadComplete += _ => addBlueprint();
+            blueprint.Selected += onBlueprintSelected;
+            blueprint.Deselected += onBlueprintDeselected;
+            blueprint.SelectionRequested += onSelectionRequested;
+            blueprint.DragRequested += onDragRequested;
 
-            void addBlueprint()
-            {
-                blueprint.Selected += onBlueprintSelected;
-                blueprint.Deselected += onBlueprintDeselected;
-                blueprint.SelectionRequested += onSelectionRequested;
-                blueprint.DragRequested += onDragRequested;
-
-                selectionBlueprints.Add(blueprint);
-            }
+            selectionBlueprints.Add(blueprint);
         }
 
         private void removeBlueprintFor(DrawableHitObject hitObject) => removeBlueprintFor(hitObject.HitObject);


### PR DESCRIPTION
This is made primarily for the editor but I've kept hitobject pooling in the back of my mind. The reason this is required is two scenarios:
1. In the editor, `ApplyDefaults` is invoked, which creates new nested `HitObject`s. Nested `DrawableHitObject`s are not recreated so they become out-of-date.
2. In pooling, we'll need to give `DrawableHitObject`s a model from which they'll update.

To do this I've introduced 3 virtual methods:
1. `CreateNestedHitObject` - Creates the drawable representation for a nested `HitObject`. Eventually with pooling this will likely be moved to a higher level (something like `pool.GetDrawableRepresentation(HitObject)`).
2. `AddNestedHitObject` - Adds the nested `DrawableHitObject` to the hierarchy.
3. `ClearNestedHitObjects` - Removes all previously added `DrawableHitObject`s from the hierarchy.

The general invocation structure is:
```
ClearNestedHitObjects()
for each hitObject:
    drawable = CreateNestedHitObject(hitObject)
    AddNestedHitObject(drawable)
```

The existing method, `AddNested()`, has been obsoleted for removal on 20200417.

This all happens in the `Apply(HitObject)` method, which is currently protected but will be made public with hitobject pooling. Eventually it'll also have another method such as `ApplyToSelf()` which will contain the ability to copy over properties (position/etc).