### PR TITLE
Refactor blueprint movement and selection events

### DIFF
--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -36,19 +36,9 @@ namespace osu.Game.Rulesets.Edit
         public event Action<SelectionBlueprint, InputState> SelectionRequested;
 
         /// <summary>
-        /// Invoked when this <see cref="SelectionBlueprint"/> has requested drag.
-        /// </summary>
-        public event Action<SelectionBlueprint, DragEvent> DragRequested;
-
-        /// <summary>
         /// The <see cref="DrawableHitObject"/> which this <see cref="SelectionBlueprint"/> applies to.
         /// </summary>
         public readonly DrawableHitObject DrawableObject;
-
-        /// <summary>
-        /// The screen-space position of <see cref="DrawableObject"/> prior to handling a movement event.
-        /// </summary>
-        internal Vector2 ScreenSpaceMovementStartPosition { get; private set; }
 
         protected override bool ShouldBeAlive => (DrawableObject.IsAlive && DrawableObject.IsPresent) || State == SelectionState.Selected;
         public override bool HandlePositionalInput => ShouldBeAlive;
@@ -134,18 +124,6 @@ namespace osu.Game.Rulesets.Edit
             }
 
             return base.OnClick(e);
-        }
-
-        protected override bool OnDragStart(DragStartEvent e)
-        {
-            ScreenSpaceMovementStartPosition = DrawableObject.ToScreenSpace(DrawableObject.OriginPosition);
-            return true;
-        }
-
-        protected override bool OnDrag(DragEvent e)
-        {
-            DragRequested?.Invoke(this, e);
-            return true;
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -6,8 +6,6 @@ using osu.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
-using osu.Framework.Input.Events;
-using osu.Framework.Input.States;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
@@ -28,12 +26,6 @@ namespace osu.Game.Rulesets.Edit
         /// Invoked when this <see cref="SelectionBlueprint"/> has been deselected.
         /// </summary>
         public event Action<SelectionBlueprint> Deselected;
-
-        /// <summary>
-        /// Invoked when this <see cref="SelectionBlueprint"/> has requested selection.
-        /// Will fire even if already selected. Does not actually perform selection.
-        /// </summary>
-        public event Action<SelectionBlueprint, InputState> SelectionRequested;
 
         /// <summary>
         /// The <see cref="DrawableHitObject"/> which this <see cref="SelectionBlueprint"/> applies to.
@@ -98,33 +90,6 @@ namespace osu.Game.Rulesets.Edit
         public bool IsSelected => State == SelectionState.Selected;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => DrawableObject.ReceivePositionalInputAt(screenSpacePos);
-
-        private bool selectionRequested;
-
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            selectionRequested = false;
-
-            if (State == SelectionState.NotSelected)
-            {
-                SelectionRequested?.Invoke(this, e.CurrentState);
-                selectionRequested = true;
-            }
-
-            return IsSelected;
-        }
-
-        protected override bool OnClick(ClickEvent e)
-        {
-            if (State == SelectionState.Selected && !selectionRequested)
-            {
-                selectionRequested = true;
-                SelectionRequested?.Invoke(this, e.CurrentState);
-                return true;
-            }
-
-            return base.OnClick(e);
-        }
 
         /// <summary>
         /// The screen-space point that causes this <see cref="SelectionBlueprint"/> to be selected.

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
     {
         public event Action<IEnumerable<HitObject>> SelectionChanged;
 
+        private DragBox dragBox;
         private SelectionBlueprintContainer selectionBlueprints;
         private Container<PlacementBlueprint> placementBlueprintContainer;
         private PlacementBlueprint currentPlacement;
@@ -46,12 +47,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             selectionHandler = composer.CreateSelectionHandler();
             selectionHandler.DeselectAll = deselectAll;
 
-            var dragBox = new DragBox(select);
-            dragBox.DragEnd += () => selectionHandler.UpdateVisibility();
-
             InternalChildren = new[]
             {
-                dragBox,
+                dragBox = new DragBox(select),
                 selectionHandler,
                 selectionBlueprints = new SelectionBlueprintContainer { RelativeSizeAxes = Axes.Both },
                 placementBlueprintContainer = new Container<PlacementBlueprint> { RelativeSizeAxes = Axes.Both },
@@ -228,6 +226,28 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         private void onSelectionRequested(SelectionBlueprint blueprint, InputState state) => selectionHandler.HandleSelectionRequested(blueprint, state);
+
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            if (!selectionHandler.SelectedBlueprints.Any(b => b.IsHovered))
+                dragBox.FadeIn(250, Easing.OutQuint);
+
+            return true;
+        }
+
+        protected override bool OnDrag(DragEvent e)
+        {
+            dragBox.UpdateDrag(e);
+            return true;
+        }
+
+        protected override bool OnDragEnd(DragEndEvent e)
+        {
+            dragBox.FadeOut(250, Easing.OutQuint);
+            selectionHandler.UpdateVisibility();
+
+            return true;
+        }
 
         private void onDragRequested(SelectionBlueprint blueprint, DragEvent dragEvent)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -109,7 +109,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             blueprint.Selected -= onBlueprintSelected;
             blueprint.Deselected -= onBlueprintDeselected;
-            blueprint.SelectionRequested -= onSelectionRequested;
 
             selectionBlueprints.Remove(blueprint);
         }
