### PR TITLE
Implement colour schemes for OverlayHeader

### DIFF
--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Graphics
 
         public Color4 ForOverlayElement(OverlayColourScheme colourScheme, float saturation, float lightness, float opacity = 1) => Color4.FromHsl(new Vector4(getBaseHue(colourScheme), saturation, lightness, opacity));
 
+        // See https://github.com/ppy/osu-web/blob/4218c288292d7c810b619075471eaea8bbb8f9d8/app/helpers.php#L1463
         private static float getBaseHue(OverlayColourScheme colourScheme)
         {
             float hue;

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Game.Beatmaps;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Graphics
@@ -61,6 +62,24 @@ namespace osu.Game.Graphics
                 case DifficultyRating.ExpertPlus:
                     return useLighterColour ? Gray9 : Gray0;
             }
+        }
+
+        public Color4 ForOverlayElement(OverlayColourScheme colourScheme, float saturation, float lightness, float opacity = 1) => Color4.FromHsl(new Vector4(getBaseHue(colourScheme), saturation, lightness, opacity));
+
+        private static float getBaseHue(OverlayColourScheme colourScheme)
+        {
+            var hue = colourScheme switch
+            {
+                OverlayColourScheme.Red => 0,
+                OverlayColourScheme.Pink => 333,
+                OverlayColourScheme.Orange => 46,
+                OverlayColourScheme.Green => 115,
+                OverlayColourScheme.Purple => 255,
+                OverlayColourScheme.Blue => 200,
+                _ => 0,
+            };
+
+            return hue / 360f;
         }
 
         // See https://github.com/ppy/osu-web/blob/master/resources/assets/less/colors.less
@@ -164,5 +183,15 @@ namespace osu.Game.Graphics
         public readonly Color4 ChatBlue = FromHex(@"17292e");
 
         public readonly Color4 ContextMenuGray = FromHex(@"223034");
+    }
+
+    public enum OverlayColourScheme
+    {
+        Red,
+        Pink,
+        Orange,
+        Green,
+        Purple,
+        Blue
     }
 }

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -68,16 +68,37 @@ namespace osu.Game.Graphics
 
         private static float getBaseHue(OverlayColourScheme colourScheme)
         {
-            var hue = colourScheme switch
+            float hue;
+
+            switch (colourScheme)
             {
-                OverlayColourScheme.Red => 0,
-                OverlayColourScheme.Pink => 333,
-                OverlayColourScheme.Orange => 46,
-                OverlayColourScheme.Green => 115,
-                OverlayColourScheme.Purple => 255,
-                OverlayColourScheme.Blue => 200,
-                _ => 0,
-            };
+                default:
+                    throw new ArgumentException(@"Used colourScheme has no hue value!");
+
+                case OverlayColourScheme.Red:
+                    hue = 0;
+                    break;
+
+                case OverlayColourScheme.Pink:
+                    hue = 333;
+                    break;
+
+                case OverlayColourScheme.Orange:
+                    hue = 46;
+                    break;
+
+                case OverlayColourScheme.Green:
+                    hue = 115;
+                    break;
+
+                case OverlayColourScheme.Purple:
+                    hue = 255;
+                    break;
+
+                case OverlayColourScheme.Blue:
+                    hue = 200;
+                    break;
+            }
 
             return hue / 360f;
         }

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Graphics
             switch (colourScheme)
             {
                 default:
-                    throw new ArgumentException(@"Used colourScheme has no hue value!");
+                    throw new ArgumentException($@"{colourScheme} colour scheme does not provide a hue value in {nameof(getBaseHue)}.");
 
                 case OverlayColourScheme.Red:
                     hue = 0;

--- a/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
+++ b/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays
@@ -12,6 +14,17 @@ namespace osu.Game.Overlays
         protected OverlayHeaderBreadcrumbControl BreadcrumbControl;
 
         protected override TabControl<string> CreateTabControl() => BreadcrumbControl = new OverlayHeaderBreadcrumbControl();
+
+        protected BreadcrumbControlOverlayHeader(OverlayColourScheme colourScheme)
+            : base(colourScheme)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            BreadcrumbControl.AccentColour = colours.ForOverlayElement(ColourScheme, 1, 0.75f);
+        }
 
         public class OverlayHeaderBreadcrumbControl : BreadcrumbControl<string>
         {

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Overlays.Changelog
         private const string listing_string = "listing";
 
         public ChangelogHeader()
+            : base(OverlayColourScheme.Purple)
         {
             BreadcrumbControl.AddItem(listing_string);
             BreadcrumbControl.Current.ValueChanged += e =>
@@ -41,14 +42,6 @@ namespace osu.Game.Overlays.Changelog
                 if (e.NewValue?.LatestBuild != null && e.NewValue != Current.Value?.UpdateStream)
                     Current.Value = e.NewValue.LatestBuild;
             };
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            BreadcrumbControl.AccentColour = colours.Violet;
-            TitleBackgroundColour = colours.GreyVioletDarker;
-            ControlBackgroundColour = colours.GreyVioletDark;
         }
 
         private ChangelogHeaderTitle title;
