### PR TITLE
Move control point removal to SliderSelectionBlueprint

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -18,8 +17,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Screens.Edit.Compose;
-using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
@@ -34,10 +31,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private InputManager inputManager;
 
-        [Resolved(CanBeNull = true)]
-        private IPlacementHandler placementHandler { get; set; }
-
         private IBindableList<PathControlPoint> controlPoints;
+
+        public Action<List<PathControlPoint>> RemoveControlPointsRequested;
 
         public PathControlPointVisualiser(Slider slider, bool allowSelection)
         {
@@ -123,29 +119,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (toRemove.Count == 0)
                 return false;
 
-            foreach (var c in toRemove)
-            {
-                // The first control point in the slider must have a type, so take it from the previous "first" one
-                // Todo: Should be handled within SliderPath itself
-                if (c == slider.Path.ControlPoints[0] && slider.Path.ControlPoints.Count > 1 && slider.Path.ControlPoints[1].Type.Value == null)
-                    slider.Path.ControlPoints[1].Type.Value = slider.Path.ControlPoints[0].Type.Value;
-
-                slider.Path.ControlPoints.Remove(c);
-            }
-
-            // If there are 0 or 1 remaining control points, the slider is in a degenerate (single point) form and should be deleted
-            if (slider.Path.ControlPoints.Count <= 1)
-            {
-                placementHandler?.Delete(slider);
-                return true;
-            }
-
-            // The path will have a non-zero offset if the head is removed, but sliders don't support this behaviour since the head is positioned at the slider's position
-            // So the slider needs to be offset by this amount instead, and all control points offset backwards such that the path is re-positioned at (0, 0)
-            Vector2 first = slider.Path.ControlPoints[0].Position.Value;
-            foreach (var c in slider.Path.ControlPoints)
-                c.Position.Value -= first;
-            slider.Position += first;
+            RemoveControlPointsRequested?.Invoke(toRemove);
 
             // Since pieces are re-used, they will not point to the deleted control points while remaining selected
             foreach (var piece in Pieces)


### PR DESCRIPTION
Wanted to get the add/remove algorithms in the same place, to make sanity checks easier to implement.