### PR TITLE
Increase padding on mod section title

### DIFF
--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Overlays.Mods
                     Spacing = new Vector2(50f, 0f),
                     Margin = new MarginPadding
                     {
-                        Top = 6,
+                        Top = 20,
                     },
                     AlwaysPresent = true
                 },


### PR DESCRIPTION
Minor change, increase the margin/padding of the mod section's title to look better

Before:
![image](https://user-images.githubusercontent.com/10289119/69450599-72586b80-0d55-11ea-8829-5937c699e20d.png)


After:
![image](https://user-images.githubusercontent.com/10289119/69450648-8ac88600-0d55-11ea-9b62-e33aa512d4e3.png)

