### PR TITLE
Fix hard crash when changing ruleset while presenting a score

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -774,6 +774,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestChangeRulesetWhilePresentingScore()
         {
+            BeatmapInfo getPresentBeatmap() => manager.QueryBeatmap(b => !b.BeatmapSet.DeletePending && b.RulesetID == 0);
+            BeatmapInfo getSwitchBeatmap() => manager.QueryBeatmap(b => !b.BeatmapSet.DeletePending && b.RulesetID == 1);
+
             changeRuleset(0);
 
             createSongSelect();
@@ -783,55 +786,52 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("present score", () =>
             {
-                var presentBeatmap = manager.QueryBeatmap(b => b.RulesetID == 0);
-                var switchBeatmap = manager.QueryBeatmap(b => b.RulesetID == 1);
-
                 // this ruleset change should be overridden by the present.
-                Ruleset.Value = switchBeatmap.Ruleset;
+                Ruleset.Value = getSwitchBeatmap().Ruleset;
 
                 songSelect.PresentScore(new ScoreInfo
                 {
                     User = new User { Username = "woo" },
-                    Beatmap = presentBeatmap,
-                    Ruleset = presentBeatmap.Ruleset
+                    Beatmap = getPresentBeatmap(),
+                    Ruleset = getPresentBeatmap().Ruleset
                 });
             });
 
             AddUntilStep("wait for results screen presented", () => !songSelect.IsCurrentScreen());
 
-            AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.Equals(manager.QueryBeatmap(b => b.RulesetID == 0)));
+            AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.Equals(getPresentBeatmap()));
             AddAssert("check ruleset is correct for score", () => Ruleset.Value.ID == 0);
         }
 
         [Test]
         public void TestChangeBeatmapWhilePresentingScore()
         {
-            changeRuleset(0);
+            BeatmapInfo getPresentBeatmap() => manager.QueryBeatmap(b => !b.BeatmapSet.DeletePending && b.RulesetID == 0);
+            BeatmapInfo getSwitchBeatmap() => manager.QueryBeatmap(b => !b.BeatmapSet.DeletePending && b.RulesetID == 1);
 
-            createSongSelect();
+            changeRuleset(0);
 
             addRulesetImportStep(0);
             addRulesetImportStep(1);
 
+            createSongSelect();
+
             AddStep("present score", () =>
             {
-                var presentBeatmap = manager.QueryBeatmap(b => b.RulesetID == 0);
-                var switchBeatmap = manager.QueryBeatmap(b => b.RulesetID == 1);
-
                 // this beatmap change should be overridden by the present.
-                Beatmap.Value = manager.GetWorkingBeatmap(switchBeatmap);
+                Beatmap.Value = manager.GetWorkingBeatmap(getSwitchBeatmap());
 
                 songSelect.PresentScore(new ScoreInfo
                 {
                     User = new User { Username = "woo" },
-                    Beatmap = presentBeatmap,
-                    Ruleset = presentBeatmap.Ruleset
+                    Beatmap = getPresentBeatmap(),
+                    Ruleset = getPresentBeatmap().Ruleset
                 });
             });
 
             AddUntilStep("wait for results screen presented", () => !songSelect.IsCurrentScreen());
 
-            AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.Equals(manager.QueryBeatmap(b => b.RulesetID == 0)));
+            AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.Equals(getPresentBeatmap()));
             AddAssert("check ruleset is correct for score", () => Ruleset.Value.ID == 0);
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -24,10 +24,12 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Users;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.SongSelect
@@ -769,6 +771,70 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("Check first item in group selected", () => Beatmap.Value.BeatmapInfo == groupIcon.Items.First().Beatmap);
         }
 
