### PR TITLE
Rewrite beatmap carousel's select next logic to not use drawables

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -85,66 +85,47 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         [TestCase(true)]
         [TestCase(false)]
-        public void TestTraversalHold(bool forwards)
+        public void TestTraversalBeyondVisible(bool forwards)
         {
             var sets = new List<BeatmapSetInfo>();
-            const int create_this_many_sets = 200;
 
-            for (int i = 0; i < create_this_many_sets; i++)
-            {
-                var set = createTestBeatmapSet(i + 1);
-                sets.Add(set);
-            }
+            const int total_set_count = 200;
+
+            for (int i = 0; i < total_set_count; i++)
+                sets.Add(createTestBeatmapSet(i + 1));
 
             loadBeatmaps(sets);
 
+            for (int i = 1; i < total_set_count; i += i)
+                selectNextAndAssert(i);
+
             void selectNextAndAssert(int amount)
             {
-                setSelected(forwards ? 1 : create_this_many_sets, 1);
-                string text = forwards ? "Next" : "Previous";
-                AddStep($"{text} beatmap {amount} times", () =>
+                setSelected(forwards ? 1 : total_set_count, 1);
+
+                AddStep($"{(forwards ? "Next" : "Previous")} beatmap {amount} times", () =>
                 {
                     for (int i = 0; i < amount; i++)
                     {
                         carousel.SelectNext(forwards ? 1 : -1);
                     }
                 });
-                waitForSelection(forwards ? amount + 1 : create_this_many_sets - amount);
-            }
 
-            for (int i = 1; i < create_this_many_sets; i += i)
-            {
-                selectNextAndAssert(i);
+                waitForSelection(forwards ? amount + 1 : total_set_count - amount);
             }
         }
 
         [Test]
-        public void TestTraversalHoldDifficulties()
+        public void TestTraversalBeyondVisibleDifficulties()
         {
             var sets = new List<BeatmapSetInfo>();
 
-            for (int i = 0; i < 20; i++)
-            {
-                var set = createTestBeatmapSet(i + 1);
-                sets.Add(set);
-            }
+            const int total_set_count = 200;
+
+            for (int i = 0; i < total_set_count; i++)
+                sets.Add(createTestBeatmapSet(i + 1));
 
             loadBeatmaps(sets);
-
-            void selectNextAndAssert(int amount, bool forwards, int expectedSet, int expectedDiff)
-            {
-                // Select very first or very last difficulty
-                setSelected(forwards ? 1 : 20, forwards ? 1 : 3);
-                string text = forwards ? "Next" : "Previous";
-                AddStep($"{text} difficulty {amount} times", () =>
-                {
-                    for (int i = 0; i < amount; i++)
-                    {
-                        carousel.SelectNext(forwards ? 1 : -1, false);
-                    }
-                });
-                waitForSelection(expectedSet, expectedDiff);
-            }
 
             // Selects next set once, difficulty index doesn't change
             selectNextAndAssert(3, true, 2, 1);
@@ -162,6 +143,20 @@ namespace osu.Game.Tests.Visual.SongSelect
             selectNextAndAssert(3, false, 19, 3);
             selectNextAndAssert(50, false, 4, 1);
             selectNextAndAssert(200, false, 14, 1);
+
+            void selectNextAndAssert(int amount, bool forwards, int expectedSet, int expectedDiff)
+            {
+                // Select very first or very last difficulty
+                setSelected(forwards ? 1 : 20, forwards ? 1 : 3);
+
+                AddStep($"{(forwards ? "Next" : "Previous")} difficulty {amount} times", () =>
+                {
+                    for (int i = 0; i < amount; i++)
+                        carousel.SelectNext(forwards ? 1 : -1, false);
+                });
+
+                waitForSelection(expectedSet, expectedDiff);
+            }
         }
 
         /// <summary>

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -87,8 +87,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestTraversalHold()
         {
             var sets = new List<BeatmapSetInfo>();
+            const int create_this_many_sets = 200;
 
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < create_this_many_sets; i++)
             {
                 var set = createTestBeatmapSet(i);
                 sets.Add(set);
@@ -109,7 +110,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 waitForSelection(amount + 1);
             }
 
-            for (int i = 1; i < 15; i += i)
+            for (int i = 1; i < create_this_many_sets; i += i)
             {
                 selectNextAndAssert(i);
             }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -148,11 +148,13 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             // Selects next set once, difficulty index doesn't change
             selectNextAndAssert(3, true, 2, 1);
-            // Selects next set 16 times (50 // 3 == 16), difficulty index changes twice (50 % 3 == 2)
+
+            // Selects next set 16 times (50 \ 3 == 16), difficulty index changes twice (50 % 3 == 2)
             selectNextAndAssert(50, true, 17, 3);
-            // Travels around the carousel thrice (200/60 == 3)
-            // continues to select 20 times (200 % 60 == 20)
-            // selects next set 6 times (20 // 3 == 6)
+
+            // Travels around the carousel thrice (200 \ 60 == 3)
+            // continues to select 20 times (200 \ 60 == 20)
+            // selects next set 6 times (20 \ 3 == 6)
             // difficulty index changes twice (20 % 3 == 2)
             selectNextAndAssert(200, true, 7, 3);
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -83,6 +83,38 @@ namespace osu.Game.Tests.Visual.SongSelect
             waitForSelection(set_count, 3);
         }
 
