### PR TITLE
Bring UserProfileOverlay colour scheme in line with web

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Profile.Sections;
 using osu.Game.Overlays.Profile.Sections.Historical;
 using osu.Game.Users;
@@ -26,6 +28,9 @@ namespace osu.Game.Tests.Visual.Online
             typeof(DrawableMostPlayedBeatmap),
             typeof(DrawableProfileRow)
         };
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
 
         public TestSceneHistoricalSection()
         {

--- a/osu.Game/Overlays/FullscreenOverlay.cs
+++ b/osu.Game/Overlays/FullscreenOverlay.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Overlays
         protected IAPIProvider API { get; private set; }
 
         [Cached]
-        private readonly OverlayColourProvider colourProvider;
+        protected readonly OverlayColourProvider colourProvider;
 
         protected FullscreenOverlay(OverlayColourScheme colourScheme)
         {

--- a/osu.Game/Overlays/FullscreenOverlay.cs
+++ b/osu.Game/Overlays/FullscreenOverlay.cs
@@ -18,11 +18,11 @@ namespace osu.Game.Overlays
         protected IAPIProvider API { get; private set; }
 
         [Cached]
-        protected readonly OverlayColourProvider colourProvider;
+        protected readonly OverlayColourProvider ColourProvider;
 
         protected FullscreenOverlay(OverlayColourScheme colourScheme)
         {
-            colourProvider = new OverlayColourProvider(colourScheme);
+            ColourProvider = new OverlayColourProvider(colourScheme);
 
             RelativeSizeAxes = Axes.Both;
             RelativePositionAxes = Axes.Both;
@@ -43,10 +43,10 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load()
         {
-            Waves.FirstWaveColour = colourProvider.Light4;
-            Waves.SecondWaveColour = colourProvider.Light3;
-            Waves.ThirdWaveColour = colourProvider.Dark4;
-            Waves.FourthWaveColour = colourProvider.Dark3;
+            Waves.FirstWaveColour = ColourProvider.Light4;
+            Waves.SecondWaveColour = ColourProvider.Light3;
+            Waves.ThirdWaveColour = ColourProvider.Dark4;
+            Waves.FourthWaveColour = ColourProvider.Dark3;
         }
 
         public override void Show()

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -33,16 +33,16 @@ namespace osu.Game.Overlays.Profile.Header
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
-            iconColour = colours.GreySeafoamLighter;
+            iconColour = colourProvider.Foreground1;
 
             InternalChildren = new Drawable[]
             {
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.GreySeafoamDark,
+                    Colour = colourProvider.Background4
                 },
                 new FillFlowContainer
                 {

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
-using osu.Game.Graphics;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Users;
 using osuTK;

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.Profile.Header
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, TextureStore textures)
+        private void load(OverlayColourProvider colourProvider, TextureStore textures)
         {
             Container<Drawable> hiddenDetailContainer;
             Container<Drawable> expandedDetailContainer;
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.Profile.Header
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.GreySeafoam
+                    Colour = colourProvider.Background4
                 },
                 new FillFlowContainer
                 {
@@ -119,12 +119,12 @@ namespace osu.Game.Overlays.Profile.Header
                                 hiddenDetailGlobal = new OverlinedInfoContainer
                                 {
                                     Title = "Global Ranking",
-                                    LineColour = colours.Yellow
+                                    LineColour = colourProvider.Highlight1
                                 },
                                 hiddenDetailCountry = new OverlinedInfoContainer
                                 {
                                     Title = "Country Ranking",
-                                    LineColour = colours.Yellow
+                                    LineColour = colourProvider.Highlight1
                                 },
                             }
                         }

--- a/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
@@ -6,7 +6,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics;
 using osuTK;
 
 namespace osu.Game.Overlays.Profile.Header.Components

--- a/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
@@ -25,10 +25,10 @@ namespace osu.Game.Overlays.Profile.Header.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
-            IdleColour = colours.GreySeafoamLight;
-            HoverColour = colours.GreySeafoamLight.Darken(0.2f);
+            IdleColour = colourProvider.Background2;
+            HoverColour = colourProvider.Background2.Lighten(0.2f);
 
             Child = icon = new SpriteIcon
             {

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
@@ -12,6 +12,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public class OverlinedInfoContainer : CompositeDrawable
     {
+        /// <summary>
+        /// The amount of space between the overline and the underneath text.
+        /// </summary>
+        private const float line_bottom_margin = 2;
+
         private readonly Circle line;
         private readonly OsuSpriteText title;
         private readonly OsuSpriteText content;
@@ -44,6 +49,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = 2,
+                        Margin = new MarginPadding { Bottom = line_bottom_margin }
                     },
                     title = new OsuSpriteText
                     {

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
@@ -12,11 +12,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public class OverlinedInfoContainer : CompositeDrawable
     {
-        /// <summary>
-        /// The amount of space between the overline and the underneath text.
-        /// </summary>
-        private const float line_bottom_margin = 2;
-
         private readonly Circle line;
         private readonly OsuSpriteText title;
         private readonly OsuSpriteText content;
@@ -49,7 +44,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = 2,
-                        Margin = new MarginPadding { Bottom = line_bottom_margin }
+                        Margin = new MarginPadding { Bottom = 2 }
                     },
                     title = new OsuSpriteText
                     {

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     line = new Circle
                     {
                         RelativeSizeAxes = Axes.X,
-                        Height = 4,
+                        Height = 2,
                     },
                     title = new OsuSpriteText
                     {

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
@@ -27,12 +27,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
             InternalChild = info = new OverlinedInfoContainer
             {
                 Title = "Total Play Time",
-                LineColour = colours.Yellow,
+                LineColour = colourProvider.Highlight1,
             };
 
             User.BindValueChanged(updateTime, true);

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
@@ -6,7 +6,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Game.Graphics;
 using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile.Header.Components

--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Profile.Header
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider, OsuColour colours)
         {
             AutoSizeAxes = Axes.Y;
 
@@ -65,7 +65,7 @@ namespace osu.Game.Overlays.Profile.Header
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.GreySeafoamDarker,
+                    Colour = colourProvider.Background5,
                 },
                 fillFlow = new FillFlowContainer
                 {
@@ -152,12 +152,12 @@ namespace osu.Game.Overlays.Profile.Header
                                         detailGlobalRank = new OverlinedInfoContainer(true, 110)
                                         {
                                             Title = "Global Ranking",
-                                            LineColour = colours.Yellow,
+                                            LineColour = colourProvider.Highlight1,
                                         },
                                         detailCountryRank = new OverlinedInfoContainer(false, 110)
                                         {
                                             Title = "Country Ranking",
-                                            LineColour = colours.Yellow,
+                                            LineColour = colourProvider.Highlight1,
                                         },
                                     }
                                 }

--- a/osu.Game/Overlays/Profile/Header/MedalHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/MedalHeaderContainer.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Users;
 using osuTK;

--- a/osu.Game/Overlays/Profile/Header/MedalHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/MedalHeaderContainer.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Overlays.Profile.Header
         public readonly Bindable<User> User = new Bindable<User>();
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
             Alpha = 0;
             AutoSizeAxes = Axes.Y;
@@ -34,7 +34,7 @@ namespace osu.Game.Overlays.Profile.Header
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.GreySeafoamDarker,
+                    Colour = colourProvider.Background5,
                 },
                 new Container //artificial shadow
                 {

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays.Profile.Header
         private FillFlowContainer userStats;
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
             Height = 150;
 
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.Profile.Header
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.GreySeafoamDark,
+                    Colour = colourProvider.Background5,
                 },
                 new FillFlowContainer
                 {
@@ -117,7 +117,7 @@ namespace osu.Game.Overlays.Profile.Header
                                             RelativeSizeAxes = Axes.X,
                                             Height = 1.5f,
                                             Margin = new MarginPadding { Top = 10 },
-                                            Colour = colours.GreySeafoamLighter,
+                                            Colour = colourProvider.Light1,
                                         },
                                         new FillFlowContainer
                                         {
@@ -137,7 +137,7 @@ namespace osu.Game.Overlays.Profile.Header
                                                     Margin = new MarginPadding { Left = 10 },
                                                     Origin = Anchor.CentreLeft,
                                                     Anchor = Anchor.CentreLeft,
-                                                    Colour = colours.GreySeafoamLighter,
+                                                    Colour = colourProvider.Light1,
                                                 }
                                             }
                                         },

--- a/osu.Game/Overlays/Profile/ProfileSection.cs
+++ b/osu.Game/Overlays/Profile/ProfileSection.cs
@@ -95,10 +95,10 @@ namespace osu.Game.Overlays.Profile
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
-            background.Colour = colours.GreySeafoamDarker;
-            underscore.Colour = colours.Seafoam;
+            background.Colour = colourProvider.Background5;
+            underscore.Colour = colourProvider.Highlight1;
         }
 
         private class SectionTriangles : Container
