### PR TITLE
Do not use beatmap hitsounds on timing points without custom sample bank

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -410,6 +410,10 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual("normal-hitnormal2", getTestableSampleInfo(hitObjects[2]).LookupNames.First());
                 Assert.AreEqual("normal-hitnormal", getTestableSampleInfo(hitObjects[3]).LookupNames.First());
 
+                Assert.IsTrue(getTestableSampleInfo(hitObjects[1]).IsCustom);
+                Assert.IsTrue(getTestableSampleInfo(hitObjects[2]).IsCustom);
+                Assert.IsFalse(getTestableSampleInfo(hitObjects[3]).IsCustom);
+
                 // The control point at the end time of the slider should be applied
                 Assert.AreEqual("soft-hitnormal8", getTestableSampleInfo(hitObjects[4]).LookupNames.First());
             }

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -38,6 +38,11 @@ namespace osu.Game.Audio
         public int Volume { get; set; }
 
         /// <summary>
+        /// Whether the sample is custom or if it uses osu!'s default hitsounds.
+        /// </summary>
+        public bool IsCustom;
+
+        /// <summary>
         /// Retrieve all possible filenames that can be used as a source, returned in order of preference (highest first).
         /// </summary>
         public virtual IEnumerable<string> LookupNames

--- a/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         public readonly Bindable<string> SampleBankBindable = new Bindable<string>(DEFAULT_BANK) { Default = DEFAULT_BANK };
 
         /// <summary>
-        /// The speed multiplier at this control point.
+        /// The default sample bank at this control point.
         /// </summary>
         public string SampleBank
         {
@@ -25,7 +25,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         }
 
         /// <summary>
-        /// The default sample bank at this control point.
+        /// The default sample volume at this control point.
         /// </summary>
         public readonly BindableInt SampleVolumeBindable = new BindableInt(100)
         {

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -170,6 +170,9 @@ namespace osu.Game.Beatmaps.Formats
 
                 if (string.IsNullOrEmpty(baseInfo.Suffix) && CustomSampleBank > 1)
                     baseInfo.Suffix = CustomSampleBank.ToString();
+                
+                // 0 means osu!'s default hitsounds
+                baseInfo.IsCustom = CustomSampleBank != 0;
 
                 return baseInfo;
             }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Beatmaps.Formats
 
                 if (string.IsNullOrEmpty(baseInfo.Suffix) && CustomSampleBank > 1)
                     baseInfo.Suffix = CustomSampleBank.ToString();
