### PR TITLE
Fix scrolling hitobjects expiring too soon

### DIFF
--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -13,12 +13,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
 {
     public class ScrollingHitObjectContainer : HitObjectContainer
     {
-        /// <summary>
-        /// A multiplier applied to the length of the scrolling area to determine a safe default lifetime end for hitobjects.
-        /// This is only used to limit the lifetime end within reason, as proper lifetime management should be implemented on hitobjects themselves.
-        /// </summary>
-        private const float safe_lifetime_end_multiplier = 2;
-
         private readonly IBindable<double> timeRange = new BindableDouble();
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
 
@@ -123,27 +117,21 @@ namespace osu.Game.Rulesets.UI.Scrolling
             if (cached.IsValid)
                 return;
 
-            double endTime = hitObject.HitObject.StartTime;
-
             if (hitObject.HitObject is IHasEndTime e)
             {
-                endTime = e.EndTime;
-
                 switch (direction.Value)
                 {
                     case ScrollingDirection.Up:
                     case ScrollingDirection.Down:
-                        hitObject.Height = scrollingInfo.Algorithm.GetLength(hitObject.HitObject.StartTime, endTime, timeRange.Value, scrollLength);
+                        hitObject.Height = scrollingInfo.Algorithm.GetLength(hitObject.HitObject.StartTime, e.EndTime, timeRange.Value, scrollLength);
                         break;
 
                     case ScrollingDirection.Left:
                     case ScrollingDirection.Right:
-                        hitObject.Width = scrollingInfo.Algorithm.GetLength(hitObject.HitObject.StartTime, endTime, timeRange.Value, scrollLength);
+                        hitObject.Width = scrollingInfo.Algorithm.GetLength(hitObject.HitObject.StartTime, e.EndTime, timeRange.Value, scrollLength);
                         break;
                 }
             }
-
-            hitObject.LifetimeEnd = scrollingInfo.Algorithm.TimeAt(scrollLength * safe_lifetime_end_multiplier, endTime, timeRange.Value, scrollLength);
 
             foreach (var obj in hitObject.NestedHitObjects)
             {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/6252

Livetime is now managed at a `DrawableHitObject` level automatically.