### PR TITLE
Improve robustness of loader tests

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneLoader.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneLoader.cs
@@ -36,8 +36,6 @@ namespace osu.Game.Tests.Visual.Menus
         [Test]
         public void TestInstantLoad()
         {
-            // visual only, very impossible to test this using asserts.
-
             AddStep("load immediately", () =>
             {
                 loader = new TestLoader();
@@ -46,11 +44,16 @@ namespace osu.Game.Tests.Visual.Menus
                 LoadScreen(loader);
             });
 
-            AddAssert("spinner did not display", () => loader.LoadingSpinner?.Alpha == 0);
+            spinnerNotPresentOrHidden();
 
             AddUntilStep("loaded", () => loader.ScreenLoaded);
             AddUntilStep("not current", () => !loader.IsCurrentScreen());
+
+            spinnerNotPresentOrHidden();
         }
+
+        private void spinnerNotPresentOrHidden() =>
+            AddAssert("spinner did not display", () => loader.LoadingSpinner == null || loader.LoadingSpinner.Alpha == 0);
 
         [Test]
         public void TestDelayedLoad()


### PR DESCRIPTION
# Summary

In headless tests it was possible for `TestInstantLoad()` to erroneously fail. There were two scenarios in which `LoadingSpinner` could be null:

1. If the test runner was quick enough, the assert could end up running even before `Loader.OnEntering()` had even had a chance to, meaning that the spinner was never even actually assigned to or instantiated at that point in time.

2. Even if `Loader.OnEntering()` had managed to run, there was also a possibility that the spinner itself wasn't loaded at the point of checking the assertion. As the spinner is accessed through `ChildrenOfType()`, which only checks `InternalChildren` and ignores all currently-loading drawables, it would therefore return null.

As `null != 0`, both of these cases would actually fail the test (this is best seen running headless, preferably with a `[Repeat]` attribute attached).

To resolve, allow the spinner to be null at the point of asserting and duplicate the assertion step at the end. This weakens the test, as case (1) should probably be waited for and case (2) could be solved with exposition as protected in the base, but when attempting to wait for the loader itself to be loaded to ensure `Loader.OnEntering()` has actually been run, there were also cases where the appropriate until step would take so much time that the spinner would actually become visible in line with the delayed display logic, so this is a best-effort attempt to address both points without radical changes.

# Remarks

Spotted in a local `dotnet test` run when preparing #8474. Weirdly enough I haven't seen this one on appveyor, which is strange as I'm hitting it almost 100% of the time headless when running through rider.

Not overly sold on this resolution. Suggestions for changes welcome.