### PR TITLE
Add ability to set stable path for tourney client via environment variable

### DIFF
--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -163,12 +163,7 @@ namespace osu.Game.Tournament.IPC
                 {
                     try
                     {
-                        stableInstallPath = "G:\\My Drive\\Main\\osu!tourney";
-
-                        if (checkExists(stableInstallPath))
-                            return stableInstallPath;
-
-                        stableInstallPath = "G:\\My Drive\\Main\\osu!mappool";
+                        stableInstallPath = Environment.GetEnvironmentVariable("OSU_STABLE_PATH");
 
                         if (checkExists(stableInstallPath))
                             return stableInstallPath;


### PR DESCRIPTION
I have a seperate osu! install just for tourney related things, this is not my main osu! install that I use for normal gameplay. This results in lazer picking up my main install (from registry) instead of the tourney specific install I want.

I noticed there where some hardcoded paths and thought it might be useful to replace those with a simple environment variable lookup. That way I don't necessarily have to run a custom build anymore just for the purpose of setting the correct path to my tourney client install.

I first tried to use a commandline argument for it, but I couldnt get that to work because if I simply pass a extra variable to the constructor of the StableStorage class it wouldnt be able to be used in the overridden LocateBasePath method, since that one is being called inside the constructor of the base Storage class (https://github.com/ppy/osu-framework/blob/master/osu.Framework/Platform/Storage.cs#L31). In other words while the LocateBasePath method is running the constructor of StableStorage hasnt ran yet so I cannot access any initialized class variables.

So next best thing I could come up with was using environment variables. I used `OSU_STABLE_PATH` as variable name since the variable in code was called `stableInstallPath`. Feel free to suggest another if the name does not fit its purpose.

I also removed the hardcoded paths since I thought that either they're not being used anymore anyway or if they are whoever is using them can just start using the environment variable right? If this is not desirable for whatever reason let me know and I'll change it back