### PR TITLE
Apply precision when determining bar colour in difficulty statistics

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -1,0 +1,125 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Select.Details;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.SongSelect
+{
+    [System.ComponentModel.Description("Advanced beatmap statistics display")]
+    public class TestSceneAdvancedStats : OsuTestScene
+    {
+        private TestAdvancedStats advancedStats;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        [SetUp]
+        public void Setup() => Schedule(() => Child = advancedStats = new TestAdvancedStats
+        {
+            Width = 500
+        });
+
+        private BeatmapInfo exampleBeatmapInfo => new BeatmapInfo
+        {
+            RulesetID = 0,
+            Ruleset = rulesets.AvailableRulesets.First(),
+            BaseDifficulty = new BeatmapDifficulty
+            {
+                CircleSize = 7.2f,
+                DrainRate = 1,
+                OverallDifficulty = 5.7f,
+                ApproachRate = 3.5f
+            },
+            StarDifficulty = 4.5f
+        };
+
+        [Test]
+        public void TestNoMod()
+        {
+            AddStep("set beatmap", () => advancedStats.Beatmap = exampleBeatmapInfo);
+
+            AddStep("no mods selected", () => SelectedMods.Value = Array.Empty<Mod>());
+
+            AddAssert("first bar text is Circle Size", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == "Circle Size");
+            AddAssert("circle size bar is white", () => advancedStats.FirstValue.ModBar.AccentColour == Color4.White);
+            AddAssert("HP drain bar is white", () => advancedStats.HpDrain.ModBar.AccentColour == Color4.White);
+            AddAssert("accuracy bar is white", () => advancedStats.Accuracy.ModBar.AccentColour == Color4.White);
+            AddAssert("approach rate bar is white", () => advancedStats.ApproachRate.ModBar.AccentColour == Color4.White);
+        }
+
+        [Test]
+        public void TestManiaFirstBarText()
+        {
+            AddStep("set beatmap", () => advancedStats.Beatmap = new BeatmapInfo
+            {
+                Ruleset = rulesets.GetRuleset(3),
+                BaseDifficulty = new BeatmapDifficulty
+                {
+                    CircleSize = 5,
+                    DrainRate = 4.3f,
+                    OverallDifficulty = 4.5f,
+                    ApproachRate = 3.1f
+                },
+                StarDifficulty = 8
+            });
+
+            AddAssert("first bar text is Key Count", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == "Key Count");
+        }
+
+        [Test]
+        public void TestEasyMod()
+        {
+            AddStep("set beatmap", () => advancedStats.Beatmap = exampleBeatmapInfo);
+
+            AddStep("select EZ mod", () =>
+            {
+                var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
+                SelectedMods.Value = new[] { ruleset.GetAllMods().OfType<ModEasy>().Single() };
+            });
+
+            AddAssert("circle size bar is blue", () => advancedStats.FirstValue.ModBar.AccentColour == colours.BlueDark);
+            AddAssert("HP drain bar is blue", () => advancedStats.HpDrain.ModBar.AccentColour == colours.BlueDark);
+            AddAssert("accuracy bar is blue", () => advancedStats.Accuracy.ModBar.AccentColour == colours.BlueDark);
+            AddAssert("approach rate bar is blue", () => advancedStats.ApproachRate.ModBar.AccentColour == colours.BlueDark);
+        }
+
+        [Test]
+        public void TestHardRockMod()
+        {
+            AddStep("set beatmap", () => advancedStats.Beatmap = exampleBeatmapInfo);
+
+            AddStep("select HR mod", () =>
+            {
+                var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
+                SelectedMods.Value = new[] { ruleset.GetAllMods().OfType<ModHardRock>().Single() };
+            });
+
+            AddAssert("circle size bar is red", () => advancedStats.FirstValue.ModBar.AccentColour == colours.Red);
+            AddAssert("HP drain bar is red", () => advancedStats.HpDrain.ModBar.AccentColour == colours.Red);
+            AddAssert("accuracy bar is red", () => advancedStats.Accuracy.ModBar.AccentColour == colours.Red);
+            AddAssert("approach rate bar is red", () => advancedStats.ApproachRate.ModBar.AccentColour == colours.Red);
+        }
+
+        private class TestAdvancedStats : AdvancedStats
+        {
+            public new StatisticRow FirstValue => base.FirstValue;
+            public new StatisticRow HpDrain => base.HpDrain;
+            public new StatisticRow Accuracy => base.Accuracy;
+            public new StatisticRow ApproachRate => base.ApproachRate;
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetails.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetails.cs
@@ -3,14 +3,8 @@
 
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 
 namespace osu.Game.Tests.Visual.SongSelect
@@ -179,28 +173,6 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 OnlineBeatmapID = 162,
             });
-        }
-
-        [Resolved]
-        private RulesetStore rulesets { get; set; }
-
-        [Resolved]
-        private OsuColour colours { get; set; }
-
-        [Test]
-        public void TestModAdjustments()
-        {
-            TestAllMetrics();
-
-            Ruleset ruleset = rulesets.AvailableRulesets.First().CreateInstance();
-
-            AddStep("with EZ mod", () => SelectedMods.Value = new[] { ruleset.GetAllMods().First(m => m is ModEasy) });
-
-            AddAssert("first bar coloured blue", () => details.ChildrenOfType<Bar>().Skip(1).First().AccentColour == colours.BlueDark);
-
-            AddStep("with HR mod", () => SelectedMods.Value = new[] { ruleset.GetAllMods().First(m => m is ModHardRock) });
-
-            AddAssert("first bar coloured red", () => details.ChildrenOfType<Bar>().Skip(1).First().AccentColour == colours.Red);
         }
     }
 }

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using System.Linq;
 using osu.Framework.Threading;
