### PR TITLE
Disable retry hotkey overlay when viewing results from leaderboard

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneResults.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneResults.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
+using osu.Game.Screens;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Ranking.Pages;
@@ -27,7 +32,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             typeof(ScoreResultsPage),
             typeof(RetryButton),
             typeof(ReplayDownloadButton),
-            typeof(LocalLeaderboardPage)
+            typeof(LocalLeaderboardPage),
+            typeof(TestPlayer)
         };
 
         [BackgroundDependencyLoader]
@@ -43,26 +49,82 @@ namespace osu.Game.Tests.Visual.Gameplay
             var beatmapInfo = beatmaps.QueryBeatmap(b => b.RulesetID == 0);
             if (beatmapInfo != null)
                 Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo);
+        }
 
-            LoadScreen(new SoloResults(new ScoreInfo
+        private TestSoloResults createResultsScreen() => new TestSoloResults(new ScoreInfo
+        {
+            TotalScore = 2845370,
+            Accuracy = 0.98,
+            MaxCombo = 123,
+            Rank = ScoreRank.A,
+            Date = DateTimeOffset.Now,
+            Statistics = new Dictionary<HitResult, int>
             {
-                TotalScore = 2845370,
-                Accuracy = 0.98,
-                MaxCombo = 123,
-                Rank = ScoreRank.A,
-                Date = DateTimeOffset.Now,
-                Statistics = new Dictionary<HitResult, int>
+                { HitResult.Great, 50 },
+                { HitResult.Good, 20 },
+                { HitResult.Meh, 50 },
+                { HitResult.Miss, 1 }
+            },
+            User = new User
+            {
+                Username = "peppy",
+            }
+        });
+
+        [Test]
+        public void ResultsWithoutPlayer()
+        {
+            TestSoloResults screen = null;
+
+            AddStep("load results", () => Child = new OsuScreenStack(screen = createResultsScreen())
+            {
+                RelativeSizeAxes = Axes.Both
+            });
+            AddUntilStep("wait for loaded", () => screen.IsLoaded);
+            AddAssert("retry overlay not present", () => screen.RetryOverlay == null);
+        }
+
+        [Test]
+        public void ResultsWithPlayer()
+        {
+            TestSoloResults screen = null;
+
+            AddStep("load results", () => Child = new TestResultsContainer(screen = createResultsScreen()));
+            AddUntilStep("wait for loaded", () => screen.IsLoaded);
+            AddAssert("retry overlay present", () => screen.RetryOverlay != null);
+        }
+
+        private class TestResultsContainer : Container
+        {
+            [Cached(typeof(Player))]
+            private readonly Player player = new TestPlayer();
+
+            public TestResultsContainer(IScreen screen)
+            {
+                RelativeSizeAxes = Axes.Both;
+
+                InternalChild = new OsuScreenStack(screen)
                 {
-                    { HitResult.Great, 50 },
-                    { HitResult.Good, 20 },
-                    { HitResult.Meh, 50 },
-                    { HitResult.Miss, 1 }
-                },
-                User = new User
-                {
-                    Username = "peppy",
-                }
-            }));
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+        }
+
+        private class TestSoloResults : SoloResults
+        {
+            public HotkeyRetryOverlay RetryOverlay;
+
+            public TestSoloResults(ScoreInfo score)
+                : base(score)
+            {
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                RetryOverlay = InternalChildren.OfType<HotkeyRetryOverlay>().SingleOrDefault();
+            }
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Results.cs
+++ b/osu.Game/Screens/Ranking/Results.cs
@@ -116,146 +116,147 @@ namespace osu.Game.Screens.Ranking
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            InternalChildren = new Drawable[]
+            InternalChild = new AspectContainer
             {
-                new AspectContainer
+                RelativeSizeAxes = Axes.Y,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Height = overscan,
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Height = overscan,
-                    Children = new Drawable[]
+                    circleOuterBackground = new CircularContainer
                     {
-                        circleOuterBackground = new CircularContainer
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Masking = true,
+                        Children = new Drawable[]
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Masking = true,
-                            Children = new Drawable[]
+                            new Box
                             {
-                                new Box
-                                {
-                                    Alpha = 0.2f,
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = Color4.Black,
-                                }
-                            }
-                        },
-                        circleOuter = new CircularContainer
-                        {
-                            Size = new Vector2(circle_outer_scale),
-                            EdgeEffect = new EdgeEffectParameters
-                            {
-                                Colour = Color4.Black.Opacity(0.4f),
-                                Type = EdgeEffectType.Shadow,
-                                Radius = 15,
-                            },
-                            RelativeSizeAxes = Axes.Both,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = Color4.White,
-                                },
-                                backgroundParallax = new ParallaxContainer
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    ParallaxAmount = 0.01f,
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Sprite
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Alpha = 0.2f,
-                                            Texture = Beatmap.Value.Background,
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            FillMode = FillMode.Fill
-                                        }
-                                    }
-                                },
-                                modeChangeButtons = new ResultModeTabControl
-                                {
-                                    Anchor = Anchor.BottomCentre,
-                                    Origin = Anchor.BottomCentre,
-                                    RelativeSizeAxes = Axes.X,
-                                    Height = 50,
-                                    Margin = new MarginPadding { Bottom = 110 },
-                                },
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.BottomCentre,
-                                    Text = $"{Score.MaxCombo}x",
-                                    RelativePositionAxes = Axes.X,
-                                    Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 40),
-                                    X = 0.1f,
-                                    Colour = colours.BlueDarker,
-                                },
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.TopCentre,
-                                    Text = "max combo",
-                                    Font = OsuFont.GetFont(size: 20),
-                                    RelativePositionAxes = Axes.X,
-                                    X = 0.1f,
-                                    Colour = colours.Gray6,
-                                },
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.BottomCentre,
-                                    Text = $"{Score.Accuracy:P2}",
-                                    Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 40),
-                                    RelativePositionAxes = Axes.X,
-                                    X = 0.9f,
-                                    Colour = colours.BlueDarker,
-                                },
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.TopCentre,
-                                    Text = "accuracy",
-                                    Font = OsuFont.GetFont(size: 20),
-                                    RelativePositionAxes = Axes.X,
-                                    X = 0.9f,
-                                    Colour = colours.Gray6,
-                                },
-                            }
-                        },
-                        circleInner = new CircularContainer
-                        {
-                            Size = new Vector2(0.6f),
-                            EdgeEffect = new EdgeEffectParameters
-                            {
-                                Colour = Color4.Black.Opacity(0.4f),
-                                Type = EdgeEffectType.Shadow,
-                                Radius = 15,
-                            },
-                            RelativeSizeAxes = Axes.Both,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = Color4.White,
-                                },
+                                Alpha = 0.2f,
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.Black,
                             }
                         }
