### PR TITLE
Make osu! ruleset placements happen on mouse down

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderPlacementBlueprint.cs
@@ -259,6 +259,23 @@ namespace osu.Game.Rulesets.Osu.Tests
             assertControlPointType(2, PathType.PerfectCurve);
         }
 
+        [Test]
+        public void TestBeginPlacementWithoutReleasingMouse()
+        {
+            addMovementStep(new Vector2(200));
+            AddStep("press left button", () => InputManager.PressButton(MouseButton.Left));
+
+            addMovementStep(new Vector2(400, 200));
+            AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            addClickStep(MouseButton.Right);
+
+            assertPlaced(true);
+            assertLength(200);
+            assertControlPointCount(2);
+            assertControlPointType(0, PathType.Linear);
+        }
+
         private void addMovementStep(Vector2 position) => AddStep($"move mouse to {position}", () => InputManager.MoveMouseTo(InputManager.ToScreenSpace(position)));
 
         private void addClickStep(MouseButton button)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -33,17 +33,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
         {
             if (e.Button == MouseButton.Left)
             {
-                BeginPlacement();
+                EndPlacement(true);
                 return true;
             }
 
             return base.OnMouseDown(e);
-        }
-
-        protected override void OnMouseUp(MouseUpEvent e)
-        {
-            if (e.Button == MouseButton.Left)
-                EndPlacement(true);
         }
 
         public override void UpdatePosition(Vector2 screenSpacePosition) => HitObject.Position = ToLocalSpace(screenSpacePosition);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -6,6 +6,7 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
 {
@@ -28,16 +29,23 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
             circlePiece.UpdateFrom(HitObject);
         }
 
-        protected override bool OnClick(ClickEvent e)
+        protected override bool OnMouseDown(MouseDownEvent e)
         {
-            EndPlacement(true);
-            return true;
+            if (e.Button == MouseButton.Left)
+            {
+                BeginPlacement();
+                return true;
+            }
+
+            return base.OnMouseDown(e);
         }
 
-        public override void UpdatePosition(Vector2 screenSpacePosition)
+        protected override void OnMouseUp(MouseUpEvent e)
         {
-            BeginPlacement();
-            HitObject.Position = ToLocalSpace(screenSpacePosition);
+            if (e.Button == MouseButton.Left)
+                EndPlacement(true);
         }
+
+        public override void UpdatePosition(Vector2 screenSpacePosition) => HitObject.Position = ToLocalSpace(screenSpacePosition);
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         public Action<PathControlPointPiece, MouseButtonEvent> RequestSelection;
 
         public readonly BindableBool IsSelected = new BindableBool();
-
         public readonly PathControlPoint ControlPoint;
 
         private readonly Slider slider;
@@ -146,6 +145,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         protected override bool OnDragStart(DragStartEvent e)
         {
+            if (RequestSelection == null)
+                return false;
+
             if (e.Button == MouseButton.Left)
             {
                 changeHandler?.BeginChange();

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -82,8 +82,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             }
         }
 
-        protected override bool OnClick(ClickEvent e)
+        protected override bool OnMouseDown(MouseDownEvent e)
         {
+            if (e.Button != MouseButton.Left)
+                return base.OnMouseDown(e);
+
             switch (state)
             {
                 case PlacementState.Initial:
@@ -91,9 +94,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                     break;
 
                 case PlacementState.Body:
-                    if (e.Button != MouseButton.Left)
-                        break;
-
                     if (canPlaceNewControlPoint(out var lastPoint))
                     {
                         // Place a new point by detatching the current cursor.
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                         currentSegmentLength = 1;
                     }
 
-                    return true;
+                    break;
             }
 
             return true;


### PR DESCRIPTION
Definitely feels better. For hitcircles, the position keeps updating while the mouse button hasn't been released, but the placement doesn't show - only the blueprint changes.