### PR TITLE
Add local beatmap lookup cache to improve performance of imports

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Beatmaps
         private readonly BeatmapStore beatmaps;
         private readonly AudioManager audioManager;
         private readonly GameHost host;
-        private readonly BeatmapUpdateQueue updateQueue;
+        private readonly BeatmapOnlineLookupQueue onlineLookupQueue;
         private readonly Storage exportStorage;
 
         public BeatmapManager(Storage storage, IDatabaseContextFactory contextFactory, RulesetStore rulesets, IAPIProvider api, AudioManager audioManager, GameHost host = null,
@@ -77,7 +77,7 @@ namespace osu.Game.Beatmaps
             beatmaps.BeatmapHidden += b => BeatmapHidden?.Invoke(b);
             beatmaps.BeatmapRestored += b => BeatmapRestored?.Invoke(b);
 
-            updateQueue = new BeatmapUpdateQueue(api, storage);
+            onlineLookupQueue = new BeatmapOnlineLookupQueue(api, storage);
             exportStorage = storage.GetStorageForDirectory("exports");
         }
 
@@ -104,7 +104,7 @@ namespace osu.Game.Beatmaps
 
             bool hadOnlineBeatmapIDs = beatmapSet.Beatmaps.Any(b => b.OnlineBeatmapID > 0);
 
-            await updateQueue.UpdateAsync(beatmapSet, cancellationToken);
+            await onlineLookupQueue.UpdateAsync(beatmapSet, cancellationToken);
 
             // ensure at least one beatmap was able to retrieve or keep an online ID, else drop the set ID.
             if (hadOnlineBeatmapIDs && !beatmapSet.Beatmaps.Any(b => b.OnlineBeatmapID > 0))

--- a/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Data.Sqlite;
+using osu.Framework.Development;
 using osu.Framework.IO.Network;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -40,7 +41,8 @@ namespace osu.Game.Beatmaps
                 this.api = api;
                 this.storage = storage;
 
-                if (!storage.Exists(cache_database_name))
+                // avoid downloading / using cache for unit tests.
+                if (!DebugUtils.IsNUnitRunning && !storage.Exists(cache_database_name))
                     prepareLocalCache();
             }
 

