### PR TITLE
Protect against potential nullref when exiting player

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -562,7 +562,7 @@ namespace osu.Game.Screens.Play
 
             // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.
             // as we are no longer the current screen, we cannot guarantee the track is still usable.
-            GameplayClockContainer.StopUsingBeatmapClock();
+            GameplayClockContainer?.StopUsingBeatmapClock();
 
             fadeOut();
             return base.OnExiting(next);


### PR DESCRIPTION
If the beatmap fails to load, `GameplayClockContainer` will be uninitialised. `OnExiting()` is the only interesting code that will be run regardless, so I've only added it here for that reason.