### PR TITLE
Implement NewsArticleCover class

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private class TestNewsOverlay : NewsOverlay
         {
-            public new void LoadAndShowChild(NewsContent content) => base.LoadAndShowChild(content);
+            public new void LoadAndShowChild(NewsContent content) => base.LoadAndShowContent(content);
         }
 
         private class NewsCoverTest : NewsContent

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Overlays.News;
 
@@ -19,11 +22,46 @@ namespace osu.Game.Tests.Visual.Online
 
             AddStep(@"Show front page", () => news.ShowFrontPage());
             AddStep(@"Custom article", () => news.Current.Value = "Test Article 101");
+
+            AddStep(@"Article covers", () => news.LoadAndShowChild(new NewsCoverTest()));
         }
 
         private class TestNewsOverlay : NewsOverlay
         {
             public new void LoadAndShowChild(NewsContent content) => base.LoadAndShowChild(content);
+        }
+
+        private class NewsCoverTest : NewsContent
+        {
+            public NewsCoverTest()
+            {
+                Spacing = new osuTK.Vector2(0, 10);
+
+                var article = new NewsArticleCover.ArticleInfo()
+                {
+                    Author = "Ephemeral",
+                    CoverURL = "https://assets.ppy.sh/artists/58/header.jpg",
+                    Time = new DateTime(2019, 12, 4),
+                    Title = "New Featured Artist: Kurokotei"
+                };
+
+                Children = new Drawable[]
+                {
+                    new NewsArticleCover(article)
+                    {
+                        Height = 200
+                    },
+                    new NewsArticleCover(article)
+                    {
+                        Height = 120
+                    },
+                    new NewsArticleCover(article)
+                    {
+                        RelativeSizeAxes = Axes.None,
+                        Size = new osuTK.Vector2(400, 200),
+                    }
+                };
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -22,12 +22,12 @@ namespace osu.Game.Tests.Visual.Online
             AddStep(@"Show front page", () => news.ShowFrontPage());
             AddStep(@"Custom article", () => news.Current.Value = "Test Article 101");
 
-            AddStep(@"Article covers", () => news.LoadAndShowChild(new NewsCoverTest()));
+            AddStep(@"Article covers", () => news.LoadAndShowContent(new NewsCoverTest()));
         }
 
         private class TestNewsOverlay : NewsOverlay
         {
-            public new void LoadAndShowChild(NewsContent content) => base.LoadAndShowContent(content);
+            public new void LoadAndShowContent(NewsContent content) => base.LoadAndShowContent(content);
         }
 
         private class NewsCoverTest : NewsContent

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Overlays.News;
 
@@ -37,10 +36,10 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Spacing = new osuTK.Vector2(0, 10);
 
-                var article = new NewsArticleCover.ArticleInfo()
+                var article = new NewsArticleCover.ArticleInfo
                 {
                     Author = "Ephemeral",
-                    CoverURL = "https://assets.ppy.sh/artists/58/header.jpg",
+                    CoverUrl = "https://assets.ppy.sh/artists/58/header.jpg",
                     Time = new DateTime(2019, 12, 4),
                     Title = "New Featured Artist: Kurokotei"
                 };

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -2,22 +2,28 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Overlays;
+using osu.Game.Overlays.News;
 
 namespace osu.Game.Tests.Visual.Online
 {
     public class TestSceneNewsOverlay : OsuTestScene
     {
-        private NewsOverlay news;
+        private TestNewsOverlay news;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            Add(news = new NewsOverlay());
+            Add(news = new TestNewsOverlay());
             AddStep(@"Show", news.Show);
             AddStep(@"Hide", news.Hide);
 
             AddStep(@"Show front page", () => news.ShowFrontPage());
             AddStep(@"Custom article", () => news.Current.Value = "Test Article 101");
+        }
+
+        private class TestNewsOverlay : NewsOverlay
+        {
+            public new void LoadAndShowChild(NewsContent content) => base.LoadAndShowChild(content);
         }
     }
 }

--- a/osu.Game/Overlays/News/NewsArticleCover.cs
+++ b/osu.Game/Overlays/News/NewsArticleCover.cs
@@ -90,7 +90,6 @@ namespace osu.Game.Overlays.News
             bg.OnLoadComplete += d => d.FadeIn(250, Easing.In);
         }
 
