### PR TITLE
Fix key overlay appearing regardless of the setting

### DIFF
--- a/osu.Game/Screens/Play/KeyCounterDisplay.cs
+++ b/osu.Game/Screens/Play/KeyCounterDisplay.cs
@@ -43,6 +43,11 @@ namespace osu.Game.Screens.Play
         private void load(OsuConfigManager config)
         {
             config.BindWith(OsuSetting.KeyOverlay, configVisibility);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
 
             Visible.BindValueChanged(_ => updateVisibility());
             configVisibility.BindValueChanged(_ => updateVisibility(), true);


### PR DESCRIPTION
- Fixes key overlay appearing regardless of the setting, caused by transforming on BDL which might cause timing issues, see https://github.com/ppy/osu/pull/6288#issuecomment-538835727

Closes #7288