### PR TITLE
Fix mod buttons being selected when drag scrolling overlay

### DIFF
--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -178,11 +178,9 @@ namespace osu.Game.Overlays.Mods
 
         protected override bool OnClick(ClickEvent e)
         {
-            scaleContainer.ScaleTo(1, 500, Easing.OutElastic);
-
             SelectNext(1);
 
-            return base.OnClick(e);
+            return true;
         }
 
         /// <summary>

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Overlays.Mods
         protected override bool OnClick(ClickEvent e)
         {
             scaleContainer.ScaleTo(1, 500, Easing.OutElastic);
-            
+
             SelectNext(1);
 
             return base.OnClick(e);

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -167,10 +167,6 @@ namespace osu.Game.Overlays.Mods
             {
                 switch (e.Button)
                 {
-                    case MouseButton.Left:
-                        SelectNext(1);
-                        break;
-
                     case MouseButton.Right:
                         SelectNext(-1);
                         break;
@@ -178,6 +174,15 @@ namespace osu.Game.Overlays.Mods
             }
 
             return true;
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            scaleContainer.ScaleTo(1, 500, Easing.OutElastic);
+            
+            SelectNext(1);
+
+            return base.OnClick(e);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/3174.

`OnMouseUp` is still there to handle right clicks. It can be completely removed once https://github.com/ppy/osu-framework/issues/1594 is resolved.