### PR TITLE
Fix crashes on custom skins due to extension-less file lookups

### DIFF
--- a/osu.Game/Skinning/LegacySkinResourceStore.cs
+++ b/osu.Game/Skinning/LegacySkinResourceStore.cs
@@ -22,10 +22,8 @@ namespace osu.Game.Skinning
             if (source.Files == null)
                 return null;
 
-            bool hasExtension = filename.Contains('.');
-
             var file = source.Files.Find(f =>
-                string.Equals(hasExtension ? f.Filename : Path.ChangeExtension(f.Filename, null), filename, StringComparison.InvariantCultureIgnoreCase));
+                string.Equals(f.Filename, filename, StringComparison.InvariantCultureIgnoreCase));
             return file?.FileInfo.StoragePath;
         }
 

--- a/osu.Game/Skinning/LegacySkinResourceStore.cs
+++ b/osu.Game/Skinning/LegacySkinResourceStore.cs
@@ -3,75 +3,39 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using osu.Framework.IO.Stores;
 using osu.Game.Database;
 
 namespace osu.Game.Skinning
 {
-    public class LegacySkinResourceStore<T> : IResourceStore<byte[]>
+    public class LegacySkinResourceStore<T> : ResourceStore<byte[]>
         where T : INamedFileInfo
     {
         private readonly IHasFiles<T> source;
-        private readonly IResourceStore<byte[]> underlyingStore;
-
-        private string getPathForFile(string filename)
-        {
-            if (source.Files == null)
-                return null;
-
-            var file = source.Files.Find(f =>
-                string.Equals(f.Filename, filename, StringComparison.InvariantCultureIgnoreCase));
-            return file?.FileInfo.StoragePath;
-        }
 
         public LegacySkinResourceStore(IHasFiles<T> source, IResourceStore<byte[]> underlyingStore)
+            : base(underlyingStore)
         {
             this.source = source;
-            this.underlyingStore = underlyingStore;
         }
 
-        public Stream GetStream(string name)
+        protected override IEnumerable<string> GetFilenames(string name)
         {
-            string path = getPathForFile(name);
-            return path == null ? null : underlyingStore.GetStream(path);
-        }
+            if (source.Files == null)
+                yield break;
 
-        public IEnumerable<string> GetAvailableResources() => source.Files.Select(f => f.Filename);
-
-        byte[] IResourceStore<byte[]>.Get(string name) => GetAsync(name).Result;
-
-        public Task<byte[]> GetAsync(string name)
-        {
-            string path = getPathForFile(name);
-            return path == null ? Task.FromResult<byte[]>(null) : underlyingStore.GetAsync(path);
-        }
-
-        #region IDisposable Support
-
-        private bool isDisposed;
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!isDisposed)
+            foreach (var filename in base.GetFilenames(name))
             {
-                isDisposed = true;
+                var path = getPathForFile(filename);
+                if (path != null)
+                    yield return path;
             }
         }
 
-        ~LegacySkinResourceStore()
-        {
-            Dispose(false);
-        }
+        private string getPathForFile(string filename) =>
+            source.Files.Find(f => string.Equals(f.Filename, filename, StringComparison.InvariantCultureIgnoreCase))?.FileInfo.StoragePath;
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        #endregion
+        public override IEnumerable<string> GetAvailableResources() => source.Files.Select(f => f.Filename);
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/7179 (via local fix; framework resolution still required).

File extensions are already provided in all usages (`SampleStore` and `TextureLoaderStore`) so this logic is not required. Blaming back, it comes from the initial implementation.