+        [Test]
+        public void TestTraversalHold()
+        {
+            var sets = new List<BeatmapSetInfo>();
+
+            for (int i = 0; i < 20; i++)
+            {
+                var set = createTestBeatmapSet(i);
+                sets.Add(set);
+            }
+
+            loadBeatmaps(sets);
+
+            void selectNextAndAssert(int amount)
+            {
+                setSelected(1, 1);
+                AddStep($"Next beatmap {amount} times", () =>
+                {
+                    for (int i = 0; i < amount; i++)
+                    {
+                        carousel.SelectNext();
+                    }
+                });
+                waitForSelection(amount + 1);
+            }
+
+            for (int i = 1; i < 15; i += i)
+            {
+                selectNextAndAssert(i);
+            }
+        }
+
         /// <summary>
         /// Test filtering
         /// </summary>

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -83,8 +83,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             waitForSelection(set_count, 3);
         }
 
-        [Test]
-        public void TestTraversalHold()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestTraversalHold(bool forwards)
         {
             var sets = new List<BeatmapSetInfo>();
             const int create_this_many_sets = 200;
@@ -99,15 +100,16 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             void selectNextAndAssert(int amount)
             {
-                setSelected(1, 1);
-                AddStep($"Next beatmap {amount} times", () =>
+                setSelected(forwards ? 1 : create_this_many_sets, 1);
+                string text = forwards ? "Next" : "Previous";
+                AddStep($"{text} beatmap {amount} times", () =>
                 {
                     for (int i = 0; i < amount; i++)
                     {
-                        carousel.SelectNext();
+                        carousel.SelectNext(forwards ? 1 : -1);
                     }
                 });
-                waitForSelection(amount + 1);
+                waitForSelection(forwards ? amount + 1 : create_this_many_sets - amount);
             }
 
             for (int i = 1; i < create_this_many_sets; i += i)

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -118,6 +118,50 @@ namespace osu.Game.Tests.Visual.SongSelect
             }
         }
 
+        [Test]
+        public void TestTraversalHoldDifficulties()
+        {
+            var sets = new List<BeatmapSetInfo>();
+
+            for (int i = 0; i < 20; i++)
+            {
+                var set = createTestBeatmapSet(i + 1);
+                sets.Add(set);
+            }
+
+            loadBeatmaps(sets);
+
+            void selectNextAndAssert(int amount, bool forwards, int expectedSet, int expectedDiff)
+            {
+                // Select very first or very last difficulty
+                setSelected(forwards ? 1 : 20, forwards ? 1 : 3);
+                string text = forwards ? "Next" : "Previous";
+                AddStep($"{text} difficulty {amount} times", () =>
+                {
+                    for (int i = 0; i < amount; i++)
+                    {
+                        carousel.SelectNext(forwards ? 1 : -1, false);
+                    }
+                });
+                waitForSelection(expectedSet, expectedDiff);
+            }
+
+            // Selects next set once, difficulty index doesn't change
+            selectNextAndAssert(3, true, 2, 1);
+            // Selects next set 16 times (50 // 3 == 16), difficulty index changes twice (50 % 3 == 2)
+            selectNextAndAssert(50, true, 17, 3);
+            // Travels around the carousel thrice (200/60 == 3)
+            // continues to select 20 times (200 % 60 == 20)
+            // selects next set 6 times (20 // 3 == 6)
+            // difficulty index changes twice (20 % 3 == 2)
+            selectNextAndAssert(200, true, 7, 3);
+
+            // All same but in reverse
+            selectNextAndAssert(3, false, 19, 3);
+            selectNextAndAssert(50, false, 4, 1);
+            selectNextAndAssert(200, false, 14, 1);
+        }
+
         /// <summary>
         /// Test filtering
         /// </summary>

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             for (int i = 0; i < create_this_many_sets; i++)
             {
-                var set = createTestBeatmapSet(i);
+                var set = createTestBeatmapSet(i + 1);
                 sets.Add(set);
             }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             var sets = new List<BeatmapSetInfo>();
 
