### PR TITLE
Fix presenting new ruleset and beatmap at once causing wedge display desync

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -360,6 +360,68 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestPresentNewRulesetNewBeatmap()
+        {
+            createSongSelect();
+            changeRuleset(2);
+
+            addRulesetImportStep(2);
+            AddUntilStep("has selection", () => songSelect.Carousel.SelectedBeatmap.RulesetID == 2);
+
+            addRulesetImportStep(0);
+            addRulesetImportStep(0);
+            addRulesetImportStep(0);
+
+            BeatmapInfo target = null;
+
+            AddStep("select beatmap/ruleset externally", () =>
+            {
+                target = manager.GetAllUsableBeatmapSets()
+                                .Last(b => b.Beatmaps.Any(bi => bi.RulesetID == 0)).Beatmaps.Last();
+
+                Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == 0);
+                Beatmap.Value = manager.GetWorkingBeatmap(target);
+            });
+
+            AddUntilStep("has selection", () => songSelect.Carousel.SelectedBeatmap.Equals(target));
+
+            // this is an important check, to make sure updateComponentFromBeatmap() was actually run
+            AddUntilStep("selection shown on wedge", () => songSelect.CurrentBeatmapDetailsBeatmap.BeatmapInfo == target);
+        }
+
+        [Test]
+        public void TestPresentNewBeatmapNewRuleset()
+        {
+            createSongSelect();
+            changeRuleset(2);
+
+            addRulesetImportStep(2);
+            AddUntilStep("has selection", () => songSelect.Carousel.SelectedBeatmap.RulesetID == 2);
+
+            addRulesetImportStep(0);
+            addRulesetImportStep(0);
+            addRulesetImportStep(0);
+
+            BeatmapInfo target = null;
+
+            AddStep("select beatmap/ruleset externally", () =>
+            {
+                target = manager.GetAllUsableBeatmapSets()
+                                .Last(b => b.Beatmaps.Any(bi => bi.RulesetID == 0)).Beatmaps.Last();
+
+                Beatmap.Value = manager.GetWorkingBeatmap(target);
+                Ruleset.Value = rulesets.AvailableRulesets.First(r => r.ID == 0);
+            });
+
+            AddUntilStep("has selection", () => songSelect.Carousel.SelectedBeatmap.Equals(target));
+
+            AddUntilStep("has correct ruleset", () => Ruleset.Value.ID == 0);
+
+            // this is an important check, to make sure updateComponentFromBeatmap() was actually run
+            AddUntilStep("selection shown on wedge", () => songSelect.CurrentBeatmapDetailsBeatmap.BeatmapInfo == target);
+        }
+
+        [Test]
         public void TestRulesetChangeResetsMods()
         {
             createSongSelect();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -448,8 +448,10 @@ namespace osu.Game.Screens.Select
                 {
                     Mods.Value = Array.Empty<Mod>();
 
-                    // required to return once in order to have the carousel in a good state.
-                    // if the ruleset changed, the rest of the selection update will happen via updateSelectedRuleset.
+                    // the ruleset transfer may cause a deselection of the current beatmap (due to incompatibility).
+                    // this can happen via Carousel.FlushPendingFilterOperations().
+                    // to ensure a good state, re-transfer no-debounce values.
+                    performUpdateSelected();
                     return;
                 }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8344

Previously, if `OsuGame.PresentBeatmap` was called in a scenario where it would change the ruleset and beatmap while song select was already visible, the following flow would happen:

- Ruleset is changed, triggering `transferRulesetValue` and returning, under the presumption that this would end up calling `performUpdateSelected` again.
- This would not necessarily happen if the current beatmap is not filtered by the ruleset change (ie. convert displayed and selected).
- Due to the early exit, `updateComponentFromBeatmap` would not get hit.

This fix ensures there is a re-run of the `performUpdateSelected` method regardless. It's a very simple fix and should be easy to comprehend why this failed from a review perspective, but tracking down what was going wrong took several hours.

If song select logic regresses again it may be time to rethink this pattern altogether.
