### PR TITLE
Hide red tint when "Show health display even when you can't fail" option is on

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -168,11 +168,13 @@ namespace osu.Game.Screens.Play
                 if (healthBar.NewValue)
                 {
                     HealthDisplay.FadeIn(fade_duration, fade_easing);
+                    FailingLayer.FadeIn(fade_duration, fade_easing);
                     topScoreContainer.MoveToY(30, fade_duration, fade_easing);
                 }
                 else
                 {
                     HealthDisplay.FadeOut(fade_duration, fade_easing);
+                    FailingLayer.FadeOut(fade_duration, fade_easing);
                     topScoreContainer.MoveToY(0, fade_duration, fade_easing);
                 }
             }, true);


### PR DESCRIPTION
Resolves #8789

Implemented based on the "Show health display even when you can't fail" option as suggested by @bdach 