### PR TITLE
Add explicit app manifest to desktop project

### DIFF
--- a/osu.Desktop/app.manifest
+++ b/osu.Desktop/app.manifest
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity version="1.0.0.0" name="osu!" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+      <applicationRequestMinimum>
+        <defaultAssemblyRequest permissionSetReference="Custom" />
+        <PermissionSet class="System.Security.PermissionSet" version="1" Unrestricted="true" ID="Custom" SameSite="site" />
+      </applicationRequestMinimum>
+    </security>
+  </trustInfo>
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</asmv1:assembly>

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -8,6 +8,7 @@
     <Title>osu!lazer</Title>
     <Product>osu!lazer</Product>
     <ApplicationIcon>lazer.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
     <Version>0.0.0</Version>
     <FileVersion>0.0.0</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
Resolves #6496.

# Summary

After the .NET Core bump to version 3.0 in the 2019.1011.0 release, reports popped up of the game not starting any more on some computers using older Intel graphics cards (HD 3000 in particular).

After investigation the auto-generated application manifest changed in .NET Core 3.0. In particular this seems to be a root cause for the failed start-ups on Intel cards, due to a Windows version compatibility section appearing. The section in turn affects some WinAPI calls like `GetVersionEx`, which will return major version 10 instead of 6 if compatibility with Windows 10 is declared. This combined with a broken check in the Intel OpenGL driver caused the crashes.

To resolve this without having to patch binaries, add an explicit application manifest to the desktop project with the compatibility section removed.

# Remarks

Due to not having the hardware required to test on hand I can't with 100% certainty declare that this will resolve the problem, however [at least one user owning an affected card has confirmed that this does indeed fix it](https://github.com/ppy/osu/issues/6496#issuecomment-562884138).

Since the manifest lands in the binary verbatim as ASCII, the results of this PR can be verified empirically by inspecting the `osu!.exe` binary with a hex editor or using `strings` or similar tools.

It's worth noting that the manifest will only take effect when running through the app host (`osu!.exe`) and not through passing the DLL path to `dotnet` ([source](https://github.com/dotnet/sdk/issues/3462#issuecomment-515181591)).

For reference, here are the previous manifest contents:

* [pre-2019.1011.0](https://gist.github.com/bdach/09bc5c6cb2fc080017295379b1d13b00#file-pre-2019-1011-0-xml),
* [post-2019.1011.0](https://gist.github.com/bdach/09bc5c6cb2fc080017295379b1d13b00#file-post-2019-1011-0-xml).

I've based the version in the PR on the newer one, but removed the `<compatibility>` entries, and also the declaration of the `Microsoft.Windows.Common-Controls` assembly (from what I can tell, it's used to enable visual styles in Windows Forms applications, so it's not necessary here). I'm not really sure what the new `<applicationRequestMinimum>` entry is all about and MSDN isn't helping, so I left it in, but I can also remove it.