### PR TITLE
Fix game-wide performance drop when triangles intro is used

### DIFF
--- a/osu.Game/Screens/Menu/IntroSequence.cs
+++ b/osu.Game/Screens/Menu/IntroSequence.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Screens.Menu
         public IntroSequence()
         {
             RelativeSizeAxes = Axes.Both;
+            Alpha = 0;
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
This is a hotfix. More correct fix will come via https://github.com/ppy/osu/issues/6643.