### PR TITLE
Remove some remaining untyped boxing calls

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -1,5 +1,6 @@
 M:System.Object.Equals(System.Object,System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
 M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
+M:System.Nullable`1.Equals(System.Object)~System.Boolean;Use == instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
 M:osu.Framework.Graphics.Sprites.SpriteText.#ctor;Use OsuSpriteText.

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
@@ -37,12 +37,12 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         {
             mods = Score.Mods;
             scaledScore = Score.TotalScore;
-            countPerfect = Convert.ToInt32(Score.Statistics[HitResult.Perfect]);
-            countGreat = Convert.ToInt32(Score.Statistics[HitResult.Great]);
-            countGood = Convert.ToInt32(Score.Statistics[HitResult.Good]);
-            countOk = Convert.ToInt32(Score.Statistics[HitResult.Ok]);
-            countMeh = Convert.ToInt32(Score.Statistics[HitResult.Meh]);
-            countMiss = Convert.ToInt32(Score.Statistics[HitResult.Miss]);
+            countPerfect = Score.Statistics[HitResult.Perfect];
+            countGreat = Score.Statistics[HitResult.Great];
+            countGood = Score.Statistics[HitResult.Good];
+            countOk = Score.Statistics[HitResult.Ok];
+            countMeh = Score.Statistics[HitResult.Meh];
+            countMiss = Score.Statistics[HitResult.Miss];
 
             if (mods.Any(m => !m.Ranked))
                 return 0;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -45,10 +45,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             mods = Score.Mods;
             accuracy = Score.Accuracy;
             scoreMaxCombo = Score.MaxCombo;
-            countGreat = Convert.ToInt32(Score.Statistics[HitResult.Great]);
-            countGood = Convert.ToInt32(Score.Statistics[HitResult.Good]);
-            countMeh = Convert.ToInt32(Score.Statistics[HitResult.Meh]);
-            countMiss = Convert.ToInt32(Score.Statistics[HitResult.Miss]);
+            countGreat = Score.Statistics[HitResult.Great];
+            countGood = Score.Statistics[HitResult.Good];
+            countMeh = Score.Statistics[HitResult.Meh];
+            countMiss = Score.Statistics[HitResult.Miss];
 
             // Don't count scores made with supposedly unranked mods
             if (mods.Any(m => !m.Ranked))

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -31,10 +31,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         public override double Calculate(Dictionary<string, double> categoryDifficulty = null)
         {
             mods = Score.Mods;
-            countGreat = Convert.ToInt32(Score.Statistics[HitResult.Great]);
-            countGood = Convert.ToInt32(Score.Statistics[HitResult.Good]);
-            countMeh = Convert.ToInt32(Score.Statistics[HitResult.Meh]);
-            countMiss = Convert.ToInt32(Score.Statistics[HitResult.Miss]);
+            countGreat = Score.Statistics[HitResult.Great];
+            countGood = Score.Statistics[HitResult.Good];
+            countMeh =Score.Statistics[HitResult.Meh];
+            countMiss = Score.Statistics[HitResult.Miss];
 
             // Don't count scores made with supposedly unranked mods
             if (mods.Any(m => !m.Ranked))

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             mods = Score.Mods;
             countGreat = Score.Statistics[HitResult.Great];
             countGood = Score.Statistics[HitResult.Good];
-            countMeh =Score.Statistics[HitResult.Meh];
+            countMeh = Score.Statistics[HitResult.Meh];
             countMiss = Score.Statistics[HitResult.Miss];
 
             // Don't count scores made with supposedly unranked mods

--- a/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
@@ -25,6 +25,6 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// <returns>Whether equivalent.</returns>
         public abstract bool EquivalentTo(ControlPoint other);
 
-        public bool Equals(ControlPoint other) => Time.Equals(other?.Time) && EquivalentTo(other);
+        public bool Equals(ControlPoint other) => Time == other?.Time && EquivalentTo(other);
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -151,18 +151,18 @@ namespace osu.Game.Graphics.UserInterface
         private void updateTooltipText(T value)
         {
             if (CurrentNumber.IsInteger)
-                TooltipText = ((int)Convert.ChangeType(value, typeof(int))).ToString("N0");
+                TooltipText = value.ToInt32(NumberFormatInfo.InvariantInfo).ToString("N0");
             else
             {
-                double floatValue = (double)Convert.ChangeType(value, typeof(double));
-                double floatMinValue = (double)Convert.ChangeType(CurrentNumber.MinValue, typeof(double));
-                double floatMaxValue = (double)Convert.ChangeType(CurrentNumber.MaxValue, typeof(double));
+                double floatValue = value.ToDouble(NumberFormatInfo.InvariantInfo);
+                double floatMinValue = CurrentNumber.MinValue.ToDouble(NumberFormatInfo.InvariantInfo);
+                double floatMaxValue = CurrentNumber.MaxValue.ToDouble(NumberFormatInfo.InvariantInfo);
 
                 if (floatMaxValue == 1 && floatMinValue >= -1)
                     TooltipText = floatValue.ToString("P0");
                 else
                 {
-                    var decimalPrecision = normalise((decimal)Convert.ChangeType(CurrentNumber.Precision, typeof(decimal)), max_decimal_digits);
+                    var decimalPrecision = normalise(CurrentNumber.Precision.ToDecimal(NumberFormatInfo.InvariantInfo), max_decimal_digits);
 
                     // Find the number of significant digits (we could have less than 5 after normalize())
                     var significantDigits = findPrecision(decimalPrecision);

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -273,14 +273,6 @@ namespace osu.Game.Rulesets.Objects
             return p0 + (p1 - p0) * (float)w;
         }
 
-        public bool Equals(SliderPath other)
-        {
-            if (ControlPoints == null && other.ControlPoints != null)
-                return false;
-            if (other.ControlPoints == null && ControlPoints != null)
-                return false;
-
-            return ControlPoints.SequenceEqual(other.ControlPoints) && ExpectedDistance == other.ExpectedDistance && Type == other.Type;
-        }
+        public bool Equals(SliderPath other) => ControlPoints.SequenceEqual(other.ControlPoints) && ExpectedDistance == other.ExpectedDistance && Type == other.Type;
     }
 }

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Rulesets.Objects
             if (other.ControlPoints == null && ControlPoints != null)
                 return false;
 
-            return ControlPoints.SequenceEqual(other.ControlPoints) && ExpectedDistance.Equals(other.ExpectedDistance) && Type == other.Type;
+            return ControlPoints.SequenceEqual(other.ControlPoints) && ExpectedDistance == other.ExpectedDistance && Type == other.Type;
         }
     }
 }

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -79,8 +79,8 @@ namespace osu.Game.Screens.Select
             public bool IsUpperInclusive;
 
             public bool Equals(OptionalRange<T> other)
-                => Min.Equals(other.Min)
-                   && Max.Equals(other.Max)
+                => EqualityComparer<T?>.Default.Equals(Min, other.Min)
+                   && EqualityComparer<T?>.Default.Equals(Max, other.Max)
                    && IsLowerInclusive.Equals(other.IsLowerInclusive)
                    && IsUpperInclusive.Equals(other.IsUpperInclusive);
         }

--- a/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
@@ -240,6 +240,6 @@ namespace osu.Game.Tests.Beatmaps
             set => Objects = value;
         }
 
-        public virtual bool Equals(ConvertMapping<TConvertValue> other) => StartTime.Equals(other?.StartTime);
+        public virtual bool Equals(ConvertMapping<TConvertValue> other) => StartTime == other?.StartTime;
     }
 }


### PR DESCRIPTION
The remaining scenarios are all `Nullable<T>` related.
Since CLR doesn't support implementing interfaces conditionally, `Nullable<T>` can't implement any one.

Please always prefer `==` over `Equals` when writing code.

Note: `==` and `Equals` have different behavior on `NaN`. I think `NaN` should be unexpected in these scenarios.