### PR TITLE
Update star rating in song select statistics when changing mods/mod settings

### DIFF
--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Screens.Select.Details
 
             ScheduledDelegate debounce = null;
 
-            foreach (var mod in mods.NewValue.OfType<IApplicableToDifficulty>())
+            foreach (var mod in mods.NewValue.Where(m => m is IApplicableToDifficulty || m is IApplicableToTrack))
             {
                 foreach (var setting in mod.CreateSettingsControls().OfType<ISettingsItem>())
                 {


### PR DESCRIPTION
Thanks to #7303 , the implementation becomes very simple.
HardRock:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/5644458/71543127-96d5e200-29aa-11ea-9e59-8e50362cfc3b.png">
DoubleTime:
<img width="325" alt="image" src="https://user-images.githubusercontent.com/5644458/71543151-e1575e80-29aa-11ea-8966-4a7d8cebaedf.png">

But, I'm afraid we are on the wrong way of beatmap details processing. There should be a centralized "Playable state of beatmap", in contrast of "original beatmap", and all the displaying should simply read from the playable state.

Also, there needs a redesign of beatmap info UI.