### PR TITLE
Highlight max combo on beatmap leaderboards

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Beatmaps
         [NotMapped]
         public BeatmapOnlineInfo OnlineInfo { get; set; }
 
+        [NotMapped]
+        public int? MaxCombo { get; set; }
+
         /// <summary>
         /// The playable length in milliseconds of this beatmap.
         /// </summary>

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -61,6 +61,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"failtimes")]
         private BeatmapMetrics metrics { get; set; }
 
+        [JsonProperty(@"max_combo")]
+        private int? maxCombo { get; set; }
+
         public BeatmapInfo ToBeatmap(RulesetStore rulesets)
         {
             var set = BeatmapSet?.ToBeatmapSet(rulesets);
@@ -76,6 +79,7 @@ namespace osu.Game.Online.API.Requests.Responses
                 Status = Status,
                 BeatmapSet = set,
                 Metrics = metrics,
+                MaxCombo = maxCombo,
                 BaseDifficulty = new BeatmapDifficulty
                 {
                     DrainRate = drainRate,

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -146,7 +146,8 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 new OsuSpriteText
                 {
                     Text = $@"{score.MaxCombo:N0}x",
-                    Font = OsuFont.GetFont(size: text_size)
+                    Font = OsuFont.GetFont(size: text_size),
+                    Colour = score.MaxCombo == score.Beatmap.MaxCombo ? highAccuracyColour : Color4.White
                 }
             });
 

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 {
                     Text = $@"{score.MaxCombo:N0}x",
                     Font = OsuFont.GetFont(size: text_size),
-                    Colour = score.MaxCombo == score.Beatmap.MaxCombo ? highAccuracyColour : Color4.White
+                    Colour = score.MaxCombo == score.Beatmap?.MaxCombo ? highAccuracyColour : Color4.White
                 }
             });
 


### PR DESCRIPTION
Fixes #7862 

Made `MaxCombo` nullable because there were situations where `max_combo` returned from the server was null and caused the beatmap overlay to load infinitely.

![dotnet_2020-02-19_17-53-26](https://user-images.githubusercontent.com/27722894/74856463-70954880-5342-11ea-8678-17d87fbe30da.png)

