### PR TITLE
Increase size of default osu!mania skin's keys to allow clearance with HUD

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneStage.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneStage.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
 
                 return new ManiaInputManager(new ManiaRuleset().RulesetInfo, 4)
                 {
-                    Child = new ManiaStage(0, new StageDefinition { Columns = 4 }, ref normalAction, ref specialAction)
+                    Child = new Stage(0, new StageDefinition { Columns = 4 }, ref normalAction, ref specialAction)
                 };
             });
         }

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [Cached(typeof(IReadOnlyList<Mod>))]
         private IReadOnlyList<Mod> mods { get; set; } = Array.Empty<Mod>();
 
-        private readonly List<ManiaStage> stages = new List<ManiaStage>();
+        private readonly List<Stage> stages = new List<Stage>();
 
         private FillFlowContainer<ScrollingTestContainer> fill;
 
@@ -81,9 +81,9 @@ namespace osu.Game.Rulesets.Mania.Tests
             AddAssert("check bar anchors", () => barsInStageAreAnchored(stages[1], Anchor.TopCentre));
         }
 
-        private bool notesInStageAreAnchored(ManiaStage stage, Anchor anchor) => stage.Columns.SelectMany(c => c.AllHitObjects).All(o => o.Anchor == anchor);
+        private bool notesInStageAreAnchored(Stage stage, Anchor anchor) => stage.Columns.SelectMany(c => c.AllHitObjects).All(o => o.Anchor == anchor);
 
