### PR TITLE
Remove default-to-cancel assumption on exiting popup dialogs

### DIFF
--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class DialogButton : OsuClickableContainer
     {
+        private const float idle_width = 0.8f;
         private const float hover_width = 0.9f;
         private const float hover_duration = 500;
         private const float glow_fade_duration = 250;
@@ -99,7 +100,7 @@ namespace osu.Game.Graphics.UserInterface
                             RelativeSizeAxes = Axes.Both,
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                            Width = 0.8f,
+                            Width = idle_width,
                             Masking = true,
                             MaskingSmoothness = 2,
                             EdgeEffect = new EdgeEffectParameters
@@ -206,7 +207,7 @@ namespace osu.Game.Graphics.UserInterface
 
             this.Delay(click_duration).Schedule(delegate
             {
-                colourContainer.ResizeTo(new Vector2(0.8f, 1f));
+                colourContainer.ResizeTo(new Vector2(idle_width, 1f));
                 spriteText.Spacing = Vector2.Zero;
                 glowContainer.FadeOut();
             });
@@ -238,7 +239,7 @@ namespace osu.Game.Graphics.UserInterface
             }
             else
             {
-                colourContainer.ResizeTo(new Vector2(0.8f, 1f), hover_duration, Easing.OutElastic);
+                colourContainer.ResizeTo(new Vector2(idle_width, 1f), hover_duration, Easing.OutElastic);
                 spriteText.TransformSpacingTo(Vector2.Zero, hover_duration, Easing.OutElastic);
                 glowContainer.FadeOut(glow_fade_duration, Easing.Out);
             }

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -241,11 +241,6 @@ namespace osu.Game.Overlays.Dialog
 
         protected override void PopOut()
         {
-            if (!actionInvoked)
-                // In the case a user did not choose an action before a hide was triggered, press the last button.
-                // This is presumed to always be a sane default "cancel" action.
-                buttonsContainer.Last().Click();
-
             content.FadeOut(EXIT_DURATION, Easing.InSine);
         }
 


### PR DESCRIPTION
Fix #6822 Aside from some minor refactoring in the same PR, I think that #6825 might be a better solution if the default-to-cancel assumption is correct.