### PR TITLE
Add loved enum on BeatmapApproval

### DIFF
--- a/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUserRecentActivitiesRequest.cs
@@ -42,5 +42,6 @@ namespace osu.Game.Online.API.Requests
         Ranked,
         Approved,
         Qualified,
+        Loved
     }
 }


### PR DESCRIPTION
Fix #6994 

Seems BeatmapApproval missing Loved status, that's why user with loved message related not loaded

azr8's userpage:
![image](https://user-images.githubusercontent.com/6506864/69816357-c7e7b900-122a-11ea-94d0-1f7f68d28b15.png)

gemboyong's userpage:
![image](https://user-images.githubusercontent.com/6506864/69816408-e483f100-122a-11ea-9703-d32a5e7f30bb.png)
