### PR TITLE
Make beatmap carousel use queue for its selection of next beatmap

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -87,8 +87,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestTraversalHold()
         {
             var sets = new List<BeatmapSetInfo>();
+            const int create_this_many_sets = 200;
 
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < create_this_many_sets; i++)
             {
                 var set = createTestBeatmapSet(i);
                 sets.Add(set);
@@ -109,7 +110,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 waitForSelection(amount + 1);
             }
 
-            for (int i = 1; i < 15; i += i)
+            for (int i = 1; i < create_this_many_sets; i += i)
             {
                 selectNextAndAssert(i);
             }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -83,15 +83,16 @@ namespace osu.Game.Tests.Visual.SongSelect
             waitForSelection(set_count, 3);
         }
 
-        [Test]
-        public void TestTraversalHold()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestTraversalHold(bool forwards)
         {
             var sets = new List<BeatmapSetInfo>();
             const int create_this_many_sets = 200;
 
             for (int i = 0; i < create_this_many_sets; i++)
             {
-                var set = createTestBeatmapSet(i);
+                var set = createTestBeatmapSet(i + 1);
                 sets.Add(set);
             }
 
@@ -99,15 +100,16 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             void selectNextAndAssert(int amount)
             {
-                setSelected(1, 1);
-                AddStep($"Next beatmap {amount} times", () =>
+                setSelected(forwards ? 1 : create_this_many_sets, 1);
+                string text = forwards ? "Next" : "Previous";
+                AddStep($"{text} beatmap {amount} times", () =>
                 {
                     for (int i = 0; i < amount; i++)
                     {
-                        carousel.SelectNext();
+                        carousel.SelectNext(forwards ? 1 : -1);
                     }
                 });
-                waitForSelection(amount + 1);
+                waitForSelection(forwards ? amount + 1 : create_this_many_sets - amount);
             }
 
             for (int i = 1; i < create_this_many_sets; i += i)

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -83,6 +83,38 @@ namespace osu.Game.Tests.Visual.SongSelect
             waitForSelection(set_count, 3);
         }
 
+        [Test]
+        public void TestTraversalHold()
+        {
+            var sets = new List<BeatmapSetInfo>();
+
+            for (int i = 0; i < 20; i++)
+            {
+                var set = createTestBeatmapSet(i);
+                sets.Add(set);
+            }
+
+            loadBeatmaps(sets);
+
+            void selectNextAndAssert(int amount)
+            {
+                setSelected(1, 1);
+                AddStep($"Next beatmap {amount} times", () =>
+                {
+                    for (int i = 0; i < amount; i++)
+                    {
+                        carousel.SelectNext();
+                    }
+                });
+                waitForSelection(amount + 1);
+            }
+
+            for (int i = 1; i < 15; i += i)
+            {
+                selectNextAndAssert(i);
+            }
+        }
+
         /// <summary>
         /// Test filtering
         /// </summary>

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -246,12 +246,19 @@ namespace osu.Game.Screens.Select
             return false;
         }
 
+        private readonly Queue<Tuple<int, bool>> selectionQueue = new Queue<Tuple<int, bool>>();
+
         /// <summary>
         /// Increment selection in the carousel in a chosen direction.
         /// </summary>
         /// <param name="direction">The direction to increment. Negative is backwards.</param>
         /// <param name="skipDifficulties">Whether to skip individual difficulties and only increment over full groups.</param>
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
+        {
+            selectionQueue.Enqueue(new Tuple<int, bool>(direction, skipDifficulties));
+        }
+
+        private void selectNext(int direction, bool skipDifficulties)
         {
             var visibleItems = Items.Where(s => !s.Item.Filtered.Value).ToList();
 
@@ -475,6 +482,12 @@ namespace osu.Game.Screens.Select
         protected override void Update()
         {
             base.Update();
+
+            if (selectionQueue.Any())
+            {
+                var queued = selectionQueue.Dequeue();
+                selectNext(queued.Item1, queued.Item2);
+            }
 
             if (!itemsCache.IsValid)
                 updateItems();

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -302,6 +302,18 @@ namespace osu.Game.Screens.Select
             }
         }
 
+        internal void DequeueFromSelectionQueue(bool dequeueAll = false)
+        {
+            do
+            {
+                if (selectionQueue.Any())
+                {
+                    var queued = selectionQueue.Dequeue();
+                    selectNext(queued.Item1, queued.Item2);
+                }
+            } while (selectionQueue.Any() && dequeueAll);
+        }
+
         /// <summary>
         /// Select the next beatmap in the random sequence.
         /// </summary>
@@ -483,11 +495,7 @@ namespace osu.Game.Screens.Select
         {
             base.Update();
 
-            if (selectionQueue.Any())
-            {
-                var queued = selectionQueue.Dequeue();
-                selectNext(queued.Item1, queued.Item2);
-            }
+            DequeueFromSelectionQueue();
 
             if (!itemsCache.IsValid)
                 updateItems();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -345,6 +345,8 @@ namespace osu.Game.Screens.Select
             if (!Carousel.BeatmapSetsLoaded)
                 return;
 
+            Carousel.DequeueFromSelectionQueue(true);
+
             transferRulesetValue();
 
             // while transferRulesetValue will flush, it only does so if the ruleset changes.


### PR DESCRIPTION
Resolves #3051

This PR splits ``BeatmapCarousel``'s ``SelectNext`` function into public and private ones. Public function will enqueue the request to be called later in ``Update``. Test is included.