### PR TITLE
Make discord status text in line with stable during gameplay

### DIFF
--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -52,7 +52,29 @@ namespace osu.Game.Users
                 Ruleset = ruleset;
             }
 
-            public override string Status => @"Playing alone";
+            public override string Status
+            {
+                get
+                {
+                    switch (Ruleset.ID)
+                    {
+                        case 0:
+                            return "Clicking circles";
+
+                        case 1:
+                            return "Bashing drums";
+
+                        case 2:
+                            return "Catching fruit";
+
+                        case 3:
+                            return "Smashing keys";
+
+                        default:
+                            return "Playing solo";
+                    }
+                }
+            }
         }
 
         public class Spectating : UserActivity


### PR DESCRIPTION
The default text is changed to "Playing solo" for consistent terminology.