### PR TITLE
Replace AllJudged event logic with HasCompleted bindable

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Rulesets.Mania.Tests
         private const double time_after_tail = 5250;
 
         private List<JudgementResult> judgementResults;
-        private bool allJudgedFired;
 
         /// <summary>
         ///     -----[           ]-----
@@ -283,20 +282,15 @@ namespace osu.Game.Rulesets.Mania.Tests
                     {
                         if (currentPlayer == p) judgementResults.Add(result);
                     };
-                    p.ScoreProcessor.AllJudged += () =>
-                    {
-                        if (currentPlayer == p) allJudgedFired = true;
-                    };
                 };
 
                 LoadScreen(currentPlayer = p);
-                allJudgedFired = false;
                 judgementResults = new List<JudgementResult>();
             });
 
             AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
             AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
-            AddUntilStep("Wait for all judged", () => allJudgedFired);
+            AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
         }
 
         private class ScoreAccessibleReplayPlayer : ReplayPlayer

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
@@ -316,7 +316,6 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private ScoreAccessibleReplayPlayer currentPlayer;
         private List<JudgementResult> judgementResults;
-        private bool allJudgedFired;
 
         private void performTest(List<OsuHitObject> hitObjects, List<ReplayFrame> frames)
         {
@@ -342,20 +341,15 @@ namespace osu.Game.Rulesets.Osu.Tests
                     {
                         if (currentPlayer == p) judgementResults.Add(result);
                     };
-                    p.ScoreProcessor.AllJudged += () =>
-                    {
-                        if (currentPlayer == p) allJudgedFired = true;
-                    };
                 };
 
                 LoadScreen(currentPlayer = p);
-                allJudgedFired = false;
                 judgementResults = new List<JudgementResult>();
             });
 
             AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
             AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
-            AddUntilStep("Wait for all judged", () => allJudgedFired);
+            AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
         }
 
         private class TestHitCircle : HitCircle

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -47,7 +47,6 @@ namespace osu.Game.Rulesets.Osu.Tests
         private const double time_slider_end = 4000;
 
         private List<JudgementResult> judgementResults;
-        private bool allJudgedFired;
 
         /// <summary>
         /// Scenario:
@@ -375,20 +374,15 @@ namespace osu.Game.Rulesets.Osu.Tests
                     {
                         if (currentPlayer == p) judgementResults.Add(result);
                     };
-                    p.ScoreProcessor.AllJudged += () =>
-                    {
-                        if (currentPlayer == p) allJudgedFired = true;
-                    };
                 };
 
                 LoadScreen(currentPlayer = p);
-                allJudgedFired = false;
                 judgementResults = new List<JudgementResult>();
             });
 
             AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
             AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
-            AddUntilStep("Wait for all judged", () => allJudgedFired);
+            AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
         }
 
         private class ScoreAccessibleReplayPlayer : ReplayPlayer

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneSwellJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneSwellJudgements.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         [Test]
         public void TestZeroTickTimeOffsets()
         {
-            AddUntilStep("gameplay finished", () => Player.ScoreProcessor.HasCompleted);
+            AddUntilStep("gameplay finished", () => Player.ScoreProcessor.HasCompleted.Value);
             AddAssert("all tick offsets are 0", () => Player.Results.Where(r => r.HitObject is SwellTick).All(r => r.TimeOffset == 0));
         }
 

--- a/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
@@ -12,11 +13,6 @@ namespace osu.Game.Rulesets.Scoring
 {
     public abstract class JudgementProcessor : Component
     {
-        /// <summary>
-        /// Invoked when all <see cref="HitObject"/>s have been judged by this <see cref="JudgementProcessor"/>.
-        /// </summary>
-        public event Action AllJudged;
-
         /// <summary>
         /// Invoked when a new judgement has occurred. This occurs after the judgement has been processed by this <see cref="JudgementProcessor"/>.
         /// </summary>
@@ -32,10 +28,12 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         public int JudgedHits { get; private set; }
 
+        private readonly BindableBool hasCompleted = new BindableBool();
+
         /// <summary>
         /// Whether all <see cref="Judgement"/>s have been processed.
         /// </summary>
-        public bool HasCompleted => JudgedHits == MaxHits;
+        public IBindable<bool> HasCompleted => hasCompleted;
 
         /// <summary>
         /// Applies a <see cref="IBeatmap"/> to this <see cref="ScoreProcessor"/>.
@@ -60,8 +58,8 @@ namespace osu.Game.Rulesets.Scoring
 
             NewJudgement?.Invoke(result);
 
-            if (HasCompleted)
-                AllJudged?.Invoke();
+            if (JudgedHits == MaxHits)
+                hasCompleted.Value = true;
         }
 
         /// <summary>
@@ -71,6 +69,9 @@ namespace osu.Game.Rulesets.Scoring
         public void RevertResult(JudgementResult result)
         {
             JudgedHits--;
+
+            if (JudgedHits < MaxHits)
+                hasCompleted.Value = false;
 
             RevertResultInternal(result);
         }

--- a/osu.Game/Screens/Play/BreakTracker.cs
+++ b/osu.Game/Screens/Play/BreakTracker.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Play
 
             isBreakTime.Value = getCurrentBreak()?.HasEffect == true
                                 || Clock.CurrentTime < gameplayStartTime
-                                || scoreProcessor?.HasCompleted == true;
+                                || scoreProcessor?.HasCompleted.Value == true;
         }
 
         private BreakPeriod getCurrentBreak()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Screens.Play
             };
 
             // Bind the judgement processors to ourselves
-            ScoreProcessor.AllJudged += onCompletion;
+            ScoreProcessor.HasCompleted.ValueChanged += updateCompletionState;
             HealthProcessor.Failed += onFail;
 
             foreach (var mod in Mods.Value.OfType<IApplicableToScoreProcessor>())
@@ -412,7 +412,7 @@ namespace osu.Game.Screens.Play
 
         private ScheduledDelegate completionProgressDelegate;
 
-        private void onCompletion()
+        private void updateCompletionState(ValueChangedEvent<bool> completionState)
         {
             // screen may be in the exiting transition phase.
             if (!this.IsCurrentScreen())

--- a/osu.Game/Tests/Visual/ModPerfectTestScene.cs
+++ b/osu.Game/Tests/Visual/ModPerfectTestScene.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual
             public bool CheckFailed(bool failed)
             {
                 if (!failed)
-                    return ScoreProcessor.HasCompleted && !HealthProcessor.HasFailed;
+                    return ScoreProcessor.HasCompleted.Value && !HealthProcessor.HasFailed;
 
                 return HealthProcessor.HasFailed;
             }


### PR DESCRIPTION
Dependency for #8800

Now with the dependent PR, the `Player` has to know if a judgement has been reverted after `AllJudged` has been raised, so I've decided to remove the event altogether and replace it with a `Bindable` instead.

## Remarks

- I'm not quite sure about whether to name it `HasCompleted` or `AllJudged` as they mostly serve the same meaning..., went with `HasCompleted`.