### PR TITLE
Remove all usages of Bindable<float> and Bindable<double>

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         /// <summary>
         /// The start time of <see cref="Start"/>.
         /// </summary>
-        public readonly Bindable<double> StartTime = new Bindable<double>();
+        public readonly Bindable<double> StartTime = new BindableDouble();
 
         /// <summary>
         /// The <see cref="DrawableOsuHitObject"/> which <see cref="FollowPoint"/>s will exit from.

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
         private readonly IBindable<int> stackHeightBindable = new Bindable<int>();
-        private readonly IBindable<float> scaleBindable = new Bindable<float>();
+        private readonly IBindable<float> scaleBindable = new BindableFloat();
 
         public OsuAction? HitAction => HitArea.HitAction;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableRepeatPoint.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             InternalChild = scaleContainer = new ReverseArrowPiece();
         }
 
-        private readonly IBindable<float> scaleBindable = new Bindable<float>();
+        private readonly IBindable<float> scaleBindable = new BindableFloat();
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
         private readonly IBindable<int> stackHeightBindable = new Bindable<int>();
-        private readonly IBindable<float> scaleBindable = new Bindable<float>();
+        private readonly IBindable<float> scaleBindable = new BindableFloat();
 
         public DrawableSlider(Slider s)
             : base(s)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             };
         }
 
-        private readonly IBindable<float> scaleBindable = new Bindable<float>();
+        private readonly IBindable<float> scaleBindable = new BindableFloat();
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public double Radius => OBJECT_RADIUS * Scale;
 
-        public readonly Bindable<float> ScaleBindable = new Bindable<float>(1);
+        public readonly Bindable<float> ScaleBindable = new BindableFloat(1);
 
         public float Scale
         {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             autoCursorScale = config.GetBindable<bool>(OsuSetting.AutoCursorSize);
             autoCursorScale.ValueChanged += _ => calculateScale();
 
-            CursorScale = new Bindable<float>();
+            CursorScale = new BindableFloat();
             CursorScale.ValueChanged += e => ActiveCursor.Scale = cursorTrail.Scale = new Vector2(e.NewValue);
 
             calculateScale();

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.UI
             {
                 Add(localCursorContainer = new OsuCursorContainer());
 
-                localCursorScale = new Bindable<float>();
+                localCursorScale = new BindableFloat();
                 localCursorScale.BindTo(localCursorContainer.CursorScale);
                 localCursorScale.BindValueChanged(scale => cursorScaleContainer.Scale = new Vector2(scale.NewValue), true);
             }

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -302,8 +302,8 @@ namespace osu.Game.Tests.Visual.Background
             }
 
             public readonly Bindable<bool> DimEnabled = new Bindable<bool>();
-            public readonly Bindable<double> DimLevel = new Bindable<double>();
-            public readonly Bindable<double> BlurLevel = new Bindable<double>();
+            public readonly Bindable<double> DimLevel = new BindableDouble();
+            public readonly Bindable<double> BlurLevel = new BindableDouble();
 
             public new BeatmapCarousel Carousel => base.Carousel;
 

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         public event Action DefaultsApplied;
 
-        public readonly Bindable<double> StartTimeBindable = new Bindable<double>();
+        public readonly Bindable<double> StartTimeBindable = new BindableDouble();
 
         /// <summary>
         /// The time at which the HitObject starts.

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Backgrounds
         /// <summary>
         /// The amount of blur to be applied in addition to user-specified blur.
         /// </summary>
-        public readonly Bindable<float> BlurAmount = new Bindable<float>();
+        public readonly Bindable<float> BlurAmount = new BindableFloat();
 
         internal readonly IBindable<bool> IsBreakTime = new Bindable<bool>();
 
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.Backgrounds
             /// <remarks>
             /// Used in contexts where there can potentially be both user and screen-specified blurring occuring at the same time, such as in <see cref="PlayerLoader"/>
             /// </remarks>
-            public readonly Bindable<float> BlurAmount = new Bindable<float>();
+            public readonly Bindable<float> BlurAmount = new BindableFloat();
 
             public Background Background
             {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -149,8 +149,8 @@ namespace osu.Game.Screens.Select
         private readonly IBindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
 
         private readonly Bindable<bool> showConverted = new Bindable<bool>();
-        private readonly Bindable<double> minimumStars = new Bindable<double>();
-        private readonly Bindable<double> maximumStars = new Bindable<double>();
+        private readonly Bindable<double> minimumStars = new BindableDouble();
+        private readonly Bindable<double> maximumStars = new BindableDouble();
 
         public readonly Box Background;
 

--- a/osu.Game/Tests/Visual/ScrollingTestContainer.cs
+++ b/osu.Game/Tests/Visual/ScrollingTestContainer.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Visual
             public readonly Bindable<ScrollingDirection> Direction = new Bindable<ScrollingDirection>();
             IBindable<ScrollingDirection> IScrollingInfo.Direction => Direction;
 
-            public readonly Bindable<double> TimeRange = new Bindable<double>(1000) { Value = 1000 };
+            public readonly Bindable<double> TimeRange = new BindableDouble(1000) { Value = 1000 };
             IBindable<double> IScrollingInfo.TimeRange => TimeRange;
 
             public readonly TestScrollAlgorithm Algorithm = new TestScrollAlgorithm();


### PR DESCRIPTION
Resolves #7708.

# Summary

Due to using `Bindable<double>`s previously, song select's filter control would not apply tolerance when checking `IsDefault`, therefore wrongly hiding maps with star ratings above 10.1.

To avoid further floating-point comparison bugs, remove all usages of `Bindable<{float,double}>`, replacing them with their `Bindable{Float,Double}` counterparts.

# Remarks

No tests this time, mostly because I consider the old versions as accidental mis-use of the framework and therefore I'd be only testing the framework usage.

I'm not sure if some of those original ones weren't intended. I don't know what reason there would be to use `Bindable<{float,double}>` other than performance. Because of this I split off the PR into two commits, the first of which resolves the issue and the second all the other remaining usages, for easy revertability of the latter if deemed too far-reaching.

I also wanted to use the `BannedApiAnalyzer` to report usages of the constructor at the time of static analysis, but it seems that won't be possible as it uses [the documentation ID string format](https://github.com/dotnet/csharplang/blob/master/spec/documentation-comments.md#id-string-format) for identifying code elements, which does not permit specifying type parameters when referring to genericised members.

I also opened ppy/osu-framework#3229 for further discussion on whether we want to allow usage of `Bindable<{float,double}>` at framework level at all.