### PR TITLE
Fix order and naming of Difficulty Adjust mod settings

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             Value = 5,
         };
 
-        [SettingSource("Drain Rate", "Override a beatmap's set HP.")]
+        [SettingSource("HP Drain", "Override a beatmap's set HP.")]
         new public BindableNumber<float> DrainRate { get; } = new BindableFloat
         {
             Precision = 0.1f,
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             Value = 5,
         };
 
-        [SettingSource("Overall Difficulty", "Override a beatmap's set OD.")]
+        [SettingSource("Accuracy", "Override a beatmap's set Accuracy.")]
         new public BindableNumber<float> OverallDifficulty { get; } = new BindableFloat
         {
             Precision = 0.1f,

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -20,6 +20,26 @@ namespace osu.Game.Rulesets.Osu.Mods
             Value = 5,
         };
 
+        [SettingSource("Drain Rate", "Override a beatmap's set HP.")]
+        new public BindableNumber<float> DrainRate { get; } = new BindableFloat
+        {
+            Precision = 0.1f,
+            MinValue = 1,
+            MaxValue = 10,
+            Default = 5,
+            Value = 5,
+        };
+
+        [SettingSource("Overall Difficulty", "Override a beatmap's set OD.")]
+        new public BindableNumber<float> OverallDifficulty { get; } = new BindableFloat
+        {
+            Precision = 0.1f,
+            MinValue = 1,
+            MaxValue = 10,
+            Default = 5,
+            Value = 5,
+        };
+
         [SettingSource("Approach Rate", "Override a beatmap's set AR.")]
         public BindableNumber<float> ApproachRate { get; } = new BindableFloat
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -52,17 +52,21 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected override void TransferSettings(BeatmapDifficulty difficulty)
         {
-            base.TransferSettings(difficulty);
+            // base.TransferSettings(difficulty);
 
             TransferSetting(CircleSize, difficulty.CircleSize);
+            TransferSetting(DrainRate, difficulty.DrainRate);
+            TransferSetting(OverallDifficulty, difficulty.OverallDifficulty);
             TransferSetting(ApproachRate, difficulty.ApproachRate);
         }
 
         protected override void ApplySettings(BeatmapDifficulty difficulty)
         {
-            base.ApplySettings(difficulty);
+            // base.ApplySettings(difficulty);
 
             difficulty.CircleSize = CircleSize.Value;
+            difficulty.DrainRate = DrainRate.Value;
+            difficulty.OverallDifficulty = OverallDifficulty.Value;
             difficulty.ApproachRate = ApproachRate.Value;
         }
     }

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModHardRock) };
 
-        [SettingSource("Drain Rate", "Override a beatmap's set HP.")]
+        [SettingSource("HP Drain", "Override a beatmap's set HP.")]
         public BindableNumber<float> DrainRate { get; } = new BindableFloat
         {
             Precision = 0.1f,
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Mods
             Value = 5,
         };
 
-        [SettingSource("Overall Difficulty", "Override a beatmap's set OD.")]
+        [SettingSource("Accuracy", "Override a beatmap's set Accuracy.")]
         public BindableNumber<float> OverallDifficulty { get; } = new BindableFloat
         {
             Precision = 0.1f,


### PR DESCRIPTION
Fixes issue #7387 by changing visible names of settings and by changing order of settings to [Circle Size, HP Drain, Accuracy, Approach Rate].

I used the solution of the user ICantDrive, because it seems good enough for now.