### PR TITLE
Fix BeatSyncContainer failing at song select

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Beatmaps
             switch (lastObject)
             {
                 case null:
-                    length = excess_length;
+                    length = 0;
                     break;
 
                 case IHasEndTime endTime:

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Beatmaps
             BeatmapSetInfo = beatmapInfo.BeatmapSet;
             Metadata = beatmapInfo.Metadata ?? BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
 
-            track = new RecyclableLazy<Track>(() => GetTrack() ?? GetVirtualTrack());
+            track = new RecyclableLazy<Track>(() => GetTrack() ?? GetVirtualTrack(1000));
             background = new RecyclableLazy<Texture>(GetBackground, BackgroundStillValid);
             waveform = new RecyclableLazy<Waveform>(GetWaveform);
             storyboard = new RecyclableLazy<Storyboard>(GetStoryboard);
@@ -48,7 +48,7 @@ namespace osu.Game.Beatmaps
             total_count.Value++;
         }
 
-        protected virtual Track GetVirtualTrack()
+        protected virtual Track GetVirtualTrack(double emptyLength = 0)
         {
             const double excess_length = 1000;
 
@@ -59,7 +59,7 @@ namespace osu.Game.Beatmaps
             switch (lastObject)
             {
                 case null:
-                    length = 0;
+                    length = emptyLength;
                     break;
 
                 case IHasEndTime endTime:

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -59,9 +59,9 @@ namespace osu.Game.Graphics.Containers
             Track track = null;
             IBeatmap beatmap = null;
 
-            double currentTrackTime;
-            TimingControlPoint timingPoint;
-            EffectControlPoint effectPoint;
+            double currentTrackTime = 0;
+            TimingControlPoint timingPoint = null;
+            EffectControlPoint effectPoint = null;
 
             if (Beatmap.Value.TrackLoaded && Beatmap.Value.BeatmapLoaded)
             {
@@ -69,24 +69,18 @@ namespace osu.Game.Graphics.Containers
                 beatmap = Beatmap.Value.Beatmap;
             }
 
-            if (track != null && beatmap != null && track.IsRunning)
+            if (track != null && beatmap != null && track.IsRunning && track.Length > 0)
             {
-                currentTrackTime = track.Length > 0 ? track.CurrentTime + EarlyActivationMilliseconds : Clock.CurrentTime;
+                currentTrackTime = track.CurrentTime + EarlyActivationMilliseconds;
 
                 timingPoint = beatmap.ControlPointInfo.TimingPointAt(currentTrackTime);
                 effectPoint = beatmap.ControlPointInfo.EffectPointAt(currentTrackTime);
-
-                if (timingPoint.BeatLength == 0)
-                {
-                    IsBeatSyncedWithTrack = false;
-                    return;
-                }
-
-                IsBeatSyncedWithTrack = true;
             }
-            else
+
+            IsBeatSyncedWithTrack = timingPoint?.BeatLength > 0;
+
+            if (timingPoint == null || !IsBeatSyncedWithTrack)
             {
-                IsBeatSyncedWithTrack = false;
                 currentTrackTime = Clock.CurrentTime;
                 timingPoint = defaultTiming;
                 effectPoint = defaultEffect;


### PR DESCRIPTION
Due to an unfortunate clash of sane defaults, `BeatSyncContainer` could skip beats while displaying the dummy beatmap at song select. This is due to its default beat length being 1,000ms, which aligns with `DummyWorkingBeatmap`'s virtual track length of 1,000ms. As this is looped at song select, there's a race condition where the BeatSyncContainer would incorrectly fire multiple or no times.

Hard to test this one, so no additional tests are provided.

Closes issue pointed out at https://github.com/ppy/osu/pull/7761#issuecomment-583772201.