### PR TITLE
Remove usages of FileSafety class

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -54,6 +54,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.1210.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2019.1212.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using osu.Framework.IO.File;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Beatmaps.ControlPoints;
@@ -112,7 +112,7 @@ namespace osu.Game.Beatmaps.Formats
             switch (pair.Key)
             {
                 case @"AudioFilename":
-                    metadata.AudioFile = FileSafety.PathStandardise(pair.Value);
+                    metadata.AudioFile = pair.Value.PathStandardise();
                     break;
 
                 case @"AudioLeadIn":
@@ -300,12 +300,12 @@ namespace osu.Game.Beatmaps.Formats
             {
                 case EventType.Background:
                     string bgFilename = split[2].Trim('"');
-                    beatmap.BeatmapInfo.Metadata.BackgroundFile = FileSafety.PathStandardise(bgFilename);
+                    beatmap.BeatmapInfo.Metadata.BackgroundFile = bgFilename.PathStandardise();
                     break;
 
                 case EventType.Video:
                     string videoFilename = split[2].Trim('"');
-                    beatmap.BeatmapInfo.Metadata.VideoFile = FileSafety.PathStandardise(videoFilename);
+                    beatmap.BeatmapInfo.Metadata.VideoFile = videoFilename.PathStandardise();
                     break;
 
                 case EventType.Break:

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Beatmaps.Formats
             switch (pair.Key)
             {
                 case @"AudioFilename":
-                    metadata.AudioFile = pair.Value.PathStandardise();
+                    metadata.AudioFile = pair.Value.ToStandardisedPath();
                     break;
 
                 case @"AudioLeadIn":
@@ -300,12 +300,12 @@ namespace osu.Game.Beatmaps.Formats
             {
                 case EventType.Background:
                     string bgFilename = split[2].Trim('"');
-                    beatmap.BeatmapInfo.Metadata.BackgroundFile = bgFilename.PathStandardise();
+                    beatmap.BeatmapInfo.Metadata.BackgroundFile = bgFilename.ToStandardisedPath();
                     break;
 
                 case EventType.Video:
                     string videoFilename = split[2].Trim('"');
-                    beatmap.BeatmapInfo.Metadata.VideoFile = videoFilename.PathStandardise();
+                    beatmap.BeatmapInfo.Metadata.VideoFile = videoFilename.ToStandardisedPath();
                     break;
 
                 case EventType.Break:

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -335,6 +335,6 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private string cleanFilename(string path) => path.Trim('"').PathStandardise();
+        private string cleanFilename(string path) => path.Trim('"').ToStandardisedPath();
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -8,8 +8,8 @@ using System.IO;
 using System.Linq;
 using osuTK;
 using osuTK.Graphics;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.IO.File;
 using osu.Game.IO;
 using osu.Game.Storyboards;
 
@@ -335,6 +335,6 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private string cleanFilename(string path) => FileSafety.PathStandardise(path.Trim('"'));
+        private string cleanFilename(string path) => path.Trim('"').PathStandardise();
     }
 }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -82,7 +82,6 @@ namespace osu.Game.Beatmaps
         /// <returns>The absolute path of the output file.</returns>
         public string Save()
         {
-            // copied from osu.Framework.IO.File.FileSafety.GetTempPath
             string directory = Path.Combine(Path.GetTempPath(), @"osu!");
             Directory.CreateDirectory(directory);
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -7,7 +7,6 @@ using osu.Game.Rulesets.Mods;
 using System;
 using System.Collections.Generic;
 using osu.Game.Storyboards;
-using osu.Framework.IO.File;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -83,7 +82,11 @@ namespace osu.Game.Beatmaps
         /// <returns>The absolute path of the output file.</returns>
         public string Save()
         {
-            var path = FileSafety.GetTempPath(Guid.NewGuid().ToString().Replace("-", string.Empty) + ".json");
+            // copied from osu.Framework.IO.File.FileSafety.GetTempPath
+            string directory = Path.Combine(Path.GetTempPath(), @"osu!");
+            Directory.CreateDirectory(directory);
+
+            var path = Path.Combine(directory, Guid.NewGuid().ToString().Replace("-", string.Empty) + ".json");
             using (var sw = new StreamWriter(path))
                 sw.WriteLine(Beatmap.Serialize());
             return path;

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -492,7 +492,7 @@ namespace osu.Game.Database
                 {
                     fileInfos.Add(new TFileModel
                     {
-                        Filename = file.Substring(prefix.Length).PathStandardise(),
+                        Filename = file.Substring(prefix.Length).ToStandardisedPath(),
                         FileInfo = files.Add(s)
                     });
                 }

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -13,7 +13,6 @@ using Microsoft.EntityFrameworkCore;
 using osu.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
-using osu.Framework.IO.File;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
@@ -493,7 +492,7 @@ namespace osu.Game.Database
                 {
                     fileInfos.Add(new TFileModel
                     {
-                        Filename = FileSafety.PathStandardise(file.Substring(prefix.Length)),
+                        Filename = file.Substring(prefix.Length).PathStandardise(),
                         FileInfo = files.Add(s)
                     });
                 }

--- a/osu.Game/Database/DatabaseContextFactory.cs
+++ b/osu.Game/Database/DatabaseContextFactory.cs
@@ -149,7 +149,15 @@ namespace osu.Game.Database
             lock (writeLock)
             {
                 recycleThreadContexts();
-                storage.DeleteDatabase(database_name);
+
+                try
+                {
+                    storage.DeleteDatabase(database_name);
+                }
+                catch
+                {
+                    // for now we are not sure why file handles are kept open by EF, but this is generally only used in testing
+                }
             }
         }
     }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.1210.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.1212.0" />
     <PackageReference Include="Sentry" Version="1.2.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1010.0" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.1210.1" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2019.1212.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">
@@ -82,7 +82,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2019.1210.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2019.1212.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
As https://github.com/ppy/osu-framework/pull/3004#discussion_r347746661 , the entire class is going to be removed. Since game side is using totally different methods with framework side, just copying implementations of the 2 used methods.

- [x] Depends on ppy/osu-framework#3004 after change.