@@ -124,15 +123,31 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             blueprint.Selected += onBlueprintSelected;
             blueprint.Deselected += onBlueprintDeselected;
-            blueprint.SelectionRequested += onSelectionRequested;
 
             selectionBlueprints.Add(blueprint);
         }
 
         private void removeBlueprintFor(DrawableHitObject hitObject) => removeBlueprintFor(hitObject.HitObject);
 
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            foreach (SelectionBlueprint blueprint in selectionBlueprints.AliveBlueprints)
+            {
+                if (blueprint.IsHovered)
+                {
+                    selectionHandler.HandleSelectionRequested(blueprint, e.CurrentState);
+                    break;
+                }
+            }
+
+            return true;
+        }
+
         protected override bool OnClick(ClickEvent e)
         {
+            if (selectionBlueprints.AliveBlueprints.Any(b => b.IsHovered))
+                return true;
+
             deselectAll();
             return true;
         }
@@ -298,6 +313,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private class SelectionBlueprintContainer : Container<SelectionBlueprint>
         {
+            public IEnumerable<SelectionBlueprint> AliveBlueprints => AliveInternalChildren.Cast<SelectionBlueprint>();
+
             protected override int Compare(Drawable x, Drawable y)
             {
                 if (!(x is SelectionBlueprint xBlueprint) || !(y is SelectionBlueprint yBlueprint))

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -89,43 +89,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private void addBlueprintFor(HitObject hitObject)
-        {
-            var drawable = composer.HitObjects.FirstOrDefault(d => d.HitObject == hitObject);
-            if (drawable == null)
-                return;
-
-            addBlueprintFor(drawable);
-        }
-
-        private void removeBlueprintFor(HitObject hitObject)
-        {
-            var blueprint = selectionBlueprints.Single(m => m.DrawableObject.HitObject == hitObject);
-            if (blueprint == null)
-                return;
-
-            blueprint.Deselect();
-
-            blueprint.Selected -= onBlueprintSelected;
-            blueprint.Deselected -= onBlueprintDeselected;
-
-            selectionBlueprints.Remove(blueprint);
-        }
-
-        private void addBlueprintFor(DrawableHitObject hitObject)
-        {
-            refreshTool();
-
-            var blueprint = composer.CreateBlueprintFor(hitObject);
-            if (blueprint == null)
-                return;
-
-            blueprint.Selected += onBlueprintSelected;
-            blueprint.Deselected += onBlueprintDeselected;
-
-            selectionBlueprints.Add(blueprint);
-        }
-
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             beginClickSelection(e);
@@ -201,6 +164,49 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
+        #region Blueprint Addition/Removal
+
+        private void addBlueprintFor(HitObject hitObject)
+        {
+            var drawable = composer.HitObjects.FirstOrDefault(d => d.HitObject == hitObject);
+            if (drawable == null)
+                return;
+
+            addBlueprintFor(drawable);
+        }
+
+        private void removeBlueprintFor(HitObject hitObject)
+        {
+            var blueprint = selectionBlueprints.Single(m => m.DrawableObject.HitObject == hitObject);
+            if (blueprint == null)
+                return;
+
+            blueprint.Deselect();
+
+            blueprint.Selected -= onBlueprintSelected;
+            blueprint.Deselected -= onBlueprintDeselected;
+
+            selectionBlueprints.Remove(blueprint);
+        }
+
+        private void addBlueprintFor(DrawableHitObject hitObject)
+        {
+            refreshTool();
+
+            var blueprint = composer.CreateBlueprintFor(hitObject);
+            if (blueprint == null)
+                return;
+
+            blueprint.Selected += onBlueprintSelected;
+            blueprint.Deselected += onBlueprintDeselected;
+
+            selectionBlueprints.Add(blueprint);
+        }
+
+        #endregion
+
+        #region Placement
+
         /// <summary>
         /// Refreshes the current placement tool.
         /// </summary>
@@ -227,6 +233,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             currentPlacement.UpdatePosition(snappedScreenSpacePosition);
         }
+
+        #endregion
 
         #region Selection
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Framework.Input.States;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Objects;
@@ -127,8 +126,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             selectionBlueprints.Add(blueprint);
         }
 
