### PR TITLE
Add support for Markdown inline links

### DIFF
--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -274,6 +274,54 @@ namespace osu.Game.Tests.Chat
         }
 
         [Test]
+        public void TestMarkdownFormatLinkWithInlineTitle()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [this link format](https://osu.ppy.sh \"osu!\") before..." });
+
+            Assert.AreEqual("I haven't seen this link format before...", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(15, result.Links[0].Index);
+            Assert.AreEqual(16, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestMarkdownFormatLinkWithInlineTitleAndEscapedQuotes()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [this link format](https://osu.ppy.sh \"inner quote \\\" just to confuse \") before..." });
+
+            Assert.AreEqual("I haven't seen this link format before...", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(15, result.Links[0].Index);
+            Assert.AreEqual(16, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestMarkdownFormatLinkWithUrlInTextAndInlineTitle()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [https://osu.ppy.sh](https://osu.ppy.sh \"https://osu.ppy.sh\") before..." });
+
+            Assert.AreEqual("I haven't seen https://osu.ppy.sh before...", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(15, result.Links[0].Index);
+            Assert.AreEqual(18, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestMarkdownFormatLinkWithMisleadingUrlInText()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [https://google.com](https://osu.ppy.sh) before..." });
+
+            Assert.AreEqual("I haven't seen https://google.com before...", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(15, result.Links[0].Index);
+            Assert.AreEqual(18, result.Links[0].Length);
+        }
+
+        [Test]
         public void TestChannelLink()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is an #english and #japanese." });

--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -334,6 +334,36 @@ namespace osu.Game.Tests.Chat
         }
 
         [Test]
+        public void TestMarkdownFormatLinkThatContractsIntoLargerLink()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "super broken https://[osu.ppy](https://reddit.com).sh/" });
+
+            Assert.AreEqual("super broken https://osu.ppy.sh/", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://reddit.com", result.Links[0].Url);
+            Assert.AreEqual(21, result.Links[0].Index);
+            Assert.AreEqual(7, result.Links[0].Length);
+        }
+
+        [Test]
+        public void TestMarkdownFormatLinkDirectlyNextToRawLink()
+        {
+            // the raw link has a port at the end of it, so that the raw link regex terminates at the port and doesn't consume display text from the formatted one
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "https://localhost:8080[https://osu.ppy.sh](https://osu.ppy.sh) should be two links" });
+
+            Assert.AreEqual("https://localhost:8080https://osu.ppy.sh should be two links", result.DisplayContent);
+            Assert.AreEqual(2, result.Links.Count);
+
+            Assert.AreEqual("https://localhost:8080", result.Links[0].Url);
+            Assert.AreEqual(0, result.Links[0].Index);
+            Assert.AreEqual(22, result.Links[0].Length);
+
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[1].Url);
+            Assert.AreEqual(22, result.Links[1].Index);
+            Assert.AreEqual(18, result.Links[1].Length);
+        }
+
+        [Test]
         public void TestChannelLink()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is an #english and #japanese." });

--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -310,6 +310,18 @@ namespace osu.Game.Tests.Chat
         }
 
         [Test]
+        public void TestMarkdownFormatLinkWithUrlAndTextInTitle()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [oh no, text here! https://osu.ppy.sh](https://osu.ppy.sh) before..." });
+
+            Assert.AreEqual("I haven't seen oh no, text here! https://osu.ppy.sh before...", result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual("https://osu.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual(15, result.Links[0].Index);
+            Assert.AreEqual(36, result.Links[0].Length);
+        }
+
+        [Test]
         public void TestMarkdownFormatLinkWithMisleadingUrlInText()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "I haven't seen [https://google.com](https://osu.ppy.sh) before..." });

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Online.Chat
                 // sometimes an already-processed formatted link can reduce to a simple URL, too
                 // (example: [mean example - https://osu.ppy.sh](https://osu.ppy.sh))
                 // therefore we need to check if any of the pre-existing links contains the raw one we found
-                if (result.Links.All(existingLink => !existingLink.Contains(link)))
+                if (result.Links.All(existingLink => !existingLink.Overlaps(link)))
                     result.Links.Add(link);
             }
         }
@@ -298,7 +298,7 @@ namespace osu.Game.Online.Chat
             Argument = argument;
         }
 
