### PR TITLE
Fix catch beatmap processing not matching stable

### DIFF
--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -74,6 +74,12 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                         break;
 
                     case JuiceStream juiceStream:
+                        // Todo: BUG!! Stable used the last control point as the final position of the path, but it should use the computed path instead.
+                        lastPosition = juiceStream.X + juiceStream.Path.ControlPoints[^1].Position.Value.X / CatchPlayfield.BASE_WIDTH;
+
+                        // Todo: BUG!! Stable attempted to use the end time of the stream, but referenced it too early in execution and used the start time instead.
+                        lastStartTime = juiceStream.StartTime;
+
                         foreach (var nested in juiceStream.NestedHitObjects)
                         {
                             var catchObject = (CatchHitObject)nested;
@@ -94,13 +100,6 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
         private static void applyHardRockOffset(CatchHitObject hitObject, ref float? lastPosition, ref double lastStartTime, FastRandom rng)
         {
-            if (hitObject is JuiceStream stream)
-            {
-                lastPosition = stream.EndX;
-                lastStartTime = stream.EndTime;
-                return;
-            }
-
             if (!(hitObject is Fruit))
                 return;
 

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -112,7 +112,9 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             }
 
             float positionDiff = offsetPosition - lastPosition.Value;
-            double timeDiff = startTime - lastStartTime;
+
+            // Todo: BUG!! Stable calculated time deltas as ints, which affects randomisation. This should be changed to a double.
+            int timeDiff = (int)(startTime - lastStartTime);
 
             if (timeDiff > 1000)
             {
@@ -128,7 +130,8 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                 return;
             }
 
-            if (Math.Abs(positionDiff * CatchPlayfield.BASE_WIDTH) < timeDiff / 3d)
+            // ReSharper disable once PossibleLossOfFraction
+            if (Math.Abs(positionDiff * CatchPlayfield.BASE_WIDTH) < timeDiff / 3)
                 applyOffset(ref offsetPosition, positionDiff);
 
             hitObject.XOffset = offsetPosition - hitObject.X;

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -100,9 +100,6 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
 
         private static void applyHardRockOffset(CatchHitObject hitObject, ref float? lastPosition, ref double lastStartTime, FastRandom rng)
         {
-            if (!(hitObject is Fruit))
-                return;
-
             float offsetPosition = hitObject.X;
             double startTime = hitObject.StartTime;
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/4622

Along with https://github.com/ppy/osu/pull/8219, these are the full list of differences among ranked beatmaps: https://docs.google.com/spreadsheets/d/13BrTLEg6_MzUlwj4nEix7UqR3XbdstslJTImAoNtOVU/edit?usp=sharing
Since my beatmap dump is old, what I've found is that the ones with any differences are actually broken beatmaps, this can occur in various ways:
1. Simultaneous hitobjects at the same time.
2. Timing points that have "timing change" set to true along with a negative beatlength.
3. Beatmaps hit other limitations that are enforced by lazer's parsing.

In general, I can't find any reasonable ranked map that has >0.05 star difference, which is close enough for me.

Regarding the int truncation... I don't like it, but without it beatmaps change significantly since this entire method is 1) random, 2) based on previous hitobject's positions.