### PR TITLE
Add taiko drumroll skinning support

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TaikoSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TaikoSkinnableTestScene.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Taiko.Skinning;
 using osu.Game.Tests.Visual;
 
-namespace osu.Game.Rulesets.Taiko.Tests
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 {
     public abstract class TaikoSkinnableTestScene : SkinnableTestScene
     {

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRoll.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Skinning;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Tests.Visual;
 
@@ -23,6 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         {
             typeof(DrawableDrumRoll),
             typeof(DrawableDrumRollTick),
+            typeof(LegacyDrumRoll),
         }).ToList();
 
         [Cached(typeof(IScrollingInfo))]

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRoll.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
+{
+    [TestFixture]
+    public class TestSceneDrawableDrumRoll : TaikoSkinnableTestScene
+    {
+        public override IReadOnlyList<Type> RequiredTypes => base.RequiredTypes.Concat(new[]
+        {
+            typeof(DrawableDrumRoll),
+            typeof(DrawableDrumRollTick),
+        }).ToList();
+
+        [Cached(typeof(IScrollingInfo))]
+        private ScrollingTestContainer.TestScrollingInfo info = new ScrollingTestContainer.TestScrollingInfo
+        {
+            Direction = { Value = ScrollingDirection.Left },
+            TimeRange = { Value = 5000 },
+        };
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddStep("Drum roll", () => SetContents(() =>
+            {
+                var hoc = new ScrollingHitObjectContainer();
+
+                hoc.Add(new DrawableDrumRoll(createDrumRollAtCurrentTime())
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 500,
+                });
+
+                return hoc;
+            }));
+
+            AddStep("Drum roll (strong)", () => SetContents(() =>
+            {
+                var hoc = new ScrollingHitObjectContainer();
+
+                hoc.Add(new DrawableDrumRoll(createDrumRollAtCurrentTime(true))
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 500,
+                });
+
+                return hoc;
+            }));
+        }
+
+        private DrumRoll createDrumRollAtCurrentTime(bool strong = false)
+        {
+            var drumroll = new DrumRoll
+            {
+                IsStrong = strong,
+                StartTime = Time.Current + 1000,
+                Duration = 4000,
+            };
+
+            var cpi = new ControlPointInfo();
+            cpi.Add(0, new TimingControlPoint { BeatLength = 500 });
+
+            drumroll.ApplyDefaults(cpi, new BeatmapDifficulty());
+
+            return drumroll;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning;
 
-namespace osu.Game.Rulesets.Taiko.Tests
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 {
     [TestFixture]
     public class TestSceneDrawableHit : TaikoSkinnableTestScene

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             typeof(DrawableCentreHit),
             typeof(DrawableRimHit),
             typeof(LegacyHit),
+            typeof(LegacyCirclePiece),
         }).ToList();
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneInputDrum.cs
@@ -6,14 +6,14 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osuTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Taiko.Skinning;
 using osu.Game.Rulesets.Taiko.UI;
+using osuTK;
 
-namespace osu.Game.Rulesets.Taiko.Tests
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 {
     [TestFixture]
     public class TestSceneInputDrum : TaikoSkinnableTestScene

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableCentreHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableCentreHit.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
@@ -16,7 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
         }
 
-        protected override CompositeDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.CentreHit),
+        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.CentreHit),
             _ => new CentreHitCirclePiece(), confineMode: ConfineMode.ScaleToFit);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -29,25 +30,29 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// </summary>
         private int rollingHits;
 
-        private readonly Container<DrawableDrumRollTick> tickContainer;
+        private Container<DrawableDrumRollTick> tickContainer;
 
         private Color4 colourIdle;
         private Color4 colourEngaged;
-
-        private ElongatedCirclePiece elongatedPiece;
 
         public DrawableDrumRoll(DrumRoll drumRoll)
             : base(drumRoll)
         {
             RelativeSizeAxes = Axes.Y;
-            elongatedPiece.Add(tickContainer = new Container<DrawableDrumRollTick> { RelativeSizeAxes = Axes.Both });
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            elongatedPiece.AccentColour = colourIdle = colours.YellowDark;
+            colourIdle = colours.YellowDark;
             colourEngaged = colours.YellowDarker;
+
+            updateColour();
+
+            ((Container)MainPiece.Drawable).Add(tickContainer = new Container<DrawableDrumRollTick> { RelativeSizeAxes = Axes.Both });
+
+            if (MainPiece.Drawable is IHasAccentColour accentMain)
+                accentMain.AccentColour = colourIdle;
         }
 
         protected override void LoadComplete()
