### PR TITLE
Make HUDOverlay overridable

### DIFF
--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -487,6 +487,9 @@ namespace osu.Game.Rulesets.UI
 
         protected virtual ResumeOverlay CreateResumeOverlay() => null;
 
+        public virtual HUDOverlay CreateHUDOverlay(ScoreProcessor scoreProcessor, HealthProcessor healthProcessor, DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods)
+            => new HUDOverlay(scoreProcessor, healthProcessor, drawableRuleset, mods);
+
         /// <summary>
         /// Sets a replay to be used, overriding local input.
         /// </summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -265,23 +265,20 @@ namespace osu.Game.Screens.Play
                 // display the cursor above some HUD elements.
                 DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),
                 DrawableRuleset.ResumeOverlay?.CreateProxy() ?? new Container(),
-                HUDOverlay = new HUDOverlay(ScoreProcessor, HealthProcessor, DrawableRuleset, Mods.Value)
+                HUDOverlay = DrawableRuleset.CreateHUDOverlay(ScoreProcessor, HealthProcessor, DrawableRuleset, Mods.Value).With(hudOverlay=>
                 {
-                    HoldToQuit =
-                    {
-                        Action = performUserRequestedExit,
-                        IsPaused = { BindTarget = GameplayClockContainer.IsPaused }
-                    },
-                    PlayerSettingsOverlay = { PlaybackSettings = { UserPlaybackRate = { BindTarget = GameplayClockContainer.UserPlaybackRate } } },
-                    KeyCounter =
-                    {
-                        AlwaysVisible = { BindTarget = DrawableRuleset.HasReplayLoaded },
-                        IsCounting = false
-                    },
-                    RequestSeek = GameplayClockContainer.Seek,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
-                },
+                    hudOverlay.HoldToQuit.Action = performUserRequestedExit;
+                    hudOverlay.HoldToQuit.IsPaused.BindTarget = GameplayClockContainer.IsPaused;
+
+                    hudOverlay.PlayerSettingsOverlay.PlaybackSettings.UserPlaybackRate.BindTarget = GameplayClockContainer.UserPlaybackRate;
+
+                    hudOverlay.KeyCounter.AlwaysVisible.BindTarget = DrawableRuleset.HasReplayLoaded;
+                    hudOverlay.KeyCounter.IsCounting = false;
+
+                    hudOverlay.RequestSeek = GameplayClockContainer.Seek;
+                    hudOverlay.Anchor = Anchor.Centre;
+                    hudOverlay.Origin = Anchor.Centre;
+                }),
                 new SkipOverlay(DrawableRuleset.GameplayStartTime)
                 {
                     RequestSkip = GameplayClockContainer.Skip

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -265,7 +265,7 @@ namespace osu.Game.Screens.Play
                 // display the cursor above some HUD elements.
                 DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),
                 DrawableRuleset.ResumeOverlay?.CreateProxy() ?? new Container(),
-                HUDOverlay = DrawableRuleset.CreateHUDOverlay(ScoreProcessor, HealthProcessor, DrawableRuleset, Mods.Value).With(hudOverlay=>
+                HUDOverlay = DrawableRuleset.CreateHUDOverlay(ScoreProcessor, HealthProcessor, DrawableRuleset, Mods.Value).With(hudOverlay =>
                 {
                     hudOverlay.HoldToQuit.Action = performUserRequestedExit;
                     hudOverlay.HoldToQuit.IsPaused.BindTarget = GameplayClockContainer.IsPaused;


### PR DESCRIPTION
In compare to make `HUDOverlay` public in #8945 
I think it's better to make `HUDOverlay` overridable, and do the logic(like hiding or change to customize component) in `MyCoolRulesetHUDOverlay`.