### PR TITLE
Allow changing volume in song select with arrow keys when pressing alt

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -412,6 +412,9 @@ namespace osu.Game.Screens.Select
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            if (e.AltPressed)
+                return base.OnKeyDown(e);
+
             int direction = 0;
             bool skipDifficulties = false;
 
@@ -436,7 +439,7 @@ namespace osu.Game.Screens.Select
                     break;
             }
 
-            if (direction == 0 || e.AltPressed)
+            if (direction == 0)
                 return base.OnKeyDown(e);
 
             SelectNext(direction, skipDifficulties);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -412,6 +412,8 @@ namespace osu.Game.Screens.Select
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            // allow for controlling volume when alt is held.
+            // mostly for compatibility with osu-stable.
             if (e.AltPressed)
                 return base.OnKeyDown(e);
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -413,7 +413,8 @@ namespace osu.Game.Screens.Select
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             // allow for controlling volume when alt is held.
-            // mostly for compatibility with osu-stable.
+            // this is required as the VolumeControlReceptor uses OnPressed, which is
+            // executed after all OnKeyDown events.
             if (e.AltPressed)
                 return base.OnKeyDown(e);
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -436,7 +436,7 @@ namespace osu.Game.Screens.Select
                     break;
             }
 
-            if (direction == 0)
+            if (direction == 0 || e.AltPressed)
                 return base.OnKeyDown(e);
 
             SelectNext(direction, skipDifficulties);


### PR DESCRIPTION
![](https://puu.sh/EZEqI/3129b61255.png)

Volume overlay still needs navigation with left and right arrows for more usability, tracked in https://github.com/ppy/osu/issues/7527.