### PR TITLE
Disable automatic retry of failed discord RPC connections

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -43,6 +43,10 @@ namespace osu.Desktop
             };
 
             client.OnReady += onReady;
+
+            // safety measure for now, until we performance test / improve backoff for failed connections.
+            client.OnConnectionFailed += (_, __) => client.Deinitialize();
+
             client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Code} {e.Message}", LoggingTarget.Network);
 
             (user = provider.LocalUser.GetBoundCopy()).BindValueChanged(u =>


### PR DESCRIPTION
It seems like the overhead from retries was affecting some low-spec'd users on osu-stable. Disabling reconnect logic for now as a safety measure, pending further investigation.