### PR TITLE
Adjust overlay header elements to match osu-web

### DIFF
--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Graphics.UserInterface
         private const float text_padding = 17.5f; // 15px padding + 2.5px compensation for line-height
 
         private SpriteIcon iconSprite;
-        protected readonly OsuSpriteText TitleText, PageText;
+        private readonly OsuSpriteText titleText, pageText;
         protected readonly Circle Separator;
 
         protected IconUsage Icon
@@ -37,18 +37,18 @@ namespace osu.Game.Graphics.UserInterface
 
         protected string Title
         {
-            set => TitleText.Text = value;
+            set => titleText.Text = value;
         }
 
         protected string Section
         {
-            set => PageText.Text = value;
+            set => pageText.Text = value;
         }
 
         public Color4 AccentColour
         {
-            get => PageText.Colour;
-            set => PageText.Colour = value;
+            get => pageText.Colour;
+            set => pageText.Colour = value;
         }
 
         public Color4 SeparatorColour
@@ -81,7 +81,7 @@ namespace osu.Game.Graphics.UserInterface
                             t.Origin = Anchor.Centre;
                             t.Margin = new MarginPadding { Horizontal = 5 }; // compensates for osu-web sprites having around 5px of whitespace on each side
                         }),
-                        TitleText = new OsuSpriteText
+                        titleText = new OsuSpriteText
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -96,7 +96,7 @@ namespace osu.Game.Graphics.UserInterface
                             Colour = Color4.Gray,
                             Margin = new MarginPadding { Top = 3 } // compensation for osu-web using a font here making the circle appear a bit lower
                         },
-                        PageText = new OsuSpriteText
+                        pageText = new OsuSpriteText
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,

--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
 
@@ -16,11 +18,12 @@ namespace osu.Game.Graphics.UserInterface
     {
         public const float ICON_WIDTH = ICON_SIZE + spacing;
 
-        public const float ICON_SIZE = 25;
-        private const float spacing = 6;
-        private const int text_offset = 2;
+        public const float ICON_SIZE = 30; // osu-web uses 40, but the images there aren't cropped edge-to-edge
+        private const float spacing = 10;
+        private const float text_padding = 17.5f; // 15px padding + 2.5px compensation for line-height
 
         private SpriteIcon iconSprite;
+        private readonly Circle circle;
         private readonly OsuSpriteText titleText, pageText;
 
         protected IconUsage Icon
@@ -72,31 +75,38 @@ namespace osu.Game.Graphics.UserInterface
                         {
                             t.Anchor = Anchor.Centre;
                             t.Origin = Anchor.Centre;
+                            t.Margin = new MarginPadding { Horizontal = 5 }; // compensates for osu-web sprites having around 5px of whitespace on each side
                         }),
                         titleText = new OsuSpriteText
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Font = OsuFont.GetFont(size: 20, weight: FontWeight.Bold),
-                            Margin = new MarginPadding { Bottom = text_offset }
+                            Margin = new MarginPadding { Vertical = text_padding }
                         },
-                        new Circle
+                        circle = new Circle
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Size = new Vector2(4),
-                            Colour = Color4.Gray,
+                            Size = new Vector2(5),
+                            Margin = new MarginPadding { Top = 3 } // compensation for osu-web using a font here making the circle appear a bit lower
                         },
                         pageText = new OsuSpriteText
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Font = OsuFont.GetFont(size: 20),
-                            Margin = new MarginPadding { Bottom = text_offset }
+                            Margin = new MarginPadding { Vertical = text_padding }
                         }
                     }
                 },
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            circle.Colour = colourProvider.Foreground1;
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -51,6 +51,12 @@ namespace osu.Game.Graphics.UserInterface
             set => PageText.Colour = value;
         }
 
