### PR TITLE
Rename editor tests namespace from "Editor" to "Editing"

### DIFF
--- a/osu.Game.Tests/Editing/EditorChangeHandlerTest.cs
+++ b/osu.Game.Tests/Editing/EditorChangeHandlerTest.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Edit;
 
-namespace osu.Game.Tests.Editor
+namespace osu.Game.Tests.Editing
 {
     [TestFixture]
     public class EditorChangeHandlerTest

--- a/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
+++ b/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
@@ -17,7 +17,7 @@ using osu.Game.Screens.Edit;
 using osuTK;
 using Decoder = osu.Game.Beatmaps.Formats.Decoder;
 
-namespace osu.Game.Tests.Editor
+namespace osu.Game.Tests.Editing
 {
     [TestFixture]
     public class LegacyEditorBeatmapPatcherTest

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -14,7 +14,7 @@ using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Screens.Edit;
 using osu.Game.Tests.Visual;
 
-namespace osu.Game.Tests.Editor
+namespace osu.Game.Tests.Editing
 {
     [HeadlessTest]
     public class TestSceneHitObjectComposerDistanceSnapping : EditorClockTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -14,7 +14,7 @@ using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 using osuTK.Input;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     public class TestSceneBeatDivisorControl : OsuManualInputManagerTestScene
     {

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeScreen.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneComposeScreen : EditorClockTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -13,7 +13,7 @@ using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     public class TestSceneDistanceSnapGrid : EditorClockTestScene
     {

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorChangeStates.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorChangeStates.cs
@@ -11,7 +11,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     public class TestSceneEditorChangeStates : ScreenTestScene
     {
@@ -162,7 +162,7 @@ namespace osu.Game.Tests.Visual.Editor
 
         private void addRedoSteps() => AddStep("redo", () => editor.Redo());
 
-        private class TestEditor : Screens.Edit.Editor
+        private class TestEditor : Editor
         {
             public new void Undo() => base.Undo();
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorComposeRadioButtons.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorComposeRadioButtons.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Edit.Components.RadioButtons;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneEditorComposeRadioButtons : OsuTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorMenuBar.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorMenuBar.cs
@@ -10,7 +10,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Edit.Components.Menus;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneEditorMenuBar : OsuTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSeekSnapping.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSeekSnapping.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneEditorSeekSnapping : EditorClockTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSummaryTimeline.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSummaryTimeline.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
 using osuTK;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneEditorSummaryTimeline : EditorClockTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectComposer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectComposer.cs
@@ -20,7 +20,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneHitObjectComposer : EditorClockTestScene

--- a/osu.Game.Tests/Visual/Editing/TestScenePlaybackControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlaybackControl.cs
@@ -9,7 +9,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Screens.Edit.Components;
 using osuTK;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestScenePlaybackControl : OsuTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineBlueprintContainer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineBlueprintContainer.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneTimelineBlueprintContainer : TimelineTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineTickDisplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineTickDisplay.cs
@@ -8,7 +8,7 @@ using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneTimelineTickDisplay : TimelineTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Timing;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneTimingScreen : EditorClockTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneWaveform.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneWaveform.cs
@@ -14,7 +14,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Osu;
 using osuTK.Graphics;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     [TestFixture]
     public class TestSceneWaveform : OsuTestScene

--- a/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
@@ -15,7 +15,7 @@ using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     public class TestSceneZoomableScrollContainer : OsuManualInputManagerTestScene
     {

--- a/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
+++ b/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
@@ -18,7 +18,7 @@ using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Tests.Visual.Editor
+namespace osu.Game.Tests.Visual.Editing
 {
     public abstract class TimelineTestScene : EditorClockTestScene
     {


### PR DESCRIPTION
Shouldn't be used as it makes using the `Editor` class requires writing the full namespace of it (`Screens.Edit.Editor`)

I was initially going to pick up `Edit` to line up with the namespace used in game `osu.Game.Screens.Edit` but it was a bit short for a visual test, so chose `Editing`.