### PR TITLE
Prevent SliderHead from moving along the slider

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -32,17 +32,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             pathVersion.BindValueChanged(_ => updatePosition(), true);
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            double completionProgress = Math.Clamp((Time.Current - slider.StartTime) / slider.Duration, 0, 1);
-
-            //todo: we probably want to reconsider this before adding scoring, but it looks and feels nice.
-            if (!IsHit)
-                Position = slider.CurvePositionAt(completionProgress);
-        }
-
         public Action<double> OnShake;
 
         protected override void Shake(double maximumLength) => OnShake?.Invoke(maximumLength);


### PR DESCRIPTION
Partially fixes #7521.

Brings `SliderHead` behavior into line with stable (see [this video](https://www.youtube.com/watch?v=eqhPDrPV5Ac)).

No other changes seem to be necessary, though it won't hurt to consider modifying the slider snaking-out behavior - currently it starts no matter if `SliderHead` is hit, which in some cases (low OD + high SV for example) might look weird ([like this](https://user-images.githubusercontent.com/27722894/72269741-5de17280-3624-11ea-8ff6-2de7d16fe1f6.jpg)).