-        //news article cover background
         [LongRunningLoad]
         private class NewsBackground : Sprite
         {
@@ -108,7 +107,6 @@ namespace osu.Game.Overlays.News
             }
         }
 
-        //date container
         private class DateContainer : Container, IHasTooltip
         {
             private readonly DateTime date;
@@ -134,7 +132,7 @@ namespace osu.Game.Overlays.News
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Font = OsuFont.GetFont(Typeface.Exo, 12, FontWeight.Black, false, false),
-                        Text = date.ToString("dd MMM yyy"),
+                        Text = date.ToString("d MMM yyy").ToUpper(),
                         Margin = new MarginPadding
                         {
                             Vertical = 4,
@@ -144,7 +142,7 @@ namespace osu.Game.Overlays.News
                 };
             }
 
-            public string TooltipText => date.ToString("dddd dd MMMM yyyy hh:mm:ss UTCz");
+            public string TooltipText => date.ToString("dddd dd MMMM yyyy hh:mm:ss UTCz").ToUpper();
         }
 
         //fake API data struct to use for now as a skeleton for data, as there is no API struct for news article info for now

--- a/osu.Game/Overlays/News/NewsArticleCover.cs
+++ b/osu.Game/Overlays/News/NewsArticleCover.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osuTK.Graphics;
+
+namespace osu.Game.Overlays.News
+{
+    public class NewsArticleCover : Container
+    {
+        public NewsArticleCover(ArticleInfo info)
+        {
+            RelativeSizeAxes = Axes.X;
+            Masking = true;
+            CornerRadius = 4;
+
+            NewsBackground bg;
+
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.1f))
+                },
+                new DelayedLoadWrapper(bg = new NewsBackground(info.CoverURL)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = FillMode.Fill,
+                    Alpha = 0
+                })
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0.1f), Color4.Black.Opacity(0.6f)),
+                    Alpha = 1f,
+                },
+                new DateContainer(info.Time)
+                {
+                    Margin = new MarginPadding()
+                    {
+                        Right = 20,
+                        Top = 20,
+                    }
+                },
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Margin = new MarginPadding()
+                    {
+                        Left = 25,
+                        Bottom = 50,
+                    },
+                    Font = OsuFont.GetFont(Typeface.Exo, 24, FontWeight.Bold),
+                    Text = info.Title,
+                },
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Margin = new MarginPadding()
+                    {
+                        Left = 25,
+                        Bottom = 30,
+                    },
+                    Font = OsuFont.GetFont(Typeface.Exo, 16, FontWeight.Bold),
+                    Text = "by " + info.Author
+                }
+            };
+
+            bg.OnLoadComplete += d => d.FadeIn(250, Easing.In);
+        }
+
+        //news article cover background
+        [LongRunningLoad]
+        private class NewsBackground : Sprite
+        {
+            private readonly string url;
+
+            public NewsBackground(string coverUrl)
+            {
+                url = coverUrl ?? "Headers/news";
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(LargeTextureStore store)
+            {
+                Texture = store.Get(url);
+            }
+        }
+
+        //date container
+        private class DateContainer : Container, IHasTooltip
+        {
+            private readonly DateTime date;
+
+            public DateContainer(DateTime date)
+            {
+                this.date = date;
+
+                Anchor = Anchor.TopRight;
+                Origin = Anchor.TopRight;
+                Masking = true;
+                CornerRadius = 4;
+                AutoSizeAxes = Axes.Both;
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.Black.Opacity(0.5f),
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Font = OsuFont.GetFont(Typeface.Exo, 12, FontWeight.Black, false, false),
+                        Text = date.ToString("dd MMM yyy"),
+                        Margin = new MarginPadding()
+                        {
+                            Vertical = 4,
+                            Horizontal = 8,
+                        }
+                    }
+                };
+            }
+
+            public string TooltipText => date.ToString("dddd dd MMMM yyyy hh:mm:ss UTCz");
+        }
+
+        //fake API data struct to use for now as a skeleton for data, as there is no API struct for news article info for now
+        public class ArticleInfo
+        {
+            public string Title { get; set; }
+            public string CoverURL { get; set; }
+            public DateTime Time { get; set; }
+            public string Author { get; set; }
+        }
+    }
+}

--- a/osu.Game/Overlays/News/NewsArticleCover.cs
+++ b/osu.Game/Overlays/News/NewsArticleCover.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -31,7 +34,7 @@ namespace osu.Game.Overlays.News
                     RelativeSizeAxes = Axes.Both,
                     Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.2f), OsuColour.Gray(0.1f))
                 },