-        public bool Contains(Link otherLink) => otherLink.Index >= Index && otherLink.Index + otherLink.Length <= Index + Length;
+        public bool Overlaps(Link otherLink) => Index < otherLink.Index + otherLink.Length && otherLink.Index < Index + Length;
 
         public int CompareTo(Link otherLink) => Index > otherLink.Index ? 1 : -1;
     }

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -95,11 +95,17 @@ namespace osu.Game.Online.Chat
             foreach (Match m in regex.Matches(result.Text, startIndex))
             {
                 var index = m.Index;
-                var link = m.Groups["link"].Value;
-                var indexLength = link.Length;
+                var linkText = m.Groups["link"].Value;
+                var indexLength = linkText.Length;
 
-                var details = getLinkDetails(link);
-                result.Links.Add(new Link(link, index, indexLength, details.Action, details.Argument));
+                var details = getLinkDetails(linkText);
+                var link = new Link(linkText, index, indexLength, details.Action, details.Argument);
+
+                // sometimes an already-processed formatted link can reduce to a simple URL, too
+                // (example: [mean example - https://osu.ppy.sh](https://osu.ppy.sh))
+                // therefore we need to check if any of the pre-existing links contains the raw one we found
+                if (result.Links.All(existingLink => !existingLink.Contains(link)))
+                    result.Links.Add(link);
             }
         }
 
@@ -291,6 +297,8 @@ namespace osu.Game.Online.Chat
             Action = action;
             Argument = argument;
         }
+
+        public bool Contains(Link otherLink) => otherLink.Index >= Index && otherLink.Index + otherLink.Length <= Index + Length;
 
         public int CompareTo(Link otherLink) => Index > otherLink.Index ? 1 : -1;
     }

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -20,7 +20,7 @@ namespace osu.Game.Online.Chat
         private static readonly Regex new_link_regex = new Regex(@"\[(?<url>[a-z]+://[^ ]+) (?<text>(((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]");
 
         // [test](https://osu.ppy.sh/b/1234) -> test (https://osu.ppy.sh/b/1234) aka correct markdown format
-        private static readonly Regex markdown_link_regex = new Regex(@"\[(?<text>(((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]\((?<url>[a-z]+://[^ ]+)\)");
+        private static readonly Regex markdown_link_regex = new Regex(@"\[(?<text>(((?<=\\)[\[\]])|[^\[\]])*(((?<open>\[)(((?<=\\)[\[\]])|[^\[\]])*)+((?<close-open>\])(((?<=\\)[\[\]])|[^\[\]])*)+)*(?(open)(?!)))\]\((?<url>[a-z]+://[^ ]+)(\s+(?<title>""([^""]|(?<=\\)"")*""))?\)");
 
         // advanced, RFC-compatible regular expression that matches any possible URL, *but* allows certain invalid characters that are widely used
         // This is in the format (<required>, [optional]):


### PR DESCRIPTION
# Summary

While reviewing #6542 it became apparent that there was another Markdown link format variant, used in comments that came from the web API, called the "inline link" style. It allows to specify the tooltip title within the actual URL portion, as such:
```
[link text](https://osu.ppy.sh "tooltip text")
```
Extend the Markdown parsing regex to allow parsing these inline links. Within the parenthesis () part of the Markdown URL syntax, introduce a new capturing group:
```
    (
      \s+              // whitespace between actual URL and inline title
      (?<title>        // start of "title" named group
        ""             // opening double quote (doubled inside @ string)
        (
          [^""]        // any character but a double quote
          |            // or
          (?<=\\)      // the next character should be preceded by a \
          ""           // a double quote
        )*             // zero or more times
        ""             // closing double quote
      )
    )?                 // the whole group is optional
```
This allows for parsing the inline links as-provided by web, with support for escaping double quotes inside of the title part. Correctness is displayed by the passing tests.

Testing with #6542 additionally surfaced a latent bug leading to a crash, caused by formatted links that had URLs in the display text, for example
```
[mean example - https://osu.ppy.sh](https://osu.ppy.sh)
```
In that case the outer Markdown link would get picked up once, and then reduced to the link text when looking for other links, leading to it being picked up again the second time when the raw link is found.

To resolve that case, add a check in the raw link parsing path that ensures that the found URL is not a part of a bigger, pre-existing link.

# Remarks

I'm not currently using the `title` named group to change mouseover text as web seems to do, since as discussed in Discord it could lead to users posting links with in chat or in comments with misleading tooltip text.