### PR TITLE
Clean up carousel tests

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -334,10 +334,19 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestHiding()
         {
-            BeatmapSetInfo hidingSet = createTestBeatmapSet(1);
-            hidingSet.Beatmaps[1].Hidden = true;
+            BeatmapSetInfo hidingSet = null;
+            List<BeatmapSetInfo> hiddenList = new List<BeatmapSetInfo>();
 
-            loadBeatmaps(new List<BeatmapSetInfo> { hidingSet });
+            AddStep("create hidden set", () =>
+            {
+                hidingSet = createTestBeatmapSet(1);
+                hidingSet.Beatmaps[1].Hidden = true;
+
+                hiddenList.Clear();
+                hiddenList.Add(hidingSet);
+            });
+
+            loadBeatmaps(hiddenList);
 
             setSelected(1, 1);
 
@@ -371,11 +380,14 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestSelectingFilteredRuleset()
         {
+            BeatmapSetInfo testMixed = null;
+
             createCarousel();
 
-            var testMixed = createTestBeatmapSet(set_count + 1);
             AddStep("add mixed ruleset beatmapset", () =>
             {
+                testMixed = createTestBeatmapSet(set_count + 1);
+
                 for (int i = 0; i <= 2; i++)
                 {
                     testMixed.Beatmaps[i].Ruleset = rulesets.AvailableRulesets.ElementAt(i);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
@@ -51,11 +52,6 @@ namespace osu.Game.Tests.Visual.SongSelect
         private void load(RulesetStore rulesets)
         {
             this.rulesets = rulesets;
-
-            Add(carousel = new TestBeatmapCarousel
-            {
-                RelativeSizeAxes = Axes.Both,
-            });
         }
 
         /// <summary>
@@ -375,6 +371,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestSelectingFilteredRuleset()
         {
+            createCarousel();
+
             var testMixed = createTestBeatmapSet(set_count + 1);
             AddStep("add mixed ruleset beatmapset", () =>
             {
@@ -429,6 +427,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void loadBeatmaps(List<BeatmapSetInfo> beatmapSets = null)
         {
+            createCarousel();
+
             if (beatmapSets == null)
             {
                 beatmapSets = new List<BeatmapSetInfo>();
@@ -446,6 +446,17 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
 
             AddUntilStep("Wait for load", () => changed);
+        }
+
+        private void createCarousel(Container target = null)
+        {
+            AddStep($"Create carousel", () =>
+            {
+                (target ?? this).Child = carousel = new TestBeatmapCarousel
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            });
         }
 
         private void ensureRandomFetchSuccess() =>

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -450,7 +450,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void createCarousel(Container target = null)
         {
-            AddStep($"Create carousel", () =>
+            AddStep("Create carousel", () =>
             {
                 (target ?? this).Child = carousel = new TestBeatmapCarousel
                 {

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -452,6 +452,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddStep("Create carousel", () =>
             {
+                selectedSets.Clear();
+                eagerSelectedIDs.Clear();
+
                 (target ?? this).Child = carousel = new TestBeatmapCarousel
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
I thought I was going to use this but I didn't end up doing so. Still a worthwhile change, I believe (causes the carousel to be recreated per test).