### PR TITLE
Fix GetDecoder getting fallback decoder too often

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -127,6 +127,31 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 .Assert();
         }
 
+        [Test]
+        public void TestGetJsonDecoder()
+        {
+            Decoder<Beatmap> decoder;
+
+            using (var stream = TestResources.OpenResource(normal))
+            using (var sr = new LineBufferedReader(stream))
+            {
+                var legacyDecoded = new LegacyBeatmapDecoder { ApplyOffsets = false }.Decode(sr);
+
+                using (var ms = new MemoryStream())
+                using (var sw = new StreamWriter(ms))
+                using (var sr2 = new LineBufferedReader(ms))
+                {
+                    sw.Write(legacyDecoded.Serialize());
+                    sw.Flush();
+
+                    ms.Position = 0;
+                    decoder = Decoder.GetDecoder<Beatmap>(sr2);
+                }
+            }
+
+            Assert.IsInstanceOf(typeof(JsonBeatmapDecoder), decoder);
+        }
+
         /// <summary>
         /// Reads a .osu file first with a <see cref="LegacyBeatmapDecoder"/>, serializes the resulting <see cref="Beatmap"/> to JSON
         /// and then deserializes the result back into a <see cref="Beatmap"/> through an <see cref="JsonBeatmapDecoder"/>.

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -137,15 +137,15 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var legacyDecoded = new LegacyBeatmapDecoder { ApplyOffsets = false }.Decode(sr);
 
-                using (var ms = new MemoryStream())
-                using (var sw = new StreamWriter(ms))
-                using (var sr2 = new LineBufferedReader(ms))
+                using (var memStream = new MemoryStream())
+                using (var memWriter = new StreamWriter(memStream))
+                using (var memReader = new LineBufferedReader(memStream))
                 {
-                    sw.Write(legacyDecoded.Serialize());
-                    sw.Flush();
+                    memWriter.Write(legacyDecoded.Serialize());
+                    memWriter.Flush();
 
-                    ms.Position = 0;
-                    decoder = Decoder.GetDecoder<Beatmap>(sr2);
+                    memStream.Position = 0;
+                    decoder = Decoder.GetDecoder<Beatmap>(memReader);
                 }
             }
 

--- a/osu.Game/Beatmaps/Formats/Decoder.cs
+++ b/osu.Game/Beatmaps/Formats/Decoder.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Beatmaps.Formats
             if (line == null)
                 throw new IOException("Unknown file format (null)");
 
-            var decoder = typedDecoders.Where(d => line.StartsWith(d.Key, StringComparison.InvariantCulture)).FirstOrDefault().Value;
+            var decoder = typedDecoders.Where(d => line.StartsWith(d.Key, StringComparison.InvariantCulture)).Select(d => d.Value).FirstOrDefault();
 
             // it's important the magic does NOT get consumed here, since sometimes it's part of the structure
             // (see JsonBeatmapDecoder - the magic string is the opening brace)

--- a/osu.Game/Beatmaps/Formats/Decoder.cs
+++ b/osu.Game/Beatmaps/Formats/Decoder.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Beatmaps.Formats
             if (line == null)
                 throw new IOException("Unknown file format (null)");
 
-            var decoder = typedDecoders.Select(d => line.StartsWith(d.Key, StringComparison.InvariantCulture) ? d.Value : null).FirstOrDefault();
+            var decoder = typedDecoders.Where(d => line.StartsWith(d.Key, StringComparison.InvariantCulture)).FirstOrDefault().Value;
 
             // it's important the magic does NOT get consumed here, since sometimes it's part of the structure
             // (see JsonBeatmapDecoder - the magic string is the opening brace)


### PR DESCRIPTION
Changes:
 * Fixed issue where `GetDecoder` would return the fallback decoder if the correct decoder wasn't first in the Dictionary.
 * Added test to make sure the JsonBeatmapDecoder is returned when calling GetDecoder<Beatmap> with a JSON beatmap file.