### PR TITLE
Fix DummyWorkingBeatmap's track completion attempting to change game-wide beatmap

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
+++ b/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
@@ -97,6 +97,8 @@ namespace osu.Game.Tests.Visual.Navigation
 
             public new SettingsPanel Settings => base.Settings;
 
+            public new MusicController MusicController => base.MusicController;
+
             public new OsuConfigManager LocalConfig => base.LocalConfig;
 
             public new Bindable<WorkingBeatmap> Beatmap => base.Beatmap;

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -114,6 +114,22 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("Options overlay was closed", () => Game.Settings.State.Value == Visibility.Hidden);
         }
 
+        [Test]
+        public void TestWaitForNextTrackInMenu()
+        {
+            bool trackCompleted = false;
+
+            AddUntilStep("Wait for music controller", () => Game.MusicController.IsLoaded);
+            AddStep("Seek close to end", () =>
+            {
+                Game.MusicController.SeekTo(Game.Beatmap.Value.Track.Length - 1000);
+                Game.Beatmap.Value.Track.Completed += () => trackCompleted = true;
+            });
+
+            AddUntilStep("Track was completed", () => trackCompleted);
+            AddUntilStep("Track was restarted", () => Game.Beatmap.Value.Track.IsRunning);
+        }
+
         private void pushEscape() =>
             AddStep("Press escape", () => pressAndRelease(Key.Escape));
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -428,11 +428,17 @@ namespace osu.Game
             }
         }
 
-        private void currentTrackCompleted() => Schedule(() =>
+        private void currentTrackCompleted()
         {
-            if (!Beatmap.Value.Track.Looping && !Beatmap.Disabled)
-                musicController.NextTrack();
-        });
+            if (Beatmap.Value is DummyWorkingBeatmap)
+                return;
+
+            Schedule(() =>
+            {
+                if (Beatmap.Value.Track.Looping && !Beatmap.Disabled)
+                    musicController.NextTrack();
+            });
+        }
 
         #endregion
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -414,8 +414,8 @@ namespace osu.Game
                 if (Beatmap.Value != b)
                     return;
 
-                if (Beatmap.Value.Track.Looping && !Beatmap.Disabled)
-                    musicController.NextTrack();
+                if (!Beatmap.Value.Track.Looping && !Beatmap.Disabled)
+                    MusicController.NextTrack();
             }
         }
 
@@ -588,7 +588,7 @@ namespace osu.Game
 
             loadComponentSingleFile(new OnScreenDisplay(), Add, true);
 
-            loadComponentSingleFile(musicController = new MusicController(), Add, true);
+            loadComponentSingleFile(MusicController = new MusicController(), Add, true);
 
             loadComponentSingleFile(notifications = new NotificationOverlay
             {
@@ -896,7 +896,7 @@ namespace osu.Game
 
         private ScalingContainer screenContainer;
 
-        private MusicController musicController;
+        protected MusicController MusicController { get; private set; }
 
         protected override bool OnExiting()
         {
@@ -954,7 +954,7 @@ namespace osu.Game
             {
                 OverlayActivationMode.Value = newOsuScreen.InitialOverlayActivationMode;
 
-                musicController.AllowRateAdjustments = newOsuScreen.AllowRateAdjustments;
+                MusicController.AllowRateAdjustments = newOsuScreen.AllowRateAdjustments;
 
                 if (newOsuScreen.HideOverlaysOnEnter)
                     CloseAllOverlays();

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -410,7 +410,7 @@ namespace osu.Game
 
             void trackCompleted(WorkingBeatmap b)
             {
-                // the source of track completion is the audio thread, so the beatmap may have changed before a firing.
+                // the source of track completion is the audio thread, so the beatmap may have changed before firing.
                 if (Beatmap.Value != b)
                     return;
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -214,7 +214,7 @@ namespace osu.Game
 
             // ScheduleAfterChildren is safety against something in the current frame accessing the previous beatmap's track
             // and potentially causing a reload of it after just unloading.
-            // Note that the reason for this being added *has* been resolved, so it may be feasible to remover this if required.
+            // Note that the reason for this being added *has* been resolved, so it may be feasible to removed this if required.
             Beatmap.BindValueChanged(b => ScheduleAfterChildren(() =>
             {
                 // compare to last beatmap as sometimes the two may share a track representation (optimisation, see WorkingBeatmap.TransferTo)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -211,6 +211,10 @@ namespace osu.Game
             Audio.Tracks.AddAdjustment(AdjustableProperty.Volume, new BindableDouble(0.8));
 
             Beatmap = new NonNullableBindable<WorkingBeatmap>(defaultBeatmap);
+
+            // ScheduleAfterChildren is safety against something in the current frame accessing the previous beatmap's track
+            // and potentially causing a reload of it after just unloading.
+            // Note that the reason for this being added *has* been resolved, so it may be feasible to remover this if required.
             Beatmap.BindValueChanged(b => ScheduleAfterChildren(() =>
             {
                 // compare to last beatmap as sometimes the two may share a track representation (optimisation, see WorkingBeatmap.TransferTo)


### PR DESCRIPTION
Quite hard to test this one reliably (used to trigger a feedback loop, but not always, timing dependent), but the case where this can happen should be quite understandable.

- Closes https://github.com/ppy/osu/issues/8111
- Fixes long freezes occasionally occurring when selecting beatmaps from notifications or osu!direct.
- Has a chance of fixing https://github.com/ppy/osu/issues/3051
- [x] Depends on https://github.com/ppy/osu-framework/pull/3333
