### PR TITLE
Add show/hide toggle for Discord Rich Presence

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -66,7 +66,7 @@ namespace osu.Desktop
             if (!noVersionOverlay)
                 LoadComponentAsync(versionManager = new VersionManager { Depth = int.MinValue }, Add);
 
-            LoadComponentAsync(new DiscordRichPresence(), Add);
+            LoadComponentAsync(new DiscordRichPresence(LocalConfig), Add);
         }
 
         protected override void ScreenChanged(IScreen lastScreen, IScreen newScreen)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -18,17 +18,14 @@ namespace osu.Game.Configuration
     {
         protected override void InitialiseDefaults()
         {
-
             // Discord RPC
             Set(OsuSetting.HideDiscordRPC, false).ValueChanged += enabled =>
             {
                 if (enabled.NewValue) Set(OsuSetting.HideDiscordRPC, true);
             };
-
             // UI/selection defaults
             Set(OsuSetting.Ruleset, 0, 0, int.MaxValue);
             Set(OsuSetting.Skin, 0, -1, int.MaxValue);
-
 
             Set(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -10,6 +10,7 @@ using osu.Game.Overlays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
+using System;
 
 namespace osu.Game.Configuration
 {
@@ -17,9 +18,17 @@ namespace osu.Game.Configuration
     {
         protected override void InitialiseDefaults()
         {
+
+            // Discord RPC
+            Set(OsuSetting.HideDiscordRPC, false).ValueChanged += enabled =>
+            {
+                if (enabled.NewValue) Set(OsuSetting.HideDiscordRPC, true);
+            };
+
             // UI/selection defaults
             Set(OsuSetting.Ruleset, 0, 0, int.MaxValue);
             Set(OsuSetting.Skin, 0, -1, int.MaxValue);
+
 
             Set(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
 
@@ -214,6 +223,7 @@ namespace osu.Game.Configuration
         IncreaseFirstObjectVisibility,
         ScoreDisplayMode,
         ExternalLinkWarning,
+        HideDiscordRPC,
         Scaling,
         ScalingPositionX,
         ScalingPositionY,

--- a/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/WebSettings.cs
@@ -21,6 +21,13 @@ namespace osu.Game.Overlays.Settings.Sections.Online
                     LabelText = "Warn about opening external links",
                     Bindable = config.GetBindable<bool>(OsuSetting.ExternalLinkWarning)
                 },
+
+                new SettingsCheckbox
+                {
+                    LabelText = "Hide Discord Rich Presence information",
+                    Bindable = config.GetBindable<bool>(OsuSetting.HideDiscordRPC)
+                },
+
             };
         }
     }


### PR DESCRIPTION
~~So, let's try this again~~

This PR is for a feature I requested (#5090), for allowing a user to either show their username/rank info with Discord's Rich Presence, or to hide their username/rank info (for a few reasons...). I have already acknowledged that the original issue has been closed, but gave this a shot.

I added a toggle under the 'Web' settings for allowing a user to either hide/show their info. Default value for this toggle is false.

![image](https://user-images.githubusercontent.com/27045730/76582218-dcc32200-6492-11ea-8cca-54cf8090a514.png)

Here's how it looks when a user has "Hide Discord Rich Presence information" disabled:

![image](https://user-images.githubusercontent.com/27045730/76581869-09c30500-6492-11ea-8fc9-46e61dfd340c.png)

Here's how it looks when a user has "Hide Discord Rich Presence information" enabled:

![image](https://user-images.githubusercontent.com/27045730/76581958-43940b80-6492-11ea-80c8-992121a2b66e.png)