### PR TITLE
Add beatmap loading timeout to prevent runaway loading scenarios

### DIFF
--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="ruleset">The <see cref="RulesetInfo"/> to create a playable <see cref="IBeatmap"/> for.</param>
         /// <param name="mods">The <see cref="Mod"/>s to apply to the <see cref="IBeatmap"/>.</param>
-        /// <param name="timeout">The loading timeout.</param>
+        /// <param name="timeout">The maximum length in milliseconds to wait for load to complete. Defaults to 10,000ms.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
         IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IReadOnlyList<Mod> mods = null, TimeSpan? timeout = null);

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
@@ -60,8 +61,9 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="ruleset">The <see cref="RulesetInfo"/> to create a playable <see cref="IBeatmap"/> for.</param>
         /// <param name="mods">The <see cref="Mod"/>s to apply to the <see cref="IBeatmap"/>.</param>
+        /// <param name="timeout">The loading timeout.</param>
         /// <returns>The converted <see cref="IBeatmap"/>.</returns>
         /// <exception cref="BeatmapInvalidForRulesetException">If <see cref="Beatmap"/> could not be converted to <paramref name="ruleset"/>.</exception>
-        IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IReadOnlyList<Mod> mods = null);
+        IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IReadOnlyList<Mod> mods = null, TimeSpan? timeout = null);
     }
 }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -83,55 +83,73 @@ namespace osu.Game.Beatmaps
         /// <returns>The applicable <see cref="IBeatmapConverter"/>.</returns>
         protected virtual IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap, Ruleset ruleset) => ruleset.CreateBeatmapConverter(beatmap);
 
-        public IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IReadOnlyList<Mod> mods = null)
+        public IBeatmap GetPlayableBeatmap(RulesetInfo ruleset, IReadOnlyList<Mod> mods = null, TimeSpan? timeout = null)
         {
-            mods ??= Array.Empty<Mod>();
-
-            var rulesetInstance = ruleset.CreateInstance();
-
-            IBeatmapConverter converter = CreateBeatmapConverter(Beatmap, rulesetInstance);
-
-            // Check if the beatmap can be converted
-            if (Beatmap.HitObjects.Count > 0 && !converter.CanConvert())
-                throw new BeatmapInvalidForRulesetException($"{nameof(Beatmaps.Beatmap)} can not be converted for the ruleset (ruleset: {ruleset.InstantiationInfo}, converter: {converter}).");
-
-            // Apply conversion mods
-            foreach (var mod in mods.OfType<IApplicableToBeatmapConverter>())
-                mod.ApplyToBeatmapConverter(converter);
-
-            // Convert
-            IBeatmap converted = converter.Convert();
-
-            // Apply difficulty mods
-            if (mods.Any(m => m is IApplicableToDifficulty))
+            using (var cancellationSource = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(10)))
             {
-                converted.BeatmapInfo = converted.BeatmapInfo.Clone();
-                converted.BeatmapInfo.BaseDifficulty = converted.BeatmapInfo.BaseDifficulty.Clone();
+                mods ??= Array.Empty<Mod>();
 
-                foreach (var mod in mods.OfType<IApplicableToDifficulty>())
-                    mod.ApplyToDifficulty(converted.BeatmapInfo.BaseDifficulty);
-            }
+                var rulesetInstance = ruleset.CreateInstance();
 
-            IBeatmapProcessor processor = rulesetInstance.CreateBeatmapProcessor(converted);
+                IBeatmapConverter converter = CreateBeatmapConverter(Beatmap, rulesetInstance);
 
-            processor?.PreProcess();
+                // Check if the beatmap can be converted
+                if (Beatmap.HitObjects.Count > 0 && !converter.CanConvert())
+                    throw new BeatmapInvalidForRulesetException($"{nameof(Beatmaps.Beatmap)} can not be converted for the ruleset (ruleset: {ruleset.InstantiationInfo}, converter: {converter}).");
 
-            // Compute default values for hitobjects, including creating nested hitobjects in-case they're needed
-            foreach (var obj in converted.HitObjects)
-                obj.ApplyDefaults(converted.ControlPointInfo, converted.BeatmapInfo.BaseDifficulty);
+                // Apply conversion mods
+                foreach (var mod in mods.OfType<IApplicableToBeatmapConverter>())
+                {
+                    cancellationSource.Token.ThrowIfCancellationRequested();
+                    mod.ApplyToBeatmapConverter(converter);
+                }
 
