### PR TITLE
Fix osu! hitbox accepting input outside of circle

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
@@ -1,0 +1,108 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public class TestSceneHitCircleArea : ManualInputManagerTestScene
+    {
+        private HitCircle hitCircle;
+        private DrawableHitCircle drawableHitCircle;
+        private DrawableHitCircle.HitReceptor hitAreaReceptor => drawableHitCircle.HitArea;
+
+        [SetUp]
+        public new void SetUp()
+        {
+            base.SetUp();
+
+            Schedule(() =>
+            {
+                hitCircle = new HitCircle
+                {
+                    Position = new Vector2(100, 100),
+                    StartTime = Time.Current + 500
+                };
+
+                hitCircle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+                Child = new SkinProvidingContainer(new DefaultSkin())
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = drawableHitCircle = new DrawableHitCircle(hitCircle)
+                    {
+                        Size = new Vector2(100)
+                    }
+                };
+            });
+        }
+
+        [Test]
+        public void TestCircleHitCentre()
+        {
+            AddStep("move mouse to centre", () => InputManager.MoveMouseTo(hitAreaReceptor.ScreenSpaceDrawQuad.Centre));
+            scheduleHit();
+
+            AddAssert("hit registered", () => hitAreaReceptor.HitAction == OsuAction.LeftButton);
+        }
+
+        [Test]
+        public void TestCircleHitLeftEdge()
+        {
+            AddStep("move mouse to left edge", () =>
+            {
+                var drawQuad = hitAreaReceptor.ScreenSpaceDrawQuad;
+                var mousePosition = new Vector2(drawQuad.TopLeft.X, drawQuad.Centre.Y);
+
+                InputManager.MoveMouseTo(mousePosition);
+            });
+            scheduleHit();
+
+            AddAssert("hit registered", () => hitAreaReceptor.HitAction == OsuAction.LeftButton);
+        }
+
+        [Test]
+        public void TestCircleHitTopLeftEdge()
+        {
+            AddStep("move mouse to top left circle edge", () =>
+            {
+                var drawQuad = hitAreaReceptor.ScreenSpaceDrawQuad;
+                // sqrt(2) / 2 = sin(45deg) = cos(45deg)
+                // draw width halved to get radius
+                // 0.95f taken for leniency
+                float correction = 0.95f * (float)Math.Sqrt(2) / 2 * (drawQuad.Width / 2);
+                var mousePosition = new Vector2(drawQuad.Centre.X - correction, drawQuad.Centre.Y - correction);
+
+                InputManager.MoveMouseTo(mousePosition);
+            });
+            scheduleHit();
+
+            AddAssert("hit registered", () => hitAreaReceptor.HitAction == OsuAction.LeftButton);
+        }
+
+        [Test]
+        public void TestCircleMissBoundingBoxCorner()
+        {
+            AddStep("move mouse to top left corner of bounding box", () => InputManager.MoveMouseTo(hitAreaReceptor.ScreenSpaceDrawQuad.TopLeft));
+            scheduleHit();
+
+            AddAssert("hit not registered", () => hitAreaReceptor.HitAction == null);
+        }
+
+        private void scheduleHit() => AddStep("schedule action", () =>
+        {
+            var delay = hitCircle.StartTime - hitCircle.HitWindows.WindowFor(HitResult.Great) - Time.Current;
+            Scheduler.AddDelayed(() => hitAreaReceptor.OnPressed(OsuAction.LeftButton), delay);
+        });
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
@@ -71,23 +71,23 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("hit registered", () => hitAreaReceptor.HitAction == OsuAction.LeftButton);
         }
 
-        [Test]
-        public void TestCircleHitTopLeftEdge()
+        [TestCase(0.95f, OsuAction.LeftButton)]
+        [TestCase(1.05f, null)]
+        public void TestHitsCloseToEdge(float relativeDistanceFromCentre, OsuAction? expectedAction)
         {
             AddStep("move mouse to top left circle edge", () =>
             {
                 var drawQuad = hitAreaReceptor.ScreenSpaceDrawQuad;
                 // sqrt(2) / 2 = sin(45deg) = cos(45deg)
                 // draw width halved to get radius
-                // 0.95f taken for leniency
-                float correction = 0.95f * (float)Math.Sqrt(2) / 2 * (drawQuad.Width / 2);
+                float correction = relativeDistanceFromCentre * (float)Math.Sqrt(2) / 2 * (drawQuad.Width / 2);
                 var mousePosition = new Vector2(drawQuad.Centre.X - correction, drawQuad.Centre.Y - correction);
 
                 InputManager.MoveMouseTo(mousePosition);
             });
             scheduleHit();
 
-            AddAssert("hit registered", () => hitAreaReceptor.HitAction == OsuAction.LeftButton);
+            AddAssert($"hit {(expectedAction == null ? "not " : string.Empty)}registered", () => hitAreaReceptor.HitAction == expectedAction);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public Drawable ProxiedLayer => ApproachCircle;
 
-        public class HitReceptor : Drawable, IKeyBindingHandler<OsuAction>
+        public class HitReceptor : CompositeDrawable, IKeyBindingHandler<OsuAction>
         {
             // IsHovered is used
             public override bool HandlePositionalInput => true;
@@ -185,6 +185,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
+
+                CornerRadius = OsuHitObject.OBJECT_RADIUS;
+                CornerExponent = 2;
             }
 
             public bool OnPressed(OsuAction action)


### PR DESCRIPTION
Resolves #8158.

# Summary

Hitboxes of circle pieces in osu! seem to have unintentionally regressed with commit 8592335. The reason for the regression was that hit detection was moved from `CirclePiece` itself to a newly-introduced private `HitArea` class (now named `HitReceptor`).

As `HitArea` inherited from `Drawable`, it would return `IsHovered == true` over its entire bounding box. This meant that the hit area could wrongly pick up actions that are not within circle radius and make them into hits.

To resolve, make `HitReceptor` a `CompositeDrawable` and set its corner radius to match the circle piece. This fixes the invalid hitbox, as `IsHovered` takes radius into account.

# Remarks

Includes a test scene, so this should hopefully never regress again. I do realise it might be a little awkwardly written - I tried to not base on either `PlayerTestScene` or `SkinnableTestScene` as the first one seems too slow for what the tests aim to test and the skinnable one would probably look broken and it's not what that test class is for anyway.