### PR TITLE
Increase sample concurrency to better match stable

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -47,6 +47,8 @@ namespace osu.Game
     {
         public const string CLIENT_STREAM_NAME = "lazer";
 
+        public const int SAMPLE_CONCURRENCY = 6;
+
         protected OsuConfigManager LocalConfig;
 
         protected BeatmapManager BeatmapManager;
@@ -152,6 +154,8 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Venera-Light");
             AddFont(Resources, @"Fonts/Venera-Bold");
             AddFont(Resources, @"Fonts/Venera-Black");
+
+            Audio.Samples.PlaybackConcurrency = SAMPLE_CONCURRENCY;
 
             runMigrations();
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -158,6 +158,7 @@ namespace osu.Game.Rulesets.UI
                 dependencies.Cache(textureStore);
 
                 localSampleStore = dependencies.Get<AudioManager>().GetSampleStore(new NamespacedResourceStore<byte[]>(resources, "Samples"));
+                localSampleStore.PlaybackConcurrency = OsuGameBase.SAMPLE_CONCURRENCY;
                 dependencies.CacheAs<ISampleStore>(new FallbackSampleStore(localSampleStore, dependencies.Get<ISampleStore>()));
             }
 

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -52,7 +52,11 @@ namespace osu.Game.Skinning
 
             if (storage != null)
             {
-                Samples = audioManager?.GetSampleStore(storage);
+                var samples = audioManager?.GetSampleStore(storage);
+                if (samples != null)
+                    samples.PlaybackConcurrency = OsuGameBase.SAMPLE_CONCURRENCY;
+
+                Samples = samples;
                 Textures = new TextureStore(new TextureLoaderStore(storage));
 
                 (storage as ResourceStore<byte[]>)?.AddExtension("ogg");


### PR DESCRIPTION
Unfortunately we need to set this quite liberally due to the resource fallback path.

- Closes https://github.com/ppy/osu/issues/8375