### PR TITLE
Don't reuse the same control point references for sliders

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
                 if (value != null)
                 {
-                    path.ControlPoints.AddRange(value.ControlPoints);
+                    path.ControlPoints.AddRange(value.ControlPoints.Select(c => new PathControlPoint(c.Position.Value, c.Type.Value)));
                     path.ExpectedDistance.Value = value.ExpectedDistance.Value;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
                 if (value != null)
                 {
-                    path.ControlPoints.AddRange(value.ControlPoints);
+                    path.ControlPoints.AddRange(value.ControlPoints.Select(c => new PathControlPoint(c.Position.Value, c.Type.Value)));
                     path.ExpectedDistance.Value = value.ExpectedDistance.Value;
                 }
             }


### PR DESCRIPTION
Fixes HR being duplicated when retrying beatmaps.