### PR TITLE
Fix overlays closing when dragging from in/out or out/in

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -67,33 +67,21 @@ namespace osu.Game.Graphics.Containers
         // receive input outside our bounds so we can trigger a close event on ourselves.
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => BlockScreenWideMouse || base.ReceivePositionalInputAt(screenSpacePos);
 
-        protected override bool OnClick(ClickEvent e)
-        {
-            if (!base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
-                Hide();
+        private bool closeOnMouseUp;
 
-            return base.OnClick(e);
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            closeOnMouseUp = !base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition) ? true : false;
+
+            return base.OnMouseDown(e);
         }
 
-        private bool closeOnDragEnd;
-
-        protected override bool OnDragStart(DragStartEvent e)
+        protected override bool OnMouseUp(MouseUpEvent e)
         {
-            if (!base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
-                closeOnDragEnd = true;
-
-            return base.OnDragStart(e);
-        }
-
-        protected override bool OnDragEnd(DragEndEvent e)
-        {
-            if (closeOnDragEnd)
-            {
+            if (closeOnMouseUp && !base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
                 Hide();
-                closeOnDragEnd = false;
-            }
 
-            return base.OnDragEnd(e);
+            return base.OnMouseUp(e);
         }
 
         public virtual bool OnPressed(GlobalAction action)

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Graphics.Containers
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            closeOnMouseUp = !base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition) ? true : false;
+            closeOnMouseUp = !base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
 
             return base.OnMouseDown(e);
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/6950.

I've simplified it to `OnMouseDown` and `OnMouseUp`.

`OnMouseDown` is equivalent to `OnDragStart`, but `OnDragStart` needs a drag. It needs to handle the bools, ~since~ so that if we left click outside of the overlay, then right click inside and drag outside, the `closeOnDragEnd` will be false and the overlay will not close.

`OnMouseUp` is equivalent to `OnClick` and `OnDragEnd`, but `OnClick` is only left click and `OnDragEnd` needs a starting drag. It'll handle `Hide()`.

Issues fixed in issue:
- [X] While holding the left mouse button outside the dialog and dragging it into the dialog though, should not disgard the dialog, which is not the case.
- [X] Holding the left mouse button and additionally holding the right mouse button and dragging the mouse outside the dialog closes the dialog, which should not happen.
	- Note: this can be done with just one of the buttons.

Other changes:
- Right clicking outside in place will close the overlay (from what I said on top).