### PR TITLE
Truncate beatmap title and artist on score panel

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -20,6 +20,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
+using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Ranking.Expanded;
 using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osu.Game.Screens.Ranking.Expanded.Statistics;
@@ -74,6 +75,8 @@ namespace osu.Game.Tests.Visual.Ranking
         {
             var beatmap = new TestBeatmap(rulesetStore.GetRuleset(0));
             beatmap.Metadata.Author = author;
+            beatmap.Metadata.Title = "Verrrrrrrrrrrrrrrrrrry looooooooooooooooooooooooong beatmap title";
+            beatmap.Metadata.Artist = "Verrrrrrrrrrrrrrrrrrry looooooooooooooooooooooooong beatmap artist";
 
             return new TestWorkingBeatmap(beatmap);
         }
@@ -114,7 +117,7 @@ namespace osu.Game.Tests.Visual.Ranking
 
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
-                Size = new Vector2(500, 700);
+                Size = new Vector2(ScorePanel.EXPANDED_WIDTH, 700);
                 Children = new Drawable[]
                 {
                     new Box

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Screens.Ranking.Expanded
 
         private RollingCounter<long> scoreCounter;
 
+        private const float padding = 10;
+
         /// <summary>
         /// Creates a new <see cref="ExpandedPanelMiddleContent"/>.
         /// </summary>
@@ -46,7 +48,7 @@ namespace osu.Game.Screens.Ranking.Expanded
             RelativeSizeAxes = Axes.Both;
             Masking = true;
 
-            Padding = new MarginPadding { Vertical = 10, Horizontal = 10 };
+            Padding = new MarginPadding(padding);
         }
 
         [BackgroundDependencyLoader]
@@ -92,13 +94,17 @@ namespace osu.Game.Screens.Ranking.Expanded
                                 Origin = Anchor.TopCentre,
                                 Text = new LocalisedString((metadata.TitleUnicode, metadata.Title)),
                                 Font = OsuFont.Torus.With(size: 20, weight: FontWeight.SemiBold),
+                                MaxWidth = ScorePanel.EXPANDED_WIDTH - padding * 2,
+                                Truncate = true,
                             },
                             new OsuSpriteText
                             {
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
                                 Text = new LocalisedString((metadata.ArtistUnicode, metadata.Artist)),
-                                Font = OsuFont.Torus.With(size: 14, weight: FontWeight.SemiBold)
+                                Font = OsuFont.Torus.With(size: 14, weight: FontWeight.SemiBold),
+                                MaxWidth = ScorePanel.EXPANDED_WIDTH - padding * 2,
+                                Truncate = true,
                             },
                             new Container
                             {

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Ranking
         /// <summary>
         /// Width of the panel when expanded.
         /// </summary>
-        private const float expanded_width = 360;
+        public const float EXPANDED_WIDTH = 360;
 
         /// <summary>
         /// Height of the panel when expanded.
@@ -183,7 +183,7 @@ namespace osu.Game.Screens.Ranking
             switch (state)
             {
                 case PanelState.Expanded:
-                    this.ResizeTo(new Vector2(expanded_width, expanded_height), resize_duration, Easing.OutQuint);
+                    this.ResizeTo(new Vector2(EXPANDED_WIDTH, expanded_height), resize_duration, Easing.OutQuint);
 
                     topLayerBackground.FadeColour(expanded_top_layer_colour, resize_duration, Easing.OutQuint);
                     middleLayerBackground.FadeColour(expanded_middle_layer_colour, resize_duration, Easing.OutQuint);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/8315 and resolves part of https://github.com/ppy/osu/issues/3504.

Since `SpriteText`'s text can't be aligned when using `RelativeSizeAxes` right now, I am using its `MaxWidth` so truncation can occur even when auto sizing.

![image](https://user-images.githubusercontent.com/35318437/80783906-28f41f80-8b30-11ea-962b-2f206e7d35e8.png)
