### PR TITLE
Fix score serialisation failing for unknown mod properties

### DIFF
--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Scoring
                 if (mods == null)
                     return null;
 
-                return modsJson = JsonConvert.SerializeObject(mods);
+                return modsJson = JsonConvert.SerializeObject(mods.Select(m => new DeserializedMod { Acronym = m.Acronym }));
             }
             set
             {


### PR DESCRIPTION
Keep things simple for now. Going forward this will need to change to support mod settings etc.

Closes https://github.com/ppy/osu/issues/7236.