### PR TITLE
Fix beatmap lookups failing for beatmaps with no local path

### DIFF
--- a/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
@@ -15,6 +15,6 @@ namespace osu.Game.Online.API.Requests
             this.beatmap = beatmap;
         }
 
-        protected override string Target => $@"beatmaps/lookup?id={beatmap.OnlineBeatmapID}&checksum={beatmap.MD5Hash}&filename={System.Uri.EscapeUriString(beatmap.Path)}";
+        protected override string Target => $@"beatmaps/lookup?id={beatmap.OnlineBeatmapID}&checksum={beatmap.MD5Hash}&filename={System.Uri.EscapeUriString(beatmap.Path ?? string.Empty)}";
     }
 }


### PR DESCRIPTION
Turns out the underlying `EscapeUriString` doesn't like nulls