### PR TITLE
Create test specific select next beatmap function for TestSceneBeatmapCarousel

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -112,6 +112,17 @@ namespace osu.Game.Tests.Visual.SongSelect
             waitForSelection(set_count, 3);
         }
 
+        [Test]
+        public void TestNoTraversalWithoutInitialSelection()
+        {
+            // This is testing behaviour when carousel root doesn't do eager selection. This is only happens in testing.
+
+            loadBeatmaps();
+            checkNoSelection();
+            advanceSelection(direction: 1, diff: true);
+            checkNoSelection();
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         public void TestTraversalBeyondVisible(bool forwards)
@@ -889,6 +900,14 @@ namespace osu.Game.Tests.Visual.SongSelect
             public bool PendingFilterTask => PendingFilter != null;
 
             protected override IEnumerable<BeatmapSetInfo> GetLoadableBeatmaps() => Enumerable.Empty<BeatmapSetInfo>();
+
+            public new void SelectNext(int direction = 1, bool skipDifficulties = true)
+            {
+                if (!skipDifficulties && SelectedBeatmapSet == null)
+                    return;
+
+                base.SelectNext(direction, skipDifficulties);
+            }
         }
     }
 }


### PR DESCRIPTION
Alternative to and closes #8729

Not to copy the description from that PR... There's a nullref that will crash visual browser when you use ``TestSceneBeatmapCarousel``. When you initially create the carousel, it doesn't have a selection, when you then use <kbd>Up</kbd> or <kbd>Down</kbd>, current selection would be used to select next difficulty.

This PR disables that behaviour while testing. From what I can see, the fact that carousel doesn't have initial selection is actually relied on by some tests (namely those that want to choose what type of initial selection is needed, like testing recommendation function would mean that function needs to be set before initial selection) so you couldn't change actual behaviour to always have initial selection. 
