### PR TITLE
Remap osu!mania dual stage key bindings to be more ergonomic

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -237,19 +237,19 @@ namespace osu.Game.Rulesets.Mania
                     {
                         LeftKeys = new[]
                         {
-                            InputKey.Number1,
-                            InputKey.Number2,
-                            InputKey.Number3,
-                            InputKey.Number4,
+                            InputKey.Q,
+                            InputKey.W,
+                            InputKey.E,
+                            InputKey.R,
                         },
                         RightKeys = new[]
                         {
-                            InputKey.Z,
                             InputKey.X,
                             InputKey.C,
-                            InputKey.V
+                            InputKey.V,
+                            InputKey.B
                         },
-                        SpecialKey = InputKey.Tilde,
+                        SpecialKey = InputKey.S,
                         SpecialAction = ManiaAction.Special1,
                         NormalActionStart = ManiaAction.Key1
                     }.GenerateKeyBindingsFor(keys, out var nextNormal);
@@ -265,12 +265,12 @@ namespace osu.Game.Rulesets.Mania
                         },
                         RightKeys = new[]
                         {
-                            InputKey.O,
-                            InputKey.P,
-                            InputKey.BracketLeft,
-                            InputKey.BracketRight
+                            InputKey.K,
+                            InputKey.L,
+                            InputKey.Semicolon,
+                            InputKey.Quote
                         },
-                        SpecialKey = InputKey.BackSlash,
+                        SpecialKey = InputKey.I,
                         SpecialAction = ManiaAction.Special2,
                         NormalActionStart = nextNormal
                     }.GenerateKeyBindingsFor(keys, out _);


### PR DESCRIPTION
Closes #7575.

Previous:

![image](https://user-images.githubusercontent.com/191335/73133359-db68a200-406a-11ea-8822-ef9aecf1ee2c.png)

Now:

![image](https://user-images.githubusercontent.com/191335/73133332-8af14480-406a-11ea-9684-fd82c341f4d5.png)

Allows for a comfortable and consistent layout for both players, with left thumb on special key,