### PR TITLE
Add global action for toggling now playing overlay

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Input.Bindings
 
         public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {
+            new KeyBinding(InputKey.F6, GlobalAction.ToggleNowPlaying),
             new KeyBinding(InputKey.F8, GlobalAction.ToggleChat),
             new KeyBinding(InputKey.F9, GlobalAction.ToggleSocial),
             new KeyBinding(InputKey.F10, GlobalAction.ToggleGameplayMouseButtons),
@@ -137,5 +138,8 @@ namespace osu.Game.Input.Bindings
 
         [Description("Play / pause")]
         MusicPlay,
+
+        [Description("Toggle now playing overlay")]
+        ToggleNowPlaying,
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -61,6 +61,8 @@ namespace osu.Game
 
         private NotificationOverlay notifications;
 
+        private NowPlayingOverlay nowPlaying;
+
         private DirectOverlay direct;
 
         private SocialOverlay social;
@@ -624,7 +626,7 @@ namespace osu.Game
                 Origin = Anchor.TopRight,
             }, rightFloatingOverlayContent.Add, true);
 
-            loadComponentSingleFile(new NowPlayingOverlay
+            loadComponentSingleFile(nowPlaying = new NowPlayingOverlay
             {
                 GetToolbarHeight = () => ToolbarOffset,
                 Anchor = Anchor.TopRight,
@@ -822,6 +824,10 @@ namespace osu.Game
 
             switch (action)
             {
+                case GlobalAction.ToggleNowPlaying:
+                    nowPlaying.ToggleVisibility();
+                    return true;
+
                 case GlobalAction.ToggleChat:
                     chatOverlay.ToggleVisibility();
                     return true;


### PR DESCRIPTION
Added the new global action to the bottom of enum to avoid migrations. If organizing is needed, I'll try to do it. If not, the comments in the enum can be removed.