### PR TITLE
Add ability to load long comment trees in CommentsContainer (Alternative)

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneCommentsPage.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneCommentsPage.cs
@@ -58,8 +58,8 @@ namespace osu.Game.Tests.Visual.Online
                 }
             });
 
-            AddStep("load comments", () => createPage(comment_bundle));
-            AddStep("load empty comments", () => createPage(empty_comment_bundle));
+            AddStep("load comments", () => createPage(getCommentBundle()));
+            AddStep("load empty comments", () => createPage(getEmptyCommentBundle()));
         }
 
         private void createPage(CommentBundle commentBundle)
@@ -71,13 +71,12 @@ namespace osu.Game.Tests.Visual.Online
             });
         }
 
-        private static readonly CommentBundle empty_comment_bundle = new CommentBundle
+        private CommentBundle getEmptyCommentBundle() => new CommentBundle
         {
             Comments = new List<Comment>(),
-            Total = 0,
         };
 
-        private static readonly CommentBundle comment_bundle = new CommentBundle
+        private CommentBundle getCommentBundle() => new CommentBundle
         {
             Comments = new List<Comment>
             {
@@ -88,6 +87,33 @@ namespace osu.Game.Tests.Visual.Online
                     LegacyName = "TestUser1",
                     CreatedAt = DateTimeOffset.Now,
                     VotesCount = 5
+                },
+                new Comment
+                {
+                    Id = 100,
+                    Message = "This comment has \"load replies\" button because it has unloaded replies",
+                    LegacyName = "TestUser1100",
+                    CreatedAt = DateTimeOffset.Now,
+                    VotesCount = 5,
+                    RepliesCount = 2,
+                },
+                new Comment
+                {
+                    Id = 111,
+                    Message = "This comment has \"Show More\" button because it has unloaded replies, but some of them are loaded",
+                    LegacyName = "TestUser1111",
+                    CreatedAt = DateTimeOffset.Now,
+                    VotesCount = 100,
+                    RepliesCount = 2,
+                },
+                new Comment
+                {
+                    Id = 112,
+                    ParentId = 111,
+                    Message = "I'm here to make my parent work",
+                    LegacyName = "someone",
+                    CreatedAt = DateTimeOffset.Now,
+                    VotesCount = 2,
                 },
                 new Comment
                 {
@@ -155,8 +181,6 @@ namespace osu.Game.Tests.Visual.Online
                     Username = "Good_Admin"
                 }
             },
-            TopLevelCount = 4,
-            Total = 7
         };
     }
 }

