### PR TITLE
Fix duration snapping still being incorrect

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -289,7 +289,11 @@ namespace osu.Game.Rulesets.Edit
             => beatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime) - referenceTime;
 
         public override float GetSnappedDistanceFromDistance(double referenceTime, float distance)
-            => DurationToDistance(referenceTime, beatSnapProvider.SnapTime(DistanceToDuration(referenceTime, distance), referenceTime));
+        {
+            var snappedEndTime = beatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime);
+
+            return DurationToDistance(referenceTime, snappedEndTime - referenceTime);
+        }
 
         public override void UpdateHitObject(HitObject hitObject) => EditorBeatmap.UpdateHitObject(hitObject);
 


### PR DESCRIPTION
It was trying to snap an arbitrary duration, rather than the actual end position. All beat snapping must be applied in absolute time, not relative.