### PR TITLE
Support widescreen per-layer storyboard masking

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Storyboards.Drawables
 
             AddInternal(Content = new Container<DrawableStoryboardLayer>
             {
-                Size = new Vector2(640, 480),
+                RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             });

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardLayer.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardLayer.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.Containers;
 
 namespace osu.Game.Storyboards.Drawables
 {
-    public class DrawableStoryboardLayer : LifetimeManagementContainer
+    public class DrawableStoryboardLayer : CompositeDrawable
     {
         public StoryboardLayer Layer { get; }
         public bool Enabled;
@@ -23,17 +23,34 @@ namespace osu.Game.Storyboards.Drawables
             Origin = Anchor.Centre;
             Enabled = layer.VisibleWhenPassing;
             Masking = layer.Masking;
+
+            InternalChild = new LayerElementContainer(layer);
         }
 
-        [BackgroundDependencyLoader]
-        private void load(CancellationToken? cancellationToken)
+        private class LayerElementContainer : LifetimeManagementContainer
         {
-            foreach (var element in Layer.Elements)
-            {
-                cancellationToken?.ThrowIfCancellationRequested();
+            private readonly StoryboardLayer storyboardLayer;
 
-                if (element.IsDrawable)
-                    AddInternal(element.CreateDrawable());
+            public LayerElementContainer(StoryboardLayer layer)
+            {
+                storyboardLayer = layer;
+
+                Width = 640;
+                Height = 480;
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(CancellationToken? cancellationToken)
+            {
+                foreach (var element in storyboardLayer.Elements)
+                {
+                    cancellationToken?.ThrowIfCancellationRequested();
+
+                    if (element.IsDrawable)
+                        AddInternal(element.CreateDrawable());
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #8459.

# Summary

[As described here](https://github.com/ppy/osu/issues/8459#issuecomment-605698881), #8426 caused a regression in widescreen storyboard display due to adding per-layer masking, which did not work as intended, as all individual layers had a hard-coded 640x480 size for the sake of proper storyboard element placement.

This PR implements the proposal made in the comment above by constraining widescreen storyboards to a 16:9 aspect ratio. This is done by individual layers sizing to the parent, which is the entire `DrawableStoryboard`, whose size is properly set here:

https://github.com/ppy/osu/blob/f414b7fbb60d9e47a054f1d61493d846696125bc/osu.Game/Storyboards/Storyboard.cs#L57-L62

and then internally having a nested, centred `LayerElementContainer` that is hard-sized to 640x480 to ensure proper placement.

The overall behaviour is now as follows:
* the video layer is never masked,
* normal layers are masked to 4:3 if `WidescreenStoryboard` is not set, and masked to 16:9 otherwise.

This is a departure from stable, which as far as I can see will mask to 4:3 if `WidescreenStoryboard` is not set, but will not mask at all if it is set. Masking to 16:9 feels more correct to me as an owner of an ultra-wide monitor (many storyboards look janky without it since things are shown that are not supposed to be).

# Remarks

As far as I can see, this does not have a major effect on performance compared to current `master`. Here's some not-too-scientific evidence from one run of [`world.execute(me)`](https://osu.ppy.sh/beatmapsets/470977#osu/1012836) (times are the sum of update times for storyboard sprites & layers):

| timestamp |current `master` | | this PR | |
| -: | :-: | -: | :-: | -: |
| ~0:09 | ![osu_2020-03-30_21-57-21](https://user-images.githubusercontent.com/20418176/77957618-09b96680-72d4-11ea-937b-c6e4e37093cf.jpg) | 4.8ms | ![osu_2020-03-30_22-00-34](https://user-images.githubusercontent.com/20418176/77957726-34a3ba80-72d4-11ea-9b46-0cfecf40f6ec.jpg) | 5.4ms |
| ~0:33 | ![osu_2020-03-30_21-57-34](https://user-images.githubusercontent.com/20418176/77958009-b1369900-72d4-11ea-943e-6bf1cea9da60.jpg) | 9.2ms | ![osu_2020-03-30_22-00-58](https://user-images.githubusercontent.com/20418176/77958044-c0b5e200-72d4-11ea-85a3-c2cb83a950cd.jpg) | 9.6ms |
| ~0:51 | ![osu_2020-03-30_21-57-42](https://user-images.githubusercontent.com/20418176/77958091-d4614880-72d4-11ea-9524-7231c8d17bb4.jpg) | 7.0ms | ![osu_2020-03-30_22-01-16](https://user-images.githubusercontent.com/20418176/77958132-e04d0a80-72d4-11ea-978a-55460284a80f.jpg) | 7.2ms |
| ~1:31 | ![osu_2020-03-30_21-57-56](https://user-images.githubusercontent.com/20418176/77958181-f064ea00-72d4-11ea-8a61-3738d09275ac.jpg) | 10.2ms | ![osu_2020-03-30_22-01-56](https://user-images.githubusercontent.com/20418176/77958216-fbb81580-72d4-11ea-8e1e-fa56c0bf5ea9.jpg) | 11.1ms |
| ~2:32 | ![osu_2020-03-30_21-58-12](https://user-images.githubusercontent.com/20418176/77958265-138f9980-72d5-11ea-9c76-0e1e7ec8f659.jpg) | 21.2ms | ![osu_2020-03-30_22-02-28](https://user-images.githubusercontent.com/20418176/77958313-2904c380-72d5-11ea-8328-27cf1863c19c.jpg) | 24.2ms |
| ~2:53 | ![osu_2020-03-30_21-58-34](https://user-images.githubusercontent.com/20418176/77958377-3f128400-72d5-11ea-86e6-718a20346ec8.jpg) | 69.6ms | ![osu_2020-03-30_22-02-49](https://user-images.githubusercontent.com/20418176/77958422-4df93680-72d5-11ea-9893-41f89b6f2bf7.jpg) | 69.5ms |

Results are slightly worse, but I don't think that much worse as to disqualify this outright, and I think the correctness is worth it. It was one run, too, so might have been a fluke as well. I strongly encourage attempting reproduction.

(As a side note: I wrote a now-deleted comment in the issue thread earlier, thinking this way was inefficient due to the multiple maskings, but then noticed I had mistakenly used a `CompositeDrawable` instead of a `LifetimeManagementContainer` when going through all possible variants of fixes I could come up with. I *did* use a lifetime container initially but then wondered why'd performance tank so much the second time I tried this solution and forgot to use it...)

Not sure how testable this is. I can include something if you think it's worth it.