### PR TITLE
Make expert plus colour on tooltip more readable

### DIFF
--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Beatmaps.Drawables
 
                 difficultyName.Text = beatmap.Version;
                 starRating.Text = $"{beatmap.StarDifficulty:0.##}";
-                difficultyFlow.Colour = beatmap.DifficultyRating == DifficultyRating.ExpertPlus ? colours.Gray9 : colours.ForDifficultyRating(beatmap.DifficultyRating);
+                difficultyFlow.Colour = colours.ForDifficultyRating(beatmap.DifficultyRating, true);
 
                 return true;
             }

--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Beatmaps.Drawables
 
                 difficultyName.Text = beatmap.Version;
                 starRating.Text = $"{beatmap.StarDifficulty:0.##}";
-                difficultyFlow.Colour = colours.ForDifficultyRating(beatmap.DifficultyRating);
+                difficultyFlow.Colour = beatmap.DifficultyRating == DifficultyRating.ExpertPlus ? colours.Gray9 : colours.ForDifficultyRating(beatmap.DifficultyRating);
 
                 return true;
             }

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Graphics
             }
         }
 
-        public Color4 ForDifficultyRating(DifficultyRating difficulty)
+        public Color4 ForDifficultyRating(DifficultyRating difficulty, bool useLighterColour = false)
         {
             switch (difficulty)
             {
@@ -56,10 +56,10 @@ namespace osu.Game.Graphics
                     return Pink;
 
                 case DifficultyRating.Expert:
-                    return Purple;
+                    return useLighterColour ? PurpleLight : Purple;
 
                 case DifficultyRating.ExpertPlus:
-                    return Gray0;
+                    return useLighterColour ? Gray9 : Gray0;
             }
         }
 


### PR DESCRIPTION
Resolve #7058 

Using same colour with website (# 999)

Example: 
![image](https://user-images.githubusercontent.com/6506864/70215388-f6f0b400-176f-11ea-9be9-c78c9aead0f6.png)
![image](https://user-images.githubusercontent.com/6506864/70215429-0a038400-1770-11ea-8627-9610c874e66e.png)

