### PR TITLE
Fix beatmap background not displaying when video is present

### DIFF
--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -47,9 +47,6 @@ namespace osu.Game.Storyboards
                 if (backgroundPath == null)
                     return false;
 
-                if (GetLayer("Video").Elements.Any())
-                    return true;
-
                 return GetLayer("Background").Elements.Any(e => e.Path.ToLowerInvariant() == backgroundPath);
             }
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/8688. Was implemented in https://github.com/ppy/osu/pull/8167 but this is a regression to some extent.

A correct solution requires quite a bit of refactoring if we are to match osu-stable behaviour, since the background is dynamically hidden when the video starts, then brought back when it ends. Currently handling is in `Storyboard` and only applied once on entering. This would need to be moved to `DrawableStoryboard` and applied constantly.

Note that with this change, the background will *always* be displayed behind the video. I am also willing to change this to only have it display if the video is not present, if that is deemed a better interim solution.