### PR TITLE
Replace hashcode override with local equality comparer

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -179,6 +179,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("item 0 is selected", () => playlist.SelectedItem.Value == playlist.Items[0]);
         }
 
+        [Test]
+        public void TestChangeBeatmapAndRemove()
+        {
+            createPlaylist(true, true);
+
+            AddStep("change beatmap of first item", () => playlist.Items[0].BeatmapID = 30);
+            moveToDeleteButton(0);
+            AddStep("click delete button", () => InputManager.Click(MouseButton.Left));
+        }
+
         private void moveToItem(int index, Vector2? offset = null)
             => AddStep($"move mouse to item {index}", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<OsuRearrangeableListItem<PlaylistItem>>().ElementAt(index), offset));
 

--- a/osu.Game/Online/Multiplayer/PlaylistItem.cs
+++ b/osu.Game/Online/Multiplayer/PlaylistItem.cs
@@ -93,12 +93,5 @@ namespace osu.Game.Online.Multiplayer
         public bool ShouldSerializeapiBeatmap() => false;
 
         public bool Equals(PlaylistItem other) => ID == other?.ID && BeatmapID == other.BeatmapID && RulesetID == other.RulesetID;
-
-        public override int GetHashCode()
-        {
-            // ReSharper disable NonReadonlyMemberInGetHashCode
-            return HashCode.Combine(ID, BeatmapID, RulesetID);
-            // ReSharper restore NonReadonlyMemberInGetHashCode
-        }
     }
 }

--- a/osu.Game/Online/Multiplayer/Room.cs
+++ b/osu.Game/Online/Multiplayer/Room.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
@@ -128,14 +127,17 @@ namespace osu.Game.Online.Multiplayer
                     item.Beatmap.Value.Metadata = localItem.Beatmap.Value.Metadata;
             }
 
-            foreach (var removeableItem in Playlist.Except(other.Playlist, new PlaylistEqualityComparer()).ToArray())
-                Playlist.Remove(removeableItem);
+            if (!Playlist.SequenceEqual(other.Playlist))
+            {
+                Playlist.Clear();
+                Playlist.AddRange(other.Playlist);
+            }
 
-            Playlist.AddRange(other.Playlist.Except(Playlist, new PlaylistEqualityComparer()).ToArray());
-
-            foreach (var removedItem in Participants.Except(other.Participants).ToArray())
-                Participants.Remove(removedItem);
-            Participants.AddRange(other.Participants.Except(Participants).ToArray());
+            if (!Participants.SequenceEqual(other.Participants))
+            {
+                Participants.Clear();
+                Participants.AddRange(other.Participants);
+            }
 
             Position = other.Position;
         }
@@ -143,12 +145,5 @@ namespace osu.Game.Online.Multiplayer
         public bool ShouldSerializeRoomID() => false;
         public bool ShouldSerializeHost() => false;
         public bool ShouldSerializeEndDate() => false;
-
-        private class PlaylistEqualityComparer : IEqualityComparer<PlaylistItem>
-        {
-            public bool Equals(PlaylistItem x, PlaylistItem y) => x?.Equals(y) ?? false;
-
-            public int GetHashCode(PlaylistItem obj) => HashCode.Combine(obj.ID, obj.BeatmapID, obj.RulesetID);
-        }
     }
 }

--- a/osu.Game/Online/Multiplayer/Room.cs
+++ b/osu.Game/Online/Multiplayer/Room.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
@@ -124,15 +125,13 @@ namespace osu.Game.Online.Multiplayer
                 var localItem = Playlist.FirstOrDefault(i => i.BeatmapID == item.BeatmapID);
 
                 if (localItem != null)
-                {
                     item.Beatmap.Value.Metadata = localItem.Beatmap.Value.Metadata;
-                }
             }
 
-            foreach (var removeableItem in Playlist.Except(other.Playlist).ToArray())
+            foreach (var removeableItem in Playlist.Except(other.Playlist, new PlaylistEqualityComparer()).ToArray())
                 Playlist.Remove(removeableItem);
 
-            Playlist.AddRange(other.Playlist.Except(Playlist).ToArray());
+            Playlist.AddRange(other.Playlist.Except(Playlist, new PlaylistEqualityComparer()).ToArray());
 
             foreach (var removedItem in Participants.Except(other.Participants).ToArray())
                 Participants.Remove(removedItem);
@@ -144,5 +143,12 @@ namespace osu.Game.Online.Multiplayer
         public bool ShouldSerializeRoomID() => false;
         public bool ShouldSerializeHost() => false;
         public bool ShouldSerializeEndDate() => false;
+
+        private class PlaylistEqualityComparer : IEqualityComparer<PlaylistItem>
+        {
+            public bool Equals(PlaylistItem x, PlaylistItem y) => x?.Equals(y) ?? false;
+
+            public int GetHashCode(PlaylistItem obj) => HashCode.Combine(obj.ID, obj.BeatmapID, obj.RulesetID);
+        }
     }
 }


### PR DESCRIPTION
The hashcode override was only used in the de-duping process, but it causes issues with rearrangeable beatmap list.

This is probably why c# requires hashcode fields to be readonly :p