@@ -128,11 +128,11 @@ namespace osu.Game.Overlays.Profile
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            private void load(OverlayColourProvider colourProvider)
             {
-                triangles.ColourLight = colours.GreySeafoamDark;
-                triangles.ColourDark = colours.GreySeafoamDarker.Darken(0.2f);
-                foreground.Colour = ColourInfo.GradientVertical(colours.GreySeafoamDarker, colours.GreySeafoamDarker.Opacity(0));
+                triangles.ColourLight = colourProvider.Background4;
+                triangles.ColourDark = colourProvider.Background5.Darken(0.2f);
+                foreground.Colour = ColourInfo.GradientVertical(colourProvider.Background5, colourProvider.Background5.Opacity(0));
             }
         }
     }

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/KudosuInfo.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/KudosuInfo.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
                         {
                             Masking = true,
                             RelativeSizeAxes = Axes.X,
-                            Height = 5,
+                            Height = 2,
                             Child = lineBackground = new Box
                             {
                                 RelativeSizeAxes = Axes.Both,
@@ -128,10 +128,10 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            private void load(OverlayColourProvider colourProvider)
             {
-                lineBackground.Colour = colours.Yellow;
-                DescriptionText.Colour = colours.GreySeafoamLighter;
+                lineBackground.Colour = colourProvider.Highlight1;
+                DescriptionText.Colour = colourProvider.Foreground1;
             }
         }
     }

