### PR TITLE
Fix beatmap carousel tests loading beatmap manager beatmaps in test browser

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -497,7 +497,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             }
 
             bool changed = false;
-            AddStep($"Load {beatmapSets.Count} Beatmaps", () =>
+            AddStep($"Load {(beatmapSets.Count > 0 ? beatmapSets.Count.ToString() : "some")} beatmaps", () =>
             {
                 carousel.Filter(new FilterCriteria());
                 carousel.BeatmapSetsChanged = () => changed = true;
@@ -697,6 +697,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             public new List<DrawableCarouselItem> Items => base.Items;
 
             public bool PendingFilterTask => PendingFilter != null;
+
+            protected override IEnumerable<BeatmapSetInfo> GetLoadableBeatmaps() => Enumerable.Empty<BeatmapSetInfo>();
         }
     }
 }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -153,8 +153,10 @@ namespace osu.Game.Screens.Select
             beatmaps.BeatmapHidden += beatmapHidden;
             beatmaps.BeatmapRestored += beatmapRestored;
 
-            loadBeatmapSets(beatmaps.GetAllUsableBeatmapSetsEnumerable());
+            loadBeatmapSets(GetLoadableBeatmaps());
         }
+
+        protected virtual IEnumerable<BeatmapSetInfo> GetLoadableBeatmaps() => beatmaps.GetAllUsableBeatmapSetsEnumerable();
 
         public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
         {


### PR DESCRIPTION
Now bypasses the beatmap manager (and any local database) to make tests easier to parse.