### PR TITLE
Update framework

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -54,6 +54,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1230.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.213.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.216.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1230.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.213.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.216.0" />
     <PackageReference Include="Sentry" Version="2.0.2" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Game.Resources" Version="2019.1230.0" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.213.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.216.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">
@@ -82,7 +82,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.213.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.216.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
Previous update didn't correctly include NativeLibs, meaning old windows bass libs and un-notarizable macOS libs.