### PR TITLE
Fix user status dropdown having no padding around items

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -323,8 +323,6 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         Colour = Color4.Black.Opacity(0.25f),
                         Radius = 4,
                     };
-
-                    ItemsContainer.Padding = new MarginPadding();
                 }
 
                 [BackgroundDependencyLoader]


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/7489.

![](https://puu.sh/EYAtu/b37210d4da.png)
