### PR TITLE
Fix break overlay not displaying progress information

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.Break;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -27,7 +28,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("seek to break time", () => Player.GameplayClockContainer.Seek(Player.ChildrenOfType<BreakTracker>().First().Breaks.First().StartTime));
             AddUntilStep("wait for seek to complete", () =>
                 Player.HUDOverlay.Progress.ReferenceClock.CurrentTime >= Player.BreakOverlay.Breaks.First().StartTime);
-            AddAssert("test keys not counting", () => !Player.HUDOverlay.KeyCounter.IsCounting);
+            AddAssert("keys not counting", () => !Player.HUDOverlay.KeyCounter.IsCounting);
+            AddAssert("overlay displays 100% accuracy", () => Player.BreakOverlay.ChildrenOfType<BreakInfo>().Single().AccuracyDisplay.Current.Value == 1);
             AddStep("rewind", () => Player.GameplayClockContainer.Seek(-80000));
             AddUntilStep("key counter reset", () => Player.HUDOverlay.KeyCounter.Children.All(kc => kc.CountPresses == 0));
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddRange(new Drawable[]
             {
                 breakTracker = new TestBreakTracker(),
-                breakOverlay = new BreakOverlay(true)
+                breakOverlay = new BreakOverlay(true, null)
                 {
                     ProcessCustomClock = false,
                 }

--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Play
         private readonly RemainingTimeCounter remainingTimeCounter;
         private readonly BreakArrows breakArrows;
 
-        public BreakOverlay(bool letterboxing, ScoreProcessor scoreProcessor = null)
+        public BreakOverlay(bool letterboxing, ScoreProcessor scoreProcessor)
         {
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -308,7 +308,7 @@ namespace osu.Game.Screens.Play
                     },
                 },
                 failAnimation = new FailAnimation(DrawableRuleset) { OnComplete = onFailComplete, },
-                BreakOverlay = new BreakOverlay(working.Beatmap.BeatmapInfo.LetterboxInBreaks)
+                BreakOverlay = new BreakOverlay(working.Beatmap.BeatmapInfo.LetterboxInBreaks, ScoreProcessor)
                 {
                     Clock = DrawableRuleset.FrameStableClock,
                     ProcessCustomClock = false,


### PR DESCRIPTION
Resolves #8469.

# Summary

Progress information display in break overlay has regressed in #8447 due to what seems to be a simple oversight of not passing `ScoreProcessor` to the break overlay.

# Remarks

Added a verification test step in `TestSceneAutoplay` to try and make sure this doesn't happen again. It kind of tests that autoplay works fine too, so two birds with one stone I guess?

As an aside this kind of bug is why I sort of dislike default argument values. Easy to forget that the argument is there as things just compile.