### PR TITLE
Editor timeline hitobject display

### DIFF
--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
@@ -13,6 +13,10 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 using osuTK.Graphics;
@@ -25,10 +29,22 @@ namespace osu.Game.Tests.Visual.Editor
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
             typeof(TimelineArea),
+            typeof(TimelineHitObjectDisplay),
             typeof(Timeline),
             typeof(TimelineButton),
             typeof(CentreMarker)
         };
+
+        [Cached(typeof(IEditorBeatmap))]
+        private readonly EditorBeatmap<OsuHitObject> editorBeatmap;
+
+        public TestSceneEditorComposeTimeline()
+        {
+            editorBeatmap = new EditorBeatmap<OsuHitObject>(
+                (Beatmap<OsuHitObject>)
+                CreateWorkingBeatmap(new OsuRuleset().RulesetInfo).GetPlayableBeatmap(new OsuRuleset().RulesetInfo, new Mod[] { })
+            );
+        }
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
@@ -35,20 +35,14 @@ namespace osu.Game.Tests.Visual.Editor
             typeof(CentreMarker)
         };
 
-        [Cached(typeof(IEditorBeatmap))]
-        private readonly EditorBeatmap<OsuHitObject> editorBeatmap;
-
-        public TestSceneEditorComposeTimeline()
-        {
-            editorBeatmap = new EditorBeatmap<OsuHitObject>(
-                (Beatmap<OsuHitObject>)
-                CreateWorkingBeatmap(new OsuRuleset().RulesetInfo).GetPlayableBeatmap(new OsuRuleset().RulesetInfo, new Mod[] { })
-            );
-        }
-
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
+            var editorBeatmap = new EditorBeatmap<OsuHitObject>(
+                (Beatmap<OsuHitObject>)
+                CreateWorkingBeatmap(new OsuRuleset().RulesetInfo).GetPlayableBeatmap(new OsuRuleset().RulesetInfo, new Mod[] { })
+            );
+
             Beatmap.Value = new WaveformTestBeatmap(audio);
 
             Children = new Drawable[]

--- a/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
+++ b/osu.Game.Tests/Visual/Editor/TestSceneEditorComposeTimeline.cs
@@ -13,9 +13,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
@@ -38,12 +36,9 @@ namespace osu.Game.Tests.Visual.Editor
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            var editorBeatmap = new EditorBeatmap<OsuHitObject>(
-                (Beatmap<OsuHitObject>)
-                CreateWorkingBeatmap(new OsuRuleset().RulesetInfo).GetPlayableBeatmap(new OsuRuleset().RulesetInfo, new Mod[] { })
-            );
-
             Beatmap.Value = new WaveformTestBeatmap(audio);
