### PR TITLE
Deassociate LegacyLastTick from slider tail

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -32,13 +32,13 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             typeof(Slider),
             typeof(SliderTick),
-            typeof(SliderTailCircle),
+            typeof(SliderLegacyLastTick),
             typeof(SliderBall),
             typeof(SliderBody),
             typeof(SnakingSliderBody),
             typeof(DrawableSlider),
             typeof(DrawableSliderTick),
-            typeof(DrawableSliderTail),
+            typeof(DrawableSliderLegacyLastTick),
             typeof(DrawableSliderHead),
             typeof(DrawableRepeatPoint),
             typeof(DrawableOsuHitObject)
@@ -146,7 +146,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("head samples updated", () => assertSamples(((Slider)slider.HitObject).HeadCircle));
             AddAssert("tick samples not updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<SliderTick>().All(assertTickSamples));
             AddAssert("repeat samples updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<RepeatPoint>().All(assertSamples));
-            AddAssert("tail has no samples", () => ((Slider)slider.HitObject).TailCircle.Samples.Count == 0);
+            AddAssert("tail has no samples", () => ((Slider)slider.HitObject).LastTick.Samples.Count == 0);
 
             static bool assertTickSamples(SliderTick tick) => tick.Samples.Single().Name == "slidertick";
 
@@ -181,7 +181,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("head samples not updated", () => assertSamples(((Slider)slider.HitObject).HeadCircle));
             AddAssert("tick samples not updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<SliderTick>().All(assertTickSamples));
             AddAssert("repeat samples not updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<RepeatPoint>().All(assertSamples));
-            AddAssert("tail has no samples", () => ((Slider)slider.HitObject).TailCircle.Samples.Count == 0);
+            AddAssert("tail has no samples", () => ((Slider)slider.HitObject).LastTick.Samples.Count == 0);
 
             static bool assertTickSamples(SliderTick tick) => tick.Samples.Single().Name == "slidertick";
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             typeof(DrawableRepeatPoint),
             typeof(DrawableOsuHitObject),
             typeof(DrawableSliderHead),
-            typeof(DrawableSliderTail),
+            typeof(DrawableSliderLegacyLastTick),
         };
 
         private const double time_before_slider = 250;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         {
             base.Update();
 
-            CirclePiece.UpdateFrom(position == SliderPosition.Start ? HitObject.HeadCircle : HitObject.TailCircle);
+            CirclePiece.UpdateFrom(position == SliderPosition.Start ? HitObject.HeadCircle : HitObject.LastTick);
         }
 
         // Todo: This is temporary, since the slider circle masks don't do anything special yet. In the future they will handle input.

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             bodyPiece.UpdateFrom(HitObject);
             headCirclePiece.UpdateFrom(HitObject.HeadCircle);
-            tailCirclePiece.UpdateFrom(HitObject.TailCircle);
+            tailCirclePiece.UpdateFrom(HitObject.LastTick);
         }
 
         private void setState(PlacementState newState)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModeObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModeObjectScaleTween.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             switch (drawable)
             {
                 case DrawableSliderHead _:
-                case DrawableSliderTail _:
+                case DrawableSliderLegacyLastTick _:
                     // special cases we should *not* be scaling.
                     break;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -22,12 +22,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     public class DrawableSlider : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
         public DrawableSliderHead HeadCircle => headContainer.Child;
-        public DrawableSliderTail TailCircle => tailContainer.Child;
+        public DrawableSliderLegacyLastTick TailCircle => lastTickContainer.Child;
 
         public readonly SnakingSliderBody Body;
         public readonly SliderBall Ball;
 
         private readonly Container<DrawableSliderHead> headContainer;
+        private readonly Container<DrawableSliderLegacyLastTick> lastTickContainer;
         private readonly Container<DrawableSliderTail> tailContainer;
         private readonly Container<DrawableSliderTick> tickContainer;
         private readonly Container<DrawableRepeatPoint> repeatContainer;
@@ -54,6 +55,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 Body = new SnakingSliderBody(s),
                 tickContainer = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
                 repeatContainer = new Container<DrawableRepeatPoint> { RelativeSizeAxes = Axes.Both },
+                tailContainer = new Container<DrawableSliderTail> { RelativeSizeAxes = Axes.Both },
                 Ball = new SliderBall(s, this)
                 {
                     GetInitialHitAction = () => HeadCircle.HitAction,
@@ -63,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     Alpha = 0
                 },
                 headContainer = new Container<DrawableSliderHead> { RelativeSizeAxes = Axes.Both },
-                tailContainer = new Container<DrawableSliderTail> { RelativeSizeAxes = Axes.Both },
+                lastTickContainer = new Container<DrawableSliderLegacyLastTick> { RelativeSizeAxes = Axes.Both },
             };
         }
 
@@ -107,6 +109,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     headContainer.Child = head;
                     break;
 
+                case DrawableSliderLegacyLastTick lastTick:
+                    lastTickContainer.Child = lastTick;
+                    break;
+
                 case DrawableSliderTail tail:
                     tailContainer.Child = tail;
                     break;
@@ -126,6 +132,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.ClearNestedHitObjects();
 
             headContainer.Clear();
+            lastTickContainer.Clear();
             tailContainer.Clear();
             repeatContainer.Clear();
             tickContainer.Clear();
@@ -135,6 +142,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             switch (hitObject)
             {
+                case SliderLegacyLastTick lastTick:
+                    return new DrawableSliderLegacyLastTick(slider, lastTick);
+
                 case SliderTailCircle tail:
                     return new DrawableSliderTail(slider, tail);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderLegacyLastTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderLegacyLastTick.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Objects.Drawables
+{
+    public class DrawableSliderLegacyLastTick : DrawableOsuHitObject, IRequireTracking
+    {
+        private readonly Slider slider;
+
+        /// <summary>
+        /// The judgement text is provided by the <see cref="DrawableSlider"/>.
+        /// </summary>
+        public override bool DisplayResult => false;
+
+        public bool Tracking { get; set; }
+
+        private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
+        private readonly IBindable<int> pathVersion = new Bindable<int>();
+
+        public DrawableSliderLegacyLastTick(Slider slider, SliderLegacyLastTick hitCircle)
+            : base(hitCircle)
+        {
+            this.slider = slider;
+
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+            FillMode = FillMode.Fit;
+
+            AlwaysPresent = true;
+
+            positionBindable.BindTo(hitCircle.PositionBindable);
+            pathVersion.BindTo(slider.Path.Version);
+
+            positionBindable.BindValueChanged(_ => updatePosition());
+            pathVersion.BindValueChanged(_ => updatePosition(), true);
+        }
+
+        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        {
+            if (!userTriggered && timeOffset >= 0)
+                ApplyResult(r => r.Type = Tracking ? HitResult.Great : HitResult.Miss);
+        }
+
+        private void updatePosition() => Position = HitObject.Position - slider.Position;
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double TickDistanceMultiplier = 1;
 
         public HitCircle HeadCircle;
-        public SliderTailCircle TailCircle;
+        public SliderLegacyLastTick LastTick;
 
         public Slider()
         {
@@ -162,9 +162,16 @@ namespace osu.Game.Rulesets.Osu.Objects
 
                     case SliderEventType.LegacyLastTick:
                         // we need to use the LegacyLastTick here for compatibility reasons (difficulty).
-                        // it is *okay* to use this because the TailCircle is not used for any meaningful purpose in gameplay.
-                        // if this is to change, we should revisit this.
-                        AddNested(TailCircle = new SliderTailCircle(this)
+                        AddNested(LastTick = new SliderLegacyLastTick(this)
+                        {
+                            StartTime = e.Time,
+                            Position = EndPosition,
+                            StackHeight = StackHeight
+                        });
+                        break;
+
+                    case SliderEventType.Tail:
+                        AddNested(new SliderTailCircle(this)
                         {
                             StartTime = e.Time,
                             Position = EndPosition,
@@ -196,8 +203,8 @@ namespace osu.Game.Rulesets.Osu.Objects
             if (HeadCircle != null)
                 HeadCircle.Position = Position;
 
-            if (TailCircle != null)
-                TailCircle.Position = EndPosition;
+            if (LastTick != null)
+                LastTick.Position = EndPosition;
         }
 
         private void updateNestedSamples()

--- a/osu.Game.Rulesets.Osu/Objects/SliderLegacyLastTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderLegacyLastTick.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Objects
+{
+    /// <summary>
+    /// Note that this should not be used for timing correctness.
+    /// See <see cref="SliderEventType.LegacyLastTick"/> usage in <see cref="Slider"/> for more information.
+    /// </summary>
+    public class SliderLegacyLastTick : SliderCircle
+    {
+        private readonly IBindable<int> pathVersion = new Bindable<int>();
+
+        public SliderLegacyLastTick(Slider slider)
+        {
+            pathVersion.BindTo(slider.Path.Version);
+            pathVersion.BindValueChanged(_ => Position = slider.EndPosition);
+        }
+
+        public override Judgement CreateJudgement() => new OsuSliderTailJudgement();
+
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+    }
+}

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                     break;
 
                 case Slider slider:
-                    hitWindows = slider.TailCircle.HitWindows;
+                    hitWindows = slider.LastTick.HitWindows;
                     break;
 
                 case Spinner _:


### PR DESCRIPTION
Cases that mean to use the real tail instead of `LegacyLastTick` remain.