### PR TITLE
Avoid throwing exceptions on DrawableRuleset load interruption

### DIFF
--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -214,11 +214,14 @@ namespace osu.Game.Rulesets.UI
         {
             foreach (TObject h in Beatmap.HitObjects)
             {
-                cancellationToken?.ThrowIfCancellationRequested();
+                if (cancellationToken?.IsCancellationRequested == true)
+                    return;
+
                 addHitObject(h);
             }
 
-            cancellationToken?.ThrowIfCancellationRequested();
+            if (cancellationToken?.IsCancellationRequested == true)
+                return;
 
             Playfield.PostProcess();
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/7759.