### PR TITLE
Fix crash when holding a key down while entering player

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -136,6 +136,8 @@ namespace osu.Game.Screens.Select
 
         public void Deactivate()
         {
+            searchTextBox.ReadOnly = true;
+
             searchTextBox.HoldFocus = false;
             if (searchTextBox.HasFocus)
                 GetContainingInputManager().ChangeFocus(searchTextBox);
@@ -143,6 +145,7 @@ namespace osu.Game.Screens.Select
 
         public void Activate()
         {
+            searchTextBox.ReadOnly = false;
             searchTextBox.HoldFocus = true;
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8168

Reproduction steps:
- Make sure you have one or more beatmaps matching search for a single `/`.
- Make sure you have no beatmaps matching search for `//`.
- Hold key down `/` until one character appears in the search box.
- While keeping key held down, click (has to be a click) on the osu! logo before the next `/` appears (from key repeat).

If it doesn't crash, repeat from scratch until it does (timing is quite important).

The cause of this can be seen in [TextBox](https://github.com/ppy/osu-framework/blob/43edfc3653444793bd8268e5d5c7f66705b519e2/osu.Framework/Graphics/UserInterface/TextBox.cs#L625), where text will continue to be consumed and fire events until the next key up event. We were not protecting song select against this scenario.

Easy fix is making the textbox readonly at the moment we no longer want the filter control to apply.

No tests as hard to test.