+
+            var editorBeatmap = new EditorBeatmap<HitObject>((Beatmap<HitObject>)Beatmap.Value.Beatmap);
 
             Children = new Drawable[]
             {
@@ -60,6 +55,7 @@ namespace osu.Game.Tests.Visual.Editor
                 },
                 new TimelineArea
                 {
+                    Child = new TimelineHitObjectDisplay(editorBeatmap),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -34,7 +34,9 @@ namespace osu.Game.Rulesets.Edit
         where TObject : HitObject
     {
         protected IRulesetConfigManager Config { get; private set; }
-        protected EditorBeatmap<TObject> EditorBeatmap { get; private set; }
+
+        protected new EditorBeatmap<TObject> EditorBeatmap { get; private set; }
+
         protected readonly Ruleset Ruleset;
 
         [Resolved]
@@ -148,7 +150,7 @@ namespace osu.Game.Rulesets.Edit
 
             beatmapProcessor = Ruleset.CreateBeatmapProcessor(playableBeatmap);
 
-            EditorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
+            base.EditorBeatmap = EditorBeatmap = new EditorBeatmap<TObject>(playableBeatmap);
             EditorBeatmap.HitObjectAdded += addHitObject;
             EditorBeatmap.HitObjectRemoved += removeHitObject;
             EditorBeatmap.StartTimeChanged += UpdateHitObject;
@@ -332,6 +334,8 @@ namespace osu.Game.Rulesets.Edit
         /// All the <see cref="DrawableHitObject"/>s.
         /// </summary>
         public abstract IEnumerable<DrawableHitObject> HitObjects { get; }
+
+        public IEditorBeatmap EditorBeatmap { get; protected set; }
 
         /// <summary>
         /// Whether the user's cursor is currently in an area of the <see cref="HitObjectComposer"/> that is valid for placement.

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -335,6 +335,9 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         public abstract IEnumerable<DrawableHitObject> HitObjects { get; }
 
+        /// <summary>
+        /// An editor-specific beatmap, exposing mutation events.
+        /// </summary>
         public IEditorBeatmap EditorBeatmap { get; protected set; }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
@@ -14,11 +14,13 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// <summary>
     /// Represents a part of the summary timeline..
     /// </summary>
-    public abstract class TimelinePart : CompositeDrawable
+    public abstract class TimelinePart : Container
     {
         protected readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
 
         private readonly Container timeline;
+
+        protected override Container<Drawable> Content => timeline;
 
         protected TimelinePart()
         {
@@ -49,8 +51,6 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 
             timeline.RelativeChildSize = new Vector2((float)Math.Max(1, Beatmap.Value.Track.Length), 1);
         }
-
-        protected void Add(Drawable visualisation) => timeline.Add(visualisation);
 
         protected virtual void LoadBeatmap(WorkingBeatmap beatmap)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -36,14 +36,21 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             this.adjustableClock = adjustableClock;
 
-            Child = waveform = new WaveformGraph
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Colour = colours.Blue.Opacity(0.2f),
-                LowColour = colours.BlueLighter,
-                MidColour = colours.BlueDark,
-                HighColour = colours.BlueDarker,
-                Depth = float.MaxValue
+                waveform = new WaveformGraph
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Blue.Opacity(0.2f),
+                    LowColour = colours.BlueLighter,
+                    MidColour = colours.BlueDark,
+                    HighColour = colours.BlueDarker,
+                    Depth = float.MaxValue
+                },
+                new TimelineHitObjectDisplay
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
             };
 
             // We don't want the centre marker to scroll

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -47,10 +47,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     HighColour = colours.BlueDarker,
                     Depth = float.MaxValue
                 },
-                new TimelineHitObjectDisplay
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
             };
 
             // We don't want the centre marker to scroll

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -36,18 +36,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             this.adjustableClock = adjustableClock;
 
-            Children = new Drawable[]
+            Add(waveform = new WaveformGraph
             {
-                waveform = new WaveformGraph
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = colours.Blue.Opacity(0.2f),
-                    LowColour = colours.BlueLighter,
-                    MidColour = colours.BlueDark,
-                    HighColour = colours.BlueDarker,
-                    Depth = float.MaxValue
-                },
-            };
+                RelativeSizeAxes = Axes.Both,
+                Colour = colours.Blue.Opacity(0.2f),
+                LowColour = colours.BlueLighter,
+                MidColour = colours.BlueDark,
+                HighColour = colours.BlueDarker,
+                Depth = float.MaxValue
+            });
 
             // We don't want the centre marker to scroll
             AddInternal(new CentreMarker());

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -24,8 +24,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             Masking = true;
             CornerRadius = 5;
 
-            OsuCheckbox hitObjectsCheckbox;
-            OsuCheckbox hitSoundsCheckbox;
             OsuCheckbox waveformCheckbox;
 
             InternalChildren = new Drawable[]
@@ -64,8 +62,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                         Spacing = new Vector2(0, 4),
                                         Children = new[]
                                         {
-                                            hitObjectsCheckbox = new OsuCheckbox { LabelText = "Hit objects" },
-                                            hitSoundsCheckbox = new OsuCheckbox { LabelText = "Hit sounds" },
                                             waveformCheckbox = new OsuCheckbox { LabelText = "Waveform" }
                                         }
                                     }
@@ -123,8 +119,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 }
             };
 
-            hitObjectsCheckbox.Current.Value = true;
-            hitSoundsCheckbox.Current.Value = true;
             waveformCheckbox.Current.Value = true;
 
             timeline.WaveformVisible.BindTo(waveformCheckbox.Current);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -11,11 +12,14 @@ using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
-    public class TimelineArea : CompositeDrawable
+    public class TimelineArea : Container
     {
-        private readonly Timeline timeline;
+        private Timeline timeline;
 
-        public TimelineArea()
+        protected override Container<Drawable> Content => timeline;
+
+        [BackgroundDependencyLoader]
+        private void load()
         {
             Masking = true;
             CornerRadius = 5;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public class TimelineArea : Container
     {
-        private Timeline timeline;
+        private readonly Timeline timeline = new Timeline { RelativeSizeAxes = Axes.Both };
 
         protected override Container<Drawable> Content => timeline;
 
@@ -111,7 +111,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                     }
                                 }
                             },
