### PR TITLE
Make accuracy formatting more consistent

### DIFF
--- a/osu.Game/Graphics/UserInterface/PercentageCounter.cs
+++ b/osu.Game/Graphics/UserInterface/PercentageCounter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Game.Utils;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -29,10 +30,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(OsuColour colours) => AccentColour = colours.BlueLighter;
 
-        protected override string FormatCount(double count)
-        {
-            return $@"{count:P2}";
-        }
+        protected override string FormatCount(double count) => count.FormatAccuracy();
 
         protected override double GetProportionalDuration(double currentValue, double newValue)
         {

--- a/osu.Game/Screens/Play/Break/BreakInfoLine.cs
+++ b/osu.Game/Screens/Play/Break/BreakInfoLine.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Utils;
 
 namespace osu.Game.Screens.Play.Break
 {
@@ -85,6 +86,6 @@ namespace osu.Game.Screens.Play.Break
         {
         }
 
-        protected override string Format(double count) => $@"{count:P2}";
+        protected override string Format(double count) => count.FormatAccuracy();
     }
 }

--- a/osu.Game/Utils/FormatUtils.cs
+++ b/osu.Game/Utils/FormatUtils.cs
@@ -7,18 +7,16 @@ namespace osu.Game.Utils
     {
         /// <summary>
         /// Turns the provided accuracy into a percentage with 2 decimal places.
-        /// Omits all decimal places when <paramref name="accuracy"/> equals 1d.
         /// </summary>
         /// <param name="accuracy">The accuracy to be formatted</param>
         /// <returns>formatted accuracy in percentage</returns>
-        public static string FormatAccuracy(this double accuracy) => accuracy == 1 ? "100%" : $"{accuracy:0.00%}";
+        public static string FormatAccuracy(this double accuracy) => $"{accuracy:0.00%}";
 
         /// <summary>
         /// Turns the provided accuracy into a percentage with 2 decimal places.
-        /// Omits all decimal places when <paramref name="accuracy"/> equals 100m.
         /// </summary>
         /// <param name="accuracy">The accuracy to be formatted</param>
         /// <returns>formatted accuracy in percentage</returns>
-        public static string FormatAccuracy(this decimal accuracy) => accuracy == 100 ? "100%" : $"{accuracy:0.00}%";
+        public static string FormatAccuracy(this decimal accuracy) => $"{accuracy:0.00}%";
     }
 }


### PR DESCRIPTION
Currently, `FormatAccuracy` omits all decimal places if the accuracy equals 100%. This behaviour is consistent with neither osu-web nor osu-stable, as you can see here:

stable:
![image](https://user-images.githubusercontent.com/27722894/74066642-ca6b4980-49f7-11ea-9cb1-bf6fdf8ee214.png)

web:
![image](https://user-images.githubusercontent.com/27722894/74066674-d951fc00-49f7-11ea-9590-4cce81b7ad63.png)

lazer on master:
![image](https://user-images.githubusercontent.com/27722894/74067018-8dec1d80-49f8-11ea-9488-ecbcbdaae95d.png)

Additionally, lazer itself isn't consistent in this matter since the in-game HUD (`PercentageCounter`) doesn't use `FormatAccuracy` and happily displays both decimal places when the accuracy equals 100%:
![image](https://user-images.githubusercontent.com/27722894/74067073-ac521900-49f8-11ea-8fa3-c0a9c7dd959e.png)

As discussed [here](https://github.com/ppy/osu/pull/7730#discussion_r375457851), it doesn't really make sense to go back and forth on the amount of decimal places just because the acc value hits 100, because why `0.00%` (or any other `.00%` value) but not `100.00%`?

This PR aims to make `FormatAccuracy` consistent with what has been the standard formatting in osu! for years, making it match osu-web / osu-stable and be more consistent throughout the whole game.