### PR TITLE
Show loading spinner when carousel is not ready to be displayed

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -797,6 +797,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddStep("create song select", () => LoadScreen(songSelect = new TestSongSelect()));
             AddUntilStep("wait for present", () => songSelect.IsCurrentScreen());
+            AddUntilStep("wait for carousel loaded", () => songSelect.Carousel.IsAlive);
         }
 
         private void addManyTestMaps()

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -34,6 +34,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Select
@@ -92,6 +93,8 @@ namespace osu.Game.Screens.Select
         private SampleChannel sampleChangeDifficulty;
         private SampleChannel sampleChangeBeatmap;
 
+        private Container carouselContainer;
+
         protected BeatmapDetailArea BeatmapDetails { get; private set; }
 
         private readonly Bindable<RulesetInfo> decoupledRuleset = new Bindable<RulesetInfo>();
@@ -105,9 +108,22 @@ namespace osu.Game.Screens.Select
             // initial value transfer is required for FilterControl (it uses our re-cached bindables in its async load for the initial filter).
             transferRulesetValue();
 
+            LoadComponentAsync(Carousel = new BeatmapCarousel
+            {
+                AllowSelection = false, // delay any selection until our bindables are ready to make a good choice.
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight,
+                RelativeSizeAxes = Axes.Both,
+                BleedTop = FilterControl.HEIGHT,
+                BleedBottom = Footer.HEIGHT,
+                SelectionChanged = updateSelectedBeatmap,
+                BeatmapSetsChanged = carouselBeatmapsLoaded,
+                GetRecommendedBeatmap = (recommender = new DifficultyRecommender()).GetRecommendedBeatmap,
+            }, c => carouselContainer.Child = c);
+
             AddRangeInternal(new Drawable[]
             {
-                recommender = new DifficultyRecommender(),
+                recommender,
                 new ResetScrollContainer(() => Carousel.ScrollToSelected())
                 {
                     RelativeSizeAxes = Axes.Y,
@@ -139,7 +155,7 @@ namespace osu.Game.Screens.Select
                                             Padding = new MarginPadding { Right = -150 },
                                         },
                                     },
-                                    new Container
+                                    carouselContainer = new Container
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                         Padding = new MarginPadding
@@ -147,18 +163,7 @@ namespace osu.Game.Screens.Select
                                             Top = FilterControl.HEIGHT,
                                             Bottom = Footer.HEIGHT
                                         },
-                                        Child = Carousel = new BeatmapCarousel
-                                        {
-                                            AllowSelection = false, // delay any selection until our bindables are ready to make a good choice.
-                                            Anchor = Anchor.CentreRight,
-                                            Origin = Anchor.CentreRight,
-                                            RelativeSizeAxes = Axes.Both,
-                                            BleedTop = FilterControl.HEIGHT,
-                                            BleedBottom = Footer.HEIGHT,
-                                            SelectionChanged = updateSelectedBeatmap,
-                                            BeatmapSetsChanged = carouselBeatmapsLoaded,
-                                            GetRecommendedBeatmap = recommender.GetRecommendedBeatmap,
-                                        },
+                                        Child = new LoadingSpinner(true) { State = { Value = Visibility.Visible } }
                                     }
                                 },
                             }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Screens.Select
 
         protected BeatmapCarousel Carousel { get; private set; }
 
-        private DifficultyRecommender recommender;
+        private readonly DifficultyRecommender recommender = new DifficultyRecommender();
 
         private BeatmapInfoWedge beatmapInfoWedge;
         private DialogOverlay dialogOverlay;
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
-                GetRecommendedBeatmap = (recommender = new DifficultyRecommender()).GetRecommendedBeatmap,
+                GetRecommendedBeatmap = recommender.GetRecommendedBeatmap,
             }, c => carouselContainer.Child = c);
 
             AddRangeInternal(new Drawable[]


### PR DESCRIPTION
Allows song select to display and only the carousel to continue loading. Much better UX.

![2020-04-30 10 28 19](https://user-images.githubusercontent.com/191335/80667045-097dd800-8ad9-11ea-967d-8cc44172fdd3.gif)

Going to say this closes #8865, as the performance is already quite a lot better. Test using database in #8865 as per usual.