+        public Color4 SeparatorColour
+        {
+            get => Separator.Colour;
+            set => Separator.Colour = value;
+        }
+
         protected virtual Drawable CreateIcon() => iconSprite = new SpriteIcon
         {
             Size = new Vector2(ICON_SIZE),

--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.Sprites;
 using osuTK;

--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
 

--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -21,8 +21,7 @@ namespace osu.Game.Graphics.UserInterface
         private const float text_padding = 17.5f; // 15px padding + 2.5px compensation for line-height
 
         private SpriteIcon iconSprite;
-        private readonly OsuSpriteText titleText, pageText;
-        protected readonly Circle Separator;
+        private readonly OsuSpriteText titleText, pageText, separator;
 
         protected IconUsage Icon
         {
@@ -53,8 +52,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public Color4 SeparatorColour
         {
-            get => Separator.Colour;
-            set => Separator.Colour = value;
+            get => separator.Colour;
+            set => separator.Colour = value;
         }
 
         protected virtual Drawable CreateIcon() => iconSprite = new SpriteIcon
@@ -88,13 +87,14 @@ namespace osu.Game.Graphics.UserInterface
                             Font = OsuFont.GetFont(size: 20, weight: FontWeight.Bold),
                             Margin = new MarginPadding { Vertical = text_padding }
                         },
-                        Separator = new Circle
+                        separator = new OsuSpriteText
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Size = new Vector2(5),
+                            Font = OsuFont.GetFont(size: 20),
                             Colour = Color4.Gray,
-                            Margin = new MarginPadding { Top = 3 } // compensation for osu-web using a font here making the circle appear a bit lower
+                            Margin = new MarginPadding { Vertical = text_padding },
+                            Text = "\u2022"
                         },
                         pageText = new OsuSpriteText
                         {

--- a/osu.Game/Graphics/UserInterface/ScreenTitle.cs
+++ b/osu.Game/Graphics/UserInterface/ScreenTitle.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -23,8 +22,8 @@ namespace osu.Game.Graphics.UserInterface
         private const float text_padding = 17.5f; // 15px padding + 2.5px compensation for line-height
 
         private SpriteIcon iconSprite;
-        private readonly Circle circle;
-        private readonly OsuSpriteText titleText, pageText;
+        protected readonly OsuSpriteText TitleText, PageText;
+        protected readonly Circle Separator;
 
         protected IconUsage Icon
         {
@@ -39,18 +38,18 @@ namespace osu.Game.Graphics.UserInterface
 
         protected string Title
         {
-            set => titleText.Text = value;
+            set => TitleText.Text = value;
         }
 
         protected string Section
         {
-            set => pageText.Text = value;
+            set => PageText.Text = value;
         }
 
         public Color4 AccentColour
         {
-            get => pageText.Colour;
-            set => pageText.Colour = value;
+            get => PageText.Colour;
+            set => PageText.Colour = value;
         }
 
         protected virtual Drawable CreateIcon() => iconSprite = new SpriteIcon
@@ -77,21 +76,22 @@ namespace osu.Game.Graphics.UserInterface
                             t.Origin = Anchor.Centre;
                             t.Margin = new MarginPadding { Horizontal = 5 }; // compensates for osu-web sprites having around 5px of whitespace on each side
                         }),
-                        titleText = new OsuSpriteText
+                        TitleText = new OsuSpriteText
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Font = OsuFont.GetFont(size: 20, weight: FontWeight.Bold),
                             Margin = new MarginPadding { Vertical = text_padding }
                         },
-                        circle = new Circle
+                        Separator = new Circle
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Size = new Vector2(5),
+                            Colour = Color4.Gray,
                             Margin = new MarginPadding { Top = 3 } // compensation for osu-web using a font here making the circle appear a bit lower
                         },
-                        pageText = new OsuSpriteText
+                        PageText = new OsuSpriteText
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -101,12 +101,6 @@ namespace osu.Game.Graphics.UserInterface
                     }
                 },
             };
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
-        {
-            circle.Colour = colourProvider.Foreground1;
         }
     }
 }

