### PR TITLE
Correct banned symbols configuration

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -2,4 +2,4 @@ M:System.Object.Equals(System.Object,System.Object)~System.Boolean;Don't use obj
 M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
-T:osu.Framework.Graphics.Sprites.SpriteText.#ctor;Use OsuSpriteText.
+M:osu.Framework.Graphics.Sprites.SpriteText.#ctor;Use OsuSpriteText.


### PR DESCRIPTION
I missed the previous pull request.
Syntax reference: https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
`M` represents method and `T` represents type here.

Do I need to add comment at somewhere? The BannedSymbols.txt itself doesn't support comment, but can be simulated.