--- a/osu.Game/Online/API/Requests/GetCommentRepliesRequest.cs
+++ b/osu.Game/Online/API/Requests/GetCommentRepliesRequest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Humanizer;
+using osu.Framework.IO.Network;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays.Comments;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetCommentRepliesRequest : APIRequest<CommentBundle>
+    {
+        private readonly long commentId;
+        private readonly CommentableType commentableType;
+        private readonly long commentableId;
+        private readonly int page;
+        private readonly CommentsSortCriteria sort;
+
+        public GetCommentRepliesRequest(long commentId, CommentableType commentableType, long commentableId, CommentsSortCriteria sort, int page)
+        {
+            this.commentId = commentId;
+            this.page = page;
+            this.sort = sort;
+
+            // These parameters are necessary to get deleted comments
+            this.commentableType = commentableType;
+            this.commentableId = commentableId;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+
+            req.AddParameter("parent_id", commentId.ToString());
+            req.AddParameter("sort", sort.ToString().ToLowerInvariant());
+            req.AddParameter("commentable_type", commentableType.ToString().Underscore().ToLowerInvariant());
+            req.AddParameter("commentable_id", commentableId.ToString());
+            req.AddParameter("page", page.ToString());
+
+            return req;
+        }
+
+        protected override string Target => "comments";
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/Comment.cs
+++ b/osu.Game/Online/API/Requests/Responses/Comment.cs
@@ -5,7 +5,6 @@ using Newtonsoft.Json;
 using osu.Game.Users;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Online.API.Requests.Responses
 {
@@ -71,7 +70,5 @@ namespace osu.Game.Online.API.Requests.Responses
         public bool HasMessage => !string.IsNullOrEmpty(Message);
 
         public bool IsVoted { get; set; }
-
-        public int DeletedChildrenCount => ChildComments.Count(c => c.IsDeleted);
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/CommentBundle.cs
+++ b/osu.Game/Online/API/Requests/Responses/CommentBundle.cs
@@ -9,31 +9,8 @@ namespace osu.Game.Online.API.Requests.Responses
 {
     public class CommentBundle
     {
-        private List<Comment> comments;
-
         [JsonProperty(@"comments")]
-        public List<Comment> Comments
-        {
-            get => comments;
-            set
-            {
-                comments = value;
-                comments.ForEach(child =>
-                {
-                    if (child.ParentId != null)
-                    {
-                        comments.ForEach(parent =>
-                        {
-                            if (parent.Id == child.ParentId)
-                            {
-                                parent.ChildComments.Add(child);
-                                child.ParentComment = parent;
-                            }
-                        });
-                    }
-                });
-            }
-        }
+        public List<Comment> Comments { get; set; }
 
         [JsonProperty(@"has_more")]
         public bool HasMore { get; set; }

--- a/osu.Game/Overlays/Comments/CommentsContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentsContainer.cs
@@ -18,8 +18,8 @@ namespace osu.Game.Overlays.Comments
 {
     public class CommentsContainer : CompositeDrawable
     {
-        private CommentableType type;
-        private long? id;
+        private readonly Bindable<CommentableType> type = new Bindable<CommentableType>();
+        private readonly BindableLong id = new BindableLong();
 
         public readonly Bindable<CommentsSortCriteria> Sort = new Bindable<CommentsSortCriteria>();
         public readonly BindableBool ShowDeleted = new BindableBool();
@@ -127,8 +127,8 @@ namespace osu.Game.Overlays.Comments
         /// <param name="id">The id of the resource to get comments for.</param>
         public void ShowComments(CommentableType type, long id)
         {
-            this.type = type;
-            this.id = id;
+            this.type.Value = type;
+            this.id.Value = id;
 
             if (!IsLoaded)
                 return;
@@ -147,12 +147,12 @@ namespace osu.Game.Overlays.Comments
 
         private void getComments()
         {
-            if (!id.HasValue)
+            if (id.Value == 0)
                 return;
 
             request?.Cancel();
             loadCancellation?.Cancel();
-            request = new GetCommentsRequest(type, id.Value, Sort.Value, currentPage++);
+            request = new GetCommentsRequest(type.Value, id.Value, Sort.Value, currentPage++);
             request.Success += onSuccess;
             api.PerformAsync(request);
         }
@@ -172,7 +172,10 @@ namespace osu.Game.Overlays.Comments
 
             LoadComponentAsync(new CommentsPage(response)
             {
-                ShowDeleted = { BindTarget = ShowDeleted }
+                ShowDeleted = { BindTarget = ShowDeleted },
+                Sort = { BindTarget = Sort },
+                Type = { BindTarget = type },
+                Id = { BindTarget = id }
             }, loaded =>
             {
                 content.Add(loaded);

--- a/osu.Game/Overlays/Comments/GetCommentRepliesButton.cs
+++ b/osu.Game/Overlays/Comments/GetCommentRepliesButton.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using System.Collections.Generic;
+using osuTK;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Framework.Allocation;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Framework.Bindables;
+using System.Linq;
+
+namespace osu.Game.Overlays.Comments
+{
+    public abstract class GetCommentRepliesButton : LoadingButton
+    {
+        private const int duration = 200;
+
+        public readonly Bindable<CommentsSortCriteria> Sort = new Bindable<CommentsSortCriteria>();
+        public readonly BindableInt CurrentPage = new BindableInt();
+        public readonly BindableList<Comment> LoadedReplies = new BindableList<Comment>();
+
+        protected override IEnumerable<Drawable> EffectTargets => new[] { text };
+
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
+        private readonly Comment comment;
+        private readonly CommentableType type;
+        private readonly long commentableId;
+
+        private OsuSpriteText text;
+        private GetCommentRepliesRequest request;
+
+        protected GetCommentRepliesButton(Comment comment, CommentableType type, long commentableId)
+        {
+            this.comment = comment;
+            this.commentableId = commentableId;
+            this.type = type;
+
+            AutoSizeAxes = Axes.Both;
+            LoadingAnimationSize = new Vector2(8);
+            Action = onAction;
+        }
+
+        protected override Drawable CreateContent() => new Container
+        {
+            AutoSizeAxes = Axes.Both,
+            Child = text = new OsuSpriteText
+            {
+                AlwaysPresent = true,
+                Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
+                Text = GetText()
+            }
+        };
+
+        protected abstract string GetText();
+
+        private void onAction()
+        {
+            CurrentPage.Value++;
+
+            request = new GetCommentRepliesRequest(comment.Id, type, commentableId, Sort.Value, CurrentPage.Value);
+            request.Success += onSuccess;
+            api.PerformAsync(request);
+        }
+
+        private void onSuccess(CommentBundle response)
+        {
+            var receivedComments = response.Comments;
+
+            var uniqueComments = new List<Comment>();
+
+            // We may receive already loaded comments
+            receivedComments.ForEach(c =>
+            {
+                if (LoadedReplies.All(loadedReply => loadedReply.Id != c.Id))
+                    uniqueComments.Add(c);
+            });
+
+            uniqueComments.ForEach(c => c.ParentComment = comment);
+
+            LoadedReplies.AddRange(uniqueComments);
+        }
+
+        protected override void OnLoadStarted() => text.FadeOut(duration, Easing.OutQuint);
+
+        protected override void OnLoadFinished() => text.FadeIn(duration, Easing.OutQuint);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            request?.Cancel();
+        }
+    }
+}

--- a/osu.Game/Overlays/Comments/ShowChildrenButton.cs
+++ b/osu.Game/Overlays/Comments/ShowChildrenButton.cs
@@ -3,8 +3,9 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Framework.Input.Events;
 using osu.Framework.Bindables;
+using osuTK.Graphics;
+using osu.Game.Graphics;
 
 namespace osu.Game.Overlays.Comments
 {
@@ -15,20 +16,18 @@ namespace osu.Game.Overlays.Comments
         protected ShowChildrenButton()
         {
             AutoSizeAxes = Axes.Both;
+            IdleColour = OsuColour.Gray(0.7f);
+            HoverColour = Color4.White;
         }
 
         protected override void LoadComplete()
         {
+            Action = Expanded.Toggle;
+
             Expanded.BindValueChanged(OnExpandedChanged, true);
             base.LoadComplete();
         }
 
         protected abstract void OnExpandedChanged(ValueChangedEvent<bool> expanded);
-
-        protected override bool OnClick(ClickEvent e)
-        {
-            Expanded.Value = !Expanded.Value;
-            return true;
-        }
     }
 }


### PR DESCRIPTION
Alternative to https://github.com/ppy/osu/pull/7775
Both works the same, but in this one `CommentsPage` handle all the logic