--- a/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
+++ b/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
@@ -1,6 +1,7 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
@@ -16,6 +17,9 @@ namespace osu.Game.Overlays
             public OverlayHeaderBreadcrumbControl()
             {
                 RelativeSizeAxes = Axes.X;
+                Height = 47;
+            }
+
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
             {
@@ -26,13 +30,14 @@ namespace osu.Game.Overlays
 
             private class ControlTabItem : BreadcrumbTabItem
             {
-                protected override float ChevronSize => 8;
+                protected override float ChevronSize => 10;
 
                 public ControlTabItem(string value)
                     : base(value)
                 {
+                    RelativeSizeAxes = Axes.Y;
                     Text.Font = Text.Font.With(size: 14);
-                    Chevron.Y = 3;
+                    Text.Margin = new MarginPadding { Vertical = 16.5f }; // 15px padding + 1.5px line-height difference compensation
                     Bar.Height = 0;
                 }
             }

--- a/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
+++ b/osu.Game/Overlays/BreadcrumbControlOverlayHeader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
@@ -16,6 +16,10 @@ namespace osu.Game.Overlays
             public OverlayHeaderBreadcrumbControl()
             {
                 RelativeSizeAxes = Axes.X;
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                AccentColour = colourProvider.Light2;
             }
 
             protected override TabItem<string> CreateTabItem(string value) => new ControlTabItem(value);

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Overlays
     {
         private readonly Box titleBackground;
         private readonly ScreenTitle title;
-        private readonly Container content;
 
         protected readonly FillFlowContainer HeaderInfo;
 
@@ -55,7 +54,7 @@ namespace osu.Game.Overlays
                                         RelativeSizeAxes = Axes.Both,
                                         Colour = Color4.Gray,
                                     },
-                                    content = new Container
+                                    new Container
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -57,7 +57,6 @@ namespace osu.Game.Overlays
                                         Padding = new MarginPadding
                                         {
                                             Horizontal = UserProfileOverlay.CONTENT_X_MARGIN,
-                                            Vertical = 10,
                                         },
                                         Children = new[]
                                         {

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays
         public virtual float HorizontalMargin
         {
             get => content.Padding.Left;
-            set => content.Padding = new MarginPadding { Horizontal = value, Vertical = 10 };
+            set => content.Padding = new MarginPadding { Horizontal = value };
         }
 
         protected OverlayHeader()

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -15,8 +15,17 @@ namespace osu.Game.Overlays
     {
         private readonly Box titleBackground;
         private readonly ScreenTitle title;
+        private readonly Container content;
 
         protected readonly FillFlowContainer HeaderInfo;
+
+        public const float CONTENT_X_MARGIN = 50;
+
+        public virtual float HorizontalMargin
+        {
+            get => content.Padding.Left;
+            set => content.Padding = new MarginPadding { Horizontal = value, Vertical = 10 };
+        }
 
         protected OverlayHeader()
         {
@@ -50,14 +59,11 @@ namespace osu.Game.Overlays
                                         RelativeSizeAxes = Axes.Both,
                                         Colour = Color4.Gray,
                                     },
-                                    new Container
+                                    content = new Container
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         AutoSizeAxes = Axes.Y,
-                                        Padding = new MarginPadding
-                                        {
-                                            Horizontal = UserProfileOverlay.CONTENT_X_MARGIN,
-                                        },
+                                        Padding = new MarginPadding { Horizontal = CONTENT_X_MARGIN },
                                         Children = new[]
                                         {
                                             title = CreateTitle().With(title =>

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -21,11 +21,7 @@ namespace osu.Game.Overlays
 
         public const float CONTENT_X_MARGIN = 50;
 
-        public virtual float HorizontalMargin
-        {
-            get => content.Padding.Left;
-            set => content.Padding = new MarginPadding { Horizontal = value };
-        }
+        protected virtual float HorizontalMargin => CONTENT_X_MARGIN;
 
         protected OverlayHeader()
         {
@@ -63,7 +59,7 @@ namespace osu.Game.Overlays
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         AutoSizeAxes = Axes.Y,
-                                        Padding = new MarginPadding { Horizontal = CONTENT_X_MARGIN },
+                                        Padding = new MarginPadding { Horizontal = HorizontalMargin },
                                         Children = new[]
                                         {
                                             title = CreateTitle().With(title =>

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Overlays
         {
             titleBackground.Colour = colourProvider.Dark5;
             title.AccentColour = colourProvider.Highlight1;
+            title.SeparatorColour = colourProvider.Foreground1;
         }
 
         [NotNull]

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Overlays
         {
             AutoSizeAxes = Axes.Both,
             Direction = FillDirection.Horizontal,
-            Spacing = new Vector2(25, 0),
+            Spacing = new Vector2(40, 0),
         };
     }
 }

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Overlays
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
                         Text = value.Name,
+                        Font = OsuFont.GetFont(size: 18)
                     }
                 },
                 new HoverClickSounds()

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -53,7 +53,8 @@ namespace osu.Game.Overlays
                         Origin = Anchor.Centre,
                         Anchor = Anchor.Centre,
                         Text = value.Name,
-                        Font = OsuFont.GetFont(size: 18)
+                        Font = OsuFont.GetFont(size: 18),
+                        ShadowColour = new Color4(0, 0, 0, 0.75f)
                     }
                 },
                 new HoverClickSounds()

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets;
 using osuTK.Graphics;
 using osuTK;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Game.Overlays
 {
@@ -54,7 +55,7 @@ namespace osu.Game.Overlays
                         Anchor = Anchor.Centre,
                         Text = value.Name,
                         Font = OsuFont.GetFont(size: 18),
-                        ShadowColour = new Color4(0, 0, 0, 0.75f)
+                        ShadowColour = Color4.Black.Opacity(0.75f)
                     }
                 },
                 new HoverClickSounds()

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
@@ -101,7 +101,7 @@ namespace osu.Game.Overlays
                 {
                     Text = new OsuSpriteText
                     {
-                        Margin = new MarginPadding { Vertical = 16.5f }, // 15px padding + 1.5px line-height difference compensation
+                        Margin = new MarginPadding { Bottom = 10 },
                         Origin = Anchor.BottomLeft,
                         Anchor = Anchor.BottomLeft,
                         Font = OsuFont.GetFont(),

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -41,10 +41,9 @@ namespace osu.Game.Overlays
             AddInternal(bar = new Box
             {
                 RelativeSizeAxes = Axes.X,
-                Margin = new MarginPadding { Top = -1 },
                 Height = 2,
                 Anchor = Anchor.BottomLeft,
-                Origin = Anchor.CentreLeft
+                Origin = Anchor.BottomLeft
             });
         }
 
@@ -102,9 +101,9 @@ namespace osu.Game.Overlays
                     Bar = new ExpandingBar
                     {
                         Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.Centre,
                         ExpandedSize = 7.5f,
                         CollapsedSize = 0,
-                        Margin = new MarginPadding { Top = -1 }
                     },
                     new HoverClickSounds()
                 };

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays
 
             private Color4 idleColour;
 
-            protected Color4 IdleColour
+            public Color4 IdleColour
             {
                 get => idleColour;
                 set

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
@@ -107,7 +107,7 @@ namespace osu.Game.Overlays
                 {
                     Text = new OsuSpriteText
                     {
-                        Margin = new MarginPadding { Bottom = 10 },
+                        Margin = new MarginPadding { Vertical = 16.5f }, // 15px padding + 1.5px line-height difference compensation
                         Origin = Anchor.BottomLeft,
                         Anchor = Anchor.BottomLeft,
                         Font = OsuFont.GetFont(),

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -34,20 +33,6 @@ namespace osu.Game.Overlays
             }
         }
 
-        private Color4 textColour;
-
-        public Color4 TextColour
-        {
-            get => textColour;
-            set
-            {
-                textColour = value;
-
-                foreach (var i in TabContainer.Children.OfType<OverlayTabItem>())
-                    i.TextColour = value;
-            }
-        }
-
         protected OverlayTabControl()
         {
             TabContainer.Masking = false;
@@ -67,7 +52,6 @@ namespace osu.Game.Overlays
         private void load(OverlayColourProvider colourProvider)
         {
             AccentColour = colourProvider.Highlight1;
-            TextColour = colourProvider.Light2;
         }
 
         protected override Dropdown<T> CreateDropdown() => null;
@@ -85,17 +69,17 @@ namespace osu.Game.Overlays
                 set => Bar.Colour = value;
             }
 
-            private Color4 textColour;
+            private Color4 idleColour;
 
-            public Color4 TextColour
+            protected Color4 IdleColour
             {
-                get => textColour;
+                get => idleColour;
                 set
                 {
-                    if (textColour == value)
+                    if (idleColour == value)
                         return;
 
-                    textColour = value;
+                    idleColour = value;
                     updateState();
                 }
             }
@@ -124,6 +108,12 @@ namespace osu.Game.Overlays
                     },
                     new HoverClickSounds()
                 };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                IdleColour = colourProvider.Light2;
             }
 
             protected override bool OnHover(HoverEvent e)
