### PR TITLE
Remove unlimited timing points in difficulty calculation

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyDifficultyCalculatorBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDifficultyCalculatorBeatmapDecoder.cs
@@ -26,17 +26,5 @@ namespace osu.Game.Beatmaps.Formats
             AddDecoder<Beatmap>(@"osu file format v", m => new LegacyDifficultyCalculatorBeatmapDecoder(int.Parse(m.Split('v').Last())));
             SetFallbackDecoder<Beatmap>(() => new LegacyDifficultyCalculatorBeatmapDecoder());
         }
-
-        protected override TimingControlPoint CreateTimingControlPoint()
-            => new LegacyDifficultyCalculatorTimingControlPoint();
-
-        private class LegacyDifficultyCalculatorTimingControlPoint : TimingControlPoint
-        {
-            public LegacyDifficultyCalculatorTimingControlPoint()
-            {
-                BeatLengthBindable.MinValue = double.MinValue;
-                BeatLengthBindable.MaxValue = double.MaxValue;
-            }
-        }
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDifficultyCalculatorBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDifficultyCalculatorBeatmapDecoder.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Game.Beatmaps.ControlPoints;
 
 namespace osu.Game.Beatmaps.Formats
 {


### PR DESCRIPTION
This was just silly since some beatmaps have reeeeeeally slow timing sections. This will break aspire/loved maps.

Let me know if you want a full recomputation so we can see the changes better.