### PR TITLE
Add automatic pagination to BeatmapListingOverlay

### DIFF
--- a/osu.Game/Online/API/Requests/ResponseWithCursor.cs
+++ b/osu.Game/Online/API/Requests/ResponseWithCursor.cs
@@ -11,6 +11,15 @@ namespace osu.Game.Online.API.Requests
         /// A collection of parameters which should be passed to the search endpoint to fetch the next page.
         /// </summary>
         [JsonProperty("cursor")]
-        public object CursorJson;
+        public dynamic Cursor;
+    }
+
+    public abstract class ResponseWithCursor<T> : ResponseWithCursor where T : class
+    {
+        /// <summary>
+        /// A collection of parameters which should be passed to the search endpoint to fetch the next page.
+        /// </summary>
+        [JsonProperty("cursor")]
+        public new T Cursor;
     }
 }

--- a/osu.Game/Online/API/Requests/ResponseWithCursor.cs
+++ b/osu.Game/Online/API/Requests/ResponseWithCursor.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Online.API.Requests
         /// A collection of parameters which should be passed to the search endpoint to fetch the next page.
         /// </summary>
         [JsonProperty("cursor")]
-        public dynamic CursorJson;
+        public object CursorJson;
     }
 }

--- a/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
+++ b/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using Newtonsoft.Json;
 using osu.Framework.IO.Network;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Direct;
