### PR TITLE
Mark dummy api test scene as headless

### DIFF
--- a/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
+++ b/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -11,6 +12,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Tests.Online
 {
+    [HeadlessTest]
     public class TestDummyAPIRequestHandling : OsuTestScene
     {
         [Test]


### PR DESCRIPTION
Causes incorrect grouping in the test browser.