### PR TITLE
Fix android usage of obsoleted VersionCode

### DIFF
--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -18,7 +18,8 @@ namespace osu.Android
 
                 try
                 {
-                    string versionName = packageInfo.VersionCode.ToString();
+                    // todo: needs checking before play store redeploy.
+                    string versionName = packageInfo.VersionName;
                     // undo play store version garbling
                     return new Version(int.Parse(versionName.Substring(0, 4)), int.Parse(versionName.Substring(4, 4)), int.Parse(versionName.Substring(8, 1)));
                 }


### PR DESCRIPTION
Causing build failures with newer xamarin updates. Has been tested with deploy process, but may regress play store (not really a consideration for now). There's a newer `LongVersionCode` but needs reassessment and target API changes.