### PR TITLE
Integrate osu! distance snapping grid

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapGrid.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         public OsuDistanceSnapGrid(OsuHitObject hitObject)
             : base(hitObject, hitObject.StackedEndPosition)
         {
+            Masking = true;
         }
 
         protected override float GetVelocity(double time, ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             if (objects.Count == 0)
             {
-                var lastObject = EditorBeatmap.HitObjects.LastOrDefault(h => h.StartTime < EditorClock.CurrentTime);
+                var lastObject = EditorBeatmap.HitObjects.LastOrDefault(h => h.StartTime <= EditorClock.CurrentTime);
 
                 if (lastObject == null)
                     return null;

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
@@ -51,6 +53,32 @@ namespace osu.Game.Rulesets.Osu.Edit
             }
 
             return base.CreateBlueprintFor(hitObject);
+        }
+
+        protected override DistanceSnapGrid CreateDistanceSnapGrid(IEnumerable<HitObject> selectedHitObjects)
+        {
+            var objects = selectedHitObjects.ToList();
+
+            if (objects.Count == 0)
+            {
+                var lastObject = EditorBeatmap.HitObjects.LastOrDefault(h => h.StartTime < EditorClock.CurrentTime);
+
+                if (lastObject == null)
+                    return null;
+
+                return new OsuDistanceSnapGrid(lastObject);
+            }
+            else
+            {
+                double minTime = objects.Min(h => h.StartTime);
+
+                var lastObject = EditorBeatmap.HitObjects.LastOrDefault(h => h.StartTime < minTime);
+
+                if (lastObject == null)
+                    return null;
+
+                return new OsuDistanceSnapGrid(lastObject);
+            }
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -240,6 +240,7 @@ namespace osu.Game.Rulesets.Edit
 
         public void BeginPlacement(HitObject hitObject)
         {
+            hitObject.StartTime = GetSnappedTime(hitObject.StartTime, inputManager.CurrentState.Mouse.Position);
         }
 
         public void EndPlacement(HitObject hitObject) => EditorBeatmap.Add(hitObject);

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -30,12 +30,11 @@ namespace osu.Game.Rulesets.Edit
         where TObject : HitObject
     {
         protected IRulesetConfigManager Config { get; private set; }
-
+        protected EditorBeatmap<TObject> EditorBeatmap { get; private set; }
         protected readonly Ruleset Ruleset;
 
         private IWorkingBeatmap workingBeatmap;
         private Beatmap<TObject> playableBeatmap;
-        private EditorBeatmap<TObject> editorBeatmap;
         private IBeatmapProcessor beatmapProcessor;
 
         private DrawableEditRulesetWrapper<TObject> drawableRulesetWrapper;
@@ -129,14 +128,14 @@ namespace osu.Game.Rulesets.Edit
 
             beatmapProcessor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
 
-            editorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
-            editorBeatmap.HitObjectAdded += addHitObject;
-            editorBeatmap.HitObjectRemoved += removeHitObject;
-            editorBeatmap.StartTimeChanged += updateHitObject;
+            EditorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
+            EditorBeatmap.HitObjectAdded += addHitObject;
+            EditorBeatmap.HitObjectRemoved += removeHitObject;
+            EditorBeatmap.StartTimeChanged += updateHitObject;
 
             var dependencies = new DependencyContainer(parent);
-            dependencies.CacheAs<IEditorBeatmap>(editorBeatmap);
-            dependencies.CacheAs<IEditorBeatmap<TObject>>(editorBeatmap);
+            dependencies.CacheAs<IEditorBeatmap>(EditorBeatmap);
+            dependencies.CacheAs<IEditorBeatmap<TObject>>(EditorBeatmap);
 
             Config = dependencies.Get<RulesetConfigCache>().GetConfigFor(Ruleset);
 
@@ -189,18 +188,18 @@ namespace osu.Game.Rulesets.Edit
         {
         }
 
-        public void EndPlacement(HitObject hitObject) => editorBeatmap.Add(hitObject);
+        public void EndPlacement(HitObject hitObject) => EditorBeatmap.Add(hitObject);
 
-        public void Delete(HitObject hitObject) => editorBeatmap.Remove(hitObject);
+        public void Delete(HitObject hitObject) => EditorBeatmap.Remove(hitObject);
 
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
 
-            if (editorBeatmap != null)
+            if (EditorBeatmap != null)
             {
-                editorBeatmap.HitObjectAdded -= addHitObject;
-                editorBeatmap.HitObjectRemoved -= removeHitObject;
+                EditorBeatmap.HitObjectAdded -= addHitObject;
+                EditorBeatmap.HitObjectRemoved -= removeHitObject;
             }
         }
     }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -242,9 +242,9 @@ namespace osu.Game.Rulesets.Edit
 
         public void Delete(HitObject hitObject) => EditorBeatmap.Remove(hitObject);
 
