### PR TITLE
Don't log discord connection failures

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -43,8 +43,7 @@ namespace osu.Desktop
             };
 
             client.OnReady += onReady;
-            client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Code} {e.Message}", LoggingTarget.Network, LogLevel.Error);
-            client.OnConnectionFailed += (_, e) => Logger.Log($"An connection occurred with Discord RPC Client: {e.Type}", LoggingTarget.Network, LogLevel.Error);
+            client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Code} {e.Message}", LoggingTarget.Network);
 
             (user = provider.LocalUser.GetBoundCopy()).BindValueChanged(u =>
             {


### PR DESCRIPTION
More common a scenario than expected. Also reduces verbosity of all discord log output so it is not displayed to the user.

Closes https://github.com/ppy/osu/issues/7266.