@@ -86,7 +91,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             return base.CreateNestedHitObject(hitObject);
         }
 
-        protected override CompositeDrawable CreateMainPiece() => elongatedPiece = new ElongatedCirclePiece();
+        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.DrumRollBody),
+            _ => new ElongatedCirclePiece());
 
         public override bool OnPressed(TaikoAction action) => false;
 
@@ -102,8 +108,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             rollingHits = Math.Clamp(rollingHits, 0, rolling_hits_for_engaged_colour);
 
-            Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
-            (MainPiece as IHasAccentColour)?.FadeAccent(newColour, 100);
+            updateColour();
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -150,6 +155,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             }
 
             public override bool OnPressed(TaikoAction action) => false;
+        }
+
+        private void updateColour()
+        {
+            Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
+            (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, 100);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// </summary>
         private int rollingHits;
 
-        private Container<DrawableDrumRollTick> tickContainer;
+        private Container tickContainer;
 
         private Color4 colourIdle;
         private Color4 colourEngaged;
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             updateColour();
 
-            ((Container)MainPiece.Drawable).Add(tickContainer = new Container<DrawableDrumRollTick> { RelativeSizeAxes = Axes.Both });
+            Content.Add(tickContainer = new Container { RelativeSizeAxes = Axes.Both });
 
             if (MainPiece.Drawable is IHasAccentColour accentMain)
                 accentMain.AccentColour = colourIdle;
@@ -139,6 +139,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override DrawableStrongNestedHit CreateStrongHit(StrongHitObject hitObject) => new StrongNestedHit(hitObject, this);
 
+        private void updateColour()
+        {
+            Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
+            (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, 100);
+        }
+
         private class StrongNestedHit : DrawableStrongNestedHit
         {
             public StrongNestedHit(StrongHitObject strong, DrawableDrumRoll drumRoll)
@@ -155,12 +161,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             }
 
             public override bool OnPressed(TaikoAction action) => false;
-        }
-
-        private void updateColour()
-        {
-            Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
-            (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, 100);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -135,6 +136,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     this.Delay(HitObject.Duration).FadeOut(100);
                     break;
             }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            OriginPosition = new Vector2(DrawHeight);
+            Content.X = DrawHeight / 2;
         }
 
         protected override DrawableStrongNestedHit CreateStrongHit(StrongHitObject hitObject) => new StrongNestedHit(hitObject, this);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -21,7 +21,10 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         public override bool DisplayResult => false;
 
         protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.DrumRollTick),
-            _ => new TickPiece());
+            _ => new TickPiece
+            {
+                Filled = HitObject.FirstTick
+            });
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -3,10 +3,10 @@
 
 using System;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -20,10 +20,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool DisplayResult => false;
 
-        protected override CompositeDrawable CreateMainPiece() => new TickPiece
-        {
-            Filled = HitObject.FirstTick
-        };
+        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.DrumRollTick),
+            _ => new TickPiece());
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     // If we're far enough away from the left stage, we should bring outselves in front of it
                     ProxyContent();
 
-                    var flash = (MainPiece as CirclePiece)?.FlashBox;
+                    var flash = (MainPiece.Drawable as CirclePiece)?.FlashBox;
                     flash?.FadeTo(0.9f).FadeOut(300);
 
                     const float gravity_time = 300;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableRimHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableRimHit.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
@@ -16,7 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
         }
 
-        protected override CompositeDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.RimHit),
+        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.RimHit),
             _ => new RimHitCirclePiece(), confineMode: ConfineMode.ScaleToFit);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -114,12 +115,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             targetRing.BorderColour = colours.YellowDark.Opacity(0.25f);
         }
 
-        protected override CompositeDrawable CreateMainPiece() => new SwellCirclePiece
-        {
-            // to allow for rotation transform
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-        };
+        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.Swell),
+            _ => new SwellCirclePiece
+            {
+                // to allow for rotation transform
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            });
 
         protected override void LoadComplete()
         {
@@ -184,7 +186,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     .Then()
                     .FadeTo(completion / 8, 2000, Easing.OutQuint);
 
-                MainPiece.RotateTo((float)(completion * HitObject.Duration / 8), 4000, Easing.OutQuint);
+                MainPiece.Drawable.RotateTo((float)(completion * HitObject.Duration / 8), 4000, Easing.OutQuint);
 
                 expandingRing.ScaleTo(1f + Math.Min(target_ring_scale - 1f, (target_ring_scale - 1f) * completion * 1.3f), 260, Easing.OutQuint);
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -31,6 +31,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool OnPressed(TaikoAction action) => false;
 
-        protected override CompositeDrawable CreateMainPiece() => new TickPiece();
+        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.DrumRollTick),
+            _ => new TickPiece());
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -115,7 +116,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         public new TObject HitObject;
 
         protected readonly Vector2 BaseSize;
