### PR TITLE
Fix regressed direct panel test scene

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Direct;
 using osu.Game.Rulesets;
@@ -14,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    public class TestSceneDirectPanel : OsuTestScene
+    public class TestSceneDirectPanel : OsuTestScene, IPreviewTrackOwner
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
@@ -22,6 +23,13 @@ namespace osu.Game.Tests.Visual.Online
             typeof(DirectListPanel),
             typeof(IconPill)
         };
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+            dependencies.CacheAs<IPreviewTrackOwner>(this);
+            return dependencies;
+        }
 
         private BeatmapSetInfo getUndownloadableBeatmapSet() => new BeatmapSetInfo
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
@@ -15,6 +15,7 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Online
 {
+    [Cached(typeof(IPreviewTrackOwner))]
     public class TestSceneDirectPanel : OsuTestScene, IPreviewTrackOwner
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
@@ -23,13 +24,6 @@ namespace osu.Game.Tests.Visual.Online
             typeof(DirectListPanel),
             typeof(IconPill)
         };
-
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-        {
-            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-            dependencies.CacheAs<IPreviewTrackOwner>(this);
-            return dependencies;
-        }
 
         private BeatmapSetInfo getUndownloadableBeatmapSet() => new BeatmapSetInfo
         {


### PR DESCRIPTION
# Summary

Due to unnoticed past changes `TestSceneDirectPanel` has regressed in that clicking the preview track button would cause a crash due to an unregistered `IPreviewTrackOwner` dependency.

Make the test scene itself implement that empty interface and cache itself as `IPreviewTrackOwner` so that preview tracks lower down can resolve the dependency.

# Remarks

As the test is purely visual and has no assertions, and the important logic in that area (preview track playing logic) is already well-covered enough elsewhere, no further changes were made.