### PR TITLE
Reduce database includes where possible

### DIFF
--- a/osu.Game/Beatmaps/BeatmapStore.cs
+++ b/osu.Game/Beatmaps/BeatmapStore.cs
@@ -87,6 +87,18 @@ namespace osu.Game.Beatmaps
             base.Purge(items, context);
         }
 
+        public IQueryable<BeatmapSetInfo> BeatmapSetsOverview => ContextFactory.Get().BeatmapSetInfo
+                                                                               .Include(s => s.Metadata)
+                                                                               .Include(s => s.Beatmaps)
+                                                                               .AsNoTracking();
+
+        public IQueryable<BeatmapSetInfo> BeatmapSetsWithoutFiles => ContextFactory.Get().BeatmapSetInfo
+                                                                                   .Include(s => s.Metadata)
+                                                                                   .Include(s => s.Beatmaps).ThenInclude(s => s.Ruleset)
+                                                                                   .Include(s => s.Beatmaps).ThenInclude(b => b.BaseDifficulty)
+                                                                                   .Include(s => s.Beatmaps).ThenInclude(b => b.Metadata)
+                                                                                   .AsNoTracking();
+
         public IQueryable<BeatmapInfo> Beatmaps =>
             ContextFactory.Get().BeatmapInfo
                           .Include(b => b.BeatmapSet).ThenInclude(s => s.Metadata)

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Overlays
             beatmaps.ItemAdded += handleBeatmapAdded;
             beatmaps.ItemRemoved += handleBeatmapRemoved;
 
-            beatmapSets.AddRange(beatmaps.GetAllUsableBeatmapSets().OrderBy(_ => RNG.Next()));
+            beatmapSets.AddRange(beatmaps.GetAllUsableBeatmapSets(IncludedDetails.Minimal).OrderBy(_ => RNG.Next()));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.Menu
 
             if (!MenuMusic.Value)
             {
-                var sets = beatmaps.GetAllUsableBeatmapSets();
+                var sets = beatmaps.GetAllUsableBeatmapSets(IncludedDetails.Minimal);
                 if (sets.Count > 0)
                     setInfo = beatmaps.QueryBeatmapSet(s => s.ID == sets[RNG.Next(0, sets.Count - 1)].ID);
             }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Screens.Select
             loadBeatmapSets(GetLoadableBeatmaps());
         }
 
-        protected virtual IEnumerable<BeatmapSetInfo> GetLoadableBeatmaps() => beatmaps.GetAllUsableBeatmapSetsEnumerable();
+        protected virtual IEnumerable<BeatmapSetInfo> GetLoadableBeatmaps() => beatmaps.GetAllUsableBeatmapSetsEnumerable(IncludedDetails.AllButFiles);
 
         public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
         {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -286,7 +286,7 @@ namespace osu.Game.Screens.Select
                 Schedule(() =>
                 {
                     // if we have no beatmaps but osu-stable is found, let's prompt the user to import.
-                    if (!beatmaps.GetAllUsableBeatmapSetsEnumerable().Any() && beatmaps.StableInstallationAvailable)
+                    if (!beatmaps.GetAllUsableBeatmapSetsEnumerable(IncludedDetails.Minimal).Any() && beatmaps.StableInstallationAvailable)
                     {
                         dialogOverlay.Push(new ImportFromStablePopup(() =>
                         {


### PR DESCRIPTION
Hesitantly PRing this since I already finished it and the improvements are sizable and complexity increase is minimal. Consider this a stop-gap improvement until we move forward with a more final database optimisation (realm or EF core 3.x with lazy-loading).

Using the database provided in #8865 :

BeatmapCarousel:
before: 3min30s
after: 2min15s

MusicController:
before: 2min47s
after: 3s