--- a/osu.Game/Beatmaps/BeatmapManager_UpdateQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_UpdateQueue.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Beatmaps
                     {
                         using (var db = new SqliteConnection(storage.GetDatabaseConnectionString("online")))
                         {
-                            var found = db.QueryFirstOrDefault<CachedOnlineBeatmapLookup>(
+                            var found = db.QuerySingleOrDefault<CachedOnlineBeatmapLookup>(
                                 "SELECT * FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineBeatmapID OR filename = @Path", beatmap);
 
                             if (found != null)

--- a/osu.Game/Beatmaps/BeatmapManager_UpdateQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_UpdateQueue.cs
@@ -1,0 +1,180 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Data.Sqlite;
+using osu.Framework.IO.Network;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Threading;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using SharpCompress.Compressors;
+using SharpCompress.Compressors.BZip2;
+
+namespace osu.Game.Beatmaps
+{
+    public partial class BeatmapManager
+    {
+        private class BeatmapUpdateQueue
+        {
+            private readonly IAPIProvider api;
+            private readonly Storage storage;
+
+            private const int update_queue_request_concurrency = 4;
+
+            private readonly ThreadedTaskScheduler updateScheduler = new ThreadedTaskScheduler(update_queue_request_concurrency, nameof(BeatmapUpdateQueue));
+
+            private FileWebRequest cacheDownloadRequest;
+
+            private const string cache_database_name = "online.db";
+
+            public BeatmapUpdateQueue(IAPIProvider api, Storage storage)
+            {
+                this.api = api;
+                this.storage = storage;
+
+                if (!storage.Exists(cache_database_name))
+                    prepareLocalCache();
+            }
+
+            public Task UpdateAsync(BeatmapSetInfo beatmapSet, CancellationToken cancellationToken)
+            {
+                if (api?.State != APIState.Online)
+                    return Task.CompletedTask;
+
+                LogForModel(beatmapSet, "Performing online lookups...");
+                return Task.WhenAll(beatmapSet.Beatmaps.Select(b => UpdateAsync(beatmapSet, b, cancellationToken)).ToArray());
+            }
+
+            // todo: expose this when we need to do individual difficulty lookups.
+            protected Task UpdateAsync(BeatmapSetInfo beatmapSet, BeatmapInfo beatmap, CancellationToken cancellationToken)
+                => Task.Factory.StartNew(() => update(beatmapSet, beatmap), cancellationToken, TaskCreationOptions.HideScheduler, updateScheduler);
+
+            private void update(BeatmapSetInfo set, BeatmapInfo beatmap)
+            {
+                if (cacheDownloadRequest == null && storage.Exists(cache_database_name))
+                {
+                    try
+                    {
+                        using (var db = new SqliteConnection(storage.GetDatabaseConnectionString("online")))
+                        {
+                            var found = db.QueryFirstOrDefault<CachedOnlineBeatmapLookup>(
+                                "SELECT * FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineBeatmapID OR filename = @Path", beatmap);
+
+                            if (found != null)
+                            {
+                                var status = (BeatmapSetOnlineStatus)found.approved;
+
+                                beatmap.Status = status;
+                                beatmap.BeatmapSet.Status = status;
+                                beatmap.BeatmapSet.OnlineBeatmapSetID = found.beatmapset_id;
+                                beatmap.OnlineBeatmapID = found.beatmap_id;
+
+                                LogForModel(set, $"Cached local retrieval for {beatmap}.");
+                                return;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        LogForModel(set, $"Cached local retrieval for {beatmap} failed with {ex}.");
+                    }
+                }
+
+                if (api?.State != APIState.Online)
+                    return;
+
+                var req = new GetBeatmapRequest(beatmap);
+
+                req.Failure += fail;
+
+                try
+                {
+                    // intentionally blocking to limit web request concurrency
+                    api.Perform(req);
+
+                    var res = req.Result;
+
+                    if (res != null)
+                    {
+                        beatmap.Status = res.Status;
+                        beatmap.BeatmapSet.Status = res.BeatmapSet.Status;
+                        beatmap.BeatmapSet.OnlineBeatmapSetID = res.OnlineBeatmapSetID;
+                        beatmap.OnlineBeatmapID = res.OnlineBeatmapID;
+
+                        LogForModel(set, $"Online retrieval mapped {beatmap} to {res.OnlineBeatmapSetID} / {res.OnlineBeatmapID}.");
+                    }
+                }
+                catch (Exception e)
+                {
+                    fail(e);
+                }
+
+                void fail(Exception e)
+                {
+                    beatmap.OnlineBeatmapID = null;
+                    LogForModel(set, $"Online retrieval failed for {beatmap} ({e.Message})");
+                }
+            }
+
+            private void prepareLocalCache()
+            {
+                string cacheFilePath = storage.GetFullPath(cache_database_name);
+                string compressedCacheFilePath = $"{cacheFilePath}.bz2";
+
+                cacheDownloadRequest = new FileWebRequest(compressedCacheFilePath, $"https://assets.ppy.sh/client-resources/{cache_database_name}.bz2");
+
+                cacheDownloadRequest.Failed += ex =>
+                {
+                    File.Delete(compressedCacheFilePath);
+                    File.Delete(cacheFilePath);
+
+                    Logger.Log($"{nameof(BeatmapUpdateQueue)}'s online cache download failed: {ex}", LoggingTarget.Database);
+                };
+
+                cacheDownloadRequest.Finished += () =>
+                {
+                    try
+                    {
+                        using (var stream = File.OpenRead(cacheDownloadRequest.Filename))
+                        using (var outStream = File.OpenWrite(cacheFilePath))
+                        using (var bz2 = new BZip2Stream(stream, CompressionMode.Decompress, false))
+                            bz2.CopyTo(outStream);
+
+                        // set to null on completion to allow lookups to begin using the new source
+                        cacheDownloadRequest = null;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"{nameof(BeatmapUpdateQueue)}'s online cache extraction failed: {ex}", LoggingTarget.Database);
+                    }
+                    finally
+                    {
+                        File.Delete(compressedCacheFilePath);
+                        File.Delete(cacheFilePath);
+                    }
+                };
+
+                cacheDownloadRequest.PerformAsync();
+            }
+
+            [Serializable]
+            [SuppressMessage("ReSharper", "InconsistentNaming")]
+            private class CachedOnlineBeatmapLookup
+            {
+                public int approved { get; set; }
+
+                public int? beatmapset_id { get; set; }
+
+                public int? beatmap_id { get; set; }
+            }
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapManager_UpdateQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_UpdateQueue.cs
@@ -154,11 +154,11 @@ namespace osu.Game.Beatmaps
                     catch (Exception ex)
                     {
                         Logger.Log($"{nameof(BeatmapUpdateQueue)}'s online cache extraction failed: {ex}", LoggingTarget.Database);
+                        File.Delete(cacheFilePath);
                     }
                     finally
                     {
                         File.Delete(compressedCacheFilePath);
-                        File.Delete(cacheFilePath);
                     }
                 };
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -245,7 +245,7 @@ namespace osu.Game.Database
         /// </summary>
         protected abstract string[] HashableFileTypes { get; }
 
-        protected static void LogForModel(TModel model, string message, Exception e = null)
+        internal static void LogForModel(TModel model, string message, Exception e = null)
         {
             string prefix = $"[{(model?.Hash ?? "?????").Substring(0, 5)}]";
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,6 +18,7 @@
     </None>
   </ItemGroup>
   <ItemGroup Label="Package References">
+    <PackageReference Include="Dapper" Version="2.0.35" />
     <PackageReference Include="DiffPlex" Version="1.6.1" />
     <PackageReference Include="Humanizer" Version="2.8.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8265

Importing from stable (194 beatmaps):

Offline (master): 30.2s
Online (master): 38.2s
With local cache: 30.6s

Note that these results are with very good internet (<50ms responses to lookups). Performance will be *magnitudes* better on lesser internet connections. This also reduces a large burden on the server infrastructure during imports, where previously over 500,000 request could be fired for a normal user's beatmap collection.

Update support would need to be added at some point, but I think this is good to go as an initial implementation (it's not supposed to have 100% coverage and will gracefully fallback when not available locally). May add tests covering download / lookup if required (potentially moving the `BeatmapUpdateQueue` out of nesting – left it there for simplicity as it uses a couple of methods in `ArchiveModelManager`).

Notes about the database itself:
- 11mb after bz2 (35mb extracted)
- Contains all ranked / approved / loved beatmaps
- Contains more metadata than is being used (can be further pruned if we deem that to be useless)