### PR TITLE
Fix slider ball and follow circle blending for legacy skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -31,7 +31,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 
-            Blending = BlendingParameters.Additive;
             Origin = Anchor.Centre;
 
             InternalChild = scaleContainer = new ReverseArrowPiece();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ReverseArrowPiece.cs
@@ -21,13 +21,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            Blending = BlendingParameters.Additive;
-
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 
             Child = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.ReverseArrow), _ => new SpriteIcon
             {
                 RelativeSizeAxes = Axes.Both,
+                Blending = BlendingParameters.Additive,
                 Icon = FontAwesome.Solid.ChevronRight,
                 Size = new Vector2(0.35f)
             })

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -40,7 +40,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             this.drawableSlider = drawableSlider;
             this.slider = slider;
 
-            Blending = BlendingParameters.Additive;
             Origin = Anchor.Centre;
 
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
@@ -241,6 +240,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                     Scale = new Vector2(radius / OsuHitObject.OBJECT_RADIUS),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Blending = BlendingParameters.Additive,
                     BorderThickness = 10,
                     BorderColour = Color4.White,
                     Alpha = 1,


### PR DESCRIPTION
This regressed with the blending *fix* framework side (has been wrongly applied all along but only started to actually show due to the fix).