### PR TITLE
Fix slider heads not being blocked when hit out-of-order

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
@@ -296,6 +296,44 @@ namespace osu.Game.Rulesets.Osu.Tests
             addJudgementAssert(hitObjects[1], HitResult.Great);
         }
 
+        [Test]
+        public void TestHitSliderHeadBeforeHitCircle()
+        {
+            const double time_circle = 1000;
+            const double time_slider = 1200;
+            Vector2 positionCircle = Vector2.Zero;
+            Vector2 positionSlider = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_circle,
+                    Position = positionCircle
+                },
+                new TestSlider
+                {
+                    StartTime = time_slider,
+                    Position = positionSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_circle - 100, Position = positionSlider, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_circle, Position = positionCircle, Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_slider, Position = positionSlider, Actions = { OsuAction.LeftButton } },
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.Great);
+        }
+
         private void addJudgementAssert(OsuHitObject hitObject, HitResult result)
         {
             AddAssert($"({hitObject.GetType().ReadableName()} @ {hitObject.StartTime}) judgement is {result}",

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
@@ -371,6 +371,9 @@ namespace osu.Game.Rulesets.Osu.Tests
                 {
                     HeadCircle.HitWindows = new TestHitWindows();
                     TailCircle.HitWindows = new TestHitWindows();
+
+                    HeadCircle.HitWindows.SetDifficulty(0);
+                    TailCircle.HitWindows.SetDifficulty(0);
                 };
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -125,7 +125,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     return new DrawableSliderTail(slider, tail);
 
                 case SliderHeadCircle head:
-                    return new DrawableSliderHead(slider, head) { OnShake = Shake };
+                    return new DrawableSliderHead(slider, head)
+                    {
+                        OnShake = Shake,
+                        CheckHittable = (d, t) => CheckHittable?.Invoke(d, t) ?? true
+                    };
 
                 case SliderTick tick:
                     return new DrawableSliderTick(tick) { Position = tick.Position - slider.Position };

--- a/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.UI;
 namespace osu.Game.Rulesets.Osu.UI
 {
     /// <summary>
-    /// Ensures that <see cref="HitObject"/>s are hit in-order.
+    /// Ensures that <see cref="HitObject"/>s are hit in-order. Affectionately known as "note lock".
     /// If a <see cref="HitObject"/> is hit out of order:
     /// <list type="number">
     /// <item><description>The hit is blocked if it occurred earlier than the previous <see cref="HitObject"/>'s start time.</description></item>

--- a/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
@@ -51,10 +51,7 @@ namespace osu.Game.Rulesets.Osu.UI
             // 1. The last blocking hitobject has been judged.
             // 2. The current time is after the last hitobject's start time.
             // Hits at exactly the same time as the blocking hitobject are allowed for maps that contain simultaneous hitobjects (e.g. /b/372245).
-            if (blockingObject.Judged || time >= blockingObject.HitObject.StartTime)
-                return true;
-
-            return false;
+            return blockingObject.Judged || time >= blockingObject.HitObject.StartTime;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -71,6 +72,9 @@ namespace osu.Game.Rulesets.Osu.UI
             // Hitobjects which themselves don't block future hitobjects don't cause misses (e.g. slider ticks, spinners).
             if (!hitObjectCanBlockFutureHits(hitObject))
                 return;
+
+            if (!IsHittable(hitObject, hitObject.HitObject.StartTime + hitObject.Result.TimeOffset))
+                throw new InvalidOperationException($"A {hitObject} was hit before it become hittable!");
 
             var enumerator = new HitObjectEnumerator(hitObjectContainer, hitObject.HitObject.StartTime);
 

--- a/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
@@ -39,14 +39,15 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             DrawableHitObject blockingObject = null;
 
-            var enumerator = new HitObjectEnumerator(hitObjectContainer, hitObject.HitObject.StartTime);
-
-            while (enumerator.MoveNext())
+            using (var enumerator = new HitObjectEnumerator(hitObjectContainer, hitObject.HitObject.StartTime))
             {
-                Debug.Assert(enumerator.Current != null);
+                while (enumerator.MoveNext())
+                {
+                    Debug.Assert(enumerator.Current != null);
 
-                if (hitObjectCanBlockFutureHits(enumerator.Current))
-                    blockingObject = enumerator.Current;
+                    if (hitObjectCanBlockFutureHits(enumerator.Current))
+                        blockingObject = enumerator.Current;
+                }
             }
 
             // If there is no previous hitobject, allow the hit.
@@ -76,17 +77,18 @@ namespace osu.Game.Rulesets.Osu.UI
             if (!IsHittable(hitObject, hitObject.HitObject.StartTime + hitObject.Result.TimeOffset))
                 throw new InvalidOperationException($"A {hitObject} was hit before it become hittable!");
 
-            var enumerator = new HitObjectEnumerator(hitObjectContainer, hitObject.HitObject.StartTime);
-
-            while (enumerator.MoveNext())
+            using (var enumerator = new HitObjectEnumerator(hitObjectContainer, hitObject.HitObject.StartTime))
             {
-                Debug.Assert(enumerator.Current != null);
+                while (enumerator.MoveNext())
+                {
+                    Debug.Assert(enumerator.Current != null);
 
-                if (enumerator.Current.Judged)
-                    continue;
+                    if (enumerator.Current.Judged)
+                        continue;
 
-                if (hitObjectCanBlockFutureHits(enumerator.Current))
-                    ((DrawableOsuHitObject)enumerator.Current).MissForcefully();
+                    if (hitObjectCanBlockFutureHits(enumerator.Current))
+                        ((DrawableOsuHitObject)enumerator.Current).MissForcefully();
+                }
             }
         }
 
@@ -180,6 +182,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
             public void Dispose()
             {
+                hitObjectEnumerator?.Dispose();
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
@@ -93,12 +93,12 @@ namespace osu.Game.Rulesets.Osu.UI
 
                 yield return obj;
 
-                for (int i = 0; i < obj.NestedHitObjects.Count; i++)
+                foreach (var nestedObj in obj.NestedHitObjects)
                 {
-                    if (obj.NestedHitObjects[i].HitObject.StartTime >= targetTime)
+                    if (nestedObj.HitObject.StartTime >= targetTime)
                         break;
 
-                    yield return obj.NestedHitObjects[i];
+                    yield return nestedObj;
                 }
             }
         }

--- a/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -36,11 +38,14 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             DrawableHitObject blockingObject = null;
 
-            // Find the last hitobject which blocks future hits.
-            foreach (var obj in enumerateHitObjectsUpTo(hitObject))
+            var enumerator = new HitObjectEnumerator(hitObjectContainer, hitObject.HitObject.StartTime);
+
+            while (enumerator.MoveNext())
             {
-                if (hitObjectCanBlockFutureHits(obj))
-                    blockingObject = obj;
+                Debug.Assert(enumerator.Current != null);
+
+                if (hitObjectCanBlockFutureHits(enumerator.Current))
+                    blockingObject = enumerator.Current;
             }
 
             // If there is no previous hitobject, allow the hit.
@@ -67,13 +72,17 @@ namespace osu.Game.Rulesets.Osu.UI
             if (!hitObjectCanBlockFutureHits(hitObject))
                 return;
 
-            foreach (var obj in enumerateHitObjectsUpTo(hitObject))
+            var enumerator = new HitObjectEnumerator(hitObjectContainer, hitObject.HitObject.StartTime);
+
+            while (enumerator.MoveNext())
             {
-                if (obj.Judged)
+                Debug.Assert(enumerator.Current != null);
+
+                if (enumerator.Current.Judged)
                     continue;
 
-                if (hitObjectCanBlockFutureHits(obj))
-                    ((DrawableOsuHitObject)obj).MissForcefully();
+                if (hitObjectCanBlockFutureHits(enumerator.Current))
+                    ((DrawableOsuHitObject)enumerator.Current).MissForcefully();
             }
         }
 