--- a/osu.Game/Overlays/Profile/Sections/ProfileShowMoreButton.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileShowMoreButton.cs
@@ -10,11 +10,11 @@ namespace osu.Game.Overlays.Profile.Sections
     public class ProfileShowMoreButton : ShowMoreButton
     {
         [BackgroundDependencyLoader]
-        private void load(OsuColour colors)
+        private void load(OverlayColourProvider colourProvider)
         {
-            IdleColour = colors.GreySeafoamDark;
-            HoverColour = colors.GreySeafoam;
-            ChevronIconColour = colors.Yellow;
+            IdleColour = colourProvider.Background2;
+            HoverColour = colourProvider.Background1;
+            ChevronIconColour = colourProvider.Foreground1;
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/ProfileShowMoreButton.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileShowMoreButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Profile.Sections

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Profile;
@@ -74,7 +73,7 @@ namespace osu.Game.Overlays
             Add(new Box
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = OsuColour.Gray(0.1f)
+                Colour = colourProvider.Background6
             });
 
             Add(sectionsContainer = new ProfileSectionsContainer
@@ -83,7 +82,8 @@ namespace osu.Game.Overlays
                 FixedHeader = tabs,
                 HeaderBackground = new Box
                 {
-                    Colour = OsuColour.Gray(34),
+                    // this is only visible as the ProfileTabControl background
+                    Colour = colourProvider.Background5,
                     RelativeSizeAxes = Axes.Both
                 },
             });

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Overlays
             Add(new Box
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = colourProvider.Background6
+                Colour = ColourProvider.Background6
             });
 
             Add(sectionsContainer = new ProfileSectionsContainer
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays
                 HeaderBackground = new Box
                 {
                     // this is only visible as the ProfileTabControl background
-                    Colour = colourProvider.Background5,
+                    Colour = ColourProvider.Background5,
                     RelativeSizeAxes = Axes.Both
                 },
             });

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays
         public const float CONTENT_X_MARGIN = 70;
 
         public UserProfileOverlay()
-            : base(OverlayColourScheme.Green)
+            : base(OverlayColourScheme.Pink)
         {
         }
 

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -165,9 +165,9 @@ namespace osu.Game.Overlays
             };
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            private void load(OverlayColourProvider colourProvider)
             {
-                AccentColour = colours.Seafoam;
+                AccentColour = colourProvider.Highlight1;
             }
 
             private class ProfileTabItem : OverlayTabItem


### PR DESCRIPTION
Partially fixes #7669. Makes use of the `OverlayColourProvider`. Manually checked (probably) every colour variant on the web implementation, should match it 99%, with exceptions being the link sprites in the bottom part of the header.

Before: 

![image](https://user-images.githubusercontent.com/27722894/73399343-5ccc6880-42e7-11ea-8826-2b024b398b18.png)

After:

![image](https://user-images.githubusercontent.com/27722894/73399018-c9933300-42e6-11ea-83ca-5c64911ae855.png)
