### PR TITLE
Add extra check to attempt to track down cause of test failures

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -86,6 +86,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             manager?.Delete(manager.GetAllUsableBeatmapSets());
         });
 
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddUntilStep("bindable lease returned", () => !Beatmap.Disabled);
+        }
+
         [Test]
         public void TestSingleFilterOnEnter()
         {

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -29,8 +29,9 @@ namespace osu.Game.Tests.Visual
 
         protected void LoadScreen(OsuScreen screen)
         {
-            if (Stack.CurrentScreen != null)
+            while (Stack.CurrentScreen != null)
                 Stack.Exit();
+
             Stack.Push(screen);
         }
     }


### PR DESCRIPTION
End goal is to fix regressed test failures that we cannot figure out the cause of (https://ci.appveyor.com/project/peppy/osu/builds/30461381/tests).

Likely a completely separate scene leaving the game bindable in a bad state.