### PR TITLE
Implement legacy slider border shadow

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/PlaySliderBody.cs
@@ -24,16 +24,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         private OsuRulesetConfigManager config { get; set; }
 
         private Slider slider;
-        private float defaultPathRadius;
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin)
         {
             slider = (Slider)drawableObject.HitObject;
-            defaultPathRadius = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderPathRadius)?.Value ?? OsuHitObject.OBJECT_RADIUS;
 
             scaleBindable = slider.ScaleBindable.GetBoundCopy();
-            scaleBindable.BindValueChanged(_ => updatePathRadius(), true);
+            scaleBindable.BindValueChanged(scale => PathRadius = OsuHitObject.OBJECT_RADIUS * scale.NewValue, true);
 
             pathVersion = slider.Path.Version.GetBoundCopy();
             pathVersion.BindValueChanged(_ => Refresh());
@@ -47,9 +45,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             BorderSize = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderBorderSize)?.Value ?? 1;
             BorderColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value ?? Color4.White;
         }
-
-        private void updatePathRadius()
-            => PathRadius = defaultPathRadius * scaleBindable.Value;
 
         private void updateAccentColour(ISkinSource skin, Color4 defaultAccentColour)
             => AccentColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderTrackOverride)?.Value ?? defaultAccentColour;

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySliderBody.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.MathUtils;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
 using osuTK.Graphics;
 
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private class LegacyDrawableSliderPath : DrawableSliderPath
         {
-            private const float shadow_portion = 0.06f;
+            private const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
 
             public new Color4 AccentColour => new Color4(base.AccentColour.R, base.AccentColour.G, base.AccentColour.B, base.AccentColour.A * 0.70f);
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySliderBody.cs
@@ -15,19 +15,27 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private class LegacyDrawableSliderPath : DrawableSliderPath
         {
+            private const float shadow_portion = 0.06f;
+
             public new Color4 AccentColour => new Color4(base.AccentColour.R, base.AccentColour.G, base.AccentColour.B, base.AccentColour.A * 0.70f);
 
             protected override Color4 ColourAt(float position)
             {
-                if (CalculatedBorderPortion != 0f && position <= CalculatedBorderPortion)
+                float realBorderPortion = shadow_portion + CalculatedBorderPortion;
+                float realGradientPortion = 1 - realBorderPortion;
+
+                if (position <= shadow_portion)
+                    return new Color4(0f, 0f, 0f, 0.25f * position / shadow_portion);
+
+                if (position <= realBorderPortion)
                     return BorderColour;
 
-                position -= BORDER_PORTION;
+                position -= realBorderPortion;
 
                 Color4 outerColour = AccentColour.Darken(0.1f);
                 Color4 innerColour = lighten(AccentColour, 0.5f);
 
-                return Interpolation.ValueAt(position / GRADIENT_PORTION, outerColour, innerColour, 0, 1);
+                return Interpolation.ValueAt(position / realGradientPortion, outerColour, innerColour, 0, 1);
             }
 
             /// <summary>

--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         /// Their hittable area is 128px, but the actual circle portion is 118px.
         /// We must account for some gameplay elements such as slider bodies, where this padding is not present.
         /// </summary>
-        private const float legacy_circle_radius = 64 - 5;
+        public const float LEGACY_CIRCLE_RADIUS = 64 - 5;
 
         public OsuLegacySkinTransformer(ISkinSource source)
         {
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     {
                         case OsuSkinConfiguration.SliderPathRadius:
                             if (hasHitCircle.Value)
-                                return SkinUtils.As<TValue>(new BindableFloat(legacy_circle_radius));
+                                return SkinUtils.As<TValue>(new BindableFloat(LEGACY_CIRCLE_RADIUS));
 
                             break;
                     }


### PR DESCRIPTION
Seems to look about right on a visual comparison + the metrics in the test scene. The one thing I'm unsure of is AA, which I'd need someone on less-than-retina resolution to test. If it's an issue we'll likely have to make o!f changes to adjust the AA area.