### PR TITLE
Apply osu!-side video sprite changes

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.304.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.310.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.312.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Tournament/Components/TourneyVideo.cs
+++ b/osu.Game.Tournament/Components/TourneyVideo.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tournament.Components
 
             if (stream != null)
             {
-                InternalChild = video = new VideoSprite(stream)
+                InternalChild = video = new VideoSprite(stream, false)
                 {
                     RelativeSizeAxes = Axes.Both,
                     FillMode = FillMode.Fit,

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -259,11 +259,18 @@ namespace osu.Game.Screens.Menu
 
             private class LazerLogo : CompositeDrawable
             {
+                private readonly Stream videoStream;
+
                 public LazerLogo(Stream videoStream)
                 {
+                    this.videoStream = videoStream;
                     Size = new Vector2(960);
+                }
 
-                    InternalChild = new VideoSprite(videoStream)
+                [BackgroundDependencyLoader]
+                private void load()
+                {
+                    InternalChild = new VideoSprite(videoStream, false)
                     {
                         RelativeSizeAxes = Axes.Both,
                         Clock = new FramedOffsetClock(Clock) { Offset = -logo_1 }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.304.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.310.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.312.0" />
     <PackageReference Include="Sentry" Version="2.1.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.304.0" />
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.310.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.312.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">
@@ -79,7 +79,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.310.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.312.0" />
     <PackageReference Include="SharpCompress" Version="0.24.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/3356

The triangles intro usages was completely wrong - it would pass in a `null` clock and therefore receive a stopwatch clock as the reference.