### PR TITLE
Allow parsing hex colour codes with alpha

### DIFF
--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -36,6 +36,20 @@ namespace osu.Game.Graphics
                         Convert.ToByte(hex.Substring(2, 2), 16),
                         Convert.ToByte(hex.Substring(4, 2), 16),
                         255);
+
+                case 4:
+                    return new Color4(
+                        (byte)(Convert.ToByte(hex.Substring(0, 1), 16) * 17),
+                        (byte)(Convert.ToByte(hex.Substring(1, 1), 16) * 17),
+                        (byte)(Convert.ToByte(hex.Substring(2, 1), 16) * 17),
+                        (byte)(Convert.ToByte(hex.Substring(3, 1), 16) * 17));
+
+                case 8:
+                    return new Color4(
+                        Convert.ToByte(hex.Substring(0, 2), 16),
+                        Convert.ToByte(hex.Substring(2, 2), 16),
+                        Convert.ToByte(hex.Substring(4, 2), 16),
+                        Convert.ToByte(hex.Substring(6, 2), 16));
             }
         }
 


### PR DESCRIPTION
added the capability to use rrggbbaa and rgba hex codes with `OsuColour`.
i tried to make it work the same as css hex codes.
[ccs notation](https://drafts.csswg.org/css-color/#hex-notation)
i made a quick example of a 8 diget hex code with the osu logo
![image](https://user-images.githubusercontent.com/30951475/72840463-8c9ac100-3c94-11ea-99ed-42f127c5fec9.png) ![image](https://user-images.githubusercontent.com/30951475/72840513-b18f3400-3c94-11ea-8fc8-f077145291ea.png)
i dont know if it will extually be usefull lateron.

edit: now committed from separate branch