### PR TITLE
Allow changing volume using alt when hovering scroll containers

### DIFF
--- a/osu.Game/Graphics/Containers/OsuScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuScrollContainer.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Graphics.Containers
 
         protected override bool OnScroll(ScrollEvent e)
         {
+            // allow for controlling volume when alt is held.
+            // mostly for compatibility with osu-stable.
             if (e.AltPressed) return false;
 
             return base.OnScroll(e);

--- a/osu.Game/Graphics/Containers/OsuScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuScrollContainer.cs
@@ -83,6 +83,13 @@ namespace osu.Game.Graphics.Containers
             return base.OnDragEnd(e);
         }
 
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            if (e.AltPressed) return false;
+
+            return base.OnScroll(e);
+        }
+
         protected override ScrollbarContainer CreateScrollbar(Direction direction) => new OsuScrollbar(direction);
 
         protected class OsuScrollbar : ScrollbarContainer


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/2869.

Doesn't work with scroll containers inside overlay containers.