### PR TITLE
Add support for reading skin frame rate from configuration file

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyBeatmapSkin.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyBeatmapSkin.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             public IReadOnlyList<Color4> UsableComboColours =>
                 GameplayClockContainer.ChildrenOfType<BeatmapSkinProvidingContainer>()
                                       .First()
-                                      .GetConfig<GlobalSkinConfiguration, IReadOnlyList<Color4>>(GlobalSkinConfiguration.ComboColours)?.Value;
+                                      .GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value;
         }
 
         private class CustomSkinWorkingBeatmap : ClockBackedTestWorkingBeatmap

--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -46,17 +46,20 @@ namespace osu.Game.Rulesets.Osu.Skinning
             switch (osuComponent.Component)
             {
                 case OsuSkinComponents.FollowPoint:
-                    return this.GetAnimation(component.LookupName, true, false);
+                    return this.GetAnimation(component.LookupName, true, false, true);
 
                 case OsuSkinComponents.SliderFollowCircle:
-                    var followCircle = this.GetAnimation("sliderfollowcircle", true, true);
+                    var followCircle = this.GetAnimation("sliderfollowcircle", true, true, true);
                     if (followCircle != null)
                         // follow circles are 2x the hitcircle resolution in legacy skins (since they are scaled down from >1x
                         followCircle.Scale *= 0.5f;
                     return followCircle;
 
                 case OsuSkinComponents.SliderBall:
-                    var sliderBallContent = this.GetAnimation("sliderb", true, true, "");
+                    var sliderBallContent = this.GetAnimation("sliderb", true, true, animationSeparator: "");
+
+                    // todo: slider ball has a custom frame delay based on velocity
+                    // Math.Max((150 / Velocity) * GameBase.SIXTY_FRAME_TIME, GameBase.SIXTY_FRAME_TIME);
 
                     if (sliderBallContent != null)
                     {

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectAccentColour.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectAccentColour.cs
@@ -126,10 +126,10 @@ namespace osu.Game.Tests.Gameplay
             {
                 switch (lookup)
                 {
-                    case GlobalSkinConfiguration global:
+                    case GlobalSkinColours global:
                         switch (global)
                         {
-                            case GlobalSkinConfiguration.ComboColours:
+                            case GlobalSkinColours.ComboColours:
                                 return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(ComboColours));
                         }
 

--- a/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Tests.Skins
         [Test]
         public void TestGlobalLookup()
         {
-            AddAssert("Check combo colours", () => requester.GetConfig<GlobalSkinConfiguration, IReadOnlyList<Color4>>(GlobalSkinConfiguration.ComboColours)?.Value?.Count > 0);
+            AddAssert("Check combo colours", () => requester.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value?.Count > 0);
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Skins
         public void TestEmptyComboColours()
         {
             AddAssert("Check retrieved combo colours is skin default colours", () =>
-                requester.GetConfig<GlobalSkinConfiguration, IReadOnlyList<Color4>>(GlobalSkinConfiguration.ComboColours)?.Value?.SequenceEqual(SkinConfiguration.DefaultComboColours) ?? false);
+                requester.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value?.SequenceEqual(SkinConfiguration.DefaultComboColours) ?? false);
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace osu.Game.Tests.Skins
             AddStep("Disallow default colours fallback in source2", () => source2.Configuration.AllowDefaultComboColoursFallback = false);
 
             AddAssert("Check retrieved combo colours from source1", () =>
-                requester.GetConfig<GlobalSkinConfiguration, IReadOnlyList<Color4>>(GlobalSkinConfiguration.ComboColours)?.Value?.SequenceEqual(source1.Configuration.ComboColours) ?? false);
+                requester.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value?.SequenceEqual(source1.Configuration.ComboColours) ?? false);
         }
 
         [Test]

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -349,7 +349,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             if (HitObject is IHasComboInformation combo)
             {
-                var comboColours = CurrentSkin.GetConfig<GlobalSkinConfiguration, IReadOnlyList<Color4>>(GlobalSkinConfiguration.ComboColours)?.Value;
+                var comboColours = CurrentSkin.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value;
                 AccentColour.Value = comboColours?.Count > 0 ? comboColours[combo.ComboIndex % comboColours.Count] : Color4.White;
             }
         }

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Menu
             Color4 defaultColour = Color4.White.Opacity(0.2f);
 
             if (user.Value?.IsSupporter ?? false)
-                AccentColour = skin.Value.GetConfig<GlobalSkinColour, Color4>(GlobalSkinColour.MenuGlow)?.Value ?? defaultColour;
+                AccentColour = skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? defaultColour;
             else
                 AccentColour = defaultColour;
         }

--- a/osu.Game/Screens/Menu/MenuSideFlashes.cs
+++ b/osu.Game/Screens/Menu/MenuSideFlashes.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Screens.Menu
             Color4 baseColour = colours.Blue;
 
             if (user.Value?.IsSupporter ?? false)
-                baseColour = skin.Value.GetConfig<GlobalSkinColour, Color4>(GlobalSkinColour.MenuGlow)?.Value ?? baseColour;
+                baseColour = skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? baseColour;
 
             // linear colour looks better in this case, so let's use it for now.
             Color4 gradientDark = baseColour.Opacity(0).ToLinear();

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -31,10 +31,10 @@ namespace osu.Game.Skinning
             {
                 // todo: this code is pulled from LegacySkin and should not exist.
                 // will likely change based on how databased storage of skin configuration goes.
-                case GlobalSkinConfiguration global:
+                case GlobalSkinColours global:
                     switch (global)
                     {
-                        case GlobalSkinConfiguration.ComboColours:
+                        case GlobalSkinColours.ComboColours:
                             return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(Configuration.ComboColours));
                     }
 