-        private bool barsInStageAreAnchored(ManiaStage stage, Anchor anchor) => stage.AllHitObjects.Where(obj => obj is DrawableBarLine).All(o => o.Anchor == anchor);
+        private bool barsInStageAreAnchored(Stage stage, Anchor anchor) => stage.AllHitObjects.Where(obj => obj is DrawableBarLine).All(o => o.Anchor == anchor);
 
         private void createNote()
         {
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         {
             var specialAction = ManiaAction.Special1;
 
-            var stage = new ManiaStage(0, new StageDefinition { Columns = 2 }, ref action, ref specialAction);
+            var stage = new Stage(0, new StageDefinition { Columns = 2 }, ref action, ref specialAction);
             stages.Add(stage);
 
             return new ScrollingTestContainer(direction)

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -138,6 +138,6 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
             // This probably shouldn't exist as is, but the columns in the stage are separated by a 1px border
-            => DrawRectangle.Inflate(new Vector2(ManiaStage.COLUMN_SPACING / 2, 0)).Contains(ToLocalSpace(screenSpacePos));
+            => DrawRectangle.Inflate(new Vector2(Stage.COLUMN_SPACING / 2, 0)).Contains(ToLocalSpace(screenSpacePos));
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/Components/DefaultKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/UI/Components/DefaultKeyArea.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Mania.UI.Components
             InternalChild = directionContainer = new Container
             {
                 RelativeSizeAxes = Axes.X,
-                Height = ManiaStage.HIT_TARGET_POSITION,
+                Height = Stage.HIT_TARGET_POSITION,
                 Children = new[]
                 {
                     gradient = new Box

--- a/osu.Game.Rulesets.Mania/UI/Components/DefaultKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/UI/Components/DefaultKeyArea.cs
@@ -53,9 +53,8 @@ namespace osu.Game.Rulesets.Mania.UI.Components
                     keyIcon = new Container
                     {
                         Name = "Key icon",
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
                         Size = new Vector2(key_icon_size),
+                        Origin = Anchor.Centre,
                         Masking = true,
                         CornerRadius = key_icon_corner_radius,
                         BorderThickness = 2,
@@ -88,11 +87,15 @@ namespace osu.Game.Rulesets.Mania.UI.Components
         {
             if (direction.NewValue == ScrollingDirection.Up)
             {
+                keyIcon.Anchor = Anchor.BottomCentre;
+                keyIcon.Y = -20;
                 directionContainer.Anchor = directionContainer.Origin = Anchor.TopLeft;
                 gradient.Colour = ColourInfo.GradientVertical(Color4.Black, Color4.Black.Opacity(0));
             }
             else
             {
+                keyIcon.Anchor = Anchor.TopCentre;
+                keyIcon.Y = 20;
                 directionContainer.Anchor = directionContainer.Origin = Anchor.BottomLeft;
                 gradient.Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0), Color4.Black);
             }

--- a/osu.Game.Rulesets.Mania/UI/Components/HitObjectArea.cs
+++ b/osu.Game.Rulesets.Mania/UI/Components/HitObjectArea.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Mania.UI.Components
         {
             float hitPosition = CurrentSkin.GetConfig<ManiaSkinConfigurationLookup, float>(
                                     new ManiaSkinConfigurationLookup(LegacyManiaSkinConfigurationLookups.HitPosition))?.Value
-                                ?? ManiaStage.HIT_TARGET_POSITION;
+                                ?? Stage.HIT_TARGET_POSITION;
 
             Padding = Direction.Value == ScrollingDirection.Up
                 ? new MarginPadding { Top = hitPosition }

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Mania.UI
 {
     public class ManiaPlayfield : ScrollingPlayfield
     {
-        private readonly List<ManiaStage> stages = new List<ManiaStage>();
+        private readonly List<Stage> stages = new List<Stage>();
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => stages.Any(s => s.ReceivePositionalInputAt(screenSpacePos));
 
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             for (int i = 0; i < stageDefinitions.Count; i++)
             {
-                var newStage = new ManiaStage(firstColumnIndex, stageDefinitions[i], ref normalColumnAction, ref specialColumnAction);
+                var newStage = new Stage(firstColumnIndex, stageDefinitions[i], ref normalColumnAction, ref specialColumnAction);
 
                 playfieldGrid.Content[0][i] = newStage;
 
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Mania.UI
         /// </summary>
         public int TotalColumns => stages.Sum(s => s.Columns.Count);
 
-        private ManiaStage getStageByColumn(int column)
+        private Stage getStageByColumn(int column)
         {
             int sum = 0;
 

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mania.UI
     /// <summary>
     /// A collection of <see cref="Column"/>s.
     /// </summary>
-    public class ManiaStage : ScrollingPlayfield
+    public class Stage : ScrollingPlayfield
     {
         public const float COLUMN_SPACING = 1;
 
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private readonly int firstColumnIndex;
 
-        public ManiaStage(int firstColumnIndex, StageDefinition definition, ref ManiaAction normalColumnStartAction, ref ManiaAction specialColumnStartAction)
+        public Stage(int firstColumnIndex, StageDefinition definition, ref ManiaAction normalColumnStartAction, ref ManiaAction specialColumnStartAction)
         {
             this.firstColumnIndex = firstColumnIndex;
 

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.UI
     {
         public const float COLUMN_SPACING = 1;
 
-        public const float HIT_TARGET_POSITION = 50;
+        public const float HIT_TARGET_POSITION = 110;
 
         public IReadOnlyList<Column> Columns => columnFlow.Children;
         private readonly FillFlowContainer<Column> columnFlow;


### PR DESCRIPTION
Fixes issue pointed out [here](https://github.com/ppy/osu/commit/7ba533b7a4a47cf7b2d61b4453b1cd329e7fef51#commitcomment-38277877). Eventually the HUD will likely be moved to avoid such conflicts, but for now this should do the trick.

before:

![](https://user-images.githubusercontent.com/3353318/78419095-ae56e380-7607-11ea-969a-ee3a19e567a3.png)

after:

![image](https://user-images.githubusercontent.com/191335/78746767-aea60480-79a2-11ea-8394-98b2ef330427.png)

![image](https://user-images.githubusercontent.com/191335/78746774-b5cd1280-79a2-11ea-9b62-88a7d2be3f57.png)
