### PR TITLE
Add temporary mobile report moratorium issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/mobile-issues.md
+++ b/.github/ISSUE_TEMPLATE/mobile-issues.md
@@ -1,6 +1,6 @@
 ---
 name: Mobile Report
-about: ⚠ Due to current development priorities we are currently not accepting mobile reports.
+about: ⚠ Due to current development priorities we are not accepting mobile reports at this time.
 ---
 
 ⚠ **PLEASE READ** ⚠: Due to prioritising finishing the client for desktop first we are not accepting reports related to mobile platforms for the time being.

--- a/.github/ISSUE_TEMPLATE/mobile-issues.md
+++ b/.github/ISSUE_TEMPLATE/mobile-issues.md
@@ -1,7 +1,8 @@
 ---
 name: Mobile Report
-about: ⚠ Due to current development priorities we are not accepting mobile reports at this time.
+about: ⚠ Due to current development priorities we are not accepting mobile reports at this time (unless you're willing to fix them yourself!)
 ---
 
-⚠ **PLEASE READ** ⚠: Due to prioritising finishing the client for desktop first we are not accepting reports related to mobile platforms for the time being.
-Please check back in the future when the focus of development shifts towards mobile!
+⚠ **PLEASE READ** ⚠: Due to prioritising finishing the client for desktop first we are not accepting reports related to mobile platforms for the time being, unless you're willing to fix them.
+If you'd like to report a problem or suggest a feature and then work on it, feel free to open an issue and highlight that you'd like to address it yourself in the issue body; mobile pull requests are also welcome.
+Otherwise, please check back in the future when the focus of development shifts towards mobile!

--- a/.github/ISSUE_TEMPLATE/mobile-issues.md
+++ b/.github/ISSUE_TEMPLATE/mobile-issues.md
@@ -1,0 +1,7 @@
+---
+name: Mobile Report
+about: ⚠ Due to current development priorities we are currently not accepting mobile reports.
+---
+
+⚠ **PLEASE READ** ⚠: Due to prioritising finishing the client for desktop first we are not accepting reports related to mobile platforms for the time being.
+Please check back in the future when the focus of development shifts towards mobile!


### PR DESCRIPTION
Due to an overwhelming amount of mobile reports that are not actively being worked on (neither by the core team, due to more pressing priorities, nor by external contributors) and take up considerable time to manage, add an issue template that aims to enforce a temporary moratorium on accepting mobile issues.

In case that isn't enough, I myself will be setting up a saved reply with pretty much the same content to clean up anything that gets past the template.