### PR TITLE
Display a login placeholder in direct when user isn't logged in

### DIFF
--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Overlays
 
         protected override SearchableListHeader<DirectTab> CreateHeader() => new Header();
         protected override SearchableListFilterControl<DirectSortCriteria, BeatmapSearchCategory> CreateFilterControl() => new FilterControl();
+
         protected override string LoginPlaceholder => @"Please sign in to browse direct!";
 
         private IEnumerable<BeatmapSetInfo> beatmapSets;

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Overlays
 
         protected override SearchableListHeader<DirectTab> CreateHeader() => new Header();
         protected override SearchableListFilterControl<DirectSortCriteria, BeatmapSearchCategory> CreateFilterControl() => new FilterControl();
+        protected override string LoginPlaceholder => @"Please sign in to browse direct!";
 
         private IEnumerable<BeatmapSetInfo> beatmapSets;
 

--- a/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
+++ b/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Overlays.SearchableList
         public readonly SlimEnumDropdown<T> Dropdown;
         public readonly Bindable<PanelDisplayStyle> DisplayStyle = new Bindable<PanelDisplayStyle>();
 
+        public override bool HandleNonPositionalInput => !DisplayStyle.Disabled;
+
         public DisplayStyleControl()
         {
             AutoSizeAxes = Axes.Both;
@@ -53,6 +55,13 @@ namespace osu.Game.Overlays.SearchableList
             };
 
             DisplayStyle.Value = PanelDisplayStyle.Grid;
+            DisplayStyle.DisabledChanged += disabled =>
+            {
+                if (disabled)
+                    Dropdown.Current.Disabled = true;
+                else
+                    Dropdown.Current.Disabled = false;
+            };
         }
 
         private class DisplayStyleToggleButton : OsuClickableContainer
@@ -81,7 +90,12 @@ namespace osu.Game.Overlays.SearchableList
 
                 bindable.ValueChanged += Bindable_ValueChanged;
                 Bindable_ValueChanged(new ValueChangedEvent<PanelDisplayStyle>(bindable.Value, bindable.Value));
-                Action = () => bindable.Value = this.style;
+                Action = () =>
+                {
+                    if (bindable.Disabled) return;
+
+                    bindable.Value = this.style;
+                };
             }
 
             private void Bindable_ValueChanged(ValueChangedEvent<PanelDisplayStyle> e)

--- a/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
+++ b/osu.Game/Overlays/SearchableList/DisplayStyleControl.cs
@@ -55,13 +55,7 @@ namespace osu.Game.Overlays.SearchableList
             };
 
             DisplayStyle.Value = PanelDisplayStyle.Grid;
-            DisplayStyle.DisabledChanged += disabled =>
-            {
-                if (disabled)
-                    Dropdown.Current.Disabled = true;
-                else
-                    Dropdown.Current.Disabled = false;
-            };
+            DisplayStyle.DisabledChanged += disabled => Dropdown.Current.Disabled = disabled;
         }
 
         private class DisplayStyleToggleButton : OsuClickableContainer

--- a/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListFilterControl.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Overlays.SearchableList
 {
@@ -21,6 +22,8 @@ namespace osu.Game.Overlays.SearchableList
 
         private readonly Container filterContainer;
         private readonly Box tabStrip;
+
+        public readonly Bindable<bool> Disabled = new Bindable<bool>();
 
         public readonly SearchTextBox Search;
         public readonly PageTabControl<TTab> Tabs;
@@ -115,6 +118,22 @@ namespace osu.Game.Overlays.SearchableList
 
             Tabs.Current.Value = DefaultTab;
             Tabs.Current.TriggerChange();
+
+            Disabled.ValueChanged += disabled =>
+            {
+                if (disabled.NewValue)
+                {
+                    Tabs.Current.Disabled = true;
+                    DisplayStyleControl.DisplayStyle.Disabled = true;
+                    Search.Current.Disabled = true;
+                }
+                else
+                {
+                    Tabs.Current.Disabled = false;
+                    DisplayStyleControl.DisplayStyle.Disabled = false;
+                    Search.Current.Disabled = false;
+                }
+            };
 
             DisplayStyleControl.Dropdown.Current.Value = DefaultCategory;
             DisplayStyleControl.Dropdown.Current.TriggerChange();

--- a/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
@@ -72,13 +72,7 @@ namespace osu.Game.Overlays.SearchableList
                 },
             };
 
-            Disabled.ValueChanged += disabled =>
-            {
-                if (disabled.NewValue)
-                    Tabs.Current.Disabled = true;
-                else
-                    Tabs.Current.Disabled = false;
-            };
+            Disabled.ValueChanged += disabled => Tabs.Current.Disabled = disabled.NewValue;
 
             Tabs.Current.Value = DefaultTab;
             Tabs.Current.TriggerChange();

--- a/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Overlays.SearchableList
 {
@@ -17,6 +18,8 @@ namespace osu.Game.Overlays.SearchableList
         where T : struct, Enum
     {
         public readonly HeaderTabControl<T> Tabs;
+
+        public readonly Bindable<bool> Disabled = new Bindable<bool>();
 
         protected abstract Color4 BackgroundColour { get; }
         protected abstract T DefaultTab { get; }
@@ -67,6 +70,14 @@ namespace osu.Game.Overlays.SearchableList
                         },
                     },
                 },
+            };
+
+            Disabled.ValueChanged += disabled =>
+            {
+                if (disabled.NewValue)
+                    Tabs.Current.Disabled = true;
+                else
+                    Tabs.Current.Disabled = false;
             };
 
             Tabs.Current.Value = DefaultTab;

