### PR TITLE
Fix selected mods not being retained on exiting song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -243,6 +243,22 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestModsRetainedBetweenSongSelect()
+        {
+            AddAssert("empty mods", () => !Mods.Value.Any());
+
+            createSongSelect();
+
+            addRulesetImportStep(0);
+
+            changeMods(new OsuModHardRock());
+
+            createSongSelect();
+
+            AddAssert("mods retained", () => Mods.Value.Any());
+        }
+
+        [Test]
         public void TestStartAfterUnMatchingFilterDoesNotStart()
         {
             createSongSelect();

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -925,6 +925,8 @@ namespace osu.Game
             {
                 OverlayActivationMode.Value = newOsuScreen.InitialOverlayActivationMode;
 
+                musicController.AllowRateAdjustments = newOsuScreen.AllowRateAdjustments;
+
                 if (newOsuScreen.HideOverlaysOnEnter)
                     CloseAllOverlays();
                 else

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays
         private OnScreenDisplay onScreenDisplay { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OsuGame game)
+        private void load()
         {
             beatmapSets.AddRange(beatmaps.GetAllUsableBeatmapSets().OrderBy(_ => RNG.Next()));
             beatmaps.ItemAdded += handleBeatmapAdded;

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays
         private OnScreenDisplay onScreenDisplay { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuGame game)
         {
             beatmapSets.AddRange(beatmaps.GetAllUsableBeatmapSets().OrderBy(_ => RNG.Next()));
             beatmaps.ItemAdded += handleBeatmapAdded;
@@ -233,6 +233,24 @@ namespace osu.Game.Overlays
             queuedDirection = null;
         }
 
+        private bool allowRateAdjustments;
+
+        /// <summary>
+        /// Whether mod rate adjustments are allowed to be applied.
+        /// </summary>
+        public bool AllowRateAdjustments
+        {
+            get => allowRateAdjustments;
+            set
+            {
+                if (allowRateAdjustments == value)
+                    return;
+
+                allowRateAdjustments = value;
+                ResetTrackAdjustments();
+            }
+        }
+
         public void ResetTrackAdjustments()
         {
             var track = current?.Track;
@@ -241,8 +259,11 @@ namespace osu.Game.Overlays
 
             track.ResetSpeedAdjustments();
 
-            foreach (var mod in mods.Value.OfType<IApplicableToClock>())
-                mod.ApplyToClock(track);
+            if (allowRateAdjustments)
+            {
+                foreach (var mod in mods.Value.OfType<IApplicableToClock>())
+                    mod.ApplyToClock(track);
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -51,5 +51,10 @@ namespace osu.Game.Screens
         Bindable<WorkingBeatmap> Beatmap { get; }
 
         Bindable<RulesetInfo> Ruleset { get; }
+
+        /// <summary>
+        /// Whether mod rate adjustments are allowed to be applied.
+        /// </summary>
+        bool AllowRateAdjustments { get; }
     }
 }

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Screens.Menu
 
         public override bool AllowExternalScreenChange => true;
 
+        public override bool AllowRateAdjustments => false;
+
         private Screen songSelect;
 
         private MenuSideFlashes sideFlashes;

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -91,6 +91,8 @@ namespace osu.Game.Screens
 
         public Bindable<RulesetInfo> Ruleset { get; private set; }
 
+        public virtual bool AllowRateAdjustments => true;
+
         public Bindable<IReadOnlyList<Mod>> Mods { get; private set; }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -30,7 +30,6 @@ using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Graphics.Sprites;
@@ -85,10 +84,6 @@ namespace osu.Game.Screens.Select
 
         [Resolved(canBeNull: true)]
         private MusicController music { get; set; }
-
-        [Cached]
-        [Cached(Type = typeof(IBindable<IReadOnlyList<Mod>>))]
-        private readonly Bindable<IReadOnlyList<Mod>> mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>()); // Bound to the game's mods, but is not reset on exiting
 
         protected SongSelect()
         {
@@ -222,7 +217,7 @@ namespace osu.Game.Screens.Select
         {
             if (Footer != null)
             {
-                Footer.AddButton(new FooterButtonMods { Current = mods }, ModSelect);
+                Footer.AddButton(new FooterButtonMods { Current = Mods }, ModSelect);
                 Footer.AddButton(new FooterButtonRandom { Action = triggerRandom });
                 Footer.AddButton(new FooterButtonOptions(), BeatmapOptions);
 
@@ -260,13 +255,6 @@ namespace osu.Game.Screens.Select
                     }
                 });
             }
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            mods.BindTo(Mods);
         }
 
         private DependencyContainer dependencies;
@@ -390,7 +378,7 @@ namespace osu.Game.Screens.Select
                 {
                     Logger.Log($"ruleset changed from \"{decoupledRuleset.Value}\" to \"{ruleset}\"");
 
-                    mods.Value = Array.Empty<Mod>();
+                    Mods.Value = Array.Empty<Mod>();
                     decoupledRuleset.Value = ruleset;
 
                     // force a filter before attempting to change the beatmap.
@@ -537,9 +525,6 @@ namespace osu.Game.Screens.Select
 
             if (Beatmap.Value.Track != null)
                 Beatmap.Value.Track.Looping = false;
-
-            mods.UnbindAll();
-            Mods.Value = Array.Empty<Mod>();
 
             return false;
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -30,6 +30,7 @@ using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Game/Screens/StartupScreen.cs
+++ b/osu.Game/Screens/StartupScreen.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Screens
 
         public override bool CursorVisible => false;
 
+        public override bool AllowRateAdjustments => false;
+
         public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
     }
 }


### PR DESCRIPTION
Regressed due to incorrect implementation transfer in https://github.com/ppy/osu/pull/4613 (the previous logic which was removing the mod from the `WorkingBeatmap` was incorrectly transferred to remove it from the global mod bindable).

- Closes #3186 for the third time, now with regression testing.