@@ -11,15 +12,24 @@ namespace osu.Game.Online.API.Requests
 {
     public class SearchBeatmapSetsRequest : APIRequest<SearchBeatmapSetsResponse>
     {
+        public class Cursor
+        {
+            [JsonProperty("_id")]
+            public string Id;
+
+            [JsonProperty("approved_date")]
+            public string ApprovedDate;
+        }
+
         private readonly string query;
         private readonly RulesetInfo ruleset;
-        private readonly object cursor;
+        private readonly Cursor cursor;
         private readonly BeatmapSearchCategory searchCategory;
         private readonly DirectSortCriteria sortCriteria;
         private readonly SortDirection direction;
         private string directionString => direction == SortDirection.Descending ? @"desc" : @"asc";
 
-        public SearchBeatmapSetsRequest(string query, RulesetInfo ruleset, object cursor = null, BeatmapSearchCategory searchCategory = BeatmapSearchCategory.Any, DirectSortCriteria sortCriteria = DirectSortCriteria.Ranked, SortDirection direction = SortDirection.Descending)
+        public SearchBeatmapSetsRequest(string query, RulesetInfo ruleset, Cursor cursor = null, BeatmapSearchCategory searchCategory = BeatmapSearchCategory.Any, DirectSortCriteria sortCriteria = DirectSortCriteria.Ranked, SortDirection direction = SortDirection.Descending)
         {
             this.query = string.IsNullOrEmpty(query) ? string.Empty : System.Uri.EscapeDataString(query);
             this.ruleset = ruleset;
@@ -38,7 +48,10 @@ namespace osu.Game.Online.API.Requests
                 req.AddParameter("m", ruleset.ID.Value.ToString());
 
             if (cursor != null)
-                req.AddParameter("cursor", cursor.ToString());
+            {
+                req.AddParameter("cursor[_id]", cursor.Id);
+                req.AddParameter("cursor[approved_date]", cursor.ApprovedDate);
+            }
 
             req.AddParameter("s", searchCategory.ToString().ToLowerInvariant());
             req.AddParameter("sort", $"{sortCriteria.ToString().ToLowerInvariant()}_{directionString}");

--- a/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
+++ b/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
@@ -13,15 +13,17 @@ namespace osu.Game.Online.API.Requests
     {
         private readonly string query;
         private readonly RulesetInfo ruleset;
+        private readonly object cursor;
         private readonly BeatmapSearchCategory searchCategory;
         private readonly DirectSortCriteria sortCriteria;
         private readonly SortDirection direction;
         private string directionString => direction == SortDirection.Descending ? @"desc" : @"asc";
 
-        public SearchBeatmapSetsRequest(string query, RulesetInfo ruleset, BeatmapSearchCategory searchCategory = BeatmapSearchCategory.Any, DirectSortCriteria sortCriteria = DirectSortCriteria.Ranked, SortDirection direction = SortDirection.Descending)
+        public SearchBeatmapSetsRequest(string query, RulesetInfo ruleset, object cursor = null, BeatmapSearchCategory searchCategory = BeatmapSearchCategory.Any, DirectSortCriteria sortCriteria = DirectSortCriteria.Ranked, SortDirection direction = SortDirection.Descending)
         {
             this.query = string.IsNullOrEmpty(query) ? string.Empty : System.Uri.EscapeDataString(query);
             this.ruleset = ruleset;
+            this.cursor = cursor;
             this.searchCategory = searchCategory;
             this.sortCriteria = sortCriteria;
             this.direction = direction;
@@ -34,6 +36,9 @@ namespace osu.Game.Online.API.Requests
 
             if (ruleset.ID.HasValue)
                 req.AddParameter("m", ruleset.ID.Value.ToString());
+
+            if (cursor != null)
+                req.AddParameter("cursor", cursor.ToString());
 
             req.AddParameter("s", searchCategory.ToString().ToLowerInvariant());
             req.AddParameter("sort", $"{sortCriteria.ToString().ToLowerInvariant()}_{directionString}");

--- a/osu.Game/Online/API/Requests/SearchBeatmapSetsResponse.cs
+++ b/osu.Game/Online/API/Requests/SearchBeatmapSetsResponse.cs
@@ -7,7 +7,7 @@ using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Online.API.Requests
 {
-    public class SearchBeatmapSetsResponse : ResponseWithCursor
+    public class SearchBeatmapSetsResponse : ResponseWithCursor<SearchBeatmapSetsRequest.Cursor>
     {
         [JsonProperty("beatmapsets")]
         public IEnumerable<APIBeatmapSet> BeatmapSets;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingResultsDisplay.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingResultsDisplay.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingResultsDisplay.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingResultsDisplay.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays.Direct;
+using osuTK;
+
+namespace osu.Game.Overlays.BeatmapListing
+{
+    public class BeatmapListingResultsDisplay : Container
+    {
+        private NotFoundDrawable noResultsDrawable;
+        private FillFlowContainer<DirectPanel> resultPanels;
+
+        public BeatmapListingResultsDisplay()
+        {
+            AutoSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            noResultsDrawable = new NotFoundDrawable();
+            resultPanels = new FillFlowContainer<DirectPanel>()
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(10),
+                Alpha = 0,
+                Margin = new MarginPadding { Vertical = 15 }
+            };
+        }
+
+        public void ReplaceBeatmaps(List<BeatmapSetInfo> beatmaps)
+        {
+            clearBeatmapPanels();
+
+            if (beatmaps.Count > 0)
+            {
+                if (noResultsDrawable.IsAlive)
+                    noResultsDrawable.FadeOut(100, Easing.OutQuint).Then().Schedule(() => RemoveInternal(noResultsDrawable));
+
+                if (!resultPanels.IsAlive)
+                    AddInternal(resultPanels);
+
+                resultPanels.Show();
+
+                AddBeatmaps(beatmaps);
+            }
+            else
+            {
+                if (resultPanels.IsAlive)
+                    resultPanels.FadeOut(100, Easing.OutQuint).Then().Schedule(() => RemoveInternal(resultPanels));
+
+                if (!noResultsDrawable.IsAlive)
+                    AddInternal(noResultsDrawable);
+
+                noResultsDrawable.FadeIn(200, Easing.OutQuint);
+            }
+        }
+
+        public void AddBeatmaps(List<BeatmapSetInfo> beatmaps)
+        {
+            beatmaps.ForEach(addBeatmapPanel);
+        }
+
+        private void clearBeatmapPanels()
+        {
+            resultPanels.Children.ForEach(removeBeatmapPanel);
+        }
+
+        private void addBeatmapPanel(BeatmapSetInfo beatmap)
+        {
+            LoadComponentAsync(new DirectGridPanel(beatmap)
+            {
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+            }, loaded =>
+            {
+                resultPanels.Add(loaded);
+                loaded.FadeIn(200, Easing.OutQuint);
+            });
+        }
+
+        private void removeBeatmapPanel(DirectPanel panel)
+        {
+            panel.FadeOut(100, Easing.OutQuint).Expire();
+        }
+
+        private class NotFoundDrawable : CompositeDrawable
+        {
+            public NotFoundDrawable()
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = 250;
+                Alpha = 0;
+                Margin = new MarginPadding { Top = 15 };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(TextureStore textures)
+            {
+                AddInternal(new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Y,
+                    AutoSizeAxes = Axes.X,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(10, 0),
+                    Children = new Drawable[]
+                    {
+                        new Sprite
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            RelativeSizeAxes = Axes.Both,
+                            FillMode = FillMode.Fit,
+                            Texture = textures.Get(@"Online/not-found")
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Text = @"... nope, nothing found.",
+                        }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingResultsDisplay.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingResultsDisplay.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSetPager.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSetPager.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Overlays.Direct;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Overlays.BeatmapListing
+{
+    public class BeatmapSetPager
+    {
+        private readonly IAPIProvider API;
+
+        public event PageFetchHandler PageFetch;
+
+        private readonly RulesetStore rulesets;
+
+        private readonly string query;
+        private readonly RulesetInfo ruleset;
+        private readonly BeatmapSearchCategory searchCategory;
+        private readonly DirectSortCriteria sortCriteria;
+        private readonly SortDirection sortDirection;
+
+        private SearchBeatmapSetsRequest getSetsRequest;
+
+        private SearchBeatmapSetsResponse lastResponse;
+
+        public int? TotalSets => lastResponse?.Total;
+        public bool IsPastFirstPage { get; private set; } = false;
+        public bool IsLastPageFetched { get; private set; } = false;
+        public bool IsFetching => getSetsRequest != null;
+        public bool CanFetchNextPage => !IsLastPageFetched && !IsFetching;
+
+        public BeatmapSetPager(IAPIProvider API, RulesetStore rulesets, string query, RulesetInfo ruleset, BeatmapSearchCategory searchCategory = BeatmapSearchCategory.Any, DirectSortCriteria sortCriteria = DirectSortCriteria.Ranked, SortDirection sortDirection = SortDirection.Descending)
+        {
+            this.API = API;
+
+            this.rulesets = rulesets;
+
+            this.query = query;
+            this.ruleset = ruleset;
+            this.searchCategory = searchCategory;
+            this.sortCriteria = sortCriteria;
+            this.sortDirection = sortDirection;
+        }
+
+        /// <summary>
+        /// Fetches the next page of beatmap sets. This method is not thread-safe.
+        /// </summary>
+        public void FetchNextPage()
+        {
+            if (IsFetching)
+                return;
+
+            if (lastResponse != null)
+                IsPastFirstPage = true;
+
+            getSetsRequest = new SearchBeatmapSetsRequest(
+                query,
+                ruleset,
+                lastResponse?.CursorJson,
+                searchCategory,
+                sortCriteria,
+                sortDirection);
+
+            getSetsRequest.Success += response =>
+            {
+                var sets = response.BeatmapSets.Select(r => r.ToBeatmapSet(rulesets)).ToList();
+
+                if (sets.Count == 0) IsLastPageFetched = true;
+
+                lastResponse = response;
+                getSetsRequest = null;
+
+                PageFetch?.Invoke(sets);
+            };
+
+            API.Queue(getSetsRequest);
+        }
+
+        public void Reset()
+        {
+            IsLastPageFetched = false;
+
+            lastResponse = null;
+
+            getSetsRequest?.Cancel();
+            getSetsRequest = null;
+        }
+
+        public delegate void PageFetchHandler(List<BeatmapSetInfo> sets);
+    }
+}

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSetPager.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSetPager.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays.BeatmapListing
             getSetsRequest = new SearchBeatmapSetsRequest(
                 query,
                 ruleset,
-                lastResponse?.CursorJson,
+                lastResponse?.Cursor,
                 searchCategory,
                 sortCriteria,
                 sortDirection);

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSetPager.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSetPager.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Overlays.BeatmapListing
 {
     public class BeatmapSetPager
     {
-        private readonly IAPIProvider API;
+        private readonly IAPIProvider api;
 
         public event PageFetchHandler PageFetch;
 
@@ -35,9 +35,9 @@ namespace osu.Game.Overlays.BeatmapListing
         public bool IsFetching => getSetsRequest != null;
         public bool CanFetchNextPage => !IsLastPageFetched && !IsFetching;
 
-        public BeatmapSetPager(IAPIProvider API, RulesetStore rulesets, string query, RulesetInfo ruleset, BeatmapSearchCategory searchCategory = BeatmapSearchCategory.Any, DirectSortCriteria sortCriteria = DirectSortCriteria.Ranked, SortDirection sortDirection = SortDirection.Descending)
+        public BeatmapSetPager(IAPIProvider api, RulesetStore rulesets, string query, RulesetInfo ruleset, BeatmapSearchCategory searchCategory = BeatmapSearchCategory.Any, DirectSortCriteria sortCriteria = DirectSortCriteria.Ranked, SortDirection sortDirection = SortDirection.Descending)
         {
-            this.API = API;
+            this.api = api;
 
             this.rulesets = rulesets;
 
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.BeatmapListing
                 PageFetch?.Invoke(sets);
             };
 
-            API.Queue(getSetsRequest);
+            api.Queue(getSetsRequest);
         }
 
         public void Reset()

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -28,7 +27,7 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Scroll distance from bottom at which new beatmaps will be loaded, if possible.
         /// </summary>
-        protected const int pagination_scroll_distance = 500;
+        private const int pagination_scroll_distance = 500;
 
         [Resolved]
         private PreviewTrackManager previewTrackManager { get; set; }

--- a/osu.Game/Overlays/DirectOverlay.cs
+++ b/osu.Game/Overlays/DirectOverlay.cs
@@ -258,6 +258,7 @@ namespace osu.Game.Overlays
             getSetsRequest = new SearchBeatmapSetsRequest(
                 currentQuery.Value,
                 ((FilterControl)Filter).Ruleset.Value,
+                null,
                 Filter.DisplayStyleControl.Dropdown.Current.Value,
                 Filter.Tabs.Current.Value); //todo: sort direction (?)
 


### PR DESCRIPTION
This PR adds automatic pagination to BeatmapListingOverlay and supersedes #7407. The diffs are mostly changes that have been ported from the original DirectOverlay version. However, there are some differences, including the fact that this version attempts to use the `cursor` mechanism rather than a page number for pagination.

This is somewhat of a work-in-progress; please see below for some comments on things I had questions/concerns about.

- [x] Depends on ppy/osu-framework#3302