### PR TITLE
Fix mapper info alignment in score panel

### DIFF
--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -158,6 +158,8 @@ namespace osu.Game.Screens.Ranking.Expanded
                                     },
                                     new OsuTextFlowContainer(s => s.Font = OsuFont.Torus.With(size: 12))
                                     {
+                                        Anchor = Anchor.TopCentre,
+                                        Origin = Anchor.TopCentre,
                                         AutoSizeAxes = Axes.Both,
                                         Direction = FillDirection.Horizontal,
                                     }.With(t =>


### PR DESCRIPTION
Master: 
![image](https://user-images.githubusercontent.com/41869184/76876000-e211d980-68a3-11ea-8c24-7570202cb318.png)

This PR:
![image](https://user-images.githubusercontent.com/41869184/76876114-0a013d00-68a4-11ea-9310-44f5581c1679.png)