@@ -165,7 +155,7 @@ namespace osu.Game.Overlays
             protected virtual void UnhoverAction()
             {
                 Bar.Collapse();
-                Text.FadeColour(TextColour, 120, Easing.InQuad);
+                Text.FadeColour(idleColour, 120, Easing.InQuad);
             }
         }
     }

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
@@ -73,13 +73,7 @@ namespace osu.Game.Overlays
             public Color4 AccentColour
             {
                 get => Bar.Colour;
-                set
-                {
-                    if (Bar.Colour == value)
-                        return;
-
-                    Bar.Colour = value;
-                }
+                set => Bar.Colour = value;
             }
 
             private Color4 textColour;

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Overlays
             AddInternal(bar = new Box
             {
                 RelativeSizeAxes = Axes.X,
+                Margin = new MarginPadding { Top = -1 },
                 Height = 2,
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.CentreLeft
@@ -118,7 +119,8 @@ namespace osu.Game.Overlays
                     {
                         Anchor = Anchor.BottomCentre,
                         ExpandedSize = 7.5f,
-                        CollapsedSize = 0
+                        CollapsedSize = 0,
+                        Margin = new MarginPadding { Top = -1 }
                     },
                     new HoverClickSounds()
                 };

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
@@ -32,6 +33,20 @@ namespace osu.Game.Overlays
             }
         }
 
