### PR TITLE
Fix control point overriding working incorrectly

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -241,6 +241,11 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var controlPoints = decoder.Decode(stream).ControlPointInfo;
 
+                Assert.That(controlPoints.TimingPoints.Count, Is.EqualTo(4));
+                Assert.That(controlPoints.DifficultyPoints.Count, Is.EqualTo(3));
+                Assert.That(controlPoints.EffectPoints.Count, Is.EqualTo(3));
+                Assert.That(controlPoints.SamplePoints.Count, Is.EqualTo(3));
+
                 Assert.That(controlPoints.DifficultyPointAt(500).SpeedMultiplier, Is.EqualTo(1.5).Within(0.1));
                 Assert.That(controlPoints.DifficultyPointAt(1500).SpeedMultiplier, Is.EqualTo(1.5).Within(0.1));
                 Assert.That(controlPoints.DifficultyPointAt(2500).SpeedMultiplier, Is.EqualTo(0.75).Within(0.1));


### PR DESCRIPTION
Consider the scenario:
```
<difficulty-point @ t=0>
<difficulty-point @ t=100> (same as previous)
<timing-point @ t=100> (different to previous)
```

Since an overlapping difficulty point is always preferred over a timing point but the second difficulty point is equivalent to the previous difficulty point, there should be no difficulty point added to the CPI.
But since the previous code immediately wrote the timing point's control points to the list, the de-duping code inside CPI would fail when the second difficulty point would be flushed later.