### PR TITLE
Fix custom rulesets not showing correct icons in key binding settings

### DIFF
--- a/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays.Settings;
@@ -9,7 +10,12 @@ namespace osu.Game.Overlays.KeyBinding
 {
     public class GlobalKeyBindingsSection : SettingsSection
     {
-        public override IconUsage Icon => FontAwesome.Solid.Globe;
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.Globe
+        };
+
         public override string Header => "Global";
 
         public GlobalKeyBindingsSection(GlobalActionContainer manager)

--- a/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
@@ -12,7 +12,6 @@ namespace osu.Game.Overlays.KeyBinding
     {
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.Globe
         };
 

--- a/osu.Game/Overlays/KeyBinding/RulesetBindingsSection.cs
+++ b/osu.Game/Overlays/KeyBinding/RulesetBindingsSection.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Overlays.KeyBinding
     {
         public override Drawable CreateIcon() => ruleset?.CreateInstance()?.CreateIcon() ?? new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = OsuIcon.Hot
         };
 

--- a/osu.Game/Overlays/KeyBinding/RulesetBindingsSection.cs
+++ b/osu.Game/Overlays/KeyBinding/RulesetBindingsSection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Overlays.Settings;
@@ -10,7 +11,12 @@ namespace osu.Game.Overlays.KeyBinding
 {
     public class RulesetBindingsSection : SettingsSection
     {
-        public override IconUsage Icon => (ruleset.CreateInstance().CreateIcon() as SpriteIcon)?.Icon ?? OsuIcon.Hot;
+        public override Drawable CreateIcon() => ruleset?.CreateInstance()?.CreateIcon() ?? new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = OsuIcon.Hot
+        };
+
         public override string Header => ruleset.Name;
 
         private readonly RulesetInfo ruleset;

--- a/osu.Game/Overlays/Settings/Sections/AudioSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/AudioSection.cs
@@ -13,9 +13,13 @@ namespace osu.Game.Overlays.Settings.Sections
     {
         public override string Header => "Audio";
 
-        public override IEnumerable<string> FilterTerms => base.FilterTerms.Concat(new[] { "sound" });
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.VolumeUp
+        };
 
-        public override IconUsage Icon => FontAwesome.Solid.VolumeUp;
+        public override IEnumerable<string> FilterTerms => base.FilterTerms.Concat(new[] { "sound" });
 
         public AudioSection()
         {

--- a/osu.Game/Overlays/Settings/Sections/AudioSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/AudioSection.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.VolumeUp
         };
 

--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.Bug
         };
 

--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -10,7 +10,12 @@ namespace osu.Game.Overlays.Settings.Sections
     public class DebugSection : SettingsSection
     {
         public override string Header => "Debug";
-        public override IconUsage Icon => FontAwesome.Solid.Bug;
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.Bug
+        };
 
         public DebugSection()
         {

--- a/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
@@ -13,7 +13,12 @@ namespace osu.Game.Overlays.Settings.Sections
     public class GameplaySection : SettingsSection
     {
         public override string Header => "Gameplay";
-        public override IconUsage Icon => FontAwesome.Regular.Circle;
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Regular.Circle
+        };
 
         public GameplaySection()
         {

--- a/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
@@ -16,7 +16,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Regular.Circle
         };
 

--- a/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.Cog
         };
 

--- a/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
@@ -10,7 +10,12 @@ namespace osu.Game.Overlays.Settings.Sections
     public class GeneralSection : SettingsSection
     {
         public override string Header => "General";
-        public override IconUsage Icon => FontAwesome.Solid.Cog;
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.Cog
+        };
 
         public GeneralSection()
         {

--- a/osu.Game/Overlays/Settings/Sections/GraphicsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GraphicsSection.cs
@@ -10,7 +10,12 @@ namespace osu.Game.Overlays.Settings.Sections
     public class GraphicsSection : SettingsSection
     {
         public override string Header => "Graphics";
-        public override IconUsage Icon => FontAwesome.Solid.Laptop;
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.Laptop
+        };
 
         public GraphicsSection()
         {

--- a/osu.Game/Overlays/Settings/Sections/GraphicsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GraphicsSection.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.Laptop
         };
 

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -10,7 +10,12 @@ namespace osu.Game.Overlays.Settings.Sections
     public class InputSection : SettingsSection
     {
         public override string Header => "Input";
-        public override IconUsage Icon => FontAwesome.Regular.Keyboard;
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.Keyboard
+        };
 
         public InputSection(KeyBindingPanel keyConfig)
         {

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.Keyboard
         };
 

--- a/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
@@ -11,7 +11,12 @@ namespace osu.Game.Overlays.Settings.Sections
     public class MaintenanceSection : SettingsSection
     {
         public override string Header => "Maintenance";
-        public override IconUsage Icon => FontAwesome.Solid.Wrench;
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.Wrench
+        };
 
         public MaintenanceSection()
         {

--- a/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
@@ -14,7 +14,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.Wrench
         };
 

--- a/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
@@ -10,7 +10,12 @@ namespace osu.Game.Overlays.Settings.Sections
     public class OnlineSection : SettingsSection
     {
         public override string Header => "Online";
-        public override IconUsage Icon => FontAwesome.Solid.GlobeAsia;
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.GlobeAsia
+        };
 
         public OnlineSection()
         {

--- a/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
@@ -13,7 +13,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.GlobeAsia
         };
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
-            RelativeSizeAxes = Axes.Both,
             Icon = FontAwesome.Solid.PaintBrush
         };
 

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -19,7 +19,11 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override string Header => "Skin";
 
-        public override IconUsage Icon => FontAwesome.Solid.PaintBrush;
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            RelativeSizeAxes = Axes.Both,
+            Icon = FontAwesome.Solid.PaintBrush
+        };
 
         private readonly Bindable<SkinInfo> dropdownBindable = new Bindable<SkinInfo> { Default = SkinInfo.Default };
         private readonly Bindable<int> configBindable = new Bindable<int>();

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -11,7 +11,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Overlays.Settings
 {
@@ -20,7 +19,7 @@ namespace osu.Game.Overlays.Settings
         protected FillFlowContainer FlowContent;
         protected override Container<Drawable> Content => FlowContent;
 
-        public abstract IconUsage Icon { get; }
+        public abstract Drawable CreateIcon();
         public abstract string Header { get; }
 
         public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();

--- a/osu.Game/Overlays/Settings/SidebarButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarButton.cs
@@ -11,12 +11,13 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Settings
 {
     public class SidebarButton : OsuButton
     {
-        private readonly SpriteIcon drawableIcon;
+        private readonly ConstrainedIconContainer iconContainer;
         private readonly SpriteText headerText;
         private readonly Box selectionIndicator;
         private readonly Container text;
@@ -30,7 +31,7 @@ namespace osu.Game.Overlays.Settings
             {
                 section = value;
                 headerText.Text = value.Header;
-                drawableIcon.Icon = value.Icon;
+                iconContainer.Icon = value.CreateIcon();
             }
         }
 
@@ -78,7 +79,7 @@ namespace osu.Game.Overlays.Settings
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                         },
-                        drawableIcon = new SpriteIcon
+                        iconContainer = new ConstrainedIconContainer
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,


### PR DESCRIPTION
# Summary
This PR allows setting an actual drawable constructed in `SettingsSection.CreateIcon()` as an icon for the Settings Sidebar button; which allows in-turn displaying the custom's ruleset icon in the related keybindings section:
![image](https://user-images.githubusercontent.com/20256717/80288089-da144780-8735-11ea-9e1a-262eefcda3a0.png)

# Remarks
No tests for this as I don't think they are required for such a small feature.