### PR TITLE
Update text on disclaimer screen (and add tips)

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneDisclaimer.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneDisclaimer.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Menus
                 API.LocalUser.Value = new User
                 {
                     Username = API.LocalUser.Value.Username,
-                    Id = API.LocalUser.Value.Id,
+                    Id = API.LocalUser.Value.Id + 1,
                     IsSupporter = !API.LocalUser.Value.IsSupporter,
                 };
             });

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.Menu
                 "Try scrolling down in the mod select panel to find a bunch of new fun mods!",
                 "Most of the web content (profiles, rankings, etc.) are available natively in-game from the icons on the toolbar!",
                 "Get more details, hide or delete a beatmap by right-clicking on its panel at song select!",
-                "All delete operations are temoprary until quit. Restore accidentally deleted content from the maintenance settings!",
+                "All delete operations are temporary until exiting. Restore accidentally deleted content from the maintenance settings!",
                 "Check out the \"timeshift\" multiplayer system, which has local permanent leaderboards and playlist support!",
                 "Toggle advanced frame / thread statistics with Ctrl-F11!",
                 "Take a look under the hood at performance counters and enable verbose performance logging with Ctrl-F2!",

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Screens;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
@@ -33,6 +34,7 @@ namespace osu.Game.Screens.Menu
         private readonly OsuScreen nextScreen;
 
         private readonly Bindable<User> currentUser = new Bindable<User>();
+        private FillFlowContainer fill;
 
         public Disclaimer(OsuScreen nextScreen = null)
         {
@@ -49,16 +51,16 @@ namespace osu.Game.Screens.Menu
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Icon = FontAwesome.Solid.ExclamationTriangle,
+                    Icon = FontAwesome.Solid.Poo,
                     Size = new Vector2(icon_size),
                     Y = icon_y,
                 },
-                new FillFlowContainer
+                fill = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
-                    Y = icon_y + icon_size,
+                    Y = icon_y,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.TopCentre,
                     Children = new Drawable[]
@@ -71,6 +73,8 @@ namespace osu.Game.Screens.Menu
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Spacing = new Vector2(0, 2),
+                            LayoutDuration = 2000,
+                            LayoutEasing = Easing.OutQuint
                         },
                         supportFlow = new LinkFlowContainer
                         {
@@ -86,23 +90,16 @@ namespace osu.Game.Screens.Menu
                 }
             };
 
-            textFlow.AddText("This is an ", t => t.Font = t.Font.With(Typeface.Exo, 30, FontWeight.Light));
-            textFlow.AddText("early development build", t => t.Font = t.Font.With(Typeface.Exo, 30, FontWeight.SemiBold));
+            textFlow.AddText("This project is an ongoing ", t => t.Font = t.Font.With(Typeface.Exo, 30, FontWeight.Light));
+            textFlow.AddText("work in progress", t => t.Font = t.Font.With(Typeface.Exo, 30, FontWeight.SemiBold));
 
-            textFlow.AddParagraph("Things may not work as expected", t => t.Font = t.Font.With(size: 20));
             textFlow.NewParagraph();
 
             static void format(SpriteText t) => t.Font = OsuFont.GetFont(size: 15, weight: FontWeight.SemiBold);
 
-            textFlow.AddParagraph("Detailed bug reports are welcomed via github issues.", format);
+            textFlow.AddParagraph(getRandomTip(), t => t.Font = t.Font.With(Typeface.Exo, 20, FontWeight.SemiBold));
             textFlow.NewParagraph();
 
-            textFlow.AddText("Visit ", format);
-            textFlow.AddLink("discord.gg/ppy", "https://discord.gg/ppy", creationParameters: format);
-            textFlow.AddText(" to help out or follow progress!", format);
-
-            textFlow.NewParagraph();
-            textFlow.NewParagraph();
             textFlow.NewParagraph();
 
             iconColour = colours.Yellow;
@@ -114,7 +111,7 @@ namespace osu.Game.Screens.Menu
 
                 if (e.NewValue.IsSupporter)
                 {
-                    supportFlow.AddText("Thank you for supporting osu!", format);
+                    supportFlow.AddText("Eternal thanks to you for supporting osu!", format);
                 }
                 else
                 {
@@ -125,7 +122,7 @@ namespace osu.Game.Screens.Menu
 
                 heart = supportFlow.AddIcon(FontAwesome.Solid.Heart, t =>
                 {
-                    t.Padding = new MarginPadding { Left = 5 };
+                    t.Padding = new MarginPadding { Left = 5, Top = 3 };
                     t.Font = t.Font.With(size: 12);
                     t.Origin = Anchor.Centre;
                     t.Colour = colours.Pink;
@@ -139,11 +136,6 @@ namespace osu.Game.Screens.Menu
             }, true);
         }
 
