### PR TITLE
Refine generic constraints at game side

### DIFF
--- a/osu.Game/Configuration/DatabasedConfigManager.cs
+++ b/osu.Game/Configuration/DatabasedConfigManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
@@ -9,8 +10,8 @@ using osu.Game.Rulesets;
 
 namespace osu.Game.Configuration
 {
-    public abstract class DatabasedConfigManager<T> : ConfigManager<T>
-        where T : struct
+    public abstract class DatabasedConfigManager<TLookup> : ConfigManager<TLookup>
+        where TLookup : struct, Enum
     {
         private readonly SettingsStore settings;
 
@@ -53,7 +54,7 @@ namespace osu.Game.Configuration
 
         private readonly List<DatabasedSetting> dirtySettings = new List<DatabasedSetting>();
 
-        protected override void AddBindable<TBindable>(T lookup, Bindable<TBindable> bindable)
+        protected override void AddBindable<TBindable>(TLookup lookup, Bindable<TBindable> bindable)
         {
             base.AddBindable(lookup, bindable);
 

--- a/osu.Game/Configuration/InMemoryConfigManager.cs
+++ b/osu.Game/Configuration/InMemoryConfigManager.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Configuration;
 
 namespace osu.Game.Configuration
 {
-    public class InMemoryConfigManager<T> : ConfigManager<T>
-        where T : struct
+    public class InMemoryConfigManager<TLookup> : ConfigManager<TLookup>
+        where TLookup : struct, Enum
     {
         public InMemoryConfigManager()
         {

--- a/osu.Game/Graphics/IHasAccentColour.cs
+++ b/osu.Game/Graphics/IHasAccentColour.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Graphics
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
         public static TransformSequence<T> FadeAccent<T>(this T accentedDrawable, Color4 newColour, double duration = 0, Easing easing = Easing.None)
-            where T : IHasAccentColour
+            where T : class, IHasAccentColour
             => accentedDrawable.TransformTo(nameof(accentedDrawable.AccentColour), newColour, duration, easing);
 
         /// <summary>

--- a/osu.Game/Graphics/UserInterface/OsuEnumDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuEnumDropdown.cs
@@ -6,12 +6,10 @@ using System;
 namespace osu.Game.Graphics.UserInterface
 {
     public class OsuEnumDropdown<T> : OsuDropdown<T>
+        where T : struct, Enum
     {
         public OsuEnumDropdown()
         {
-            if (!typeof(T).IsEnum)
-                throw new InvalidOperationException("OsuEnumDropdown only supports enums as the generic type argument");
-
             Items = (T[])Enum.GetValues(typeof(T));
         }
     }

--- a/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
+++ b/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osuTK;
 using osu.Framework.Graphics;
@@ -11,6 +12,7 @@ using osu.Game.Graphics.Containers;
 namespace osu.Game.Overlays.SearchableList
 {
     public class DisplayStyleControl<T> : Container
+        where T : struct, Enum
     {
         public readonly SlimEnumDropdown<T> Dropdown;
         public readonly Bindable<PanelDisplayStyle> DisplayStyle = new Bindable<PanelDisplayStyle>();

--- a/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
@@ -13,7 +13,9 @@ using osu.Framework.Graphics.Shapes;
 
 namespace osu.Game.Overlays.SearchableList
 {
-    public abstract class SearchableListFilterControl<T, U> : Container
+    public abstract class SearchableListFilterControl<TTab, TCategory> : Container
+        where TTab : struct, Enum
+        where TCategory : struct, Enum
     {
         private const float padding = 10;
 
@@ -21,12 +23,12 @@ namespace osu.Game.Overlays.SearchableList
         private readonly Box tabStrip;
 
         public readonly SearchTextBox Search;
-        public readonly PageTabControl<T> Tabs;
-        public readonly DisplayStyleControl<U> DisplayStyleControl;
+        public readonly PageTabControl<TTab> Tabs;
+        public readonly DisplayStyleControl<TCategory> DisplayStyleControl;
 
         protected abstract Color4 BackgroundColour { get; }
-        protected abstract T DefaultTab { get; }
-        protected abstract U DefaultCategory { get; }
+        protected abstract TTab DefaultTab { get; }
+        protected abstract TCategory DefaultCategory { get; }
         protected virtual Drawable CreateSupplementaryControls() => null;
 
         /// <summary>
@@ -36,9 +38,6 @@ namespace osu.Game.Overlays.SearchableList
 
         protected SearchableListFilterControl()
         {
-            if (!typeof(T).IsEnum)
-                throw new InvalidOperationException("SearchableListFilterControl's sort tabs only support enums as the generic type argument");
-
             RelativeSizeAxes = Axes.X;
 
             var controls = CreateSupplementaryControls();
@@ -90,7 +89,7 @@ namespace osu.Game.Overlays.SearchableList
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                     Padding = new MarginPadding { Right = 225 },
-                                    Child = Tabs = new PageTabControl<T>
+                                    Child = Tabs = new PageTabControl<TTab>
                                     {
                                         RelativeSizeAxes = Axes.X,
                                     },
@@ -105,7 +104,7 @@ namespace osu.Game.Overlays.SearchableList
                         },
                     },
                 },
-                DisplayStyleControl = new DisplayStyleControl<U>
+                DisplayStyleControl = new DisplayStyleControl<TCategory>
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,

--- a/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Sprites;
 namespace osu.Game.Overlays.SearchableList
 {
     public abstract class SearchableListHeader<T> : Container
+        where T : struct, Enum
     {
         public readonly HeaderTabControl<T> Tabs;
 
@@ -24,9 +25,6 @@ namespace osu.Game.Overlays.SearchableList
 
         protected SearchableListHeader()
         {
-            if (!typeof(T).IsEnum)
-                throw new InvalidOperationException("BrowseHeader only supports enums as the generic type argument");
-
             RelativeSizeAxes = Axes.X;
             Height = 90;
 

--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osuTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -16,19 +17,22 @@ namespace osu.Game.Overlays.SearchableList
         public const float WIDTH_PADDING = 80;
     }
 
-    public abstract class SearchableListOverlay<T, U, S> : SearchableListOverlay
+    public abstract class SearchableListOverlay<THeader, TTab, TCategory> : SearchableListOverlay
+        where THeader : struct, Enum
+        where TTab : struct, Enum
+        where TCategory : struct, Enum
     {
         private readonly Container scrollContainer;
 
-        protected readonly SearchableListHeader<T> Header;
-        protected readonly SearchableListFilterControl<U, S> Filter;
+        protected readonly SearchableListHeader<THeader> Header;
+        protected readonly SearchableListFilterControl<TTab, TCategory> Filter;
         protected readonly FillFlowContainer ScrollFlow;
 
         protected abstract Color4 BackgroundColour { get; }
         protected abstract Color4 TrianglesColourLight { get; }
         protected abstract Color4 TrianglesColourDark { get; }
-        protected abstract SearchableListHeader<T> CreateHeader();
-        protected abstract SearchableListFilterControl<U, S> CreateFilterControl();
+        protected abstract SearchableListHeader<THeader> CreateHeader();
+        protected abstract SearchableListFilterControl<TTab, TCategory> CreateFilterControl();
 
         protected SearchableListOverlay()
         {

--- a/osu.Game/Overlays/SearchableList/SlimEnumDropdown.cs
+++ b/osu.Game/Overlays/SearchableList/SlimEnumDropdown.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -11,6 +12,7 @@ using osuTK;
 namespace osu.Game.Overlays.SearchableList
 {
     public class SlimEnumDropdown<T> : OsuEnumDropdown<T>
+        where T : struct, Enum
     {
         protected override DropdownHeader CreateHeader() => new SlimDropdownHeader();
 

--- a/osu.Game/Overlays/Settings/SettingsEnumDropdown.cs
+++ b/osu.Game/Overlays/Settings/SettingsEnumDropdown.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Settings
 {
     public class SettingsEnumDropdown<T> : SettingsDropdown<T>
+        where T : struct, Enum
     {
         protected override OsuDropdown<T> CreateDropdown() => new DropdownControl();
 

--- a/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
+++ b/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Configuration
 {
-    public abstract class RulesetConfigManager<T> : DatabasedConfigManager<T>, IRulesetConfigManager
-        where T : struct
+    public abstract class RulesetConfigManager<TLookup> : DatabasedConfigManager<TLookup>, IRulesetConfigManager
+        where TLookup : struct, Enum
     {
         protected RulesetConfigManager(SettingsStore settings, RulesetInfo ruleset, int? variant = null)
             : base(settings, ruleset, variant)

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Select
         }
 
         public struct OptionalRange<T> : IEquatable<OptionalRange<T>>
-            where T : struct, IComparable
+            where T : struct
         {
             public bool HasFilter => Max != null || Min != null;
 

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Screens.Select
         }
 
         private static void updateCriteriaRange<T>(ref FilterCriteria.OptionalRange<T> range, string op, T value)
-            where T : struct, IComparable
+            where T : struct
         {
             switch (op)
             {

--- a/osu.Game/Skinning/SkinConfigManager.cs
+++ b/osu.Game/Skinning/SkinConfigManager.cs
@@ -1,11 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Configuration;
 
 namespace osu.Game.Skinning
 {
-    public class SkinConfigManager<T> : ConfigManager<T> where T : struct
+    public class SkinConfigManager<TLookup> : ConfigManager<TLookup> where TLookup : struct, Enum
     {
         protected override void PerformLoad()
         {

--- a/osu.Game/Storyboards/Drawables/IFlippable.cs
+++ b/osu.Game/Storyboards/Drawables/IFlippable.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Storyboards.Drawables
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
         public static TransformSequence<T> TransformFlipH<T>(this T flippable, bool newValue, double delay = 0)
-            where T : IFlippable
+            where T : class, IFlippable
             => flippable.TransformTo(flippable.PopulateTransform(new TransformFlipH(), newValue, delay));
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace osu.Game.Storyboards.Drawables
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
         public static TransformSequence<T> TransformFlipV<T>(this T flippable, bool newValue, double delay = 0)
-            where T : IFlippable
+            where T : class, IFlippable
             => flippable.TransformTo(flippable.PopulateTransform(new TransformFlipV(), newValue, delay));
     }
 }


### PR DESCRIPTION
Contains:
- changes necessary to compile with ppy/osu-framework#3017
- changing `typeof(T).IsEnum` to enum constraint
- refine generic parameter names