### PR TITLE
Less sickening parallax

### DIFF
--- a/osu.Game/Graphics/Containers/ParallaxContainer.cs
+++ b/osu.Game/Graphics/Containers/ParallaxContainer.cs
@@ -69,9 +69,11 @@ namespace osu.Game.Graphics.Containers
             {
                 Vector2 offset = (input.CurrentState.Mouse == null ? Vector2.Zero : ToLocalSpace(input.CurrentState.Mouse.Position) - DrawSize / 2) * ParallaxAmount;
 
-                double elapsed = MathHelper.Clamp(Clock.ElapsedFrameTime, 0, 1000);
+                const float parallax_duration = 100;
 
-                content.Position = Interpolation.ValueAt(elapsed, content.Position, offset, 0, 100, Easing.OutQuint);
+                double elapsed = MathHelper.Clamp(Clock.ElapsedFrameTime, 0, parallax_duration);
+
+                content.Position = Interpolation.ValueAt(elapsed, content.Position, offset, 0, parallax_duration, Easing.OutQuint);
                 content.Scale = Interpolation.ValueAt(elapsed, content.Scale, new Vector2(1 + System.Math.Abs(ParallaxAmount)), 0, 1000, Easing.OutQuint);
             }
 

--- a/osu.Game/Graphics/Containers/ParallaxContainer.cs
+++ b/osu.Game/Graphics/Containers/ParallaxContainer.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Graphics.Containers
 
                 double elapsed = MathHelper.Clamp(Clock.ElapsedFrameTime, 0, 1000);
 
-                content.Position = Interpolation.ValueAt(elapsed, content.Position, offset, 0, 1000, Easing.OutQuint);
+                content.Position = Interpolation.ValueAt(elapsed, content.Position, offset, 0, 100, Easing.OutQuint);
                 content.Scale = Interpolation.ValueAt(elapsed, content.Scale, new Vector2(1 + System.Math.Abs(ParallaxAmount)), 0, 1000, Easing.OutQuint);
             }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -36,6 +36,8 @@ namespace osu.Game.Screens.Edit
     {
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenCustom(@"Backgrounds/bg4");
 
+        public override float BackgroundParallaxAmount => 0.1f;
+
         public override bool AllowBackButton => false;
 
         public override bool HideOverlaysOnEnter => true;


### PR DESCRIPTION
Parallax should match the mouse movement more closely to reduce sickening feeling. Also reduces parallax in editor to same level as gameplay.