### PR TITLE
Fix beatmap carousel sorting instability

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -246,6 +246,28 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestSortingStability()
+        {
+            var sets = new List<BeatmapSetInfo>();
+
+            for (int i = 0; i < 20; i++)
+            {
+                var set = createTestBeatmapSet(i);
+                set.Metadata.Artist = "same artist";
+                set.Metadata.Title = "same title";
+                sets.Add(set);
+            }
+
+            loadBeatmaps(sets);
+
+            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddAssert("Items remain in original order", () => carousel.BeatmapSets.Select((set, index) => set.ID == index).All(b => b));
+
+            AddStep("Sort by title", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Title }, false));
+            AddAssert("Items remain in original order", () => carousel.BeatmapSets.Select((set, index) => set.ID == index).All(b => b));
+        }
+
+        [Test]
         public void TestSortingWithFiltered()
         {
             List<BeatmapSetInfo> sets = new List<BeatmapSetInfo>();

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -85,7 +84,8 @@ namespace osu.Game.Screens.Select.Carousel
 
             InternalChildren.ForEach(c => c.Filter(criteria));
             // IEnumerable<T>.OrderBy() is used instead of List<T>.Sort() to ensure sorting stability
-            InternalChildren = InternalChildren.OrderBy(c => c, new CriteriaComparer(criteria)).ToList();
+            var criteriaComparer = Comparer<CarouselItem>.Create((x, y) => x.CompareTo(criteria, y));
+            InternalChildren = InternalChildren.OrderBy(c => c, criteriaComparer).ToList();
         }
 
         protected virtual void ChildItemStateChanged(CarouselItem item, CarouselItemState value)
@@ -101,24 +101,6 @@ namespace osu.Game.Screens.Select.Carousel
                 }
 
                 State.Value = CarouselItemState.Selected;
-            }
-        }
-
-        private class CriteriaComparer : IComparer<CarouselItem>
-        {
-            private readonly FilterCriteria criteria;
-
-            public CriteriaComparer(FilterCriteria criteria)
-            {
-                this.criteria = criteria;
-            }
-
-            public int Compare(CarouselItem x, CarouselItem y)
-            {
-                if (x != null && y != null)
-                    return x.CompareTo(criteria, y);
-
-                throw new ArgumentNullException();
             }
         }
     }

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.Game.Screens.Select.Carousel
 {
@@ -81,12 +83,9 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Filter(criteria);
 
-            var children = new List<CarouselItem>(InternalChildren);
-
-            children.ForEach(c => c.Filter(criteria));
-            children.Sort((x, y) => x.CompareTo(criteria, y));
-
-            InternalChildren = children;
+            InternalChildren.ForEach(c => c.Filter(criteria));
+            // IEnumerable<T>.OrderBy() is used instead of List<T>.Sort() to ensure sorting stability
+            InternalChildren = InternalChildren.OrderBy(c => c, new CriteriaComparer(criteria)).ToList();
         }
 
         protected virtual void ChildItemStateChanged(CarouselItem item, CarouselItemState value)
@@ -102,6 +101,24 @@ namespace osu.Game.Screens.Select.Carousel
                 }
 
                 State.Value = CarouselItemState.Selected;
+            }
+        }
+
+        private class CriteriaComparer : IComparer<CarouselItem>
+        {
+            private readonly FilterCriteria criteria;
+
+            public CriteriaComparer(FilterCriteria criteria)
+            {
+                this.criteria = criteria;
+            }
+
+            public int Compare(CarouselItem x, CarouselItem y)
+            {
+                if (x != null && y != null)
+                    return x.CompareTo(criteria, y);
+
+                throw new ArgumentNullException();
             }
         }
     }


### PR DESCRIPTION
Resolves #3393.

# Summary

Migrate beatmap carousel item sorting from `List<T>.Sort()` to `IEnumerable<T>.OrderBy()`, as the second variant is [documented to be a stable sorting algorithm](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.orderby?view=netcore-3.0#System_Linq_Enumerable_OrderBy__2_System_Collections_Generic_IEnumerable___0__System_Func___0___1__System_Collections_Generic_IComparer___1__). This allows for eliminating unnecessary movement of carousel items occurring whenever any set of items is tied when changing sorting criteria.

Visual test case that failed for me on current `master` but doesn't after applying the stable sort also included.

# Remarks

To be sure I don't regress performance obviously badly here, I did a makeshift test locally on my machine by running the provided test, but with 10 thousand beatmap sets, and looking at the reported step execution times. I did not see any meaningful change in the performance of the actual sorting step (around 200 units - miliseconds, *I think?* - both before and after). I thought about doing a benchmark.net test case, but I felt like doing that would be a lot of pain and I wanted to be as close to the actual use case as possible.

There is however a slight *visual* improvement due to obvious reasons - since the carousel items no longer move around in the worst cases, they no longer have to load in, leading to less flickering.

After digging around corefx sources a bit I can see that `List<T>.Sort()` uses introsort, while `IEnumerable<T>.OrderBy()` uses quicksort with a midpoint pivot. While the second has a worse theoretical pessimistic time complexity, I guess it's part of the price to pay for a stable sort and I'd hope worst cases shouldn't be very common...?