### PR TITLE
Disable ruleset input in the editor

### DIFF
--- a/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
@@ -64,6 +64,10 @@ namespace osu.Game.Rulesets.Edit
             drawableRuleset.Playfield.PostProcess();
         }
 
+        public override bool PropagatePositionalInputSubTree => false;
+
+        public override bool PropagateNonPositionalInputSubTree => false;
+
         public PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => drawableRuleset.CreatePlayfieldAdjustmentContainer();
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Being able to click hitobjects and trigger judgements >_> At some point we'll want this to be a toggle.