### PR TITLE
Switch to the next chat tab upon closing an active one

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -196,14 +196,34 @@ namespace osu.Game.Tests.Visual.Online
 
         private class TestTabControl : ChannelTabControl
         {
-            protected override TabItem<Channel> CreateTabItem(Channel value) => new TestChannelTabItem(value);
+            protected override TabItem<Channel> CreateTabItem(Channel value)
+            {
+                switch (value.Type)
+                {
+                    case ChannelType.PM:
+                        return new TestPrivateChannelTabItem(value);
+
+                    default:
+                        return new TestChannelTabItem(value);
+                }
+            }
 
             public new IReadOnlyDictionary<Channel, TabItem<Channel>> TabMap => base.TabMap;
         }
 
-        private class TestChannelTabItem : PrivateChannelTabItem
+        private class TestChannelTabItem : ChannelTabItem
         {
             public TestChannelTabItem(Channel channel)
+                : base(channel)
+            {
+            }
+
+            public new ClickableContainer CloseButton => base.CloseButton;
+        }
+
+        private class TestPrivateChannelTabItem : PrivateChannelTabItem
+        {
+            public TestPrivateChannelTabItem(Channel channel)
                 : base(channel)
             {
             }

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -107,12 +107,12 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Join channel 2", () => channelManager.JoinChannel(channel2));
 
             AddStep("Switch to channel 2", () => clickDrawable(chatOverlay.TabMap[channel2]));
-            AddStep("Close channel 2", () => clickDrawable(((TestPrivateChannelTabItem)chatOverlay.TabMap[channel2]).CloseButton.Child));
+            AddStep("Close channel 2", () => clickDrawable(((TestChannelTabItem)chatOverlay.TabMap[channel2]).CloseButton.Child));
 
             AddAssert("Selector remained closed", () => chatOverlay.SelectionOverlayState == Visibility.Hidden);
             AddAssert("Current channel is channel 1", () => currentChannel == channel1);
 
-            AddStep("Close channel 1", () => clickDrawable(((TestPrivateChannelTabItem)chatOverlay.TabMap[channel1]).CloseButton.Child));
+            AddStep("Close channel 1", () => clickDrawable(((TestChannelTabItem)chatOverlay.TabMap[channel1]).CloseButton.Child));
 
             AddAssert("Selector is visible", () => chatOverlay.SelectionOverlayState == Visibility.Visible);
         }

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -38,8 +38,13 @@ namespace osu.Game.Tests.Visual.Online
         private TestChatOverlay chatOverlay;
         private ChannelManager channelManager;
 
+        private IEnumerable<Channel> visibleChannels => chatOverlay.ChannelTabControl.VisibleItems.Where(channel => channel.Name != "+");
+        private IEnumerable<Channel> joinedChannels => chatOverlay.ChannelTabControl.Items.Where(channel => channel.Name != "+");
         private readonly List<Channel> channels;
 
+        private Channel currentChannel => channelManager.CurrentChannel.Value;
+        private Channel nextChannel => joinedChannels.ElementAt(joinedChannels.ToList().IndexOf(currentChannel) + 1);
+        private Channel previousChannel => joinedChannels.ElementAt(joinedChannels.ToList().IndexOf(currentChannel) - 1);
         private Channel channel1 => channels[0];
         private Channel channel2 => channels[1];
 
@@ -91,7 +96,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Join channel 1", () => channelManager.JoinChannel(channel1));
             AddStep("Switch to channel 1", () => clickDrawable(chatOverlay.TabMap[channel1]));
 
-            AddAssert("Current channel is channel 1", () => channelManager.CurrentChannel.Value == channel1);
+            AddAssert("Current channel is channel 1", () => currentChannel == channel1);
             AddAssert("Channel selector was closed", () => chatOverlay.SelectionOverlayState == Visibility.Hidden);
         }
 
@@ -102,12 +107,12 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Join channel 2", () => channelManager.JoinChannel(channel2));
 
             AddStep("Switch to channel 2", () => clickDrawable(chatOverlay.TabMap[channel2]));
