### PR TITLE
Fix carousel potentially missing import events

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -1,0 +1,110 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Menu;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    public class TestScenePresentBeatmap : OsuGameTestScene
+    {
+        [Test]
+        public void TestFromMainMenu()
+        {
+            var firstImport = importBeatmap(1);
+            presentAndConfirm(firstImport);
+
+            AddStep("return to menu", () => Game.ScreenStack.CurrentScreen.Exit());
+            AddUntilStep("wait for menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
+
+            var secondimport = importBeatmap(2);
+            presentAndConfirm(secondimport);
+        }
+
+        [Test]
+        public void TestFromMainMenuDifferentRuleset()
+        {
+            var firstImport = importBeatmap(1);
+            presentAndConfirm(firstImport);
+
+            AddStep("return to menu", () => Game.ScreenStack.CurrentScreen.Exit());
+            AddUntilStep("wait for menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
+
+            var secondimport = importBeatmap(2, new ManiaRuleset().RulesetInfo);
+            presentAndConfirm(secondimport);
+        }
+
+        [Test]
+        public void TestFromSongSelect()
+        {
+            var firstImport = importBeatmap(1);
+            presentAndConfirm(firstImport);
+
+            var secondimport = importBeatmap(2);
+            presentAndConfirm(secondimport);
+        }
+
+        [Test]
+        public void TestFromSongSelectDifferentRuleset()
+        {
+            var firstImport = importBeatmap(1);
+            presentAndConfirm(firstImport);
+
+            var secondimport = importBeatmap(2, new ManiaRuleset().RulesetInfo);
+            presentAndConfirm(secondimport);
+        }
+
+        private Func<BeatmapSetInfo> importBeatmap(int i, RulesetInfo ruleset = null)
+        {
+            BeatmapSetInfo imported = null;
+            AddStep($"import beatmap {i}", () =>
+            {
+                var difficulty = new BeatmapDifficulty();
+                var metadata = new BeatmapMetadata
+                {
+                    Artist = "SomeArtist",
+                    AuthorString = "SomeAuthor",
+                    Title = $"import {i}"
+                };
+
+                imported = Game.BeatmapManager.Import(new BeatmapSetInfo
+                {
+                    Hash = Guid.NewGuid().ToString(),
+                    OnlineBeatmapSetID = i,
+                    Metadata = metadata,
+                    Beatmaps = new List<BeatmapInfo>
+                    {
+                        new BeatmapInfo
+                        {
+                            OnlineBeatmapID = i * 1024,
+                            Metadata = metadata,
+                            BaseDifficulty = difficulty,
+                            Ruleset = ruleset ?? new OsuRuleset().RulesetInfo
+                        },
+                    }
+                }).Result;
+            });
+
+            AddAssert($"import {i} succeeded", () => imported != null);
+
+            return () => imported;
+        }
+
+        private void presentAndConfirm(Func<BeatmapSetInfo> getImport)
+        {
+            AddStep("present beatmap", () => Game.PresentBeatmap(getImport()));
+
+            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect);
+            AddUntilStep("correct beatmap displayed", () => Game.Beatmap.Value.BeatmapSetInfo.ID == getImport().ID);
+            AddAssert("correct ruleset selected", () => Game.Ruleset.Value.ID == getImport().Beatmaps.First().Ruleset.ID);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        [Ignore("will be fixed soon")]
         public void TestFromMainMenuDifferentRuleset()
         {
             var firstImport = importBeatmap(1);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Screens.Select
 
         private IEnumerable<CarouselBeatmapSet> beatmapSets => root.Children.OfType<CarouselBeatmapSet>();
 
+        // todo: only used for testing, maybe remove.
         public IEnumerable<BeatmapSetInfo> BeatmapSets
         {
             get => beatmapSets.Select(g => g.BeatmapSet);
@@ -133,14 +134,22 @@ namespace osu.Game.Screens.Select
             };
         }
 
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
+
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(OsuConfigManager config, BeatmapManager beatmaps)
+        private void load(OsuConfigManager config)
         {
             config.BindWith(OsuSetting.RandomSelectAlgorithm, RandomAlgorithm);
             config.BindWith(OsuSetting.SongSelectRightMouseScroll, RightClickScrollingEnabled);
 
             RightClickScrollingEnabled.ValueChanged += enabled => scroll.RightMouseScrollbar = enabled.NewValue;
             RightClickScrollingEnabled.TriggerChange();
+
+            beatmaps.ItemAdded += beatmapAdded;
+            beatmaps.ItemRemoved += beatmapRemoved;
+            beatmaps.BeatmapHidden += beatmapHidden;
+            beatmaps.BeatmapRestored += beatmapRestored;
 
             loadBeatmapSets(beatmaps.GetAllUsableBeatmapSetsEnumerable());
         }
@@ -535,10 +544,26 @@ namespace osu.Game.Screens.Select
         {
             base.Dispose(isDisposing);
 
+            if (beatmaps != null)
+            {
+                beatmaps.ItemAdded -= beatmapAdded;
+                beatmaps.ItemRemoved -= beatmapRemoved;
+                beatmaps.BeatmapHidden -= beatmapHidden;
+                beatmaps.BeatmapRestored -= beatmapRestored;
+            }
+
             // aggressively dispose "off-screen" items to reduce GC pressure.
             foreach (var i in Items)
                 i.Dispose();
         }
+
+        private void beatmapRemoved(BeatmapSetInfo item) => RemoveBeatmapSet(item);
+
+        private void beatmapAdded(BeatmapSetInfo item) => UpdateBeatmapSet(item);
+
+        private void beatmapRestored(BeatmapInfo b) => UpdateBeatmapSet(beatmaps.QueryBeatmapSet(s => s.ID == b.BeatmapSetInfoID));
+
+        private void beatmapHidden(BeatmapInfo b) => UpdateBeatmapSet(beatmaps.QueryBeatmapSet(s => s.ID == b.BeatmapSetInfoID));
 
         private CarouselBeatmapSet createCarouselSet(BeatmapSetInfo beatmapSet)
         {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -72,7 +72,9 @@ namespace osu.Game.Screens.Select
 
         private BeatmapInfoWedge beatmapInfoWedge;
         private DialogOverlay dialogOverlay;
-        private BeatmapManager beatmaps;
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
 
         protected ModSelectOverlay ModSelect { get; private set; }
 
@@ -89,7 +91,7 @@ namespace osu.Game.Screens.Select
         private MusicController music { get; set; }
 
         [BackgroundDependencyLoader(true)]
-        private void load(BeatmapManager beatmaps, AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores)
+        private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores)
         {
             // initial value transfer is required for FilterControl (it uses our re-cached bindables in its async load for the initial filter).
             transferRulesetValue();
@@ -246,14 +248,6 @@ namespace osu.Game.Screens.Select
                 BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, () => clearScores(Beatmap.Value.BeatmapInfo), Key.Number2);
                 BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo), Key.Number3);
             }