-        public override Vector2 GetSnappedPosition(Vector2 position) => beatSnapGrid?.GetSnapPosition(position) ?? position;
+        public override Vector2 GetSnappedPosition(Vector2 position) => distanceSnapGrid?.GetSnapPosition(position) ?? position;
 
-        public override double GetSnappedTime(double startTime, Vector2 position) => beatSnapGrid?.GetSnapTime(position) ?? startTime;
+        public override double GetSnappedTime(double startTime, Vector2 position) => distanceSnapGrid?.GetSnapTime(position) ?? startTime;
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -244,6 +244,8 @@ namespace osu.Game.Rulesets.Edit
 
         public override Vector2 GetSnappedPosition(Vector2 position) => beatSnapGrid?.GetSnapPosition(position) ?? position;
 
+        public override double GetSnappedTime(double startTime, Vector2 position) => beatSnapGrid?.GetSnapTime(position) ?? startTime;
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
@@ -294,5 +296,7 @@ namespace osu.Game.Rulesets.Edit
         protected virtual DistanceSnapGrid CreateDistanceSnapGrid([NotNull] IEnumerable<HitObject> selectedHitObjects) => null;
 
         public abstract Vector2 GetSnappedPosition(Vector2 position);
+
+        public abstract double GetSnappedTime(double startTime, Vector2 screenSpacePosition);
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -242,6 +242,8 @@ namespace osu.Game.Rulesets.Edit
 
         public void Delete(HitObject hitObject) => EditorBeatmap.Remove(hitObject);
 
+        public override Vector2 GetSnappedPosition(Vector2 position) => beatSnapGrid?.GetSnapPosition(position) ?? position;
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
@@ -290,5 +292,7 @@ namespace osu.Game.Rulesets.Edit
         /// <returns>The <see cref="DistanceSnapGrid"/> for <paramref name="selectedHitObjects"/>.</returns>
         [CanBeNull]
         protected virtual DistanceSnapGrid CreateDistanceSnapGrid([NotNull] IEnumerable<HitObject> selectedHitObjects) => null;
+
+        public abstract Vector2 GetSnappedPosition(Vector2 position);
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -244,7 +244,11 @@ namespace osu.Game.Rulesets.Edit
                 hitObject.StartTime = GetSnappedTime(hitObject.StartTime, distanceSnapGrid.ToLocalSpace(inputManager.CurrentState.Mouse.Position));
         }
 
-        public void EndPlacement(HitObject hitObject) => EditorBeatmap.Add(hitObject);
+        public void EndPlacement(HitObject hitObject)
+        {
+            EditorBeatmap.Add(hitObject);
+            showGridFor(Enumerable.Empty<HitObject>());
+        }
 
         public void Delete(HitObject hitObject) => EditorBeatmap.Remove(hitObject);
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -240,7 +240,8 @@ namespace osu.Game.Rulesets.Edit
 
         public void BeginPlacement(HitObject hitObject)
         {
-            hitObject.StartTime = GetSnappedTime(hitObject.StartTime, inputManager.CurrentState.Mouse.Position);
+            if (distanceSnapGrid != null)
+                hitObject.StartTime = GetSnappedTime(hitObject.StartTime, distanceSnapGrid.ToLocalSpace(inputManager.CurrentState.Mouse.Position));
         }
 
         public void EndPlacement(HitObject hitObject) => EditorBeatmap.Add(hitObject);

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -27,6 +28,11 @@ namespace osu.Game.Rulesets.Objects
         /// A small adjustment to the start time of control points to account for rounding/precision errors.
         /// </summary>
         private const double control_point_leniency = 1;
+
+        /// <summary>
+        /// Invoked after <see cref="ApplyDefaults"/> has completed on this <see cref="HitObject"/>.
+        /// </summary>
+        public event Action DefaultsApplied;
 
         public readonly Bindable<double> StartTimeBindable = new Bindable<double>();
 
@@ -113,6 +119,8 @@ namespace osu.Game.Rulesets.Objects
 
             foreach (var h in nestedHitObjects)
                 h.ApplyDefaults(controlPointInfo, difficulty);
+
+            DefaultsApplied?.Invoke();
         }
 
         protected virtual void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             if (currentPlacement != null)
             {
-                currentPlacement.UpdatePosition(e.ScreenSpaceMousePosition);
+                updatePlacementPosition(e.ScreenSpaceMousePosition);
                 return true;
             }
 
