### PR TITLE
Add support for falling back on skin configuration settings

### DIFF
--- a/osu.Game.Tests/Skins/SkinSettingFallbackTest.cs
+++ b/osu.Game.Tests/Skins/SkinSettingFallbackTest.cs
@@ -1,0 +1,139 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Skinning;
+
+namespace osu.Game.Tests.Skins
+{
+    [TestFixture]
+    public class SkinSettingFallbackTest
+    {
+        private readonly ISkin skin = new TestSkin();
+
+        /// <summary>
+        /// Tests behaviour of looking for value of a setting (<see cref="TestConfiguration.ValueFBSetting"/>) that has a fallback "default" value.
+        /// </summary>
+        [Test]
+        public void TestSettingWithDefaultValue()
+        {
+            var configSetting = skin.GetConfigOrDefault<TestConfiguration, string>(TestConfiguration.ValueFBSetting);
+
+            Assert.AreEqual("default value", configSetting.Value);
+        }
+
+        /// <summary>
+        /// Tests behaviour of looking for value of a setting (<see cref="TestConfiguration.SettingFBSetting"/>)
+        /// that falls back to another setting (<see cref="FallbackConfiguration.NormalSetting"/>).
+        /// </summary>
+        [Test]
+        public void TestSettingWithFallbackToAnotherSetting()
+        {
+            var configSetting = skin.GetConfigOrDefault<TestConfiguration, string>(TestConfiguration.SettingFBSetting);
+            var fallbackSetting = skin.GetConfigOrDefault<FallbackConfiguration, string>(FallbackConfiguration.NormalSetting);
+
+            Assert.AreEqual("value", configSetting.Value);
+            Assert.AreEqual(fallbackSetting.Value, configSetting.Value);
+        }
+
+        /// <summary>
+        /// Tests behaviour of looking for value of a setting (<see cref="TestConfiguration.ValueFBSettingFBSetting"/>)
+        /// that falls back to another setting (<see cref="FallbackConfiguration.SettingFBFallbackSetting"/>)
+        /// that has a fallback "default" value.
+        /// </summary>
+        [Test]
+        public void TestSettingWithFallbackToAnotherSettingWithDefaultValue()
+        {
+            var configSetting = skin.GetConfigOrDefault<TestConfiguration, string>(TestConfiguration.ValueFBSettingFBSetting);
+            var fallbackSetting = skin.GetConfigOrDefault<FallbackConfiguration, string>(FallbackConfiguration.ValueFBFallbackSetting);
+
+            Assert.AreEqual("default value from fallback setting", configSetting.Value);
+            Assert.AreEqual(fallbackSetting.Value, configSetting.Value);
+        }
+
+        /// <summary>
+        /// Tests behaviour of looking for value of a setting (<see cref="TestConfiguration.SettingFBSettingFBSetting"/>)
+        /// that falls back to another setting (<see cref="FallbackConfiguration.SettingFBFallbackSetting"/>.
+        /// </summary>
+        [Test]
+        public void TestSettingWithDoubleFallbackToAnotherSettings()
+        {
+            var configSetting = skin.GetConfigOrDefault<TestConfiguration, string>(TestConfiguration.SettingFBSettingFBSetting);
+            var fallbackSetting = skin.GetConfigOrDefault<FallbackConfiguration, string>(FallbackConfiguration.SettingFBFallbackSetting);
+            var fallbackSetting2 = skin.GetConfigOrDefault<FallbackConfiguration, string>(FallbackConfiguration.NormalSetting);
+
+            Assert.AreEqual("value", configSetting.Value);
+            Assert.AreEqual(fallbackSetting.Value, configSetting.Value);
+            Assert.AreEqual(fallbackSetting2.Value, configSetting.Value);
+        }
+
+        /// <summary>
+        /// Tests behaviour of looking for value of a setting (<see cref="TestConfiguration.ValueFBExistingSetting"/>)
+        /// that has a fallback "default" value but has an existing value assigned to it.
+        /// </summary>
+        [Test]
+        public void TestSettingWithDefaultValueButExisting()
+        {
+            var configSetting = skin.GetConfigOrDefault<TestConfiguration, string>(TestConfiguration.ValueFBExistingSetting);
+            Assert.AreEqual("existing value", configSetting.Value);
+        }
+
+        /// <summary>
+        /// Tests behaviour of looking for value of a setting (<see cref="TestConfiguration.SettingFBExistingSetting"/>)
+        /// that falls back to another setting (<see cref="FallbackConfiguration.NormalSetting"/>) but has an existing value assigned to it.
+        /// </summary>
+        [Test]
+        public void TestSettingWithFallbackToAnotherSettingButExisting()
+        {
+            var configSetting = skin.GetConfigOrDefault<TestConfiguration, string>(TestConfiguration.SettingFBExistingSetting);
+            var fallbackSetting = skin.GetConfigOrDefault<FallbackConfiguration, string>(FallbackConfiguration.NormalSetting);
+
+            Assert.AreEqual("existing value", configSetting.Value);
+            Assert.AreNotEqual(fallbackSetting.Value, configSetting.Value);
+        }
+
+        private class TestSkin : LegacySkin
+        {
+            public TestSkin()
+                : base(new SkinInfo(), null, null, string.Empty)
+            {
+                Configuration.ConfigDictionary[nameof(TestConfiguration.ValueFBExistingSetting)] = "existing value";
+                Configuration.ConfigDictionary[nameof(TestConfiguration.SettingFBExistingSetting)] = "existing value";
+
+                Configuration.ConfigDictionary[nameof(FallbackConfiguration.NormalSetting)] = "value";
+            }
+        }
+
+        private enum TestConfiguration
+        {
+            [SkinSettingFallback(SkinSettingFallbackType.Value, "default value")]
+            ValueFBSetting,
+
+            [SkinSettingFallback(SkinSettingFallbackType.Setting, FallbackConfiguration.NormalSetting)]
+            SettingFBSetting,
+
+            [SkinSettingFallback(SkinSettingFallbackType.Setting, FallbackConfiguration.ValueFBFallbackSetting)]
+            ValueFBSettingFBSetting,
+
+            [SkinSettingFallback(SkinSettingFallbackType.Setting, FallbackConfiguration.SettingFBFallbackSetting)]
+            SettingFBSettingFBSetting,
+
+            [SkinSettingFallback(SkinSettingFallbackType.Value, "default value")]
+            ValueFBExistingSetting,
+
+            [SkinSettingFallback(SkinSettingFallbackType.Setting, FallbackConfiguration.NormalSetting)]
+            SettingFBExistingSetting,
+        }
+
+        private enum FallbackConfiguration
+        {
+            NormalSetting,
+
+            [SkinSettingFallback(SkinSettingFallbackType.Value, "default value from fallback setting")]
+            ValueFBFallbackSetting,
+
+            [SkinSettingFallback(SkinSettingFallbackType.Setting, NormalSetting)]
+            SettingFBFallbackSetting,
+        }
+    }
+}

