### PR TITLE
Reduce social overlay/direct overlay paddings

### DIFF
--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Overlays.SearchableList
 {
     public abstract class SearchableListOverlay : FullscreenOverlay
     {
-        public const float WIDTH_PADDING = 80;
+        public const float WIDTH_PADDING = 10;
 
         protected SearchableListOverlay(OverlayColourScheme colourScheme)
             : base(colourScheme)


### PR DESCRIPTION
Makes things just a little bit more dense.

Comparisons:

1.6x:
![image](https://user-images.githubusercontent.com/1329837/75751347-9e7a8400-5d69-11ea-8bbf-ff222458a4e6.png)

1.4x:
![image](https://user-images.githubusercontent.com/1329837/75751354-a33f3800-5d69-11ea-9a75-b50ad81785c0.png)

1.0x:
![image](https://user-images.githubusercontent.com/1329837/75751362-a6d2bf00-5d69-11ea-9cf1-a96edbea8df5.png)

0.8x:
![image](https://user-images.githubusercontent.com/1329837/75751368-a9cdaf80-5d69-11ea-9a0d-7f91b6fe8e10.png)