+using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Overlays.Settings;
 
@@ -177,12 +178,12 @@ namespace osu.Game.Screens.Select.Details
                     valueText.Text = (value.adjustedValue ?? value.baseValue).ToString(forceDecimalPlaces ? "0.00" : "0.##");
                     ModBar.Length = (value.adjustedValue ?? 0) / maxValue;
 
-                    if (value.adjustedValue > value.baseValue)
+                    if (Precision.AlmostEquals(value.baseValue, value.adjustedValue ?? value.baseValue, 0.05f))
+                        ModBar.AccentColour = valueText.Colour = Color4.White;
+                    else if (value.adjustedValue > value.baseValue)
                         ModBar.AccentColour = valueText.Colour = colours.Red;
                     else if (value.adjustedValue < value.baseValue)
                         ModBar.AccentColour = valueText.Colour = colours.BlueDark;
-                    else
-                        ModBar.AccentColour = valueText.Colour = Color4.White;
                 }
             }
 

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -26,7 +26,8 @@ namespace osu.Game.Screens.Select.Details
         [Resolved]
         private IBindable<IReadOnlyList<Mod>> mods { get; set; }
 
-        private readonly StatisticRow firstValue, hpDrain, accuracy, approachRate, starDifficulty;
+        protected readonly StatisticRow FirstValue, HpDrain, Accuracy, ApproachRate;
+        private readonly StatisticRow starDifficulty;
 
         private BeatmapInfo beatmap;
 
@@ -52,10 +53,10 @@ namespace osu.Game.Screens.Select.Details
                 Spacing = new Vector2(4f),
                 Children = new[]
                 {
-                    firstValue = new StatisticRow(), //circle size/key amount
-                    hpDrain = new StatisticRow { Title = "HP Drain" },
-                    accuracy = new StatisticRow { Title = "Accuracy" },
-                    approachRate = new StatisticRow { Title = "Approach Rate" },
+                    FirstValue = new StatisticRow(), //circle size/key amount
+                    HpDrain = new StatisticRow { Title = "HP Drain" },
+                    Accuracy = new StatisticRow { Title = "Accuracy" },
+                    ApproachRate = new StatisticRow { Title = "Approach Rate" },
                     starDifficulty = new StatisticRow(10, true) { Title = "Star Difficulty" },
                 },
             };
@@ -122,24 +123,24 @@ namespace osu.Game.Screens.Select.Details
                 case 3:
                     // Account for mania differences locally for now
                     // Eventually this should be handled in a more modular way, allowing rulesets to return arbitrary difficulty attributes
-                    firstValue.Title = "Key Count";
-                    firstValue.Value = (baseDifficulty?.CircleSize ?? 0, null);
+                    FirstValue.Title = "Key Count";
+                    FirstValue.Value = (baseDifficulty?.CircleSize ?? 0, null);
                     break;
 
                 default:
