### PR TITLE
Disable input for non-selected blueprints

### DIFF
--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -82,6 +82,9 @@ namespace osu.Game.Rulesets.Edit
             }
         }
 
+        // When not selected, input is only required for the blueprint itself to receive IsHovering
+        protected override bool ShouldBeConsideredForInput(Drawable child) => State == SelectionState.Selected;
+
         /// <summary>
         /// Selects this <see cref="SelectionBlueprint"/>, causing it to become visible.
         /// </summary>


### PR DESCRIPTION
Children of a selection blueprint could accept input even while not selected, leading to possibilities like dragging slider control points while the slider isn't selected.