### PR TITLE
Limit Torus font weight to bold

### DIFF
--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -136,10 +136,5 @@ namespace osu.Game.Graphics
         /// Equivalent to weight 700.
         /// </summary>
         Bold = 700,
-
-        /// <summary>
-        /// Equivalent to weight 900.
-        /// </summary>
-        Black = 900
     }
 }

--- a/osu.Game/Overlays/News/NewsArticleCover.cs
+++ b/osu.Game/Overlays/News/NewsArticleCover.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Overlays.News
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Font = OsuFont.GetFont(Typeface.Torus, 12, FontWeight.Black, false, false),
+                        Font = OsuFont.GetFont(Typeface.Torus, 12, FontWeight.Bold, false, false),
                         Text = date.ToString("d MMM yyy").ToUpper(),
                         Margin = new MarginPadding
                         {

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -84,13 +84,13 @@ namespace osu.Game.Overlays.Notifications
                                 new OsuSpriteText
                                 {
                                     Text = titleText.ToUpperInvariant(),
-                                    Font = OsuFont.GetFont(weight: FontWeight.Black)
+                                    Font = OsuFont.GetFont(weight: FontWeight.Bold)
                                 },
                                 countDrawable = new OsuSpriteText
                                 {
                                     Text = "3",
                                     Colour = colours.Yellow,
-                                    Font = OsuFont.GetFont(weight: FontWeight.Black)
+                                    Font = OsuFont.GetFont(weight: FontWeight.Bold)
                                 },
                             }
                         },

--- a/osu.Game/Overlays/OSD/Toast.cs
+++ b/osu.Game/Overlays/OSD/Toast.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays.OSD
                 {
                     Padding = new MarginPadding(10),
                     Name = "Description",
-                    Font = OsuFont.GetFont(size: 14, weight: FontWeight.Black),
+                    Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold),
                     Spacing = new Vector2(1, 0),
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,

--- a/osu.Game/Overlays/OverlayStreamItem.cs
+++ b/osu.Game/Overlays/OverlayStreamItem.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays
                         new OsuSpriteText
                         {
                             Text = MainText,
-                            Font = OsuFont.GetFont(size: 12, weight: FontWeight.Black),
+                            Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
                         },
                         new OsuSpriteText
                         {

--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         {
                             Text = "ACCOUNT",
                             Margin = new MarginPadding { Bottom = 5 },
-                            Font = OsuFont.GetFont(weight: FontWeight.Black),
+                            Font = OsuFont.GetFont(weight: FontWeight.Bold),
                         },
                         form = new LoginForm
                         {

--- a/osu.Game/Overlays/Settings/SettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSubsection.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Settings
                 {
                     Text = Header.ToUpperInvariant(),
                     Margin = new MarginPadding { Bottom = 10, Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS },
-                    Font = OsuFont.GetFont(weight: FontWeight.Black),
+                    Font = OsuFont.GetFont(weight: FontWeight.Bold),
                 },
                 FlowContent
             });

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Edit.Timing
             public HeaderText(string text)
             {
                 Text = text.ToUpper();
-                Font = OsuFont.GetFont(size: 12, weight: FontWeight.Black);
+                Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold);
             }
         }
 

--- a/osu.Game/Screens/Play/Break/BreakInfo.cs
+++ b/osu.Game/Screens/Play/Break/BreakInfo.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.Play.Break
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
                         Text = "current progress".ToUpperInvariant(),
-                        Font = OsuFont.GetFont(weight: FontWeight.Black, size: 15),
+                        Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 15),
                     },
                     new FillFlowContainer
                     {


### PR DESCRIPTION
Fixes torus fonts with `FontWeight.Black` set by changing it to `FontWeight.Bold`.

Didn't want to do fallback method because it hides the real font weight. The main font before (Exo 2) only used the black weight, so it's best removing it for now.