### PR TITLE
Make editor screens display below timeline

### DIFF
--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Screens.Edit
         private const float vertical_margins = 10;
         private const float horizontal_margins = 20;
 
+        private const float timeline_height = 110;
+
         private readonly BindableBeatDivisor beatDivisor = new BindableBeatDivisor();
 
         private Container timelineContainer;
@@ -32,65 +34,57 @@ namespace osu.Game.Screens.Edit
 
             Children = new Drawable[]
             {
-                new GridContainer
+                mainContent = new Container
                 {
+                    Name = "Main content",
                     RelativeSizeAxes = Axes.Both,
-                    Content = new[]
+                    Padding = new MarginPadding
                     {
-                        new Drawable[]
+                        Horizontal = horizontal_margins,
+                        Top = vertical_margins + timeline_height,
+                        Bottom = vertical_margins
+                    },
+                },
+                new Container
+                {
+                    Name = "Timeline",
+                    RelativeSizeAxes = Axes.X,
+                    Height = timeline_height,
+                    Children = new Drawable[]
+                    {
+                        new Box
                         {
-                            new Container
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Black.Opacity(0.5f)
+                        },
+                        new Container
+                        {
+                            Name = "Timeline content",
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Horizontal = horizontal_margins, Vertical = vertical_margins },
+                            Child = new GridContainer
                             {
-                                Name = "Timeline",
                                 RelativeSizeAxes = Axes.Both,
-                                Children = new Drawable[]
+                                Content = new[]
                                 {
-                                    new Box
+                                    new Drawable[]
                                     {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.Black.Opacity(0.5f)
-                                    },
-                                    new Container
-                                    {
-                                        Name = "Timeline content",
-                                        RelativeSizeAxes = Axes.Both,
-                                        Padding = new MarginPadding { Horizontal = horizontal_margins, Vertical = vertical_margins },
-                                        Child = new GridContainer
+                                        timelineContainer = new Container
                                         {
                                             RelativeSizeAxes = Axes.Both,
-                                            Content = new[]
-                                            {
-                                                new Drawable[]
-                                                {
-                                                    timelineContainer = new Container
-                                                    {
-                                                        RelativeSizeAxes = Axes.Both,
-                                                        Padding = new MarginPadding { Right = 5 },
-                                                    },
-                                                    new BeatDivisorControl(beatDivisor) { RelativeSizeAxes = Axes.Both }
-                                                },
-                                            },
-                                            ColumnDimensions = new[]
-                                            {
-                                                new Dimension(),
-                                                new Dimension(GridSizeMode.Absolute, 90),
-                                            }
+                                            Padding = new MarginPadding { Right = 5 },
                                         },
-                                    }
+                                        new BeatDivisorControl(beatDivisor) { RelativeSizeAxes = Axes.Both }
+                                    },
+                                },
+                                ColumnDimensions = new[]
+                                {
+                                    new Dimension(),
+                                    new Dimension(GridSizeMode.Absolute, 90),
                                 }
-                            }
-                        },
-                        new Drawable[]
-                        {
-                            mainContent = new Container
-                            {
-                                Name = "Main content",
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding { Horizontal = horizontal_margins, Vertical = vertical_margins },
-                            }
+                            },
                         }
-                    },
-                    RowDimensions = new[] { new Dimension(GridSizeMode.Absolute, 110) }
+                    }
                 },
             };
 


### PR DESCRIPTION
Avoids things like spinner blueprints blocking the view of the editor UI.