### PR TITLE
Update sliders when control points change

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             var snappedDistance = composer?.GetSnappedDistanceFromDistance(HitObject.StartTime, (float)unsnappedPath.Distance) ?? (float)unsnappedPath.Distance;
 
             HitObject.Path = new SliderPath(unsnappedPath.Type, controlPoints, snappedDistance);
+
+            UpdateHitObject();
         }
 
         public override Vector2 SelectionPoint => HeadBlueprint.SelectionPoint;

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.Edit
             EditorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
             EditorBeatmap.HitObjectAdded += addHitObject;
             EditorBeatmap.HitObjectRemoved += removeHitObject;
-            EditorBeatmap.StartTimeChanged += updateHitObject;
+            EditorBeatmap.StartTimeChanged += UpdateHitObject;
 
             var dependencies = new DependencyContainer(parent);
             dependencies.CacheAs<IEditorBeatmap>(EditorBeatmap);
@@ -225,11 +225,7 @@ namespace osu.Game.Rulesets.Edit
 
         private ScheduledDelegate scheduledUpdate;
 
-        private void addHitObject(HitObject hitObject) => updateHitObject(hitObject);
-
-        private void removeHitObject(HitObject hitObject) => updateHitObject(null);
-
-        private void updateHitObject([CanBeNull] HitObject hitObject)
+        public override void UpdateHitObject(HitObject hitObject)
         {
             scheduledUpdate?.Cancel();
             scheduledUpdate = Schedule(() =>
@@ -239,6 +235,10 @@ namespace osu.Game.Rulesets.Edit
                 beatmapProcessor?.PostProcess();
             });
         }
+
+        private void addHitObject(HitObject hitObject) => UpdateHitObject(hitObject);
+
+        private void removeHitObject(HitObject hitObject) => UpdateHitObject(null);
 
         public override IEnumerable<DrawableHitObject> HitObjects => drawableRulesetWrapper.Playfield.AllHitObjects;
         public override bool CursorInPlacementArea => drawableRulesetWrapper.Playfield.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
@@ -351,11 +351,22 @@ namespace osu.Game.Rulesets.Edit
         [CanBeNull]
         protected virtual DistanceSnapGrid CreateDistanceSnapGrid([NotNull] IEnumerable<HitObject> selectedHitObjects) => null;
 
+        /// <summary>
+        /// Updates a <see cref="HitObject"/>, invoking <see cref="HitObject.ApplyDefaults"/> and re-processing the beatmap.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to update.</param>
+        public abstract void UpdateHitObject([CanBeNull] HitObject hitObject);
+
         public abstract (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time);
+
         public abstract float GetBeatSnapDistanceAt(double referenceTime);
+
         public abstract float DurationToDistance(double referenceTime, double duration);
+
         public abstract double DistanceToDuration(double referenceTime, float distance);
+
         public abstract double GetSnappedDurationFromDistance(double referenceTime, float distance);
+
         public abstract float GetSnappedDistanceFromDistance(double referenceTime, float distance);
     }
 }

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -3,10 +3,12 @@
 
 using System;
 using osu.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 
@@ -35,6 +37,9 @@ namespace osu.Game.Rulesets.Edit
         protected override bool ShouldBeAlive => (DrawableObject.IsAlive && DrawableObject.IsPresent) || State == SelectionState.Selected;
         public override bool HandlePositionalInput => ShouldBeAlive;
         public override bool RemoveWhenNotAlive => false;
+
+        [Resolved(CanBeNull = true)]
+        private HitObjectComposer composer { get; set; }
 
         protected SelectionBlueprint(DrawableHitObject drawableObject)
         {
@@ -88,6 +93,11 @@ namespace osu.Game.Rulesets.Edit
         public void Deselect() => State = SelectionState.NotSelected;
 
         public bool IsSelected => State == SelectionState.Selected;
+
+        /// <summary>
+        /// Updates the <see cref="HitObject"/>, invoking <see cref="HitObject.ApplyDefaults"/> and re-processing the beatmap.
+        /// </summary>
+        protected void UpdateHitObject() => composer?.UpdateHitObject(DrawableObject.HitObject);
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => DrawableObject.ReceivePositionalInputAt(screenSpacePos);
 


### PR DESCRIPTION
Fixes slider ticks not moving along with changes in the path and more ticks not being generated.

- Closes https://github.com/ppy/osu/issues/5181