### PR TITLE
Replace local Equatable implementations with abstract EquivalentTo

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace osu.Game.Beatmaps.ControlPoints
 {
-    public class ControlPoint : IComparable<ControlPoint>, IEquatable<ControlPoint>
+    public abstract class ControlPoint : IComparable<ControlPoint>, IEquatable<ControlPoint>
     {
         /// <summary>
         /// The time at which the control point takes effect.
@@ -19,7 +19,13 @@ namespace osu.Game.Beatmaps.ControlPoints
 
         public int CompareTo(ControlPoint other) => Time.CompareTo(other.Time);
 
-        public bool Equals(ControlPoint other)
-            => Time.Equals(other?.Time);
+        /// <summary>
+        /// Whether this control point is equivalent to another, ignoring time.
+        /// </summary>
+        /// <param name="other">Another control point to compare with.</param>
+        /// <returns>Whether equivalent.</returns>
+        public abstract bool EquivalentTo(ControlPoint other);
+
+        public bool Equals(ControlPoint other) => Time.Equals(other?.Time) && EquivalentTo(other);
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
@@ -1,12 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osuTK;
 
 namespace osu.Game.Beatmaps.ControlPoints
 {
-    public class DifficultyControlPoint : ControlPoint, IEquatable<DifficultyControlPoint>
+    public class DifficultyControlPoint : ControlPoint
     {
         /// <summary>
         /// The speed multiplier at this control point.
@@ -19,8 +18,7 @@ namespace osu.Game.Beatmaps.ControlPoints
 
         private double speedMultiplier = 1;
 
-        public bool Equals(DifficultyControlPoint other)
-            => base.Equals(other)
-               && SpeedMultiplier.Equals(other?.SpeedMultiplier);
+        public override bool EquivalentTo(ControlPoint other) =>
+            other is DifficultyControlPoint otherTyped && otherTyped.SpeedMultiplier.Equals(speedMultiplier);
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/EffectControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/EffectControlPoint.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-
 namespace osu.Game.Beatmaps.ControlPoints
 {
-    public class EffectControlPoint : ControlPoint, IEquatable<EffectControlPoint>
+    public class EffectControlPoint : ControlPoint
     {
         /// <summary>
         /// Whether this control point enables Kiai mode.
@@ -17,8 +15,8 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         public bool OmitFirstBarLine;
 
-        public bool Equals(EffectControlPoint other)
-            => base.Equals(other)
-               && KiaiMode == other?.KiaiMode && OmitFirstBarLine == other.OmitFirstBarLine;
+        public override bool EquivalentTo(ControlPoint other) =>
+            other is EffectControlPoint otherTyped &&
+            KiaiMode == otherTyped.KiaiMode && OmitFirstBarLine == otherTyped.OmitFirstBarLine;
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
@@ -1,12 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Game.Audio;
 
 namespace osu.Game.Beatmaps.ControlPoints
 {
-    public class SampleControlPoint : ControlPoint, IEquatable<SampleControlPoint>
+    public class SampleControlPoint : ControlPoint
     {
         public const string DEFAULT_BANK = "normal";
 
@@ -45,8 +44,8 @@ namespace osu.Game.Beatmaps.ControlPoints
             return newSampleInfo;
         }
 
-        public bool Equals(SampleControlPoint other)
-            => base.Equals(other)
-               && string.Equals(SampleBank, other?.SampleBank) && SampleVolume == other?.SampleVolume;
+        public override bool EquivalentTo(ControlPoint other) =>
+            other is SampleControlPoint otherTyped &&
+            string.Equals(SampleBank, otherTyped?.SampleBank) && SampleVolume == otherTyped?.SampleVolume;
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
@@ -46,6 +46,6 @@ namespace osu.Game.Beatmaps.ControlPoints
 
         public override bool EquivalentTo(ControlPoint other) =>
             other is SampleControlPoint otherTyped &&
-            string.Equals(SampleBank, otherTyped?.SampleBank) && SampleVolume == otherTyped?.SampleVolume;
+            string.Equals(SampleBank, otherTyped.SampleBank) && SampleVolume == otherTyped.SampleVolume;
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -28,6 +28,6 @@ namespace osu.Game.Beatmaps.ControlPoints
 
         public override bool EquivalentTo(ControlPoint other) =>
             other is TimingControlPoint otherTyped
-            && TimeSignature == otherTyped?.TimeSignature && beatLength.Equals(otherTyped.beatLength);
+            && TimeSignature == otherTyped.TimeSignature && beatLength.Equals(otherTyped.beatLength);
     }
 }

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -1,13 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osuTK;
 using osu.Game.Beatmaps.Timing;
 
 namespace osu.Game.Beatmaps.ControlPoints
 {
-    public class TimingControlPoint : ControlPoint, IEquatable<TimingControlPoint>
+    public class TimingControlPoint : ControlPoint
     {
         /// <summary>
         /// The time signature at this control point.
@@ -27,8 +26,8 @@ namespace osu.Game.Beatmaps.ControlPoints
 
         private double beatLength = DEFAULT_BEAT_LENGTH;
 
-        public bool Equals(TimingControlPoint other)
-            => base.Equals(other)
-               && TimeSignature == other?.TimeSignature && beatLength.Equals(other.beatLength);
+        public override bool EquivalentTo(ControlPoint other) =>
+            other is TimingControlPoint otherTyped
+            && TimeSignature == otherTyped?.TimeSignature && beatLength.Equals(otherTyped.beatLength);
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -204,8 +204,8 @@ namespace osu.Game.Beatmaps.Formats
             }
 
             public override bool EquivalentTo(ControlPoint other) =>
-                base.EquivalentTo(other)
-                && CustomSampleBank == ((LegacySampleControlPoint)other).CustomSampleBank;
+                base.EquivalentTo(other) && other is LegacySampleControlPoint otherTyped &&
+                CustomSampleBank == otherTyped.CustomSampleBank;
         }
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Beatmaps.Formats
             Foreground = 3
         }
 
-        internal class LegacySampleControlPoint : SampleControlPoint, IEquatable<LegacySampleControlPoint>
+        internal class LegacySampleControlPoint : SampleControlPoint
         {
             public int CustomSampleBank;
 
@@ -203,9 +203,9 @@ namespace osu.Game.Beatmaps.Formats
                 return baseInfo;
             }
 
-            public bool Equals(LegacySampleControlPoint other)
-                => base.Equals(other)
-                   && CustomSampleBank == other?.CustomSampleBank;
+            public override bool EquivalentTo(ControlPoint other) =>
+                base.EquivalentTo(other)
+                && CustomSampleBank == ((LegacySampleControlPoint)other).CustomSampleBank;
         }
     }
 }


### PR DESCRIPTION
`EquivalentTo` will be used once again in a follow-up PR. Meanwhile, this makes implementation less prone to error by forcing implementation via abstract.