-                
+
                 // 0 means osu!'s default hitsounds
                 baseInfo.IsCustom = CustomSampleBank != 0;
 

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -262,17 +262,24 @@ namespace osu.Game.Skinning
 
         public override SampleChannel GetSample(ISampleInfo sampleInfo)
         {
-            foreach (var lookup in sampleInfo.LookupNames)
-            {
-                var sample = Samples?.Get(lookup);
+            var hsi = sampleInfo as HitSampleInfo;
 
-                if (sample != null)
-                    return sample;
+            if (hsi == null || hsi.IsCustom)
+            {
+                foreach (var lookup in sampleInfo.LookupNames)
+                {
+                    var sample = Samples?.Get(lookup);
+
+                    if (sample != null)
+                        return sample;
+                }
             }
 
-            if (sampleInfo is HitSampleInfo hsi)
+            if (hsi != null)
+            {
                 // Try fallback to non-bank samples.
                 return Samples?.Get(hsi.Name);
+            }
 
             return null;
         }

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Skinning
 
         public SkinnableSound(IEnumerable<HitSampleInfo> hitSamples)
         {
-            this.hitSamples = Enumerable.Select<HitSampleInfo, (ISampleInfo, bool)>(hitSamples, s => (s, s.IsCustom)).ToArray();
+            this.hitSamples = hitSamples.Select<HitSampleInfo, (ISampleInfo, bool)>(s => (s, s.IsCustom)).ToArray();
         }
 
         public SkinnableSound(IEnumerable<ISampleInfo> hitSamples)

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -15,8 +15,7 @@ namespace osu.Game.Skinning
 {
     public class SkinnableSound : SkinReloadableDrawable
     {
-        // The second element is false if osu!'s default sound should be used for this sample
-        private readonly (ISampleInfo, bool)[] hitSamples;
+        private readonly ISampleInfo[] hitSamples;
 
         private List<(AdjustableProperty property, BindableDouble bindable)> adjustments;
 
@@ -25,19 +24,14 @@ namespace osu.Game.Skinning
         [Resolved]
         private ISampleStore samples { get; set; }
 
-        public SkinnableSound(IEnumerable<HitSampleInfo> hitSamples)
-        {
-            this.hitSamples = hitSamples.Select<HitSampleInfo, (ISampleInfo, bool)>(s => (s, s.IsCustom)).ToArray();
-        }
-
         public SkinnableSound(IEnumerable<ISampleInfo> hitSamples)
         {
-            this.hitSamples = hitSamples.Select(s => (s, true)).ToArray();
+            this.hitSamples = hitSamples.ToArray();
         }
 
         public SkinnableSound(ISampleInfo hitSamples)
         {
-            this.hitSamples = new[] { (hitSamples, true) };
+            this.hitSamples = new[] { hitSamples };
         }
 
         private bool looping;
@@ -77,12 +71,9 @@ namespace osu.Game.Skinning
 
         protected override void SkinChanged(ISkinSource skin, bool allowFallback)
         {
-            channels = hitSamples.Select(sample =>
+            channels = hitSamples.Select(s =>
             {
-                var s = sample.Item1;
-                var isCustom = sample.Item2;
-
-                var ch = isCustom ? skin.GetSample(s) : null;
+                var ch = skin.GetSample(s);
 
                 if (ch == null && allowFallback)
                 {

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -32,12 +32,12 @@ namespace osu.Game.Skinning
 
         public SkinnableSound(IEnumerable<ISampleInfo> hitSamples)
         {
-            this.hitSamples = hitSamples.Select(s => (s, true)).ToArray(); ;
+            this.hitSamples = hitSamples.Select(s => (s, true)).ToArray();
         }
 
         public SkinnableSound(ISampleInfo hitSamples)
         {
-            this.hitSamples = new[] { (hitSamples, true) }; ;
+            this.hitSamples = new[] { (hitSamples, true) };
         }
 
         private bool looping;

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Skinning
     public class SkinnableSound : SkinReloadableDrawable
     {
         // The second element is false if osu!'s default sound should be used for this sample
-        private readonly (ISampleInfo, bool)[] hitSamples; 
+        private readonly (ISampleInfo, bool)[] hitSamples;
 
         private List<(AdjustableProperty property, BindableDouble bindable)> adjustments;
 
@@ -32,12 +32,12 @@ namespace osu.Game.Skinning
 
         public SkinnableSound(IEnumerable<ISampleInfo> hitSamples)
         {
-            this.hitSamples = hitSamples.Select(s => (s, true)).ToArray();;
+            this.hitSamples = hitSamples.Select(s => (s, true)).ToArray(); ;
         }
 
         public SkinnableSound(ISampleInfo hitSamples)
         {
-            this.hitSamples = new[] { (hitSamples, true) };;
+            this.hitSamples = new[] { (hitSamples, true) }; ;
         }
 
         private bool looping;
@@ -82,7 +82,7 @@ namespace osu.Game.Skinning
                 var s = sample.Item1;
                 var isCustom = sample.Item2;
 
-                var ch = isCustom? skin.GetSample(s) : null;
+                var ch = isCustom ? skin.GetSample(s) : null;
 
                 if (ch == null && allowFallback)
                 {


### PR DESCRIPTION
Resolves #8528

It seems the problem mentioned in this issue stems from the .osu file not being interpreted correctly. The author of this specific beatmap wanted the default hitsound to be played but the custom hitsound is played instead. That explains why we can only hear it through the left speaker. The sound files hitnormal-normal.wav and hitnormal-normal2.wav are both successfully played at certain points in the map where they are meant to be played.

This PR adds an attribute to HitSampleInfo in order to be aware when the sample to be played should be osu!'s default hitsound (as opposed to the beatmap's sound files).