### PR TITLE
Fix score multiplier being cut off in mod select at higher ui scales

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -117,8 +117,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestManiaMods()
         {
             changeRuleset(3);
-
-            testRankedText(new ManiaRuleset().GetModsFor(ModType.Conversion).First(m => m is ManiaModRandom));
         }
 
         [Test]
@@ -217,15 +215,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             checkLabelColor(() => Color4.White);
         }
 
-        private void testRankedText(Mod mod)
-        {
-            AddUntilStep("check for ranked", () => modSelect.UnrankedLabel.Alpha == 0);
-            selectNext(mod);
-            AddUntilStep("check for unranked", () => modSelect.UnrankedLabel.Alpha != 0);
-            selectPrevious(mod);
-            AddUntilStep("check for ranked", () => modSelect.UnrankedLabel.Alpha == 0);
-        }
-
         private void selectNext(Mod mod) => AddStep($"left click {mod.Name}", () => modSelect.GetModButton(mod)?.SelectNext(1));
 
         private void selectPrevious(Mod mod) => AddStep($"right click {mod.Name}", () => modSelect.GetModButton(mod)?.SelectNext(-1));
@@ -272,7 +261,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             }
 
             public new OsuSpriteText MultiplierLabel => base.MultiplierLabel;
-            public new OsuSpriteText UnrankedLabel => base.UnrankedLabel;
             public new TriangleButton DeselectAllButton => base.DeselectAllButton;
 
             public new Color4 LowMultiplierColour => base.LowMultiplierColour;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -14,8 +14,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Mods.Sections;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mania;
-using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -272,7 +272,7 @@ namespace osu.Game.Overlays.Mods
                                                         Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold),
                                                         Origin = Anchor.CentreLeft,
                                                         Anchor = Anchor.CentreLeft,
-                                                        Width = 70, // to avoid footer from flowing when clicking mods
+                                                        Width = 70, // to prevent footer from flowing when clicking mods
                                                     },
                                                 },
                                             },

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -219,6 +219,8 @@ namespace osu.Game.Overlays.Mods
                                         RelativeSizeAxes = Axes.X,
                                         Width = content_width,
                                         Spacing = new Vector2(footer_button_spacing, footer_button_spacing / 2),
+                                        LayoutDuration = 100,
+                                        LayoutEasing = Easing.OutQuint,
                                         Padding = new MarginPadding
                                         {
                                             Vertical = 15,

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -268,18 +268,30 @@ namespace osu.Game.Overlays.Mods
                                                         Origin = Anchor.CentreLeft,
                                                         Anchor = Anchor.CentreLeft,
                                                     },
-                                                    MultiplierLabel = new OsuSpriteText
+                                                    new FillFlowContainer
                                                     {
-                                                        Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold, fixedWidth: true),
+                                                        AutoSizeAxes = Axes.Both,
                                                         Origin = Anchor.CentreLeft,
                                                         Anchor = Anchor.CentreLeft,
-                                                    },
-                                                    UnrankedLabel = new OsuSpriteText
-                                                    {
-                                                        Text = @"(Unranked)",
-                                                        Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold),
-                                                        Origin = Anchor.CentreLeft,
-                                                        Anchor = Anchor.CentreLeft,
+                                                        Direction = FillDirection.Vertical,
+                                                        LayoutDuration = 100,
+                                                        LayoutEasing = Easing.OutQuint,
+                                                        Children = new Drawable[]
+                                                        {
+                                                            MultiplierLabel = new OsuSpriteText
+                                                            {
+                                                                Font = OsuFont.GetFont(size: 25, weight: FontWeight.Bold, fixedWidth: true),
+                                                                Origin = Anchor.TopCentre,
+                                                                Anchor = Anchor.TopCentre,
+                                                            },
+                                                            UnrankedLabel = new OsuSpriteText
+                                                            {
+                                                                Text = @"(Unranked)",
+                                                                Font = OsuFont.GetFont(size: 15, weight: FontWeight.Bold),
+                                                                Origin = Anchor.TopCentre,
+                                                                Anchor = Anchor.TopCentre,
+                                                            },
+                                                        }
                                                     },
                                                 },
                                             },

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Overlays.Mods
                     {
                         new Dimension(GridSizeMode.Absolute, 90),
                         new Dimension(GridSizeMode.Distributed),
-                        new Dimension(GridSizeMode.Absolute, 70),
+                        new Dimension(GridSizeMode.AutoSize),
                     },
                     Content = new[]
                     {
@@ -197,7 +197,8 @@ namespace osu.Game.Overlays.Mods
                             // Footer
                             new Container
                             {
-                                RelativeSizeAxes = Axes.Both,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
                                 Origin = Anchor.TopCentre,
                                 Anchor = Anchor.TopCentre,
                                 Children = new Drawable[]
@@ -215,7 +216,6 @@ namespace osu.Game.Overlays.Mods
                                         AutoSizeAxes = Axes.Y,
                                         RelativeSizeAxes = Axes.X,
                                         Width = content_width,
-                                        Direction = FillDirection.Horizontal,
                                         Padding = new MarginPadding
                                         {
                                             Vertical = 15,

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -269,9 +269,10 @@ namespace osu.Game.Overlays.Mods
                                                     },
                                                     MultiplierLabel = new OsuSpriteText
                                                     {
-                                                        Font = OsuFont.GetFont(size: 25, weight: FontWeight.Bold, fixedWidth: true),
+                                                        Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold),
                                                         Origin = Anchor.CentreLeft,
                                                         Anchor = Anchor.CentreLeft,
+                                                        Width = 70, // to avoid footer from flowing when clicking mods
                                                     },
                                                 },
                                             },

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Overlays.Mods
         protected readonly TriangleButton CloseButton;
 
         protected readonly OsuSpriteText MultiplierLabel;
