### PR TITLE
Show replay mods instead of current selection during replay load

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -147,6 +147,18 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestModDisplayChanges()
+        {
+            var testMod = new TestMod();
+
+            AddStep("load player", () => ResetPlayer(true));
+
+            AddUntilStep("wait for loader to become current", () => loader.IsCurrentScreen());
+            AddStep("set test mod in loader", () => loader.Mods.Value = new[] { testMod });
+            AddAssert("test mod is displayed", () => (TestMod)loader.DisplayedMods.Single() == testMod);
+        }
+
+        [Test]
         public void TestMutedNotificationMasterVolume() => addVolumeSteps("master volume", () => audioManager.Volume.Value = 0, null, () => audioManager.Volume.IsDefault);
 
         [Test]
@@ -220,6 +232,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             public new VisualSettings VisualSettings => base.VisualSettings;
 
             public new Task DisposalTask => base.DisposalTask;
+
+            public IReadOnlyList<Mod> DisplayedMods => MetadataInfo.Mods;
 
             public TestPlayerLoader(Func<Player> createPlayer)
                 : base(createPlayer)

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -233,7 +233,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             public new Task DisposalTask => base.DisposalTask;
 
-            public IReadOnlyList<Mod> DisplayedMods => MetadataInfo.Mods;
+            public IReadOnlyList<Mod> DisplayedMods => MetadataInfo.Mods.Value;
 
             public TestPlayerLoader(Func<Player> createPlayer)
                 : base(createPlayer)

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.Play
                 RelativeSizeAxes = Axes.Both,
             }).WithChildren(new Drawable[]
             {
-                MetadataInfo = new BeatmapMetadataDisplay(Beatmap.Value, Mods.Value, content.LogoFacade)
+                MetadataInfo = new BeatmapMetadataDisplay(Beatmap.Value, Mods, content.LogoFacade)
                 {
                     Alpha = 0,
                     Anchor = Anchor.Centre,
@@ -379,11 +379,12 @@ namespace osu.Game.Screens.Play
             }
 
             private readonly WorkingBeatmap beatmap;
+            private readonly Bindable<IReadOnlyList<Mod>> mods;
             private readonly Drawable facade;
             private LoadingAnimation loading;
             private Sprite backgroundSprite;
 
-            public IReadOnlyList<Mod> Mods { get; }
+            public IBindable<IReadOnlyList<Mod>> Mods => mods;
 
             public bool Loading
             {
@@ -402,12 +403,13 @@ namespace osu.Game.Screens.Play
                 }
             }
 
-            public BeatmapMetadataDisplay(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods, Drawable facade)
+            public BeatmapMetadataDisplay(WorkingBeatmap beatmap, Bindable<IReadOnlyList<Mod>> mods, Drawable facade)
             {
                 this.beatmap = beatmap;
                 this.facade = facade;
 
-                Mods = mods;
+                this.mods = new Bindable<IReadOnlyList<Mod>>();
+                this.mods.BindTo(mods);
             }
 
             [BackgroundDependencyLoader]
@@ -494,7 +496,7 @@ namespace osu.Game.Screens.Play
                                 Origin = Anchor.TopCentre,
                                 AutoSizeAxes = Axes.Both,
                                 Margin = new MarginPadding { Top = 20 },
-                                Current = { Value = Mods }
+                                Current = mods
                             }
                         },
                     }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Play
 
         private LogoTrackingContainer content;
 
-        private BeatmapMetadataDisplay info;
+        protected BeatmapMetadataDisplay MetadataInfo;
 
         private bool hideOverlays;
         public override bool HideOverlaysOnEnter => hideOverlays;
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.Play
                 RelativeSizeAxes = Axes.Both,
             }).WithChildren(new Drawable[]
             {
-                info = new BeatmapMetadataDisplay(Beatmap.Value, Mods.Value, content.LogoFacade)
+                MetadataInfo = new BeatmapMetadataDisplay(Beatmap.Value, Mods.Value, content.LogoFacade)
                 {
                     Alpha = 0,
                     Anchor = Anchor.Centre,
@@ -138,7 +138,7 @@ namespace osu.Game.Screens.Play
 
             contentIn();
 
-            info.Delay(750).FadeIn(500);
+            MetadataInfo.Delay(750).FadeIn(500);
             this.Delay(1800).Schedule(pushWhenLoaded);
 
             if (!muteWarningShownOnce.Value)
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.Play
 
             contentIn();
 
-            info.Loading = true;
+            MetadataInfo.Loading = true;
 
             //we will only be resumed if the player has requested a re-run (see ValidForResume setting above)
             loadNewPlayer();
@@ -174,7 +174,7 @@ namespace osu.Game.Screens.Play
             player.RestartCount = restartCount;
             player.RestartRequested = restartRequested;
 
-            LoadTask = LoadComponentAsync(player, _ => info.Loading = false);
+            LoadTask = LoadComponentAsync(player, _ => MetadataInfo.Loading = false);
         }
 
         private void contentIn()
@@ -350,7 +350,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private class BeatmapMetadataDisplay : Container
+        protected class BeatmapMetadataDisplay : Container
         {
             private class MetadataLine : Container
             {
@@ -379,10 +379,11 @@ namespace osu.Game.Screens.Play
             }
 
             private readonly WorkingBeatmap beatmap;
-            private readonly IReadOnlyList<Mod> mods;
             private readonly Drawable facade;
             private LoadingAnimation loading;
             private Sprite backgroundSprite;
+
+            public IReadOnlyList<Mod> Mods { get; }
 
             public bool Loading
             {
@@ -404,8 +405,9 @@ namespace osu.Game.Screens.Play
             public BeatmapMetadataDisplay(WorkingBeatmap beatmap, IReadOnlyList<Mod> mods, Drawable facade)
             {
                 this.beatmap = beatmap;
-                this.mods = mods;
                 this.facade = facade;
+
+                Mods = mods;
             }
 
             [BackgroundDependencyLoader]
@@ -492,7 +494,7 @@ namespace osu.Game.Screens.Play
                                 Origin = Anchor.TopCentre,
                                 AutoSizeAxes = Axes.Both,
                                 Margin = new MarginPadding { Top = 20 },
-                                Current = { Value = mods }
+                                Current = { Value = Mods }
                             }
                         },
                     }


### PR DESCRIPTION
Resolves #7478.

# Summary

As reported in the issue, mods selected in song select would show up during loading of replays which were recorded under a different set of mods. This was caused by `BeatmapMetadataDisplay` accepting a plain read-only value of the `Mods` bindable in `PlayerLoader.load()`, therefore making the mod value assignment in `ReplayPlayerLoader.OnEntering()` have no effect on that component.

To resolve this issue, make `BeatmapMetadataDisplay` accept the higher-level bindable, bind to it locally and pass it down the hierarchy to `ModDisplay`.

# Remarks

The set to `ModDisplay.Current` is properly implemented (uses a local bindable, unbinds previous bindings and binds to the value passed in setter).

Unfortunately had to expose a good bit for the test case, but I don't think any of it smells *too* bad.