### PR TITLE
Move UserDimContainer to an appropriate namespace

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimContainer.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimContainer.cs
@@ -18,7 +18,6 @@ using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu.Mods;

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Backgrounds;
-using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Play;
 using osuTK;
 

--- a/osu.Game/Screens/Play/DimmableStoryboard.cs
+++ b/osu.Game/Screens/Play/DimmableStoryboard.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Game.Graphics.Containers;
 using osu.Game.Storyboards;
 using osu.Game.Storyboards.Drawables;
 

--- a/osu.Game/Screens/Play/DimmableVideo.cs
+++ b/osu.Game/Screens/Play/DimmableVideo.cs
@@ -6,7 +6,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Video;
-using osu.Game.Graphics.Containers;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play

--- a/osu.Game/Screens/Play/UserDimContainer.cs
+++ b/osu.Game/Screens/Play/UserDimContainer.cs
@@ -6,8 +6,9 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 
-namespace osu.Game.Graphics.Containers
+namespace osu.Game.Screens.Play
 {
     /// <summary>
     /// A container that applies user-configured visual settings to its contents.


### PR DESCRIPTION
- Moves `UserDimContainer` to the `osu.Game.Screens.Play` namespace due to the component being out-of-scope to general container as an upcoming PR is adding break time logic inside this container.