### PR TITLE
Add new tournament design base elements

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentTeam.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneDrawableTournamentTeam.cs
@@ -1,0 +1,124 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Game.Tests.Visual;
+using osu.Game.Tournament.Components;
+using osu.Game.Tournament.Models;
+using osu.Game.Tournament.Screens.Drawings.Components;
+using osu.Game.Tournament.Screens.Gameplay.Components;
+using osu.Game.Tournament.Screens.Ladder.Components;
+using osu.Game.Users;
+
+namespace osu.Game.Tournament.Tests.Components
+{
+    public class TestSceneDrawableTournamentTeam : OsuGridTestScene
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(DrawableTeamFlag),
+            typeof(DrawableTeamTitle),
+            typeof(DrawableTeamTitleWithHeader),
+            typeof(DrawableMatchTeam),
+            typeof(DrawableTeamWithPlayers),
+            typeof(GroupTeam),
+            typeof(TeamDisplay),
+        };
+
+        public TestSceneDrawableTournamentTeam()
+            : base(4, 3)
+        {
+            var team = new TournamentTeam
+            {
+                FlagName = { Value = "AU" },
+                FullName = { Value = "Australia" },
+                Players =
+                {
+                    new User { Username = "ASecretBox" },
+                    new User { Username = "Dereban" },
+                    new User { Username = "mReKk" },
+                    new User { Username = "uyghti" },
+                    new User { Username = "Parkes" },
+                    new User { Username = "Shiroha" },
+                    new User { Username = "Jordan The Bear" },
+                }
+            };
+
+            var match = new TournamentMatch { Team1 = { Value = team } };
+
+            int i = 0;
+
+            Cell(i++).AddRange(new Drawable[]
+            {
+                new TournamentSpriteText { Text = "DrawableTeamFlag" },
+                new DrawableTeamFlag(team)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+
+            Cell(i++).AddRange(new Drawable[]
+            {
+                new TournamentSpriteText { Text = "DrawableTeamTitle" },
+                new DrawableTeamTitle(team)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+
+            Cell(i++).AddRange(new Drawable[]
+            {
+                new TournamentSpriteText { Text = "DrawableTeamTitleWithHeader" },
+                new DrawableTeamTitleWithHeader(team, TeamColour.Red)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+
+            Cell(i++).AddRange(new Drawable[]
+            {
+                new TournamentSpriteText { Text = "DrawableMatchTeam" },
+                new DrawableMatchTeam(team, match, false)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+
+            Cell(i++).AddRange(new Drawable[]
+            {
+                new TournamentSpriteText { Text = "TeamWithPlayers" },
+                new DrawableTeamWithPlayers(team, TeamColour.Blue)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+
+            Cell(i++).AddRange(new Drawable[]
+            {
+                new TournamentSpriteText { Text = "GroupTeam" },
+                new GroupTeam(team)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+
+            Cell(i).AddRange(new Drawable[]
+            {
+                new TournamentSpriteText { Text = "TeamDisplay" },
+                new TeamDisplay(team, TournamentGame.COLOUR_RED, false)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/DrawableTeamFlag.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamFlag.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Tournament.Models;
+
+namespace osu.Game.Tournament.Components
+{
+    public class DrawableTeamFlag : Sprite
+    {
+        private readonly TournamentTeam team;
+
+        [UsedImplicitly]
+        private Bindable<string> flag;
+
+        public DrawableTeamFlag(TournamentTeam team)
+        {
+            this.team = team;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
+        {
+            if (team == null) return;
+
+            (flag = team.FlagName.GetBoundCopy()).BindValueChanged(acronym => Texture = textures.Get($@"Flags/{team.FlagName}"), true);
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/DrawableTeamHeader.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamHeader.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Tournament.Models;
+using osuTK;
+
+namespace osu.Game.Tournament.Components
+{
+    public class DrawableTeamHeader : TournamentSpriteTextWithBackground
+    {
+        public DrawableTeamHeader(TeamColour colour)
+        {
+            Background.Colour = TournamentGame.GetTeamColour(colour);
+
+            Text.Colour = TournamentGame.TEXT_COLOUR;
+            Text.Text = $"Team {colour}".ToUpperInvariant();
+            Text.Scale = new Vector2(0.6f);
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/DrawableTeamTitle.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamTitle.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Tournament.Models;
+
+namespace osu.Game.Tournament.Components
+{
+    public class DrawableTeamTitle : TournamentSpriteTextWithBackground
+    {
+        private readonly TournamentTeam team;
+
+        [UsedImplicitly]
+        private Bindable<string> acronym;
+
+        public DrawableTeamTitle(TournamentTeam team)
+        {
+            this.team = team;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
+        {
+            if (team == null) return;
+
+            (acronym = team.Acronym.GetBoundCopy()).BindValueChanged(acronym => Text.Text = team?.FullName.Value ?? string.Empty, true);
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/DrawableTeamTitleWithHeader.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamTitleWithHeader.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Tournament.Models;
+using osuTK;
+
+namespace osu.Game.Tournament.Components
+{
+    public class DrawableTeamTitleWithHeader : CompositeDrawable
+    {
+        public DrawableTeamTitleWithHeader(TournamentTeam team, TeamColour colour)
+        {
+            AutoSizeAxes = Axes.Both;
+
+            InternalChild = new FillFlowContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(0, 10),
+                Children = new Drawable[]
+                {
+                    new DrawableTeamHeader(colour),
+                    new DrawableTeamTitle(team),
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
@@ -46,12 +46,7 @@ namespace osu.Game.Tournament.Components
                                 {
                                     Direction = FillDirection.Vertical,
                                     AutoSizeAxes = Axes.Both,
-                                    ChildrenEnumerable = team?.Players.Select(p => new TournamentSpriteText
-                                    {
-                                        Text = p.Username,
-                                        Font = OsuFont.Torus.With(size: 24, weight: FontWeight.SemiBold),
-                                        Colour = Color4.White,
-                                    }).Skip(5) ?? Enumerable.Empty<Drawable>()
+                                    ChildrenEnumerable = team?.Players.Select(createPlayerText).Skip(5) ?? Enumerable.Empty<Drawable>()
                                 },
                             }
                         },

--- a/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamWithPlayers.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Tournament.Models;
+using osu.Game.Users;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tournament.Components
+{
+    public class DrawableTeamWithPlayers : CompositeDrawable
+    {
+        public DrawableTeamWithPlayers(TournamentTeam team, TeamColour colour)
+        {
+            AutoSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(30),
+                    Children = new Drawable[]
+                    {
+                        new DrawableTeamTitleWithHeader(team, colour),
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Horizontal,
+                            Padding = new MarginPadding { Left = 10 },
+                            Spacing = new Vector2(30),
+                            Children = new Drawable[]
+                            {
+                                new FillFlowContainer
+                                {
+                                    Direction = FillDirection.Vertical,
+                                    AutoSizeAxes = Axes.Both,
+                                    ChildrenEnumerable = team?.Players.Select(createPlayerText).Take(5) ?? Enumerable.Empty<Drawable>()
+                                },
+                                new FillFlowContainer
+                                {
+                                    Direction = FillDirection.Vertical,
+                                    AutoSizeAxes = Axes.Both,
+                                    ChildrenEnumerable = team?.Players.Select(p => new TournamentSpriteText
+                                    {
+                                        Text = p.Username,
+                                        Font = OsuFont.Torus.With(size: 24, weight: FontWeight.SemiBold),
+                                        Colour = Color4.White,
+                                    }).Skip(5) ?? Enumerable.Empty<Drawable>()
+                                },
+                            }
+                        },
+                    }
+                },
+            };
+
+            TournamentSpriteText createPlayerText(User p) =>
+                new TournamentSpriteText
+                {
+                    Text = p.Username,
+                    Font = OsuFont.Torus.With(size: 24, weight: FontWeight.SemiBold),
+                    Colour = Color4.White,
+                };
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/DrawableTournamentTeam.cs
+++ b/osu.Game.Tournament/Components/DrawableTournamentTeam.cs
@@ -23,14 +23,11 @@ namespace osu.Game.Tournament.Components
         [UsedImplicitly]
         private Bindable<string> acronym;
 
-        [UsedImplicitly]
-        private Bindable<string> flag;
-
         protected DrawableTournamentTeam(TournamentTeam team)
         {
             Team = team;
 
-            Flag = new Sprite
+            Flag = new DrawableTeamFlag(team)
             {
                 RelativeSizeAxes = Axes.Both,
                 FillMode = FillMode.Fit
@@ -48,7 +45,6 @@ namespace osu.Game.Tournament.Components
             if (Team == null) return;
 
             (acronym = Team.Acronym.GetBoundCopy()).BindValueChanged(acronym => AcronymText.Text = Team?.Acronym.Value?.ToUpperInvariant() ?? string.Empty, true);
-            (flag = Team.FlagName.GetBoundCopy()).BindValueChanged(acronym => Flag.Texture = textures.Get($@"Flags/{Team.FlagName}"), true);
         }
     }
 }

--- a/osu.Game.Tournament/Components/DrawableTournamentTitleText.cs
+++ b/osu.Game.Tournament/Components/DrawableTournamentTitleText.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics;
+
+namespace osu.Game.Tournament.Components
+{
+    public class DrawableTournamentTitleText : TournamentSpriteText
+    {
+        public DrawableTournamentTitleText()
+        {
+            Text = "osu!taiko world cup 2020";
+            Font = OsuFont.Torus.With(size: 26, weight: FontWeight.SemiBold);
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/RoundDisplay.cs
+++ b/osu.Game.Tournament/Components/RoundDisplay.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Tournament.Models;
+
+namespace osu.Game.Tournament.Components
+{
+    public class RoundDisplay : CompositeDrawable
+    {
+        public RoundDisplay(TournamentMatch match)
+        {
+            AutoSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new DrawableTournamentTitleText(),
+                        new TournamentSpriteText
+                        {
+                            Text = match.Round.Value?.Name.Value ?? "Unknown Round",
+                            Font = OsuFont.Torus.With(size: 26, weight: FontWeight.SemiBold)
+                        },
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/TournamentSpriteTextWithBackground.cs
+++ b/osu.Game.Tournament/Components/TournamentSpriteTextWithBackground.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+
+namespace osu.Game.Tournament.Components
+{
+    public class TournamentSpriteTextWithBackground : CompositeDrawable
+    {
+        protected readonly TournamentSpriteText Text;
+        protected readonly Box Background;
+
+        public TournamentSpriteTextWithBackground(string text = "")
+        {
+            AutoSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                Background = new Box
+                {
+                    Colour = TournamentGame.ELEMENT_BACKGROUND_COLOUR,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                Text = new TournamentSpriteText
+                {
+                    Colour = TournamentGame.ELEMENT_FOREGROUND_COLOUR,
+                    Font = OsuFont.Torus.With(weight: FontWeight.SemiBold, size: 50),
+                    Padding = new MarginPadding { Left = 10, Right = 20 },
+                    Text = text
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Tournament/Screens/Drawings/Components/Group.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/Group.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
-using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osuTK;
 using osuTK.Graphics;
@@ -115,54 +114,6 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
             foreach (GroupTeam gt in allTeams)
                 sb.AppendLine(gt.Team.FullName.Value);
             return sb.ToString();
-        }
-
-        private class GroupTeam : DrawableTournamentTeam
-        {
-            private readonly FillFlowContainer innerContainer;
-
-            public GroupTeam(TournamentTeam team)
-                : base(team)
-            {
-                Width = 36;
-                AutoSizeAxes = Axes.Y;
-
-                Flag.Anchor = Anchor.TopCentre;
-                Flag.Origin = Anchor.TopCentre;
-
-                AcronymText.Anchor = Anchor.TopCentre;
-                AcronymText.Origin = Anchor.TopCentre;
-                AcronymText.Text = team.Acronym.Value.ToUpperInvariant();
-                AcronymText.Font = OsuFont.Torus.With(weight: FontWeight.Bold, size: 10);
-
-                InternalChildren = new Drawable[]
-                {
-                    innerContainer = new FillFlowContainer
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(0, 5f),
-
-                        Children = new Drawable[]
-                        {
-                            Flag,
-                            AcronymText
-                        }
-                    }
-                };
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-                innerContainer.ScaleTo(1.5f);
-                innerContainer.ScaleTo(1f, 200);
-            }
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Drawings/Components/GroupTeam.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/GroupTeam.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Tournament.Components;
+using osu.Game.Tournament.Models;
+using osuTK;
+
+namespace osu.Game.Tournament.Screens.Drawings.Components
+{
+    public class GroupTeam : DrawableTournamentTeam
+    {
+        private readonly FillFlowContainer innerContainer;
+
+        public GroupTeam(TournamentTeam team)
+            : base(team)
+        {
+            Width = 36;
+            AutoSizeAxes = Axes.Y;
+
+            Flag.Anchor = Anchor.TopCentre;
+            Flag.Origin = Anchor.TopCentre;
+
+            AcronymText.Anchor = Anchor.TopCentre;
+            AcronymText.Origin = Anchor.TopCentre;
+            AcronymText.Text = team.Acronym.Value.ToUpperInvariant();
+            AcronymText.Font = OsuFont.Torus.With(weight: FontWeight.Bold, size: 10);
+
+            InternalChildren = new Drawable[]
+            {
+                innerContainer = new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 5f),
+
+                    Children = new Drawable[]
+                    {
+                        Flag,
+                        AcronymText
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            innerContainer.ScaleTo(1.5f);
+            innerContainer.ScaleTo(1f, 200);
+        }
+    }
+}

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -172,19 +172,6 @@ namespace osu.Game.Tournament.Screens.Editors
                 drawableContainer.Child = new DrawableTeamFlag(Model);
             }
 
-            private class DrawableTeamFlag : DrawableTournamentTeam
-            {
-                public DrawableTeamFlag(TournamentTeam team)
-                    : base(team)
-                {
-                    InternalChild = Flag;
-                    RelativeSizeAxes = Axes.Both;
-
-                    Flag.Anchor = Anchor.Centre;
-                    Flag.Origin = Anchor.Centre;
-                }
-            }
-
             public class PlayerEditor : CompositeDrawable
             {
                 private readonly TournamentTeam team;

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
@@ -5,15 +5,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Showcase;
-using osuTK;
-using osuTK.Graphics;
 using osuTK.Input;
 
 namespace osu.Game.Tournament.Screens.Gameplay.Components
@@ -46,181 +40,75 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                 },
             };
         }
+    }
 
-        private class TeamScoreDisplay : CompositeDrawable
+    public class TeamScoreDisplay : CompositeDrawable
+    {
+        private readonly TeamColour teamColour;
+
+        private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
+        private readonly Bindable<TournamentTeam> currentTeam = new Bindable<TournamentTeam>();
+        private readonly Bindable<int?> currentTeamScore = new Bindable<int?>();
+
+        public TeamScoreDisplay(TeamColour teamColour)
         {
-            private readonly TeamColour teamColour;
+            this.teamColour = teamColour;
 
-            private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
-            private readonly Bindable<TournamentTeam> currentTeam = new Bindable<TournamentTeam>();
-            private readonly Bindable<int?> currentTeamScore = new Bindable<int?>();
+            RelativeSizeAxes = Axes.Y;
+            Width = 300;
+        }
 
-            public TeamScoreDisplay(TeamColour teamColour)
+        [BackgroundDependencyLoader]
+        private void load(LadderInfo ladder)
+        {
+            currentMatch.BindValueChanged(matchChanged);
+            currentMatch.BindTo(ladder.CurrentMatch);
+        }
+
+        private void matchChanged(ValueChangedEvent<TournamentMatch> match)
+        {
+            currentTeamScore.UnbindBindings();
+            currentTeamScore.BindTo(teamColour == TeamColour.Red ? match.NewValue.Team1Score : match.NewValue.Team2Score);
+
+            currentTeam.UnbindBindings();
+            currentTeam.BindTo(teamColour == TeamColour.Red ? match.NewValue.Team1 : match.NewValue.Team2);
+
+            // team may change to same team, which means score is not in a good state.
+            // thus we handle this manually.
+            teamChanged(currentTeam.Value);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            switch (e.Button)
             {
-                this.teamColour = teamColour;
+                case MouseButton.Left:
+                    if (currentTeamScore.Value < currentMatch.Value.PointsToWin)
+                        currentTeamScore.Value++;
+                    return true;
 
-                RelativeSizeAxes = Axes.Y;
-                Width = 300;
+                case MouseButton.Right:
+                    if (currentTeamScore.Value > 0)
+                        currentTeamScore.Value--;
+                    return true;
             }
 
-            [BackgroundDependencyLoader]
-            private void load(LadderInfo ladder)
+            return base.OnMouseDown(e);
+        }
+
+        private void teamChanged(TournamentTeam team)
+        {
+            var colour = teamColour == TeamColour.Red ? TournamentGame.COLOUR_RED : TournamentGame.COLOUR_BLUE;
+            var flip = teamColour == TeamColour.Red;
+
+            InternalChildren = new Drawable[]
             {
-                currentMatch.BindValueChanged(matchChanged);
-                currentMatch.BindTo(ladder.CurrentMatch);
-            }
-
-            private void matchChanged(ValueChangedEvent<TournamentMatch> match)
-            {
-                currentTeamScore.UnbindBindings();
-                currentTeamScore.BindTo(teamColour == TeamColour.Red ? match.NewValue.Team1Score : match.NewValue.Team2Score);
-
-                currentTeam.UnbindBindings();
-                currentTeam.BindTo(teamColour == TeamColour.Red ? match.NewValue.Team1 : match.NewValue.Team2);
-
-                // team may change to same team, which means score is not in a good state.
-                // thus we handle this manually.
-                teamChanged(currentTeam.Value);
-            }
-
-            protected override bool OnMouseDown(MouseDownEvent e)
-            {
-                switch (e.Button)
+                new TeamDisplay(team, colour, flip),
+                new TeamScore(currentTeamScore, flip, currentMatch.Value.PointsToWin)
                 {
-                    case MouseButton.Left:
-                        if (currentTeamScore.Value < currentMatch.Value.PointsToWin)
-                            currentTeamScore.Value++;
-                        return true;
-
-                    case MouseButton.Right:
-                        if (currentTeamScore.Value > 0)
-                            currentTeamScore.Value--;
-                        return true;
+                    Colour = colour
                 }
-
-                return base.OnMouseDown(e);
-            }
-
-            private void teamChanged(TournamentTeam team)
-            {
-                var colour = teamColour == TeamColour.Red ? TournamentGame.COLOUR_RED : TournamentGame.COLOUR_BLUE;
-                var flip = teamColour != TeamColour.Red;
-
-                InternalChildren = new Drawable[]
-                {
-                    new TeamDisplay(team, colour, flip),
-                    new TeamScore(currentTeamScore, flip, currentMatch.Value.PointsToWin)
-                    {
-                        Colour = colour
-                    }
-                };
-            }
-        }
-
-        private class TeamScore : CompositeDrawable
-        {
-            private readonly Bindable<int?> currentTeamScore = new Bindable<int?>();
-            private readonly StarCounter counter;
-
-            public TeamScore(Bindable<int?> score, bool flip, int count)
-            {
-                var anchor = flip ? Anchor.CentreRight : Anchor.CentreLeft;
-
-                Anchor = anchor;
-                Origin = anchor;
-
-                InternalChild = counter = new StarCounter(count)
-                {
-                    Anchor = anchor,
-                    X = (flip ? -1 : 1) * 90,
-                    Y = 5,
-                    Scale = flip ? new Vector2(-1, 1) : Vector2.One,
-                };
-
-                currentTeamScore.BindValueChanged(scoreChanged);
-                currentTeamScore.BindTo(score);
-            }
-
-            private void scoreChanged(ValueChangedEvent<int?> score) => counter.CountStars = score.NewValue ?? 0;
-        }
-
-        private class TeamDisplay : DrawableTournamentTeam
-        {
-            public TeamDisplay(TournamentTeam team, Color4 colour, bool flip)
-                : base(team)
-            {
-                RelativeSizeAxes = Axes.Both;
-
-                var anchor = flip ? Anchor.CentreRight : Anchor.CentreLeft;
-
-                Anchor = Origin = anchor;
-
-                Flag.Anchor = Flag.Origin = anchor;
-                Flag.RelativeSizeAxes = Axes.None;
-                Flag.Size = new Vector2(60, 40);
-                Flag.Margin = new MarginPadding(20);
-
-                InternalChild = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
-                        Flag,
-                        new TournamentSpriteText
-                        {
-                            Text = team?.FullName.Value.ToUpper() ?? "???",
-                            X = (flip ? -1 : 1) * 90,
-                            Y = -10,
-                            Colour = colour,
-                            Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 20),
-                            Origin = anchor,
-                            Anchor = anchor,
-                        },
-                    }
-                };
-            }
-        }
-
-        private class RoundDisplay : CompositeDrawable
-        {
-            private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
-
-            private readonly TournamentSpriteText text;
-
-            public RoundDisplay()
-            {
-                Width = 200;
-                Height = 20;
-
-                Masking = true;
-                CornerRadius = 10;
-
-                InternalChildren = new Drawable[]
-                {
-                    new Box
-                    {
-                        Colour = OsuColour.Gray(0.18f),
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    text = new TournamentSpriteText
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Colour = Color4.White,
-                        Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 16),
-                    },
-                };
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(LadderInfo ladder)
-            {
-                currentMatch.BindValueChanged(matchChanged);
-                currentMatch.BindTo(ladder.CurrentMatch);
-            }
-
-            private void matchChanged(ValueChangedEvent<TournamentMatch> match) =>
-                text.Text = match.NewValue.Round.Value?.Name.Value ?? "Unknown Round";
+            };
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/RoundDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/RoundDisplay.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Tournament.Models;
+using osuTK.Graphics;
+
+namespace osu.Game.Tournament.Screens.Gameplay.Components
+{
+    public class RoundDisplay : CompositeDrawable
+    {
+        private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
+
+        private readonly TournamentSpriteText text;
+
+        public RoundDisplay()
+        {
+            Width = 200;
+            Height = 20;
+
+            Masking = true;
+            CornerRadius = 10;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = OsuColour.Gray(0.18f),
+                    RelativeSizeAxes = Axes.Both,
+                },
+                text = new TournamentSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Colour = Color4.White,
+                    Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 16),
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(LadderInfo ladder)
+        {
+            currentMatch.BindValueChanged(matchChanged);
+            currentMatch.BindTo(ladder.CurrentMatch);
+        }
+
+        private void matchChanged(ValueChangedEvent<TournamentMatch> match) =>
+            text.Text = match.NewValue.Round.Value?.Name.Value ?? "Unknown Round";
+    }
+}

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Tournament.Components;
+using osu.Game.Tournament.Models;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tournament.Screens.Gameplay.Components
+{
+    public class TeamDisplay : DrawableTournamentTeam
+    {
+        public TeamDisplay(TournamentTeam team, Color4 colour, bool flip)
+            : base(team)
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            var anchor = flip ? Anchor.CentreRight : Anchor.CentreLeft;
+
+            Anchor = Origin = anchor;
+
+            Flag.Anchor = Flag.Origin = anchor;
+            Flag.RelativeSizeAxes = Axes.None;
+            Flag.Size = new Vector2(60, 40);
+            Flag.Margin = new MarginPadding(20);
+
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    Flag,
+                    new TournamentSpriteText
+                    {
+                        Text = team?.FullName.Value.ToUpper() ?? "???",
+                        X = (flip ? -1 : 1) * 90,
+                        Y = -10,
+                        Colour = colour,
+                        Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: 20),
+                        Origin = anchor,
+                        Anchor = anchor,
+                    },
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+
+namespace osu.Game.Tournament.Screens.Gameplay.Components
+{
+    public class TeamScore : CompositeDrawable
+    {
+        private readonly Bindable<int?> currentTeamScore = new Bindable<int?>();
+        private readonly StarCounter counter;
+
+        public TeamScore(Bindable<int?> score, bool flip, int count)
+        {
+            var anchor = flip ? Anchor.CentreRight : Anchor.CentreLeft;
+
+            Anchor = anchor;
+            Origin = anchor;
+
+            InternalChild = counter = new StarCounter(count)
+            {
+                Anchor = anchor,
+                X = (flip ? -1 : 1) * 90,
+                Y = 5,
+                Scale = flip ? new Vector2(-1, 1) : Vector2.One,
+            };
+
+            currentTeamScore.BindValueChanged(scoreChanged);
+            currentTeamScore.BindTo(score);
+        }
+
+        private void scoreChanged(ValueChangedEvent<int?> score) => counter.CountStars = score.NewValue ?? 0;
+    }
+}

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScore.cs
@@ -33,6 +33,6 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             currentTeamScore.BindTo(score);
         }
 
-        private void scoreChanged(ValueChangedEvent<int?> score) => counter.CountStars = score.NewValue ?? 0;
+        private void scoreChanged(ValueChangedEvent<int?> score) => counter.Current = score.NewValue ?? 0;
     }
 }

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
@@ -37,11 +37,13 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         private readonly Func<bool> isWinner;
         private LadderEditorScreen ladderEditor;
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
         private LadderInfo ladderInfo { get; set; }
 
         private void setCurrent()
         {
+            if (ladderInfo == null) return;
+
             //todo: tournamentgamebase?
             if (ladderInfo.CurrentMatch.Value != null)
                 ladderInfo.CurrentMatch.Value.Current.Value = false;


### PR DESCRIPTION
Adds new styles and tidies up DrawableTeam classes, combining implementations where possible to reduce local implementations and copy-paste.

- [x] Depends on #8170