--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
+using osu.Game.Online;
 
 namespace osu.Game.Overlays.SearchableList
 {
@@ -34,16 +35,20 @@ namespace osu.Game.Overlays.SearchableList
         protected readonly SearchableListFilterControl<TTab, TCategory> Filter;
         protected readonly FillFlowContainer ScrollFlow;
 
+        protected override Container<Drawable> Content => scrollContainer;
+
         protected abstract Color4 BackgroundColour { get; }
         protected abstract Color4 TrianglesColourLight { get; }
         protected abstract Color4 TrianglesColourDark { get; }
         protected abstract SearchableListHeader<THeader> CreateHeader();
         protected abstract SearchableListFilterControl<TTab, TCategory> CreateFilterControl();
 
+        protected abstract string LoginPlaceholder { get; }
+
         protected SearchableListOverlay(OverlayColourScheme colourScheme)
             : base(colourScheme)
         {
-            Children = new Drawable[]
+            base.Content.Children = new Drawable[]
             {
                 new Box
                 {
@@ -65,7 +70,7 @@ namespace osu.Game.Overlays.SearchableList
                         },
                     },
                 },
-                scrollContainer = new Container
+                scrollContainer = new PanelContainer(LoginPlaceholder)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Child = new OsuContextMenuContainer
@@ -124,6 +129,14 @@ namespace osu.Game.Overlays.SearchableList
             base.PopOut();
 
             Filter.Search.HoldFocus = false;
+        }
+
+        private class PanelContainer : OnlineViewContainer
+        {
+            public PanelContainer(string placeholderMessage)
+                : base(placeholderMessage)
+            {
+            }
         }
     }
 }

--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -11,6 +11,8 @@ using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online;
+using osu.Framework.Bindables;
+using osu.Game.Online.API;
 
 namespace osu.Game.Overlays.SearchableList
 {
@@ -30,6 +32,7 @@ namespace osu.Game.Overlays.SearchableList
         where TCategory : struct, Enum
     {
         private readonly Container scrollContainer;
+        private readonly Bindable<bool> disabled = new Bindable<bool>();
 
         protected readonly SearchableListHeader<THeader> Header;
         protected readonly SearchableListFilterControl<TTab, TCategory> Filter;
@@ -103,6 +106,26 @@ namespace osu.Game.Overlays.SearchableList
                     },
                 },
             };
+
+            Header.Disabled.BindTo(disabled);
+            Filter.Disabled.BindTo(disabled);
+        }
+
+        public override void APIStateChanged(IAPIProvider api, APIState state)
+        {
+            switch (state)
+            {
+                case APIState.Offline:
+                case APIState.Failing:
+                case APIState.Connecting:
+                    disabled.Value = true;
+                    break;
+
+                case APIState.Online:
+                    disabled.Value = false;
+                    break;
+            }
+            base.APIStateChanged(api, state);   
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -125,7 +125,8 @@ namespace osu.Game.Overlays.SearchableList
                     disabled.Value = false;
                     break;
             }
-            base.APIStateChanged(api, state);   
+
+            base.APIStateChanged(api, state);
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/SocialOverlay.cs
+++ b/osu.Game/Overlays/SocialOverlay.cs
@@ -238,6 +238,7 @@ namespace osu.Game.Overlays
                     clearPanels();
                     break;
             }
+            base.APIStateChanged(api, state);
         }
     }
 

--- a/osu.Game/Overlays/SocialOverlay.cs
+++ b/osu.Game/Overlays/SocialOverlay.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Overlays
 
         protected override SearchableListHeader<SocialTab> CreateHeader() => new Header();
         protected override SearchableListFilterControl<SocialSortCriteria, SortDirection> CreateFilterControl() => new FilterControl();
+
         protected override string LoginPlaceholder => @"Please sign in to browse social!";
 
         private User[] users = Array.Empty<User>();

--- a/osu.Game/Overlays/SocialOverlay.cs
+++ b/osu.Game/Overlays/SocialOverlay.cs
@@ -238,6 +238,7 @@ namespace osu.Game.Overlays
                     clearPanels();
                     break;
             }
+
             base.APIStateChanged(api, state);
         }
     }

--- a/osu.Game/Overlays/SocialOverlay.cs
+++ b/osu.Game/Overlays/SocialOverlay.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Overlays
 
         protected override SearchableListHeader<SocialTab> CreateHeader() => new Header();
         protected override SearchableListFilterControl<SocialSortCriteria, SortDirection> CreateFilterControl() => new FilterControl();
+        protected override string LoginPlaceholder => @"Please sign in to browse social!";
 
         private User[] users = Array.Empty<User>();
 


### PR DESCRIPTION
# Summary

- Fixes #4550

- This PR adds a login placeholder to the osu!direct overlay through the use of an OnlineViewContainer.
Since the direct overlay inherits `SearchableListOverlay` and only online overlays derive from this class, I chose to implement it in `SearchableListOverlay` as it allows every overlay inheriting from this class to inherit the functionality (social overlay now benefits of this)

- The displayed placeholder message can be customized through the abstract `SearchableListOverlay.LoginPlaceholder` property.

- The `SearchableListOverlay` filter controls are now disabled when the user is offline.

## Todo
- [x] Make use of `OnlineViewContainer` in `SearchableListOverlay`
- [x] Disable filter input when offline


## Visual Demo

[Avalaible here](https://streamable.com/ytcej)