### PR TITLE
Improve tournament screen transitions

### DIFF
--- a/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
+++ b/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
@@ -24,7 +24,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Screens.Drawings
 {
-    public class DrawingsScreen : CompositeDrawable
+    public class DrawingsScreen : TournamentScreen
     {
         private const string results_filename = "drawings_results.txt";
 

--- a/osu.Game.Tournament/Screens/TournamentScreen.cs
+++ b/osu.Game.Tournament/Screens/TournamentScreen.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Tournament.Screens
 {
     public abstract class TournamentScreen : CompositeDrawable
     {
+        public const double FADE_DELAY = 200;
+
         [Resolved]
         protected LadderInfo LadderInfo { get; private set; }
 
@@ -18,14 +20,8 @@ namespace osu.Game.Tournament.Screens
             RelativeSizeAxes = Axes.Both;
         }
 
-        public override void Hide()
-        {
-            this.FadeOut(200);
-        }
+        public override void Hide() => this.FadeOut(FADE_DELAY);
 
-        public override void Show()
-        {
-            this.FadeIn(200);
-        }
+        public override void Show() => this.FadeIn(FADE_DELAY);
     }
 }

--- a/osu.Game.Tournament/TournamentSceneManager.cs
+++ b/osu.Game.Tournament/TournamentSceneManager.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Platform;
+using osu.Framework.Threading;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
@@ -130,37 +131,58 @@ namespace osu.Game.Tournament
                 },
             };
 
+            foreach (var drawable in screens)
+                drawable.Hide();
+
             SetScreen(typeof(SetupScreen));
         }
 
+        private float depth;
+
+        private Drawable currentScreen;
+        private ScheduledDelegate scheduledHide;
+
         public void SetScreen(Type screenType)
         {
-            var screen = screens.FirstOrDefault(s => s.GetType() == screenType);
-            if (screen == null) return;
+            var target = screens.FirstOrDefault(s => s.GetType() == screenType);
 
-            foreach (var s in screens.Children)
+            if (target == null || currentScreen == target) return;
+
+            if (scheduledHide?.Completed == false)
             {
-                if (s == screen)
-                {
-                    s.Show();
-                    if (s is IProvideVideo)
-                        video.FadeOut(200);
-                    else
-                        video.Show();
-                }
-                else
-                    s.Hide();
+                scheduledHide.RunTask();
+                scheduledHide.Cancel(); // see https://github.com/ppy/osu-framework/issues/2967
+                scheduledHide = null;
             }
 
-            switch (screen)
+            var lastScreen = currentScreen;
+            currentScreen = target;
+
+            if (currentScreen is IProvideVideo)
+            {
+                video.FadeOut(200);
+
+                // delay the hide to avoid a double-fade transition.
+                scheduledHide = Scheduler.AddDelayed(() => lastScreen?.Hide(), TournamentScreen.FADE_DELAY);
+            }
+            else
+            {
+                lastScreen?.Hide();
+                video.Show();
+            }
+
+            screens.ChangeChildDepth(currentScreen, depth--);
+            currentScreen.Show();
+
+            switch (currentScreen)
             {
                 case GameplayScreen _:
                 case MapPoolScreen _:
-                    chatContainer.FadeIn(100);
+                    chatContainer.FadeIn(TournamentScreen.FADE_DELAY);
                     break;
 
                 default:
-                    chatContainer.FadeOut(100);
+                    chatContainer.FadeOut(TournamentScreen.FADE_DELAY);
                     break;
             }
         }


### PR DESCRIPTION
Better tracks the current screen, avoids fading out the previous screen before the new one is completely visible (except when the new screen is using a shared video).

Also fixes `Drawings` not deriving from the correct class, meaning it had no transitions.