### PR TITLE
Fix Exit Confirmation "Goodbye" Spelling

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -294,7 +294,7 @@ namespace osu.Game.Screens.Menu
                 {
                     new PopupDialogOkButton
                     {
-                        Text = @"Good bye",
+                        Text = @"Goodbye",
                         Action = confirm
                     },
                     new PopupDialogCancelButton


### PR DESCRIPTION
Closes #8666 

Changes the spelling of "Good bye" to "Goodbye".