### PR TITLE
Fix song select tests potentially failing due to difficulty panels not yet displayed

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             createSongSelect();
 
-            AddUntilStep("wait for initial selection", () => !Beatmap.IsDefault);
+            waitForInitialSelection();
 
             WorkingBeatmap selected = null;
 
@@ -135,7 +135,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             createSongSelect();
 
-            AddUntilStep("wait for initial selection", () => !Beatmap.IsDefault);
+            waitForInitialSelection();
 
             WorkingBeatmap selected = null;
 
@@ -189,7 +189,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             createSongSelect();
 
-            AddUntilStep("wait for initial selection", () => !Beatmap.IsDefault);
+            waitForInitialSelection();
 
             WorkingBeatmap selected = null;
 
@@ -767,6 +767,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.ID == 3);
 
             AddAssert("Check first item in group selected", () => Beatmap.Value.BeatmapInfo == groupIcon.Items.First().Beatmap);
+        }
+
+        private void waitForInitialSelection()
+        {
+            AddUntilStep("wait for initial selection", () => !Beatmap.IsDefault);
+            AddUntilStep("wait for difficulty panels visible", () => songSelect.Carousel.ChildrenOfType<DrawableCarouselBeatmap>().Any());
         }
 
         private int getBeatmapIndex(BeatmapSetInfo set, BeatmapInfo info) => set.Beatmaps.FindIndex(b => b == info);

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Beatmaps
         {
             var beatmapIds = beatmapSet.Beatmaps.Where(b => b.OnlineBeatmapID.HasValue).Select(b => b.OnlineBeatmapID).ToList();
 
-            LogForModel(beatmapSet, "Validating online IDs...");
+            LogForModel(beatmapSet, $"Validating online IDs for {beatmapSet.Beatmaps.Count} beatmaps...");
 
             // ensure all IDs are unique
             if (beatmapIds.GroupBy(b => b).Any(g => g.Count() > 1))


### PR DESCRIPTION
We were waiting for the global beatmap to change, but this is potentially triggered one frame earlier than the panels become visible (as part of the `ChildItemStateChanged` logic)