-        protected readonly CompositeDrawable MainPiece;
+        protected readonly SkinnableDrawable MainPiece;
 
         private readonly Container<DrawableStrongNestedHit> strongHitContainer;
 
@@ -167,7 +168,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         // Normal and clap samples are handled by the drum
         protected override IEnumerable<HitSampleInfo> GetSamples() => HitObject.Samples.Where(s => s.Name != HitSampleInfo.HIT_NORMAL && s.Name != HitSampleInfo.HIT_CLAP);
 
-        protected abstract CompositeDrawable CreateMainPiece();
+        protected abstract SkinnableDrawable CreateMainPiece();
 
         /// <summary>
         /// Creates the handler for this <see cref="DrawableHitObject"/>'s <see cref="StrongHitObject"/>.

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/Pieces/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/Pieces/CirclePiece.cs
@@ -10,6 +10,7 @@ using osuTK.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Effects;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces
     /// for a usage example.
     /// </para>
     /// </summary>
-    public abstract class CirclePiece : BeatSyncedContainer
+    public abstract class CirclePiece : BeatSyncedContainer, IHasAccentColour
     {
         public const float SYMBOL_SIZE = 0.45f;
         public const float SYMBOL_BORDER = 8;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/Pieces/ElongatedCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/Pieces/ElongatedCirclePiece.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces
 {
@@ -12,18 +14,15 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces
             RelativeSizeAxes = Axes.Y;
         }
 
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            AccentColour = colours.YellowDark;
+        }
+
         protected override void Update()
         {
             base.Update();
-
-            var padding = Content.DrawHeight * Content.Width / 2;
-
-            Content.Padding = new MarginPadding
-            {
-                Left = padding,
-                Right = padding,
-            };
-
             Width = Parent.DrawSize.X + DrawHeight;
         }
     }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyCirclePiece.cs