+                    },
+                    circleOuter = new CircularContainer
+                    {
+                        Size = new Vector2(circle_outer_scale),
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Colour = Color4.Black.Opacity(0.4f),
+                            Type = EdgeEffectType.Shadow,
+                            Radius = 15,
+                        },
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Masking = true,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.White,
+                            },
+                            backgroundParallax = new ParallaxContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                ParallaxAmount = 0.01f,
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Children = new Drawable[]
+                                {
+                                    new Sprite
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Alpha = 0.2f,
+                                        Texture = Beatmap.Value.Background,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        FillMode = FillMode.Fill
+                                    }
+                                }
+                            },
+                            modeChangeButtons = new ResultModeTabControl
+                            {
+                                Anchor = Anchor.BottomCentre,
+                                Origin = Anchor.BottomCentre,
+                                RelativeSizeAxes = Axes.X,
+                                Height = 50,
+                                Margin = new MarginPadding { Bottom = 110 },
+                            },
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.BottomCentre,
+                                Text = $"{Score.MaxCombo}x",
+                                RelativePositionAxes = Axes.X,
+                                Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 40),
+                                X = 0.1f,
+                                Colour = colours.BlueDarker,
+                            },
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.TopCentre,
+                                Text = "max combo",
+                                Font = OsuFont.GetFont(size: 20),
+                                RelativePositionAxes = Axes.X,
+                                X = 0.1f,
+                                Colour = colours.Gray6,
+                            },
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.BottomCentre,
+                                Text = $"{Score.Accuracy:P2}",
+                                Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 40),
+                                RelativePositionAxes = Axes.X,
+                                X = 0.9f,
+                                Colour = colours.BlueDarker,
+                            },
+                            new OsuSpriteText
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.TopCentre,
+                                Text = "accuracy",
+                                Font = OsuFont.GetFont(size: 20),
+                                RelativePositionAxes = Axes.X,
+                                X = 0.9f,
+                                Colour = colours.Gray6,
+                            },
+                        }
+                    },
+                    circleInner = new CircularContainer
+                    {
+                        Size = new Vector2(0.6f),
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Colour = Color4.Black.Opacity(0.4f),
+                            Type = EdgeEffectType.Shadow,
+                            Radius = 15,
+                        },
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Masking = true,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.White,
+                            },
+                        }
                     }
-                },
-                new HotkeyRetryOverlay
+                }
+            };
+
+            if (player != null)
+            {
+                AddInternal(new HotkeyRetryOverlay
                 {
                     Action = () =>
                     {
@@ -263,8 +264,8 @@ namespace osu.Game.Screens.Ranking
 
                         player?.Restart();
                     },
-                },
-            };
+                });
+            }
 
             var pages = CreateResultPages();
 


### PR DESCRIPTION
Resolves #6701.

# Summary

Do not add the hold-to-retry hotkey overlay to the visual hierarchy if the user has navigated to the results screen from the leaderboard and not from gameplay.

# Remarks

I expanded existing visual tests to demonstrate the above, but this is the first proper PR I've submitted thus far that touches visual components and DI in general, so buyer beware, I might be doing things very wrong, and apologies in advance if I am.

The github diff is sort of broken. Most of the changes in `Results` is indentation.