### PR TITLE
Add VS launcher profile for tournament client

### DIFF
--- a/osu.Desktop/Properties/launchSettings.json
+++ b/osu.Desktop/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "osu! Desktop": {
+      "commandName": "Project"
+    },
+    "osu! Tournament": {
+      "commandName": "Project",
+      "commandLineArgs": "--tournament"
+    }
+  }
+}


### PR DESCRIPTION
Tournament should be the only one that doesn't have entry itself?