### PR TITLE
Hide the menu cursor while inside the playfield by default

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -29,6 +30,8 @@ namespace osu.Game.Rulesets.Osu.UI
             : base(ruleset, beatmap, mods)
         {
         }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true; // always show the gameplay cursor
 
         public override ScoreProcessor CreateScoreProcessor() => new OsuScoreProcessor(this);
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -34,6 +34,7 @@ using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
+using osuTK;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -330,6 +331,9 @@ namespace osu.Game.Rulesets.UI
         #region IProvideCursor
 
         protected override bool OnHover(HoverEvent e) => true; // required for IProvideCursor
+
+        // only show the cursor when within the playfield, by default.
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Playfield.ReceivePositionalInputAt(screenSpacePos);
 
         CursorContainer IProvideCursor.Cursor => Playfield.Cursor;
 

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -100,10 +100,13 @@ namespace osu.Game.Rulesets.UI
         public GameplayCursorContainer Cursor { get; private set; }
 
         /// <summary>
-        /// Provide an optional cursor which is to be used for gameplay.
+        /// Provide a cursor which is to be used for gameplay.
         /// </summary>
-        /// <returns>The cursor, or null if a cursor is not rqeuired.</returns>
-        protected virtual GameplayCursorContainer CreateCursor() => null;
+        /// <remarks>
+        /// The default provided cursor is invisible when inside the bounds of the <see cref="Playfield"/>.
+        /// </remarks>
+        /// <returns>The cursor, or null to show the menu cursor.</returns>
+        protected virtual GameplayCursorContainer CreateCursor() => new InvisibleCursorContainer();
 
         /// <summary>
         /// Registers a <see cref="Playfield"/> as a nested <see cref="Playfield"/>.
@@ -143,5 +146,14 @@ namespace osu.Game.Rulesets.UI
         /// Creates the container that will be used to contain the <see cref="DrawableHitObject"/>s.
         /// </summary>
         protected virtual HitObjectContainer CreateHitObjectContainer() => new HitObjectContainer();
+
+        public class InvisibleCursorContainer : GameplayCursorContainer
+        {
+            protected override Drawable CreateCursor() => new InvisibleCursor();
+
+            private class InvisibleCursor : Drawable
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
This changes the default behaviour of `DrawableRuleset` to provide an invisible cursor, but only "display" it while within the bounds of the `Playfield`. osu! is an exception, where it chooses to display its cursor everywhere.

This provides better default behaviour for other rulesets, and allows for cursor hiding when it would otherwise be overlapping gameplay elements.