### PR TITLE
Move reverse-order comparer to ChannelTabControl

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -10,7 +10,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -83,14 +82,6 @@ namespace osu.Game.Graphics.UserInterface
             get => strip.Colour;
             set => strip.Colour = value;
         }
-
-        protected override TabFillFlowContainer CreateTabFlow() => new OsuTabFillFlowContainer
-        {
-            Direction = FillDirection.Full,
-            RelativeSizeAxes = Axes.Both,
-            Depth = -1,
-            Masking = true
-        };
 
         protected override void UpdateAfterChildren()
         {
@@ -282,11 +273,6 @@ namespace osu.Game.Graphics.UserInterface
                     base.OnHoverLost(e);
                 }
             }
-        }
-
-        private class OsuTabFillFlowContainer : TabFillFlowContainer
-        {
-            protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
         }
     }
 }

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabControl.cs
@@ -9,6 +9,7 @@ using osuTK;
 using System;
 using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
 
 namespace osu.Game.Overlays.Chat.Tabs
 {
@@ -112,6 +113,19 @@ namespace osu.Game.Overlays.Chat.Tabs
                 SelectTab(selectorTab);
 
             OnRequestLeave?.Invoke(tab.Value);
+        }
+
+        protected override TabFillFlowContainer CreateTabFlow() => new ChannelTabFillFlowContainer
+        {
+            Direction = FillDirection.Full,
+            RelativeSizeAxes = Axes.Both,
+            Depth = -1,
+            Masking = true
+        };
+
+        private class ChannelTabFillFlowContainer : TabFillFlowContainer
+        {
+            protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
         }
     }
 }


### PR DESCRIPTION
Small code quality change. As mentioned [here](https://github.com/ppy/osu/pull/7466#issuecomment-574067746), there's no need to have this in  `OsuTabControl`, since it's only needed for a specific case that is the `ChannelTabControl` and its tab shadows.