### PR TITLE
Fix storyboard videos being offset incorrectly

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -46,7 +46,6 @@ namespace osu.Game.Storyboards.Drawables
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Alpha = 0,
-                PlaybackPosition = Video.StartTime
             };
         }
 
@@ -55,6 +54,8 @@ namespace osu.Game.Storyboards.Drawables
             base.LoadComplete();
 
             if (video == null) return;
+
+            video.PlaybackPosition = Clock.CurrentTime - Video.StartTime;
 
             using (video.BeginAbsoluteSequence(0))
                 video.FadeIn(500);


### PR DESCRIPTION
Setting the PlaybackPosition will ignore the underlying clock with recent changes. `startAtCurrentTime = false` alone (plus a `+= offset` in `DrawableStoryboardVideo.LoadComplete`) isn't enough as we would need to delay the `PlaybackPosition` call to after the video runs its `LoadComplete`. Instead, let's just set the complete correct offset.

- [x] Depends on https://github.com/ppy/osu-framework/pull/3432