### PR TITLE
Fix crashes in catch upon ending combo with banana shower or juice stream

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneBananaShower.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneBananaShower.cs
@@ -29,6 +29,12 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
         }
 
+        [Test]
+        public void TestBananaShower()
+        {
+            AddUntilStep("player is done", () => !Player.ValidForResume);
+        }
+
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
         {
             var beatmap = new Beatmap
@@ -40,7 +46,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 }
             };
 
-            beatmap.HitObjects.Add(new BananaShower { StartTime = 200, Duration = 5000, NewCombo = true });
+            beatmap.HitObjects.Add(new BananaShower { StartTime = 200, Duration = 3000, NewCombo = true });
 
             return beatmap;
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneJuiceStream.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public class TestSceneJuiceStream : PlayerTestScene
+    {
+        public TestSceneJuiceStream()
+            : base(new CatchRuleset())
+        {
+        }
+
+        [Test]
+        public void TestJuiceStreamEndingCombo()
+        {
+            AddUntilStep("player is done", () => !Player.ValidForResume);
+        }
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
+        {
+            BeatmapInfo = new BeatmapInfo
+            {
+                BaseDifficulty = new BeatmapDifficulty { CircleSize = 5, SliderMultiplier = 2 },
+                Ruleset = ruleset
+            },
+            HitObjects = new List<HitObject>
+            {
+                new JuiceStream
+                {
+                    X = 0.5f,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(0, 100)
+                    }),
+                    StartTime = 200
+                },
+                new Banana
+                {
+                    X = 0.5f,
+                    StartTime = 1000,
+                    NewCombo = true
+                }
+            }
+        };
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             if (fruit.HitObject.LastInCombo)
             {
-                if (((CatchJudgement)result.Judgement).ShouldExplodeFor(result))
+                if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
                     runAfterLoaded(() => MovableCatcher.Explode());
                 else
                     MovableCatcher.Drop();


### PR DESCRIPTION
Fixes a regression from #7973.

# Summary

Since introduction of `IgnoreJudgement` and its usage in `JuiceStream` and `BananaShower` the hard cast in `CatcherArea` that was used to check if the drawable hit object should cause the fruits on the plate to explode at the end of combo caused a hard crash instead, since `IgnoreJudgement` was no longer deriving from `CatchJudgement`.

Replace the hard cast with a soft pattern-matched cast.

# Remarks

One test scene was hijacked and another (very primitive) one written to ensure this does not regress again, as a smoke test of sorts. I shortened the duration of the stream on the banana shower scene to make it go a little faster since it'll actually run as part of CI now.

The ignore judgements can be safely, well, ignored in the context of determining whether an explosion should be shown, since the last nested hit objects [also have `LastInCombo` set to true](https://github.com/ppy/osu/blob/ae86fa367c4835eea328f89142dcddcfaebcd1f6/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs#L41-L42).

I both ran autoplay smoke tests on the other rulesets to check if anything else crashes and searched through source to make sure there were no other suspicious casts, and I found none.