### PR TITLE
Add feedback to user when sign in form isn't filled

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -200,6 +200,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
         {
             private TextBox username;
             private TextBox password;
+            private ShakeContainer shakeSignIn;
             private IAPIProvider api;
 
             public Action RequestHide;
@@ -208,6 +209,8 @@ namespace osu.Game.Overlays.Settings.Sections.General
             {
                 if (!string.IsNullOrEmpty(username.Text) && !string.IsNullOrEmpty(password.Text))
                     api.Login(username.Text, password.Text);
+                else
+                    shakeSignIn.Shake();
             }
 
             [BackgroundDependencyLoader(permitNulls: true)]
@@ -244,10 +247,23 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         LabelText = "Stay signed in",
                         Bindable = config.GetBindable<bool>(OsuSetting.SavePassword),
                     },
-                    new SettingsButton
+                    new Container
                     {
-                        Text = "Sign in",
-                        Action = performLogin
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Children = new Drawable[]
+                        {
+                            shakeSignIn = new ShakeContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Child = new SettingsButton
+                                {
+                                    Text = "Sign in",
+                                    Action = performLogin
+                                },
+                            }
+                        }
                     },
                     new SettingsButton
                     {


### PR DESCRIPTION
Basically just unifying the behavior with register form. When the username or password text box isn't filled it will trigger the shake container.
Partially working on #4086 to give user more feedback on sign in flow, will do the error from API response on separate PR

https://streamable.com/ky8nz