@@ -84,23 +93,89 @@ namespace osu.Game.Rulesets.Osu.UI
         private static bool hitObjectCanBlockFutureHits(DrawableHitObject hitObject)
             => hitObject is DrawableHitCircle;
 
-        // Todo: Inefficient
-        private IEnumerable<DrawableHitObject> enumerateHitObjectsUpTo(DrawableHitObject hitObject)
+        private struct HitObjectEnumerator : IEnumerator<DrawableHitObject>
         {
-            return enumerate(hitObjectContainer.AliveObjects);
+            private readonly IEnumerator<DrawableHitObject> hitObjectEnumerator;
+            private readonly double targetTime;
 
-            IEnumerable<DrawableHitObject> enumerate(IEnumerable<DrawableHitObject> list)
+            private DrawableHitObject currentTopLevel;
+            private int currentNestedIndex;
+
+            public HitObjectEnumerator(HitObjectContainer hitObjectContainer, double targetTime)
             {
-                foreach (var obj in list)
-                {
-                    if (obj.HitObject.StartTime >= hitObject.HitObject.StartTime)
-                        yield break;
+                hitObjectEnumerator = hitObjectContainer.AliveObjects.GetEnumerator();
+                this.targetTime = targetTime;
 
-                    yield return obj;
+                currentTopLevel = null;
+                currentNestedIndex = -1;
+                Current = null;
+            }
 
-                    foreach (var nested in enumerate(obj.NestedHitObjects))
-                        yield return nested;
-                }
+            /// <summary>
+            /// Attempts to move to the next top-level or nested hitobject.
+            /// Stops when no such hitobject is found or until the hitobject start time reaches <see cref="targetTime"/>.
+            /// </summary>
+            /// <returns>Whether a new hitobject was moved to.</returns>
+            public bool MoveNext()
+            {
+                // If we don't already have a top-level hitobject, try to get one.
+                if (currentTopLevel == null)
+                    return moveNextTopLevel();
+
+                // If we have a top-level hitobject, try to move to the next nested hitobject or otherwise move to the next top-level hitobject.
+                if (!moveNextNested())
+                    return moveNextTopLevel();
+
+                // Guaranteed by moveNextNested() to have a hitobject.
+                return true;
+            }
+
+            /// <summary>
+            /// Attempts to move to the next top-level hitobject.
+            /// </summary>
+            /// <returns>Whether a new top-level hitobject was found.</returns>
+            private bool moveNextTopLevel()
+            {
+                currentNestedIndex = -1;
+
+                hitObjectEnumerator.MoveNext();
+                currentTopLevel = hitObjectEnumerator.Current;
+
+                Current = currentTopLevel;
+
+                return Current?.HitObject.StartTime < targetTime;
+            }
+
+            /// <summary>
+            /// Attempts to move to the next nested hitobject in the current top-level hitobject.
+            /// </summary>
+            /// <returns>Whether a new nested hitobject was moved to.</returns>
+            private bool moveNextNested()
+            {
+                currentNestedIndex++;
+                if (currentNestedIndex >= currentTopLevel.NestedHitObjects.Count)
+                    return false;
+
+                Current = currentTopLevel.NestedHitObjects[currentNestedIndex];
+                Debug.Assert(Current != null);
+
+                return Current?.HitObject.StartTime < targetTime;
+            }
+
+            public void Reset()
+            {
+                hitObjectEnumerator.Reset();
+                currentTopLevel = null;
+                currentNestedIndex = -1;
+                Current = null;
+            }
+
+            public DrawableHitObject Current { get; set; }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/OrderedHitPolicy.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 
@@ -37,12 +37,9 @@ namespace osu.Game.Rulesets.Osu.UI
             DrawableHitObject blockingObject = null;
 
             // Find the last hitobject which blocks future hits.
-            foreach (var obj in hitObjectContainer.AliveObjects)
+            foreach (var obj in enumerateHitObjectsUpTo(hitObject))
             {
-                if (obj == hitObject)
-                    break;
-
-                if (drawableCanBlockFutureHits(obj))
+                if (hitObjectCanBlockFutureHits(obj))
                     blockingObject = obj;
             }
 
@@ -64,64 +61,47 @@ namespace osu.Game.Rulesets.Osu.UI
         /// Handles a <see cref="HitObject"/> being hit to potentially miss all earlier <see cref="HitObject"/>s.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> that was hit.</param>
-        public void HandleHit(HitObject hitObject)
+        public void HandleHit(DrawableHitObject hitObject)
         {
             // Hitobjects which themselves don't block future hitobjects don't cause misses (e.g. slider ticks, spinners).
             if (!hitObjectCanBlockFutureHits(hitObject))
                 return;
 
-            double maximumTime = hitObject.StartTime;
-
-            // Iterate through and apply miss results to all top-level and nested hitobjects which block future hits.
-            foreach (var obj in hitObjectContainer.AliveObjects)
+            foreach (var obj in enumerateHitObjectsUpTo(hitObject))
             {
-                if (obj.Judged || obj.HitObject.StartTime >= maximumTime)
+                if (obj.Judged)
                     continue;
 
-                if (hitObjectCanBlockFutureHits(obj.HitObject))
-                    applyMiss(obj);
-
-                foreach (var nested in obj.NestedHitObjects)
-                {
-                    if (nested.Judged || nested.HitObject.StartTime >= maximumTime)
-                        continue;
-
-                    if (hitObjectCanBlockFutureHits(nested.HitObject))
-                        applyMiss(nested);
-                }
+                if (hitObjectCanBlockFutureHits(obj))
+                    ((DrawableOsuHitObject)obj).MissForcefully();
             }
-
-            static void applyMiss(DrawableHitObject obj) => ((DrawableOsuHitObject)obj).MissForcefully();
-        }
-
-        /// <summary>
-        /// Whether a <see cref="DrawableHitObject"/> blocks hits on future <see cref="DrawableHitObject"/>s until its start time is reached.
-        /// </summary>
-        /// <remarks>
-        /// This will ONLY match on top-most <see cref="DrawableHitObject"/>s.
-        /// </remarks>
-        /// <param name="hitObject">The <see cref="DrawableHitObject"/> to test.</param>
-        private static bool drawableCanBlockFutureHits(DrawableHitObject hitObject)
-        {
-            // Special considerations for slider tails aren't required since only top-most drawable hitobjects are being iterated over.
-            return hitObject is DrawableHitCircle || hitObject is DrawableSlider;
         }
 
         /// <summary>
         /// Whether a <see cref="HitObject"/> blocks hits on future <see cref="HitObject"/>s until its start time is reached.
         /// </summary>
-        /// <remarks>
-        /// This is more rigorous and may not match on top-most <see cref="HitObject"/>s as <see cref="drawableCanBlockFutureHits"/> does.
-        /// </remarks>
         /// <param name="hitObject">The <see cref="HitObject"/> to test.</param>
-        private static bool hitObjectCanBlockFutureHits(HitObject hitObject)
-        {
-            // Unlike the above we will receive slider tails, but they do not block future hits.
-            if (hitObject is SliderTailCircle)
-                return false;
+        private static bool hitObjectCanBlockFutureHits(DrawableHitObject hitObject)
+            => hitObject is DrawableHitCircle;
 
-            // All other hitcircles continue to block future hits.
-            return hitObject is HitCircle;
+        // Todo: Inefficient
+        private IEnumerable<DrawableHitObject> enumerateHitObjectsUpTo(DrawableHitObject hitObject)
+        {
+            return enumerate(hitObjectContainer.AliveObjects);
+
+            IEnumerable<DrawableHitObject> enumerate(IEnumerable<DrawableHitObject> list)
+            {
+                foreach (var obj in list)
+                {
+                    if (obj.HitObject.StartTime >= hitObject.HitObject.StartTime)
+                        yield break;
+
+                    yield return obj;
+
+                    foreach (var nested in enumerate(obj.NestedHitObjects))
+                        yield return nested;
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Osu.UI
         private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
         {
             // Hitobjects that block future hits should miss previous hitobjects if they're hit out-of-order.
-            hitPolicy.HandleHit(result.HitObject);
+            hitPolicy.HandleHit(judgedObject);
 
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/8763

I've refactored the code paths in `OrderedHitPolicy` to both iterate through nested hitobjects.

Originally I implemented it through an enumerator to save on allocations of a LINQ state machine and keep overhead low, but it seems like the difference is negligible on a performance sampling.
We can move back to the enumerator-based version if required (included in this PR's commits).