### PR TITLE
Fix icon being outside overlay header

### DIFF
--- a/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListHeader.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Overlays.SearchableList
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.BottomLeft,
-                            Position = new Vector2(-35f, 5f),
+                            Position = new Vector2(0f, 5f),
                             AutoSizeAxes = Axes.Both,
                             Direction = FillDirection.Horizontal,
                             Spacing = new Vector2(10f, 0f),


### PR DESCRIPTION
Follows #8103.
![Screenshot_20200304_151712](https://user-images.githubusercontent.com/41869184/75858663-3c825300-5e2b-11ea-9b43-3cc30b888020.png)