-            foreach (var mod in mods.OfType<IApplicableToHitObject>())
-            {
+                // Convert
+                IBeatmap converted = converter.Convert();
+
+                // Apply difficulty mods
+                if (mods.Any(m => m is IApplicableToDifficulty))
+                {
+                    converted.BeatmapInfo = converted.BeatmapInfo.Clone();
+                    converted.BeatmapInfo.BaseDifficulty = converted.BeatmapInfo.BaseDifficulty.Clone();
+
+                    foreach (var mod in mods.OfType<IApplicableToDifficulty>())
+                    {
+                        cancellationSource.Token.ThrowIfCancellationRequested();
+                        mod.ApplyToDifficulty(converted.BeatmapInfo.BaseDifficulty);
+                    }
+                }
+
+                IBeatmapProcessor processor = rulesetInstance.CreateBeatmapProcessor(converted);
+
+                processor?.PreProcess();
+
+                // Compute default values for hitobjects, including creating nested hitobjects in-case they're needed
                 foreach (var obj in converted.HitObjects)
-                    mod.ApplyToHitObject(obj);
+                {
+                    cancellationSource.Token.ThrowIfCancellationRequested();
+                    obj.ApplyDefaults(converted.ControlPointInfo, converted.BeatmapInfo.BaseDifficulty);
+                }
+
+                foreach (var mod in mods.OfType<IApplicableToHitObject>())
+                {
+                    foreach (var obj in converted.HitObjects)
+                    {
+                        cancellationSource.Token.ThrowIfCancellationRequested();
+                        mod.ApplyToHitObject(obj);
+                    }
+                }
+
+                processor?.PostProcess();
+
+                foreach (var mod in mods.OfType<IApplicableToBeatmap>())
+                {
+                    cancellationSource.Token.ThrowIfCancellationRequested();
+                    mod.ApplyToBeatmap(converted);
+                }
+
+                return converted;
             }
-
-            processor?.PostProcess();
-
-            foreach (var mod in mods.OfType<IApplicableToBeatmap>())
-                mod.ApplyToBeatmap(converted);
-
-            return converted;
         }
 
         private CancellationTokenSource loadCancellation = new CancellationTokenSource();

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -93,8 +93,8 @@ namespace osu.Game.Screens.Edit
             }
             catch (Exception e)
             {
-                Logger.Error(e, "Could not load beatmap sucessfully!");
-                //couldn't load, hard abort!
+                Logger.Error(e, "Could not load beatmap successfully!");
+                // couldn't load, hard abort!
                 this.Exit();
                 return;
             }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -23,6 +23,7 @@ using osuTK.Input;
 using System.Collections.Generic;
 using osu.Framework;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Input.Bindings;
@@ -86,7 +87,18 @@ namespace osu.Game.Screens.Edit
             // todo: remove caching of this and consume via editorBeatmap?
             dependencies.Cache(beatDivisor);
 
-            playableBeatmap = Beatmap.Value.GetPlayableBeatmap(Beatmap.Value.BeatmapInfo.Ruleset);
+            try
+            {
+                playableBeatmap = Beatmap.Value.GetPlayableBeatmap(Beatmap.Value.BeatmapInfo.Ruleset);
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Could not load beatmap sucessfully!");
+                //couldn't load, hard abort!
+                this.Exit();
+                return;
+            }
+
             AddInternal(editorBeatmap = new EditorBeatmap(playableBeatmap));
 
             dependencies.CacheAs(editorBeatmap);

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -331,7 +331,7 @@ namespace osu.Game.Screens.Select
                     }
                     catch (Exception e)
                     {
-                        Logger.Error(e, "Could not load beatmap sucessfully!");
+                        Logger.Error(e, "Could not load beatmap successfully!");
                     }
                 }
 

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -23,6 +23,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Framework.Logging;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
@@ -311,20 +312,27 @@ namespace osu.Game.Screens.Select
                         Content = getBPMRange(b),
                     }));
 
-                    IBeatmap playableBeatmap;
-
                     try
                     {
-                        // Try to get the beatmap with the user's ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(ruleset, Array.Empty<Mod>());
-                    }
-                    catch (BeatmapInvalidForRulesetException)
-                    {
-                        // Can't be converted to the user's ruleset, so use the beatmap's own ruleset
-                        playableBeatmap = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset, Array.Empty<Mod>());
-                    }
+                        IBeatmap playableBeatmap;
 
-                    labels.AddRange(playableBeatmap.GetStatistics().Select(s => new InfoLabel(s)));
+                        try
+                        {
+                            // Try to get the beatmap with the user's ruleset
+                            playableBeatmap = beatmap.GetPlayableBeatmap(ruleset, Array.Empty<Mod>());
+                        }
+                        catch (BeatmapInvalidForRulesetException)
+                        {
+                            // Can't be converted to the user's ruleset, so use the beatmap's own ruleset
+                            playableBeatmap = beatmap.GetPlayableBeatmap(beatmap.BeatmapInfo.Ruleset, Array.Empty<Mod>());
+                        }
+
+                        labels.AddRange(playableBeatmap.GetStatistics().Select(s => new InfoLabel(s)));
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, "Could not load beatmap sucessfully!");
+                    }
                 }
 
                 return labels.ToArray();


### PR DESCRIPTION
I've set the timeout to a very lenient 10 seconds, just to cover for slower devices. Although this stuff should really complete within a second on a normal beatmap (e.g. centipede takes <120ms across all modes).

Can be tested with this beatmap: https://osu.ppy.sh/beatmapsets/367431#osu/805850