-
-            if (this.beatmaps == null)
-                this.beatmaps = beatmaps;
-
-            this.beatmaps.ItemAdded += onBeatmapSetAdded;
-            this.beatmaps.ItemRemoved += onBeatmapSetRemoved;
-            this.beatmaps.BeatmapHidden += onBeatmapHidden;
-            this.beatmaps.BeatmapRestored += onBeatmapRestored;
 
             dialogOverlay = dialog;
 
@@ -563,14 +557,6 @@ namespace osu.Game.Screens.Select
             base.Dispose(isDisposing);
 
             decoupledRuleset.UnbindAll();
-
-            if (beatmaps != null)
-            {
-                beatmaps.ItemAdded -= onBeatmapSetAdded;
-                beatmaps.ItemRemoved -= onBeatmapSetRemoved;
-                beatmaps.BeatmapHidden -= onBeatmapHidden;
-                beatmaps.BeatmapRestored -= onBeatmapRestored;
-            }
         }
 
         /// <summary>
@@ -616,11 +602,6 @@ namespace osu.Game.Screens.Select
 
             lastTrack.SetTarget(track);
         }
-
-        private void onBeatmapSetAdded(BeatmapSetInfo s) => Carousel.UpdateBeatmapSet(s);
-        private void onBeatmapSetRemoved(BeatmapSetInfo s) => Carousel.RemoveBeatmapSet(s);
-        private void onBeatmapRestored(BeatmapInfo b) => Carousel.UpdateBeatmapSet(beatmaps.QueryBeatmapSet(s => s.ID == b.BeatmapSetInfoID));
-        private void onBeatmapHidden(BeatmapInfo b) => Carousel.UpdateBeatmapSet(beatmaps.QueryBeatmapSet(s => s.ID == b.BeatmapSetInfoID));
 
         private void carouselBeatmapsLoaded()
         {


### PR DESCRIPTION
There was a period during which the carousel may still be loading in the background but an import could occur. Due to the order of binding to ItemAdded/Removed, import events would be missed and the carousel would end up in a bad state.

This PR ensures the events are bound before performing the initial lookup (and handling of the events occurs *after* the lookup completes for safety).

- Adds tests covering `PresentBeatmap`, one of which is ignored temporarily (see https://github.com/ppy/osu/issues/6908)
- [x] Depends on https://github.com/ppy/osu/pull/7661
