### PR TITLE
Remove duplicate returns in KeyCounterAction

### DIFF
--- a/osu.Game/Screens/Play/KeyCounterAction.cs
+++ b/osu.Game/Screens/Play/KeyCounterAction.cs
@@ -18,7 +18,8 @@ namespace osu.Game.Screens.Play
 
         public bool OnPressed(T action, bool forwards)
         {
-            if (EqualityComparer<T>.Default.Equals(action, Action)) {
+            if (EqualityComparer<T>.Default.Equals(action, Action))
+            {
                 IsLit = true;
                 if (forwards)
                     Increment();
@@ -29,7 +30,8 @@ namespace osu.Game.Screens.Play
 
         public bool OnReleased(T action, bool forwards)
         {
-            if (EqualityComparer<T>.Default.Equals(action, Action)) {
+            if (EqualityComparer<T>.Default.Equals(action, Action))
+            {
                 IsLit = false;
                 if (!forwards)
                     Decrement();

--- a/osu.Game/Screens/Play/KeyCounterAction.cs
+++ b/osu.Game/Screens/Play/KeyCounterAction.cs
@@ -18,23 +18,23 @@ namespace osu.Game.Screens.Play
 
         public bool OnPressed(T action, bool forwards)
         {
-            if (!EqualityComparer<T>.Default.Equals(action, Action))
-                return false;
+            if (EqualityComparer<T>.Default.Equals(action, Action)) {
+                IsLit = true;
+                if (forwards)
+                    Increment();
+            }
 
-            IsLit = true;
-            if (forwards)
-                Increment();
             return false;
         }
 
         public bool OnReleased(T action, bool forwards)
         {
-            if (!EqualityComparer<T>.Default.Equals(action, Action))
-                return false;
+            if (EqualityComparer<T>.Default.Equals(action, Action)) {
+                IsLit = false;
+                if (!forwards)
+                    Decrement();
+            }
 
-            IsLit = false;
-            if (!forwards)
-                Decrement();
             return false;
         }
     }


### PR DESCRIPTION
This should not affect semantics at all - just makes what `OnPressed/Released` do a bit clearer.