-                new DelayedLoadWrapper(bg = new NewsBackground(info.CoverURL)
+                new DelayedLoadWrapper(bg = new NewsBackground(info.CoverUrl)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -52,7 +55,7 @@ namespace osu.Game.Overlays.News
                 },
                 new DateContainer(info.Time)
                 {
-                    Margin = new MarginPadding()
+                    Margin = new MarginPadding
                     {
                         Right = 20,
                         Top = 20,
@@ -62,7 +65,7 @@ namespace osu.Game.Overlays.News
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
-                    Margin = new MarginPadding()
+                    Margin = new MarginPadding
                     {
                         Left = 25,
                         Bottom = 50,
@@ -74,7 +77,7 @@ namespace osu.Game.Overlays.News
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
-                    Margin = new MarginPadding()
+                    Margin = new MarginPadding
                     {
                         Left = 25,
                         Bottom = 30,
@@ -132,7 +135,7 @@ namespace osu.Game.Overlays.News
                         Origin = Anchor.Centre,
                         Font = OsuFont.GetFont(Typeface.Exo, 12, FontWeight.Black, false, false),
                         Text = date.ToString("dd MMM yyy"),
-                        Margin = new MarginPadding()
+                        Margin = new MarginPadding
                         {
                             Vertical = 4,
                             Horizontal = 8,
@@ -148,7 +151,7 @@ namespace osu.Game.Overlays.News
         public class ArticleInfo
         {
             public string Title { get; set; }
-            public string CoverURL { get; set; }
+            public string CoverUrl { get; set; }
             public DateTime Time { get; set; }
             public string Author { get; set; }
         }

--- a/osu.Game/Overlays/NewsOverlay.cs
+++ b/osu.Game/Overlays/NewsOverlay.cs
@@ -59,19 +59,19 @@ namespace osu.Game.Overlays
             Current.TriggerChange();
         }
 
-        private CancellationTokenSource loadChildCancellation;
+        private CancellationTokenSource loadContentCancellation;
 
-        protected void LoadAndShowChild(NewsContent newContent)
+        protected void LoadAndShowContent(NewsContent newContent)
         {
             content.FadeTo(0.2f, 300, Easing.OutQuint);
 
-            loadChildCancellation?.Cancel();
+            loadContentCancellation?.Cancel();
 
             LoadComponentAsync(newContent, c =>
             {
                 content.Child = c;
                 content.FadeIn(300, Easing.OutQuint);
-            }, (loadChildCancellation = new CancellationTokenSource()).Token);
+            }, (loadContentCancellation = new CancellationTokenSource()).Token);
         }
 
         public void ShowFrontPage()

--- a/osu.Game/Overlays/NewsOverlay.cs
+++ b/osu.Game/Overlays/NewsOverlay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -16,7 +17,6 @@ namespace osu.Game.Overlays
     {
         private NewsHeader header;
 
-        //ReSharper disable NotAccessedField.Local
         private Container<NewsContent> content;
 
         public readonly Bindable<string> Current = new Bindable<string>(null);
@@ -57,6 +57,21 @@ namespace osu.Game.Overlays
 
             header.Current.BindTo(Current);
             Current.TriggerChange();
+        }
+
+        private CancellationTokenSource loadChildCancellation;
+
+        protected void LoadAndShowChild(NewsContent newContent)
+        {
+            content.FadeTo(0.2f, 300, Easing.OutQuint);
+
+            loadChildCancellation?.Cancel();
+
+            LoadComponentAsync(newContent, c =>
+            {
+                content.Child = c;
+                content.FadeIn(300, Easing.OutQuint);
+            }, (loadChildCancellation = new CancellationTokenSource()).Token);
         }
 
         public void ShowFrontPage()


### PR DESCRIPTION
This PR implements the `NewsArticleCover` class.
Note that I'm using a dummy struct (see `ArticleInfo` class in`NewsArticleCover` ) as there is no API struct for news article info for now

Visual reference | This PR
----------------|--------
![70392687-f6814300-1a25-11ea-9453-74008d2f0fc9](https://user-images.githubusercontent.com/20256717/70821361-3146fa80-1ddb-11ea-9221-955b9c76e284.png) | ![image](https://user-images.githubusercontent.com/20256717/70822093-ff369800-1ddc-11ea-8fde-6692211d1c2f.png) |


