### PR TITLE
Fix storyboard incorrectly re-ordering elements

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual(new Vector2(320, 240), sprite.InitialPosition);
                 Assert.IsTrue(sprite.IsDrawable);
                 Assert.AreEqual(Anchor.Centre, sprite.Origin);
-                Assert.AreEqual("SB/black.jpg", sprite.Path);
+                Assert.AreEqual("SB/lyric/ja-21.png", sprite.Path);
 
                 var animation = background.Elements.OfType<StoryboardAnimation>().First();
                 Assert.NotNull(animation);

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Extensions;
@@ -42,10 +41,6 @@ namespace osu.Game.Beatmaps.Formats
         {
             this.storyboard = storyboard;
             base.ParseStreamInto(stream, storyboard);
-
-            // OrderBy is used to guarantee that the parsing order of elements with equal start times is maintained (stably-sorted)
-            foreach (StoryboardLayer layer in storyboard.Layers)
-                layer.Elements = layer.Elements.OrderBy(h => h.StartTime).ToList();
         }
 
         protected override void ParseLine(Storyboard storyboard, Section section, string line)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/7283
Fixes https://github.com/ppy/osu/issues/7264

As per osu-stable and the [official specification](https://osu.ppy.sh/community/forums/topics/1869?start=12468#p12468):
> Z-order (back to front) is determined by the order the files appear in the .osu file.

We shouldn't re-order based on start time.