### PR TITLE
Fix channel tab control test scene

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChannelTabControl.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChannelTabControl.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -25,7 +26,7 @@ namespace osu.Game.Tests.Visual.Online
             typeof(ChannelTabControl),
         };
 
-        private readonly ChannelTabControl channelTabControl;
+        private readonly TestTabControl channelTabControl;
 
         public TestSceneChannelTabControl()
         {
@@ -37,7 +38,7 @@ namespace osu.Game.Tests.Visual.Online
                 Anchor = Anchor.Centre,
                 Children = new Drawable[]
                 {
-                    channelTabControl = new ChannelTabControl
+                    channelTabControl = new TestTabControl
                     {
                         RelativeSizeAxes = Axes.X,
                         Origin = Anchor.Centre,
@@ -73,32 +74,40 @@ namespace osu.Game.Tests.Visual.Online
             channelTabControl.Current.ValueChanged += channel => currentText.Text = "Currently selected channel: " + channel.NewValue;
 
             AddStep("Add random private channel", addRandomPrivateChannel);
-            AddAssert("There is only one channels", () => channelTabControl.Items.Count() == 2);
+            AddAssert("There is only one channels", () => channelTabControl.Items.Count == 2);
             AddRepeatStep("Add 3 random private channels", addRandomPrivateChannel, 3);
-            AddAssert("There are four channels", () => channelTabControl.Items.Count() == 5);
+            AddAssert("There are four channels", () => channelTabControl.Items.Count == 5);
             AddStep("Add random public channel", () => addChannel(RNG.Next().ToString()));
 
-            AddRepeatStep("Select a random channel", () => channelTabControl.Current.Value = channelTabControl.Items.ElementAt(RNG.Next(channelTabControl.Items.Count() - 1)), 20);
+            AddRepeatStep("Select a random channel", () =>
+            {
+                List<Channel> validChannels = channelTabControl.Items.Where(c => !(c is ChannelSelectorTabItem.ChannelSelectorTabChannel)).ToList();
+                channelTabControl.SelectChannel(validChannels[RNG.Next(0, validChannels.Count)]);
+            }, 20);
 
-            Channel channelBefore = channelTabControl.Items.First();
-            AddStep("set first channel", () => channelTabControl.Current.Value = channelBefore);
+            Channel channelBefore = null;
+            AddStep("set first channel", () => channelTabControl.SelectChannel(channelBefore = channelTabControl.Items.First(c => !(c is ChannelSelectorTabItem.ChannelSelectorTabChannel))));
 
-            AddStep("select selector tab", () => channelTabControl.Current.Value = channelTabControl.Items.Last());
+            AddStep("select selector tab", () => channelTabControl.SelectChannel(channelTabControl.Items.Single(c => c is ChannelSelectorTabItem.ChannelSelectorTabChannel)));
             AddAssert("selector tab is active", () => channelTabControl.ChannelSelectorActive.Value);
 
             AddAssert("check channel unchanged", () => channelBefore == channelTabControl.Current.Value);
 
-            AddStep("set second channel", () => channelTabControl.Current.Value = channelTabControl.Items.Skip(1).First());
+            AddStep("set second channel", () => channelTabControl.SelectChannel(channelTabControl.Items.GetNext(channelBefore)));
             AddAssert("selector tab is inactive", () => !channelTabControl.ChannelSelectorActive.Value);
 
             AddUntilStep("remove all channels", () =>
             {
-                var first = channelTabControl.Items.First();
-                if (first is ChannelSelectorTabItem.ChannelSelectorTabChannel)
-                    return true;
+                foreach (var item in channelTabControl.Items.ToList())
+                {
+                    if (item is ChannelSelectorTabItem.ChannelSelectorTabChannel)
+                        continue;
 
-                channelTabControl.RemoveChannel(first);
-                return false;
+                    channelTabControl.RemoveChannel(item);
+                    return false;
+                }
+
+                return true;
             });
 
             AddAssert("selector tab is active", () => channelTabControl.ChannelSelectorActive.Value);
@@ -117,5 +126,10 @@ namespace osu.Game.Tests.Visual.Online
                 Type = ChannelType.Public,
                 Name = name
             });
+
+        private class TestTabControl : ChannelTabControl
+        {
+            public void SelectChannel(Channel channel) => base.SelectTab(TabMap[channel]);
+        }
     }
 }

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -81,7 +81,10 @@ namespace osu.Game.Overlays.Chat.Tabs
             RemoveItem(channel);
 
             if (Current.Value == channel)
-                Current.Value = Items.FirstOrDefault();
+            {
+                // Prefer non-selector channels first
+                Current.Value = Items.FirstOrDefault(c => !(c is ChannelSelectorTabItem.ChannelSelectorTabChannel)) ?? Items.FirstOrDefault();
+            }
         }
 
         protected override void SelectTab(TabItem<Channel> tab)


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/3183

Exacerbated by the framework PR, which shows two issues:

1. Setting the bindable value to the selector directly causes a deselect of a channel (whereas clicking does not, as intended).
2. The test scene tests the above scenario incorrectly.

This can be replicated (on master) by fixing the test scene:

```diff
- Channel channelBefore = channelTabControl.Items.First();
- AddStep("set first channel", () => channelTabControl.Current.Value = channelBefore);
+ Channel channelBefore = null;
+ AddStep("set first channel", () => channelTabControl.Current.Value = channelBefore = channelTabControl.Items.First());
```

I haven't fixed fixed (1) - I've coded around it by invoking `SelectTab()` instead of changing the bindable value.
I have fixed (2) in a way similar to the above code.