### PR TITLE
Switch android to using managed network components

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -16,6 +16,8 @@
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <MandroidI18n>cjk,mideast,other,rare,west</MandroidI18n>
+    <AndroidHttpClientHandlerType>System.Net.Http.HttpClientHandler</AndroidHttpClientHandlerType>
+    <AndroidTlsProvider>legacy</AndroidTlsProvider>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>


### PR DESCRIPTION
Aims to avoid triggering the bug mentioned in https://github.com/ppy/osu/issues/6264.

Note that this *is* a workaround and as such does not close the referenced issue.