### PR TITLE
Add a simple constructor for BreakPeriod

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
@@ -26,16 +26,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private readonly IReadOnlyList<BreakPeriod> testBreaks = new List<BreakPeriod>
         {
-            new BreakPeriod
-            {
-                StartTime = 1000,
-                EndTime = 5000,
-            },
-            new BreakPeriod
-            {
-                StartTime = 6000,
-                EndTime = 13500,
-            },
+            new BreakPeriod(1000, 5000),
+            new BreakPeriod(6000, 13500),
         };
 
         public TestSceneBreakTracker()
@@ -70,7 +62,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestNoEffectsBreak()
         {
-            var shortBreak = new BreakPeriod { EndTime = 500 };
+            var shortBreak = new BreakPeriod(0, 500);
 
             setClock(true);
             loadBreaksStep("short break", new[] { shortBreak });
@@ -127,13 +119,12 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void addShowBreakStep(double seconds)
         {
-            AddStep($"show '{seconds}s' break", () => breakOverlay.Breaks = breakTracker.Breaks = new List<BreakPeriod>
+            AddStep($"show '{seconds}s' break", () =>
             {
-                new BreakPeriod
+                breakOverlay.Breaks = breakTracker.Breaks = new List<BreakPeriod>
                 {
-                    StartTime = Clock.CurrentTime,
-                    EndTime = Clock.CurrentTime + seconds * 1000,
-                }
+                    new BreakPeriod(Clock.CurrentTime, Clock.CurrentTime + seconds * 1000)
+                };
             });
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -305,12 +305,9 @@ namespace osu.Game.Beatmaps.Formats
 
                 case LegacyEventType.Break:
                     double start = getOffsetTime(Parsing.ParseDouble(split[1]));
+                    double end = Math.Max(start, getOffsetTime(Parsing.ParseDouble(split[2])));
 
-                    var breakEvent = new BreakPeriod
-                    {
-                        StartTime = start,
-                        EndTime = Math.Max(start, getOffsetTime(Parsing.ParseDouble(split[2])))
-                    };
+                    var breakEvent = new BreakPeriod(start, end);
 
                     if (!breakEvent.HasEffect)
                         return;

--- a/osu.Game/Beatmaps/Timing/BreakPeriod.cs
+++ b/osu.Game/Beatmaps/Timing/BreakPeriod.cs
@@ -33,6 +33,17 @@ namespace osu.Game.Beatmaps.Timing
         public bool HasEffect => Duration >= MIN_BREAK_DURATION;
 
         /// <summary>
+        /// Constructs a new break period.
+        /// </summary>
+        /// <param name="startTime">The start time of the break period.</param>
+        /// <param name="endTime">The end time of the break period.</param>
+        public BreakPeriod(double startTime, double endTime)
+        {
+            StartTime = startTime;
+            EndTime = endTime;
+        }
+
+        /// <summary>
         /// Whether this break contains a specified time.
         /// </summary>
         /// <param name="time">The time to check in milliseconds.</param>


### PR DESCRIPTION
For simple construction of a list of break periods (e.g. filling a method with an array of break periods inside a test case)