### PR TITLE
Improve skip button feel

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
             AddStep("button down", () => InputManager.PressButton(MouseButton.Left));
-            AddUntilStep("wait for overlay disapper", () => !skip.IsAlive);
+            AddUntilStep("wait for overlay disappear", () => !skip.IsPresent);
             AddAssert("ensure button didn't disappear", () => skip.Children.First().Alpha > 0);
             AddStep("button up", () => InputManager.ReleaseButton(MouseButton.Left));
             checkRequestCount(0);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -4,8 +4,8 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Timing;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play;
 using osuTK;
 using osuTK.Input;
@@ -18,40 +18,38 @@ namespace osu.Game.Tests.Visual.Gameplay
         private SkipOverlay skip;
         private int requestCount;
 
-        private FramedOffsetClock offsetClock;
-        private StopwatchClock stopwatchClock;
-
         private double increment;
+
+        private GameplayClockContainer gameplayClockContainer;
+        private GameplayClock gameplayClock;
+
+        private const double skip_time = 6000;
 
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
             requestCount = 0;
-            increment = 6000;
+            increment = skip_time;
 
-            Child = new Container
+            Child = gameplayClockContainer = new GameplayClockContainer(CreateWorkingBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo)), new Mod[] { }, 0)
             {
                 RelativeSizeAxes = Axes.Both,
-                Clock = offsetClock = new FramedOffsetClock(stopwatchClock = new StopwatchClock(true)),
                 Children = new Drawable[]
                 {
-                    skip = new SkipOverlay(6000)
+                    skip = new SkipOverlay(skip_time)
                     {
                         RequestSkip = () =>
                         {
                             requestCount++;
-                            offsetClock.Offset += increment;
+                            gameplayClockContainer.Seek(gameplayClock.CurrentTime + increment);
                         }
                     }
                 },
             };
-        });
 
-        protected override void Update()
-        {
-            if (stopwatchClock != null)
-                stopwatchClock.Rate = Clock.Rate;
-        }
+            gameplayClockContainer.Start();
+            gameplayClock = gameplayClockContainer.GameplayClock;
+        });
 
         [Test]
         public void TestFadeOnIdle()
@@ -80,7 +78,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
             AddStep("click", () =>
             {
-                increment = 6000 - offsetClock.CurrentTime - GameplayClockContainer.MINIMUM_SKIP_TIME / 2;
+                increment = skip_time - gameplayClock.CurrentTime - GameplayClockContainer.MINIMUM_SKIP_TIME / 2;
                 InputManager.Click(MouseButton.Left);
             });
             AddStep("click", () => InputManager.Click(MouseButton.Left));

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -19,6 +19,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.MathUtils;
 using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Play
@@ -35,6 +36,9 @@ namespace osu.Game.Screens.Play
         private FadeContainer fadeContainer;
         private double displayTime;
 
+        [Resolved]
+        private GameplayClock gameplayClock { get; set; }
+
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         /// <summary>
@@ -44,8 +48,6 @@ namespace osu.Game.Screens.Play
         public SkipOverlay(double startTime)
         {
             this.startTime = startTime;
-
-            Show();
 
             RelativePositionAxes = Axes.Both;
             RelativeSizeAxes = Axes.X;
@@ -57,13 +59,8 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, GameplayClock clock)
+        private void load(OsuColour colours)
         {
-            var baseClock = Clock;
-
-            if (clock != null)
-                Clock = clock;
-
             Children = new Drawable[]
             {
                 fadeContainer = new FadeContainer
@@ -73,7 +70,6 @@ namespace osu.Game.Screens.Play
                     {
                         button = new Button
                         {
-                            Clock = baseClock,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },
@@ -92,40 +88,40 @@ namespace osu.Game.Screens.Play
 
         private const double fade_time = 300;
 
-        private double beginFadeTime => startTime - fade_time;
+        private double fadeOutBeginTime => startTime - GameplayClockContainer.MINIMUM_SKIP_TIME;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
             // skip is not required if there is no extra "empty" time to skip.
-            if (Clock.CurrentTime > beginFadeTime - GameplayClockContainer.MINIMUM_SKIP_TIME)
+            // we may need to remove this if rewinding before the initial player load position becomes a thing.
+            if (fadeOutBeginTime < gameplayClock.CurrentTime)
             {
-                Alpha = 0;
                 Expire();
                 return;
             }
 
-            this.FadeInFromZero(fade_time);
-            using (BeginAbsoluteSequence(beginFadeTime))
-                this.FadeOut(fade_time);
-
             button.Action = () => RequestSkip?.Invoke();
+            displayTime = gameplayClock.CurrentTime;
 
-            displayTime = Time.Current;
-            Expire();
+            Show();
         }
 
-        protected override void PopIn() => this.FadeIn();
+        protected override void PopIn() => this.FadeIn(fade_time);
 
-        protected override void PopOut() => this.FadeOut();
+        protected override void PopOut() => this.FadeOut(fade_time);
 
         protected override void Update()
         {
             base.Update();
-            remainingTimeBox.ResizeWidthTo((float)Math.Max(0, 1 - (Time.Current - displayTime) / (beginFadeTime - displayTime)), 120, Easing.OutQuint);
 
-            button.Enabled.Value = Time.Current < startTime - GameplayClockContainer.MINIMUM_SKIP_TIME;
+            var progress = Math.Max(0, 1 - (gameplayClock.CurrentTime - displayTime) / (fadeOutBeginTime - displayTime));
+
+            remainingTimeBox.Width = (float)Interpolation.Lerp(remainingTimeBox.Width, progress, Math.Clamp(Time.Elapsed / 40, 0, 1));
+
+            button.Enabled.Value = progress > 0;
+            State.Value = progress > 0 ? Visibility.Visible : Visibility.Hidden;
         }
 
         protected override bool OnMouseMove(MouseMoveEvent e)


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/6900.

This brings the skip button in line with my expectations as far as visual and UX is concerned. It recovers from a minor animation regression in #6900 (due to the fade being tied to the gameplay clock until now).