-        protected readonly OsuSpriteText UnrankedLabel;
 
         protected override bool BlockNonPositionalInput => false;
 
@@ -268,30 +267,11 @@ namespace osu.Game.Overlays.Mods
                                                         Origin = Anchor.CentreLeft,
                                                         Anchor = Anchor.CentreLeft,
                                                     },
-                                                    new FillFlowContainer
+                                                    MultiplierLabel = new OsuSpriteText
                                                     {
-                                                        AutoSizeAxes = Axes.Both,
+                                                        Font = OsuFont.GetFont(size: 25, weight: FontWeight.Bold, fixedWidth: true),
                                                         Origin = Anchor.CentreLeft,
                                                         Anchor = Anchor.CentreLeft,
-                                                        Direction = FillDirection.Vertical,
-                                                        LayoutDuration = 100,
-                                                        LayoutEasing = Easing.OutQuint,
-                                                        Children = new Drawable[]
-                                                        {
-                                                            MultiplierLabel = new OsuSpriteText
-                                                            {
-                                                                Font = OsuFont.GetFont(size: 25, weight: FontWeight.Bold, fixedWidth: true),
-                                                                Origin = Anchor.TopCentre,
-                                                                Anchor = Anchor.TopCentre,
-                                                            },
-                                                            UnrankedLabel = new OsuSpriteText
-                                                            {
-                                                                Text = @"(Unranked)",
-                                                                Font = OsuFont.GetFont(size: 15, weight: FontWeight.Bold),
-                                                                Origin = Anchor.TopCentre,
-                                                                Anchor = Anchor.TopCentre,
-                                                            },
-                                                        }
                                                     },
                                                 },
                                             },