+        private Color4 textColour;
+
+        public Color4 TextColour
+        {
+            get => textColour;
+            set
+            {
+                textColour = value;
+
+                foreach (var i in TabContainer.Children.OfType<OverlayTabItem>())
+                    i.TextColour = value;
+            }
+        }
+
         protected OverlayTabControl()
         {
             TabContainer.Masking = false;
@@ -55,19 +70,29 @@ namespace osu.Game.Overlays
             protected readonly ExpandingBar Bar;
             protected readonly OsuSpriteText Text;
 
-            private Color4 accentColour;
-
             public Color4 AccentColour
             {
-                get => accentColour;
+                get => Bar.Colour;
                 set
                 {
-                    if (accentColour == value)
+                    if (Bar.Colour == value)
                         return;
 
-                    accentColour = value;
                     Bar.Colour = value;
+                }
+            }
 
+            private Color4 textColour;
+
+            public Color4 TextColour
+            {
+                get => textColour;
+                set
+                {
+                    if (textColour == value)
+                        return;
+
+                    textColour = value;
                     updateState();
                 }
             }
@@ -144,7 +169,7 @@ namespace osu.Game.Overlays
             protected virtual void UnhoverAction()
             {
                 Bar.Collapse();
-                Text.FadeColour(AccentColour, 120, Easing.InQuad);
+                Text.FadeColour(TextColour, 120, Easing.InQuad);
             }
         }
     }

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -101,8 +101,7 @@ namespace osu.Game.Overlays
                     Bar = new ExpandingBar
                     {
                         Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.Centre,
-                        ExpandedSize = 7.5f,
+                        ExpandedSize = 5f,
                         CollapsedSize = 0,
                     },
                     new HoverClickSounds()

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -142,17 +142,9 @@ namespace osu.Game.Overlays
                     UnhoverAction();
             }
 
-            protected override void OnActivated()
-            {
-                HoverAction();
-                Text.Font = Text.Font.With(weight: FontWeight.Bold);
-            }
+            protected override void OnActivated() => HoverAction();
 
-            protected override void OnDeactivated()
-            {
-                UnhoverAction();
-                Text.Font = Text.Font.With(weight: FontWeight.Medium);
-            }
+            protected override void OnDeactivated() => UnhoverAction();
 
             private void updateState()
             {

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
@@ -59,6 +60,13 @@ namespace osu.Game.Overlays
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.CentreLeft
             });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            AccentColour = colourProvider.Highlight1;
+            TextColour = colourProvider.Light2;
         }
 
         protected override Dropdown<T> CreateDropdown() => null;

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -103,6 +103,7 @@ namespace osu.Game.Overlays
                         Anchor = Anchor.BottomCentre,
                         ExpandedSize = 5f,
                         CollapsedSize = 0,
+                        Margin = new MarginPadding { Bottom = 1 }
                     },
                     new HoverClickSounds()
                 };

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays
             AddInternal(bar = new Box
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 2,
+                Height = 1,
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft
             });

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Overlays.Profile
         private CentreHeaderContainer centreHeaderContainer;
         private DetailHeaderContainer detailHeaderContainer;
 
+        protected override float HorizontalMargin => UserProfileOverlay.CONTENT_X_MARGIN;
+
         public ProfileHeader()
         {
             User.ValueChanged += e => updateDisplay(e.NewValue);

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -98,6 +98,7 @@ namespace osu.Game.Overlays
                 {
                     Text.Text = value.ToString().ToLower();
                     Text.Font = OsuFont.GetFont(size: 14);
+                    Text.Margin = new MarginPadding { Vertical = 16.5f }; // 15px padding + 1.5px line-height difference compensation
                     Bar.ExpandedSize = 5;
                 }
             }

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using JetBrains.Annotations;
@@ -72,7 +72,8 @@ namespace osu.Game.Overlays
                 AutoSizeAxes = Axes.X;
                 Anchor = Anchor.BottomLeft;
                 Origin = Anchor.BottomLeft;
