### PR TITLE
Match osu-stable follow circle behaviour and size

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -302,6 +302,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
                 new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
+
             AddAssert("Tracking kept", assertGreatJudge);
         }
 
@@ -322,6 +323,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
                 new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
+
             AddAssert("Tracking dropped", assertMidSliderJudgementFail);
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -300,7 +300,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
                 new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
-                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+                new OsuReplayFrame { Position = new Vector2(slider_path_length, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
 
             AddAssert("Tracking kept", assertGreatJudge);
@@ -321,7 +321,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
                 new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
-                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+                new OsuReplayFrame { Position = new Vector2(slider_path_length, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
 
             AddAssert("Tracking dropped", assertMidSliderJudgementFail);
@@ -336,6 +336,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         private bool assertMidSliderJudgementFail() => judgementResults[^2].Type == HitResult.Miss;
 
         private ScoreAccessibleReplayPlayer currentPlayer;
+
+        private const float slider_path_length = 25;
 
         private void performTest(List<ReplayFrame> frames)
         {
@@ -352,8 +354,8 @@ namespace osu.Game.Rulesets.Osu.Tests
                             Path = new SliderPath(PathType.PerfectCurve, new[]
                             {
                                 Vector2.Zero,
-                                new Vector2(25, 0),
-                            }, 25),
+                                new Vector2(slider_path_length, 0),
+                            }, slider_path_length),
                         }
                     },
                     BeatmapInfo =

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -285,7 +285,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("Tracking acquired", assertMidSliderJudgements);
         }
 
-
         /// <summary>
         /// Scenario:
         /// - Press a key on the slider head

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -300,8 +300,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             performTest(new List<ReplayFrame>
             {
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
-                new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.199f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
-                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.199f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+                new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
+                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
             AddAssert("Tracking kept", assertGreatJudge);
         }
@@ -320,8 +320,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             performTest(new List<ReplayFrame>
             {
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
-                new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.2f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
-                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.2f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+                new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
+                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
             AddAssert("Tracking dropped", assertMidSliderJudgementFail);
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private const double time_during_slide_2 = 3000;
         private const double time_during_slide_3 = 3500;
         private const double time_during_slide_4 = 3800;
+        private const double time_slider_end = 4000;
 
         private List<JudgementResult> judgementResults;
         private bool allJudgedFired;
@@ -282,6 +283,47 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             AddAssert("Tracking acquired", assertMidSliderJudgements);
+        }
+
+
+        /// <summary>
+        /// Scenario:
+        /// - Press a key on the slider head
+        /// - While holding the key, move cursor close to the edge of tracking area
+        /// - Keep the cursor on the edge of tracking area until the slider ends
+        /// Expected Result:
+        /// A passing test case will have the slider track the cursor throughout the whole test.
+        /// </summary>
+        [Test]
+        public void TestTrackingAreaEdge()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
+                new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.199f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
+                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.199f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+            });
+            AddAssert("Tracking kept", assertGreatJudge);
+        }
+
+        /// <summary>
+        /// Scenario:
+        /// - Press a key on the slider head
+        /// - While holding the key, move cursor just outside the tracking area
+        /// - Keep the cursor just outside the tracking area until the slider ends
+        /// Expected Result:
+        /// A passing test case will have the slider drop the tracking on frame 2.
+        /// </summary>
+        [Test]
+        public void TestTrackingAreaOutsideEdge()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
+                new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.2f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
+                new OsuReplayFrame { Position = new Vector2(25, OsuHitObject.OBJECT_RADIUS * 1.2f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+            });
+            AddAssert("Tracking dropped", assertMidSliderJudgementFail);
         }
 
         private bool assertGreatJudge() => judgementResults.Last().Type == HitResult.Great;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -300,7 +300,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
                 new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
