### PR TITLE
Prevent unnecessary auto-size computations in mania

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/ManiaStage.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaStage.cs
@@ -115,9 +115,8 @@ namespace osu.Game.Rulesets.Mania.UI
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.Centre,
-                            AutoSizeAxes = Axes.Both,
+                            RelativeSizeAxes = Axes.Both,
                             Y = HIT_TARGET_POSITION + 150,
-                            BypassAutoSizeAxes = Axes.Both
                         },
                         topLevelContainer = new Container { RelativeSizeAxes = Axes.Both }
                     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/8056

While https://github.com/ppy/osu-framework/pull/3327 is a general fix, this is a supplementary change to reduce general auto-size load. It's really unnecessary here.