### PR TITLE
Fix File Sharing on iOS 13

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -14,15 +14,15 @@
 	<string>0.1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<true/>
 	<key>MinimumOSVersion</key>
 	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
 		<integer>2</integer>
-	</array>
+    </array>
+    <key>UIFileSharingEnabled</key>
+    <true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -51,7 +51,7 @@
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>
-				<string></string>
+				<string>public.data</string>
 			</array>
 			<key>UTTypeIdentifier</key>
 			<string>sh.ppy.osu.items</string>
@@ -104,7 +104,9 @@
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>CFBundleTypeName</key>
-			<string>Supported osu! files</string>
+            <string>Supported osu! files</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>sh.ppy.osu.items</string>

--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -20,9 +20,9 @@
 	<array>
 		<integer>1</integer>
 		<integer>2</integer>
-    </array>
-    <key>UIFileSharingEnabled</key>
-    <true/>
+	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -104,9 +104,9 @@
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>CFBundleTypeName</key>
-            <string>Supported osu! files</string>
-            <key>CFBundleTypeRole</key>
-            <string>Viewer</string>
+			<string>Supported osu! files</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>sh.ppy.osu.items</string>


### PR DESCRIPTION
Fixes #7049 
A patch to fix the disability to import files via the "Share" menu.
Refer: https://forums.developer.apple.com/thread/118932 