### PR TITLE
Adjust catch + mania hp increase values

### DIFF
--- a/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
                     return 0;
 
                 case HitResult.Perfect:
-                    return 0.008;
+                    return 0.01;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
@@ -18,17 +18,5 @@ namespace osu.Game.Rulesets.Catch.Judgements
                     return 30;
             }
         }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return base.HealthIncreaseFor(result);
-
-                case HitResult.Perfect:
-                    return 0.007;
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
@@ -23,18 +23,6 @@ namespace osu.Game.Rulesets.Catch.Judgements
             }
         }
 
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return -0.02;
-
-                case HitResult.Perfect:
-                    return 0.01;
-            }
-        }
-
         /// <summary>
         /// Whether fruit on the platter should explode or drop.
         /// Note that this is only checked if the owning object is also <see cref="IHasComboInformation.LastInCombo" />

--- a/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
                     return 0;
 
                 case HitResult.Perfect:
-                    return 0.004;
+                    return 0.02;
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
@@ -15,11 +15,11 @@ namespace osu.Game.Rulesets.Mania.Judgements
         {
             switch (result)
             {
-                case HitResult.Miss:
+                default:
                     return 0;
 
-                default:
-                    return 0.040;
+                case HitResult.Perfect:
+                    return 0.01;
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -29,32 +29,5 @@ namespace osu.Game.Rulesets.Mania.Judgements
                     return 300;
             }
         }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.Miss:
-                    return -0.125;
-
-                case HitResult.Meh:
-                    return 0.005;
-
-                case HitResult.Ok:
-                    return 0.010;
-
-                case HitResult.Good:
-                    return 0.035;
-
-                case HitResult.Great:
-                    return 0.055;
-
-                case HitResult.Perfect:
-                    return 0.065;
-
-                default:
-                    return 0;
-            }
-        }
     }
 }


### PR DESCRIPTION
Catch felt bad since hits were providing < 1% health back per caught fruit (or in that range).
Mania is already kind-of close, maybe half the HP gained/lost after these changes (meaning drain is slightly sharper).

Just simplifying things for now. Taiko is still on the horizon but since it uses a completely different health mode I've kept the previous behaviour.