### PR TITLE
Fix results star rating display not being centered when no mods are present

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
                     AutoSizeAxes = Axes.Both,
-                    Position = new Vector2(0, 25),
+                    Position = new Vector2(-5, 25),
                     Current = { BindTarget = modSelect.SelectedMods }
                 }
             };

--- a/osu.Game/Screens/Multi/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/Multi/DrawableRoomPlaylistItem.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Screens.Multi
                                 {
                                     AutoSizeAxes = Axes.Both,
                                     Direction = FillDirection.Horizontal,
-                                    Spacing = new Vector2(10, 0),
+                                    Spacing = new Vector2(15, 0),
                                     Children = new Drawable[]
                                     {
                                         authorText = new LinkFlowContainer { AutoSizeAxes = Axes.Both },

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Play.HUD
             }
         }
 
-        protected readonly FillFlowContainer<ModIcon> IconsContainer;
+        private readonly FillFlowContainer<ModIcon> iconsContainer;
         private readonly OsuSpriteText unrankedText;
 
         public ModDisplay()
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Play.HUD
 
             Children = new Drawable[]
             {
-                IconsContainer = new ReverseChildIDFillFlowContainer<ModIcon>
+                iconsContainer = new ReverseChildIDFillFlowContainer<ModIcon>
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
@@ -68,11 +68,11 @@ namespace osu.Game.Screens.Play.HUD
 
             Current.ValueChanged += mods =>
             {
-                IconsContainer.Clear();
+                iconsContainer.Clear();
 
                 foreach (Mod mod in mods.NewValue)
                 {
-                    IconsContainer.Add(new ModIcon(mod) { Scale = new Vector2(0.6f) });
+                    iconsContainer.Add(new ModIcon(mod) { Scale = new Vector2(0.6f) });
                 }
 
                 if (IsLoaded)
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.Play.HUD
             base.LoadComplete();
 
             appearTransform();
-            IconsContainer.FadeInFromZero(fade_duration, Easing.OutQuint);
+            iconsContainer.FadeInFromZero(fade_duration, Easing.OutQuint);
         }
 
         private void appearTransform()
@@ -103,20 +103,20 @@ namespace osu.Game.Screens.Play.HUD
 
             expand();
 
-            using (IconsContainer.BeginDelayedSequence(1200))
+            using (iconsContainer.BeginDelayedSequence(1200))
                 contract();
         }
 
         private void expand()
         {
             if (ExpansionMode != ExpansionMode.AlwaysContracted)
-                IconsContainer.TransformSpacingTo(new Vector2(5, 0), 500, Easing.OutQuint);
+                iconsContainer.TransformSpacingTo(new Vector2(5, 0), 500, Easing.OutQuint);
         }
 
         private void contract()
         {
             if (ExpansionMode != ExpansionMode.AlwaysExpanded)
-                IconsContainer.TransformSpacingTo(new Vector2(-25, 0), 500, Easing.OutQuint);
+                iconsContainer.TransformSpacingTo(new Vector2(-25, 0), 500, Easing.OutQuint);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -56,7 +56,6 @@ namespace osu.Game.Screens.Play.HUD
                     Origin = Anchor.TopCentre,
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
-                    Margin = new MarginPadding { Left = 10, Right = 10 },
                 },
                 unrankedText = new OsuSpriteText
                 {

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -285,7 +285,7 @@ namespace osu.Game.Screens.Play
             Anchor = Anchor.TopRight,
             Origin = Anchor.TopRight,
             AutoSizeAxes = Axes.Both,
-            Margin = new MarginPadding { Top = 20, Right = 10 },
+            Margin = new MarginPadding { Top = 20, Right = 20 },
         };
 
         protected virtual HitErrorDisplay CreateHitErrorDisplayOverlay() => new HitErrorDisplay(scoreProcessor, drawableRuleset?.FirstAvailableHitWindows);

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Screens.Ranking.Expanded
         private readonly ScoreInfo score;
 
         private readonly List<StatisticDisplay> statisticDisplays = new List<StatisticDisplay>();
+
+        private FillFlowContainer starAndModDisplay;
+
         private RollingCounter<long> scoreCounter;
 
         /// <summary>
@@ -119,7 +122,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                 Alpha = 0,
                                 AlwaysPresent = true
                             },
-                            new FillFlowContainer
+                            starAndModDisplay = new FillFlowContainer
                             {
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
@@ -132,15 +135,6 @@ namespace osu.Game.Screens.Ranking.Expanded
                                         Anchor = Anchor.CentreLeft,
                                         Origin = Anchor.CentreLeft
                                     },
-                                    new ModDisplay
-                                    {
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        DisplayUnrankedText = false,
-                                        ExpansionMode = ExpansionMode.AlwaysExpanded,
-                                        Scale = new Vector2(0.5f),
-                                        Current = { Value = score.Mods }
-                                    }
                                 }
                             },
                             new FillFlowContainer
@@ -215,6 +209,19 @@ namespace osu.Game.Screens.Ranking.Expanded
                     }
                 }
             };
+
+            if (score.Mods.Any())
+            {
+                starAndModDisplay.Add(new ModDisplay
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    DisplayUnrankedText = false,
+                    ExpansionMode = ExpansionMode.AlwaysExpanded,
+                    Scale = new Vector2(0.5f),
+                    Current = { Value = score.Mods }
+                });
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -124,6 +124,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
                                 AutoSizeAxes = Axes.Both,
+                                Spacing = new Vector2(5, 0),
                                 Children = new Drawable[]
                                 {
                                     new StarRatingDisplay(beatmap)

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -27,18 +27,19 @@ namespace osu.Game.Screens.Select
         }
 
         protected readonly OsuSpriteText MultiplierText;
-        private readonly FooterModDisplay modDisplay;
+        private readonly ModDisplay modDisplay;
         private Color4 lowMultiplierColour;
         private Color4 highMultiplierColour;
 
         public FooterButtonMods()
         {
-            ButtonContentContainer.Add(modDisplay = new FooterModDisplay
+            ButtonContentContainer.Add(modDisplay = new ModDisplay
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 DisplayUnrankedText = false,
-                Scale = new Vector2(0.8f)
+                Scale = new Vector2(0.8f),
+                ExpansionMode = ExpansionMode.AlwaysContracted,
             });
             ButtonContentContainer.Add(MultiplierText = new OsuSpriteText
             {
@@ -83,16 +84,6 @@ namespace osu.Game.Screens.Select
                 modDisplay.FadeIn();
             else
                 modDisplay.FadeOut();
-        }
-
-        private class FooterModDisplay : ModDisplay
-        {
-            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parent?.Parent?.ReceivePositionalInputAt(screenSpacePos) ?? false;
-
-            public FooterModDisplay()
-            {
-                ExpansionMode = ExpansionMode.AlwaysContracted;
-            }
         }
     }
 }

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -92,7 +92,6 @@ namespace osu.Game.Screens.Select
             public FooterModDisplay()
             {
                 ExpansionMode = ExpansionMode.AlwaysContracted;
-                IconsContainer.Margin = new MarginPadding();
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/8599.

Actually this is also misaligned with mods (fix in first commit), but made title represent issue.

Test scene uses `Position` while hud overlay uses `Margin`, not sure what's correct in these top right "padding" cases.