### PR TITLE
Fix legacy skin texture fallback logic

### DIFF
--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Skinning;
+
+namespace osu.Game.Tests.NonVisual.Skinning
+{
+    [TestFixture]
+    public sealed class LegacySkinTextureFallbackTest
+    {
+        private static object[][] fallbackTestCases =
+        {
+            new object[]
+            {
+                // textures in store
+                new[] { "Gameplay/osu/followpoint@2x", "Gameplay/osu/followpoint" },
+                // requested component
+                "Gameplay/osu/followpoint",
+                // returned texture name & scale
+                "Gameplay/osu/followpoint@2x", 2
+            },
+            new object[]
+            {
+                new[] { "Gameplay/osu/followpoint@2x" },
+                "Gameplay/osu/followpoint",
+                "Gameplay/osu/followpoint@2x", 2
+            },
+            new object[]
+            {
+                new[] { "Gameplay/osu/followpoint" },
+                "Gameplay/osu/followpoint",
+                "Gameplay/osu/followpoint", 1
+            },
+            new object[]
+            {
+                new[] { "Gameplay/osu/followpoint", "followpoint@2x" },
+                "Gameplay/osu/followpoint",
+                "Gameplay/osu/followpoint", 1
+            },
+            new object[]
+            {
+                new[] { "followpoint@2x", "followpoint" },
+                "Gameplay/osu/followpoint",
+                "followpoint@2x", 2
+            },
+            new object[]
+            {
+                new[] { "followpoint@2x" },
+                "Gameplay/osu/followpoint",
+                "followpoint@2x", 2
+            },
+            new object[]
+            {
+                new[] { "followpoint" },
+                "Gameplay/osu/followpoint",
+                "followpoint", 1
+            },
+        };
+
+        [TestCaseSource(nameof(fallbackTestCases))]
+        public void TestFallbackOrder(string[] filesInStore, string requestedComponent, string expectedTexture, float expectedScale)
+        {
+            var textureStore = new TestTextureStore(filesInStore);
+            var legacySkin = new TestLegacySkin(textureStore);
+
+            var texture = legacySkin.GetTexture(requestedComponent);
+
+            Assert.IsNotNull(texture);
+            Assert.AreEqual(textureStore.Textures[expectedTexture], texture);
+            Assert.AreEqual(expectedScale, texture.ScaleAdjust);
+        }
+
+        [Test]
+        public void TestReturnNullOnFallbackFailure()
+        {
+            var textureStore = new TestTextureStore("sliderb", "hit100");
+            var legacySkin = new TestLegacySkin(textureStore);
+
+            var texture = legacySkin.GetTexture("Gameplay/osu/followpoint");
+
+            Assert.IsNull(texture);
+        }
+
+        private class TestLegacySkin : LegacySkin
+        {
+            public TestLegacySkin(TextureStore textureStore)
+                : base(new SkinInfo(), null, null, string.Empty)
+            {
+                Textures = textureStore;
+            }
+        }
+
+        private class TestTextureStore : TextureStore
+        {
+            public readonly Dictionary<string, Texture> Textures;
+
+            public TestTextureStore(params string[] fileNames)
+            {
+                Textures = fileNames.ToDictionary(fileName => fileName, fileName => new Texture(1, 1));
+            }
+
+            public override Texture Get(string name) => Textures.GetValueOrDefault(name);
+        }
+    }
+}

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -293,9 +293,10 @@ namespace osu.Game.Skinning
                     texture = Textures?.Get(name);
                 }
 
-                if (texture != null)
-                    texture.ScaleAdjust = ratio;
+                if (texture == null)
+                    continue;
 
+                texture.ScaleAdjust = ratio;
                 return texture;
             }
 


### PR DESCRIPTION
Resolves #8665.

# Summary

The recently-modified (in eff17c2) skin texture fallback logic was very subtly incorrect. If at the end of the first loop no texture was found, it would be checked for null to avoid setting scale adjust on a null texture, but then returned anyway, bypassing the fallback logic for subsequent possible paths entirely.

Invert the check and explicitly continue to the next fallback path if neither a 2x, nor 1x texture with the given name is found in the store.

# Remarks

Missed the bug during review... The fallback logic now has somewhat comprehensive test cases so hopefully should be rigorously checked with any subsequent changes.