### PR TITLE
Fix ruleset selector not receiving key input on toolbar absence

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -5,13 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Game.Overlays.Toolbar;
+using osu.Game.Rulesets;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Menus
 {
     [TestFixture]
-    public class TestSceneToolbar : OsuTestScene
+    public class TestSceneToolbar : OsuManualInputManagerTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
@@ -21,24 +25,62 @@ namespace osu.Game.Tests.Visual.Menus
             typeof(ToolbarNotificationButton),
         };
 
-        public TestSceneToolbar()
+        private Toolbar toolbar;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
-            var toolbar = new Toolbar { State = { Value = Visibility.Visible } };
+            Child = toolbar = new Toolbar { State = { Value = Visibility.Visible } };
+        });
+
+        [Test]
+        public void TestNotificationCounter()
+        {
             ToolbarNotificationButton notificationButton = null;
 
-            AddStep("create toolbar", () =>
-            {
-                Add(toolbar);
-                notificationButton = toolbar.Children.OfType<FillFlowContainer>().Last().Children.OfType<ToolbarNotificationButton>().First();
-            });
-
-            void setNotifications(int count) => AddStep($"set notification count to {count}", () => notificationButton.NotificationCount.Value = count);
+            AddStep("retrieve notification button", () => notificationButton = toolbar.ChildrenOfType<ToolbarNotificationButton>().Single());
 
             setNotifications(1);
             setNotifications(2);
             setNotifications(3);
             setNotifications(0);
             setNotifications(144);
+
+            void setNotifications(int count)
+                => AddStep($"set notification count to {count}",
+                    () => notificationButton.NotificationCount.Value = count);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestRulesetSwitchingShortcut(bool toolbarHidden)
+        {
+            ToolbarRulesetSelector rulesetSelector = null;
+
+            if (toolbarHidden)
+                AddStep("hide toolbar", () => toolbar.Hide());
+
+            AddStep("retrieve ruleset selector", () => rulesetSelector = toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single());
+
+            for (int i = 0; i < 4; i++)
+            {
+                var expected = rulesets.AvailableRulesets.ElementAt(i);
+                var numberKey = Key.Number1 + i;
+
+                AddStep($"switch to ruleset {i} via shortcut", () =>
+                {
+                    InputManager.PressKey(Key.ControlLeft);
+                    InputManager.PressKey(numberKey);
+
+                    InputManager.ReleaseKey(Key.ControlLeft);
+                    InputManager.ReleaseKey(numberKey);
+                });
+
+                AddUntilStep("ruleset switched", () => rulesetSelector.Current.Value.Equals(expected));
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -33,6 +33,10 @@ namespace osu.Game.Overlays.Toolbar
 
         private readonly Bindable<OverlayActivation> overlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
+        // Required for toolbar components that need to listen for key input
+        // to invoke specific actions while toolbar is in hidden state.
+        public override bool PropagateNonPositionalInputSubTree => true;
+
         public Toolbar()
         {
             RelativeSizeAxes = Axes.X;

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -33,8 +33,7 @@ namespace osu.Game.Overlays.Toolbar
 
         private readonly Bindable<OverlayActivation> overlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
-        // Required for toolbar components that need to listen for key input
-        // to invoke specific actions while toolbar is in hidden state.
+        // Toolbar components like RulesetSelector should receive keyboard input events even when the toolbar is hidden.
         public override bool PropagateNonPositionalInputSubTree => true;
 
         public Toolbar()


### PR DESCRIPTION
Closes #8861 

- [x] Depends on #8862 (for null ref)

Fixes toolbar ruleset selector not receiving key input while the toolbar is not present / hidden off-screen.
