### PR TITLE
Add support for consecutive skips

### DIFF
--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -89,6 +89,11 @@ namespace osu.Game.Screens.Play
 
         private double totalOffset => userOffsetClock.Offset + platformOffsetClock.Offset;
 
+        /// <summary>
+        /// Duration before gameplay start time required before skip button displays.
+        /// </summary>
+        public const double MINIMUM_SKIP_TIME = 1000;
+
         private readonly BindableDouble pauseFreqAdjust = new BindableDouble(1);
 
         [BackgroundDependencyLoader]
@@ -128,6 +133,23 @@ namespace osu.Game.Screens.Play
             IsPaused.Value = false;
 
             this.TransformBindableTo(pauseFreqAdjust, 1, 200, Easing.In);
+        }
+
+        /// <summary>
+        /// Skip forward to the next valid skip point.
+        /// </summary>
+        public void Skip()
+        {
+            if (GameplayClock.CurrentTime > gameplayStartTime - MINIMUM_SKIP_TIME)
+                return;
+
+            double skipTarget = gameplayStartTime - MINIMUM_SKIP_TIME;
+
+            if (GameplayClock.CurrentTime < 0 && skipTarget > 6000)
+                // double skip exception for storyboards with very long intros
+                skipTarget = 0;
+
+            Seek(skipTarget);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Screens.Play
                 },
                 new SkipOverlay(DrawableRuleset.GameplayStartTime)
                 {
-                    RequestSeek = GameplayClockContainer.Seek
+                    RequestSkip = GameplayClockContainer.Skip
                 },
                 FailOverlay = new FailOverlay
                 {

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Play
     {
         private readonly double startTime;
 
-        public Action<double> RequestSeek;
+        public Action RequestSkip;
 
         private Button button;
         private Box remainingTimeBox;
@@ -90,11 +90,6 @@ namespace osu.Game.Screens.Play
             };
         }
 
-        /// <summary>
-        /// Duration before gameplay start time required before skip button displays.
-        /// </summary>
-        private const double skip_buffer = 1000;
-
         private const double fade_time = 300;
 
         private double beginFadeTime => startTime - fade_time;
@@ -104,7 +99,7 @@ namespace osu.Game.Screens.Play
             base.LoadComplete();
 
             // skip is not required if there is no extra "empty" time to skip.
-            if (Clock.CurrentTime > beginFadeTime - skip_buffer)
+            if (Clock.CurrentTime > beginFadeTime - GameplayClockContainer.MINIMUM_SKIP_TIME)
             {
                 Alpha = 0;
                 Expire();
@@ -115,10 +110,9 @@ namespace osu.Game.Screens.Play
             using (BeginAbsoluteSequence(beginFadeTime))
                 this.FadeOut(fade_time);
 
-            button.Action = () => RequestSeek?.Invoke(beginFadeTime);
+            button.Action = () => RequestSkip?.Invoke();
 
             displayTime = Time.Current;
-
             Expire();
         }
 
@@ -130,6 +124,8 @@ namespace osu.Game.Screens.Play
         {
             base.Update();
             remainingTimeBox.ResizeWidthTo((float)Math.Max(0, 1 - (Time.Current - displayTime) / (beginFadeTime - displayTime)), 120, Easing.OutQuint);
+
+            button.Enabled.Value = Time.Current < startTime - GameplayClockContainer.MINIMUM_SKIP_TIME;
         }
 
         protected override bool OnMouseMove(MouseMoveEvent e)
@@ -335,13 +331,7 @@ namespace osu.Game.Screens.Play
                 box.FlashColour(Color4.White, 500, Easing.OutQuint);
                 aspect.ScaleTo(1.2f, 2000, Easing.OutQuint);
 
-                bool result = base.OnClick(e);
-
-                // for now, let's disable the skip button after the first press.
-                // this will likely need to be contextual in the future (bound from external components).
-                Enabled.Value = false;
-
-                return result;
+                return base.OnClick(e);
             }
         }
     }


### PR DESCRIPTION
Allows the skip button to be actuated multiple times to make way for storyboards (or other future cases) which require multiple skips.

Resolves half of #6840.