### PR TITLE
Fix InfoColumn minWidth implementation

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -131,9 +131,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         new Dimension(GridSizeMode.Absolute, 4),
                         new Dimension(GridSizeMode.AutoSize)
                     },
-                    Content = new Drawable[][]
+                    Content = new[]
                     {
-                        new []
+                        new Drawable[]
                         {
                             text = new OsuSpriteText
                             {
@@ -141,7 +141,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 Text = title.ToUpper()
                             }
                         },
-                        new[]
+                        new Drawable[]
                         {
                             separator = new Box
                             {
@@ -150,7 +150,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 Height = 2
                             }
                         },
-                        new[]
+                        new Drawable[]
                         {
                             content
                         }

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -131,9 +131,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         new Dimension(GridSizeMode.Absolute, 4),
                         new Dimension(GridSizeMode.AutoSize)
                     },
-                    Content = new[]
+                    Content = new Drawable[][]
                     {
-                        new[]
+                        new []
                         {
                             text = new OsuSpriteText
                             {

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -118,26 +118,42 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             {
                 AutoSizeAxes = Axes.Both;
 
-                InternalChild = new FillFlowContainer
+                InternalChild = new GridContainer
                 {
                     AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0, 1),
-                    Children = new[]
+                    ColumnDimensions = new[]
                     {
-                        text = new OsuSpriteText
+                        new Dimension(GridSizeMode.AutoSize, minSize: minWidth ?? 0)
+                    },
+                    RowDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(GridSizeMode.Absolute, 4),
+                        new Dimension(GridSizeMode.AutoSize)
+                    },
+                    Content = new[]
+                    {
+                        new[]
                         {
-                            Font = OsuFont.GetFont(size: 10, weight: FontWeight.Bold),
-                            Text = title.ToUpper()
+                            text = new OsuSpriteText
+                            {
+                                Font = OsuFont.GetFont(size: 10, weight: FontWeight.Bold),
+                                Text = title.ToUpper()
+                            }
                         },
-                        separator = new Box
+                        new[]
                         {
-                            RelativeSizeAxes = minWidth == null ? Axes.X : Axes.None,
-                            Width = minWidth ?? 1f,
-                            Height = 2,
-                            Margin = new MarginPadding { Top = 2 }
+                            separator = new Box
+                            {
+                                Anchor = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.X,
+                                Height = 2
+                            }
                         },
-                        content
+                        new[]
+                        {
+                            content
+                        }
                     }
                 };
             }

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                 Height = 2
                             }
                         },
-                        new Drawable[]
+                        new[]
                         {
                             content
                         }


### PR DESCRIPTION
This fixes the incorrect separator width in InfoColumn.
Before:
![](https://user-images.githubusercontent.com/41869184/74225422-3cd87400-4ced-11ea-9d69-fcddec9b6326.png)
After:
![](https://user-images.githubusercontent.com/41869184/74225573-8b860e00-4ced-11ea-97ab-5482d495f447.png)