### PR TITLE
Implement slider distance snapping

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuDistanceSnapGrid.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void assertSnappedDistance(float expectedDistance) => AddAssert($"snap distance = {expectedDistance}", () =>
         {
-            Vector2 snappedPosition = grid.GetSnapPosition(grid.ToLocalSpace(InputManager.CurrentState.Mouse.Position));
+            Vector2 snappedPosition = grid.GetSnappedPosition(grid.ToLocalSpace(InputManager.CurrentState.Mouse.Position));
             float distance = Vector2.Distance(snappedPosition, grid_position);
 
             return Precision.AlmostEquals(expectedDistance, distance);
@@ -160,7 +160,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                         Colour = Color4.SlateGray
                     },
                     grid = new TestOsuDistanceSnapGrid(new HitCircle { Position = grid_position }),
-                    new SnappingCursorContainer { GetSnapPosition = v => grid.GetSnapPosition(grid.ToLocalSpace(v)) }
+                    new SnappingCursorContainer { GetSnapPosition = v => grid.GetSnappedPosition(grid.ToLocalSpace(v)) }
                 };
             });
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -8,7 +9,6 @@ using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 {
     public class PathControlPointPiece : BlueprintPiece<Slider>
     {
+        public Action<Vector2[]> ControlPointsChanged;
+
         private readonly Slider slider;
         private readonly int index;
 
@@ -96,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (isSegmentSeparatorWithPrevious)
                 newControlPoints[index - 1] = newControlPoints[index];
 
-            slider.Path = new SliderPath(slider.Path.Type, newControlPoints);
+            ControlPointsChanged?.Invoke(newControlPoints);
 
             return true;
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -1,14 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Osu.Objects;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 {
     public class PathControlPointVisualiser : CompositeDrawable
     {
+        public Action<Vector2[]> ControlPointsChanged;
+
         private readonly Slider slider;
 
         private readonly Container<PathControlPointPiece> pieces;
@@ -25,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             base.Update();
 
             while (slider.Path.ControlPoints.Length > pieces.Count)
-                pieces.Add(new PathControlPointPiece(slider, pieces.Count));
+                pieces.Add(new PathControlPointPiece(slider, pieces.Count) { ControlPointsChanged = c => ControlPointsChanged?.Invoke(c) });
             while (slider.Path.ControlPoints.Length < pieces.Count)
                 pieces.Remove(pieces[pieces.Count - 1]);
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             var unsnappedPath = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints);
             var snappedDistance = composer?.GetSnappedDistance((float)unsnappedPath.Distance) ?? (float)unsnappedPath.Distance;
 
-            HitObject.Path = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints, snappedDistance);
+            HitObject.Path = new SliderPath(unsnappedPath.Type, newControlPoints, snappedDistance);
 
             bodyPiece.UpdateFrom(HitObject);
             headCirclePiece.UpdateFrom(HitObject.HeadCircle);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private PlacementState state;
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private HitObjectComposer composer { get; set; }
 
         public SliderPlacementBlueprint()
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             Vector2[] newControlPoints = segments.SelectMany(s => s.ControlPoints).Concat(cursor.Yield()).ToArray();
 
             var unsnappedPath = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints);
-            var snappedDistance = composer.GetSnappedDistance((float)unsnappedPath.Distance);
+            var snappedDistance = composer?.GetSnappedDistance((float)unsnappedPath.Distance) ?? (float)unsnappedPath.Distance;
 
             HitObject.Path = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints, snappedDistance);
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 bodyPiece = new SliderBodyPiece(),
                 headCirclePiece = new HitCirclePiece(),
                 tailCirclePiece = new HitCirclePiece(),
-                new PathControlPointVisualiser(HitObject),
+                new PathControlPointVisualiser(HitObject) { ControlPointsChanged = _ => updateSlider() },
             };
 
             setState(PlacementState.Initial);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -33,6 +33,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private PlacementState state;
 
