### PR TITLE
Fix textbox characters not animating when typing/backspacing

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
@@ -18,7 +18,11 @@ namespace osu.Game.Graphics.UserInterface
 {
     public class OsuPasswordTextBox : OsuTextBox, ISuppressKeyEventLogging
     {
-        protected override Drawable GetDrawableCharacter(char c) => new PasswordMaskChar(CalculatedTextSize);
+        protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
+        {
+            AutoSizeAxes = Axes.Both,
+            Child = new PasswordMaskChar(CalculatedTextSize),
+        };
 
         protected override bool AllowClipboardExport => false;
 

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -63,7 +63,11 @@ namespace osu.Game.Graphics.UserInterface
             base.OnFocusLost(e);
         }
 
-        protected override Drawable GetDrawableCharacter(char c) => new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: CalculatedTextSize) };
+        protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
+        {
+            AutoSizeAxes = Axes.Both,
+            Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: CalculatedTextSize) },
+        };
 
         protected override Caret CreateCaret() => new OsuCaret
         {

--- a/osu.Game/Overlays/Comments/CommentEditor.cs
+++ b/osu.Game/Overlays/Comments/CommentEditor.cs
@@ -158,7 +158,11 @@ namespace osu.Game.Overlays.Comments
                 Font = OsuFont.GetFont(weight: FontWeight.Regular),
             };
 
-            protected override Drawable GetDrawableCharacter(char c) => new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: CalculatedTextSize) };
+            protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: CalculatedTextSize) },
+            };
         }
 
         private class CommitButton : LoadingButton


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu-framework/pull/3072/commits/f969b3b47cc4872f36dfc7a2e84067561284523c.

The framework animation implementation was moved to `FallingDownContainer` and put to `BasicTextBox`'s `GetDrawableCharacter` method override, so overrides of that need it too.