### PR TITLE
Fix song progress not displaying correctly

### DIFF
--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -106,6 +106,8 @@ namespace osu.Game.Screens.Play
 
         protected override void LoadComplete()
         {
+            base.LoadComplete();
+
             Show();
 
             replayLoaded.ValueChanged += loaded => AllowSeeking = loaded.NewValue;


### PR DESCRIPTION
Missing base call, which is now quite important to be present (due to `VisiblityContainer` changes).