@@ -1,0 +1,96 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Taiko.Skinning
+{
+    public class LegacyCirclePiece : CompositeDrawable, IHasAccentColour
+    {
+        private Drawable backgroundLayer;
+
+        public LegacyCirclePiece()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skin, DrawableHitObject drawableHitObject)
+        {
+            Drawable getDrawableFor(string lookup)
+            {
+                const string normal_hit = "taikohit";
+                const string big_hit = "taikobig";
+
+                string prefix = ((drawableHitObject as DrawableTaikoHitObject)?.HitObject.IsStrong ?? false) ? big_hit : normal_hit;
+
+                return skin.GetAnimation($"{prefix}{lookup}", true, false) ??
+                       // fallback to regular size if "big" version doesn't exist.
+                       skin.GetAnimation($"{normal_hit}{lookup}", true, false);
+            }
+
+            // backgroundLayer is guaranteed to exist due to the pre-check in TaikoLegacySkinTransformer.
+            AddInternal(backgroundLayer = getDrawableFor("circle"));
+
+            var foregroundLayer = getDrawableFor("circleoverlay");
+            if (foregroundLayer != null)
+                AddInternal(foregroundLayer);
+
+            // Animations in taiko skins are used in a custom way (>150 combo and animating in time with beat).
+            // For now just stop at first frame for sanity.
+            foreach (var c in InternalChildren)
+            {
+                (c as IFramedAnimation)?.Stop();
+
+                c.Anchor = Anchor.Centre;
+                c.Origin = Anchor.Centre;
+            }
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateAccentColour();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // Not all skins (including the default osu-stable) have similar sizes for "hitcircle" and "hitcircleoverlay".
+            // This ensures they are scaled relative to each other but also match the expected DrawableHit size.
+            foreach (var c in InternalChildren)
+                c.Scale = new Vector2(DrawHeight / 128);
+        }
+
+        private Color4 accentColour;
+
+        public Color4 AccentColour
+        {
+            get => accentColour;
+            set
+            {
+                if (value == accentColour)
+                    return;
+
+                accentColour = value;
+                if (IsLoaded)
+                    updateAccentColour();
+            }
+        }
+
+        private void updateAccentColour()
+        {
+            backgroundLayer.Colour = accentColour;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
@@ -1,0 +1,110 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Taiko.Skinning
+{
+    public class LegacyDrumRoll : Container, IHasAccentColour
+    {
+        protected override Container<Drawable> Content => content;
+
+        private Container content;
+
+        private LegacyCirclePiece headCircle;
+
+        private Sprite body;
+
+        private Sprite end;
+
+        public LegacyDrumRoll()
+        {
+            RelativeSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skin)
+        {
+            InternalChildren = new Drawable[]
+            {
+                content = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        headCircle = new LegacyCirclePiece
+                        {
+                            Depth = float.MinValue,
+                            RelativeSizeAxes = Axes.Y,
+                            Anchor = Anchor.TopLeft,
+                            Origin = Anchor.TopLeft,
+                        },
+                        body = new Sprite
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Texture = skin.GetTexture("taiko-roll-middle"),
+                        },
+                        end = new Sprite
+                        {
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.CentreLeft,
+                            RelativeSizeAxes = Axes.Both,
+                            Texture = skin.GetTexture("taiko-roll-end"),
+                            FillMode = FillMode.Fit,
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateAccentColour();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var padding = Content.DrawHeight * Content.Width / 2;
+
+            Content.Padding = new MarginPadding
+            {
+                Left = padding,
+                Right = padding,
+            };
+
+            Width = Parent.DrawSize.X + DrawHeight;
+        }
+
+        private Color4 accentColour;
+
+        public Color4 AccentColour
+        {
+            get => accentColour;
+            set
+            {
+                if (value == accentColour)
+                    return;
+
+                accentColour = value;
+                if (IsLoaded)
+                    updateAccentColour();
+            }
+        }
+
+        private void updateAccentColour()
+        {
+            headCircle.AccentColour = accentColour;
+            body.Colour = accentColour;
+            end.Colour = accentColour;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
@@ -11,12 +11,8 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Skinning
 {
-    public class LegacyDrumRoll : Container, IHasAccentColour
+    public class LegacyDrumRoll : CompositeDrawable, IHasAccentColour
     {
-        protected override Container<Drawable> Content => content;
-
-        private Container content;
-
         private LegacyCirclePiece headCircle;
 
         private Sprite body;
@@ -25,63 +21,40 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         public LegacyDrumRoll()
         {
-            RelativeSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
-        private void load(ISkinSource skin)
+        private void load(ISkinSource skin, OsuColour colours)
         {
             InternalChildren = new Drawable[]
             {
-                content = new Container
+                end = new Sprite
+                {
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreLeft,
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = skin.GetTexture("taiko-roll-end"),
+                    FillMode = FillMode.Fit,
+                },
+                body = new Sprite
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
-                        headCircle = new LegacyCirclePiece
-                        {
-                            Depth = float.MinValue,
-                            RelativeSizeAxes = Axes.Y,
-                            Anchor = Anchor.TopLeft,
-                            Origin = Anchor.TopLeft,
-                        },
-                        body = new Sprite
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Texture = skin.GetTexture("taiko-roll-middle"),
-                        },
-                        end = new Sprite
-                        {
-                            Anchor = Anchor.CentreRight,
-                            Origin = Anchor.CentreLeft,
-                            RelativeSizeAxes = Axes.Both,
-                            Texture = skin.GetTexture("taiko-roll-end"),
-                            FillMode = FillMode.Fit,
-                        },
-                    },
+                    Texture = skin.GetTexture("taiko-roll-middle"),
+                },
+                headCircle = new LegacyCirclePiece
+                {
+                    RelativeSizeAxes = Axes.Y,
                 },
             };
+
+            AccentColour = colours.YellowDark;
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
             updateAccentColour();
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            var padding = Content.DrawHeight * Content.Width / 2;
-
-            Content.Padding = new MarginPadding
-            {
-                Left = padding,
-                Right = padding,
-            };
-
-            Width = Parent.DrawSize.X + DrawHeight;
         }
 
         private Color4 accentColour;

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHit.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHit.cs
@@ -2,90 +2,25 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Animations;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Taiko.Objects.Drawables;
-using osu.Game.Skinning;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Skinning
 {
-    public class LegacyHit : CompositeDrawable, IHasAccentColour
+    public class LegacyHit : LegacyCirclePiece
     {
         private readonly TaikoSkinComponents component;
-
-        private Drawable backgroundLayer;
 
         public LegacyHit(TaikoSkinComponents component)
         {
             this.component = component;
-
-            RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
-        private void load(ISkinSource skin, DrawableHitObject drawableHitObject)
+        private void load()
         {
-            Drawable getDrawableFor(string lookup)
-            {
-                const string normal_hit = "taikohit";
-                const string big_hit = "taikobig";
-
-                string prefix = ((drawableHitObject as DrawableTaikoHitObject)?.HitObject.IsStrong ?? false) ? big_hit : normal_hit;
-
-                return skin.GetAnimation($"{prefix}{lookup}", true, false) ??
-                       // fallback to regular size if "big" version doesn't exist.
-                       skin.GetAnimation($"{normal_hit}{lookup}", true, false);
-            }
-
-            // backgroundLayer is guaranteed to exist due to the pre-check in TaikoLegacySkinTransformer.
-            AddInternal(backgroundLayer = getDrawableFor("circle"));
-
-            var foregroundLayer = getDrawableFor("circleoverlay");
-            if (foregroundLayer != null)
-                AddInternal(foregroundLayer);
-
-            // Animations in taiko skins are used in a custom way (>150 combo and animating in time with beat).
-            // For now just stop at first frame for sanity.
-            foreach (var c in InternalChildren)
-            {
-                (c as IFramedAnimation)?.Stop();
-
-                c.Anchor = Anchor.Centre;
-                c.Origin = Anchor.Centre;
-            }
-
             AccentColour = component == TaikoSkinComponents.CentreHit
                 ? new Color4(235, 69, 44, 255)
                 : new Color4(67, 142, 172, 255);
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            // Not all skins (including the default osu-stable) have similar sizes for "hitcircle" and "hitcircleoverlay".
-            // This ensures they are scaled relative to each other but also match the expected DrawableHit size.
-            foreach (var c in InternalChildren)
-                c.Scale = new Vector2(DrawWidth / 128);
-        }
-
-        private Color4 accentColour;
-
-        public Color4 AccentColour
-        {
-            get => accentColour;
-            set
-            {
-                if (value == accentColour)
-                    return;
-
-                backgroundLayer.Colour = accentColour = value;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                         return new LegacyHit(taikoComponent.Component);
 
                     return null;
+
+                case TaikoSkinComponents.DrumRollTick:
+                    return this.GetAnimation("sliderscorepoint", false, false);
             }
 
             return source.GetDrawableComponent(component);

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -27,6 +27,12 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
             switch (taikoComponent.Component)
             {
+                case TaikoSkinComponents.DrumRollBody:
+                    if (GetTexture("taiko-roll-middle") != null)
+                        return new LegacyDrumRoll();
+
+                    return null;
+
                 case TaikoSkinComponents.InputDrum:
                     if (GetTexture("taiko-bar-left") != null)
                         return new LegacyInputDrum();

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -7,6 +7,9 @@ namespace osu.Game.Rulesets.Taiko
     {
         InputDrum,
         CentreHit,
-        RimHit
+        RimHit,
+        DrumRollBody,
+        DrumRollTick,
+        Swell
     }
 }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -398,7 +398,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
         }
 
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => AllJudged && base.UpdateSubTreeMasking(source, maskingBounds);
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
 
         protected override void UpdateAfterChildren()
         {

--- a/osu.Game/Tests/Visual/ScrollingTestContainer.cs
+++ b/osu.Game/Tests/Visual/ScrollingTestContainer.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual
 
         public void Flip() => scrollingInfo.Direction.Value = scrollingInfo.Direction.Value == ScrollingDirection.Up ? ScrollingDirection.Down : ScrollingDirection.Up;
 
-        private class TestScrollingInfo : IScrollingInfo
+        public class TestScrollingInfo : IScrollingInfo
         {
             public readonly Bindable<ScrollingDirection> Direction = new Bindable<ScrollingDirection>();
             IBindable<ScrollingDirection> IScrollingInfo.Direction => Direction;
@@ -54,7 +54,7 @@ namespace osu.Game.Tests.Visual
             IScrollAlgorithm IScrollingInfo.Algorithm => Algorithm;
         }
 
-        private class TestScrollAlgorithm : IScrollAlgorithm
+        public class TestScrollAlgorithm : IScrollAlgorithm
         {
             public readonly SortedList<MultiplierControlPoint> ControlPoints = new SortedList<MultiplierControlPoint>();
 


### PR DESCRIPTION
Still needs metric elements added, but mostly works.

- Adds remaining skinnable hitobjects (without implementations) to allow for using `SkinnableDrawable` across `TaikoHitObject` classes.
- Tidies up sizing logic (aka removes a heap that we don't need)
- Stretched piece gets gradiented to transparent at each end. Will fix this in a follow-up PR (also happens in mania, see https://github.com/ppy/osu/issues/8543)
- [x] Figure why LegacyCirclePiece is not visible after rewind (related to proxying?)