-                Height = 35;
+                Height = 47;
+                TabContainer.Spacing = new Vector2(20, 0);
             }
 
             protected override TabItem<T> CreateTabItem(T value) => new OverlayHeaderTabItem(value);
@@ -82,7 +83,6 @@ namespace osu.Game.Overlays
                 RelativeSizeAxes = Axes.Y,
                 AutoSizeAxes = Axes.X,
                 Direction = FillDirection.Horizontal,
-                Spacing = new Vector2(5, 0),
             };
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using JetBrains.Annotations;
@@ -65,7 +65,6 @@ namespace osu.Game.Overlays
         {
             public OverlayHeaderTabControl()
             {
-                BarHeight = 1;
                 RelativeSizeAxes = Axes.None;
                 AutoSizeAxes = Axes.X;
                 Anchor = Anchor.BottomLeft;

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using JetBrains.Annotations;
@@ -84,6 +84,12 @@ namespace osu.Game.Overlays
                 Direction = FillDirection.Horizontal,
                 Spacing = new Vector2(5, 0),
             };
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                TextColour = colourProvider.Light2;
+            }
 
             private class OverlayHeaderTabItem : OverlayTabItem
             {

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Overlays
         protected OsuTabControl<T> TabControl;
 
         private readonly BindableWithCurrent<T> current = new BindableWithCurrent<T>();
+        private readonly Box controlBackground;
 
         public Bindable<T> Current
         {
@@ -30,7 +31,15 @@ namespace osu.Game.Overlays
             set => current.Current = value;
         }
 
-        private readonly Box controlBackground;
+        public override float HorizontalMargin
+        {
+            get => base.HorizontalMargin;
+            set
+            {
+                base.HorizontalMargin = value;
+                TabControl.Margin = new MarginPadding { Left = value };
+            }
+        }
 
         protected TabControlOverlayHeader()
         {
@@ -46,7 +55,7 @@ namespace osu.Game.Overlays
                     },
                     TabControl = CreateTabControl().With(control =>
                     {
-                        control.Margin = new MarginPadding { Left = UserProfileOverlay.CONTENT_X_MARGIN };
+                        control.Margin = new MarginPadding { Left = CONTENT_X_MARGIN };
                         control.Current = Current;
                     })
                 }

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -56,7 +56,6 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            TabControl.AccentColour = colourProvider.Highlight1;
             controlBackground.Colour = colourProvider.Dark4;
         }
 
@@ -84,12 +83,6 @@ namespace osu.Game.Overlays
                 AutoSizeAxes = Axes.X,
                 Direction = FillDirection.Horizontal,
             };
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                TextColour = colourProvider.Light2;
-            }
 
             private class OverlayHeaderTabItem : OverlayTabItem
             {

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -90,7 +90,6 @@ namespace osu.Game.Overlays
                     Text.Text = value.ToString().ToLower();
                     Text.Font = OsuFont.GetFont(size: 14);
                     Text.Margin = new MarginPadding { Vertical = 16.5f }; // 15px padding + 1.5px line-height difference compensation
-                    Bar.ExpandedSize = 5;
                 }
             }
         }

--- a/osu.Game/Overlays/TabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/TabControlOverlayHeader.cs
@@ -31,16 +31,6 @@ namespace osu.Game.Overlays
             set => current.Current = value;
         }
 
-        public override float HorizontalMargin
-        {
-            get => base.HorizontalMargin;
-            set
-            {
-                base.HorizontalMargin = value;
-                TabControl.Margin = new MarginPadding { Left = value };
-            }
-        }
-
         protected TabControlOverlayHeader()
         {
             HeaderInfo.Add(new Container
@@ -55,7 +45,7 @@ namespace osu.Game.Overlays
                     },
                     TabControl = CreateTabControl().With(control =>
                     {
-                        control.Margin = new MarginPadding { Left = CONTENT_X_MARGIN };
+                        control.Margin = new MarginPadding { Left = HorizontalMargin };
                         control.Current = Current;
                     })
                 }

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -14,6 +14,7 @@ using osu.Game.Overlays.Profile;
 using osu.Game.Overlays.Profile.Sections;
 using osu.Game.Users;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays
 {
@@ -87,6 +88,7 @@ namespace osu.Game.Overlays
                     RelativeSizeAxes = Axes.Both
                 },
             });
