### PR TITLE
Centralise screen exit logic to ScreenTestScene

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -54,6 +54,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1230.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.125.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.131.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyBeatmapSkin.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyBeatmapSkin.cs
@@ -7,12 +7,10 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Graphics;
 using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Screens;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
@@ -21,7 +19,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
-    public class TestSceneLegacyBeatmapSkin : OsuTestScene
+    public class TestSceneLegacyBeatmapSkin : ScreenTestScene
     {
         [Resolved]
         private AudioManager audio { get; set; }
@@ -65,7 +63,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             ExposedPlayer player;
 
             Beatmap.Value = new CustomSkinWorkingBeatmap(audio, beatmapHasColours);
-            Child = new OsuScreenStack(player = new ExposedPlayer(userHasCustomColours)) { RelativeSizeAxes = Axes.Both };
+
+            LoadScreen(player = new ExposedPlayer(userHasCustomColours));
 
             return player;
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
@@ -2,47 +2,64 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens.Play;
 
-namespace osu.Game.Tests.Visual
+namespace osu.Game.Tests.Visual.Gameplay
 {
     /// <summary>
     /// A base class which runs <see cref="Player"/> test for all available rulesets.
     /// Steps to be run for each ruleset should be added via <see cref="AddCheckSteps"/>.
     /// </summary>
-    public abstract class AllPlayersTestScene : RateAdjustedBeatmapTestScene
+    public abstract class TestSceneAllRulesetPlayers : RateAdjustedBeatmapTestScene
     {
         protected Player Player;
 
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
         {
-            foreach (var r in rulesets.AvailableRulesets)
-            {
-                Player p = null;
-                AddStep(r.Name, () => p = loadPlayerFor(r));
-                AddUntilStep("player loaded", () =>
-                {
-                    if (p?.IsLoaded == true)
-                    {
-                        p = null;
-                        return true;
-                    }
-
-                    return false;
-                });
-
-                AddCheckSteps();
-            }
-
             OsuConfigManager manager;
             Dependencies.Cache(manager = new OsuConfigManager(LocalStorage));
             manager.GetBindable<double>(OsuSetting.DimLevel).Value = 1.0;
+        }
+
+        [Test]
+        public void TestOsu() => runForRuleset(new OsuRuleset().RulesetInfo);
+
+        [Test]
+        public void TestTaiko() => runForRuleset(new TaikoRuleset().RulesetInfo);
+
+        [Test]
+        public void TestCatch() => runForRuleset(new CatchRuleset().RulesetInfo);
+
+        [Test]
+        public void TestMania() => runForRuleset(new ManiaRuleset().RulesetInfo);
+
+        private void runForRuleset(RulesetInfo ruleset)
+        {
+            Player p = null;
+            AddStep($"load {ruleset.Name} player", () => p = loadPlayerFor(ruleset));
+            AddUntilStep("player loaded", () =>
+            {
+                if (p?.IsLoaded == true)
+                {
+                    p = null;
+                    return true;
+                }
+
+                return false;
+            });
+
+            AddCheckSteps();
         }
 
         protected abstract void AddCheckSteps();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
@@ -12,7 +12,7 @@ using osu.Game.Storyboards;
 namespace osu.Game.Tests.Visual.Gameplay
 {
     [Description("Player instantiated with an autoplay mod.")]
-    public class TestSceneAutoplay : AllPlayersTestScene
+    public class TestSceneAutoplay : TestSceneAllRulesetPlayers
     {
         private ClockBackedTestWorkingBeatmap.TrackVirtualManual track;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailAnimation.cs
@@ -10,7 +10,7 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    public class TestSceneFailAnimation : AllPlayersTestScene
+    public class TestSceneFailAnimation : TestSceneAllRulesetPlayers
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
-            typeof(AllPlayersTestScene),
+            typeof(TestSceneAllRulesetPlayers),
             typeof(TestPlayer),
             typeof(Player),
         };

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
@@ -10,7 +10,7 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    public class TestSceneFailJudgement : AllPlayersTestScene
+    public class TestSceneFailJudgement : TestSceneAllRulesetPlayers
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         public override void SetUpSteps()
         {
             base.SetUpSteps();
+
             AddStep("resume player", () => Player.GameplayClockContainer.Start());
             confirmClockRunning(true);
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerReferenceLeaking.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerReferenceLeaking.cs
@@ -10,7 +10,7 @@ using osu.Game.Storyboards;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    public class TestScenePlayerReferenceLeaking : AllPlayersTestScene
+    public class TestScenePlayerReferenceLeaking : TestSceneAllRulesetPlayers
     {
         private readonly WeakList<WorkingBeatmap> workingWeakReferences = new WeakList<WorkingBeatmap>();
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
@@ -13,7 +13,7 @@ using osu.Game.Screens.Play;
 namespace osu.Game.Tests.Visual.Gameplay
 {
     [Description("Player instantiated with a replay.")]
-    public class TestSceneReplay : AllPlayersTestScene
+    public class TestSceneReplay : TestSceneAllRulesetPlayers
     {
         protected override Player CreatePlayer(Ruleset ruleset)
         {

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -79,12 +79,17 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private OsuConfigManager config;
 
-        [SetUp]
-        public virtual void SetUp() => Schedule(() =>
+        [SetUpSteps]
+        public override void SetUpSteps()
         {
-            Ruleset.Value = new OsuRuleset().RulesetInfo;
-            manager?.Delete(manager.GetAllUsableBeatmapSets());
-        });
+            base.SetUpSteps();
+
+            AddStep("delete all beatmaps", () =>
+            {
+                Ruleset.Value = new OsuRuleset().RulesetInfo;
+                manager?.Delete(manager.GetAllUsableBeatmapSets());
+            });
+        }
 
         [Test]
         public void TestSingleFilterOnEnter()
@@ -120,9 +125,6 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
             AddAssert("ensure selection changed", () => selected != Beatmap.Value);
-
-            AddUntilStep("wait for return to song select", () => songSelect.IsCurrentScreen());
-            AddUntilStep("bindable lease returned", () => !Beatmap.Disabled);
         }
 
         [Test]
@@ -148,9 +150,6 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
             AddAssert("ensure selection didn't change", () => selected == Beatmap.Value);
-
-            AddUntilStep("wait for return to song select", () => songSelect.IsCurrentScreen());
-            AddUntilStep("bindable lease returned", () => !Beatmap.Disabled);
         }
 
         [Test]
@@ -180,9 +179,6 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
             AddAssert("ensure selection changed", () => selected != Beatmap.Value);
-
-            AddUntilStep("wait for return to song select", () => songSelect.IsCurrentScreen());
-            AddUntilStep("bindable lease returned", () => !Beatmap.Disabled);
         }
 
         [Test]
@@ -213,9 +209,6 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
             AddAssert("ensure selection didn't change", () => selected == Beatmap.Value);
-
-            AddUntilStep("wait for return to song select", () => songSelect.IsCurrentScreen());
-            AddUntilStep("bindable lease returned", () => !Beatmap.Disabled);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -72,8 +72,6 @@ namespace osu.Game.Tests.Visual.SongSelect
             // required to get bindables attached
             Add(music);
 
-            Beatmap.SetDefault();
-
             Dependencies.Cache(config = new OsuConfigManager(LocalStorage));
         }
 
@@ -88,6 +86,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 Ruleset.Value = new OsuRuleset().RulesetInfo;
                 manager?.Delete(manager.GetAllUsableBeatmapSets());
+
+                Beatmap.SetDefault();
             });
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Screens.Play
 
         public override float BackgroundParallaxAmount => 0.1f;
 
+        public override bool DisallowExternalBeatmapRulesetChanges => true;
+
         public override bool HideOverlaysOnEnter => true;
 
         public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.UserTriggered;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -39,8 +39,6 @@ namespace osu.Game.Screens.Play
 
         public override float BackgroundParallaxAmount => 0.1f;
 
-        public override bool DisallowExternalBeatmapRulesetChanges => true;
-
         public override bool HideOverlaysOnEnter => true;
 
         public override OverlayActivation InitialOverlayActivationMode => OverlayActivation.UserTriggered;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -345,8 +345,8 @@ namespace osu.Game.Screens.Select
                 selectionChangedDebounce = null;
             }
 
-            if (performStartAction)
-                OnStart();
+            if (performStartAction && OnStart())
+                Carousel.AllowSelection = false;
         }
 
         /// <summary>