--- a/osu.Game/Skinning/GlobalSkinColours.cs
+++ b/osu.Game/Skinning/GlobalSkinColours.cs
@@ -3,8 +3,9 @@
 
 namespace osu.Game.Skinning
 {
-    public enum GlobalSkinColour
+    public enum GlobalSkinColours
     {
+        ComboColours,
         MenuGlow
     }
 }

--- a/osu.Game/Skinning/GlobalSkinConfiguration.cs
+++ b/osu.Game/Skinning/GlobalSkinConfiguration.cs
@@ -5,5 +5,6 @@ namespace osu.Game.Skinning
 {
     public enum GlobalSkinConfiguration
     {
+        AnimationFramerate
     }
 }

--- a/osu.Game/Skinning/GlobalSkinConfiguration.cs
+++ b/osu.Game/Skinning/GlobalSkinConfiguration.cs
@@ -5,6 +5,5 @@ namespace osu.Game.Skinning
 {
     public enum GlobalSkinConfiguration
     {
-        ComboColours
     }
 }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -68,21 +69,21 @@ namespace osu.Game.Skinning
         {
             switch (lookup)
             {
-                case GlobalSkinConfiguration global:
-                    switch (global)
+                case GlobalSkinColours colour:
+                    switch (colour)
                     {
-                        case GlobalSkinConfiguration.ComboColours:
+                        case GlobalSkinColours.ComboColours:
                             var comboColours = Configuration.ComboColours;
                             if (comboColours != null)
                                 return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(comboColours));
 
                             break;
+
+                        default:
+                            return SkinUtils.As<TValue>(getCustomColour(colour.ToString()));
                     }
 
                     break;
-
-                case GlobalSkinColour colour:
-                    return SkinUtils.As<TValue>(getCustomColour(colour.ToString()));
 
                 case LegacySkinConfiguration.LegacySetting legacy:
                     switch (legacy)
@@ -100,6 +101,8 @@ namespace osu.Game.Skinning
                     return SkinUtils.As<TValue>(getCustomColour(customColour.Lookup.ToString()));
 
                 default:
+                    // handles lookups like GlobalSkinConfiguration
+
                     try
                     {
                         if (Configuration.ConfigDictionary.TryGetValue(lookup.ToString(), out var val))

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Sprites;
@@ -10,48 +12,62 @@ namespace osu.Game.Skinning
 {
     public static class LegacySkinExtensions
     {
-        public static Drawable GetAnimation(this ISkin source, string componentName, bool animatable, bool looping, string animationSeparator = "-")
+        public static Drawable GetAnimation(this ISkin source, string componentName, bool animatable, bool looping, bool applyConfigFrameRate = false, string animationSeparator = "-")
         {
-            const double default_frame_time = 1000 / 60d;
-
             Texture texture;
-
-            Texture getFrameTexture(int frame) => source.GetTexture($"{componentName}{animationSeparator}{frame}");
-
-            TextureAnimation animation = null;
 
             if (animatable)
             {
-                for (int i = 0; true; i++)
+                var textures = getTextures().ToArray();
+
+                if (textures.Length > 0)
                 {
-                    if ((texture = getFrameTexture(i)) == null)
-                        break;
-
-                    if (animation == null)
+                    var animation = new TextureAnimation
                     {
-                        animation = new TextureAnimation
-                        {
-                            DefaultFrameLength = default_frame_time,
-                            Repeat = looping
-                        };
-                    }
+                        DefaultFrameLength = getFrameLength(source, applyConfigFrameRate, textures),
+                        Repeat = looping,
+                    };
 
-                    animation.AddFrame(texture);
+                    foreach (var t in textures)
+                        animation.AddFrame(t);
+
+                    return animation;
                 }
             }
 
-            if (animation != null)
-                return animation;
-
+            // if an animation was not allowed or not found, fall back to a sprite retrieval.
             if ((texture = source.GetTexture(componentName)) != null)
-            {
-                return new Sprite
-                {
-                    Texture = texture
-                };
-            }
+                return new Sprite { Texture = texture };
 
             return null;
+
+            IEnumerable<Texture> getTextures()
+            {
+                for (int i = 0; true; i++)
+                {
+                    if ((texture = source.GetTexture($"{componentName}{animationSeparator}{i}")) == null)
+                        break;
+
+                    yield return texture;
+                }
+            }
+        }
+
+        private const double default_frame_time = 1000 / 60d;
+
+        private static double getFrameLength(ISkin source, bool applyConfigFrameRate, Texture[] textures)
+        {
+            if (applyConfigFrameRate)
+            {
+                var iniRate = source.GetConfig<GlobalSkinConfiguration, int>(GlobalSkinConfiguration.AnimationFramerate);
+
+                if (iniRate != null)
+                    return 1000f / iniRate.Value;
+
+                return 1000f / textures.Length;
+            }
+
+            return default_frame_time;
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/7547.

Tidies up configuration retrieval slightly by moving colours into the same enum (and removing the custom handling of `GlobalSkinConfiguration`, allowing it to fall through to the generic parsing method).