### PR TITLE
Make BeginPlacement() set the hitobject start time

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -49,10 +49,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
             if (Column == null)
                 return base.OnMouseDown(e);
 
-            HitObject.StartTime = TimeAt(e.ScreenSpaceMousePosition);
             HitObject.Column = Column.Index;
-
-            BeginPlacement();
+            BeginPlacement(TimeAt(e.ScreenSpaceMousePosition));
             return true;
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
 
         protected override bool OnClick(ClickEvent e)
         {
-            HitObject.StartTime = EditorClock.CurrentTime;
             EndPlacement();
             return true;
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -104,8 +104,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private void beginCurve()
         {
             BeginPlacement();
-
-            HitObject.StartTime = EditorClock.CurrentTime;
             setState(PlacementState.Body);
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -41,8 +41,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
             }
             else
             {
-                HitObject.StartTime = EditorClock.CurrentTime;
-
                 isPlacingEnd = true;
                 piece.FadeTo(1f, 150, Easing.OutQuint);
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -91,8 +91,10 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// Signals that the placement of <see cref="HitObject"/> has started.
         /// </summary>
-        protected void BeginPlacement()
+        /// <param name="startTime">The start time of <see cref="HitObject"/> at the placement point. If null, the current clock time is used.</param>
+        protected void BeginPlacement(double? startTime = null)
         {
+            HitObject.StartTime = startTime ?? EditorClock.CurrentTime;
             placementHandler.BeginPlacement(HitObject);
             PlacementBegun = true;
         }


### PR DESCRIPTION
Just to make sure that the start time is properly set when the hitobject composer receives the placement began event. `SliderPlacementBlueprint` already handled this incorrectly.