### PR TITLE
Add offline status handling to OverlayView

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
@@ -64,15 +64,6 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("spinner is hidden", () => !view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
         }
 
-        [Test]
-        public void TestPerformFetch()
-        {
-            AddStep("setup API request handler", () => ((DummyAPIAccess)API).HandleRequest = req => Task.Delay(2000).ContinueWith(t => req.TriggerSuccess()));
-            AddStep("perform fetch request", () => view.PerformFetch());
-            AddUntilStep("spinner is visible", () => view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
-            AddUntilStep("spinner hid on request completion", () => !view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
-        }
-
         private class TestOverlayView : OverlayView<DummyData>
         {
             public IEnumerable<Drawable> InternalContents => InternalChildren;

--- a/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
+using osu.Game.Online.Placeholders;
+using osu.Game.Overlays;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public class TestSceneOverlayView : OsuTestScene
+    {
+        private readonly TestOverlayView view;
+
+        public TestSceneOverlayView()
+        {
+            Child = view = new TestOverlayView
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+            };
+        }
+
+        [Test]
+        public void TestOfflineStatus()
+        {
+            AddStep("set status to offline", () => ((DummyAPIAccess)API).State = APIState.Offline);
+            AddUntilStep("placeholder is visible", () => view.InternalContents.OfType<LoginPlaceholder>().First().IsPresent);
+            AddUntilStep("spinner is hidden", () => !view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
+        }
+
+        [Test]
+        public void TestConnectingStatus()
+        {
+            AddStep("set status to connecting", () => ((DummyAPIAccess)API).State = APIState.Connecting);
+            AddUntilStep("placeholder is hidden", () => !view.InternalContents.OfType<LoginPlaceholder>().First().IsPresent);
+            AddUntilStep("spinner is visible", () => view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
+        }
+
+        [Test]
+        public void TestFailingStatus()
+        {
+            AddStep("set status to failing", () => ((DummyAPIAccess)API).State = APIState.Failing);
+            AddUntilStep("placeholder is hidden", () => !view.InternalContents.OfType<LoginPlaceholder>().First().IsPresent);
+            AddUntilStep("spinner is visible", () => view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
+        }
+
+        [Test]
+        public void TestOnlineStatus()
+        {
+            AddStep("setup API request handler", () => ((DummyAPIAccess)API).HandleRequest = req => req.TriggerSuccess());
+            AddStep("set status to online", () => ((DummyAPIAccess)API).State = APIState.Online);
+            AddUntilStep("placeholder is hidden", () => !view.InternalContents.OfType<LoginPlaceholder>().First().IsPresent);
+            AddUntilStep("spinner is hidden", () => !view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
+        }
+
+        [Test]
+        public void TestPerformFetch()
+        {
+            AddStep("setup API request handler", () => ((DummyAPIAccess)API).HandleRequest = req => Task.Delay(2000).ContinueWith(t => req.TriggerSuccess()));
+            AddStep("perform fetch request", () => view.PerformFetch());
+            AddUntilStep("spinner is visible", () => view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
+            AddUntilStep("spinner hid on request completion", () => !view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
+        }
+
+        private class TestOverlayView : OverlayView<DummyData>
+        {
+            public IEnumerable<Drawable> InternalContents => InternalChildren;
+
+            public new void PerformFetch() => base.PerformFetch();
+
+            public TestOverlayView()
+            {
+                Child = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 400,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Blue
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Font = OsuFont.GetFont(Typeface.Torus, 32),
+                            Text = "View content"
+                        },
+                    }
+                };
+            }
+
+            protected override APIRequest<DummyData> CreateRequest() => new DummyAPIRequest();
+
+            protected override void OnSuccess(DummyData response)
+            {
+            }
+
+            private class DummyAPIRequest : APIRequest<DummyData>
+            {
+                protected override string Target => "";
+            }
+        }
+
+        //ReSharper disable once ClassNeverInstantiated.Local
+        private class DummyData
+        {
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneOverlayView.cs
@@ -57,7 +57,6 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestOnlineStatus()
         {
-            AddStep("setup API request handler", () => ((DummyAPIAccess)API).HandleRequest = req => req.TriggerSuccess());
             AddStep("set status to online", () => ((DummyAPIAccess)API).State = APIState.Online);
             AddUntilStep("placeholder is hidden", () => !view.InternalContents.OfType<LoginPlaceholder>().First().IsPresent);
             AddUntilStep("spinner is hidden", () => !view.InternalContents.OfType<LoadingSpinner>().First().IsPresent);
@@ -66,8 +65,6 @@ namespace osu.Game.Tests.Visual.Online
         private class TestOverlayView : OverlayView<DummyData>
         {
             public IEnumerable<Drawable> InternalContents => InternalChildren;
-
-            public new void PerformFetch() => base.PerformFetch();
 
             public TestOverlayView()
             {

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            InternalChild = new FillFlowContainer
+            Child = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/OverlayView.cs
+++ b/osu.Game/Overlays/OverlayView.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays
         [Resolved]
         protected IAPIProvider API { get; private set; }
 
-        protected LoadingSpinner LoadingSpinner { get; }
+        private LoadingSpinner spinner { get; }
 
         protected override Container<Drawable> Content { get; } = new Container
         {
@@ -60,7 +60,7 @@ namespace osu.Game.Overlays
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                 },
-                LoadingSpinner = new LoadingSpinner
+                spinner = new LoadingSpinner
                 {
                     Alpha = 0,
                     Size = new osuTK.Vector2(40),
@@ -96,8 +96,6 @@ namespace osu.Game.Overlays
             request = CreateRequest();
             request.Success += onSuccess;
 
-            LoadingSpinner.Show();
-
             API.Queue(request);
         }
 
@@ -109,19 +107,19 @@ namespace osu.Game.Overlays
                     blockingBox.FadeIn(300, Easing.OutQuint);
                     currentPlaceholder.ScaleTo(0.8f).Then().ScaleTo(1, 600, Easing.OutQuint);
                     currentPlaceholder.FadeInFromZero(2 * 300, Easing.OutQuint);
-                    LoadingSpinner.Hide();
+                    spinner.Hide();
                     break;
 
                 case APIState.Online:
                     blockingBox.FadeOut(300, Easing.OutQuint);
                     currentPlaceholder.FadeOut(300, Easing.OutQuint);
-                    LoadingSpinner.Hide();
+                    spinner.Hide();
                     PerformFetch();
                     break;
 
                 case APIState.Failing:
                 case APIState.Connecting:
-                    LoadingSpinner.Show();
+                    spinner.Show();
                     blockingBox.FadeIn(300, Easing.OutQuint);
                     currentPlaceholder.FadeOut(300, Easing.OutQuint);
                     break;
@@ -130,7 +128,6 @@ namespace osu.Game.Overlays
 
         private void onSuccess(T content)
         {
-            LoadingSpinner.Hide();
             Schedule(() => OnSuccess(content));
         }
 

--- a/osu.Game/Overlays/OverlayView.cs
+++ b/osu.Game/Overlays/OverlayView.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays
         [Resolved]
         protected IAPIProvider API { get; private set; }
 
-        protected LoadingSpinner LoadingSpinner { get; private set; }
+        protected LoadingSpinner LoadingSpinner { get; }
 
         protected override Container<Drawable> Content { get; } = new Container
         {
@@ -35,9 +35,9 @@ namespace osu.Game.Overlays
             AutoSizeAxes = Axes.Y,
         };
 
-        private Placeholder currentPlaceholder;
+        private readonly Placeholder currentPlaceholder;
 
-        private BlockingBox blockingBox;
+        private readonly BlockingBox blockingBox;
 
         private APIRequest<T> request;
 
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays
                 {
                     RelativeSizeAxes = Axes.Both,
                 },
-                currentPlaceholder = new LoginPlaceholder("Please login to view content!")
+                currentPlaceholder = new LoginPlaceholder(@"Please login to view content!")
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -66,7 +66,7 @@ namespace osu.Game.Overlays
                     Size = new osuTK.Vector2(40),
                     Margin = new MarginPadding { Top = 25 }
                 }
-}           ;
+            };
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/OverlayView.cs
+++ b/osu.Game/Overlays/OverlayView.cs
@@ -27,15 +27,15 @@ namespace osu.Game.Overlays
         [Resolved]
         protected IAPIProvider API { get; private set; }
 
-        private LoadingSpinner spinner { get; }
-
-        private const double transform_time = 600;
-
         protected override Container<Drawable> Content { get; } = new Container
         {
             RelativeSizeAxes = Axes.X,
             AutoSizeAxes = Axes.Y,
         };
+
+        private const double transform_time = 600;
+
+        private readonly LoadingSpinner spinner;
 
         private readonly Placeholder currentPlaceholder;
 

--- a/osu.Game/Overlays/OverlayView.cs
+++ b/osu.Game/Overlays/OverlayView.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Overlays
 
         private LoadingSpinner spinner { get; }
 
+        private const double transform_time = 600;
+
         protected override Container<Drawable> Content { get; } = new Container
         {
             RelativeSizeAxes = Axes.X,
@@ -104,15 +106,15 @@ namespace osu.Game.Overlays
             switch (state)
             {
                 case APIState.Offline:
-                    blockingBox.FadeIn(300, Easing.OutQuint);
-                    currentPlaceholder.ScaleTo(0.8f).Then().ScaleTo(1, 600, Easing.OutQuint);
-                    currentPlaceholder.FadeInFromZero(2 * 300, Easing.OutQuint);
+                    blockingBox.FadeIn(transform_time, Easing.OutQuint);
+                    currentPlaceholder.ScaleTo(0.8f).Then().ScaleTo(1, transform_time, Easing.OutQuint);
+                    currentPlaceholder.FadeInFromZero(transform_time, Easing.OutQuint);
                     spinner.Hide();
                     break;
 
                 case APIState.Online:
-                    blockingBox.FadeOut(300, Easing.OutQuint);
-                    currentPlaceholder.FadeOut(300, Easing.OutQuint);
+                    blockingBox.FadeOut(transform_time / 2, Easing.OutQuint);
+                    currentPlaceholder.FadeOut(transform_time / 2, Easing.OutQuint);
                     spinner.Hide();
                     PerformFetch();
                     break;
@@ -120,8 +122,8 @@ namespace osu.Game.Overlays
                 case APIState.Failing:
                 case APIState.Connecting:
                     spinner.Show();
-                    blockingBox.FadeIn(300, Easing.OutQuint);
-                    currentPlaceholder.FadeOut(300, Easing.OutQuint);
+                    blockingBox.FadeIn(transform_time, Easing.OutQuint);
+                    currentPlaceholder.FadeOut(transform_time / 2, Easing.OutQuint);
                     break;
             }
         }

--- a/osu.Game/Overlays/OverlayView.cs
+++ b/osu.Game/Overlays/OverlayView.cs
@@ -65,8 +65,6 @@ namespace osu.Game.Overlays
                 spinner = new LoadingSpinner
                 {
                     Alpha = 0,
-                    Size = new osuTK.Vector2(40),
-                    Margin = new MarginPadding { Top = 25 }
                 }
             };
         }
@@ -96,7 +94,7 @@ namespace osu.Game.Overlays
             request?.Cancel();
 
             request = CreateRequest();
-            request.Success += onSuccess;
+            request.Success += response => Schedule(() => OnSuccess(response));
 
             API.Queue(request);
         }
@@ -126,11 +124,6 @@ namespace osu.Game.Overlays
                     currentPlaceholder.FadeOut(transform_time / 2, Easing.OutQuint);
                     break;
             }
-        }
-
-        private void onSuccess(T content)
-        {
-            Schedule(() => OnSuccess(content));
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
# Summary
This adds offline handling behaviour to OverlayView (as well as tests) in a very similar fashion to #8044, making it an actual replacement of what was proposed in that PR.

I have been tempted to include in this PR changes to DashboardOverlay and existing views in order to leverage the newly introduced behaviour (as for now the overlay will instant trash out the views on user log out, leaving no chance to display any hint) but decided to keep it for a follow up as it may require further discussion; unless it is fine adding it there.