### PR TITLE
Fix osu! gameplay cursor not adjusting to mod/convert circle size changes

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -7,7 +7,9 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing.Input;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu.UI.Cursor;
+using osu.Game.Screens.Play;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
@@ -21,12 +23,50 @@ namespace osu.Game.Rulesets.Osu.Tests
             typeof(CursorTrail)
         };
 
-        [BackgroundDependencyLoader]
-        private void load()
+        [Cached]
+        private GameplayBeatmap gameplayBeatmap;
+
+        private ClickingCursorContainer lastContainer;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
+        public TestSceneGameplayCursor()
+        {
+            gameplayBeatmap = new GameplayBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
+        }
+
+        [TestCase(1, 1)]
+        [TestCase(5, 1)]
+        [TestCase(10, 1)]
+        [TestCase(1, 1.5f)]
+        [TestCase(5, 1.5f)]
+        [TestCase(10, 1.5f)]
+        public void TestSizing(int circleSize, float userScale)
+        {
+            AddStep($"set user scale to {userScale}", () => config.Set(OsuSetting.GameplayCursorSize, userScale));
+            AddStep($"adjust cs to {circleSize}", () => gameplayBeatmap.BeatmapInfo.BaseDifficulty.CircleSize = circleSize);
+            AddStep("turn on autosizing", () => config.Set(OsuSetting.AutoCursorSize, true));
+
+            AddStep("load content", loadContent);
+
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == OsuCursorContainer.GetScaleForCircleSize(circleSize) * userScale);
+
+            AddStep("set user scale to 1", () => config.Set(OsuSetting.GameplayCursorSize, 1f));
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == OsuCursorContainer.GetScaleForCircleSize(circleSize));
+
+            AddStep("turn off autosizing", () => config.Set(OsuSetting.AutoCursorSize, false));
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == 1);
+
+            AddStep($"set user scale to {userScale}", () => config.Set(OsuSetting.GameplayCursorSize, userScale));
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == userScale);
+        }
+
+        private void loadContent()
         {
             SetContents(() => new MovingCursorInputManager
             {
-                Child = new ClickingCursorContainer
+                Child = lastContainer = new ClickingCursorContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Masking = true,

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -30,7 +30,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private readonly Drawable cursorTrail;
 
-        public Bindable<float> CursorScale;
+        public Bindable<float> CursorScale = new BindableFloat(1);
+
         private Bindable<float> userCursorScale;
         private Bindable<bool> autoCursorScale;
 
@@ -57,6 +58,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         protected override void LoadComplete()
         {
+            base.LoadComplete();
+
             showTrail.BindValueChanged(v => cursorTrail.FadeTo(v.NewValue ? 1 : 0, 200), true);
 
             userCursorScale = config.GetBindable<float>(OsuSetting.GameplayCursorSize);
@@ -65,7 +68,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             autoCursorScale = config.GetBindable<bool>(OsuSetting.AutoCursorSize);
             autoCursorScale.ValueChanged += _ => calculateScale();
 
-            CursorScale = new BindableFloat();
             CursorScale.ValueChanged += e =>
             {
                 var newScale = new Vector2(e.NewValue);
@@ -75,8 +77,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             };
 
             calculateScale();
-
-            base.LoadComplete();
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/GameplayBeatmap.cs
+++ b/osu.Game/Screens/Play/GameplayBeatmap.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Screens.Play
+{
+    public class GameplayBeatmap : Component, IBeatmap
+    {
+        public readonly IBeatmap PlayableBeatmap;
+
+        public GameplayBeatmap(IBeatmap playableBeatmap)
+        {
+            PlayableBeatmap = playableBeatmap;
+        }
+
+        public BeatmapInfo BeatmapInfo
+        {
+            get => PlayableBeatmap.BeatmapInfo;
+            set => PlayableBeatmap.BeatmapInfo = value;
+        }
+
+        public BeatmapMetadata Metadata => PlayableBeatmap.Metadata;
+
+        public ControlPointInfo ControlPointInfo => PlayableBeatmap.ControlPointInfo;
+
+        public List<BreakPeriod> Breaks => PlayableBeatmap.Breaks;
+
+        public double TotalBreakTime => PlayableBeatmap.TotalBreakTime;
+
+        public IReadOnlyList<HitObject> HitObjects => PlayableBeatmap.HitObjects;
+
+        public IEnumerable<BeatmapStatistic> GetStatistics() => PlayableBeatmap.GetStatistics();
+
+        public IBeatmap Clone() => PlayableBeatmap.Clone();
+    }
+}

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -110,6 +110,13 @@ namespace osu.Game.Screens.Play
             this.showResults = showResults;
         }
 
+        private GameplayBeatmap gameplayBeatmap;
+
+        private DependencyContainer dependencies;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+            => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, IAPIProvider api, OsuConfigManager config)
         {
@@ -142,6 +149,10 @@ namespace osu.Game.Screens.Play
                 config.BindWith(OsuSetting.ScoreDisplayMode, ScoreProcessor.Mode);
 
             InternalChild = GameplayClockContainer = new GameplayClockContainer(Beatmap.Value, Mods.Value, DrawableRuleset.GameplayStartTime);
+
+            AddInternal(gameplayBeatmap = new GameplayBeatmap(playableBeatmap));
+
+            dependencies.CacheAs(gameplayBeatmap);
 
             addUnderlayComponents(GameplayClockContainer);
             addGameplayComponents(GameplayClockContainer, Beatmap.Value);


### PR DESCRIPTION
- Moves bindings out of BDL for safety
- Fixes potential race condition between `PopIn`/`PopOut` transform and scale change (if the `CursorScale` was changed during an existing fade it would be lost; now `CursorScale` application also uses a transform to avoid this).
- Adds test coverage
- Closes https://github.com/ppy/osu/issues/6342