### PR TITLE
Fix taiko hit target alpha on legacy skins

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacyHitTarget.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacyHitTarget.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                     {
                         Texture = skin.GetTexture("approachcircle"),
                         Scale = new Vector2(0.73f),
-                        Alpha = 0.7f,
+                        Alpha = 0.47f, // eyeballed to match stable
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                     },
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                     {
                         Texture = skin.GetTexture("taikobigcircle"),
                         Scale = new Vector2(0.7f),
-                        Alpha = 0.5f,
+                        Alpha = 0.22f, // eyeballed to match stable
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                     },


### PR DESCRIPTION
Closes #8853

![image](https://user-images.githubusercontent.com/191335/80355793-7e6fc880-88b3-11ea-8541-16b9a1c9e8e2.png)

lazer (master) | stable | lazer (this pr)

Not quite sure of the reasoning behind this, but alpha applied via stable's `Color` class is dimmer than the equivalent in lazer / photoshop.