### PR TITLE
Adjust editor timeline current marker to promote tick visibility

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/CentreMarker.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/CentreMarker.cs
@@ -12,14 +12,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public class CentreMarker : CompositeDrawable
     {
-        private const float triangle_width = 20;
+        private const float triangle_width = 15;
         private const float triangle_height = 10;
         private const float bar_width = 2;
 
         public CentreMarker()
         {
             RelativeSizeAxes = Axes.Y;
-            Size = new Vector2(20, 1);
+            Size = new Vector2(triangle_width, 1);
 
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -39,6 +39,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     Origin = Anchor.BottomCentre,
                     Size = new Vector2(triangle_width, triangle_height),
                     Scale = new Vector2(1, -1)
+                },
+                new Triangle
+                {
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Size = new Vector2(triangle_width, triangle_height),
+                    Scale = new Vector2(1, 1)
                 }
             };
         }
@@ -46,7 +53,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            Colour = colours.Red;
+            Colour = colours.RedDark;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/CentreMarker.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/CentreMarker.cs
@@ -45,7 +45,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     Anchor = Anchor.BottomCentre,
                     Origin = Anchor.BottomCentre,
                     Size = new Vector2(triangle_width, triangle_height),
-                    Scale = new Vector2(1, 1)
                 }
             };
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             });
 
             // We don't want the centre marker to scroll
-            AddInternal(new CentreMarker());
+            AddInternal(new CentreMarker { Depth = float.MaxValue });
 
             WaveformVisible.ValueChanged += visible => waveform.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
 


### PR DESCRIPTION
Closes #8871

Probably not a final solution, but definitely feels better than what we had.

![image](https://user-images.githubusercontent.com/191335/80327038-b48e5780-8875-11ea-8698-1d8dbd215b54.gif)

Generally still visible even at the back-most level due to the waveform having transparency. Which means the worse case scenario now is something like this:

![image](https://user-images.githubusercontent.com/191335/80326991-90327b00-8875-11ea-8f8f-e36cd014da49.png)

I also adjusted the colour so it doesn't collide with red ticks:

![image](https://user-images.githubusercontent.com/191335/80327009-9c1e3d00-8875-11ea-914c-ac143df6702e.png)

