### PR TITLE
Fix distance snapping grid not updating on scroll

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -169,10 +169,7 @@ namespace osu.Game.Rulesets.Edit
             base.Update();
 
             if (EditorClock.CurrentTime != lastGridUpdateTime && blueprintContainer.CurrentTool != null)
-            {
                 showGridFor(Enumerable.Empty<HitObject>());
-                lastGridUpdateTime = EditorClock.CurrentTime;
-            }
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -217,9 +217,9 @@ namespace osu.Game.Rulesets.Edit
             {
                 distanceSnapGridContainer.Child = distanceSnapGrid;
                 distanceSnapGridContainer.Show();
-
-                lastGridUpdateTime = EditorClock.CurrentTime;
             }
+
+            lastGridUpdateTime = EditorClock.CurrentTime;
         }
 
         private ScheduledDelegate scheduledUpdate;

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -162,12 +162,17 @@ namespace osu.Game.Rulesets.Edit
             inputManager = GetContainingInputManager();
         }
 
+        private double lastGridUpdateTime;
+
         protected override void Update()
         {
             base.Update();
 
-            if (EditorClock.ElapsedFrameTime != 0 && blueprintContainer.CurrentTool != null)
+            if (EditorClock.CurrentTime != lastGridUpdateTime && blueprintContainer.CurrentTool != null)
+            {
                 showGridFor(Enumerable.Empty<HitObject>());
+                lastGridUpdateTime = EditorClock.CurrentTime;
+            }
         }
 
         protected override void UpdateAfterChildren()
@@ -212,6 +217,8 @@ namespace osu.Game.Rulesets.Edit
             {
                 distanceSnapGridContainer.Child = distanceSnapGrid;
                 distanceSnapGridContainer.Show();
+
+                lastGridUpdateTime = EditorClock.CurrentTime;
             }
         }
 


### PR DESCRIPTION
When scrolling, the elapsed frame time is 0, so the grid doesn't get refreshed.