@@ -500,6 +500,8 @@ namespace osu.Game.Screens.Select
 
         public override void OnResuming(IScreen last)
         {
+            Carousel.AllowSelection = true;
+
             BeatmapDetails.Leaderboard.RefreshScores();
 
             Beatmap.Value.Track.Looping = true;
@@ -647,7 +649,6 @@ namespace osu.Game.Screens.Select
             decoupledRuleset.ValueChanged += r => Ruleset.Value = r.NewValue;
             decoupledRuleset.DisabledChanged += r => Ruleset.Disabled = r;
 
-            Beatmap.BindDisabledChanged(disabled => Carousel.AllowSelection = !disabled, true);
             Beatmap.BindValueChanged(workingBeatmapChanged);
 
             boundLocalBindables = true;

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -33,8 +33,10 @@ namespace osu.Game.Tests.Visual
         }
 
         [SetUpSteps]
-        public virtual void SetUpSteps()
+        public override void SetUpSteps()
         {
+            base.SetUpSteps();
+
             AddStep(ruleset.RulesetInfo.Name, loadPlayer);
             AddUntilStep("player loaded", () => Player.IsLoaded && Player.Alpha == 1);
         }

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -33,9 +33,8 @@ namespace osu.Game.Tests.Visual
         [SetUpSteps]
         public virtual void SetUpSteps() => addExitAllScreensStep();
 
-        // pending framework update.
-        //[TearDownSteps]
-        //public void TearDownSteps() => addExitAllScreensStep();
+        [TearDownSteps]
+        public void TearDownSteps() => addExitAllScreensStep();
 
         private void addExitAllScreensStep()
         {

--- a/osu.Game/Tests/Visual/ScreenTestScene.cs
+++ b/osu.Game/Tests/Visual/ScreenTestScene.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Screens;
 
 namespace osu.Game.Tests.Visual
@@ -27,11 +28,24 @@ namespace osu.Game.Tests.Visual
             });
         }
 
-        protected void LoadScreen(OsuScreen screen)
+        protected void LoadScreen(OsuScreen screen) => Stack.Push(screen);
+
+        [SetUpSteps]
+        public virtual void SetUpSteps() => addExitAllScreensStep();
+
+        // pending framework update.
+        //[TearDownSteps]
+        //public void TearDownSteps() => addExitAllScreensStep();
+
+        private void addExitAllScreensStep()
         {
-            if (Stack.CurrentScreen != null)
+            AddUntilStep("exit all screens", () =>
+            {
+                if (Stack.CurrentScreen == null) return true;
+
                 Stack.Exit();
-            Stack.Push(screen);
+                return false;
+            });
         }
     }
 }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1230.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.125.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.131.0" />
     <PackageReference Include="Sentry" Version="1.2.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1230.0" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.125.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.131.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">
@@ -82,7 +82,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.125.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.131.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/3220

Also adds a missing `DisallowExternalBeatmapRulesetChanges => true` to player (which couldn't exist now due to test shortcomings).