### PR TITLE
Fix possible error in SpotlightsLayout after it's disposal

### DIFF
--- a/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays.Rankings
         private void getSpotlights()
         {
             spotlightsRequest = new GetSpotlightsRequest();
-            spotlightsRequest.Success += response => selector.Spotlights = response.Spotlights;
+            spotlightsRequest.Success += response => Schedule(() => selector.Spotlights = response.Spotlights);
             api.Queue(spotlightsRequest);
         }
 
@@ -151,11 +151,11 @@ namespace osu.Game.Overlays.Rankings
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
-
             spotlightsRequest?.Cancel();
             getRankingsRequest?.Cancel();
             cancellationToken?.Cancel();
+
+            base.Dispose(isDisposing);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/7823
As being discussed [here](https://github.com/ppy/osu/issues/7823#issuecomment-586205433), scheduling the callback may fix the issue, so that's what I did.