### PR TITLE
Add more sane limit for maximum slider length

### DIFF
--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
                 if (split.Length > 7)
                 {
-                    length = Math.Max(0, Parsing.ParseDouble(split[7]));
+                    length = Math.Max(0, Parsing.ParseDouble(split[7], Parsing.MAX_COORDINATE_VALUE));
                     if (length == 0)
                         length = null;
                 }


### PR DESCRIPTION
For beatmaps that have 99999999 lengths, causing potentially millions of ticks.