### PR TITLE
Always display skins at native sizes for now

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -49,7 +49,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     return this.GetAnimation(component.LookupName, true, false);
 
                 case OsuSkinComponents.SliderFollowCircle:
-                    return this.GetAnimation("sliderfollowcircle", true, true);
+                    var followCircle = this.GetAnimation("sliderfollowcircle", true, true);
+                    followCircle.Scale *= 0.5f;
+                    return followCircle;
 
                 case OsuSkinComponents.SliderBall:
                     var sliderBallContent = this.GetAnimation("sliderb", true, true, "");

--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -50,7 +50,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
                 case OsuSkinComponents.SliderFollowCircle:
                     var followCircle = this.GetAnimation("sliderfollowcircle", true, true);
-                    followCircle.Scale *= 0.5f;
+                    if (followCircle != null)
+                        followCircle.Scale *= 0.5f;
                     return followCircle;
 
                 case OsuSkinComponents.SliderBall:

--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -51,6 +51,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 case OsuSkinComponents.SliderFollowCircle:
                     var followCircle = this.GetAnimation("sliderfollowcircle", true, true);
                     if (followCircle != null)
+                        // follow circles are 2x the hitcircle resolution in legacy skins (since they are scaled down from >1x
                         followCircle.Scale *= 0.5f;
                     return followCircle;
 

--- a/osu.Game/Skinning/SkinnableDrawable.cs
+++ b/osu.Game/Skinning/SkinnableDrawable.cs
@@ -29,13 +29,13 @@ namespace osu.Game.Skinning
         /// <param name="defaultImplementation">A function to create the default skin implementation of this element.</param>
         /// <param name="allowFallback">A conditional to decide whether to allow fallback to the default implementation if a skinned element is not present.</param>
         /// <param name="confineMode">How (if at all) the <see cref="Drawable"/> should be resize to fit within our own bounds.</param>
-        public SkinnableDrawable(ISkinComponent component, Func<ISkinComponent, Drawable> defaultImplementation, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.ScaleDownToFit)
+        public SkinnableDrawable(ISkinComponent component, Func<ISkinComponent, Drawable> defaultImplementation, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.NoScaling)
             : this(component, allowFallback, confineMode)
         {
             createDefault = defaultImplementation;
         }
 
-        protected SkinnableDrawable(ISkinComponent component, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.ScaleDownToFit)
+        protected SkinnableDrawable(ISkinComponent component, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.NoScaling)
             : base(allowFallback)
         {
             this.component = component;

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Skinning
         [Resolved]
         private TextureStore textures { get; set; }
 
-        public SkinnableSprite(string textureName, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.ScaleDownToFit)
+        public SkinnableSprite(string textureName, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.NoScaling)
             : base(new SpriteComponent(textureName), allowFallback, confineMode)
         {
         }

--- a/osu.Game/Skinning/SkinnableSpriteText.cs
+++ b/osu.Game/Skinning/SkinnableSpriteText.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Skinning
 {
     public class SkinnableSpriteText : SkinnableDrawable, IHasText
     {
-        public SkinnableSpriteText(ISkinComponent component, Func<ISkinComponent, SpriteText> defaultImplementation, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.ScaleDownToFit)
+        public SkinnableSpriteText(ISkinComponent component, Func<ISkinComponent, SpriteText> defaultImplementation, Func<ISkinSource, bool> allowFallback = null, ConfineMode confineMode = ConfineMode.NoScaling)
             : base(component, defaultImplementation, allowFallback, confineMode)
         {
         }


### PR DESCRIPTION
While the [end goal](https://github.com/ppy/osu/issues/2358#issuecomment-403339734) has not changed, for now we wish to prefer compatibility rather than making breaking changes that may not be resolved in the short-term future.

This brings all skinned element sizes into parity with stable. Can re-visit using confine modes in the future.