### PR TITLE
Fix crash when loading results after gameplay

### DIFF
--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -183,6 +183,9 @@ namespace osu.Game.Scoring
 
         public override string ToString() => $"{User} playing {Beatmap}";
 
-        public bool Equals(ScoreInfo other) => other?.OnlineScoreID == OnlineScoreID;
+        public bool Equals(ScoreInfo other) =>
+            other?.OnlineScoreID == OnlineScoreID
+            && other?.BeatmapInfoID == BeatmapInfoID
+            && other.Hash == Hash;
     }
 }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -184,8 +184,9 @@ namespace osu.Game.Scoring
         public override string ToString() => $"{User} playing {Beatmap}";
 
         public bool Equals(ScoreInfo other) =>
-            other?.OnlineScoreID == OnlineScoreID
-            && other?.BeatmapInfoID == BeatmapInfoID
+            other != null
+            && other.OnlineScoreID == OnlineScoreID
+            && other.BeatmapInfoID == BeatmapInfoID
             && other.Hash == Hash;
     }
 }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -69,6 +69,6 @@ namespace osu.Game.Scoring
 
         protected override ArchiveDownloadRequest<ScoreInfo> CreateDownloadRequest(ScoreInfo score, bool minimiseDownload) => new DownloadReplayRequest(score);
 
-        protected override bool CheckLocalAvailability(ScoreInfo model, IQueryable<ScoreInfo> items) => items.Any(s => s.OnlineScoreID == model.OnlineScoreID && s.Files.Any());
+        protected override bool CheckLocalAvailability(ScoreInfo model, IQueryable<ScoreInfo> items) => items.Any(s => s.Equals(model) && s.Files.Any());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/6884

Online IDs can incorrectly match in the case of offline plays, so Beatmap ID is used.  
Beatmap IDs can incorrectly match in the case of offline plays on the same Beatmap, so hash is used.
Scores imported from stable will have a non-null hash, scores imported by lazer have a null hash as they don't currently have files. This'll change in the future. The only case to consider is `Hash (null) == Hash (null)` for scores imported from lazer, in which case there is a secondary check in `CheckLocalAvailability` for having files.

Online id and beatmap id can match in the case of offline plays. Hash is the fallback which essentially ensures that a s