-        private void animateHeart()
-        {
-            heart.FlashColour(Color4.White, 750, Easing.OutQuint).Loop();
-        }
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -155,15 +147,28 @@ namespace osu.Game.Screens.Menu
         {
             base.OnEntering(last);
 
-            icon.Delay(1000).FadeColour(iconColour, 200, Easing.OutQuint);
-            icon.Delay(1000)
-                .MoveToY(icon_y * 1.1f, 160, Easing.OutCirc)
-                .RotateTo(-10, 160, Easing.OutCirc)
-                .Then()
-                .MoveToY(icon_y, 160, Easing.InCirc)
-                .RotateTo(0, 160, Easing.InCirc);
+            icon.RotateTo(10);
+            icon.FadeOut();
+            icon.ScaleTo(0.5f);
+
+            icon.Delay(500).FadeIn(500).ScaleTo(1, 500, Easing.OutQuint);
+
+            using (BeginDelayedSequence(3000, true))
+            {
+                icon.FadeColour(iconColour, 200, Easing.OutQuint);
+                icon.MoveToY(icon_y * 1.3f, 500, Easing.OutCirc)
+                    .RotateTo(-360, 520, Easing.OutQuint)
+                    .Then()
+                    .MoveToY(icon_y, 160, Easing.InQuart)
+                    .FadeColour(Color4.White, 160);
+
+                fill.Delay(520 + 160).MoveToOffset(new Vector2(0, 15), 160, Easing.OutQuart);
+            }
 
             supportFlow.FadeOut().Delay(2000).FadeIn(500);
+            double delay = 500;
+            foreach (var c in textFlow.Children)
+                c.FadeTo(0.001f).Delay(delay += 20).FadeIn(500);
 
             animateHeart();
 
@@ -177,6 +182,36 @@ namespace osu.Game.Screens.Menu
                     if (nextScreen != null)
                         this.Push(nextScreen);
                 });
+        }
+
+        private string getRandomTip()
+        {
+            string[] tips =
+            {
+                "You can press Ctrl-T anywhere in the game to toggle the toolbar!",
+                "You can press Ctrl-O anywhere in the game to access options!",
+                "All settings are dynamic and take effect in real-time. Try changing the skin while playing!",
+                "New features are coming online every update. Make sure to stay up-to-date!",
+                "If you find the UI too large or small, try adjusting UI scale in settings!",
+                "Try adjusting the \"Screen Scaling\" mode to change your gameplay or UI area, even in fullscreen!",
+                "For now, osu!direct is available to all users on lazer. You can access it anywhere using Ctrl-D!",
+                "Seeking in replays is available by dragging on the difficulty bar at the bottom of the screen!",
+                "Multithreading support means that even with low \"FPS\" your input and judgements will be accurate!",
+                "Try scrolling down in the mod select panel to find a bunch of new fun mods!",
+                "Most of the web content (profiles, rankings, etc.) are available natively in-game from the icons on the toolbar!",
+                "Get more details, hide or delete a beatmap by right-clicking on its panel at song select!",
+                "All delete operations are temoprary until quit. Restore accidentally deleted content from the maintenance settings!",
+                "Check out the \"timeshift\" multiplayer system, which has local permanent leaderboards and playlist support!",
+                "Toggle advanced frame / thread statistics with Ctrl-F11!",
+                "Take a look under the hood at performance counters and enable verbose performance logging with Ctrl-F2!",
+            };
+
+            return tips[RNG.Next(0, tips.Length)];
+        }
+
+        private void animateHeart()
+        {
+            heart.FlashColour(Color4.White, 750, Easing.OutQuint).Loop();
         }
     }
 }


### PR DESCRIPTION
Just making things a little less serious, while also removing the "early development build" classification (because it really isn't any more) and adding some tips to give users something to do while waiting for the disclaimer to go away.

Tips can eventually be moved to the main menu once we remove the disclaimer completely.