-        private void removeBlueprintFor(DrawableHitObject hitObject) => removeBlueprintFor(hitObject.HitObject);
-
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             foreach (SelectionBlueprint blueprint in selectionBlueprints.AliveBlueprints)
@@ -238,8 +235,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             SelectionChanged?.Invoke(selectionHandler.SelectedHitObjects);
         }
-
-        private void onSelectionRequested(SelectionBlueprint blueprint, InputState state) => selectionHandler.HandleSelectionRequested(blueprint, state);
 
         private Vector2? screenSpaceMovementStartPosition;
         private SelectionBlueprint movementBlueprint;

--- a/osu.Game/Screens/Edit/Compose/Components/DragBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DragBox.cs
@@ -19,11 +19,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
     {
         private readonly Action<RectangleF> performSelection;
 
-        /// <summary>
-        /// Invoked when the drag selection has finished.
-        /// </summary>
-        public event Action DragEnd;
-
         private Drawable box;
 
         /// <summary>
@@ -55,13 +50,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
         }
 
-        protected override bool OnDragStart(DragStartEvent e)
-        {
-            this.FadeIn(250, Easing.OutQuint);
-            return true;
-        }
-
-        protected override bool OnDrag(DragEvent e)
+        public void UpdateDrag(DragEvent e)
         {
             var dragPosition = e.ScreenSpaceMousePosition;
             var dragStartPosition = e.ScreenSpaceMouseDownPosition;
@@ -78,14 +67,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             box.Size = bottomRight - topLeft;
 
             performSelection?.Invoke(dragRectangle);
-            return true;
-        }
-
-        protected override bool OnDragEnd(DragEndEvent e)
-        {
-            this.FadeOut(250, Easing.OutQuint);
-            DragEnd?.Invoke();
-            return true;
         }
     }
 }


### PR DESCRIPTION
Sorry about the scope creep here. The initial purpose of this was to make hitobject movement occur relative to the earliest of the selected hitobjects, but this turned into a full refactor of all related input handling.

In general: `BlueprintContainer` now handles all input events - drag-selection, click-selection, and drag-movement.
1. `DragBox` no longer handles drag, and instead takes in a drag event to update its display. The visibility of the box is handled by `BlueprintContainer`.
2. `SelectionBlueprint` no longer handles click selection, it is done by the `BlueprintContainer`. The `SelectionRequested` event has been removed.
3. `SelectionBlueprint` no longer handles drag movement, it is done by the `BlueprintContainer`. The `DragRequested` event has been removed and the screen space movement start position has been moved to the `BlueprintContainer`.
    1. This refactoring required changing to how the "movement" hitobject is selected (the one that previously invoked the `DragRequested` event). I've changed it to use the earliest hitobject thus satisfying the original purpose of the changes (it's a one-liner after the rest of the changes). https://github.com/ppy/osu/compare/master...smoogipoo:selection-dragged-blueprint?expand=1#diff-898e934c9e7b74048922afff49d889caR335

The rest of the changes are methods moved around in the file, both to satisfy public -> protected -> private, and to place related methods together.