+
             sectionsContainer.SelectedSection.ValueChanged += section =>
             {
                 if (lastSection != section.NewValue)
@@ -161,13 +163,16 @@ namespace osu.Game.Overlays
 
             protected override TabItem<ProfileSection> CreateTabItem(ProfileSection value) => new ProfileTabItem(value)
             {
-                AccentColour = AccentColour
+                // This needs to be set here manually because TabControl attempts to propagate these values to its children before these tabs are added
+                AccentColour = AccentColour,
+                TextColour = TextColour
             };
 
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
             {
                 AccentColour = colourProvider.Highlight1;
+                TextColour = Color4.White;
             }
 
             private class ProfileTabItem : OverlayTabItem

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -164,15 +164,8 @@ namespace osu.Game.Overlays
             protected override TabItem<ProfileSection> CreateTabItem(ProfileSection value) => new ProfileSectionTabItem(value)
             {
                 // This needs to be set here manually because TabControl attempts to propagate these values to its children before these tabs are added
-                AccentColour = AccentColour,
-                TextColour = TextColour
+                AccentColour = AccentColour
             };
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                TextColour = Color4.White;
-            }
 
             private class ProfileSectionTabItem : OverlayTabItem
             {
@@ -180,6 +173,12 @@ namespace osu.Game.Overlays
                     : base(value)
                 {
                     Text.Text = value.Title;
+                }
+
+                [BackgroundDependencyLoader]
+                private void load()
+                {
+                    IdleColour = Color4.White;
                 }
             }
         }

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -171,7 +171,6 @@ namespace osu.Game.Overlays
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
             {
-                AccentColour = colourProvider.Highlight1;
                 TextColour = Color4.White;
             }
 

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays
         private GetUserRequest userReq;
         protected ProfileHeader Header;
         private ProfileSectionsContainer sectionsContainer;
-        private ProfileTabControl tabs;
+        private ProfileSectionTabControl tabs;
 
         public const float CONTENT_X_MARGIN = 70;
 
@@ -63,7 +63,7 @@ namespace osu.Game.Overlays
                 }
                 : Array.Empty<ProfileSection>();
 
-            tabs = new ProfileTabControl
+            tabs = new ProfileSectionTabControl
             {
                 RelativeSizeAxes = Axes.X,
                 Anchor = Anchor.TopCentre,
@@ -151,9 +151,9 @@ namespace osu.Game.Overlays
             }
         }
 