-                            timeline = new Timeline { RelativeSizeAxes = Axes.Both }
+                            timeline
                         },
                     },
                     ColumnDimensions = new[]

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         public TimelineHitObjectDisplay(IEditorBeatmap beatmap)
         {
+            RelativeSizeAxes = Axes.Both;
+
             this.beatmap = beatmap;
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
@@ -48,11 +48,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             var yOffset = Children.Count(d => d.X == h.StartTime);
 
-            Add(new TimelineHitObjectRepresentation(h) { Y = -yOffset * 4 });
+            Add(new TimelineHitObjectRepresentation(h) { Y = -yOffset * TimelineHitObjectRepresentation.THICKNESS });
         }
 
         private class TimelineHitObjectRepresentation : CompositeDrawable
         {
+            public const float THICKNESS = 3;
+
             public readonly HitObject HitObject;
 
             public TimelineHitObjectRepresentation(HitObject hitObject)
@@ -74,7 +76,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     {
                         CornerRadius = 2,
                         Masking = true,
-                        Size = new Vector2(1, 3),
+                        Size = new Vector2(1, THICKNESS),
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                         RelativePositionAxes = Axes.X,
@@ -96,7 +98,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     AlwaysPresent = true,
                     Colour = Color4.White,
                     BorderColour = Color4.Black,
-                    BorderThickness = 3,
+                    BorderThickness = THICKNESS,
                 });
             }
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
@@ -44,7 +44,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 d.Expire();
         }
 
