### PR TITLE
Fix legacy skins providing null version instead of 1.0

### DIFF
--- a/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Tests.Skins
             var decoder = new LegacySkinDecoder();
             using (var resStream = TestResources.OpenResource("skin-empty.ini"))
             using (var stream = new LineBufferedReader(resStream))
-                Assert.IsNull(decoder.Decode(stream).LegacyVersion);
+                Assert.AreEqual(1m, decoder.Decode(stream).LegacyVersion);
         }
     }
 }

--- a/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
@@ -143,7 +143,6 @@ namespace osu.Game.Tests.Skins
         public void TestLegacyVersionLookup()
         {
             AddStep("Set source1 version 2.3", () => source1.Configuration.LegacyVersion = 2.3m);
-            AddStep("Set source2 version null", () => source2.Configuration.LegacyVersion = null);
             AddAssert("Check legacy version lookup", () => requester.GetConfig<LegacySkinConfiguration.LegacySetting, decimal>(LegacySkinConfiguration.LegacySetting.Version)?.Value == 2.3m);
         }
 

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -122,10 +122,7 @@ namespace osu.Game.Skinning
                     switch (legacy)
                     {
                         case LegacySkinConfiguration.LegacySetting.Version:
-                            if (Configuration.LegacyVersion is decimal version)
-                                return SkinUtils.As<TValue>(new Bindable<decimal>(version));
-
-                            break;
+                            return SkinUtils.As<TValue>(new Bindable<decimal>(Configuration.LegacyVersion));
                     }
 
                     break;

--- a/osu.Game/Skinning/LegacySkinConfiguration.cs
+++ b/osu.Game/Skinning/LegacySkinConfiguration.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Skinning
         /// <summary>
         /// Legacy version of this skin.
         /// </summary>
-        public decimal? LegacyVersion { get; internal set; }
+        public decimal LegacyVersion { get; internal set; } = 1;
 
         public enum LegacySetting
         {


### PR DESCRIPTION
This isn't actually used anywhere except mania right now, but going forward I think we'll want to refer to skin versions via comparisons, rather than having an extra check for the `null` case.

Fixes one of the skins in https://github.com/ppy/osu/issues/8546