### PR TITLE
Fix player loading sequence continuing even when a priority overlay is visible

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -194,13 +194,22 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestMutedNotificationMasterVolume() => addVolumeSteps("master volume", () => audioManager.Volume.Value = 0, null, () => audioManager.Volume.IsDefault);
+        public void TestMutedNotificationMasterVolume()
+        {
+            addVolumeSteps("master volume", () => audioManager.Volume.Value = 0, null, () => audioManager.Volume.IsDefault);
+        }
 
         [Test]
-        public void TestMutedNotificationTrackVolume() => addVolumeSteps("music volume", () => audioManager.VolumeTrack.Value = 0, null, () => audioManager.VolumeTrack.IsDefault);
+        public void TestMutedNotificationTrackVolume()
+        {
+            addVolumeSteps("music volume", () => audioManager.VolumeTrack.Value = 0, null, () => audioManager.VolumeTrack.IsDefault);
+        }
 
         [Test]
-        public void TestMutedNotificationMuteButton() => addVolumeSteps("mute button", null, () => container.VolumeOverlay.IsMuted.Value = true, () => !container.VolumeOverlay.IsMuted.Value);
+        public void TestMutedNotificationMuteButton()
+        {
+            addVolumeSteps("mute button", null, () => container.VolumeOverlay.IsMuted.Value = true, () => !container.VolumeOverlay.IsMuted.Value);
+        }
 
         /// <remarks>
         /// Created for avoiding copy pasting code for the same steps.
@@ -214,7 +223,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("reset notification lock", () => sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).Value = false);
 
             AddStep("load player", () => ResetPlayer(false, beforeLoad, afterLoad));
-            AddUntilStep("wait for player", () => player.IsLoaded);
+            AddUntilStep("wait for player", () => player.LoadState == LoadState.Ready);
 
             AddAssert("check for notification", () => container.NotificationOverlay.UnreadCount.Value == 1);
             AddStep("click notification", () =>
@@ -228,6 +237,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddAssert("check " + volumeName, assert);
+
+            AddUntilStep("wait for player load", () => player.IsLoaded);
         }
 
         private class TestPlayerLoaderContainer : Container

--- a/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
+++ b/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
@@ -117,6 +117,8 @@ namespace osu.Game.Tests.Visual.Navigation
             {
                 base.LoadComplete();
                 API.Login("Rhythm Champion", "osu!");
+
+                Dependencies.Get<SessionStatics>().Set(Static.MutedAudioNotificationShownOnce, true);
             }
         }
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -67,7 +67,14 @@ namespace osu.Game.Screens.Play
         }
 
         private bool readyForPush =>
-            player.LoadState == LoadState.Ready && (IsHovered || idleTracker.IsIdle.Value) && inputManager?.DraggedDrawable == null;
+            // don't push unless the player is completely loaded
+            player.LoadState == LoadState.Ready
+            // don't push if the user is hovering one of the panes, unless they are idle.
+            && (IsHovered || idleTracker.IsIdle.Value)
+            // don't push if the user is dragging a slider or otherwise.
+            && inputManager?.DraggedDrawable == null
+            // don't push if a focused overlay is visible, like settings.
+            && inputManager?.FocusedDrawable == null;
 
         private readonly Func<Player> createPlayer;
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/7835
- Fixes potential false-negative in existing test (was not waiting for player ready state)

---

Previously, if you had settings open while at the loading screen the game would rudely kick you straight into gameplay.