### PR TITLE
Revert Android to using native network components

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -16,8 +16,6 @@
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <MandroidI18n>cjk,mideast,other,rare,west</MandroidI18n>
-    <AndroidHttpClientHandlerType>System.Net.Http.HttpClientHandler</AndroidHttpClientHandlerType>
-    <AndroidTlsProvider>legacy</AndroidTlsProvider>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>


### PR DESCRIPTION
For best effect, should go together with ppy/osu-framework#3028.

# Summary

Revert PR #6899 ("Switch android to using managed network components") due to it breaking every online call ([see comment](https://github.com/ppy/osu/issues/6264#issuecomment-557803751)). The managed legacy TLS provider is slated for removal in later mono releases as it stands anyway.

The framework-side PR adds suppressions to the exception in #6264, which should make it less severe but still not fixed. For the fix we probably need to wait until mono/xamarin send it down their pipelines to general availability releases. I tried installing mono nightly to no avail.