-            AddStep("Close channel 2", () => clickDrawable(((TestChannelTabItem)chatOverlay.TabMap[channel2]).CloseButton.Child));
+            AddStep("Close channel 2", () => clickDrawable(((TestPrivateChannelTabItem)chatOverlay.TabMap[channel2]).CloseButton.Child));
 
             AddAssert("Selector remained closed", () => chatOverlay.SelectionOverlayState == Visibility.Hidden);
-            AddAssert("Current channel is channel 1", () => channelManager.CurrentChannel.Value == channel1);
+            AddAssert("Current channel is channel 1", () => currentChannel == channel1);
 
-            AddStep("Close channel 1", () => clickDrawable(((TestChannelTabItem)chatOverlay.TabMap[channel1]).CloseButton.Child));
+            AddStep("Close channel 1", () => clickDrawable(((TestPrivateChannelTabItem)chatOverlay.TabMap[channel1]).CloseButton.Child));
 
             AddAssert("Selector is visible", () => chatOverlay.SelectionOverlayState == Visibility.Visible);
         }
@@ -140,8 +145,65 @@ namespace osu.Game.Tests.Visual.Online
                 var targetNumberKey = oneBasedIndex % 10;
                 var targetChannel = channels[zeroBasedIndex];
                 AddStep($"press Alt+{targetNumberKey}", () => pressChannelHotkey(targetNumberKey));
-                AddAssert($"channel #{oneBasedIndex} is selected", () => channelManager.CurrentChannel.Value == targetChannel);
+                AddAssert($"channel #{oneBasedIndex} is selected", () => currentChannel == targetChannel);
             }
+        }
+
+        private Channel expectedChannel;
+
+        [Test]
+        public void TestCloseChannelWhileActive()
+        {
+            AddUntilStep("Join until dropdown has channels", () =>
+            {
+                if (visibleChannels.Count() < joinedChannels.Count())
+                    return true;
+
+                // Using temporary channels because they don't hide their names when not active
+                Channel toAdd = new Channel { Name = $"test channel {joinedChannels.Count()}", Type = ChannelType.Temporary };
+                channelManager.JoinChannel(toAdd);
+
+                return false;
+            });
+
+            AddStep("Switch to last tab", () => clickDrawable(chatOverlay.TabMap[visibleChannels.Last()]));
+            AddAssert("Last visible selected", () => currentChannel == visibleChannels.Last());
+
+            // Closing the last channel before dropdown
+            AddStep("Close current channel", () =>
+            {
+                expectedChannel = nextChannel;
+                chatOverlay.ChannelTabControl.RemoveChannel(currentChannel);
+            });
+            AddAssert("Next channel selected", () => currentChannel == expectedChannel);
+
+            // Depending on the window size, one more channel might need to be closed for the selectorTab to appear
+            AddUntilStep("Close channels until selector visible", () =>
+            {
+                if (chatOverlay.ChannelTabControl.VisibleItems.Last().Name == "+")
+                    return true;
+
+                chatOverlay.ChannelTabControl.RemoveChannel(visibleChannels.Last());
+                return false;
+            });
+            AddAssert("Last visible selected", () => currentChannel == visibleChannels.Last());
+
+            // Closing the last channel with dropdown no longer present
+            AddStep("Close last when selector next", () => 
+            {
+                expectedChannel = previousChannel;
+                chatOverlay.ChannelTabControl.RemoveChannel(currentChannel);
+            });
+            AddAssert("Channel changed to previous", () => currentChannel == expectedChannel);
+
+            // Standard channel closing
+            AddStep("Switch to previous channel", () => chatOverlay.ChannelTabControl.SwitchTab(-1));
+            AddStep("Close current channel", () => 
+            {
+                expectedChannel = nextChannel;
+                chatOverlay.ChannelTabControl.RemoveChannel(currentChannel);
+            });
+            AddAssert("Channel changed to next", () => currentChannel == expectedChannel);
         }
 
         private void pressChannelHotkey(int number)
