### PR TITLE
Add the skin setting "Color the sliderballs according to the color of the sliders"

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Scoring;
@@ -39,6 +40,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly IBindable<int> stackHeightBindable = new Bindable<int>();
         private readonly IBindable<float> scaleBindable = new Bindable<float>();
 
+        private readonly IBindable<bool> colorSliderBallBindable = new Bindable<bool>();
+
         public DrawableSlider(Slider s)
             : base(s)
         {
@@ -65,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuConfigManager config)
         {
             positionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
             stackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
@@ -80,6 +83,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 foreach (var drawableHitObject in NestedHitObjects)
                     drawableHitObject.AccentColour.Value = colour.NewValue;
             }, true);
+
+            colorSliderBallBindable.BindTo(config.GetBindable<bool>(OsuSetting.ColourSliderBalls));
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
@@ -184,7 +189,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.ApplySkin(skin, allowFallback);
 
-            bool allowBallTint = skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.AllowSliderBallTint)?.Value ?? false;
+            bool allowBallTint = (skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.AllowSliderBallTint)?.Value ?? false) && colorSliderBallBindable.Value;
             Ball.Colour = allowBallTint ? AccentColour.Value : Color4.White;
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly IBindable<int> stackHeightBindable = new Bindable<int>();
         private readonly IBindable<float> scaleBindable = new Bindable<float>();
 
-        private readonly IBindable<bool> colorSliderBallBindable = new Bindable<bool>();
+        private readonly Bindable<bool> colorSliderBallBindable = new Bindable<bool>();
 
         public DrawableSlider(Slider s)
             : base(s)
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, ISkinSource skin)
         {
             positionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
             stackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
@@ -84,7 +84,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     drawableHitObject.AccentColour.Value = colour.NewValue;
             }, true);
 
-            colorSliderBallBindable.BindTo(config.GetBindable<bool>(OsuSetting.ColourSliderBalls));
+            config.BindWith(OsuSetting.ColourSliderBalls, colorSliderBallBindable);
+
+            colorSliderBallBindable.BindValueChanged(value =>
+            {
+                bool allowBallTint = (skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.AllowSliderBallTint)?.Value ?? false) && value.NewValue;
+                Ball.Colour = allowBallTint ? AccentColour.Value : Color4.White;
+            });
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
@@ -119,6 +125,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             tailContainer.Clear();
             repeatContainer.Clear();
             tickContainer.Clear();
+
+            colorSliderBallBindable.UnbindEvents();
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -120,6 +120,8 @@ namespace osu.Game.Configuration
             Set(OsuSetting.IntroSequence, IntroSequence.Triangles);
 
             Set(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin);
+
+            Set(OsuSetting.ColourSliderBalls, true);
         }
 
         public OsuConfigManager(Storage storage)
@@ -179,6 +181,7 @@ namespace osu.Game.Configuration
         SongSelectRightMouseScroll,
         BeatmapSkins,
         BeatmapHitsounds,
+        ColourSliderBalls,
         IncreaseFirstObjectVisibility,
         ScoreDisplayMode,
         ExternalLinkWarning,

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Overlays.Settings.Sections
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = "Color the sliderballs according to the color of the sliders",
+                    LabelText = "Use combo colour as tint for slider ball",
                     Bindable = config.GetBindable<bool>(OsuSetting.ColourSliderBalls)
                 },
             };

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -62,6 +62,11 @@ namespace osu.Game.Overlays.Settings.Sections
                     LabelText = "Beatmap hitsounds",
                     Bindable = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Color the sliderballs according to the color of the sliders",
+                    Bindable = config.GetBindable<bool>(OsuSetting.ColourSliderBalls)
+                },
             };
 
             skins.ItemAdded += itemAdded;


### PR DESCRIPTION
This is only a small visual modification, but which can be useful for some people. For example, in some beatmaps, the slider colors are very dark so the sliderball and the followcircle arn't easily viewable.