### PR TITLE
Highlight user's top score on beatmap leaderboard

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -21,6 +21,7 @@ using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
 using Humanizer;
+using osu.Game.Online.API;
 
 namespace osu.Game.Online.Leaderboards
 {
@@ -59,7 +60,7 @@ namespace osu.Game.Online.Leaderboards
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(IAPIProvider api, OsuColour colour)
         {
             var user = score.User;
 
@@ -100,7 +101,7 @@ namespace osu.Game.Online.Leaderboards
                                 background = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = Color4.Black,
+                                    Colour = user.Id == api.LocalUser.Value.Id ? colour.YellowLight : Color4.Black,
                                     Alpha = background_alpha,
                                 },
                             },

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Online.Leaderboards
 
         private readonly ScoreInfo score;
         private readonly int rank;
-        private readonly bool canHighlighted;
+        private readonly bool allowHighlight;
 
         private Box background;
         private Container content;
@@ -51,11 +51,11 @@ namespace osu.Game.Online.Leaderboards
 
         private List<ScoreComponentLabel> statisticsLabels;
 
-        public LeaderboardScore(ScoreInfo score, int rank, bool canHighlighted = true)
+        public LeaderboardScore(ScoreInfo score, int rank, bool allowHighlight = true)
         {
             this.score = score;
             this.rank = rank;
-            this.canHighlighted = canHighlighted;
+            this.allowHighlight = allowHighlight;
 
             RelativeSizeAxes = Axes.X;
             Height = HEIGHT;
@@ -103,7 +103,7 @@ namespace osu.Game.Online.Leaderboards
                                 background = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = user.Id == api.LocalUser.Value.Id && canHighlighted ? colour.YellowLight : Color4.Black,
+                                    Colour = user.Id == api.LocalUser.Value.Id && allowHighlight ? colour.Green : Color4.Black,
                                     Alpha = background_alpha,
                                 },
                             },

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Online.Leaderboards
 
         private readonly ScoreInfo score;
         private readonly int rank;
+        private readonly bool canHighlighted;
 
         private Box background;
         private Container content;
@@ -50,10 +51,11 @@ namespace osu.Game.Online.Leaderboards
 
         private List<ScoreComponentLabel> statisticsLabels;
 
-        public LeaderboardScore(ScoreInfo score, int rank)
+        public LeaderboardScore(ScoreInfo score, int rank, bool canHighlighted = true)
         {
             this.score = score;
             this.rank = rank;
+            this.canHighlighted = canHighlighted;
 
             RelativeSizeAxes = Axes.X;
             Height = HEIGHT;
@@ -101,7 +103,7 @@ namespace osu.Game.Online.Leaderboards
                                 background = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Colour = user.Id == api.LocalUser.Value.Id ? colour.YellowLight : Color4.Black,
+                                    Colour = user.Id == api.LocalUser.Value.Id && canHighlighted ? colour.YellowLight : Color4.Black,
                                     Alpha = background_alpha,
                                 },
                             },

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             return req;
         }
 
-        protected override LeaderboardScore CreateDrawableScore(ScoreInfo model, int index) => new LeaderboardScore(model, index)
+        protected override LeaderboardScore CreateDrawableScore(ScoreInfo model, int index) => new LeaderboardScore(model, index, IsOnlineScope)
         {
             Action = () => ScoreSelected?.Invoke(model)
         };

--- a/osu.Game/Screens/Select/Leaderboards/UserTopScoreContainer.cs
+++ b/osu.Game/Screens/Select/Leaderboards/UserTopScoreContainer.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Select.Leaderboards
             if (newScore == null)
                 return;
 
-            LoadComponentAsync(new LeaderboardScore(newScore.Score, newScore.Position)
+            LoadComponentAsync(new LeaderboardScore(newScore.Score, newScore.Position, false)
             {
                 Action = () => ScoreSelected?.Invoke(newScore.Score)
             }, drawableScore =>


### PR DESCRIPTION
It also highlight user top score on multiplayer match.
<details><summary>Screenshots</summary>
<img src="https://user-images.githubusercontent.com/6506864/68041042-3d329d80-fd02-11e9-8fff-71ad66966b3c.png" width=75% /> <img src="https://user-images.githubusercontent.com/6506864/68041060-4a4f8c80-fd02-11e9-98ac-c955ba1dce69.png" width=75% /> <img src="https://user-images.githubusercontent.com/6506864/68041080-54718b00-fd02-11e9-9f3a-71e1199f9667.png" width=75% />
</details>