### PR TITLE
Fix hyperdash not initiating correctly when juice streams are present

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Catch.Tests
@@ -22,7 +26,16 @@ namespace osu.Game.Rulesets.Catch.Tests
         public void TestHyperDash()
         {
             AddAssert("First note is hyperdash", () => Beatmap.Value.Beatmap.HitObjects[0] is Fruit f && f.HyperDash);
+            AddUntilStep("wait for left hyperdash", () => getCatcher().Scale.X < 0 && getCatcher().HyperDashing);
+
+            for (int i = 0; i < 2; i++)
+            {
+                AddUntilStep("wait for right hyperdash", () => getCatcher().Scale.X > 0 && getCatcher().HyperDashing);
+                AddUntilStep("wait for left hyperdash", () => getCatcher().Scale.X < 0 && getCatcher().HyperDashing);
+            }
         }
+
+        private CatcherArea.Catcher getCatcher() => Player.ChildrenOfType<CatcherArea>().First().MovableCatcher;
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
         {
@@ -35,17 +48,40 @@ namespace osu.Game.Rulesets.Catch.Tests
                 }
             };
 
-            // Should produce a hyper-dash
-            beatmap.HitObjects.Add(new Fruit { StartTime = 816, X = 308 / 512f, NewCombo = true });
-            beatmap.HitObjects.Add(new Fruit { StartTime = 1008, X = 56 / 512f, });
+            // Should produce a hyper-dash (edge case test)
+            beatmap.HitObjects.Add(new Fruit { StartTime = 1816, X = 308 / 512f, NewCombo = true });
+            beatmap.HitObjects.Add(new JuiceStream { StartTime = 2008, X = 56 / 512f, });
 
-            for (int i = 0; i < 512; i++)
-            {
-                if (i % 5 < 3)
-                    beatmap.HitObjects.Add(new Fruit { X = i % 10 < 5 ? 0.02f : 0.98f, StartTime = 2000 + i * 100, NewCombo = i % 8 == 0 });
-            }
+            double startTime = 3000;
+
+            const float left_x = 0.02f;
+            const float right_x = 0.98f;
+
+            createObjects(() => new Fruit(), left_x);
+            createObjects(() => new JuiceStream(), right_x);
+            createObjects(() => new JuiceStream(), left_x);
+            createObjects(() => new Fruit(), right_x);
+            createObjects(() => new Fruit(), left_x);
+            createObjects(() => new Fruit(), right_x);
+            createObjects(() => new JuiceStream(), left_x);
 
             return beatmap;
+
+            void createObjects(Func<CatchHitObject> createObject, float x)
+            {
+                const float spacing = 140;
+
+                for (int i = 0; i < 3; i++)
+                {
+                    var hitObject = createObject();
+                    hitObject.X = x;
+                    hitObject.StartTime = startTime + i * spacing;
+
+                    beatmap.HitObjects.Add(hitObject);
+                }
+
+                startTime += 700;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -270,6 +270,10 @@ namespace osu.Game.Rulesets.Catch.UI
                     catchObjectPosition >= catcherPosition - halfCatchWidth &&
                     catchObjectPosition <= catcherPosition + halfCatchWidth;
 
+                // only update hyperdash state if we are catching a fruit.
+                // exceptions are Droplets and JuiceStreams.
+                if (!(fruit is Fruit)) return validCatch;
+
                 if (validCatch && fruit.HyperDash)
                 {
                     var target = fruit.HyperDashTarget;


### PR DESCRIPTION
Hyperdash wasn't working correctly with non-fruit objects (that have their judgements ignored). This makes hyperdash state decision changes only happen on fruit.

Closes #8016 