### PR TITLE
Fix GameplayClockContainer operating on beatmap's track after screen exited

### DIFF
--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -29,7 +30,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// The original source (usually a <see cref="WorkingBeatmap"/>'s track).
         /// </summary>
-        private readonly IAdjustableClock sourceClock;
+        private IAdjustableClock sourceClock;
 
         public readonly BindableBool IsPaused = new BindableBool();
 
@@ -151,6 +152,18 @@ namespace osu.Game.Screens.Play
             this.TransformBindableTo(pauseFreqAdjust, 0, 200, Easing.Out).OnComplete(_ => adjustableClock.Stop());
 
             IsPaused.Value = true;
+        }
+
+        /// <summary>
+        /// Changes the backing clock to avoid using the originally provided beatmap's track.
+        /// </summary>
+        public void StopUsingBeatmapClock()
+        {
+            if (sourceClock != beatmap.Track)
+                return;
+
+            sourceClock = new TrackVirtual(beatmap.Track.Length);
+            adjustableClock.ChangeSource(sourceClock);
         }
 
         public void ResetLocalAdjustments()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -527,6 +527,10 @@ namespace osu.Game.Screens.Play
 
             GameplayClockContainer.ResetLocalAdjustments();
 
+            // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.
+            // as we are no longer the current screen, we cannot guarantee the track is still usable.
+            GameplayClockContainer.StopUsingBeatmapClock();
+
             fadeOut();
             return base.OnExiting(next);
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/6410.