### PR TITLE
Add version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 
 # osu!
 
-[![Build status](https://ci.appveyor.com/api/projects/status/u2p01nx7l6og8buh?svg=true)](https://ci.appveyor.com/project/peppy/osu)  [![CodeFactor](https://www.codefactor.io/repository/github/ppy/osu/badge)](https://www.codefactor.io/repository/github/ppy/osu) [![dev chat](https://discordapp.com/api/guilds/188630481301012481/widget.png?style=shield)](https://discord.gg/ppy)
+[![Build status](https://ci.appveyor.com/api/projects/status/u2p01nx7l6og8buh?svg=true)](https://ci.appveyor.com/project/peppy/osu)
+[![GitHub release](https://img.shields.io/github/release/ppy/osu.svg)]()
+[![CodeFactor](https://www.codefactor.io/repository/github/ppy/osu/badge)](https://www.codefactor.io/repository/github/ppy/osu)
+[![dev chat](https://discordapp.com/api/guilds/188630481301012481/widget.png?style=shield)](https://discord.gg/ppy)
 
 Rhythm is just a *click* away. The future of [osu!](https://osu.ppy.sh) and the beginning of an open era! Commonly known by the codename "osu!lazer". Pew pew.
 


### PR DESCRIPTION
### Description
This adds the badge [![GitHub release](https://img.shields.io/github/release/ppy/osu.svg)]() to README in order to show the latest version of osu!

It is provided by http://shields.io/ and uses the [latest release of osu! from GitHub](https://github.com/ppy/osu/releases/latest)

### Preview

![image](https://user-images.githubusercontent.com/22953777/68892786-05751e00-0724-11ea-96a6-fad8dac57dd3.png)

