### PR TITLE
Fix crash when trying to edit long beatmaps

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -60,8 +60,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 waveform.Waveform = b.NewValue.Waveform;
                 track = b.NewValue.Track;
 
-                MinZoom = getZoomLevelForVisibleMilliseconds(10000);
                 MaxZoom = getZoomLevelForVisibleMilliseconds(500);
+                MinZoom = getZoomLevelForVisibleMilliseconds(10000);
                 Zoom = getZoomLevelForVisibleMilliseconds(2000);
             }, true);
         }


### PR DESCRIPTION
Would crash when loading https://osu.ppy.sh/beatmapsets/29157#osu/156352 because `MinZoom` would be greater than `MaxZoom`, and this would crash since the setting of `MinZoom` updates `Zoom`.

This'll probably have to be reworked at some point in the future anyway since the timeline zoom is unusable on this map.