### PR TITLE
Fix PlayerSettingsOverlay being shown by default

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplaySettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplaySettingsOverlay.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Play.PlayerSettings;
@@ -20,6 +21,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
+                State = { Value = Visibility.Visible }
             });
 
             Add(container = new ExampleContainer());

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Screens.Play.HUD
                     VisualSettings = new VisualSettings { Expanded = false }
                 }
             };
-
-            Show();
         }
 
         protected override void PopIn() => this.FadeIn(fade_duration);


### PR DESCRIPTION
While the true fix for this lies in https://github.com/ppy/osu-framework/pull/2929, the new (more correct behaviour) will look incorrect (will fade out on initial display).

This change corrects the logic to match expectations.