### PR TITLE
Fix searchable list padding

### DIFF
--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.SearchableList
                             {
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
-                                Padding = new MarginPadding { Horizontal = WIDTH_PADDING, Bottom = 50 },
+                                Padding = new MarginPadding { Horizontal = 10, Bottom = 50 },
                                 Direction = FillDirection.Vertical,
                             },
                         },

--- a/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
+++ b/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Overlays.SearchableList
 {
     public abstract class SearchableListOverlay : FullscreenOverlay
     {
-        public const float WIDTH_PADDING = 10;
+        public const float WIDTH_PADDING = 80;
 
         protected SearchableListOverlay(OverlayColourScheme colourScheme)
             : base(colourScheme)


### PR DESCRIPTION
Reverts #8103 and reduces only the content flow's padding width instead.