### PR TITLE
Fix editor crashing when loading a beatmap for an unsupported ruleset

### DIFF
--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -32,6 +32,6 @@ namespace osu.Game.Screens.Edit.Compose
             return beatmapSkinProvider.WithChild(rulesetSkinProvider.WithChild(composer));
         }
 
-        protected override Drawable CreateTimelineContent() => new TimelineHitObjectDisplay(composer.EditorBeatmap);
+        protected override Drawable CreateTimelineContent() => composer == null ? base.CreateTimelineContent() : new TimelineHitObjectDisplay(composer.EditorBeatmap);
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/7247.