-            const int total_set_count = 200;
+            const int total_set_count = 20;
 
             for (int i = 0; i < total_set_count; i++)
                 sets.Add(createTestBeatmapSet(i + 1));

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -266,12 +266,12 @@ namespace osu.Game.Screens.Select
         {
             var visibleSets = beatmapSets.Where(s => !s.Filtered.Value).ToList();
 
-            var item = visibleSets[(visibleSets.IndexOf(selectedBeatmapSet) + direction + visibleSets.Count) % visibleSets.Count];
+            var nextSet = visibleSets[(visibleSets.IndexOf(selectedBeatmapSet) + direction + visibleSets.Count) % visibleSets.Count];
 
             if (skipDifficulties)
-                select(item);
+                select(nextSet);
             else
-                select(direction > 0 ? item.Beatmaps.First(b => !b.Filtered.Value) : item.Beatmaps.Last(b => !b.Filtered.Value));
+                select(direction > 0 ? nextSet.Beatmaps.First(b => !b.Filtered.Value) : nextSet.Beatmaps.Last(b => !b.Filtered.Value));
         }
 
         private void selectNextDifficulty(int direction)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Screens.Select
         /// <param name="skipDifficulties">Whether to skip individual difficulties and only increment over full groups.</param>
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
-            if (!beatmapSets.Where(s => !s.Filtered.Value).ToList().Any())
+            if (beatmapSets.All(s => !s.Filtered.Value))
                 return;
 
             if (skipDifficulties)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -264,9 +264,9 @@ namespace osu.Game.Screens.Select
 
         private void selectNextSet(int direction, bool skipDifficulties)
         {
-            var visibleSets = beatmapSets.Where(s => !s.Filtered.Value).ToList();
+            var unfilteredSets = beatmapSets.Where(s => !s.Filtered.Value).ToList();
 
-            var nextSet = visibleSets[(visibleSets.IndexOf(selectedBeatmapSet) + direction + visibleSets.Count) % visibleSets.Count];
+            var nextSet = unfilteredSets[(unfilteredSets.IndexOf(selectedBeatmapSet) + direction + unfilteredSets.Count) % unfilteredSets.Count];
 
             if (skipDifficulties)
                 select(nextSet);
@@ -276,12 +276,14 @@ namespace osu.Game.Screens.Select
 
         private void selectNextDifficulty(int direction)
         {
-            var difficulties = selectedBeatmapSet.Children.Where(s => !s.Filtered.Value).ToList();
-            int index = difficulties.IndexOf(selectedBeatmap);
-            if (index + direction < 0 || index + direction >= difficulties.Count)
+            var unfilteredDifficulties = selectedBeatmapSet.Children.Where(s => !s.Filtered.Value).ToList();
+
+            int index = unfilteredDifficulties.IndexOf(selectedBeatmap);
+
+            if (index + direction < 0 || index + direction >= unfilteredDifficulties.Count)
                 selectNextSet(direction, false);
             else
-                select(difficulties[index + direction]);
+                select(unfilteredDifficulties[index + direction]);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Screens.Select
         /// <param name="skipDifficulties">Whether to skip individual difficulties and only increment over full groups.</param>
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
-            if (beatmapSets.All(s => !s.Filtered.Value))
+            if (beatmapSets.All(s => s.Filtered.Value))
                 return;
 
             if (skipDifficulties)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Screens.Select
         /// <param name="skipDifficulties">Whether to skip individual difficulties and only increment over full groups.</param>
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
-            if (!root.Children.Where(s => !s.Filtered.Value).ToList().Any())
+            if (!beatmapSets.Where(s => !s.Filtered.Value).ToList().Any())
                 return;
 
             if (skipDifficulties)
@@ -264,7 +264,7 @@ namespace osu.Game.Screens.Select
 
         private void selectNextSet(int direction, bool skipDifficulties)
         {
-            var visibleSets = root.Children.OfType<CarouselBeatmapSet>().Where(s => !s.Filtered.Value).ToList();
+            var visibleSets = beatmapSets.Where(s => !s.Filtered.Value).ToList();
 
             var item = visibleSets[(visibleSets.IndexOf(selectedBeatmapSet) + direction + visibleSets.Count) % visibleSets.Count];
 


### PR DESCRIPTION
Resolves #3051

Before this PR, carousel's select next logic relied on drawables being present and being in a good state (unsure what that state was, but if select next was called more than once in an update frame, carousel's selection would reset).

This PR makes select next use ``CarouselItem`` instead of ``DrawableCarouselItem``. Also removes unnecessary while loop logic by splitting select next into multiple functions.