### PR TITLE
Remove build target from Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -111,7 +111,6 @@ platform :ios do
 
     souyuz(
       platform: "ios",
-      build_target: "osu_iOS",
       plist_path: "../osu.iOS/Info.plist"
     )
   end


### PR DESCRIPTION
No longer required (fails to build if present).