-                new OsuReplayFrame { Position = new Vector2(slider_path_length, OsuHitObject.OBJECT_RADIUS * 1.19f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+                new OsuReplayFrame { Position = new Vector2(slider_path_length, OsuHitObject.OBJECT_RADIUS * 1.199f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
 
             AddAssert("Tracking kept", assertGreatJudge);
@@ -321,7 +321,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.LeftButton }, Time = time_slider_start },
                 new OsuReplayFrame { Position = new Vector2(0, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_start + 100 },
-                new OsuReplayFrame { Position = new Vector2(slider_path_length, OsuHitObject.OBJECT_RADIUS * 1.21f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
+                new OsuReplayFrame { Position = new Vector2(slider_path_length, OsuHitObject.OBJECT_RADIUS * 1.201f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
 
             AddAssert("Tracking dropped", assertMidSliderJudgementFail);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         private readonly Slider slider;
         public readonly Drawable FollowCircle;
+        public readonly Drawable InternalFollowCircle;
         private readonly DrawableSlider drawableSlider;
 
         public SliderBall(Slider slider, DrawableSlider drawableSlider = null)
@@ -38,6 +39,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Children = new[]
             {
+                InternalFollowCircle = new CircularContainer
+                {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0
+                },
                 FollowCircle = new FollowCircleContainer
                 {
                     Origin = Anchor.Centre,
@@ -95,7 +103,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
                 tracking = value;
 
-                FollowCircle.ScaleTo(tracking ? 2f : 1, 300, Easing.OutQuint);
+                // Cursor input is checked against the internal circle, which scales instantly to match osu-stable behaviour
+                InternalFollowCircle.ScaleTo(tracking ? 2.4f : 1f);
+                FollowCircle.ScaleTo(tracking ? 2f : 1f, 300, Easing.OutQuint);
                 FollowCircle.FadeTo(tracking ? 1f : 0, 300, Easing.OutQuint);
             }
         }
@@ -149,7 +159,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 // in valid time range
                 Time.Current >= slider.StartTime && Time.Current < slider.EndTime &&
                 // in valid position range
-                lastScreenSpaceMousePosition.HasValue && FollowCircle.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
+                lastScreenSpaceMousePosition.HasValue && InternalFollowCircle.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
                 // valid action
                 (actions?.Any(isValidTrackingAction) ?? false);
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -44,8 +44,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Alpha = 0
+                    RelativeSizeAxes = Axes.Both
                 },
                 FollowCircle = new FollowCircleContainer
                 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         private readonly Slider slider;
         public readonly Drawable FollowCircle;
-        public readonly Drawable InternalFollowCircle;
+        public readonly Drawable TrackingArea;
         private readonly DrawableSlider drawableSlider;
 
         public SliderBall(Slider slider, DrawableSlider drawableSlider = null)
@@ -39,7 +39,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Children = new[]
             {
-                InternalFollowCircle = new CircularContainer
+                // This is separate from the visible followcircle to ensure consistent internal tracking area (needed to match osu-stable)
+                TrackingArea = new CircularContainer
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
@@ -103,8 +104,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
                 tracking = value;
 
-                // Cursor input is checked against the internal circle, which scales instantly to match osu-stable behaviour
-                InternalFollowCircle.ScaleTo(tracking ? 2.4f : 1f);
+                // Tracking area is bigger than the visible followcircle and scales instantly to match osu-stable
+                TrackingArea.ScaleTo(tracking ? 2.4f : 1f);
                 FollowCircle.ScaleTo(tracking ? 2f : 1f, 300, Easing.OutQuint);
                 FollowCircle.FadeTo(tracking ? 1f : 0, 300, Easing.OutQuint);
             }
@@ -159,7 +160,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 // in valid time range
                 Time.Current >= slider.StartTime && Time.Current < slider.EndTime &&
                 // in valid position range
-                lastScreenSpaceMousePosition.HasValue && InternalFollowCircle.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
+                lastScreenSpaceMousePosition.HasValue && TrackingArea.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
                 // valid action
                 (actions?.Any(isValidTrackingAction) ?? false);
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -23,8 +23,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         public Func<OsuAction?> GetInitialHitAction;
 
         private readonly Slider slider;
-        public readonly Drawable FollowCircle;
-        public readonly Drawable TrackingArea;
+        private readonly Drawable followCircle;
+        private readonly Drawable trackingArea;
         private readonly DrawableSlider drawableSlider;
 
         public SliderBall(Slider slider, DrawableSlider drawableSlider = null)
@@ -40,13 +40,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             Children = new[]
             {
                 // This is separate from the visible followcircle to ensure consistent internal tracking area (needed to match osu-stable)
-                TrackingArea = new CircularContainer
+                trackingArea = new CircularContainer
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both
                 },
-                FollowCircle = new FollowCircleContainer
+                followCircle = new FollowCircleContainer
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
@@ -104,9 +104,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 tracking = value;
 
                 // Tracking area is bigger than the visible followcircle and scales instantly to match osu-stable
-                TrackingArea.ScaleTo(tracking ? 2.4f : 1f);
-                FollowCircle.ScaleTo(tracking ? 2f : 1f, 300, Easing.OutQuint);
-                FollowCircle.FadeTo(tracking ? 1f : 0, 300, Easing.OutQuint);
+                trackingArea.ScaleTo(tracking ? 2.4f : 1f);
+                followCircle.ScaleTo(tracking ? 2f : 1f, 300, Easing.OutQuint);
+                followCircle.FadeTo(tracking ? 1f : 0, 300, Easing.OutQuint);
             }
         }
 
@@ -159,7 +159,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 // in valid time range
                 Time.Current >= slider.StartTime && Time.Current < slider.EndTime &&
                 // in valid position range
-                lastScreenSpaceMousePosition.HasValue && TrackingArea.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
+                lastScreenSpaceMousePosition.HasValue && trackingArea.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
                 // valid action
                 (actions?.Any(isValidTrackingAction) ?? false);
         }


### PR DESCRIPTION
Brings `FollowCircle` behaviour in line with stable by introducing `InternalFollowCircle` (not sure about this name though) and making it scale instantly to `2.4f`, so the input check matches stable, while the visual part scales to `2f` on its own as it previously did.

Fixes part of #7521.