### PR TITLE
Add NewsArticleCover class and add missing content async loading logic

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -31,10 +31,6 @@ namespace osu.Game.Tests.Visual.Online
 
         private class TestNewsOverlay : NewsOverlay
         {
-            public TestNewsOverlay()
-            {
-            }
-
             public void ShowContent(NewsContent content) => LoadChildContent(content);
         }
 

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Overlays.News;
+using osuTK;
 
 namespace osu.Game.Tests.Visual.Online
 {
@@ -41,7 +42,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             public TestNewsContent()
             {
-                Spacing = new osuTK.Vector2(0, 10);
+                Spacing = new Vector2(0, 10);
                 Add(new TestCard("https://osu.ppy.sh/help/wiki/shared/news/banners/CWC_2019_banner.jpg"));
                 Add(new TestCard("https://osu.ppy.sh/help/wiki/shared/news/banners/CWC_2019_banner.jpg"));
                 Add(new TestCard("https://osu.ppy.sh/help/wiki/shared/news/banners/CWC_2019_banner.jpg"));

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Overlays.News;
 
@@ -19,6 +24,8 @@ namespace osu.Game.Tests.Visual.Online
 
             AddStep(@"Show front page", () => news.ShowFrontPage());
             AddStep(@"Custom article", () => news.Current.Value = "Test Article 101");
+
+            AddStep(@"News article covers", () => news.ShowContent(new TestNewsContent()));
         }
 
         private class TestNewsOverlay : NewsOverlay
@@ -28,6 +35,40 @@ namespace osu.Game.Tests.Visual.Online
             }
 
             public void ShowContent(NewsContent content) => LoadChildContent(content);
+        }
+
+        private class TestNewsContent : NewsContent
+        {
+            public TestNewsContent()
+            {
+                Spacing = new osuTK.Vector2(0, 10);
+                Add(new TestCard("https://osu.ppy.sh/help/wiki/shared/news/banners/CWC_2019_banner.jpg"));
+                Add(new TestCard("https://osu.ppy.sh/help/wiki/shared/news/banners/CWC_2019_banner.jpg"));
+                Add(new TestCard("https://osu.ppy.sh/help/wiki/shared/news/banners/CWC_2019_banner.jpg"));
+            }
+
+            private class TestCard : Container
+            {
+                public TestCard(string url)
+                {
+                    RelativeSizeAxes = Axes.X;
+                    Height = 250;
+                    Masking = true;
+                    CornerRadius = 4;
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.1f))
+                        },
+                        new NewsArticleCover(url)
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        }
+                    };
+                }
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -2,22 +2,32 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Overlays;
+using osu.Game.Overlays.News;
 
 namespace osu.Game.Tests.Visual.Online
 {
     public class TestSceneNewsOverlay : OsuTestScene
     {
-        private NewsOverlay news;
+        private TestNewsOverlay news;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            Add(news = new NewsOverlay());
+            Add(news = new TestNewsOverlay());
             AddStep(@"Show", news.Show);
             AddStep(@"Hide", news.Hide);
 
             AddStep(@"Show front page", () => news.ShowFrontPage());
             AddStep(@"Custom article", () => news.Current.Value = "Test Article 101");
+        }
+
+        private class TestNewsOverlay : NewsOverlay
+        {
+            public TestNewsOverlay()
+            {
+            }
+
+            public void ShowContent(NewsContent content) => LoadChildContent(content);
         }
     }
 }

--- a/osu.Game/Overlays/News/NewsArticleCover.cs
+++ b/osu.Game/Overlays/News/NewsArticleCover.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Game.Overlays.News
+{
+    public class NewsArticleCover : CompositeDrawable
+    {
+        public NewsArticleCover(string url)
+        {
+            NewsArticleCoverBackground background;
+            InternalChild = new DelayedLoadWrapper(background = new NewsArticleCoverBackground(url));
+
+            background.OnLoadComplete += bg => bg.FadeInFromZero(400, Easing.Out);
+        }
+
+        [LongRunningLoad]
+        private class NewsArticleCoverBackground : Sprite
+        {
+            private string url;
+
+            public NewsArticleCoverBackground(string url)
+            {
+                this.url = url;
+
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+                RelativeSizeAxes = Axes.Both;
+                FillMode = FillMode.Fill;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(LargeTextureStore store)
+            {
+                Texture = store.Get(url ?? "Headers/changelog");
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/News/NewsArticleCover.cs
+++ b/osu.Game/Overlays/News/NewsArticleCover.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.News
             [BackgroundDependencyLoader]
             private void load(LargeTextureStore store)
             {
-                Texture = store.Get(url ?? "Headers/changelog");
+                Texture = store.Get(url ?? "Headers/news");
             }
         }
     }

--- a/osu.Game/Overlays/News/NewsArticleCover.cs
+++ b/osu.Game/Overlays/News/NewsArticleCover.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Overlays.News
         [LongRunningLoad]
         private class NewsArticleCoverBackground : Sprite
         {
-            private string url;
+            private readonly string url;
 
             public NewsArticleCoverBackground(string url)
             {

--- a/osu.Game/Overlays/NewsOverlay.cs
+++ b/osu.Game/Overlays/NewsOverlay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -56,13 +57,31 @@ namespace osu.Game.Overlays
             };
 
             header.Current.BindTo(Current);
+
             Current.TriggerChange();
         }
 
-        public void ShowFrontPage()
+        private CancellationTokenSource loadChildCancellation;
+
+        protected void LoadChildContent(NewsContent newContent)
         {
-            Current.Value = null;
+            content.FadeTo(0.2f, 300, Easing.OutQuint);
+
+            loadChildCancellation?.Cancel();
+
+            LoadComponentAsync(newContent, c =>
+            {
+                content.Child = c;
+                content.FadeIn(300, Easing.OutQuint);
+            }, (loadChildCancellation = new CancellationTokenSource()).Token);
+        }
+
+        public void ShowArticle(string article)
+        {
+            Current.Value = article;
             Show();
         }
+
+        public void ShowFrontPage() => ShowArticle(null);
     }
 }


### PR DESCRIPTION
# Summary

- This PR implements the content async loading logic (`LoadChildContent`) which should have been implemented in the News Overlay skeleton PR.

- This PR also implements the `NewsArticleCover` class, used to load asynchronously and display the cover of news article cards. 

Article cards and News front page are coming in a next PR.

![image](https://user-images.githubusercontent.com/20256717/69887501-8e28b800-12e7-11ea-88cb-cc82f5ad45d4.png)
