### PR TITLE
Fix DownloadTrackingComposite incorrectly receiving cancelled state

### DIFF
--- a/osu.Game/Database/DownloadableArchiveModelManager.cs
+++ b/osu.Game/Database/DownloadableArchiveModelManager.cs
@@ -105,9 +105,10 @@ namespace osu.Game.Database
 
             void triggerFailure(Exception error)
             {
+                currentDownloads.Remove(request);
+
                 DownloadFailed?.Invoke(request);
 
-                currentDownloads.Remove(request);
                 notification.State = ProgressNotificationState.Cancelled;
 
                 if (!(error is OperationCanceledException))


### PR DESCRIPTION
Fixes buttons getting stuck in downloading state due to incorrect event firing order (as pictured below)

![image](https://user-images.githubusercontent.com/191335/74583882-5b9d7a00-500f-11ea-82ab-3432f953230e.gif)
