### PR TITLE
Hide navigation bar on android

### DIFF
--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -20,6 +20,8 @@ namespace osu.Android
 
             Window.AddFlags(WindowManagerFlags.Fullscreen);
             Window.AddFlags(WindowManagerFlags.KeepScreenOn);
+
+            UIVisibilityFlags = SystemUiFlags.LayoutFlags | SystemUiFlags.ImmersiveSticky | SystemUiFlags.HideNavigation;
         }
     }
 }


### PR DESCRIPTION
- [ ] Depends on framework pr ppy/osu-framework#2927

Closes #6266 

This makes the game run in fullscreen mode, hiding the navigation bar using some `SystemUiFlags`

Video demo avalaible at: https://streamable.com/vpo78