### PR TITLE
Update sdk and InspectCode version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -176,8 +176,8 @@ dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
 #Style - C# 8 features
 csharp_prefer_static_local_function = true:warning
 csharp_prefer_simple_using_statement = true:silent
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
 csharp_style_prefer_switch_expression = false:none
 
 #Supressing roslyn built-in analyzers

--- a/build/InspectCode.cake
+++ b/build/InspectCode.cake
@@ -1,5 +1,5 @@
 #addin "nuget:?package=CodeFileSanity&version=0.0.33"
-#addin "nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2019.2.1"
+#addin "nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2019.3.0"
 #tool "nuget:?package=NVika.MSBuild&version=1.0.1"
 var nVikaToolPath = GetFiles("./tools/NVika.MSBuild.*/tools/NVika.exe").First();
 

--- a/global.json
+++ b/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "allowPrerelease": false,
+    "rollForward": "minor",
+    "version": "3.1.100"
+  },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "2.0.24"
   }

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                 prevNoteTimes.RemoveAt(0);
             prevNoteTimes.Add(newNoteTime);
 
-            density = (prevNoteTimes[prevNoteTimes.Count - 1] - prevNoteTimes[0]) / prevNoteTimes.Count;
+            density = (prevNoteTimes[^1] - prevNoteTimes[0]) / prevNoteTimes.Count;
         }
 
         private double lastTime;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -286,11 +286,11 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private bool assertGreatJudge() => judgementResults.Last().Type == HitResult.Great;
 
-        private bool assertHeadMissTailTracked() => judgementResults[judgementResults.Count - 2].Type == HitResult.Great && judgementResults.First().Type == HitResult.Miss;
+        private bool assertHeadMissTailTracked() => judgementResults[^2].Type == HitResult.Great && judgementResults.First().Type == HitResult.Miss;
 
-        private bool assertMidSliderJudgements() => judgementResults[judgementResults.Count - 2].Type == HitResult.Great;
+        private bool assertMidSliderJudgements() => judgementResults[^2].Type == HitResult.Great;
 
