### PR TITLE
Fix potential deadlock during gameplay tests

### DIFF
--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -123,6 +123,10 @@ namespace osu.Game.Screens.Play
 
         public void Restart()
         {
+            // The Reset() call below causes speed adjustments to be reset in an async context, leading to deadlocks.
+            // The deadlock can be prevented by resetting the track synchronously before entering the async context.
+            track.ResetSpeedAdjustments();
+
             Task.Run(() =>
             {
                 track.Reset();


### PR DESCRIPTION
Very easy to replicate using https://github.com/ppy/osu/pull/8066 - load up `TestSceneOsuModDoubleTime` and click the header for the first test case. While it's loading, jiggle the test browser's rate adjustment slider bar.

A user wouldn't normally experience this issue.