@@ -115,12 +108,6 @@ namespace osu.Game.Overlays.Changelog
             {
                 Title = "changelog";
                 Version = null;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
-            {
-                AccentColour = colours.Violet;
             }
 
             protected override Drawable CreateIcon() => new ScreenTitleTextureIcon(@"Icons/changelog");

--- a/osu.Game/Overlays/News/NewsHeader.cs
+++ b/osu.Game/Overlays/News/NewsHeader.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Overlays.News
         public Action ShowFrontPage;
 
         public NewsHeader()
+            : base(OverlayColourScheme.Purple)
         {
             BreadcrumbControl.AddItem(front_page_string);
 
@@ -33,14 +34,6 @@ namespace osu.Game.Overlays.News
             };
 
             Current.ValueChanged += showPost;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            BreadcrumbControl.AccentColour = colours.Violet;
-            TitleBackgroundColour = colours.GreyVioletDarker;
-            ControlBackgroundColour = colours.GreyVioletDark;
         }
 
         private void showPost(ValueChangedEvent<string> e)
@@ -97,12 +90,6 @@ namespace osu.Game.Overlays.News
             }
 
             protected override Drawable CreateIcon() => new ScreenTitleTextureIcon(@"Icons/news");
-
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
-            {
-                AccentColour = colours.Violet;
-            }
         }
     }
 }

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osuTK.Graphics;
 
@@ -16,24 +18,19 @@ namespace osu.Game.Overlays
         private readonly Box titleBackground;
         private readonly Box controlBackground;
         private readonly Container background;
-
-        protected Color4 TitleBackgroundColour
-        {
-            set => titleBackground.Colour = value;
-        }
-
-        protected Color4 ControlBackgroundColour
-        {
-            set => controlBackground.Colour = value;
-        }
+        private readonly ScreenTitle title;
 
         protected float BackgroundHeight
         {
             set => background.Height = value;
         }
 
-        protected OverlayHeader()
+        protected OverlayColourScheme ColourScheme { get; private set; }
+
+        protected OverlayHeader(OverlayColourScheme colourScheme)
         {
+            ColourScheme = colourScheme;
+
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
@@ -60,9 +57,8 @@ namespace osu.Game.Overlays
                             titleBackground = new Box
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Colour = Color4.Gray,
                             },
-                            CreateTitle().With(title =>
+                            title = CreateTitle().With(title =>
                             {
                                 title.Margin = new MarginPadding
                                 {
@@ -90,6 +86,14 @@ namespace osu.Game.Overlays
                     CreateContent()
                 }
             });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            titleBackground.Colour = colours.ForOverlayElement(ColourScheme, 0.2f, 0.15f);
+            title.AccentColour = colours.ForOverlayElement(ColourScheme, 1, 0.7f);
+            controlBackground.Colour = colours.ForOverlayElement(ColourScheme, 0.2f, 0.2f);
         }
 
         protected abstract Drawable CreateBackground();

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays
             set => background.Height = value;
         }
 
-        protected OverlayColourScheme ColourScheme { get; private set; }
+        protected OverlayColourScheme ColourScheme { get; }
 
         protected OverlayHeader(OverlayColourScheme colourScheme)
         {

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -25,6 +24,7 @@ namespace osu.Game.Overlays.Profile
         private DetailHeaderContainer detailHeaderContainer;
 
         public ProfileHeader()
+            : base(OverlayColourScheme.Green)
         {
             BackgroundHeight = 150;
 
@@ -34,14 +34,6 @@ namespace osu.Game.Overlays.Profile
             TabControl.AddItem("modding");
 
             centreHeaderContainer.DetailsVisible.BindValueChanged(visible => detailHeaderContainer.Expanded = visible.NewValue, true);
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            TabControl.AccentColour = colours.Seafoam;
-            TitleBackgroundColour = colours.GreySeafoamDarker;
-            ControlBackgroundColour = colours.GreySeafoam;
         }
 
         protected override Drawable CreateBackground() =>
@@ -107,12 +99,6 @@ namespace osu.Game.Overlays.Profile
             {
                 Title = "player";
                 Section = "info";
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
-            {
-                AccentColour = colours.Seafoam;
             }
 
             protected override Drawable CreateIcon() => new ScreenTitleTextureIcon(@"Icons/profile");

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -14,6 +15,17 @@ namespace osu.Game.Overlays
         protected OverlayHeaderTabControl TabControl;
 
         protected override TabControl<string> CreateTabControl() => TabControl = new OverlayHeaderTabControl();
+
+        protected TabControlOverlayHeader(OverlayColourScheme colourScheme)
+            : base(colourScheme)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            TabControl.AccentColour = colours.ForOverlayElement(ColourScheme, 1, 0.75f);
+        }
 
         public class OverlayHeaderTabControl : OverlayTabControl<string>
         {


### PR DESCRIPTION
In the future will be applied to the whole overlay

Before:
![before](https://user-images.githubusercontent.com/22874522/72466791-a8145080-37ea-11ea-8e07-141fe76232d8.png)

After:
![after](https://user-images.githubusercontent.com/22874522/72466803-acd90480-37ea-11ea-9151-5a480ccaae30.png)

Web:
![web](https://user-images.githubusercontent.com/22874522/72466815-b19db880-37ea-11ea-967a-88dbbfb6da1d.png)