### PR TITLE
Fix database unique constraint issues on some imports

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -129,9 +129,12 @@ namespace osu.Game.Beatmaps
         {
             var beatmapIds = beatmapSet.Beatmaps.Where(b => b.OnlineBeatmapID.HasValue).Select(b => b.OnlineBeatmapID).ToList();
 
+            LogForModel(beatmapSet, "Validating online IDs...");
+
             // ensure all IDs are unique
             if (beatmapIds.GroupBy(b => b).Any(g => g.Count() > 1))
             {
+                LogForModel(beatmapSet, "Found non-unique IDs, resetting...");
                 resetIds();
                 return;
             }
@@ -144,8 +147,12 @@ namespace osu.Game.Beatmaps
                 // reset the import ids (to force a re-fetch) *unless* they match the candidate CheckForExisting set.
                 // we can ignore the case where the new ids are contained by the CheckForExisting set as it will either be used (import skipped) or deleted.
                 var existing = CheckForExisting(beatmapSet);
+
                 if (existing == null || existingBeatmaps.Any(b => !existing.Beatmaps.Contains(b)))
+                {
+                    LogForModel(beatmapSet, "Found existing import with IDs already, resetting...");
                     resetIds();
+                }
             }
 
             void resetIds() => beatmapSet.Beatmaps.ForEach(b => b.OnlineBeatmapID = null);

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -387,7 +387,7 @@ namespace osu.Game.Beatmaps
 
                 var req = new GetBeatmapRequest(beatmap);
 
-                req.Failure += e => { LogForModel(set, $"Online retrieval failed for {beatmap} ({e.Message})"); };
+                req.Failure += fail;
 
                 try
                 {
@@ -399,16 +399,18 @@ namespace osu.Game.Beatmaps
                     beatmap.Status = res.Status;
                     beatmap.BeatmapSet.Status = res.BeatmapSet.Status;
                     beatmap.BeatmapSet.OnlineBeatmapSetID = res.OnlineBeatmapSetID;
-
-                    // note that this check only needs to be here if two identical hashed beatmaps exist int he same import.
-                    // probably fine to leave it for safety.
-                    if (set.Beatmaps.All(b => b.OnlineBeatmapID != res.OnlineBeatmapID))
-                        beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
+                    beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
 
                     LogForModel(set, $"Online retrieval mapped {beatmap} to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.");
                 }
                 catch (Exception e)
                 {
+                    fail(e);
+                }
+
+                void fail(Exception e)
+                {
+                    beatmap.OnlineBeatmapID = null;
                     LogForModel(set, $"Online retrieval failed for {beatmap} ({e.Message})");
                 }
             }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -387,22 +387,21 @@ namespace osu.Game.Beatmaps
 
                 var req = new GetBeatmapRequest(beatmap);
 
-                req.Success += res =>
-                {
-                    LogForModel(set, $"Online retrieval mapped {beatmap} to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.");
-
-                    beatmap.Status = res.Status;
-                    beatmap.BeatmapSet.Status = res.BeatmapSet.Status;
-                    beatmap.BeatmapSet.OnlineBeatmapSetID = res.OnlineBeatmapSetID;
-                    beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
-                };
-
                 req.Failure += e => { LogForModel(set, $"Online retrieval failed for {beatmap} ({e.Message})"); };
 
                 try
                 {
                     // intentionally blocking to limit web request concurrency
                     req.Perform(api);
+
+                    var res = req.Result;
+
+                    beatmap.Status = res.Status;
+                    beatmap.BeatmapSet.Status = res.BeatmapSet.Status;
+                    beatmap.BeatmapSet.OnlineBeatmapSetID = res.OnlineBeatmapSetID;
+                    beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
+
+                    LogForModel(set, $"Online retrieval mapped {beatmap} to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.");
                 }
                 catch (Exception e)
                 {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -399,7 +399,11 @@ namespace osu.Game.Beatmaps
                     beatmap.Status = res.Status;
                     beatmap.BeatmapSet.Status = res.BeatmapSet.Status;
                     beatmap.BeatmapSet.OnlineBeatmapSetID = res.OnlineBeatmapSetID;
-                    beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
+
+                    // note that this check only needs to be here if two identical hashed beatmaps exist int he same import.
+                    // probably fine to leave it for safety.
+                    if (set.Beatmaps.All(b => b.OnlineBeatmapID != res.OnlineBeatmapID))
+                        beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
 
                     LogForModel(set, $"Online retrieval mapped {beatmap} to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.");
                 }


### PR DESCRIPTION
- Fixes #6572.

Two things were incorrect here:

- The beatmap online retrieval response running incorrectly on the API scheduler, causing incorrect import behaviour (in many cases the online IDs would not be imported correctly as they weren't populated in time).

- Online retrieved IDs could be double if two .osu files with the same content (and hash) existed. I'm making as second PR to dedupe these before we hit online retrieval, but I think the check is still valuable to have (see inline comment).

Requires login / api to test, can easily test using: https://puu.sh/EEpm3/bf5f955d21.osz

Note that as this is a thread race condition the failure may take multiple attempts, but usually happens on first.