### PR TITLE
Fallback on invalid AnimationFramerate for legacy skins

### DIFF
--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Skinning
             {
                 var iniRate = source.GetConfig<GlobalSkinConfiguration, int>(GlobalSkinConfiguration.AnimationFramerate);
 
-                if (iniRate != null && iniRate.Value > 0)
+                if (iniRate?.Value > 0)
                     return 1000f / iniRate.Value;
 
                 return 1000f / textures.Length;

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Skinning
             {
                 var iniRate = source.GetConfig<GlobalSkinConfiguration, int>(GlobalSkinConfiguration.AnimationFramerate);
 
-                if (iniRate != null)
+                if (iniRate != null && iniRate.Value > 0)
                     return 1000f / iniRate.Value;
 
                 return 1000f / textures.Length;


### PR DESCRIPTION
Had some skins with AnimationFramerate set to -1. This seems to be the way the stable client handles these cases (by experiment)