### PR TITLE
Don't allow new transformations for reverse arrow after it's hit

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private double animDuration;
 
-        private readonly Drawable scaleContainer;
+        private readonly ReverseArrowPiece scaleContainer;
 
         public DrawableSliderRepeat(SliderRepeat sliderRepeat, DrawableSlider drawableSlider)
             : base(sliderRepeat)
@@ -79,6 +80,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 case ArmedState.Hit:
                     this.FadeOut(animDuration, Easing.Out)
                         .ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
+                    scaleContainer.ShouldFollowBeats = false;
+                    scaleContainer.Transforms.ForEach(t => scaleContainer.RemoveTransform(t));
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private double animDuration;
 
-        private readonly ReverseArrowPiece scaleContainer;
+        private readonly Drawable scaleContainer;
 
         public DrawableSliderRepeat(SliderRepeat sliderRepeat, DrawableSlider drawableSlider)
             : base(sliderRepeat)
@@ -80,7 +80,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 case ArmedState.Hit:
                     this.FadeOut(animDuration, Easing.Out)
                         .ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
-                    scaleContainer.ShouldFollowBeats = false;
                     scaleContainer.Transforms.ForEach(t => scaleContainer.RemoveTransform(t));
                     break;
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -80,7 +79,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 case ArmedState.Hit:
                     this.FadeOut(animDuration, Easing.Out)
                         .ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
-                    scaleContainer.Transforms.ForEach(t => scaleContainer.RemoveTransform(t));
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class ReverseArrowPiece : BeatSyncedContainer
     {
+        public bool ShouldFollowBeats = true;
+
         public ReverseArrowPiece()
         {
             Divisor = 2;
@@ -37,7 +39,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             };
         }
 
-        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes) =>
-            Child.ScaleTo(1.3f).ScaleTo(1f, timingPoint.BeatLength, Easing.Out);
+        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
+        {
+            if (ShouldFollowBeats)
+                Child.ScaleTo(1.3f).ScaleTo(1f, timingPoint.BeatLength, Easing.Out);
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
@@ -8,12 +8,15 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 using osu.Game.Skinning;
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class ReverseArrowPiece : BeatSyncedContainer
     {
-        public bool ShouldFollowBeats = true;
+        [Resolved]
+        private DrawableHitObject drawableSlider { get; set; }
 
         public ReverseArrowPiece()
         {
@@ -41,7 +44,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
         {
-            if (ShouldFollowBeats)
+            if (!drawableSlider.IsHit)
                 Child.ScaleTo(1.3f).ScaleTo(1f, timingPoint.BeatLength, Easing.Out);
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
     public class ReverseArrowPiece : BeatSyncedContainer
     {
         [Resolved]
-        private DrawableHitObject drawableSlider { get; set; }
+        private DrawableHitObject drawableRepeat { get; set; }
 
         public ReverseArrowPiece()
         {
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
         {
-            if (!drawableSlider.IsHit)
+            if (!drawableRepeat.IsHit)
                 Child.ScaleTo(1.3f).ScaleTo(1f, timingPoint.BeatLength, Easing.Out);
         }
     }


### PR DESCRIPTION
Fixes #8618

Before, reverse arrow would quickly scale up while drawable repeat was also scaling up. This looked weird when drawable repeat's scaling synced up with reverse arrow's scaling, almost like as if wrong easing was used (one that ramps up quickly like ``InExpo`` instead of ``Out``). 

This PR ~~removes pending transformations on the arrow when the repeat is hit and~~ doesn't allow new transformations for the arrow to be applied.