### PR TITLE
Fix user panel tests

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -66,6 +66,8 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestUserActivity()
         {
+            AddStep("set online status", () => peppy.Status.Value = new UserStatusOnline());
+
             AddStep("idle", () => activity.Value = null);
             AddStep("spectating", () => activity.Value = new UserActivity.Spectating());
             AddStep("solo", () => activity.Value = new UserActivity.SoloGame(null, null));

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Visual.Online
         });
 
         [Test]
-        public void UserStatusesTests()
+        public void TestUserStatus()
         {
             AddStep("online", () => peppy.Status.Value = new UserStatusOnline());
             AddStep("do not disturb", () => peppy.Status.Value = new UserStatusDoNotDisturb());
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
-        public void UserActivitiesTests()
+        public void TestUserActivity()
         {
             AddStep("idle", () => activity.Value = null);
             AddStep("spectating", () => activity.Value = new UserActivity.Spectating());

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -57,21 +57,21 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void UserStatusesTests()
         {
-            AddStep("online", () => { peppy.Status.Value = new UserStatusOnline(); });
-            AddStep(@"do not disturb", () => { peppy.Status.Value = new UserStatusDoNotDisturb(); });
-            AddStep(@"offline", () => { peppy.Status.Value = new UserStatusOffline(); });
-            AddStep(@"null status", () => { peppy.Status.Value = null; });
+            AddStep("online", () => peppy.Status.Value = new UserStatusOnline());
+            AddStep(@"do not disturb", () => peppy.Status.Value = new UserStatusDoNotDisturb());
+            AddStep(@"offline", () => peppy.Status.Value = new UserStatusOffline());
+            AddStep(@"null status", () => peppy.Status.Value = null);
         }
 
         [Test]
         public void UserActivitiesTests()
         {
-            AddStep("idle", () => { activity.Value = null; });
-            AddStep("spectating", () => { activity.Value = new UserActivity.Spectating(); });
-            AddStep("solo", () => { activity.Value = new UserActivity.SoloGame(null, null); });
-            AddStep("choosing", () => { activity.Value = new UserActivity.ChoosingBeatmap(); });
-            AddStep("editing", () => { activity.Value = new UserActivity.Editing(null); });
-            AddStep("modding", () => { activity.Value = new UserActivity.Modding(); });
+            AddStep("idle", () => activity.Value = null);
+            AddStep("spectating", () => activity.Value = new UserActivity.Spectating());
+            AddStep("solo", () => activity.Value = new UserActivity.SoloGame(null, null));
+            AddStep("choosing", () => activity.Value = new UserActivity.ChoosingBeatmap());
+            AddStep("editing", () => activity.Value = new UserActivity.Editing(null));
+            AddStep("modding", () => activity.Value = new UserActivity.Modding());
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -13,13 +13,16 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public class TestSceneUserPanel : OsuTestScene
     {
-        private readonly UserPanel peppy;
+        private readonly Bindable<UserActivity> activity = new Bindable<UserActivity>();
 
-        public TestSceneUserPanel()
+        private UserPanel peppy;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
             UserPanel flyte;
 
-            Add(new FillFlowContainer
+            Child = new FillFlowContainer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -44,11 +47,12 @@ namespace osu.Game.Tests.Visual.Online
                         SupportLevel = 3,
                     }) { Width = 300 },
                 },
-            });
+            };
 
             flyte.Status.Value = new UserStatusOnline();
             peppy.Status.Value = null;
-        }
+            peppy.Activity.BindTo(activity);
+        });
 
         [Test]
         public void UserStatusesTests()
@@ -62,10 +66,6 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void UserActivitiesTests()
         {
-            Bindable<UserActivity> activity = new Bindable<UserActivity>();
-
-            peppy.Activity.BindTo(activity);
-
             AddStep("idle", () => { activity.Value = null; });
             AddStep("spectating", () => { activity.Value = new UserActivity.Spectating(); });
             AddStep("solo", () => { activity.Value = new UserActivity.SoloGame(null, null); });

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -58,9 +58,9 @@ namespace osu.Game.Tests.Visual.Online
         public void UserStatusesTests()
         {
             AddStep("online", () => peppy.Status.Value = new UserStatusOnline());
-            AddStep(@"do not disturb", () => peppy.Status.Value = new UserStatusDoNotDisturb());
-            AddStep(@"offline", () => peppy.Status.Value = new UserStatusOffline());
-            AddStep(@"null status", () => peppy.Status.Value = null);
+            AddStep("do not disturb", () => peppy.Status.Value = new UserStatusDoNotDisturb());
+            AddStep("offline", () => peppy.Status.Value = new UserStatusOffline());
+            AddStep("null status", () => peppy.Status.Value = null);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets;
 using osu.Game.Users;
 using osuTK;
 
@@ -16,6 +18,9 @@ namespace osu.Game.Tests.Visual.Online
         private readonly Bindable<UserActivity> activity = new Bindable<UserActivity>();
 
         private UserPanel peppy;
+
+        [Resolved]
+        private RulesetStore rulesetStore { get; set; }
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -70,10 +75,15 @@ namespace osu.Game.Tests.Visual.Online
 
             AddStep("idle", () => activity.Value = null);
             AddStep("spectating", () => activity.Value = new UserActivity.Spectating());
-            AddStep("solo", () => activity.Value = new UserActivity.SoloGame(null, null));
+            AddStep("solo (osu!)", () => activity.Value = soloGameStatusForRuleset(0));
+            AddStep("solo (osu!taiko)", () => activity.Value = soloGameStatusForRuleset(1));
+            AddStep("solo (osu!catch)", () => activity.Value = soloGameStatusForRuleset(2));
+            AddStep("solo (osu!mania)", () => activity.Value = soloGameStatusForRuleset(3));
             AddStep("choosing", () => activity.Value = new UserActivity.ChoosingBeatmap());
             AddStep("editing", () => activity.Value = new UserActivity.Editing(null));
             AddStep("modding", () => activity.Value = new UserActivity.Modding());
         }
+
+        private UserActivity soloGameStatusForRuleset(int rulesetId) => new UserActivity.SoloGame(null, rulesetStore.GetRuleset(rulesetId));
     }
 }


### PR DESCRIPTION
Result of trying to review #8132.

# Summary

The user panel tests were broken on `master`, so I took it upon myself to fix them. They were broken in the following ways:

* Constructor usage instead of `[SetUp]` made it so the tests were no longer independent in the test browser (execution of one of them affected execution of the other).
* More importantly, they were silently broken, as `UserActivitiesTests` did nothing. Since `status.Value` was set to null in the ctor, assignments to `activity.Values` made no effect on the component whatsoever, disguising a test regression (passing null ruleset was no longer valid since 3a903339d6e41aa5c37bed8928ce16be03e609b0, as there was an attempt to access `Ruleset.PlayingVerb`).

# Remarks

Also cleaned up code style along the way.