-        private void add(HitObject h) => Add(new TimelineHitObjectRepresentation(h));
+        private void add(HitObject h)
+        {
+            var yOffset = Children.Count(d => d.X == h.StartTime);
+
+            Add(new TimelineHitObjectRepresentation(h) { Y = -yOffset * 4 });
+        }
 
         private class TimelineHitObjectRepresentation : CompositeDrawable
         {
@@ -52,7 +57,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             public TimelineHitObjectRepresentation(HitObject hitObject)
             {
-                this.HitObject = hitObject;
+                HitObject = hitObject;
                 Anchor = Anchor.CentreLeft;
                 Origin = Anchor.CentreLeft;
 
@@ -63,6 +68,25 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 RelativePositionAxes = Axes.X;
                 RelativeSizeAxes = Axes.X;
 
+                if (hitObject is IHasEndTime)
+                {
+                    AddInternal(new Container
+                    {
+                        CornerRadius = 2,
+                        Masking = true,
+                        Size = new Vector2(1, 3),
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        RelativePositionAxes = Axes.X,
+                        RelativeSizeAxes = Axes.X,
+                        Colour = Color4.Black,
+                        Child = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        }
+                    });
+                }
+
                 AddInternal(new Circle
                 {
                     Size = new Vector2(16),
@@ -71,20 +95,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     RelativePositionAxes = Axes.X,
                     AlwaysPresent = true,
                     Colour = Color4.White,
+                    BorderColour = Color4.Black,
+                    BorderThickness = 3,
                 });
-
-                if (hitObject is IHasEndTime)
-                {
-                    AddInternal(new Box
-                    {
-                        Size = new Vector2(1, 5),
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        RelativePositionAxes = Axes.X,
-                        RelativeSizeAxes = Axes.X,
-                        Colour = Color4.White,
-                    });
-                }
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
@@ -16,8 +16,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     internal class TimelineHitObjectDisplay : TimelinePart
     {
-        [Resolved]
-        private IEditorBeatmap beatmap { get; set; }
+        private IEditorBeatmap beatmap { get; }
+
+        public TimelineHitObjectDisplay(IEditorBeatmap beatmap)
+        {
+            this.beatmap = beatmap;
+        }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -27,18 +31,20 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             beatmap.HitObjectAdded += add;
             beatmap.HitObjectRemoved += remove;
+            beatmap.StartTimeChanged += h =>
+            {
+                remove(h);
+                add(h);
+            };
         }
 
         private void remove(HitObject h)
         {
-            foreach (var d in InternalChildren.OfType<TimelineHitObjectRepresentation>().Where(c => c.HitObject == h))
+            foreach (var d in Children.OfType<TimelineHitObjectRepresentation>().Where(c => c.HitObject == h))
                 d.Expire();
         }
 
-        private void add(HitObject h)
-        {
-            Add(new TimelineHitObjectRepresentation(h));
-        }
+        private void add(HitObject h) => Add(new TimelineHitObjectRepresentation(h));
 
         private class TimelineHitObjectRepresentation : CompositeDrawable
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectDisplay.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Edit.Compose.Components.Timeline
+{
+    internal class TimelineHitObjectDisplay : TimelinePart
+    {
+        [Resolved]
+        private IEditorBeatmap beatmap { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            foreach (var h in beatmap.HitObjects)
+                add(h);
+
+            beatmap.HitObjectAdded += add;
+            beatmap.HitObjectRemoved += remove;
+        }
+
+        private void remove(HitObject h)
+        {
+            foreach (var d in InternalChildren.OfType<TimelineHitObjectRepresentation>().Where(c => c.HitObject == h))
+                d.Expire();
+        }
+
+        private void add(HitObject h)
+        {
+            Add(new TimelineHitObjectRepresentation(h));
+        }
+
+        private class TimelineHitObjectRepresentation : CompositeDrawable
+        {
+            public readonly HitObject HitObject;
+
+            public TimelineHitObjectRepresentation(HitObject hitObject)
+            {
+                this.HitObject = hitObject;
+                Anchor = Anchor.CentreLeft;
+                Origin = Anchor.CentreLeft;
+
+                Width = (float)(hitObject.GetEndTime() - hitObject.StartTime);
+
+                X = (float)hitObject.StartTime;
+
+                RelativePositionAxes = Axes.X;
+                RelativeSizeAxes = Axes.X;
+
+                AddInternal(new Circle
+                {
+                    Size = new Vector2(16),
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.Centre,
+                    RelativePositionAxes = Axes.X,
+                    AlwaysPresent = true,
+                    Colour = Color4.White,
+                });
+
+                if (hitObject is IHasEndTime)
+                {
+                    AddInternal(new Box
+                    {
+                        Size = new Vector2(1, 5),
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        RelativePositionAxes = Axes.X,
+                        RelativeSizeAxes = Axes.X,
+                        Colour = Color4.White,
+                    });
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -16,23 +16,20 @@ namespace osu.Game.Screens.Edit.Compose
         protected override Drawable CreateMainContent()
         {
             var ruleset = Beatmap.Value.BeatmapInfo.Ruleset?.CreateInstance();
-
             composer = ruleset?.CreateHitObjectComposer();
 
-            if (composer != null)
-            {
-                var beatmapSkinProvider = new BeatmapSkinProvidingContainer(Beatmap.Value.Skin);
+            if (ruleset == null || composer == null)
+                return new ScreenWhiteBox.UnderConstructionMessage(ruleset == null ? "This beatmap" : $"{ruleset.Description}'s composer");
 
-                // the beatmapSkinProvider is used as the fallback source here to allow the ruleset-specific skin implementation
-                // full access to all skin sources.
-                var rulesetSkinProvider = new SkinProvidingContainer(ruleset.CreateLegacySkinProvider(beatmapSkinProvider));
+            var beatmapSkinProvider = new BeatmapSkinProvidingContainer(Beatmap.Value.Skin);
 
-                // load the skinning hierarchy first.
-                // this is intentionally done in two stages to ensure things are in a loaded state before exposing the ruleset to skin sources.
-                return beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(composer));
-            }
+            // the beatmapSkinProvider is used as the fallback source here to allow the ruleset-specific skin implementation
+            // full access to all skin sources.
+            var rulesetSkinProvider = new SkinProvidingContainer(ruleset.CreateLegacySkinProvider(beatmapSkinProvider));
 
-            return new ScreenWhiteBox.UnderConstructionMessage(ruleset == null ? "This beatmap" : $"{ruleset.Description}'s composer");
+            // load the skinning hierarchy first.
+            // this is intentionally done in two stages to ensure things are in a loaded state before exposing the ruleset to skin sources.
+            return beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(composer));
         }
 
         protected override Drawable CreateTimelineContent() => new TimelineHitObjectDisplay(composer.EditorBeatmap);

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -3,17 +3,21 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Edit.Compose
 {
     public class ComposeScreen : EditorScreenWithTimeline
     {
+        private HitObjectComposer composer;
+
         protected override Drawable CreateMainContent()
         {
             var ruleset = Beatmap.Value.BeatmapInfo.Ruleset?.CreateInstance();
 
-            var composer = ruleset?.CreateHitObjectComposer();
+            composer = ruleset?.CreateHitObjectComposer();
 
             if (composer != null)
             {
@@ -25,10 +29,15 @@ namespace osu.Game.Screens.Edit.Compose
 
                 // load the skinning hierarchy first.
                 // this is intentionally done in two stages to ensure things are in a loaded state before exposing the ruleset to skin sources.
-                return beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(ruleset.CreateHitObjectComposer()));
+                return beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(composer));
             }
 
             return new ScreenWhiteBox.UnderConstructionMessage(ruleset == null ? "This beatmap" : $"{ruleset.Description}'s composer");
         }
+
+        protected override Drawable CreateTimelineContent() => new TimelineHitObjectDisplay(composer.EditorBeatmap)
+        {
+            RelativeSizeAxes = Axes.Both,
+        };
     }
 }

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -35,9 +35,6 @@ namespace osu.Game.Screens.Edit.Compose
             return new ScreenWhiteBox.UnderConstructionMessage(ruleset == null ? "This beatmap" : $"{ruleset.Description}'s composer");
         }
 
-        protected override Drawable CreateTimelineContent() => new TimelineHitObjectDisplay(composer.EditorBeatmap)
-        {
-            RelativeSizeAxes = Axes.Both,
-        };
+        protected override Drawable CreateTimelineContent() => new TimelineHitObjectDisplay(composer.EditorBeatmap);
     }
 }

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Screens.Edit
 
         private readonly BindableBeatDivisor beatDivisor = new BindableBeatDivisor();
 