@@ -187,9 +187,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 placementBlueprintContainer.Child = currentPlacement = blueprint;
 
                 // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame
-                blueprint.UpdatePosition(inputManager.CurrentState.Mouse.Position);
+                updatePlacementPosition(inputManager.CurrentState.Mouse.Position);
             }
         }
+
+        private void updatePlacementPosition(Vector2 screenSpacePosition) => currentPlacement.UpdatePosition(ToScreenSpace(composer.GetSnappedPosition(ToLocalSpace(screenSpacePosition))));
 
         /// <summary>
         /// Select all masks in a given rectangle selection area.

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -237,6 +238,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // Move the hitobjects
             selectionHandler.HandleMovement(new MoveSelectionEvent(blueprint, blueprint.ScreenSpaceMovementStartPosition, ToScreenSpace(snappedPosition)));
+
+            // Apply the start time at the newly snapped-to position
+            double offset = composer.GetSnappedTime(draggedObject.StartTime, snappedPosition) - draggedObject.StartTime;
+            foreach (HitObject obj in selectionHandler.SelectedHitObjects)
+                obj.StartTime += offset;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -231,7 +231,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void onDragRequested(SelectionBlueprint blueprint, DragEvent dragEvent)
         {
-            HitObject draggedObject = blueprint.HitObject.HitObject;
+            HitObject draggedObject = blueprint.DrawableObject.HitObject;
 
             Vector2 movePosition = blueprint.ScreenSpaceMovementStartPosition + dragEvent.ScreenSpaceMousePosition - dragEvent.ScreenSpaceMouseDownPosition;
             Vector2 snappedPosition = composer.GetSnappedPosition(ToLocalSpace(movePosition));

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -191,7 +191,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private void updatePlacementPosition(Vector2 screenSpacePosition) => currentPlacement.UpdatePosition(ToScreenSpace(composer.GetSnappedPosition(ToLocalSpace(screenSpacePosition))));
+        private void updatePlacementPosition(Vector2 screenSpacePosition)
+        {
+            Vector2 snappedGridPosition = composer.GetSnappedPosition(ToLocalSpace(screenSpacePosition));
+            Vector2 snappedScreenSpacePosition = ToScreenSpace(snappedGridPosition);
+
+            currentPlacement.UpdatePosition(snappedScreenSpacePosition);
+        }
 
         /// <summary>
         /// Select all masks in a given rectangle selection area.

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -230,9 +230,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void onDragRequested(SelectionBlueprint blueprint, DragEvent dragEvent)
         {
-            var movePosition = blueprint.ScreenSpaceMovementStartPosition + dragEvent.ScreenSpaceMousePosition - dragEvent.ScreenSpaceMouseDownPosition;
+            HitObject draggedObject = blueprint.HitObject.HitObject;
 
-            selectionHandler.HandleMovement(new MoveSelectionEvent(blueprint, blueprint.ScreenSpaceMovementStartPosition, movePosition));
+            Vector2 movePosition = blueprint.ScreenSpaceMovementStartPosition + dragEvent.ScreenSpaceMousePosition - dragEvent.ScreenSpaceMouseDownPosition;
+            Vector2 snappedPosition = composer.GetSnappedPosition(ToLocalSpace(movePosition));
+
+            // Move the hitobjects
+            selectionHandler.HandleMovement(new MoveSelectionEvent(blueprint, blueprint.ScreenSpaceMovementStartPosition, ToScreenSpace(snappedPosition)));
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -26,10 +26,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
     {
         public const float BORDER_RADIUS = 2;
 
-        protected IEnumerable<SelectionBlueprint> SelectedBlueprints => selectedBlueprints;
+        public IEnumerable<SelectionBlueprint> SelectedBlueprints => selectedBlueprints;
         private readonly List<SelectionBlueprint> selectedBlueprints;
 
-        protected IEnumerable<HitObject> SelectedHitObjects => selectedBlueprints.Select(b => b.HitObject.HitObject);
+        public IEnumerable<HitObject> SelectedHitObjects => selectedBlueprints.Select(b => b.HitObject.HitObject);
 
         private Drawable outline;
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/6527

Bit of a simple implementation for now, there are quite a few "bugs":
1. Dragging the slider start control point should snap the slider head.
2. Placing non-first control point should not snap.
3. Slider lengths should quantize to the nearest beat.
4. Dragging multiple selections should snap based on the earliest hitobject.

I want to tackle those in separate PRs because they're quite involved and will require some restructuring.