### PR TITLE
Fix chat not always scrolling to the bottom

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -62,6 +62,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.1023.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.1029.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Online/Chat/Channel.cs
+++ b/osu.Game/Online/Chat/Channel.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Online.Chat
 {
     public class Channel
     {
-        public readonly int MaxHistory = 300;
+        public const int MAX_HISTORY = 300;
 
         /// <summary>
         /// Contains every joined user except the current logged in user. Currently only returned for PM channels.
@@ -79,8 +79,6 @@ namespace osu.Game.Online.Chat
         /// Signalles if the current user joined this channel or not. Defaults to false.
         /// </summary>
         public Bindable<bool> Joined = new Bindable<bool>();
-
-        public const int MAX_HISTORY = 300;
 
         [JsonConstructor]
         public Channel()
@@ -162,8 +160,8 @@ namespace osu.Game.Online.Chat
         {
             // never purge local echos
             int messageCount = Messages.Count - pendingMessages.Count;
-            if (messageCount > MaxHistory)
-                Messages.RemoveRange(0, messageCount - MaxHistory);
+            if (messageCount > MAX_HISTORY)
+                Messages.RemoveRange(0, messageCount - MAX_HISTORY);
         }
     }
 }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -107,7 +107,7 @@ namespace osu.Game.Overlays.Chat
                 scrollToEnd();
 
             var staleMessages = chatLines.Where(c => c.LifetimeEnd == double.MaxValue).ToArray();
-            int count = staleMessages.Length - Channel.MaxHistory;
+            int count = staleMessages.Length - Channel.MAX_HISTORY;
 
             for (int i = 0; i < count; i++)
             {

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -89,8 +89,10 @@ namespace osu.Game.Overlays.Chat
 
         private void newMessagesArrived(IEnumerable<Message> newMessages)
         {
+            bool shouldScrollToEnd = scroll.IsScrolledToEnd(10) || !chatLines.Any() || newMessages.Any(m => m is LocalMessage);
+
             // Add up to last Channel.MAX_HISTORY messages
-            var displayMessages = newMessages.Skip(Math.Max(0, newMessages.Count() - Channel.MaxHistory));
+            var displayMessages = newMessages.Skip(Math.Max(0, newMessages.Count() - Channel.MAX_HISTORY));
 
             Message lastMessage = chatLines.LastOrDefault()?.Message;
 
@@ -103,19 +105,18 @@ namespace osu.Game.Overlays.Chat
                 lastMessage = message;
             }
 
-            if (scroll.IsScrolledToEnd(10) || !chatLines.Any() || newMessages.Any(m => m is LocalMessage))
-                scrollToEnd();
-
             var staleMessages = chatLines.Where(c => c.LifetimeEnd == double.MaxValue).ToArray();
             int count = staleMessages.Length - Channel.MAX_HISTORY;
 
             for (int i = 0; i < count; i++)
             {
                 var d = staleMessages[i];
-                if (!scroll.IsScrolledToEnd(10))
-                    scroll.OffsetScrollPosition(-d.DrawHeight);
+                scroll.OffsetScrollPosition(-d.DrawHeight);
                 d.Expire();
             }
+
+            if (shouldScrollToEnd)
+                scrollToEnd();
         }
 
         private void pendingMessageResolved(Message existing, Message updated)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.1023.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.1029.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -118,8 +118,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.1023.0" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.1023.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.1029.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.1029.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
After hitting max history, a framework-side bug would inhibit the scroll-to-end functionality.

This PR is mostly just tidying up and testing osu!-side. Framework change is required for the fix.

- [x] Depends on https://github.com/ppy/osu-framework/pull/2932
- Closes https://github.com/ppy/osu/issues/6001.