+        [Test]
+        public void TestChangeRulesetWhilePresentingScore()
+        {
+            changeRuleset(0);
+
+            createSongSelect();
+
+            addRulesetImportStep(0);
+            addRulesetImportStep(1);
+
+            AddStep("present score", () =>
+            {
+                var presentBeatmap = manager.QueryBeatmap(b => b.RulesetID == 0);
+                var switchBeatmap = manager.QueryBeatmap(b => b.RulesetID == 1);
+
+                // this ruleset change should be overridden by the present.
+                Ruleset.Value = switchBeatmap.Ruleset;
+
+                songSelect.PresentScore(new ScoreInfo
+                {
+                    User = new User { Username = "woo" },
+                    Beatmap = presentBeatmap,
+                    Ruleset = presentBeatmap.Ruleset
+                });
+            });
+
+            AddUntilStep("wait for results screen presented", () => !songSelect.IsCurrentScreen());
+
+            AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.Equals(manager.QueryBeatmap(b => b.RulesetID == 0)));
+            AddAssert("check ruleset is correct for score", () => Ruleset.Value.ID == 0);
+        }
+
+        [Test]
+        public void TestChangeBeatmapWhilePresentingScore()
+        {
+            changeRuleset(0);
+
+            createSongSelect();
+
+            addRulesetImportStep(0);
+            addRulesetImportStep(1);
+
+            AddStep("present score", () =>
+            {
+                var presentBeatmap = manager.QueryBeatmap(b => b.RulesetID == 0);
+                var switchBeatmap = manager.QueryBeatmap(b => b.RulesetID == 1);
+
+                // this beatmap change should be overridden by the present.
+                Beatmap.Value = manager.GetWorkingBeatmap(switchBeatmap);
+
+                songSelect.PresentScore(new ScoreInfo
+                {
+                    User = new User { Username = "woo" },
+                    Beatmap = presentBeatmap,
+                    Ruleset = presentBeatmap.Ruleset
+                });
+            });
+
+            AddUntilStep("wait for results screen presented", () => !songSelect.IsCurrentScreen());
+
+            AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.Equals(manager.QueryBeatmap(b => b.RulesetID == 0)));
+            AddAssert("check ruleset is correct for score", () => Ruleset.Value.ID == 0);
+        }
+
         private void waitForInitialSelection()
         {
             AddUntilStep("wait for initial selection", () => !Beatmap.IsDefault);
@@ -881,6 +947,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             public WorkingBeatmap CurrentBeatmap => Beatmap.Value;
             public WorkingBeatmap CurrentBeatmapDetailsBeatmap => BeatmapDetails.Beatmap;
             public new BeatmapCarousel Carousel => base.Carousel;
+
+            public new void PresentScore(ScoreInfo score) => base.PresentScore(score);
 
             protected override bool OnStart()
             {

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
+using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Users;
@@ -32,8 +33,11 @@ namespace osu.Game.Screens.Select
                 Edit();
             }, Key.Number4);
 
-            ((PlayBeatmapDetailArea)BeatmapDetails).Leaderboard.ScoreSelected += score => this.Push(new ResultsScreen(score));
+            ((PlayBeatmapDetailArea)BeatmapDetails).Leaderboard.ScoreSelected += PresentScore;
         }
+
+        protected void PresentScore(ScoreInfo score) =>
+            FinaliseSelection(score.Beatmap, score.Ruleset, () => this.Push(new ResultsScreen(score)));
 
         protected override BeatmapDetailArea CreateBeatmapDetailArea() => new PlayBeatmapDetailArea();
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -342,12 +342,16 @@ namespace osu.Game.Screens.Select
         /// Call to make a selection and perform the default action for this SongSelect.
         /// </summary>
         /// <param name="beatmap">An optional beatmap to override the current carousel selection.</param>
-        /// <param name="performStartAction">Whether to trigger <see cref="OnStart"/>.</param>
-        public void FinaliseSelection(BeatmapInfo beatmap = null, bool performStartAction = true)
+        /// <param name="ruleset">An optional ruleset to override the current carousel selection.</param>
+        /// <param name="customStartAction">An optional custom action to perform instead of <see cref="OnStart"/>.</param>
+        public void FinaliseSelection(BeatmapInfo beatmap = null, RulesetInfo ruleset = null, Action customStartAction = null)
         {
             // This is very important as we have not yet bound to screen-level bindables before the carousel load is completed.
             if (!Carousel.BeatmapSetsLoaded)
                 return;
+
+            if (ruleset != null)
+                Ruleset.Value = ruleset;
 
             transferRulesetValue();
 
@@ -369,7 +373,12 @@ namespace osu.Game.Screens.Select
                 selectionChangedDebounce = null;
             }
 
-            if (performStartAction && OnStart())
+            if (customStartAction != null)
+            {
+                customStartAction();
+                Carousel.AllowSelection = false;
+            }
+            else if (OnStart())
                 Carousel.AllowSelection = false;
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8692

Hopefully this should cover all song select `Push` scenarios going forward (which would also use `FinaliseSelection` with new paramter).