### PR TITLE
Fix potential crash when clicking on show more button in comments

### DIFF
--- a/osu.Game/Overlays/Comments/CommentsPage.cs
+++ b/osu.Game/Overlays/Comments/CommentsPage.cs
@@ -61,15 +61,15 @@ namespace osu.Game.Overlays.Comments
                 return;
             }
 
-            appendComments(commentBundle);
+            AppendComments(commentBundle);
         }
 
         private DrawableComment getDrawableComment(Comment comment)
         {
-            if (commentDictionary.TryGetValue(comment.Id, out var existing))
+            if (CommentDictionary.TryGetValue(comment.Id, out var existing))
                 return existing;
 
-            return commentDictionary[comment.Id] = new DrawableComment(comment)
+            return CommentDictionary[comment.Id] = new DrawableComment(comment)
             {
                 ShowDeleted = { BindTarget = ShowDeleted },
                 Sort = { BindTarget = Sort },
@@ -81,25 +81,25 @@ namespace osu.Game.Overlays.Comments
         {
             var request = new GetCommentsRequest(CommentableId.Value, Type.Value, Sort.Value, page, drawableComment.Comment.Id);
 
-            request.Success += response => Schedule(() => appendComments(response));
+            request.Success += response => Schedule(() => AppendComments(response));
 
             api.PerformAsync(request);
         }
 
-        private readonly Dictionary<long, DrawableComment> commentDictionary = new Dictionary<long, DrawableComment>();
+        protected readonly Dictionary<long, DrawableComment> CommentDictionary = new Dictionary<long, DrawableComment>();
 
         /// <summary>
         /// Appends retrieved comments to the subtree rooted of comments in this page.
         /// </summary>
         /// <param name="bundle">The bundle of comments to add.</param>
-        private void appendComments([NotNull] CommentBundle bundle)
+        protected void AppendComments([NotNull] CommentBundle bundle)
         {
             var orphaned = new List<Comment>();
 
             foreach (var comment in bundle.Comments.Concat(bundle.IncludedComments))
             {
                 // Exclude possible duplicated comments.
-                if (commentDictionary.ContainsKey(comment.Id))
+                if (CommentDictionary.ContainsKey(comment.Id))
                     continue;
 
                 addNewComment(comment);
@@ -118,7 +118,7 @@ namespace osu.Game.Overlays.Comments
                     // Comments that have no parent are added as top-level comments to the flow.
                     flow.Add(drawableComment);
                 }
-                else if (commentDictionary.TryGetValue(comment.ParentId.Value, out var parentDrawable))
+                else if (CommentDictionary.TryGetValue(comment.ParentId.Value, out var parentDrawable))
                 {
                     // The comment's parent has already been seen, so the parent<-> child links can be added.
                     comment.ParentComment = parentDrawable.Comment;

--- a/osu.Game/Overlays/Comments/CommentsPage.cs
+++ b/osu.Game/Overlays/Comments/CommentsPage.cs
@@ -96,9 +96,9 @@ namespace osu.Game.Overlays.Comments
         {
             var orphaned = new List<Comment>();
 
-            // Exclude possible duplicated comments.
             foreach (var comment in bundle.Comments.Concat(bundle.IncludedComments))
             {
+                // Exclude possible duplicated comments.
                 if (commentDictionary.ContainsKey(comment.Id))
                     continue;
 

--- a/osu.Game/Overlays/Comments/CommentsPage.cs
+++ b/osu.Game/Overlays/Comments/CommentsPage.cs
@@ -96,12 +96,17 @@ namespace osu.Game.Overlays.Comments
         {
             var orphaned = new List<Comment>();
 
+            // Exclude possible duplicated comments.
             foreach (var topLevel in bundle.Comments)
+            {
+                if (commentDictionary.ContainsKey(topLevel.Id))
+                    continue;
+
                 addNewComment(topLevel);
+            }
 
             foreach (var child in bundle.IncludedComments)
             {
-                // Included comments can contain the parent comment, which already exists in the hierarchy.
                 if (commentDictionary.ContainsKey(child.Id))
                     continue;
 

--- a/osu.Game/Overlays/Comments/CommentsPage.cs
+++ b/osu.Game/Overlays/Comments/CommentsPage.cs
@@ -97,20 +97,12 @@ namespace osu.Game.Overlays.Comments
             var orphaned = new List<Comment>();
 
             // Exclude possible duplicated comments.
-            foreach (var topLevel in bundle.Comments)
+            foreach (var comment in bundle.Comments.Concat(bundle.IncludedComments))
             {
-                if (commentDictionary.ContainsKey(topLevel.Id))
+                if (commentDictionary.ContainsKey(comment.Id))
                     continue;
 
-                addNewComment(topLevel);
-            }
-
-            foreach (var child in bundle.IncludedComments)
-            {
-                if (commentDictionary.ContainsKey(child.Id))
-                    continue;
-
-                addNewComment(child);
+                addNewComment(comment);
             }
 
             // Comments whose parents were seen later than themselves can now be added.


### PR DESCRIPTION
The reason is that we can receive already existing comments not only in `IncludedComments` list but also in the `Comments` list.