### PR TITLE
Make legacy skins use startAtCurrentTime by default

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
             if (tmp is IFramedAnimation tmpAnimation && tmpAnimation.FrameCount > 0)
                 frameLength = Math.Max(1000 / 60.0, 170.0 / tmpAnimation.FrameCount);
 
-            explosion = skin.GetAnimation(imageName, true, false, startAtCurrentTime: true, frameLength: frameLength).With(d =>
+            explosion = skin.GetAnimation(imageName, true, false, frameLength: frameLength).With(d =>
             {
                 if (d == null)
                     return;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
                     Anchor = Anchor.Centre,
                     Alpha = 0.5f,
                 }
-            }, confineMode: ConfineMode.NoScaling);
+            });
         }
 
         public double AnimationStartTime { get; set; }

--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
             switch (osuComponent.Component)
             {
                 case OsuSkinComponents.FollowPoint:
-                    return this.GetAnimation(component.LookupName, true, false, true);
+                    return this.GetAnimation(component.LookupName, true, false, true, startAtCurrentTime: false);
 
                 case OsuSkinComponents.SliderFollowCircle:
                     var followCircle = this.GetAnimation("sliderfollowcircle", true, true, true);

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Skinning
     public static class LegacySkinExtensions
     {
         public static Drawable GetAnimation(this ISkin source, string componentName, bool animatable, bool looping, bool applyConfigFrameRate = false, string animationSeparator = "-",
-                                            bool startAtCurrentTime = false, double? frameLength = null)
+                                            bool startAtCurrentTime = true, double? frameLength = null)
         {
             Texture texture;
 

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Skinning
                 if (timeReference != null)
                 {
                     Clock = timeReference.Clock;
-                    PlaybackPosition = timeReference.AnimationStartTime - timeReference.Clock.CurrentTime;
+                    PlaybackPosition = timeReference.Clock.CurrentTime - timeReference.AnimationStartTime;
                 }
             }
         }


### PR DESCRIPTION
Fixes #8604

Unsure why this wasn't enabled by default while every other implementation has it enabled (SkinnableTextureAnimation and its base TextureAnimation).