### PR TITLE
Fix beatmap string output having empty brackets when pieces are missing

### DIFF
--- a/osu.Game.Tests/Beatmaps/ToStringFormattingTest.cs
+++ b/osu.Game.Tests/Beatmaps/ToStringFormattingTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    [TestFixture]
+    public class ToStringFormattingTest
+    {
+        [Test]
+        public void TestArtistTitle()
+        {
+            var beatmap = new BeatmapInfo
+            {
+                Metadata = new BeatmapMetadata
+                {
+                    Artist = "artist",
+                    Title = "title"
+                }
+            };
+
+            Assert.That(beatmap.ToString(), Is.EqualTo("artist - title"));
+        }
+
+        [Test]
+        public void TestArtistTitleCreator()
+        {
+            var beatmap = new BeatmapInfo
+            {
+                Metadata = new BeatmapMetadata
+                {
+                    Artist = "artist",
+                    Title = "title",
+                    Author = new User { Username = "creator" }
+                }
+            };
+
+            Assert.That(beatmap.ToString(), Is.EqualTo("artist - title (creator)"));
+        }
+
+        [Test]
+        public void TestArtistTitleCreatorDifficulty()
+        {
+            var beatmap = new BeatmapInfo
+            {
+                Metadata = new BeatmapMetadata
+                {
+                    Artist = "artist",
+                    Title = "title",
+                    Author = new User { Username = "creator" }
+                },
+                Version = "difficulty"
+            };
+
+            Assert.That(beatmap.ToString(), Is.EqualTo("artist - title (creator) [difficulty]"));
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -149,7 +149,12 @@ namespace osu.Game.Beatmaps
             }
         }
 
-        public override string ToString() => $"{Metadata} [{Version}]".Trim();
+        public override string ToString()
+        {
+            string version = string.IsNullOrEmpty(Version) ? string.Empty : $"[{Version}]";
+
+            return $"{Metadata} {version}".Trim();
+        }
 
         public bool Equals(BeatmapInfo other)
         {

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -53,7 +53,11 @@ namespace osu.Game.Beatmaps
         public string AudioFile { get; set; }
         public string BackgroundFile { get; set; }
 
-        public override string ToString() => $"{Artist} - {Title} ({Author})";
+        public override string ToString()
+        {
+            string author = Author == null ? string.Empty : $"({Author})";
+            return $"{Artist} - {Title} {author}".Trim();
+        }
 
         [JsonIgnore]
         public string[] SearchableTerms => new[]


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8827
- Adds test coverage