### PR TITLE
Default replay playback settings menu to collapsed

### DIFF
--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Play.HUD
                 {
                     //CollectionSettings = new CollectionSettings(),
                     //DiscussionSettings = new DiscussionSettings(),
-                    PlaybackSettings = new PlaybackSettings(),
+                    PlaybackSettings = new PlaybackSettings { Expanded = false },
                     VisualSettings = new VisualSettings { Expanded = false }
                 }
             };


### PR DESCRIPTION
First PR so please don't drill into me too hard
UX-wise I think it makes more sense to have this menu collapsed in replays/automod 