### PR TITLE
Remove redundant package references in iOS props

### DIFF
--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -73,12 +73,6 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.1108.0" />
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.1108.0" />
-    <PackageReference Include="SharpCompress" Version="0.24.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="SharpRaven" Version="2.4.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
-    <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2019.1010.0" ExcludeAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Solves warning NU1605 when opening iOS test projects.