### PR TITLE
Truncate rich presence status strings to 128 bytes

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -98,17 +98,17 @@ namespace osu.Desktop
             client.SetPresence(presence);
         }
 
+        private static readonly int ellipsis_length = Encoding.UTF8.GetByteCount(new[] { '…' });
+
         private string truncate(ReadOnlySpan<char> str)
         {
             if (Encoding.UTF8.GetByteCount(str) <= 128)
                 return new string(str);
 
-            int ellipsisLength = Encoding.UTF8.GetByteCount(new[] { '…' });
-
             do
             {
                 str = str[..^1];
-            } while (Encoding.UTF8.GetByteCount(str) + ellipsisLength > 128);
+            } while (Encoding.UTF8.GetByteCount(str) + ellipsis_length > 128);
 
             return new string(str) + '…';
         }

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using System.Text;
 using DiscordRPC;
+using DiscordRPC.Helper;
 using DiscordRPC.Message;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -78,8 +81,8 @@ namespace osu.Desktop
 
             if (status.Value is UserStatusOnline && activity.Value != null)
             {
-                presence.State = activity.Value.Status;
-                presence.Details = getDetails(activity.Value);
+                presence.State = truncate(activity.Value.Status);
+                presence.Details = truncate(getDetails(activity.Value));
             }
             else
             {
@@ -96,6 +99,8 @@ namespace osu.Desktop
 
             client.SetPresence(presence);
         }
+
+        private string truncate(string str) => str.WithinLength(128) ? str : new string (str.TakeWhile((c, i) => Encoding.UTF8.GetByteCount(str.Substring(0, i + 1)) <= 125).ToArray()) + '…'; //the ellipsis char is 3 bytes long in UTF8
 
         private string getDetails(UserActivity activity)
         {

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -100,7 +100,7 @@ namespace osu.Desktop
 
         private string truncate(ReadOnlySpan<char> str)
         {
-            if (Encoding.UTF8.GetByteCount(str) < 128)
+            if (Encoding.UTF8.GetByteCount(str) <= 128)
                 return new string(str);
 
             int ellipsisLength = Encoding.UTF8.GetByteCount(new[] { '…' });

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -100,7 +100,13 @@ namespace osu.Desktop
             client.SetPresence(presence);
         }
 
-        private string truncate(string str) => str.WithinLength(128) ? str : new string (str.TakeWhile((c, i) => Encoding.UTF8.GetByteCount(str.Substring(0, i + 1)) <= 125).ToArray()) + '…'; //the ellipsis char is 3 bytes long in UTF8
+        private string truncate(string str)
+        {
+            if (str.WithinLength(128))
+                return str;
+
+            return new string(str.TakeWhile((c, i) => Encoding.UTF8.GetByteCount(str.Substring(0, i + 1)) <= 125).ToArray()) + '…'; //the ellipsis char is 3 bytes long in UTF8
+        }
 
         private string getDetails(UserActivity activity)
         {


### PR DESCRIPTION
Closes #7311
`State` and `Detail` strings are now truncated to 128 bytes (as stated in the DiscordRPC docs), which should stop DiscordRichPresence from throwing exceptions