--- a/osu.Game/Skinning/SkinSettingFallbackAttribute.cs
+++ b/osu.Game/Skinning/SkinSettingFallbackAttribute.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Reflection;
+using JetBrains.Annotations;
+using osu.Framework.Bindables;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// An attribute to be assigned to skin configuration settings (enum values) to
+    /// provide a fallback value in case the requested setting does not have a value.
+    /// The fallback can be either a value to be returned or another setting to retrieve the value from.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class SkinSettingFallbackAttribute : Attribute
+    {
+        public SkinSettingFallbackType FallbackType { get; }
+
+        public object FallbackValue { get; }
+
+        public SkinSettingFallbackAttribute(SkinSettingFallbackType fallbackType, object fallbackValue)
+        {
+            FallbackType = fallbackType;
+            FallbackValue = fallbackValue;
+        }
+    }
+
+    public enum SkinSettingFallbackType
+    {
+        /// <summary>
+        /// The fallback is to a default value.
+        /// </summary>
+        Value,
+
+        /// <summary>
+        /// The fallback is to another configuration setting.
+        /// </summary>
+        Setting,
+    }
+
+    public static class SkinSettingFallbackExtensions
+    {
+        /// <summary>
+        /// Retrieve a configuration value, if unavailable a fallback value or
+        /// the default value of <typeparamref cref="TValue"/> will be returned.
+        /// </summary>
+        /// <param name="skin">The skin to retrieve the requested configuration value from.</param>
+        /// <param name="lookup">The requested configuration lookup value.</param>
+        /// <returns>A matching value, fallback value or default value of <typeparamref cref="TValue"/> boxed in an <see cref="IBindable{TValue}"/>.</returns>
+        [NotNull]
+        public static IBindable<TValue> GetConfigOrDefault<TLookup, TValue>(this ISkin skin, TLookup lookup)
+        {
+            var setting = skin.GetConfig<TLookup, TValue>(lookup);
+            if (setting != null)
+                return setting;
+
+            var attr = lookup.GetType().GetField(lookup.ToString()).GetCustomAttribute<SkinSettingFallbackAttribute>();
+
+            // The setting does not have a fallback value, return default value of TValue.
+            if (attr == null)
+                return new Bindable<TValue>();
+
+            switch (attr.FallbackType)
+            {
+                case SkinSettingFallbackType.Setting:
+                    // Setup the configuration value retrieval method (GetConfigOrDefault) to the lookup type of the fallback setting.
+                    var method = typeof(SkinSettingFallbackExtensions).GetMethod(nameof(GetConfigOrDefault));
+                    var executableMethod = method?.MakeGenericMethod(attr.FallbackValue.GetType(), typeof(TValue));
+                    var returnedValue = (IBindable<TValue>)executableMethod?.Invoke(null, new[] { skin, attr.FallbackValue });
+
+                    if (returnedValue == null)
+                        return new Bindable<TValue>();
+
+                    return new Bindable<TValue>(returnedValue.Value ?? default);
+
+                case SkinSettingFallbackType.Value:
+                    return SkinUtils.As<TValue>(Activator.CreateInstance(typeof(Bindable<>).MakeGenericType(attr.FallbackValue.GetType()), attr.FallbackValue));
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(lookup), $"{lookup} provides a fallback of unknown type.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a `SkinSettingFallback` attribute to assign to enum members for providing a fallback value in case the actual setting does not have a value assigned to it.

This will pretty much help retrieving a skin configuration setting without having to take care of what to do if the setting does not have a value **in every single retrieval**. with this new attribute, you can set the fallback value / fallback setting directly to the enum member:
## Current way:
```csharp
// in some file
var value = skin.GetConfig<Configuration, string>(Configuration.TestSetting)?.Value ??
            skin.GetConfig<Configuration, string>(Configuration.FallbackSetting)?.Value ??
            "fallback value";
...

// in another file
var value = skin.GetConfig<Configuration, string>(Configuration.TestSetting)?.Value ??
            skin.GetConfig<Configuration, string>(Configuration.FallbackSetting)?.Value ??
            "fallback value";
...

public enum Configuration
{
    TestSetting,
    FallbackSetting,
}
```
(existing case for osu!catch skin configuration value retrieval: `HyperDashFruit` -> `HyperDash` -> `#FF00000`)
## With the `SkinSettingFallback` attribute:
```csharp
// in some file
var value = skin.GetConfigOrDefault<Configuration, string>(Configuration.TestSetting).Value;
...

// in another file
var value = skin.GetConfigOrDefault<Configuration, string>(Configuration.TestSetting).Value;
...

public enum Configuration
{
    [SkinSettingFallback(SkinSettingFallbackType.Setting, FallbackSetting)]
    TestSetting,

    [SkinSettingFallback(SkinSettingFallbackType.Value, "fallback value")]
    FallbackSetting,
}
```

## Remarks
- Usage will come in a separate PR just to avoid complexity of reviewing in case it does.
- I was unsure of the name `GetConfigOrDefault` but didn't want to waste my time looking for better naming so raising it up for the reviewers and the team to decide.
- Hopefully the `TestConfiguration` & `FallbackConfiguration` enum member names in `SkinSettingFallbackTest` isn't that bad as i've tried to let it make sense but not make it stupidly long.