### PR TITLE
Further improve beatmap carousel load performance by avoiding incorrect query construction

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -300,7 +300,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="includes">The level of detail to include in the returned objects.</param>
         /// <returns>A list of available <see cref="BeatmapSetInfo"/>.</returns>
-        public IQueryable<BeatmapSetInfo> GetAllUsableBeatmapSetsEnumerable(IncludedDetails includes)
+        public IEnumerable<BeatmapSetInfo> GetAllUsableBeatmapSetsEnumerable(IncludedDetails includes)
         {
             IQueryable<BeatmapSetInfo> queryable;
 
@@ -319,7 +319,10 @@ namespace osu.Game.Beatmaps
                     break;
             }
 
-            return queryable.Where(s => !s.DeletePending && !s.Protected);
+            // AsEnumerable used here to avoid applying the WHERE in sql. When done so, ef core 2.x uses an incorrect ORDER BY
+            // clause which causes queries to take 5-10x longer.
+            // TODO: remove if upgrading to EF core 3.x.
+            return queryable.AsEnumerable().Where(s => !s.DeletePending && !s.Protected);
         }
 
         /// <summary>


### PR DESCRIPTION
`BeatmapCarousel` full load time using the database provided in #8865:

before: 133s
after: 20s

Note that this is fixed in EF core 3.x. Without going into too much detail (since this is a temporary fix), the query execution was running `ORDER BY` on an incorrect piece of the complex `JOIN`, resulting in insanely slow non-index ordering.

Removing the `WHERE` is luckily enough to make it run correctly, since we cannot actually fix or control the `ORDER BY` portion (it is used internally for the mapping from sqlite to objects). In this case it is filtering very few rows out so there's no loss from doing post-query filtering.

I've checked all usages of the `GetAllUsableBeatmapSetsEnumerable` function to ensure this will not cause performance regressions where filtering may have been done via `IQueryable` previously. Should be quite safe.