### PR TITLE
Reduce hit error display performance overhead

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -9,6 +9,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Framework.Utils;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Threading;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Catch.Scoring;
 using osu.Game.Rulesets.Mania.Scoring;
@@ -43,6 +44,22 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddRepeatStep("New max negative", () => newJudgement(-hitWindows.WindowFor(HitResult.Meh)), 20);
             AddRepeatStep("New max positive", () => newJudgement(hitWindows.WindowFor(HitResult.Meh)), 20);
             AddStep("New fixed judgement (50ms)", () => newJudgement(50));
+
+            AddStep("Judgement barrage", () =>
+            {
+                int runCount = 0;
+
+                ScheduledDelegate del = null;
+
+                del = Scheduler.AddDelayed(() =>
+                {
+                    newJudgement(runCount++ / 10f);
+
+                    if (runCount == 500)
+                        // ReSharper disable once AccessToModifiedClosure
+                        del?.Cancel();
+                }, 10, true);
+            });
         }
 
         [Test]

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -215,7 +215,17 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 return;
 
             if (judgementsContainer.Count >= max_concurrent_judgements)
-                judgementsContainer.FirstOrDefault(j => j.LifetimeEnd > Clock.CurrentTime + 100)?.FadeOut(100).Expire();
+            {
+                const double quick_fade_time = 100;
+
+                var old = judgementsContainer.FirstOrDefault(j => j.LifetimeEnd > Clock.CurrentTime + quick_fade_time);
+
+                if (old != null)
+                {
+                    old.ClearTransforms();
+                    old.FadeOut(quick_fade_time).Expire();
+                }
+            }
 
             judgementsContainer.Add(new JudgementLine
             {

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -207,10 +207,15 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         private double floatingAverage;
         private Container colourBars;
 
+        private const int max_concurrent_judgements = 50;
+
         public override void OnNewJudgement(JudgementResult judgement)
         {
             if (!judgement.IsHit)
                 return;
+
+            if (judgementsContainer.Count >= max_concurrent_judgements)
+                judgementsContainer.FirstOrDefault(j => j.LifetimeEnd > Clock.CurrentTime + 100)?.FadeOut(100).Expire();
 
             judgementsContainer.Add(new JudgementLine
             {

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -228,7 +228,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
         private class JudgementLine : CompositeDrawable
         {
-            private const int judgement_fade_duration = 10000;
+            private const int judgement_fade_duration = 5000;
 
             public JudgementLine()
             {
@@ -255,7 +255,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 Width = 0;
 
                 this.ResizeWidthTo(1, 200, Easing.OutElasticHalf);
-                this.FadeTo(0.8f, 150).Then().FadeOut(judgement_fade_duration, Easing.OutQuint).Expire();
+                this.FadeTo(0.8f, 150).Then().FadeOut(judgement_fade_duration).Expire();
             }
         }
     }

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -214,11 +214,12 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             if (!judgement.IsHit)
                 return;
 
-            if (judgementsContainer.Count >= max_concurrent_judgements)
+            if (judgementsContainer.Count > max_concurrent_judgements)
             {
                 const double quick_fade_time = 100;
 
-                var old = judgementsContainer.FirstOrDefault(j => j.LifetimeEnd > Clock.CurrentTime + quick_fade_time);
+                // check with a bit of lenience to avoid precision error in comparison.
+                var old = judgementsContainer.FirstOrDefault(j => j.LifetimeEnd > Clock.CurrentTime + quick_fade_time * 1.1);
 
                 if (old != null)
                 {


### PR DESCRIPTION
Due to the number of lines (and an unnecessarily long transform time) the hit error display could end up using quite a bit of CPU time. This is especially noticeable when fast-forwarding a replay, as they run in game time while the replay is running many times faster than real-time.

![image](https://user-images.githubusercontent.com/191335/75097659-a3646880-55f0-11ea-8060-bb6ff6b4b6dd.png)
