### PR TITLE
Fix crash on switching comments page at an inopportune time

### DIFF
--- a/osu.Game/Overlays/Comments/CommentsContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentsContainer.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Overlays.Comments
             request?.Cancel();
             loadCancellation?.Cancel();
             request = new GetCommentsRequest(id.Value, type.Value, Sort.Value, currentPage++, 0);
-            request.Success += onSuccess;
+            request.Success += res => Schedule(() => onSuccess(res));
             api.PerformAsync(request);
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8690

Should be obvious enough why this was happening.