### PR TITLE
Add per-ruleset skinnable test scenes to correct dynamic compilation cases

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchSkinnableTestScene.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Catch.Skinning;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public abstract class CatchSkinnableTestScene : SkinnableTestScene
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(CatchRuleset),
+            typeof(CatchLegacySkinTransformer),
+        };
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/CatchSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchSkinnableTestScene.cs
@@ -15,5 +15,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             typeof(CatchRuleset),
             typeof(CatchLegacySkinTransformer),
         };
+
+        protected override Ruleset CreateRulesetForSkinProvider() => new CatchRuleset();
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -4,21 +4,21 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Catch.UI;
-using osu.Game.Tests.Visual;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
     [TestFixture]
-    public class TestSceneCatcher : SkinnableTestScene
+    public class TestSceneCatcher : CatchSkinnableTestScene
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[]
+        public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[]
         {
             typeof(CatcherArea),
             typeof(CatcherSprite)
-        };
+        }).ToList();
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -17,12 +17,11 @@ using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
     [TestFixture]
-    public class TestSceneCatcherArea : SkinnableTestScene
+    public class TestSceneCatcherArea : CatchSkinnableTestScene
     {
         private RulesetInfo catchRuleset;
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -3,20 +3,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
-using osu.Game.Tests.Visual;
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
     [TestFixture]
-    public class TestSceneFruitObjects : SkinnableTestScene
+    public class TestSceneFruitObjects : CatchSkinnableTestScene
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[]
+        public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[]
         {
             typeof(CatchHitObject),
             typeof(Fruit),
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             typeof(DrawableBanana),
             typeof(DrawableBananaShower),
             typeof(Pulp),
-        };
+        }).ToList();
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/ManiaSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/ManiaSkinnableTestScene.cs
@@ -1,12 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Mania.Skinning;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Rulesets.UI.Scrolling.Algorithms;
 using osu.Game.Tests.Visual;
@@ -23,6 +26,12 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
 
         [Cached(Type = typeof(IScrollingInfo))]
         private readonly TestScrollingInfo scrollingInfo = new TestScrollingInfo();
+
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(ManiaRuleset),
+            typeof(ManiaLegacySkinTransformer),
+        };
 
         protected ManiaSkinnableTestScene()
         {

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/ManiaSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/ManiaSkinnableTestScene.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
             typeof(ManiaLegacySkinTransformer),
         };
 
+        protected override Ruleset CreateRulesetForSkinProvider() => new ManiaRuleset();
+
         protected ManiaSkinnableTestScene()
         {
             scrollingInfo.Direction.Value = ScrollingDirection.Down;

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
@@ -10,11 +10,10 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests.Skinning
 {
-    public class TestSceneDrawableJudgement : SkinnableTestScene
+    public class TestSceneDrawableJudgement : ManiaSkinnableTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Game.Rulesets.Osu.Tests/OsuSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuSkinnableTestScene.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Osu.Skinning;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public abstract class OsuSkinnableTestScene : SkinnableTestScene
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(OsuRuleset),
+            typeof(OsuLegacySkinTransformer),
+        };
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/OsuSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuSkinnableTestScene.cs
@@ -15,5 +15,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             typeof(OsuRuleset),
             typeof(OsuLegacySkinTransformer),
         };
+
+        protected override Ruleset CreateRulesetForSkinProvider() => new OsuRuleset();
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -10,17 +10,16 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
-    public class TestSceneDrawableJudgement : SkinnableTestScene
+    public class TestSceneDrawableJudgement : OsuSkinnableTestScene
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[]
+        public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[]
         {
             typeof(DrawableJudgement),
             typeof(DrawableOsuJudgement)
-        };
+        }).ToList();
 
         public TestSceneDrawableJudgement()
         {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -3,26 +3,32 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing.Input;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.UI.Cursor;
+using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
-using osu.Game.Tests.Visual;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
     [TestFixture]
-    public class TestSceneGameplayCursor : SkinnableTestScene
+    public class TestSceneGameplayCursor : OsuSkinnableTestScene
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[]
+        public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[]
         {
+            typeof(GameplayCursorContainer),
             typeof(OsuCursorContainer),
+            typeof(OsuCursor),
+            typeof(LegacyCursor),
+            typeof(LegacyCursorTrail),
             typeof(CursorTrail)
-        };
+        }).ToList();
 
         [Cached]
         private GameplayBeatmap gameplayBeatmap;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -14,12 +14,11 @@ using osu.Game.Rulesets.Mods;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
     [TestFixture]
-    public class TestSceneHitCircle : SkinnableTestScene
+    public class TestSceneHitCircle : OsuSkinnableTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -22,12 +22,11 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
     [TestFixture]
-    public class TestSceneSlider : SkinnableTestScene
+    public class TestSceneSlider : OsuSkinnableTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoSkinnableTestScene.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Taiko.Skinning;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public abstract class TaikoSkinnableTestScene : SkinnableTestScene
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(TaikoRuleset),
+            typeof(TaikoLegacySkinTransformer),
+        };
+
+        protected override Ruleset CreateRulesetForSkinProvider() => new TaikoRuleset();
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneInputDrum.cs
@@ -3,24 +3,26 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osuTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Taiko.Skinning;
 using osu.Game.Rulesets.Taiko.UI;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {
     [TestFixture]
-    public class TestSceneInputDrum : SkinnableTestScene
+    public class TestSceneInputDrum : TaikoSkinnableTestScene
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[]
+        public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[]
         {
             typeof(InputDrum),
-        };
+            typeof(LegacyInputDrum),
+        }).ToList();
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -33,6 +34,9 @@ namespace osu.Game.Tests.Visual
             : base(2, 3)
         {
         }
+
+        // Required to be part of the per-ruleset implementation to construct the newer version of the Ruleset.
+        protected abstract Ruleset CreateRulesetForSkinProvider();
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, SkinManager skinManager)
@@ -106,7 +110,7 @@ namespace osu.Game.Tests.Visual
                         {
                             new OutlineBox { Alpha = autoSize ? 1 : 0 },
                             mainProvider.WithChild(
-                                new SkinProvidingContainer(Ruleset.Value.CreateInstance().CreateLegacySkinProvider(mainProvider, beatmap))
+                                new SkinProvidingContainer(CreateRulesetForSkinProvider().CreateLegacySkinProvider(mainProvider, beatmap))
                                 {
                                     Child = created,
                                     RelativeSizeAxes = !autoSize ? Axes.Both : Axes.None,


### PR DESCRIPTION
Tested each and every test scene to work as expected. `TestSceneSliders` doesn't work but that needs some more intensive fixes.

- [x] Depends on https://github.com/ppy/osu-framework/pull/3434