### PR TITLE
Allow 10k to be played on a single stage

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             {
                 TargetColumns = (int)Math.Max(1, roundedCircleSize);
 
-                if (TargetColumns > 10)
+                if (TargetColumns > ManiaRuleset.MAX_STAGE_KEYS)
                 {
                     TargetColumns /= 2;
                     Dual = true;

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             {
                 TargetColumns = (int)Math.Max(1, roundedCircleSize);
 
-                if (TargetColumns >= 10)
+                if (TargetColumns > 10)
                 {
                     TargetColumns /= 2;
                     Dual = true;

--- a/osu.Game.Rulesets.Mania/DualStageVariantGenerator.cs
+++ b/osu.Game.Rulesets.Mania/DualStageVariantGenerator.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Game.Rulesets.Mania
+{
+    public class DualStageVariantGenerator
+    {
+        private readonly int singleStageVariant;
+        private readonly InputKey[] stage1LeftKeys;
+        private readonly InputKey[] stage1RightKeys;
+        private readonly InputKey[] stage2LeftKeys;
+        private readonly InputKey[] stage2RightKeys;
+
+        public DualStageVariantGenerator(int singleStageVariant)
+        {
+            this.singleStageVariant = singleStageVariant;
+
+            // 10K is special because it expands towards the centre of the keyboard (VM/BN), rather than towards the edges of the keyboard.
+            if (singleStageVariant == 10)
+            {
+                stage1LeftKeys = new[] { InputKey.Q, InputKey.W, InputKey.E, InputKey.R, InputKey.V };
+                stage1RightKeys = new[] { InputKey.M, InputKey.I, InputKey.O, InputKey.P, InputKey.BracketLeft };
+
+                stage2LeftKeys = new[] { InputKey.S, InputKey.D, InputKey.F, InputKey.G, InputKey.B };
+                stage2RightKeys = new[] { InputKey.N, InputKey.J, InputKey.K, InputKey.L, InputKey.Semicolon };
+            }
+            else
+            {
+                stage1LeftKeys = new[] { InputKey.Q, InputKey.W, InputKey.E, InputKey.R };
+                stage1RightKeys = new[] { InputKey.I, InputKey.O, InputKey.P, InputKey.BracketLeft };
+
+                stage2LeftKeys = new[] { InputKey.S, InputKey.D, InputKey.F, InputKey.G };
+                stage2RightKeys = new[] { InputKey.J, InputKey.K, InputKey.L, InputKey.Semicolon };
+            }
+        }
+
+        public IEnumerable<KeyBinding> GenerateMappings()
+        {
+            var stage1Bindings = new VariantMappingGenerator
+            {
+                LeftKeys = stage1LeftKeys,
+                RightKeys = stage1RightKeys,
+                SpecialKey = InputKey.V,
+                SpecialAction = ManiaAction.Special1,
+                NormalActionStart = ManiaAction.Key1
+            }.GenerateKeyBindingsFor(singleStageVariant, out var nextNormal);
+
+            var stage2Bindings = new VariantMappingGenerator
+            {
+                LeftKeys = stage2LeftKeys,
+                RightKeys = stage2RightKeys,
+                SpecialKey = InputKey.B,
+                SpecialAction = ManiaAction.Special2,
+                NormalActionStart = nextNormal
+            }.GenerateKeyBindingsFor(singleStageVariant, out _);
+
+            return stage1Bindings.Concat(stage2Bindings);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/ManiaInputManager.cs
+++ b/osu.Game.Rulesets.Mania/ManiaInputManager.cs
@@ -78,5 +78,11 @@ namespace osu.Game.Rulesets.Mania
 
         [Description("Key 18")]
         Key18,
+
+        [Description("Key 19")]
+        Key19,
+
+        [Description("Key 20")]
+        Key20,
     }
 }

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -35,6 +35,11 @@ namespace osu.Game.Rulesets.Mania
 {
     public class ManiaRuleset : Ruleset, ILegacyRuleset
     {
+        /// <summary>
+        /// The maximum number of supported keys in a single stage.
+        /// </summary>
+        public const int MAX_STAGE_KEYS = 10;
+
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableManiaRuleset(this, beatmap, mods);
 
         public override ScoreProcessor CreateScoreProcessor() => new ManiaScoreProcessor();
@@ -251,9 +256,9 @@ namespace osu.Game.Rulesets.Mania
         {
             get
             {
-                for (int i = 1; i <= 10; i++)
+                for (int i = 1; i <= MAX_STAGE_KEYS; i++)
                     yield return (int)PlayfieldType.Single + i;
-                for (int i = 2; i <= 20; i += 2)
+                for (int i = 2; i <= MAX_STAGE_KEYS * 2; i += 2)
                     yield return (int)PlayfieldType.Dual + i;
             }
         }

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -284,6 +284,8 @@ namespace osu.Game.Rulesets.Mania
                                     InputKey.L,
                                     InputKey.Semicolon,
                                 },
+                                SpecialKey = InputKey.Space,
+                                SpecialAction = ManiaAction.Special1,
                                 NormalActionStart = ManiaAction.Key1,
                             }.GenerateKeyBindingsFor(variant, out _);
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -202,6 +202,7 @@ namespace osu.Game.Rulesets.Mania
                             new ManiaModKey7(),
                             new ManiaModKey8(),
                             new ManiaModKey9(),
+                            new ManiaModKey10(),
                             new ManiaModKey1(),
                             new ManiaModKey2(),
                             new ManiaModKey3()),
@@ -252,7 +253,7 @@ namespace osu.Game.Rulesets.Mania
             {
                 for (int i = 1; i <= 10; i++)
                     yield return (int)PlayfieldType.Single + i;
-                for (int i = 2; i <= 18; i += 2)
+                for (int i = 2; i <= 20; i += 2)
                     yield return (int)PlayfieldType.Dual + i;
             }
         }
@@ -262,102 +263,10 @@ namespace osu.Game.Rulesets.Mania
             switch (getPlayfieldType(variant))
             {
                 case PlayfieldType.Single:
-                    switch (variant)
-                    {
-                        case 10:
-                            // 10K is special because it extents one key towards the centre of the keyboard (V/N), rather than towards the edges of the keyboard.
-                            return new VariantMappingGenerator
-                            {
-                                LeftKeys = new[]
-                                {
-                                    InputKey.A,
-                                    InputKey.S,
-                                    InputKey.D,
-                                    InputKey.F,
-                                    InputKey.V
-                                },
-                                RightKeys = new[]
-                                {
-                                    InputKey.N,
-                                    InputKey.J,
-                                    InputKey.K,
-                                    InputKey.L,
-                                    InputKey.Semicolon,
-                                },
-                                SpecialKey = InputKey.Space,
-                                SpecialAction = ManiaAction.Special1,
-                                NormalActionStart = ManiaAction.Key1,
-                            }.GenerateKeyBindingsFor(variant, out _);
-
-                        default:
-                            return new VariantMappingGenerator
-                            {
-                                LeftKeys = new[]
-                                {
-                                    InputKey.A,
-                                    InputKey.S,
-                                    InputKey.D,
-                                    InputKey.F
-                                },
-                                RightKeys = new[]
-                                {
-                                    InputKey.J,
-                                    InputKey.K,
-                                    InputKey.L,
-                                    InputKey.Semicolon
-                                },
-                                SpecialKey = InputKey.Space,
-                                SpecialAction = ManiaAction.Special1,
-                                NormalActionStart = ManiaAction.Key1,
-                            }.GenerateKeyBindingsFor(variant, out _);
-                    }
+                    return new SingleStageVariantGenerator(variant).GenerateMappings();
 
                 case PlayfieldType.Dual:
-                    int keys = getDualStageKeyCount(variant);
-
-                    var stage1Bindings = new VariantMappingGenerator
-                    {
-                        LeftKeys = new[]
-                        {
-                            InputKey.Q,
-                            InputKey.W,
-                            InputKey.E,
-                            InputKey.R,
-                        },
-                        RightKeys = new[]
-                        {
-                            InputKey.X,
-                            InputKey.C,
-                            InputKey.V,
-                            InputKey.B
-                        },
-                        SpecialKey = InputKey.S,
-                        SpecialAction = ManiaAction.Special1,
-                        NormalActionStart = ManiaAction.Key1
-                    }.GenerateKeyBindingsFor(keys, out var nextNormal);
-
-                    var stage2Bindings = new VariantMappingGenerator
-                    {
-                        LeftKeys = new[]
-                        {
-                            InputKey.Number7,
-                            InputKey.Number8,
-                            InputKey.Number9,
-                            InputKey.Number0
-                        },
-                        RightKeys = new[]
-                        {
-                            InputKey.K,
-                            InputKey.L,
-                            InputKey.Semicolon,
-                            InputKey.Quote
-                        },
-                        SpecialKey = InputKey.I,
-                        SpecialAction = ManiaAction.Special2,
-                        NormalActionStart = nextNormal
-                    }.GenerateKeyBindingsFor(keys, out _);
-
-                    return stage1Bindings.Concat(stage2Bindings);
+                    return new DualStageVariantGenerator(getDualStageKeyCount(variant)).GenerateMappings();
             }
 
             return Array.Empty<KeyBinding>();
@@ -392,59 +301,6 @@ namespace osu.Game.Rulesets.Mania
         private PlayfieldType getPlayfieldType(int variant)
         {
             return (PlayfieldType)Enum.GetValues(typeof(PlayfieldType)).Cast<int>().OrderByDescending(i => i).First(v => variant >= v);
-        }
-
-        private class VariantMappingGenerator
-        {
-            /// <summary>
-            /// All the <see cref="InputKey"/>s available to the left hand.
-            /// </summary>
-            public InputKey[] LeftKeys;
-
-            /// <summary>
-            /// All the <see cref="InputKey"/>s available to the right hand.
-            /// </summary>
-            public InputKey[] RightKeys;
-
-            /// <summary>
-            /// The <see cref="InputKey"/> for the special key.
-            /// </summary>
-            public InputKey SpecialKey;
-
-            /// <summary>
-            /// The <see cref="ManiaAction"/> at which the normal columns should begin.
-            /// </summary>
-            public ManiaAction NormalActionStart;
-
-            /// <summary>
-            /// The <see cref="ManiaAction"/> for the special column.
-            /// </summary>
-            public ManiaAction SpecialAction;
-
-            /// <summary>
-            /// Generates a list of <see cref="KeyBinding"/>s for a specific number of columns.
-            /// </summary>
-            /// <param name="columns">The number of columns that need to be bound.</param>
-            /// <param name="nextNormalAction">The next <see cref="ManiaAction"/> to use for normal columns.</param>
-            /// <returns>The keybindings.</returns>
-            public IEnumerable<KeyBinding> GenerateKeyBindingsFor(int columns, out ManiaAction nextNormalAction)
-            {
-                ManiaAction currentNormalAction = NormalActionStart;
-
-                var bindings = new List<KeyBinding>();
-
-                for (int i = LeftKeys.Length - columns / 2; i < LeftKeys.Length; i++)
-                    bindings.Add(new KeyBinding(LeftKeys[i], currentNormalAction++));
-
-                if (columns % 2 == 1)
-                    bindings.Add(new KeyBinding(SpecialKey, SpecialAction));
-
-                for (int i = 0; i < columns / 2; i++)
-                    bindings.Add(new KeyBinding(RightKeys[i], currentNormalAction++));
-
-                nextNormalAction = currentNormalAction;
-                return bindings;
-            }
         }
     }
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Rulesets.Mania
         {
             get
             {
-                for (int i = 1; i <= 9; i++)
+                for (int i = 1; i <= 10; i++)
                     yield return (int)PlayfieldType.Single + i;
                 for (int i = 2; i <= 18; i += 2)
                     yield return (int)PlayfieldType.Dual + i;
@@ -262,26 +262,53 @@ namespace osu.Game.Rulesets.Mania
             switch (getPlayfieldType(variant))
             {
                 case PlayfieldType.Single:
-                    return new VariantMappingGenerator
+                    switch (variant)
                     {
-                        LeftKeys = new[]
-                        {
-                            InputKey.A,
-                            InputKey.S,
-                            InputKey.D,
-                            InputKey.F
-                        },
-                        RightKeys = new[]
-                        {
-                            InputKey.J,
-                            InputKey.K,
-                            InputKey.L,
-                            InputKey.Semicolon
-                        },
-                        SpecialKey = InputKey.Space,
-                        SpecialAction = ManiaAction.Special1,
-                        NormalActionStart = ManiaAction.Key1,
-                    }.GenerateKeyBindingsFor(variant, out _);
+                        case 10:
+                            // 10K is special because it extents one key towards the centre of the keyboard (V/N), rather than towards the edges of the keyboard.
+                            return new VariantMappingGenerator
+                            {
+                                LeftKeys = new[]
+                                {
+                                    InputKey.A,
+                                    InputKey.S,
+                                    InputKey.D,
+                                    InputKey.F,
+                                    InputKey.V
+                                },
+                                RightKeys = new[]
+                                {
+                                    InputKey.N,
+                                    InputKey.J,
+                                    InputKey.K,
+                                    InputKey.L,
+                                    InputKey.Semicolon,
+                                },
+                                NormalActionStart = ManiaAction.Key1,
+                            }.GenerateKeyBindingsFor(variant, out _);
+
+                        default:
+                            return new VariantMappingGenerator
+                            {
+                                LeftKeys = new[]
+                                {
+                                    InputKey.A,
+                                    InputKey.S,
+                                    InputKey.D,
+                                    InputKey.F
+                                },
+                                RightKeys = new[]
+                                {
+                                    InputKey.J,
+                                    InputKey.K,
+                                    InputKey.L,
+                                    InputKey.Semicolon
+                                },
+                                SpecialKey = InputKey.Space,
+                                SpecialAction = ManiaAction.Special1,
+                                NormalActionStart = ManiaAction.Key1,
+                            }.GenerateKeyBindingsFor(variant, out _);
+                    }
 
                 case PlayfieldType.Dual:
                     int keys = getDualStageKeyCount(variant);

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModKey10 : ManiaKeyMod
+    {
+        public override int KeyCount => 10;
+        public override string Name => "Ten Keys";
+        public override string Acronym => "10K";
+        public override string Description => @"Play with ten keys.";
+    }
+}

--- a/osu.Game.Rulesets.Mania/SingleStageVariantGenerator.cs
+++ b/osu.Game.Rulesets.Mania/SingleStageVariantGenerator.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Game.Rulesets.Mania
+{
+    public class SingleStageVariantGenerator
+    {
+        private readonly int variant;
+        private readonly InputKey[] leftKeys;
+        private readonly InputKey[] rightKeys;
+
+        public SingleStageVariantGenerator(int variant)
+        {
+            this.variant = variant;
+
+            // 10K is special because it expands towards the centre of the keyboard (V/N), rather than towards the edges of the keyboard.
+            if (variant == 10)
+            {
+                leftKeys = new[] { InputKey.A, InputKey.S, InputKey.D, InputKey.F, InputKey.V };
+                rightKeys = new[] { InputKey.N, InputKey.J, InputKey.K, InputKey.L, InputKey.Semicolon };
+            }
+            else
+            {
+                leftKeys = new[] { InputKey.A, InputKey.S, InputKey.D, InputKey.F };
+                rightKeys = new[] { InputKey.J, InputKey.K, InputKey.L, InputKey.Semicolon };
+            }
+        }
+
+        public IEnumerable<KeyBinding> GenerateMappings() => new VariantMappingGenerator
+        {
+            LeftKeys = leftKeys,
+            RightKeys = rightKeys,
+            SpecialKey = InputKey.Space,
+            SpecialAction = ManiaAction.Special1,
+            NormalActionStart = ManiaAction.Key1,
+        }.GenerateKeyBindingsFor(variant, out _);
+    }
+}

--- a/osu.Game.Rulesets.Mania/VariantMappingGenerator.cs
+++ b/osu.Game.Rulesets.Mania/VariantMappingGenerator.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Game.Rulesets.Mania
+{
+    public class VariantMappingGenerator
+    {
+        /// <summary>
+        /// All the <see cref="InputKey"/>s available to the left hand.
+        /// </summary>
+        public InputKey[] LeftKeys;
+
+        /// <summary>
+        /// All the <see cref="InputKey"/>s available to the right hand.
+        /// </summary>
+        public InputKey[] RightKeys;
+
+        /// <summary>
+        /// The <see cref="InputKey"/> for the special key.
+        /// </summary>
+        public InputKey SpecialKey;
+
+        /// <summary>
+        /// The <see cref="ManiaAction"/> at which the normal columns should begin.
+        /// </summary>
+        public ManiaAction NormalActionStart;
+
+        /// <summary>
+        /// The <see cref="ManiaAction"/> for the special column.
+        /// </summary>
+        public ManiaAction SpecialAction;
+
+        /// <summary>
+        /// Generates a list of <see cref="KeyBinding"/>s for a specific number of columns.
+        /// </summary>
+        /// <param name="columns">The number of columns that need to be bound.</param>
+        /// <param name="nextNormalAction">The next <see cref="ManiaAction"/> to use for normal columns.</param>
+        /// <returns>The keybindings.</returns>
+        public IEnumerable<KeyBinding> GenerateKeyBindingsFor(int columns, out ManiaAction nextNormalAction)
+        {
+            ManiaAction currentNormalAction = NormalActionStart;
+
+            var bindings = new List<KeyBinding>();
+
+            for (int i = LeftKeys.Length - columns / 2; i < LeftKeys.Length; i++)
+                bindings.Add(new KeyBinding(LeftKeys[i], currentNormalAction++));
+
+            if (columns % 2 == 1)
+                bindings.Add(new KeyBinding(SpecialKey, SpecialAction));
+
+            for (int i = 0; i < columns / 2; i++)
+                bindings.Add(new KeyBinding(RightKeys[i], currentNormalAction++));
+
+            nextNormalAction = currentNormalAction;
+            return bindings;
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/8780

Default keybindings: `A S D F V N J K L ;`
A little different from the proposal, mainly because our second hand bindings start on J rather than K.

Not implementing the 10K mod yet, because that needs implementation for 20K via dual stages and I couldn't figure out good bindings for that.

Probably want to clean this up at some point.