### PR TITLE
Add missing async content loading logic to NewsOverlay

### DIFF
--- a/osu.Game/Overlays/NewsOverlay.cs
+++ b/osu.Game/Overlays/NewsOverlay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -16,7 +17,6 @@ namespace osu.Game.Overlays
     {
         private NewsHeader header;
 
-        //ReSharper disable NotAccessedField.Local
         private Container<NewsContent> content;
 
         public readonly Bindable<string> Current = new Bindable<string>(null);
@@ -57,6 +57,21 @@ namespace osu.Game.Overlays
 
             header.Current.BindTo(Current);
             Current.TriggerChange();
+        }
+
+        private CancellationTokenSource loadChildCancellation;
+
+        protected void LoadAndShowChild(NewsContent newContent)
+        {
+            content.FadeTo(0.2f, 300, Easing.OutQuint);
+
+            loadChildCancellation?.Cancel();
+
+            LoadComponentAsync(newContent, c =>
+            {
+                content.Child = c;
+                content.FadeIn(300, Easing.OutQuint);
+            }, (loadChildCancellation = new CancellationTokenSource()).Token);
         }
 
         public void ShowFrontPage()


### PR DESCRIPTION
Split from #7016

Adds the missing bits for loading asynchronously and showing content on the NewsOverlay