-        private bool assertMidSliderJudgementFail() => judgementResults[judgementResults.Count - 2].Type == HitResult.Miss;
+        private bool assertMidSliderJudgementFail() => judgementResults[^2].Type == HitResult.Miss;
 
         private ScoreAccessibleReplayPlayer currentPlayer;
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         protected override bool OnDoubleClick(DoubleClickEvent e)
         {
             // Todo: This should all not occur on double click, but rather if the previous control point is hovered.
-            segmentStart = HitObject.Path.ControlPoints[HitObject.Path.ControlPoints.Count - 1];
+            segmentStart = HitObject.Path.ControlPoints[^1];
             segmentStart.Type.Value = PathType.Linear;
 
             currentSegmentLength = 1;

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -156,9 +156,9 @@ namespace osu.Game.Rulesets.Osu.Replays
             // TODO: Shouldn't the spinner always spin in the same direction?
             if (h is Spinner)
             {
-                calcSpinnerStartPosAndDirection(((OsuReplayFrame)Frames[Frames.Count - 1]).Position, out startPosition, out spinnerDirection);
+                calcSpinnerStartPosAndDirection(((OsuReplayFrame)Frames[^1]).Position, out startPosition, out spinnerDirection);
 
-                Vector2 spinCentreOffset = SPINNER_CENTRE - ((OsuReplayFrame)Frames[Frames.Count - 1]).Position;
+                Vector2 spinCentreOffset = SPINNER_CENTRE - ((OsuReplayFrame)Frames[^1]).Position;
 
                 if (spinCentreOffset.Length > SPIN_RADIUS)
                 {
@@ -230,7 +230,7 @@ namespace osu.Game.Rulesets.Osu.Replays
 
         private void moveToHitObject(OsuHitObject h, Vector2 targetPos, Easing easing)
         {
-            OsuReplayFrame lastFrame = (OsuReplayFrame)Frames[Frames.Count - 1];
+            OsuReplayFrame lastFrame = (OsuReplayFrame)Frames[^1];
 
             // Wait until Auto could "see and react" to the next note.
             double waitTime = h.StartTime - Math.Max(0.0, h.TimePreempt - reactionTime);
@@ -363,7 +363,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             }
 
             // We only want to let go of our button if we are at the end of the current replay. Otherwise something is still going on after us so we need to keep the button pressed!
-            if (Frames[Frames.Count - 1].Time <= endFrame.Time)
+            if (Frames[^1].Time <= endFrame.Time)
                 AddFrameToReplay(endFrame);
         }
 

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlayDetails.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlayDetails.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("set second set", () => details.BeatmapSet = secondSet);
             AddAssert("ratings set", () => details.Ratings.Metrics == secondSet.Metrics);
 
-            BeatmapSetInfo createSet() => new BeatmapSetInfo
+            static BeatmapSetInfo createSet() => new BeatmapSetInfo
             {
                 Metrics = new BeatmapSetMetrics { Ratings = Enumerable.Range(0, 11).Select(_ => RNG.Next(10)).ToArray() },
                 Beatmaps = new List<BeatmapInfo>

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatSyncedContainer.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             private TimingControlPoint getNextTimingPoint(TimingControlPoint current)
             {
-                if (timingPoints[timingPoints.Count - 1] == current)
+                if (timingPoints[^1] == current)
                     return current;
 
                 int index = timingPoints.IndexOf(current); // -1 means that this is a "default beat"
@@ -169,7 +169,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             {
                 if (timingPoints.Count == 0) return 0;
 
-                if (timingPoints[timingPoints.Count - 1] == current)
+                if (timingPoints[^1] == current)
                     return (int)Math.Ceiling((Beatmap.Value.Track.Length - current.Time) / current.BeatLength);
 
                 return (int)Math.Ceiling((getNextTimingPoint(current).Time - current.Time) / current.BeatLength);

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -195,8 +195,8 @@ namespace osu.Game.Beatmaps.ControlPoints
             if (time < list[0].Time)
                 return null;
 
-            if (time >= list[list.Count - 1].Time)
-                return list[list.Count - 1];
+            if (time >= list[^1].Time)
+                return list[^1];
 
             int l = 0;
             int r = list.Count - 2;

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Beatmaps.Formats
 
                 if (line.StartsWith(@"[", StringComparison.Ordinal) && line.EndsWith(@"]", StringComparison.Ordinal))
                 {
-                    if (!Enum.TryParse(line.Substring(1, line.Length - 2), out section))
+                    if (!Enum.TryParse(line[1..^1], out section))
                     {
                         Logger.Log($"Unknown section \"{line}\" in \"{output}\"");
                         section = Section.None;

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Graphics.Containers
 
             foreach (var link in links)
             {
-                AddText(text.Substring(previousLinkEnd, link.Index - previousLinkEnd));
+                AddText(text[previousLinkEnd..link.Index]);
                 AddLink(text.Substring(link.Index, link.Length), link.Action, link.Argument ?? link.Url);
                 previousLinkEnd = link.Index + link.Length;
             }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 result = CreateSlider(pos, combo, comboOffset, convertControlPoints(points, pathType), length, repeatCount, nodeSamples);
 
                 // The samples are played when the slider ends, which is the last node
-                result.Samples = nodeSamples[nodeSamples.Count - 1];
+                result.Samples = nodeSamples[^1];
             }
             else if (type.HasFlag(ConvertHitObjectType.Spinner))
             {
@@ -279,7 +279,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             {
                 if (vertices[i] == vertices[i - 1])
                 {
-                    points[points.Count - 1].Type.Value = type;
+                    points[^1].Type.Value = type;
                     continue;
                 }
 

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Objects
             get
             {
                 ensureValid();
-                return cumulativeLength.Count == 0 ? 0 : cumulativeLength[cumulativeLength.Count - 1];
+                return cumulativeLength.Count == 0 ? 0 : cumulativeLength[^1];
             }
         }
 
@@ -251,7 +251,7 @@ namespace osu.Game.Rulesets.Objects
                 if (calculatedLength > expectedDistance)
                 {
                     // The path will be shortened further, in which case we should trim any more unnecessary lengths and their associated path segments
-                    while (cumulativeLength.Count > 0 && cumulativeLength[cumulativeLength.Count - 1] >= expectedDistance)
+                    while (cumulativeLength.Count > 0 && cumulativeLength[^1] >= expectedDistance)
                     {
                         cumulativeLength.RemoveAt(cumulativeLength.Count - 1);
                         calculatedPath.RemoveAt(pathEndIndex--);
@@ -269,7 +269,7 @@ namespace osu.Game.Rulesets.Objects
                 // The direction of the segment to shorten or lengthen
                 Vector2 dir = (calculatedPath[pathEndIndex] - calculatedPath[pathEndIndex - 1]).Normalized();
 
-                calculatedPath[pathEndIndex] = calculatedPath[pathEndIndex - 1] + dir * (float)(expectedDistance - cumulativeLength[cumulativeLength.Count - 1]);
+                calculatedPath[pathEndIndex] = calculatedPath[pathEndIndex - 1] + dir * (float)(expectedDistance - cumulativeLength[^1]);
                 cumulativeLength.Add(expectedDistance);
             }
         }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -587,13 +587,16 @@ namespace osu.Game.Screens.Select
                     switch (d)
                     {
                         case DrawableCarouselBeatmapSet set:
+                        {
                             lastSet = set;
 
                             set.MoveToX(set.Item.State.Value == CarouselItemState.Selected ? -100 : 0, 500, Easing.OutExpo);
                             set.MoveToY(currentY, 750, Easing.OutExpo);
                             break;
+                        }
 
                         case DrawableCarouselBeatmap beatmap:
+                        {
                             if (beatmap.Item.State.Value == CarouselItemState.Selected)
                                 scrollTarget = currentY + beatmap.DrawHeight / 2 - DrawHeight / 2;
 
@@ -619,6 +622,7 @@ namespace osu.Game.Screens.Select
                             }
 
                             break;
+                        }
                     }
                 }
 

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -220,7 +220,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseCollectionCountProperty/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseFormatSpecifierInFormatString/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseFormatSpecifierInInterpolation/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseIndexFromEndExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseIndexFromEndExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNameofExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNegatedPatternMatching/@EntryIndexedValue"></s:String>
 	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNegatedPatternMatching/@EntryIndexRemoved">True</s:Boolean>

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -215,6 +215,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMethodReturnValue_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedType_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseAwaitUsing/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseCollectionCountProperty/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseFormatSpecifierInFormatString/@EntryIndexedValue">WARNING</s:String>


### PR DESCRIPTION
This will unblock switch expressions, default interface implementations, and some other new features.

Notes for sdk version in `global.json`:
Previously, `global.json` doesn't support rolling forward, thus can only be used to lock the sdk version. From .NET Core 3, it can be used to specify _minimal required SDK version_ now. Reference: https://github.com/dotnet/designs/blob/master/accepted/global-json-updates.md
My opinions for setting rolling level:
- Prefer lower to higher. This helps finding usages requiring SDK version update
- Only rolling feature brands seems too strict. Will major rolling bring unpredictable changes? Minor should be a medium level.

Including index and range expressions in this PR as they are small changes.

NOT updating the target framework to 3.1. Should we do this now? Updating target framework will be much easier in .NET Core.