### PR TITLE
Simplify tournament video construction

### DIFF
--- a/osu.Game.Tournament/Components/TourneyVideo.cs
+++ b/osu.Game.Tournament/Components/TourneyVideo.cs
@@ -1,12 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.IO;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Video;
+using osu.Framework.Platform;
 using osu.Framework.Timing;
 using osu.Game.Graphics;
 
@@ -14,27 +15,38 @@ namespace osu.Game.Tournament.Components
 {
     public class TourneyVideo : CompositeDrawable
     {
-        private readonly VideoSprite video;
+        private readonly string filename;
+        private readonly bool drawFallbackGradient;
+        private VideoSprite video;
 
-        private readonly ManualClock manualClock;
+        private ManualClock manualClock;
 
-        public TourneyVideo(Stream stream)
+        public TourneyVideo(string filename, bool drawFallbackGradient = false)
         {
-            if (stream == null)
-            {
-                InternalChild = new Box
-                {
-                    Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.3f), OsuColour.Gray(0.6f)),
-                    RelativeSizeAxes = Axes.Both,
-                };
-            }
-            else
+            this.filename = filename;
+            this.drawFallbackGradient = drawFallbackGradient;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(Storage storage)
+        {
+            var stream = storage.GetStream($@"videos/{filename}.m4v");
+
+            if (stream != null)
             {
                 InternalChild = video = new VideoSprite(stream)
                 {
                     RelativeSizeAxes = Axes.Both,
                     FillMode = FillMode.Fit,
                     Clock = new FramedClock(manualClock = new ManualClock())
+                };
+            }
+            else if (drawFallbackGradient)
+            {
+                InternalChild = new Box
+                {
+                    Colour = ColourInfo.GradientVertical(OsuColour.Gray(0.3f), OsuColour.Gray(0.6f)),
+                    RelativeSizeAxes = Axes.Both,
                 };
             }
         }

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
 
             AddRangeInternal(new Drawable[]
             {
-                new TourneyVideo(storage.GetStream("videos/gameplay.m4v"))
+                new TourneyVideo("gameplay")
                 {
                     Loop = true,
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Tournament.Components;
@@ -19,7 +20,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Screens.Gameplay
 {
-    public class GameplayScreen : BeatmapInfoScreen
+    public class GameplayScreen : BeatmapInfoScreen, IProvideVideo
     {
         private readonly BindableBool warmup = new BindableBool();
 
@@ -39,12 +40,17 @@ namespace osu.Game.Tournament.Screens.Gameplay
         private TournamentMatchChatDisplay chat { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(LadderInfo ladder, MatchIPCInfo ipc)
+        private void load(LadderInfo ladder, MatchIPCInfo ipc, Storage storage)
         {
             this.ipc = ipc;
 
             AddRangeInternal(new Drawable[]
             {
+                new TourneyVideo(storage.GetStream("videos/gameplay.m4v"))
+                {
+                    Loop = true,
+                    RelativeSizeAxes = Axes.Both,
+                },
                 new MatchHeader(),
                 new Container
                 {

--- a/osu.Game.Tournament/Screens/Ladder/LadderScreen.cs
+++ b/osu.Game.Tournament/Screens/Ladder/LadderScreen.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tournament.Screens.Ladder
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    new TourneyVideo(storage.GetStream(@"videos/ladder.m4v"))
+                    new TourneyVideo("ladder")
                     {
                         RelativeSizeAxes = Axes.Both,
                         Loop = true,

--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -18,7 +18,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Screens.Schedule
 {
-    public class ScheduleScreen : TournamentScreen, IProvideVideo
+    public class ScheduleScreen : TournamentScreen
     {
         private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
         private Container mainContainer;
@@ -33,7 +33,7 @@ namespace osu.Game.Tournament.Screens.Schedule
 
             InternalChildren = new Drawable[]
             {
-                new TourneyVideo(storage.GetStream(@"videos/schedule.m4v"))
+                new TourneyVideo("schedule")
                 {
                     RelativeSizeAxes = Axes.Both,
                     Loop = true,

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 
             InternalChildren = new Drawable[]
             {
-                new TourneyVideo(storage.GetStream(@"videos/seeding.m4v"))
+                new TourneyVideo("seeding")
                 {
                     RelativeSizeAxes = Axes.Both,
                     Loop = true,

--- a/osu.Game.Tournament/Screens/TeamIntro/TeamIntroScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/TeamIntroScreen.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 
             InternalChildren = new Drawable[]
             {
-                new TourneyVideo(storage.GetStream(@"videos/teamintro.m4v"))
+                new TourneyVideo("teamintro")
                 {
                     RelativeSizeAxes = Axes.Both,
                     Loop = true,

--- a/osu.Game.Tournament/Screens/TeamWin/TeamWinScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamWin/TeamWinScreen.cs
@@ -31,13 +31,13 @@ namespace osu.Game.Tournament.Screens.TeamWin
 
             InternalChildren = new Drawable[]
             {
-                blueWinVideo = new TourneyVideo(storage.GetStream(@"videos/teamwin-blue.m4v"))
+                blueWinVideo = new TourneyVideo("teamwin-blue")
                 {
                     Alpha = 1,
                     RelativeSizeAxes = Axes.Both,
                     Loop = true,
                 },
-                redWinVideo = new TourneyVideo(storage.GetStream(@"videos/teamwin-red.m4v"))
+                redWinVideo = new TourneyVideo("teamwin-red")
                 {
                     Alpha = 0,
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game.Tournament/TournamentSceneManager.cs
+++ b/osu.Game.Tournament/TournamentSceneManager.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tournament
                     //Masking = true,
                     Children = new Drawable[]
                     {
-                        video = new TourneyVideo(storage.GetStream("videos/main.m4v"))
+                        video = new TourneyVideo("main", true)
                         {
                             Loop = true,
                             RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Move video stream retrieval internal to `TourneyVideo`. Allows for more optional video specifications at a per-screen level even if they potentially aren't being implemented (will fallback to `main`, handled by `TournamentSceneManager`).