### PR TITLE
Add ability to adjust (and save) chroma-key area width

### DIFF
--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -24,7 +24,13 @@ namespace osu.Game.Tournament.Models
         // only used for serialisation
         public List<TournamentProgression> Progressions = new List<TournamentProgression>();
 
-        [JsonIgnore]
+        [JsonIgnore] // updated manually in TournamentGameBase
         public Bindable<TournamentMatch> CurrentMatch = new Bindable<TournamentMatch>();
+
+        public Bindable<int> ChromaKeyWidth = new BindableInt(1024)
+        {
+            MinValue = 640,
+            MaxValue = 1366,
+        };
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
@@ -35,6 +36,8 @@ namespace osu.Game.Tournament.Screens.Gameplay
         [Resolved]
         private TournamentMatchChatDisplay chat { get; set; }
 
+        private Box chroma;
+
         [BackgroundDependencyLoader]
         private void load(LadderInfo ladder, MatchIPCInfo ipc, Storage storage)
         {
@@ -60,11 +63,10 @@ namespace osu.Game.Tournament.Screens.Gameplay
                     Origin = Anchor.TopCentre,
                     Children = new Drawable[]
                     {
-                        new Box
+                        chroma = new Box
                         {
                             // chroma key area for stable gameplay
                             Name = "chroma",
-                            RelativeSizeAxes = Axes.X,
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Height = 512,
@@ -93,6 +95,12 @@ namespace osu.Game.Tournament.Screens.Gameplay
                             RelativeSizeAxes = Axes.X,
                             Text = "Toggle chat",
                             Action = () => { State.Value = State.Value == TourneyState.Idle ? TourneyState.Playing : TourneyState.Idle; }
+                        },
+                        new SettingsSlider<int>
+                        {
+                            LabelText = "Chroma Width",
+                            Bindable = LadderInfo.ChromaKeyWidth,
+                            KeyboardStep = 1,
                         }
                     }
                 }
@@ -100,6 +108,8 @@ namespace osu.Game.Tournament.Screens.Gameplay
 
             State.BindTo(ipc.State);
             State.BindValueChanged(stateChanged, true);
+
+            ladder.ChromaKeyWidth.BindValueChanged(width => chroma.Width = width.NewValue, true);
 
             currentMatch.BindValueChanged(m =>
             {

--- a/osu.Game.Tournament/Screens/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/SetupScreen.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Tournament.Screens
                     {
                         windowSize.Value = new Size((int)(1920 / TournamentSceneManager.STREAM_AREA_WIDTH * TournamentSceneManager.REQUIRED_WIDTH), 1080);
                     }
-                }
+                },
             };
         }
 


### PR DESCRIPTION
One of two remaining hacks for taiko world cup usability. Generally required when there are less than 8 osu! screens present.