### PR TITLE
Handle beatmap import from a stable installation with a custom Songs path

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -119,9 +119,8 @@ namespace osu.Desktop
         {
             private const string default_songs_path = "Songs";
 
-            private string songsPath;
-            private bool usesCustomSongsPath;
-            private DesktopGameHost host;
+            private readonly string songsPath;
+            private readonly DesktopGameHost host;
 
             public StableStorage(DesktopGameHost host)
                 : base(string.Empty, host)
@@ -160,10 +159,9 @@ namespace osu.Desktop
             }
 
             /// <summary>
-            /// osu! stable Songs folder can be moved to another location by changing the 'BeatmapDirectory' setting in the stable configuration file.
-            /// This locates the Songs folder location for this stable instalation and sets flags if the songs folder location has been customized.
+            /// osu!stable <c>Songs</c> folder can be moved to another location by changing the <c>BeatmapDirectory</c> setting in the stable configuration file.
+            /// This locates the <c>Songs</c> folder location for this stable installation and sets flags if the song folder location has been customized.
             /// </summary>
-            /// <returns></returns>
             private string locateSongsDirectory()
             {
                 //we get the user config file.
@@ -174,24 +172,17 @@ namespace osu.Desktop
                 {
                     var line = textReader.ReadLine();
 
-                    if (line.StartsWith("BeatmapDirectory"))
-                    {
-                        var dir = line.Split('=')[1].TrimStart();
-                        if (!dir.Equals(default_songs_path, StringComparison.Ordinal))
-                        {
-                            usesCustomSongsPath = true;
-                            return Path.GetFullPath(dir);
-                        }
-                    }
+                    if (line?.StartsWith("BeatmapDirectory") == true)
+                        return line.Split('=')[1].TrimStart();
                 }
 
-                return null;
+                return default_songs_path;
             }
 
             public override Storage GetStorageForDirectory(string directory)
             {
-                if (directory.Equals(default_songs_path, StringComparison.Ordinal) && usesCustomSongsPath)
-                    return new StableSongsStorage(songsPath, host);
+                if (directory.Equals(default_songs_path, StringComparison.Ordinal) && !songsPath.Equals(default_songs_path, StringComparison.Ordinal))
+                    return new StableSongsStorage(Path.GetFullPath(songsPath), host);
 
                 return base.GetStorageForDirectory(directory);
             }

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -132,7 +132,7 @@ namespace osu.Desktop
 
             protected override string LocateBasePath()
             {
-                static bool checkExists(string p) => Directory.Exists(Path.Combine(p, "Songs"));
+                static bool checkExists(string p) => File.Exists(Path.Combine(p, "osu!.exe"));
 
                 string stableInstallPath;
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -560,7 +560,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
-        protected virtual IEnumerable<string> GetStableImportPaths(Storage stableStoage) => stableStoage.GetDirectories(ImportFromStablePath);
+        protected virtual IEnumerable<string> GetStableImportPaths(Storage stableStoage) => stableStoage.GetDirectories(".");
 
         /// <summary>
         /// Whether this specified path should be removed after successful import.
@@ -589,7 +589,9 @@ namespace osu.Game.Database
                 return Task.CompletedTask;
             }
 
-            return Task.Run(async () => await Import(GetStableImportPaths(GetStableStorage()).Select(f => stable.GetFullPath(f)).ToArray()));
+            var directory = stable.GetStorageForDirectory(ImportFromStablePath);
+
+            return Task.Run(async () => await Import(GetStableImportPaths(directory).Select(f => directory.GetFullPath(f)).ToArray()));
         }
 
         #endregion

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -558,7 +558,7 @@ namespace osu.Game.Database
         protected virtual string ImportFromStablePath => null;
 
         /// <summary>
-        /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
+        /// Select paths to import from the target stable data directory. Default implementation iterates all directories in the target directory.
         /// </summary>
         protected virtual IEnumerable<string> GetStableImportPaths(Storage stableStorage) => stableStorage.GetDirectories(".");
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -560,7 +560,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
-        protected virtual IEnumerable<string> GetStableImportPaths(Storage stableStoage) => stableStoage.GetDirectories(".");
+        protected virtual IEnumerable<string> GetStableImportPaths(Storage stableStorage) => stableStorage.GetDirectories(".");
 
         /// <summary>
         /// Whether this specified path should be removed after successful import.

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Scoring
         }
 
         protected override IEnumerable<string> GetStableImportPaths(Storage stableStorage)
-            => stableStorage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false));
+            => stableStorage.GetFiles(".").Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false));
 
         public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);
 


### PR DESCRIPTION

Depends on 
- [ ] ppy/osu-framework#3384

# Summary

The songs directory location of an osu!stable installation can be modified through the osu! configuration file.
This PR adds the ability to the `StableStorage` to detect if the user has modified the Songs directory location by reading the osu! stable config file.

Changes have been made to the way `ArchiveModelManager`s access to stable data, they now get access only to the data directory they require (using `Storage.GetStorageForDirectory()`) 
instead of the whole installation directory since `NativeStorage` possess functionnality to prevent path traversal outside of the base directory (blocking import in case of a custom Songs directory location)

`StableStorage` overrides `GetStorageForDirectory()` to return a `Storage` pointing to the Songs folder if the asked folder is the Songs folder.

## Remarks

Implementing automated tests for this is quite hard, so I tested the behaviour myself by creating a directory containing a few beatmaps, modifying my `BeatmapDirectory` in my osu! stable config file to point to that directory and trying importing from lazer. It **works** on my machine.



