### PR TITLE
Hide scrollbars in tournament chat display

### DIFF
--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -70,6 +70,17 @@ namespace osu.Game.Tournament.Components
 
         protected override ChatLine CreateMessage(Message message) => new MatchMessage(message);
 
+        protected override StandAloneDrawableChannel CreateDrawableChannel(Channel channel) => new MatchChannel(channel);
+
+        public class MatchChannel : StandAloneDrawableChannel
+        {
+            public MatchChannel(Channel channel)
+                : base(channel)
+            {
+                ScrollbarVisible = false;
+            }
+        }
+
         protected class MatchMessage : StandAloneMessage
         {
             public MatchMessage(Message message)

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Online.Chat
 
         protected ChannelManager ChannelManager;
 
-        private DrawableChannel drawableChannel;
+        private StandAloneDrawableChannel drawableChannel;
 
         private readonly bool postingTextbox;
 
@@ -77,6 +77,9 @@ namespace osu.Game.Online.Chat
                 ChannelManager = manager;
         }
 
+        protected virtual StandAloneDrawableChannel CreateDrawableChannel(Channel channel) =>
+            new StandAloneDrawableChannel(channel);
+
         private void postMessage(TextBox sender, bool newtext)
         {
             var text = textbox.Text.Trim();
@@ -100,14 +103,14 @@ namespace osu.Game.Online.Chat
 
             if (e.NewValue == null) return;
 
-            AddInternal(drawableChannel = new StandAloneDrawableChannel(e.NewValue)
-            {
-                CreateChatLineAction = CreateMessage,
-                Padding = new MarginPadding { Bottom = postingTextbox ? textbox_height : 0 }
-            });
+            drawableChannel = CreateDrawableChannel(e.NewValue);
+            drawableChannel.CreateChatLineAction = CreateMessage;
+            drawableChannel.Padding = new MarginPadding { Bottom = postingTextbox ? textbox_height : 0 };
+
+            AddInternal(drawableChannel);
         }
 
-        protected class StandAloneDrawableChannel : DrawableChannel
+        public class StandAloneDrawableChannel : DrawableChannel
         {
             public Func<Message, ChatLine> CreateChatLineAction;
 

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -26,6 +26,20 @@ namespace osu.Game.Overlays.Chat
         protected FillFlowContainer ChatLineFlow;
         private OsuScrollContainer scroll;
 
+        private bool scrollbarVisible = true;
+
+        public bool ScrollbarVisible
+        {
+            set
+            {
+                if (scrollbarVisible == value) return;
+
+                scrollbarVisible = value;
+                if (scroll != null)
+                    scroll.ScrollbarVisible = value;
+            }
+        }
+
         [Resolved]
         private OsuColour colours { get; set; }
 
@@ -44,6 +58,7 @@ namespace osu.Game.Overlays.Chat
                 Masking = true,
                 Child = scroll = new OsuScrollContainer
                 {
+                    ScrollbarVisible = scrollbarVisible,
                     RelativeSizeAxes = Axes.Both,
                     // Some chat lines have effects that slightly protrude to the bottom,
                     // which we do not want to mask away, hence the padding.


### PR DESCRIPTION
Second of two remaining hacks for taiko world cup usability.