### PR TITLE
Add missing null-allowance to leaderboard

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Online.Leaderboards
 
         private List<ScoreComponentLabel> statisticsLabels;
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private DialogOverlay dialogOverlay { get; set; }
 
         public LeaderboardScore(ScoreInfo score, int rank, bool allowHighlight = true)


### PR DESCRIPTION
Already expected to be nullable:

https://github.com/ppy/osu/blob/e022352812371f6ce57cbbbbf0bc7b5ade7b856e/osu.Game/Online/Leaderboards/LeaderboardScore.cs#L377