@@ -186,6 +248,8 @@ namespace osu.Game.Tests.Visual.Online
         private class TestChatOverlay : ChatOverlay
         {
             public Visibility SelectionOverlayState => ChannelSelectionOverlay.State.Value;
+
+            public new ChannelTabControl ChannelTabControl => base.ChannelTabControl;
 
             public new ChannelSelectionOverlay ChannelSelectionOverlay => base.ChannelSelectionOverlay;
 

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -107,12 +107,12 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Join channel 2", () => channelManager.JoinChannel(channel2));
 
             AddStep("Switch to channel 2", () => clickDrawable(chatOverlay.TabMap[channel2]));
-            AddStep("Close channel 2", () => clickDrawable(((TestChannelTabItem)chatOverlay.TabMap[channel2]).CloseButton.Child));
+            AddStep("Close channel 2", () => clickDrawable(((TestPrivateChannelTabItem)chatOverlay.TabMap[channel2]).CloseButton.Child));
 
             AddAssert("Selector remained closed", () => chatOverlay.SelectionOverlayState == Visibility.Hidden);
             AddAssert("Current channel is channel 1", () => currentChannel == channel1);
 
-            AddStep("Close channel 1", () => clickDrawable(((TestChannelTabItem)chatOverlay.TabMap[channel1]).CloseButton.Child));
+            AddStep("Close channel 1", () => clickDrawable(((TestPrivateChannelTabItem)chatOverlay.TabMap[channel1]).CloseButton.Child));
 
             AddAssert("Selector is visible", () => chatOverlay.SelectionOverlayState == Visibility.Visible);
         }
@@ -189,7 +189,7 @@ namespace osu.Game.Tests.Visual.Online
             AddAssert("Last visible selected", () => currentChannel == visibleChannels.Last());
 
             // Closing the last channel with dropdown no longer present
-            AddStep("Close last when selector next", () => 
+            AddStep("Close last when selector next", () =>
             {
                 expectedChannel = previousChannel;
                 chatOverlay.ChannelTabControl.RemoveChannel(currentChannel);
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.Online
 
             // Standard channel closing
             AddStep("Switch to previous channel", () => chatOverlay.ChannelTabControl.SwitchTab(-1));
-            AddStep("Close current channel", () => 
+            AddStep("Close current channel", () =>
             {
                 expectedChannel = nextChannel;
                 chatOverlay.ChannelTabControl.RemoveChannel(currentChannel);

--- a/osu.Game/Online/Chat/ChannelType.cs
+++ b/osu.Game/Online/Chat/ChannelType.cs
@@ -12,5 +12,6 @@ namespace osu.Game.Online.Chat
         Temporary,
         PM,
         Group,
+        System,
     }
 }

--- a/osu.Game/Overlays/Chat/Tabs/ChannelSelectorTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelSelectorTabItem.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Chat.Tabs
             public ChannelSelectorTabChannel()
             {
                 Name = "+";
-                Type = ChannelType.Temporary;
+                Type = ChannelType.System;
             }
         }
     }

--- a/osu.Game/Overlays/Chat/Tabs/ChannelSelectorTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelSelectorTabItem.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Overlays.Chat.Tabs
             public ChannelSelectorTabChannel()
             {
                 Name = "+";
+                Type = ChannelType.Temporary;
             }
         }
     }


### PR DESCRIPTION
Supersedes #7466.

## Summary
Brings chat tab closing behaviour to what's intended - if possible, switches to the next opened chat tab upon closing an active one. If not possible (if the `ChannelSelectorTab` is the next tab), switches to the previous channel, and if there are no channels left, opens the channel selector.

Tests taken from #7466, with some small readibility improvements and more explicit checks added.

## Remarks
There are issues with other tests in the `ChatOverlay` scene.

Right now, other tests use the PM chat tabs which change their size and have different `CloseButton` appereance behaviour. Closing of these tabs is done via `clickDrawable`. A problem arises when attempting to use that on non-PM tabs, though - due to the `CloseButton` not showing up instantly on hover, using `clickDrawable` there won't work properly - we'd have to explicitly hover the chat tab and only then attempt to click the button, but that's not a good solution IMO.

![2020-03-13_18-46-38](https://user-images.githubusercontent.com/27722894/76646329-13646f80-655b-11ea-9226-89d09684d5a3.gif)
(notice the first click being ignored)

Due to that, my tests use `ChannelTabControl.RemoveChannel()`, as I kind of had to use non-PM tabs for them (due to their static width). 

Should we just switch to using the `RemoveChannel()` in all cases for consistency? That would let us switch to having non-PM tabs in all tests (or at least mix them in), which kind of reflects the actual use case a bit more I think.
