### PR TITLE
Fix potentially invalid push in player while already exiting

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -387,6 +387,10 @@ namespace osu.Game.Screens.Play
 
         private void onCompletion()
         {
+            // screen may be in the exiting transition phase.
+            if (!this.IsCurrentScreen())
+                return;
+
             // Only show the completion screen if the player hasn't failed
             if (HealthProcessor.HasFailed || completionProgressDelegate != null)
                 return;
@@ -581,7 +585,7 @@ namespace osu.Game.Screens.Play
             if (completionProgressDelegate != null && !completionProgressDelegate.Cancelled && !completionProgressDelegate.Completed)
             {
                 // proceed to result screen if beatmap already finished playing
-                scheduleGotoRanking();
+                completionProgressDelegate.RunTask();
                 return true;
             }
 
@@ -623,7 +627,12 @@ namespace osu.Game.Screens.Play
             {
                 var score = CreateScore();
                 if (DrawableRuleset.ReplayScore == null)
-                    scoreManager.Import(score).ContinueWith(_ => Schedule(() => this.Push(CreateResults(score))));
+                    scoreManager.Import(score).ContinueWith(_ => Schedule(() =>
+                    {
+                        // screen may be in the exiting transition phase.
+                        if (this.IsCurrentScreen())
+                            this.Push(CreateResults(score));
+                    }));
                 else
                     this.Push(CreateResults(score));
             });

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -626,13 +626,16 @@ namespace osu.Game.Screens.Play
             completionProgressDelegate = Schedule(delegate
             {
                 var score = CreateScore();
+
                 if (DrawableRuleset.ReplayScore == null)
+                {
                     scoreManager.Import(score).ContinueWith(_ => Schedule(() =>
                     {
                         // screen may be in the exiting transition phase.
                         if (this.IsCurrentScreen())
                             this.Push(CreateResults(score));
                     }));
+                }
                 else
                     this.Push(CreateResults(score));
             });


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8352.

Would hope we can figure a more streamlined path of ensuring this kind of consistency, but in discussion all the possible solutions we have available are not what we want.

No test because it's a very hard one to test (requires specific score import timing which will take way too much effort to test). If it regresses another time I'll put the effort in to add proper test coverage (would need a custom `ScoreManager` and multiple mutexes).