+        [Resolved]
+        private HitObjectComposer composer { get; set; }
+
         public SliderPlacementBlueprint()
             : base(new Objects.Slider())
         {
@@ -131,8 +134,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateSlider()
         {
-            var newControlPoints = segments.SelectMany(s => s.ControlPoints).Concat(cursor.Yield()).ToArray();
-            HitObject.Path = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints);
+            Vector2[] newControlPoints = segments.SelectMany(s => s.ControlPoints).Concat(cursor.Yield()).ToArray();
+
+            var unsnappedPath = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints);
+            var snappedDistance = composer.GetSnappedDistance((float)unsnappedPath.Distance);
+
+            HitObject.Path = new SliderPath(newControlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, newControlPoints, snappedDistance);
 
             bodyPiece.UpdateFrom(HitObject);
             headCirclePiece.UpdateFrom(HitObject.HeadCircle);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         protected readonly SliderCircleSelectionBlueprint HeadBlueprint;
         protected readonly SliderCircleSelectionBlueprint TailBlueprint;
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private HitObjectComposer composer { get; set; }
 
         public SliderSelectionBlueprint(DrawableSlider slider)
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private void onNewControlPoints(Vector2[] controlPoints)
         {
             var unsnappedPath = new SliderPath(controlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, controlPoints);
-            var snappedDistance = composer.GetSnappedDistance((float)unsnappedPath.Distance);
+            var snappedDistance = composer?.GetSnappedDistance((float)unsnappedPath.Distance) ?? (float)unsnappedPath.Distance;
 
             HitObject.Path = new SliderPath(unsnappedPath.Type, controlPoints, snappedDistance);
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -15,6 +19,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         protected readonly SliderCircleSelectionBlueprint HeadBlueprint;
         protected readonly SliderCircleSelectionBlueprint TailBlueprint;
 
+        [Resolved]
+        private HitObjectComposer composer { get; set; }
+
         public SliderSelectionBlueprint(DrawableSlider slider)
             : base(slider)
         {
@@ -25,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 BodyPiece = new SliderBodyPiece(),
                 HeadBlueprint = CreateCircleSelectionBlueprint(slider, SliderPosition.Start),
                 TailBlueprint = CreateCircleSelectionBlueprint(slider, SliderPosition.End),
-                new PathControlPointVisualiser(sliderObject),
+                new PathControlPointVisualiser(sliderObject) { ControlPointsChanged = onNewControlPoints },
             };
         }
 
@@ -34,6 +41,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             base.Update();
 
             BodyPiece.UpdateFrom(HitObject);
+        }
+
+        private void onNewControlPoints(Vector2[] controlPoints)
+        {
+            var unsnappedPath = new SliderPath(controlPoints.Length > 2 ? PathType.Bezier : PathType.Linear, controlPoints);
+            var snappedDistance = composer.GetSnappedDistance((float)unsnappedPath.Distance);
+
+            HitObject.Path = new SliderPath(unsnappedPath.Type, controlPoints, snappedDistance);
         }
 
         public override Vector2 SelectionPoint => HeadBlueprint.SelectionPoint;

--- a/osu.Game.Tests/Visual/Editor/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneDistanceSnapGrid.cs
@@ -106,10 +106,10 @@ namespace osu.Game.Tests.Visual.Editor
 
             Vector2 snapPosition = Vector2.Zero;
             AddStep("get first tick position", () => snapPosition = grid_position + new Vector2((float)beat_length, 0));
-            AddAssert("snap time is 1 beat away", () => Precision.AlmostEquals(beat_length, grid.GetSnapTime(snapPosition), 0.01));
+            AddAssert("snap time is 1 beat away", () => Precision.AlmostEquals(beat_length, grid.GetSnappedTime(snapPosition), 0.01));
 
             createGrid(g => g.Velocity = 2, "with velocity = 2");
-            AddAssert("snap time is now 0.5 beats away", () => Precision.AlmostEquals(beat_length / 2, grid.GetSnapTime(snapPosition), 0.01));
+            AddAssert("snap time is now 0.5 beats away", () => Precision.AlmostEquals(beat_length / 2, grid.GetSnappedTime(snapPosition), 0.01));
         }
 
         private void createGrid(Action<TestDistanceSnapGrid> func = null, string description = null)
@@ -206,7 +206,7 @@ namespace osu.Game.Tests.Visual.Editor
             protected override float GetVelocity(double time, ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
                 => Velocity;
 
-            public override Vector2 GetSnapPosition(Vector2 screenSpacePosition)
+            public override Vector2 GetSnappedPosition(Vector2 screenSpacePosition)
                 => Vector2.Zero;
         }
     }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -257,11 +257,11 @@ namespace osu.Game.Rulesets.Edit
 
         public void Delete(HitObject hitObject) => EditorBeatmap.Remove(hitObject);
 
