### PR TITLE
Fix crash when quickly exiting multiplayer after joining a room

### DIFF
--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -212,6 +212,8 @@ namespace osu.Game.Screens.Multi
 
         public override bool OnExiting(IScreen next)
         {
+            roomManager.PartRoom();
+
             if (screenStack.CurrentScreen != null && !(screenStack.CurrentScreen is LoungeSubScreen))
             {
                 screenStack.Exit();

--- a/osu.Game/Screens/Multi/RoomManager.cs
+++ b/osu.Game/Screens/Multi/RoomManager.cs
@@ -98,7 +98,8 @@ namespace osu.Game.Screens.Multi
 
             currentJoinRoomRequest.Failure += exception =>
             {
-                Logger.Log($"Failed to join room: {exception}", level: LogLevel.Important);
+                if (!(exception is OperationCanceledException))
+                    Logger.Log($"Failed to join room: {exception}", level: LogLevel.Important);
                 onError?.Invoke(exception.ToString());
             };
 

--- a/osu.Game/Screens/Multi/RoomManager.cs
+++ b/osu.Game/Screens/Multi/RoomManager.cs
@@ -87,9 +87,8 @@ namespace osu.Game.Screens.Multi
         public void JoinRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)
         {
             currentJoinRoomRequest?.Cancel();
-            currentJoinRoomRequest = null;
-
             currentJoinRoomRequest = new JoinRoomRequest(room, api.LocalUser.Value);
+
             currentJoinRoomRequest.Success += () =>
             {
                 joinedRoom = room;
@@ -108,6 +107,8 @@ namespace osu.Game.Screens.Multi
 
         public void PartRoom()
         {
+            currentJoinRoomRequest?.Cancel();
+
             if (joinedRoom == null)
                 return;
 


### PR DESCRIPTION
Fixes #6664

This stops the callbacks from occurring after multiplayer has been exited. This doesn't ensure the room is actually parted, but that's not too big of an issue right now and will be fixed with a refactor of how `PartRoom()` works - this code will remain the same in any case.