### PR TITLE
Comment out log locations in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-issues.md
+++ b/.github/ISSUE_TEMPLATE/01-bug-issues.md
@@ -9,6 +9,8 @@ about: Issues regarding encountered bugs.
 **osu!lazer version:** 
 
 **Logs:**
+<!--
 *please attach logs here, which are located at:*
 - `%AppData%/osu/logs` *(on Windows),*
 - `~/.local/share/osu/logs` *(on Linux & macOS).*
+-->


### PR DESCRIPTION
This info is only useful for reporters of issues, and people viewing the issue can find them distracting.