### PR TITLE
Make daycore and nightcore rate slider also adjust pitch

### DIFF
--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mods
         {
             SpeedChange.BindValueChanged(val =>
             {
-                freqAdjust.Value = SpeedChange.Default;
+                freqAdjust.Value = val.NewValue;
                 tempoAdjust.Value = val.NewValue / SpeedChange.Default;
             }, true);
         }

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Mods
         {
             SpeedChange.BindValueChanged(val =>
             {
-                freqAdjust.Value = SpeedChange.Default;
+                freqAdjust.Value = val.NewValue;
                 tempoAdjust.Value = val.NewValue / SpeedChange.Default;
             }, true);
         }


### PR DESCRIPTION
Naive implementation currently; Should behave as e.g. one octave higher than base pitch when tempo is doubled.