### PR TITLE
Fix tournament video sizing being incorrect

### DIFF
--- a/osu.Game.Tournament/Components/TourneyVideo.cs
+++ b/osu.Game.Tournament/Components/TourneyVideo.cs
@@ -36,7 +36,6 @@ namespace osu.Game.Tournament.Components
                 InternalChild = video = new Video(stream, false)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    FillMode = FillMode.Fit,
                     Clock = new FramedClock(manualClock = new ManualClock()),
                     Loop = loop,
                 };


### PR DESCRIPTION
Regressed with framework changes (FillMode behaves differently now).

Closes #8645.