### PR TITLE
Handle SharpRaven deprecation

### DIFF
--- a/osu.Game.Tests/Visual/TestSceneOsuGame.cs
+++ b/osu.Game.Tests/Visual/TestSceneOsuGame.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual
         private IReadOnlyList<Type> requiredGameDependencies => new[]
         {
             typeof(OsuGame),
-            typeof(RavenLogger),
+            typeof(SentryLogger),
             typeof(OsuLogo),
             typeof(IdleTracker),
             typeof(OnScreenDisplay),

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -71,7 +71,7 @@ namespace osu.Game
         [Cached]
         private readonly ScreenshotManager screenshotManager = new ScreenshotManager();
 
-        protected SentryLogger RavenLogger;
+        protected SentryLogger SentryLogger;
 
         public virtual Storage GetStorageForStableInstall() => null;
 
@@ -110,7 +110,7 @@ namespace osu.Game
 
             forwardLoggedErrorsToNotifications();
 
-            RavenLogger = new SentryLogger(this);
+            SentryLogger = new SentryLogger(this);
         }
 
         private void updateBlockingOverlayFade() =>
@@ -166,7 +166,7 @@ namespace osu.Game
 
             dependencies.CacheAs(this);
 
-            dependencies.Cache(RavenLogger);
+            dependencies.Cache(SentryLogger);
 
             dependencies.Cache(osuLogo = new OsuLogo { Alpha = 0 });
 
@@ -486,7 +486,7 @@ namespace osu.Game
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            RavenLogger.Dispose();
+            SentryLogger.Dispose();
         }
 
         protected override void LoadComplete()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -71,7 +71,7 @@ namespace osu.Game
         [Cached]
         private readonly ScreenshotManager screenshotManager = new ScreenshotManager();
 
-        protected RavenLogger RavenLogger;
+        protected SentryLogger RavenLogger;
 
         public virtual Storage GetStorageForStableInstall() => null;
 
@@ -110,7 +110,7 @@ namespace osu.Game
 
             forwardLoggedErrorsToNotifications();
 
-            RavenLogger = new RavenLogger(this);
+            RavenLogger = new SentryLogger(this);
         }
 
         private void updateBlockingOverlayFade() =>

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Utils
                 Dsn = new Dsn("https://5e342cd55f294edebdc9ad604d28bbd3@sentry.io/1255255"),
                 Release = game.Version
             };
+
             sentry = new SentryClient(options);
             sentryScope = new Scope(options);
 

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -2,10 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Threading.Tasks;
 using osu.Framework.Logging;
 using Sentry;
 
@@ -102,7 +100,7 @@ namespace osu.Game.Utils
                 return;
 
             isDisposed = true;
-            sentry.Dispose();
+            sentry?.Dispose();
             sentry = null;
         }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -22,9 +22,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2019.1112.0" />
+    <PackageReference Include="Sentry" Version="1.2.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="SharpRaven" Version="2.4.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
SharpRaven is [deprecated](https://www.nuget.org/packages/SharpRaven/2.4.0) by its owner. Switching to supported new SDK.

Note: the new SDK is using much more static members. The instance members actually used are internal. Since we are subscribing to static event, it feels OK to me.