### PR TITLE
Fix NullReferenceException when starting the no-video version of a beatmap with video

### DIFF
--- a/osu.Game.Tests/Resources/storyboard_no_video.osu
+++ b/osu.Game.Tests/Resources/storyboard_no_video.osu
@@ -1,0 +1,31 @@
+osu file format v14
+
+[Events]
+//Background and Video events
+0,0,"BG.jpg",0,0
+Video,0,"video.avi"
+//Break Periods
+//Storyboard Layer 0 (Background)
+//Storyboard Layer 1 (Fail)
+//Storyboard Layer 2 (Pass)
+//Storyboard Layer 3 (Foreground)
+//Storyboard Layer 4 (Overlay)
+//Storyboard Sound Samples
+
+[TimingPoints]
+1674,333.333333333333,4,2,1,70,1,0
+1674,-100,4,2,1,70,0,0
+3340,-100,4,2,1,70,0,0
+3507,-100,4,2,1,70,0,0
+3673,-100,4,2,1,70,0,0
+
+[Colours]
+Combo1 : 240,80,80
+Combo2 : 171,252,203
+Combo3 : 128,128,255
+Combo4 : 249,254,186
+
+[HitObjects]
+148,303,1674,5,6,3:2:0:0:
+378,252,1840,1,0,0:0:0:0:
+389,270,2340,5,2,0:1:0:0:

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Storyboards.Drawables
         {
             base.LoadComplete();
 
+            if (videoSprite == null) return;
+
             using (videoSprite.BeginAbsoluteSequence(0))
                 videoSprite.FadeIn(500);
         }


### PR DESCRIPTION
Fixes potential NRE when playing the downloaded without video version of a beatmap with a video file.

Can be reproduced with any beatmap that has a video by downloading the no video version of the beatmap, importing it and start it.