@@ -340,7 +320,6 @@ namespace osu.Game.Overlays.Mods
         {
             LowMultiplierColour = colours.Red;
             HighMultiplierColour = colours.Green;
-            UnrankedLabel.Colour = colours.Blue;
 
             availableMods = osu.AvailableMods.GetBoundCopy();
 
@@ -444,12 +423,10 @@ namespace osu.Game.Overlays.Mods
         private void updateMods()
         {
             var multiplier = 1.0;
-            var ranked = true;
 
             foreach (var mod in SelectedMods.Value)
             {
                 multiplier *= mod.ScoreMultiplier;
-                ranked &= mod.Ranked;
             }
 
             MultiplierLabel.Text = $"{multiplier:N2}x";
@@ -459,8 +436,6 @@ namespace osu.Game.Overlays.Mods
                 MultiplierLabel.FadeColour(LowMultiplierColour, 200);
             else
                 MultiplierLabel.FadeColour(Color4.White, 200);
-
-            UnrankedLabel.FadeTo(ranked ? 0 : 1, 200);
         }
 
         private void updateModSettings(ValueChangedEvent<IReadOnlyList<Mod>> selectedMods)

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -57,6 +57,8 @@ namespace osu.Game.Overlays.Mods
         protected Color4 HighMultiplierColour;
 
         private const float content_width = 0.8f;
+        private const float footer_button_spacing = 20;
+
         private readonly FillFlowContainer footerContainer;
 
         private SampleChannel sampleOn, sampleOff;
@@ -216,6 +218,7 @@ namespace osu.Game.Overlays.Mods
                                         AutoSizeAxes = Axes.Y,
                                         RelativeSizeAxes = Axes.X,
                                         Width = content_width,
+                                        Spacing = new Vector2(footer_button_spacing, footer_button_spacing / 2),
                                         Padding = new MarginPadding
                                         {
                                             Vertical = 15,
@@ -228,10 +231,8 @@ namespace osu.Game.Overlays.Mods
                                                 Width = 180,
                                                 Text = "Deselect All",
                                                 Action = DeselectAll,
-                                                Margin = new MarginPadding
-                                                {
-                                                    Right = 20
-                                                }
+                                                Origin = Anchor.CentreLeft,
+                                                Anchor = Anchor.CentreLeft,
                                             },
                                             CustomiseButton = new TriangleButton
                                             {
@@ -239,49 +240,47 @@ namespace osu.Game.Overlays.Mods
                                                 Text = "Customisation",
                                                 Action = () => ModSettingsContainer.Alpha = ModSettingsContainer.Alpha == 1 ? 0 : 1,
                                                 Enabled = { Value = false },
-                                                Margin = new MarginPadding
-                                                {
-                                                    Right = 20
-                                                }
+                                                Origin = Anchor.CentreLeft,
+                                                Anchor = Anchor.CentreLeft,
                                             },
                                             CloseButton = new TriangleButton
                                             {
                                                 Width = 180,
                                                 Text = "Close",
                                                 Action = Hide,
-                                                Margin = new MarginPadding
-                                                {
-                                                    Right = 20
-                                                }
+                                                Origin = Anchor.CentreLeft,
+                                                Anchor = Anchor.CentreLeft,
                                             },
-                                            new OsuSpriteText
+                                            new FillFlowContainer
                                             {
-                                                Text = @"Score Multiplier:",
-                                                Font = OsuFont.GetFont(size: 30),
-                                                Margin = new MarginPadding
+                                                AutoSizeAxes = Axes.Both,
+                                                Spacing = new Vector2(footer_button_spacing / 2, 0),
+                                                Origin = Anchor.CentreLeft,
+                                                Anchor = Anchor.CentreLeft,
+                                                Children = new Drawable[]
                                                 {
-                                                    Top = 5,
-                                                    Right = 10
-                                                }
+                                                    new OsuSpriteText
+                                                    {
+                                                        Text = @"Score Multiplier:",
+                                                        Font = OsuFont.GetFont(size: 30),
+                                                        Origin = Anchor.CentreLeft,
+                                                        Anchor = Anchor.CentreLeft,
+                                                    },
+                                                    MultiplierLabel = new OsuSpriteText
+                                                    {
+                                                        Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold, fixedWidth: true),
+                                                        Origin = Anchor.CentreLeft,
+                                                        Anchor = Anchor.CentreLeft,
+                                                    },
+                                                    UnrankedLabel = new OsuSpriteText
+                                                    {
+                                                        Text = @"(Unranked)",
+                                                        Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold),
+                                                        Origin = Anchor.CentreLeft,
+                                                        Anchor = Anchor.CentreLeft,
+                                                    },
+                                                },
                                             },
-                                            MultiplierLabel = new OsuSpriteText
-                                            {
-                                                Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold),
-                                                Margin = new MarginPadding
-                                                {
-                                                    Top = 5
-                                                }
-                                            },
-                                            UnrankedLabel = new OsuSpriteText
-                                            {
-                                                Text = @"(Unranked)",
-                                                Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold),
-                                                Margin = new MarginPadding
-                                                {
-                                                    Top = 5,
-                                                    Left = 10
-                                                }
-                                            }
                                         }
                                     }
                                 },

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -272,7 +272,7 @@ namespace osu.Game.Overlays.Mods
                                                         Font = OsuFont.GetFont(size: 30, weight: FontWeight.Bold),
                                                         Origin = Anchor.CentreLeft,
                                                         Anchor = Anchor.CentreLeft,
-                                                        Width = 70, // to prevent footer from flowing when clicking mods
+                                                        Width = 70, // make width fixed so reflow doesn't occur when multiplier number changes.
                                                     },
                                                 },
                                             },


### PR DESCRIPTION
Notable changes:
- ~Score multiplier number is now fixed width.~
	- ~Won't unnecessarily flow to next row when enabling/disabling mods. Also needed to have more width than the unranked label for layout.~
- ~Unranked label is now under the score multiplier number with a transition when appearing/disappearing.~
	- ~" unranked mods.~
	![8kiB1syLWP](https://user-images.githubusercontent.com/35318437/80268522-8aae1880-865c-11ea-9ca4-53f15663fc64.gif)
- ~Score multiplier number and unranked label text size have changed, 25 and 15 respectively, to add up to the button size of 40.~
	- ~Or it'll autosize the footer when the unranked label is visible.~

~640x480 at 1.60x (max) scale~
![image](https://user-images.githubusercontent.com/35318437/80268508-618d8800-865c-11ea-8468-3045bdb1fa3b.png)