### PR TITLE
Ensure tournament screens respect aspect ratio in tests

### DIFF
--- a/osu.Game.Tournament/Screens/TournamentScreen.cs
+++ b/osu.Game.Tournament/Screens/TournamentScreen.cs
@@ -18,6 +18,9 @@ namespace osu.Game.Tournament.Screens
         protected TournamentScreen()
         {
             RelativeSizeAxes = Axes.Both;
+
+            FillMode = FillMode.Fit;
+            FillAspectRatio = 16 / 9f;
         }
 
         public override void Hide() => this.FadeOut(FADE_DELAY);


### PR DESCRIPTION
Previously, tournament screens would expand relative sized elements to match the full window width (only in tests). This same aspect fit is enforced by the `TournamentSceneManager`, which is not present in the per-screen testing hierarchy.