+        private TimelineArea timelineArea;
+
         [BackgroundDependencyLoader(true)]
         private void load([CanBeNull] BindableBeatDivisor beatDivisor)
         {
@@ -64,7 +66,7 @@ namespace osu.Game.Screens.Edit
                                                     {
                                                         RelativeSizeAxes = Axes.Both,
                                                         Padding = new MarginPadding { Right = 5 },
-                                                        Child = CreateTimeline()
+                                                        Child = timelineArea = CreateTimelineArea()
                                                     },
                                                     new BeatDivisorControl(beatDivisor) { RelativeSizeAxes = Axes.Both }
                                                 },
@@ -97,11 +99,15 @@ namespace osu.Game.Screens.Edit
             {
                 mainContent.Add(content);
                 content.FadeInFromZero(300, Easing.OutQuint);
+
+                LoadComponentAsync(CreateTimelineContent(), timelineArea.Add);
             });
         }
 
         protected abstract Drawable CreateMainContent();
 
-        protected virtual Drawable CreateTimeline() => new TimelineArea { RelativeSizeAxes = Axes.Both };
+        protected virtual Drawable CreateTimelineContent() => new Container { };
+
+        protected TimelineArea CreateTimelineArea() => new TimelineArea { RelativeSizeAxes = Axes.Both };
     }
 }

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Screens.Edit
 
         protected abstract Drawable CreateMainContent();
 
-        protected virtual Drawable CreateTimelineContent() => new Container { };
+        protected virtual Drawable CreateTimelineContent() => new Container();
 
         protected TimelineArea CreateTimelineArea() => new TimelineArea { RelativeSizeAxes = Axes.Both };
     }

--- a/osu.Game/Screens/Edit/IEditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/IEditorBeatmap.cs
@@ -23,6 +23,11 @@ namespace osu.Game.Screens.Edit
         /// Invoked when a <see cref="HitObject"/> is removed from this <see cref="IEditorBeatmap"/>.
         /// </summary>
         event Action<HitObject> HitObjectRemoved;
+
+        /// <summary>
+        /// Invoked when the start time of a <see cref="HitObject"/> in this <see cref="EditorBeatmap{T}"/> was changed.
+        /// </summary>
+        event Action<HitObject> StartTimeChanged;
     }
 
     /// <summary>


### PR DESCRIPTION
A basic first implementation. Selection, selected object display and fixes for updates to hitobjects will come later. Toggle checkboxes apart from "waveform" have been removed for now, as we are not sure if (or how many) of these will be required going forward.

![image](https://user-images.githubusercontent.com/191335/70292794-89519000-1822-11ea-97eb-309e23fea9ec.png)
