### PR TITLE
Reduce allocations of followpoints by reusing existing

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -88,8 +88,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
         private void refresh()
         {
-            ClearInternal();
-
             OsuHitObject osuStart = Start.HitObject;
             double startTime = osuStart.GetEndTime();
 
@@ -116,6 +114,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             double? firstTransformStartTime = null;
             double finalTransformEndTime = startTime;
 
+            int point = 0;
+
             for (int d = (int)(spacing * 1.5); d < distance - spacing; d += spacing)
             {
                 float fraction = (float)d / distance;
@@ -126,13 +126,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
                 FollowPoint fp;
 
-                AddInternal(fp = new FollowPoint
+                if (InternalChildren.Count > point)
                 {
-                    Position = pointStartPosition,
-                    Rotation = rotation,
-                    Alpha = 0,
-                    Scale = new Vector2(1.5f * osuEnd.Scale),
-                });
+                    fp = (FollowPoint)InternalChildren[point];
+                    fp.ClearTransforms();
+                }
+                else
+                    AddInternal(fp = new FollowPoint());
+
+                fp.Position = pointStartPosition;
+                fp.Rotation = rotation;
+                fp.Alpha = 0;
+                fp.Scale = new Vector2(1.5f * osuEnd.Scale);
 
                 if (firstTransformStartTime == null)
                     firstTransformStartTime = fadeInTime;
@@ -146,7 +151,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
                     finalTransformEndTime = fadeOutTime + osuEnd.TimeFadeIn;
                 }
+
+                point++;
             }
+
+            int excessPoints = InternalChildren.Count - point;
+            for (int i = 0; i < excessPoints; i++)
+                RemoveInternal(InternalChildren[^1]);
 
             // todo: use Expire() on FollowPoints and take lifetime from them when https://github.com/ppy/osu-framework/issues/3300 is fixed.
             LifetimeStart = firstTransformStartTime ?? startTime;


### PR DESCRIPTION
I'm open to alternative fixes to follow point logic, but feel we probably want to hold off on any drastic changes until we reconsider skinning and pooling. Consider this a hotfix until we get to a point we can look into that.

Before:
![image](https://user-images.githubusercontent.com/191335/76977973-6da96a00-6979-11ea-9567-7f3c3c98df98.png)

After:
![image](https://user-images.githubusercontent.com/191335/76978912-a138c400-697a-11ea-8dd2-681ca3a4a224.png)

Reduces [centipede](https://osu.ppy.sh/beatmapsets/150945#osu/372245) allocation overhead during load by 4.8gb