-        public override Vector2 GetSnappedPosition(Vector2 position) => distanceSnapGrid?.GetSnapPosition(position) ?? position;
+        public override Vector2 GetSnappedPosition(Vector2 position) => distanceSnapGrid?.GetSnappedPosition(position) ?? position;
 
-        public override double GetSnappedTime(double startTime, Vector2 position) => distanceSnapGrid?.GetSnapTime(position) ?? startTime;
+        public override double GetSnappedTime(double startTime, Vector2 position) => distanceSnapGrid?.GetSnappedTime(position) ?? startTime;
 
-        public override float GetSnappedDistance(float distance) => distanceSnapGrid?.GetSnapDistance(distance) ?? distance;
+        public override float GetSnappedDistance(float distance) => distanceSnapGrid?.GetSnappedDistance(distance) ?? distance;
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -261,6 +261,8 @@ namespace osu.Game.Rulesets.Edit
 
         public override double GetSnappedTime(double startTime, Vector2 position) => distanceSnapGrid?.GetSnapTime(position) ?? startTime;
 
+        public override float GetSnappedDistance(float distance) => distanceSnapGrid?.GetSnapDistance(distance) ?? distance;
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
@@ -313,5 +315,7 @@ namespace osu.Game.Rulesets.Edit
         public abstract Vector2 GetSnappedPosition(Vector2 position);
 
         public abstract double GetSnappedTime(double startTime, Vector2 screenSpacePosition);
+
+        public abstract float GetSnappedDistance(float distance);
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        public override Vector2 GetSnapPosition(Vector2 position)
+        public override Vector2 GetSnappedPosition(Vector2 position)
         {
             Vector2 direction = position - CentrePosition;
 

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Snaps a distance by the snap distance of this grid.
         /// </summary>
-        /// <param name="distance">The distance to snap.</param>
+        /// <param name="distance">The distance to snap in coordinate space local to this <see cref="DistanceSnapGrid"/>.</param>
         /// <returns>The snapped distance.</returns>
         public float GetSnappedDistance(float distance) => (int)(distance / DistanceSpacing) * DistanceSpacing;
 

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -129,6 +129,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public double GetSnapTime(Vector2 position) => startTime + (position - CentrePosition).Length / Velocity;
 
         /// <summary>
+        /// Snaps a distance by the snap distance of this grid.
+        /// </summary>
+        /// <param name="distance">The distance to snap.</param>
+        /// <returns>The snapped distance.</returns>
+        public float GetSnapDistance(float distance) => (int)(distance / DistanceSpacing) * DistanceSpacing;
+
+        /// <summary>
         /// Retrieves the applicable colour for a beat index.
         /// </summary>
         /// <param name="index">The 0-based beat index.</param>

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -119,21 +119,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <param name="position">The original position in coordinate space local to this <see cref="DistanceSnapGrid"/>.</param>
         /// <returns>The snapped position in coordinate space local to this <see cref="DistanceSnapGrid"/>.</returns>
-        public abstract Vector2 GetSnapPosition(Vector2 position);
+        public abstract Vector2 GetSnappedPosition(Vector2 position);
 
         /// <summary>
         /// Retrieves the time at a snapped position.
         /// </summary>
         /// <param name="position">The snapped position in coordinate space local to this <see cref="DistanceSnapGrid"/>.</param>
         /// <returns>The time at the snapped position.</returns>
-        public double GetSnapTime(Vector2 position) => startTime + (position - CentrePosition).Length / Velocity;
+        public double GetSnappedTime(Vector2 position) => startTime + (position - CentrePosition).Length / Velocity;
 
         /// <summary>
         /// Snaps a distance by the snap distance of this grid.
         /// </summary>
         /// <param name="distance">The distance to snap.</param>
         /// <returns>The snapped distance.</returns>
-        public float GetSnapDistance(float distance) => (int)(distance / DistanceSpacing) * DistanceSpacing;
+        public float GetSnappedDistance(float distance) => (int)(distance / DistanceSpacing) * DistanceSpacing;
 
         /// <summary>
         /// Retrieves the applicable colour for a beat index.


### PR DESCRIPTION
I don't know why `SliderPath` returns a `double` distance. Will probably fix later.