### PR TITLE
Fix auto mod results screen not displaying correctly

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Screens;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
@@ -73,9 +72,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             Beatmap.Value = working;
             SelectedMods.Value = new[] { ruleset.GetAllMods().First(m => m is ModNoFail) };
-
-            Player?.Exit();
-            Player = null;
 
             Player = CreatePlayer(ruleset);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
@@ -5,8 +5,11 @@ using System.ComponentModel;
 using System.Linq;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.Break;
+using osu.Game.Screens.Ranking;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -17,8 +20,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected override Player CreatePlayer(Ruleset ruleset)
         {
-            SelectedMods.Value = SelectedMods.Value.Concat(new[] { ruleset.GetAutoplayMod() }).ToArray();
-            return new TestPlayer(false, false);
+            SelectedMods.Value = new[] { ruleset.GetAutoplayMod() };
+            return new TestPlayer(false);
         }
 
         protected override void AddCheckSteps()
@@ -32,6 +35,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("overlay displays 100% accuracy", () => Player.BreakOverlay.ChildrenOfType<BreakInfo>().Single().AccuracyDisplay.Current.Value == 1);
             AddStep("rewind", () => Player.GameplayClockContainer.Seek(-80000));
             AddUntilStep("key counter reset", () => Player.HUDOverlay.KeyCounter.Children.All(kc => kc.CountPresses == 0));
+
+            AddStep("complete", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
+            AddUntilStep("results displayed", () => getResultsScreen() != null);
+
+            AddAssert("score has combo", () => getResultsScreen().Score.Combo > 100);
+            AddAssert("score has no misses", () => getResultsScreen().Score.Statistics[HitResult.Miss] == 0);
+
+            ResultsScreen getResultsScreen() => Stack.CurrentScreen as ResultsScreen;
         }
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -637,6 +637,39 @@ namespace osu.Game.Screens.Play
             return base.OnExiting(next);
         }
 
+        protected virtual void GotoRanking()
+        {
+            if (DrawableRuleset.ReplayScore != null)
+            {
+                // if a replay is present, we likely don't want to import into the local database.
+                this.Push(CreateResults(CreateScore()));
+                return;
+            }
+
+            LegacyByteArrayReader replayReader = null;
+
+            var score = new Score { ScoreInfo = CreateScore() };
+
+            if (recordingReplay?.Frames.Count > 0)
+            {
+                score.Replay = recordingReplay;
+
+                using (var stream = new MemoryStream())
+                {
+                    new LegacyScoreEncoder(score, gameplayBeatmap.PlayableBeatmap).Encode(stream);
+                    replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
+                }
+            }
+
+            scoreManager.Import(score.ScoreInfo, replayReader)
+                        .ContinueWith(imported => Schedule(() =>
+                        {
+                            // screen may be in the exiting transition phase.
+                            if (this.IsCurrentScreen())
+                                this.Push(CreateResults(imported.Result));
+                        }));
+        }
+
         private void fadeOut(bool instant = false)
         {
             float fadeOutDuration = instant ? 0 : 250;
@@ -649,36 +682,7 @@ namespace osu.Game.Screens.Play
         private void scheduleGotoRanking()
         {
             completionProgressDelegate?.Cancel();
-            completionProgressDelegate = Schedule(delegate
-            {
-                if (DrawableRuleset.ReplayScore != null)
-                    this.Push(CreateResults(DrawableRuleset.ReplayScore.ScoreInfo));
-                else
-                {
-                    var score = new Score { ScoreInfo = CreateScore() };
-
-                    LegacyByteArrayReader replayReader = null;
-
-                    if (recordingReplay?.Frames.Count > 0)
-                    {
-                        score.Replay = recordingReplay;
-
-                        using (var stream = new MemoryStream())
-                        {
-                            new LegacyScoreEncoder(score, gameplayBeatmap.PlayableBeatmap).Encode(stream);
-                            replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
-                        }
-                    }
-
-                    scoreManager.Import(score.ScoreInfo, replayReader)
-                                .ContinueWith(imported => Schedule(() =>
-                                {
-                                    // screen may be in the exiting transition phase.
-                                    if (this.IsCurrentScreen())
-                                        this.Push(CreateResults(imported.Result));
-                                }));
-                }
-            });
+            completionProgressDelegate = Schedule(GotoRanking);
         }
 
         #endregion

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Screens;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Play
@@ -21,6 +22,11 @@ namespace osu.Game.Screens.Play
         protected override void PrepareReplay()
         {
             DrawableRuleset?.SetReplayScore(score);
+        }
+
+        protected override void GotoRanking()
+        {
+            this.Push(CreateResults(DrawableRuleset.ReplayScore.ScoreInfo));
         }
 
         protected override ScoreInfo CreateScore() => score.ScoreInfo;

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -31,13 +31,13 @@ namespace osu.Game.Screens.Ranking
         [Resolved(CanBeNull = true)]
         private Player player { get; set; }
 
-        private readonly ScoreInfo score;
+        public readonly ScoreInfo Score;
 
         private Drawable bottomPanel;
 
         public ResultsScreen(ScoreInfo score)
         {
-            this.score = score;
+            this.Score = score;
         }
 
         [BackgroundDependencyLoader]
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Ranking
             {
                 new ResultsScrollContainer
                 {
-                    Child = new ScorePanel(score)
+                    Child = new ScorePanel(Score)
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Ranking
                             Direction = FillDirection.Horizontal,
                             Children = new Drawable[]
                             {
-                                new ReplayDownloadButton(score) { Width = 300 },
+                                new ReplayDownloadButton(Score) { Width = 300 },
                                 new RetryButton { Width = 300 },
                             }
                         }

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Ranking
 
         public ResultsScreen(ScoreInfo score)
         {
-            this.Score = score;
+            Score = score;
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8436.

Tidies up results screen handling, allowing ReplayPlayer to have its own logic.