### PR TITLE
Fix break overlay displaying in front of all other player overlays

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -251,6 +251,12 @@ namespace osu.Game.Screens.Play
         {
             target.AddRange(new[]
             {
+                BreakOverlay = new BreakOverlay(working.Beatmap.BeatmapInfo.LetterboxInBreaks, ScoreProcessor)
+                {
+                    Clock = DrawableRuleset.FrameStableClock,
+                    ProcessCustomClock = false,
+                    Breaks = working.Beatmap.Breaks
+                },
                 // display the cursor above some HUD elements.
                 DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),
                 DrawableRuleset.ResumeOverlay?.CreateProxy() ?? new Container(),
@@ -308,12 +314,6 @@ namespace osu.Game.Screens.Play
                     },
                 },
                 failAnimation = new FailAnimation(DrawableRuleset) { OnComplete = onFailComplete, },
-                BreakOverlay = new BreakOverlay(working.Beatmap.BeatmapInfo.LetterboxInBreaks, ScoreProcessor)
-                {
-                    Clock = DrawableRuleset.FrameStableClock,
-                    ProcessCustomClock = false,
-                    Breaks = working.Beatmap.Breaks
-                },
             });
         }
 


### PR DESCRIPTION
Resolves #8473.

- [x] Depends on #8474 (for mergeability).

# Summary

Another regression from #8447. Moving the break overlay from `DrawableRuleset`'s overlays to `Player` itself has affected z-order of all overlays, as the break overlay (which was added as last in that PR) then ended up the topmost overlay. This means the change also affected i.e. the cursor container, as can be seen on the following screenshots:

| `master` | this PR |
| :-: | :-: |
| ![osu_2020-03-27_22-26-01](https://user-images.githubusercontent.com/20418176/77802712-bf3dad00-707b-11ea-9490-07a4072ca9f2.jpg) | ![osu_2020-03-27_22-28-57](https://user-images.githubusercontent.com/20418176/77802716-c2d13400-707b-11ea-8d47-0ead64ee70e5.jpg) |

It's subtle, but on the first screenshot the break overlay is in front of the gameplay cursor.

To resolve, make `BreakOverlay` be the first drawable in `addOverlayComponents`. Since before the overlay was the topmost component in `DrawableRuleset`, this mostly restores behaviour, with the exception of `ComboEffects` (which used to be above, and is now below the break overlay).

# Remarks

No tests here, as I couldn't really figure out a good way to test this that wouldn't be too brittle in regards to potential future changes. Suggestions on best way to test however welcome as I'd like to include one here if possible.