### PR TITLE
Add delay for loading multiplayer beatmap covers

### DIFF
--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Beatmaps.Drawables
     {
         public readonly Bindable<BeatmapInfo> Beatmap = new Bindable<BeatmapInfo>();
 
+        protected override double LoadDelay => 500;
+
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
 


### PR DESCRIPTION
Scrolling down the multiplayer listing fast could cause thousands of web requests to get fired...