### PR TITLE
Make the Easy mod's extra life count customizable

### DIFF
--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -21,7 +22,14 @@ namespace osu.Game.Rulesets.Mods
         public override bool Ranked => true;
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock) };
 
-        private int retries = 2;
+        [SettingSource("Extra Lives", "Number of extra lives")]
+        public Bindable<int> Retries { get; } = new BindableInt(2)
+        {
+            MinValue = 0,
+            MaxValue = 10
+        };
+
+        private int retries;
 
         private BindableNumber<double> health;
 
@@ -32,6 +40,8 @@ namespace osu.Game.Rulesets.Mods
             difficulty.ApproachRate *= ratio;
             difficulty.DrainRate *= ratio;
             difficulty.OverallDifficulty *= ratio;
+
+            retries = Retries.Value;
         }
 
         public bool AllowFail


### PR DESCRIPTION
Closes #7327

This makes the number of allowed retries with the easy mod customizable.