### PR TITLE
Improve notification overlay test robustness

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -67,9 +67,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddRepeatStep(@"add many simple", sendManyNotifications, 3);
 
-            AddWaitStep("wait some", 5);
-
-            checkProgressingCount(0);
+            waitForCompletion();
 
             AddStep(@"progress #3", sendUploadProgress);
 
@@ -77,9 +75,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             checkDisplayedCount(33);
 
-            AddWaitStep("wait some", 10);
-
-            checkProgressingCount(0);
+            waitForCompletion();
         }
 
         [Test]
@@ -109,9 +105,9 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep(@"background progress #1", sendBackgroundUploadProgress);
 
-            AddWaitStep("wait some", 5);
+            checkProgressingCount(1);
 
-            checkProgressingCount(0);
+            waitForCompletion();
 
             checkDisplayedCount(2);
 
@@ -189,6 +185,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         private void setState(Visibility state) => AddStep(state.ToString(), () => notificationOverlay.State.Value = state);
 
         private void checkProgressingCount(int expected) => AddAssert($"progressing count is {expected}", () => progressingNotifications.Count == expected);
+
+        private void waitForCompletion() => AddUntilStep("wait for notification progress completion", () => progressingNotifications.Count == 0);
 
         private void sendBarrage()
         {


### PR DESCRIPTION
Fix for random test failures, as exhibited [here](https://ci.appveyor.com/project/peppy/osu/builds/29766242).

# Summary

Stress testing one of the notification overlay tests by running it 10000 times on repeat has shown that it is susceptible to intermittent failures due to races between delays and asserts checking the number of currently progressing notifications and the actual progress update, which contains a random generation factor.

To improve robustness, replace step sequences checking for notification completion by waiting and asserting with explicit until steps that don't terminate unless there are zero progressing notifications.

# Remarks

Stress tested locally using Rider's test runner and `[Repeat(10000)]`.