### PR TITLE
Fix carousel not correctly updating when selection changes to a new beatmap from a child screen

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -217,6 +217,9 @@ namespace osu.Game.Screens.Select
         /// <returns>True if a selection was made, False if it wasn't.</returns>
         public bool SelectBeatmap(BeatmapInfo beatmap, bool bypassFilters = true)
         {
+            // ensure that any pending events from BeatmapManager have been run before attempting a selection.
+            Scheduler.Update();
+
             if (beatmap?.Hidden != false)
                 return false;
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8269.

Basically, the carousel was performing its pending schedule task:

https://github.com/ppy/osu/blob/master/osu.Game/Screens/Select/BeatmapCarousel.cs#L157

after SongSelect:

https://github.com/ppy/osu/blob/master/osu.Game/Screens/Select/SongSelect.cs#L377

You could ask "why not schedule the workingBeatmapChanged?" but scheduling logic in SongSelect was recently cleaned up as it was deemed to be very fragile, so I'm against adding more schedules. I think it would require two, anyway.