### PR TITLE
Fix percentage-formatted displays containing a space

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 if (DisplayAsPercentage)
                 {
-                    TooltipText = floatValue.ToString("P0");
+                    TooltipText = floatValue.ToString("0%");
                 }
                 else
                 {

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -277,7 +277,7 @@ namespace osu.Game.Online.Leaderboards
         protected virtual IEnumerable<LeaderboardScoreStatistic> GetStatistics(ScoreInfo model) => new[]
         {
             new LeaderboardScoreStatistic(FontAwesome.Solid.Link, "Max Combo", model.MaxCombo.ToString()),
-            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, "Accuracy", string.Format(model.Accuracy % 1 == 0 ? @"{0:P0}" : @"{0:P2}", model.Accuracy))
+            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, "Accuracy", string.Format(model.Accuracy % 1 == 0 ? @"{0:0%}" : @"{0:0.00%}", model.Accuracy))
         };
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Overlays/BeatmapSet/SuccessRate.cs
+++ b/osu.Game/Overlays/BeatmapSet/SuccessRate.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.BeatmapSet
             int playCount = beatmap?.OnlineInfo?.PlayCount ?? 0;
 
             var rate = playCount != 0 ? (float)passCount / playCount : 0;
-            successPercent.Text = rate.ToString("P0");
+            successPercent.Text = rate.ToString("0%");
             successRate.Length = rate;
             percentContainer.ResizeWidthTo(successRate.Length, 250, Easing.InOutCubic);
 

--- a/osu.Game/Screens/Multi/Match/Components/MatchLeaderboardScore.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchLeaderboardScore.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Multi.Match.Components
 
         protected override IEnumerable<LeaderboardScoreStatistic> GetStatistics(ScoreInfo model) => new[]
         {
-            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, "Accuracy", string.Format(model.Accuracy % 1 == 0 ? @"{0:P0}" : @"{0:P2}", model.Accuracy)),
+            new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, "Accuracy", string.Format(model.Accuracy % 1 == 0 ? @"{0:0%}" : @"{0:0.00%}", model.Accuracy)),
             new LeaderboardScoreStatistic(FontAwesome.Solid.Sync, "Total Attempts", score.TotalAttempts.ToString()),
             new LeaderboardScoreStatistic(FontAwesome.Solid.Check, "Completed Beatmaps", score.CompletedBeatmaps.ToString()),
         };

--- a/osu.Game/Screens/Select/LocalScoreDeleteDialog.cs
+++ b/osu.Game/Screens/Select/LocalScoreDeleteDialog.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.Select
             BeatmapInfo beatmap = beatmapManager.QueryBeatmap(b => b.ID == score.BeatmapInfoID);
             Debug.Assert(beatmap != null);
 
-            string accuracy = string.Format(score.Accuracy == 1 ? "{0:P0}" : "{0:P2}", score.Accuracy);
+            string accuracy = string.Format(score.Accuracy == 1 ? "{0:0%}" : "{0:0.00%}", score.Accuracy);
             BodyText = $"{score.User} ({accuracy}, {score.Rank})";
 
             Icon = FontAwesome.Regular.TrashAlt;


### PR DESCRIPTION
`P0` will add a space, such as `100 %`. The [accepted solution](https://stackoverflow.com/a/6229129) seems to be to change this to `0%`.