### PR TITLE
Fix iOS/Android lockups by disabling LLVM

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -25,7 +25,6 @@
     <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <EnableLLVM>false</EnableLLVM>
     <AndroidManagedSymbols>false</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
@@ -34,7 +33,6 @@
     <DebugSymbols>false</DebugSymbols>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <EnableLLVM>true</EnableLLVM>
     <AndroidManagedSymbols>false</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>

--- a/osu.Android/osu.Android.csproj
+++ b/osu.Android/osu.Android.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>osu.Android</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
+    <EnableLLVM>false</EnableLLVM> <!-- This currently causes random lockups during gameplay. https://github.com/mono/mono/issues/18973 -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <MandroidI18n>cjk;mideast;other;rare;west</MandroidI18n>

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -49,9 +49,6 @@
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <IOSDebuggerPort>28126</IOSDebuggerPort>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
-    <MtouchUseLlvm>true</MtouchUseLlvm>
-  </PropertyGroup>
   <ItemGroup>
     <NativeReference Include="$(OutputPath)\libbass.a;$(OutputPath)\libbass_fx.a">
       <Kind>Static</Kind>

--- a/osu.iOS/osu.iOS.csproj
+++ b/osu.iOS/osu.iOS.csproj
@@ -7,6 +7,7 @@
     <ProjectGuid>{3F082D0B-A964-43D7-BDF7-C256D76A50D0}</ProjectGuid>
     <RootNamespace>osu.iOS</RootNamespace>
     <AssemblyName>osu.iOS</AssemblyName>
+    <MtouchUseLlvm>false</MtouchUseLlvm> <!-- This currently causes random lockups during gameplay. https://github.com/mono/mono/issues/18973 -->
   </PropertyGroup>
   <Import Project="..\osu.iOS.props" />
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/6355
This may also `fix` https://github.com/ppy/osu/issues/6315, need further confirmation.

Further discussion: https://github.com/mono/mono/issues/18973

It looks like LLVM is the cause of these lockups. Let's disable it temporarily as the game is completely unplayable on these devices.