-        private class ProfileTabControl : OverlayTabControl<ProfileSection>
+        private class ProfileSectionTabControl : OverlayTabControl<ProfileSection>
         {
-            public ProfileTabControl()
+            public ProfileSectionTabControl()
             {
                 TabContainer.RelativeSizeAxes &= ~Axes.X;
                 TabContainer.AutoSizeAxes |= Axes.X;
@@ -161,7 +161,7 @@ namespace osu.Game.Overlays
                 TabContainer.Origin |= Anchor.x1;
             }
 
-            protected override TabItem<ProfileSection> CreateTabItem(ProfileSection value) => new ProfileTabItem(value)
+            protected override TabItem<ProfileSection> CreateTabItem(ProfileSection value) => new ProfileSectionTabItem(value)
             {
                 // This needs to be set here manually because TabControl attempts to propagate these values to its children before these tabs are added
                 AccentColour = AccentColour,
@@ -175,9 +175,9 @@ namespace osu.Game.Overlays
                 TextColour = Color4.White;
             }
 
-            private class ProfileTabItem : OverlayTabItem
+            private class ProfileSectionTabItem : OverlayTabItem
             {
-                public ProfileTabItem(ProfileSection value)
+                public ProfileSectionTabItem(ProfileSection value)
                     : base(value)
                 {
                     Text.Text = value.Title;

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -155,6 +155,7 @@ namespace osu.Game.Overlays
         {
             public ProfileSectionTabControl()
             {
+                BarHeight = 2;
                 TabContainer.RelativeSizeAxes &= ~Axes.X;
                 TabContainer.AutoSizeAxes |= Axes.X;
                 TabContainer.Anchor |= Anchor.x1;

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays
 
             Add(sectionsContainer = new ProfileSectionsContainer
             {
-                ExpandableHeader = Header = new ProfileHeader { HorizontalMargin = CONTENT_X_MARGIN },
+                ExpandableHeader = Header = new ProfileHeader(),
                 FixedHeader = tabs,
                 HeaderBackground = new Box
                 {

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -1,9 +1,8 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -165,7 +164,8 @@ namespace osu.Game.Overlays
             protected override TabItem<ProfileSection> CreateTabItem(ProfileSection value) => new ProfileSectionTabItem(value)
             {
                 // This needs to be set here manually because TabControl attempts to propagate these values to its children before these tabs are added
-                AccentColour = AccentColour
+                AccentColour = AccentColour,
+                IdleColour = Color4.White
             };
 
             private class ProfileSectionTabItem : OverlayTabItem
@@ -174,12 +174,6 @@ namespace osu.Game.Overlays
                     : base(value)
                 {
                     Text.Text = value.Title;
-                }
-
-                [BackgroundDependencyLoader]
-                private void load()
-                {
-                    IdleColour = Color4.White;
                 }
             }
         }

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays
 
             Add(sectionsContainer = new ProfileSectionsContainer
             {
-                ExpandableHeader = Header = new ProfileHeader(),
+                ExpandableHeader = Header = new ProfileHeader { HorizontalMargin = CONTENT_X_MARGIN },
                 FixedHeader = tabs,
                 HeaderBackground = new Box
                 {

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -174,6 +174,7 @@ namespace osu.Game.Overlays
                     : base(value)
                 {
                     Text.Text = value.Title;
+                    Bar.ExpandedSize = 10f;
                 }
             }
         }

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -175,6 +175,7 @@ namespace osu.Game.Overlays
                 {
                     Text.Text = value.Title;
                     Bar.ExpandedSize = 10f;
+                    Bar.Margin = new MarginPadding { Bottom = 2 };
                 }
             }
         }

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -73,7 +73,6 @@ namespace osu.Game.Screens.Multi
         private class MultiHeaderTitle : ScreenTitle
         {
             private const int text_offset = 2;
-            private const float spacing = 6;
 
             public IMultiplayerSubScreen Screen
             {

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -77,12 +77,6 @@ namespace osu.Game.Screens.Multi
                 set => Section = value.ShortTitle.ToLowerInvariant();
             }
 
-            public MultiHeaderTitle()
-            {
-                Separator.Size = new Vector2(4);
-                Separator.Margin = new MarginPadding(0);
-            }
-
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -9,7 +9,6 @@ using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.SearchableList;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Multi

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -72,8 +72,6 @@ namespace osu.Game.Screens.Multi
 
         private class MultiHeaderTitle : ScreenTitle
         {
-            private const int text_offset = 2;
-
             public IMultiplayerSubScreen Screen
             {
                 set => Section = value.ShortTitle.ToLowerInvariant();
@@ -81,7 +79,6 @@ namespace osu.Game.Screens.Multi
 
             public MultiHeaderTitle()
             {
-                TitleText.Margin = PageText.Margin = new MarginPadding { Bottom = text_offset };
                 Separator.Size = new Vector2(4);
                 Separator.Margin = new MarginPadding(0);
             }

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -9,6 +9,7 @@ using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.SearchableList;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Multi
@@ -71,9 +72,19 @@ namespace osu.Game.Screens.Multi
 
         private class MultiHeaderTitle : ScreenTitle
         {
+            private const int text_offset = 2;
+            private const float spacing = 6;
+
             public IMultiplayerSubScreen Screen
             {
                 set => Section = value.ShortTitle.ToLowerInvariant();
+            }
+
+            public MultiHeaderTitle()
+            {
+                TitleText.Margin = PageText.Margin = new MarginPadding { Bottom = text_offset };
+                Separator.Size = new Vector2(4);
+                Separator.Margin = new MarginPadding(0);
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
Sizing of the `OverlayHeader` and its elements was quite off from what can be seen on osu-web. This PR brings its values as close to the web counterpart as possible.

master:
![image](https://user-images.githubusercontent.com/27722894/75286713-3b449b00-5819-11ea-9553-b5d764ea6b93.png)


this PR:
![image](https://user-images.githubusercontent.com/27722894/75634146-488fca00-5c0b-11ea-9761-b1af1e827931.png)


web:
![image](https://user-images.githubusercontent.com/27722894/75634027-46793b80-5c0a-11ea-8e04-9b2478a4c2c9.png)



Please keep in mind that this PR might make things look a bit *worse* for now since it still needs a font sizing fix to look exactly like osu-web. Until then, to mantain proper sizing and prevent things from looking *too* off, I added line-height compensations (margins) to some of the text elements (similar to the ones from `BeatmapSetOverlay` resize PR) that will be safe to remove when the font sizing fix comes.

That being said, here's a comparison with a temporary font sizing fix applied (web on the left, lazer on the right):

![image](https://user-images.githubusercontent.com/27722894/75285014-1bf83e80-5816-11ea-963f-15a9d05d832d.png)






