### PR TITLE
Fix unnecessary beatmap fetch for beatmap panel in multiplayer room

### DIFF
--- a/osu.Game/Overlays/Direct/DirectGridPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectGridPanel.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Overlays.Direct
         protected override PlayButton PlayButton => playButton;
         protected override Box PreviewBar => progressBar;
 
-        public DirectGridPanel(BeatmapSetInfo beatmap)
-            : base(beatmap)
+        public DirectGridPanel(BeatmapSetInfo beatmap, bool fetchOnline = true)
+            : base(beatmap, fetchOnline)
         {
             Width = 380;
             Height = 140 + vertical_padding; //full height of all the elements plus vertical padding (autosize uses the image)

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -44,10 +44,13 @@ namespace osu.Game.Overlays.Direct
 
         protected override Container<Drawable> Content => content;
 
-        protected DirectPanel(BeatmapSetInfo setInfo)
+        private readonly bool fetchOnline;
+
+        protected DirectPanel(BeatmapSetInfo setInfo, bool fetchOnline = false)
         {
             Debug.Assert(setInfo.OnlineBeatmapSetID != null);
 
+            this.fetchOnline = fetchOnline;
             SetInfo = setInfo;
         }
 
@@ -123,7 +126,10 @@ namespace osu.Game.Overlays.Direct
         protected override bool OnClick(ClickEvent e)
         {
             Debug.Assert(SetInfo.OnlineBeatmapSetID != null);
-            beatmapSetOverlay?.FetchAndShowBeatmapSet(SetInfo.OnlineBeatmapSetID.Value);
+            if (fetchOnline)
+                beatmapSetOverlay?.FetchAndShowBeatmapSet(SetInfo.OnlineBeatmapSetID.Value);
+            else
+                beatmapSetOverlay?.ShowBeatmapSet(SetInfo);
             return true;
         }
 

--- a/osu.Game/Overlays/Direct/DirectPanel.cs
+++ b/osu.Game/Overlays/Direct/DirectPanel.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Overlays.Direct
 
         private readonly bool fetchOnline;
 
-        protected DirectPanel(BeatmapSetInfo setInfo, bool fetchOnline = false)
+        protected DirectPanel(BeatmapSetInfo setInfo, bool fetchOnline = true)
         {
             Debug.Assert(setInfo.OnlineBeatmapSetID != null);
 

--- a/osu.Game/Screens/Multi/Match/Components/MatchBeatmapPanel.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchBeatmapPanel.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Multi.Match.Components
             request = new GetBeatmapSetRequest(beatmap.OnlineBeatmapID.Value, BeatmapSetLookupType.BeatmapId);
             request.Success += res => Schedule(() =>
             {
-                panel = new DirectGridPanel(res.ToBeatmapSet(rulesets));
+                panel = new DirectGridPanel(res.ToBeatmapSet(rulesets), false);
                 LoadComponentAsync(panel, AddInternal, loadCancellation.Token);
             });
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/ppy/osu/issues/7039

In multiplayer room we already have a populated beatmapset, so there's no neeed to fetch one when clicking on beatmap panel