### PR TITLE
Decouple ModSelectOverlay from global SelectedMods

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -23,6 +23,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
@@ -77,7 +78,6 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private OsuConfigManager config;
 
-        [SetUpSteps]
         public override void SetUpSteps()
         {
             base.SetUpSteps();
@@ -424,6 +424,31 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
 
             AddAssert("start not requested", () => !startRequested);
+        }
+
+        [Test]
+        public void TestAutoplayViaCtrlEnter()
+        {
+            addRulesetImportStep(0);
+
+            createSongSelect();
+
+            AddStep("press ctrl+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.Enter);
+
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.Enter);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("autoplay enabled", () => songSelect.Mods.Value.FirstOrDefault() is ModAutoplay);
+
+            AddUntilStep("wait for return to ss", () => songSelect.IsCurrentScreen());
+
+            AddAssert("mod disabled", () => songSelect.Mods.Value.Count == 0);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     RelativeSizeAxes = Axes.X,
                     Origin = Anchor.BottomCentre,
                     Anchor = Anchor.BottomCentre,
+                    SelectedMods = { BindTarget = SelectedMods }
                 },
 
                 modDisplay = new ModDisplay

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
@@ -27,6 +27,13 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private readonly Mod testCustomisableAutoOpenMod = new TestModCustomisable2();
 
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            SelectedMods.Value = Array.Empty<Mod>();
+            Ruleset.Value = new TestRulesetInfo();
+        });
+
         [Test]
         public void TestButtonShowsOnCustomisableMod()
         {
@@ -70,13 +77,12 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             AddStep("create mod select", () =>
             {
-                Ruleset.Value = new TestRulesetInfo();
-
                 Child = modSelect = new TestModSelectOverlay
                 {
                     RelativeSizeAxes = Axes.X,
                     Origin = Anchor.BottomCentre,
                     Anchor = Anchor.BottomCentre,
+                    SelectedMods = { BindTarget = SelectedMods }
                 };
             });
         }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays.Mods
 
         protected readonly Container ModSettingsContainer;
 
-        protected readonly Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+        public readonly Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         private Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods;
 
@@ -321,14 +321,13 @@ namespace osu.Game.Overlays.Mods
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, AudioManager audio, Bindable<IReadOnlyList<Mod>> selectedMods, OsuGameBase osu)
+        private void load(OsuColour colours, AudioManager audio, OsuGameBase osu)
         {
             LowMultiplierColour = colours.Red;
             HighMultiplierColour = colours.Green;
             UnrankedLabel.Colour = colours.Blue;
 
             availableMods = osu.AvailableMods.GetBoundCopy();
-            SelectedMods.BindTo(selectedMods);
 
             sampleOn = audio.Samples.Get(@"UI/check-on");
             sampleOff = audio.Samples.Get(@"UI/check-off");

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Screens.Select
 
         public override void OnResuming(IScreen last)
         {
+            base.OnResuming(last);
+
             player = null;
 
             if (removeAutoModOnResume)
@@ -41,8 +43,6 @@ namespace osu.Game.Screens.Select
                 ModSelect.DeselectTypes(new[] { autoType }, true);
                 removeAutoModOnResume = false;
             }
-
-            base.OnResuming(last);
         }
 
         protected override bool OnStart()

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -75,6 +75,9 @@ namespace osu.Game.Screens.Select
         [Resolved(canBeNull: true)]
         private NotificationOverlay notificationOverlay { get; set; }
 
+        [Resolved]
+        private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; }
+
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenBeatmap(Beatmap.Value);
 
         protected BeatmapCarousel Carousel { get; private set; }
@@ -468,6 +471,8 @@ namespace osu.Game.Screens.Select
 
             this.FadeInFromZero(250);
             FilterControl.Activate();
+
+            ModSelect.SelectedMods.BindTo(selectedMods);
         }
 
         private const double logo_transition = 250;
@@ -508,6 +513,12 @@ namespace osu.Game.Screens.Select
 
         public override void OnResuming(IScreen last)
         {
+            base.OnResuming(last);
+
+            // required due to https://github.com/ppy/osu-framework/issues/3218
+            ModSelect.SelectedMods.Disabled = false;
+            ModSelect.SelectedMods.BindTo(selectedMods);
+
             BeatmapDetails.Leaderboard.RefreshScores();
 
             Beatmap.Value.Track.Looping = true;
@@ -532,6 +543,7 @@ namespace osu.Game.Screens.Select
 
         public override void OnSuspending(IScreen next)
         {
+            ModSelect.SelectedMods.UnbindFrom(selectedMods);
             ModSelect.Hide();
 
             BeatmapOptions.Hide();


### PR DESCRIPTION
Fixes potential issues when a child screen of song select changes mods (`ReplayPlayerLoader` in a future PR).