### PR TITLE
Fix crashing when changing user status before rich presence is initialised

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -75,6 +75,9 @@ namespace osu.Desktop
 
         private void updateStatus()
         {
+            if (!client.IsInitialized)
+                return;
+
             if (status.Value is UserStatusOffline)
             {
                 client.ClearPresence();


### PR DESCRIPTION
Encountered this while working on direct offline handling, 
Changing the user online status when the rich presence client is not initialized / has been deinitialized would cause it to throw.
![image](https://user-images.githubusercontent.com/20256717/72206431-1aed9680-348e-11ea-930f-4d6616688502.png)

This adds a guard check to ensure the client is initialized before updating rich presence