### PR TITLE
Fix beatmap overlay scoreboards having their statistics columns unsorted

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 new TableColumn("max combo", Anchor.CentreLeft, new Dimension(GridSizeMode.Distributed, minSize: 70, maxSize: 90))
             };
 
-            foreach (var statistic in score.Statistics)
+            foreach (var statistic in score.SortedStatistics)
                 columns.Add(new TableColumn(statistic.Key.GetDescription(), Anchor.CentreLeft, new Dimension(GridSizeMode.Distributed, minSize: 50, maxSize: 70)));
 
             columns.AddRange(new[]
@@ -150,7 +150,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 }
             });
 
-            foreach (var kvp in score.Statistics)
+            foreach (var kvp in score.SortedStatistics)
             {
                 content.Add(new OsuSpriteText
                 {

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -99,9 +99,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 maxComboColumn.Text = $@"{value.MaxCombo:N0}x";
                 ppColumn.Text = $@"{value.PP:N0}";
 
-                statisticsColumns.ChildrenEnumerable = value.Statistics
-                                                            .OrderByDescending(pair => pair.Key)
-                                                            .Select(kvp => createStatisticsColumn(kvp.Key, kvp.Value));
+                statisticsColumns.ChildrenEnumerable = value.SortedStatistics.Select(kvp => createStatisticsColumn(kvp.Key, kvp.Value));
                 modsColumn.Mods = value.Mods;
             }
         }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -151,6 +151,8 @@ namespace osu.Game.Scoring
         [JsonProperty("statistics")]
         public Dictionary<HitResult, int> Statistics = new Dictionary<HitResult, int>();
 
+        public IOrderedEnumerable<KeyValuePair<HitResult, int>> SortedStatistics => Statistics.OrderByDescending(pair => pair.Key);
+
         [JsonIgnore]
         [Column("Statistics")]
         public string StatisticsJson

--- a/osu.Game/Screens/Ranking/Pages/ScoreResultsPage.cs
+++ b/osu.Game/Screens/Ranking/Pages/ScoreResultsPage.cs
@@ -188,7 +188,7 @@ namespace osu.Game.Screens.Ranking.Pages
                 },
             };
 
-            statisticsContainer.ChildrenEnumerable = Score.Statistics.OrderByDescending(p => p.Key).Select(s => new DrawableScoreStatistic(s));
+            statisticsContainer.ChildrenEnumerable = Score.SortedStatistics.Select(s => new DrawableScoreStatistic(s));
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Introduces `SortedStatistics`, centralizing the way to sort hitresults in places which need that, like scoreboards or the score results page. 

Also fixes `BeatmapSetOverlay` scoreboards having their statistics columns unsorted.