### PR TITLE
Fix osu!catch catcher hit area being too large

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -72,10 +72,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         protected override Skill[] CreateSkills(IBeatmap beatmap)
         {
             using (var catcher = new Catcher(beatmap.BeatmapInfo.BaseDifficulty))
-            {
                 halfCatcherWidth = catcher.CatchWidth * 0.5f;
-                halfCatcherWidth *= 0.8f; // We're only using 80% of the catcher's width to simulate imperfect gameplay.
-            }
 
             return new Skill[]
             {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -38,9 +38,14 @@ namespace osu.Game.Rulesets.Catch.UI
         public CatcherAnimationState CurrentState { get; private set; }
 
         /// <summary>
+        /// The width of the catcher which can receive fruit. Equivalent to "catchMargin" in osu-stable.
+        /// </summary>
+        private const float allowed_catch_range = 0.8f;
+
+        /// <summary>
         /// Width of the area that can be used to attempt catches during gameplay.
         /// </summary>
-        internal float CatchWidth => CatcherArea.CATCHER_SIZE * Math.Abs(Scale.X);
+        internal float CatchWidth => CatcherArea.CATCHER_SIZE * Math.Abs(Scale.X) * allowed_catch_range;
 
         protected bool Dashing
         {


### PR DESCRIPTION
Turns out we weren't correctly applying a sizeable "margin" adjustment present in stable. Tested using beatmap provided in https://github.com/ppy/osu/issues/8285 (and compared to be floating-point accurate against osu-stable for same circle size).

- Closes https://github.com/ppy/osu/issues/8285