### PR TITLE
Implement a login placeholder

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapLeaderboard.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Leaderboards;
+using osu.Game.Online.Placeholders;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Select.Leaderboards;

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Online.Leaderboards
                         break;
 
                     case PlaceholderState.NotLoggedIn:
-                        replacePlaceholder(new MessagePlaceholder(@"Please sign in to view online leaderboards!"));
+                        replacePlaceholder(new LoginPlaceholder(@"view online leaderboards!"));
                         break;
 
                     case PlaceholderState.NotSupporter:

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -14,6 +14,7 @@ using osu.Framework.Threading;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
+using osu.Game.Online.Placeholders;
 using osuTK;
 using osuTK.Graphics;
 

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Online.Leaderboards
                         break;
 
                     case PlaceholderState.NotLoggedIn:
-                        replacePlaceholder(new LoginPlaceholder(@"Please sign in to view online leaderboards!"));
+                        replacePlaceholder(new LoginPlaceholder());
                         break;
 
                     case PlaceholderState.NotSupporter:

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Online.Leaderboards
                         break;
 
                     case PlaceholderState.NotLoggedIn:
-                        replacePlaceholder(new LoginPlaceholder(@"view online leaderboards!"));
+                        replacePlaceholder(new LoginPlaceholder(@"Please sign in to view online leaderboards!"));
                         break;
 
                     case PlaceholderState.NotSupporter:

--- a/osu.Game/Online/Leaderboards/RetrievalFailurePlaceholder.cs
+++ b/osu.Game/Online/Leaderboards/RetrievalFailurePlaceholder.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
+using osu.Game.Online.Placeholders;
 using osuTK;
 
 namespace osu.Game.Online.Leaderboards

--- a/osu.Game/Online/Placeholders/LoginPlaceholder.cs
+++ b/osu.Game/Online/Placeholders/LoginPlaceholder.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Online.Placeholders
         [Resolved(CanBeNull = true)]
         private LoginOverlay login { get; set; }
 
-        public LoginPlaceholder(string action)
+        public LoginPlaceholder()
         {
             AddIcon(FontAwesome.Solid.UserLock, cp =>
             {
@@ -22,7 +22,7 @@ namespace osu.Game.Online.Placeholders
                 cp.Padding = new MarginPadding { Right = 10 };
             });
 
-            AddText(action);
+            AddText(@"Please sign in to view online leaderboards!");
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game/Online/Placeholders/LoginPlaceholder.cs
+++ b/osu.Game/Online/Placeholders/LoginPlaceholder.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Allocation;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
@@ -39,6 +42,5 @@ namespace osu.Game.Online.Placeholders
             login?.Show();
             return base.OnClick(e);
         }
-
     }
 }

--- a/osu.Game/Online/Placeholders/LoginPlaceholder.cs
+++ b/osu.Game/Online/Placeholders/LoginPlaceholder.cs
@@ -1,0 +1,44 @@
+﻿using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Overlays;
+
+namespace osu.Game.Online.Placeholders
+{
+    public sealed class LoginPlaceholder : Placeholder
+    {
+        [Resolved]
+        private LoginOverlay login { get; set; }
+
+        public LoginPlaceholder(string action)
+        {
+            AddIcon(FontAwesome.Solid.UserLock, cp =>
+            {
+                cp.Font = cp.Font.With(size: TEXT_SIZE);
+                cp.Padding = new MarginPadding { Right = 10 };
+            });
+
+            AddText(@"Please sign in to " + action);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            this.ScaleTo(0.8f, 4000, Easing.OutQuint);
+            return base.OnMouseDown(e);
+        }
+
+        protected override bool OnMouseUp(MouseUpEvent e)
+        {
+            this.ScaleTo(1, 1000, Easing.OutElastic);
+            return base.OnMouseUp(e);
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            login?.Show();
+            return base.OnClick(e);
+        }
+
+    }
+}

--- a/osu.Game/Online/Placeholders/LoginPlaceholder.cs
+++ b/osu.Game/Online/Placeholders/LoginPlaceholder.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Online.Placeholders
                 cp.Padding = new MarginPadding { Right = 10 };
             });
 
-            AddText(@"Please sign in to " + action);
+            AddText(action);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game/Online/Placeholders/LoginPlaceholder.cs
+++ b/osu.Game/Online/Placeholders/LoginPlaceholder.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Online.Placeholders
 {
     public sealed class LoginPlaceholder : Placeholder
     {
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private LoginOverlay login { get; set; }
 
         public LoginPlaceholder(string action)

--- a/osu.Game/Online/Placeholders/MessagePlaceholder.cs
+++ b/osu.Game/Online/Placeholders/MessagePlaceholder.cs
@@ -4,7 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 
-namespace osu.Game.Online.Leaderboards
+namespace osu.Game.Online.Placeholders
 {
     public class MessagePlaceholder : Placeholder
     {

--- a/osu.Game/Online/Placeholders/Placeholder.cs
+++ b/osu.Game/Online/Placeholders/Placeholder.cs
@@ -5,7 +5,7 @@ using System;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
 
-namespace osu.Game.Online.Leaderboards
+namespace osu.Game.Online.Placeholders
 {
     public abstract class Placeholder : OsuTextFlowContainer, IEquatable<Placeholder>
     {


### PR DESCRIPTION
# Summary
- This PR moves the Placeholder class and the MessagePlaceholder classes to a dedicated namespace (as placeholders aren't specific to leaderboards anymore) and also implements a placeholder asking for login which opens login overlay on click.
- This component is planned to be reused for upcoming PRs to refine user experience for indicating that login is required to access certain online-only views (#7417)

![image](https://user-images.githubusercontent.com/20256717/71770990-740c7600-2f34-11ea-9fb0-43b5137e5954.png)