-                    firstValue.Title = "Circle Size";
-                    firstValue.Value = (baseDifficulty?.CircleSize ?? 0, adjustedDifficulty?.CircleSize);
+                    FirstValue.Title = "Circle Size";
+                    FirstValue.Value = (baseDifficulty?.CircleSize ?? 0, adjustedDifficulty?.CircleSize);
                     break;
             }
 
             starDifficulty.Value = ((float)(Beatmap?.StarDifficulty ?? 0), null);
 
-            hpDrain.Value = (baseDifficulty?.DrainRate ?? 0, adjustedDifficulty?.DrainRate);
-            accuracy.Value = (baseDifficulty?.OverallDifficulty ?? 0, adjustedDifficulty?.OverallDifficulty);
-            approachRate.Value = (baseDifficulty?.ApproachRate ?? 0, adjustedDifficulty?.ApproachRate);
+            HpDrain.Value = (baseDifficulty?.DrainRate ?? 0, adjustedDifficulty?.DrainRate);
+            Accuracy.Value = (baseDifficulty?.OverallDifficulty ?? 0, adjustedDifficulty?.OverallDifficulty);
+            ApproachRate.Value = (baseDifficulty?.ApproachRate ?? 0, adjustedDifficulty?.ApproachRate);
         }
 
-        private class StatisticRow : Container, IHasAccentColour
+        public class StatisticRow : Container, IHasAccentColour
         {
             private const float value_width = 25;
             private const float name_width = 70;
@@ -147,7 +148,8 @@ namespace osu.Game.Screens.Select.Details
             private readonly float maxValue;
             private readonly bool forceDecimalPlaces;
             private readonly OsuSpriteText name, valueText;
-            private readonly Bar bar, modBar;
+            private readonly Bar bar;
+            public readonly Bar ModBar;
 
             [Resolved]
             private OsuColour colours { get; set; }
@@ -173,14 +175,14 @@ namespace osu.Game.Screens.Select.Details
                     bar.Length = value.baseValue / maxValue;
 
                     valueText.Text = (value.adjustedValue ?? value.baseValue).ToString(forceDecimalPlaces ? "0.00" : "0.##");
-                    modBar.Length = (value.adjustedValue ?? 0) / maxValue;
+                    ModBar.Length = (value.adjustedValue ?? 0) / maxValue;
 
                     if (value.adjustedValue > value.baseValue)
-                        modBar.AccentColour = valueText.Colour = colours.Red;
+                        ModBar.AccentColour = valueText.Colour = colours.Red;
                     else if (value.adjustedValue < value.baseValue)
-                        modBar.AccentColour = valueText.Colour = colours.BlueDark;
+                        ModBar.AccentColour = valueText.Colour = colours.BlueDark;
                     else
-                        modBar.AccentColour = valueText.Colour = Color4.White;
+                        ModBar.AccentColour = valueText.Colour = Color4.White;
                 }
             }
 
@@ -217,7 +219,7 @@ namespace osu.Game.Screens.Select.Details
                         BackgroundColour = Color4.White.Opacity(0.5f),
                         Padding = new MarginPadding { Left = name_width + 10, Right = value_width + 10 },
                     },
-                    modBar = new Bar
+                    ModBar = new Bar
                     {
                         Origin = Anchor.CentreLeft,
                         Anchor = Anchor.CentreLeft,


### PR DESCRIPTION
Resolves #7700.

# Summary

In some cases, applying the Difficulty Adjust mod without actually changing any of the settings previously caused the bar in song select beatmap details to appear red/blue instead of staying white.

This was caused by not accounting for floating-point imprecisions when determining bar colour in `AdvancedStats`. To resolve, first check equality with tolerance, and only then apply blue/red colours if that equality check does not hold.

# Remarks

I wanted to test this properly, but modifying the existing test in `TestSceneBeatmapDetails` felt wrong, and so I went ahead and I factored it out to a separate test scene and exposed what I needed to test. Unfortunately this makes tests 90% of the diff. The actual fix is in 0bfadfb.

I also covered some other recent code (i.e. the mania "Key Size" text) with the tests.