### PR TITLE
IApplicableToDrawableHitObjects should be able to get all the hitobject in nasted Playfield

### DIFF
--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -224,7 +224,7 @@ namespace osu.Game.Rulesets.UI
             Playfield.PostProcess();
 
             foreach (var mod in mods.OfType<IApplicableToDrawableHitObjects>())
-                mod.ApplyToDrawableHitObjects(Playfield.HitObjectContainer.Objects);
+                mod.ApplyToDrawableHitObjects(Playfield.AllHitObjects);
         }
 
         public override void RequestResume(Action continueResume)


### PR DESCRIPTION
`IApplicableToDrawableHitObjects` should be able to get all the `HitObjects` in main `Playfield` and it's `NastedPlayfield`