### PR TITLE
Add black layer for storyboard

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -9,6 +9,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
 using osu.Game.IO;
 using osu.Game.Screens.Play;
+using osu.Framework.Graphics.Shapes;
+using osuTK.Graphics;
 
 namespace osu.Game.Storyboards.Drawables
 {
@@ -49,11 +51,19 @@ namespace osu.Game.Storyboards.Drawables
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            AddInternal(content = new Container<DrawableStoryboardLayer>
+            AddRangeInternal(new Drawable[]
             {
-                Size = new Vector2(640, 480),
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Black
+                },
+                content = new Container<DrawableStoryboardLayer>
+                {
+                    Size = new Vector2(640, 480),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
             });
         }
 


### PR DESCRIPTION
For some storyboards there's a moment when we can see beatmap background (which in stable cannot be visible)

[Good example](https://osu.ppy.sh/beatmapsets/914120#osu/1922594)
**Stable**
![Screenshot_1](https://user-images.githubusercontent.com/22874522/68981111-747d7000-0813-11ea-8e27-f02770e95fc6.png)
**Lazer (master)**
![Screenshot_2](https://user-images.githubusercontent.com/22874522/68981128-8232f580-0813-11ea-8908-2fd2ab1ab279.png)
**Lazer (with pr)**
![Screenshot_3](https://user-images.githubusercontent.com/22874522/68981147-8ced8a80-0813-11ea-9b87-9bdd2694ae49.png)
