### PR TITLE
Fix hold note selection pieces disappearing on movement

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep("grab hold note", () =>
             {
-                holdNote = this.ChildrenOfType<DrawableHoldNote>().FirstOrDefault();
+                holdNote = this.ChildrenOfType<DrawableHoldNote>().Single();
                 InputManager.MoveMouseTo(holdNote);
                 InputManager.PressButton(MouseButton.Left);
             });

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
@@ -10,10 +10,13 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Edit;
+using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -48,6 +51,8 @@ namespace osu.Game.Rulesets.Mania.Tests
             DrawableHitObject lastObject = null;
             Vector2 originalPosition = Vector2.Zero;
 
+            setScrollStep(ScrollingDirection.Up);
+
             AddStep("seek to last object", () =>
             {
                 lastObject = this.ChildrenOfType<DrawableHitObject>().Single(d => d.HitObject == composer.EditorBeatmap.HitObjects.Last());
@@ -81,7 +86,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             DrawableHitObject lastObject = null;
             Vector2 originalPosition = Vector2.Zero;
 
-            AddStep("set down scroll", () => ((Bindable<ScrollingDirection>)composer.Composer.ScrollingInfo.Direction).Value = ScrollingDirection.Down);
+            setScrollStep(ScrollingDirection.Down);
 
             AddStep("seek to last object", () =>
             {
@@ -116,6 +121,8 @@ namespace osu.Game.Rulesets.Mania.Tests
             DrawableHitObject lastObject = null;
             Vector2 originalPosition = Vector2.Zero;
 
+            setScrollStep(ScrollingDirection.Down);
+
             AddStep("seek to last object", () =>
             {
                 lastObject = this.ChildrenOfType<DrawableHitObject>().Single(d => d.HitObject == composer.EditorBeatmap.HitObjects.Last());
@@ -146,6 +153,46 @@ namespace osu.Game.Rulesets.Mania.Tests
             // Todo: They'll move vertically by the height of a note since there's no snapping and the selection point is the middle of the note.
             AddAssert("hitobjects not moved vertically", () => lastObject.DrawPosition.Y - originalPosition.Y <= DefaultNotePiece.NOTE_HEIGHT);
         }
+
+        [Test]
+        public void TestDragHoldNoteSelectionVertically()
+        {
+            setScrollStep(ScrollingDirection.Down);
+
+            AddStep("setup beatmap", () =>
+            {
+                composer.EditorBeatmap.Clear();
+                composer.EditorBeatmap.Add(new HoldNote
+                {
+                    Column = 1,
+                    EndTime = 200
+                });
+            });
+
+            DrawableHoldNote holdNote = null;
+
+            AddStep("grab hold note", () =>
+            {
+                holdNote = this.ChildrenOfType<DrawableHoldNote>().FirstOrDefault();
+                InputManager.MoveMouseTo(holdNote);
+                InputManager.PressButton(MouseButton.Left);
+            });
+
+            AddStep("move drag upwards", () =>
+            {
+                InputManager.MoveMouseTo(holdNote, new Vector2(0, -100));
+                InputManager.ReleaseButton(MouseButton.Left);
+            });
+
+            AddAssert("head note positioned correctly", () => Precision.AlmostEquals(holdNote.ScreenSpaceDrawQuad.BottomLeft, holdNote.Head.ScreenSpaceDrawQuad.BottomLeft));
+            AddAssert("tail note positioned correctly", () => Precision.AlmostEquals(holdNote.ScreenSpaceDrawQuad.TopLeft, holdNote.Tail.ScreenSpaceDrawQuad.BottomLeft));
+
+            AddAssert("head blueprint positioned correctly", () => this.ChildrenOfType<HoldNoteNoteSelectionBlueprint>().ElementAt(0).DrawPosition == holdNote.Head.DrawPosition);
+            AddAssert("tail blueprint positioned correctly", () => this.ChildrenOfType<HoldNoteNoteSelectionBlueprint>().ElementAt(1).DrawPosition == holdNote.Tail.DrawPosition);
+        }
+
+        private void setScrollStep(ScrollingDirection direction)
+            => AddStep($"set scroll direction = {direction}", () => ((Bindable<ScrollingDirection>)composer.Composer.ScrollingInfo.Direction).Value = direction);
 
         private class TestComposer : CompositeDrawable
         {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
@@ -399,7 +399,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             public TestSlider()
             {
-                DefaultsApplied += () =>
+                DefaultsApplied += _ =>
                 {
                     HeadCircle.HitWindows = new TestHitWindows();
                     TailCircle.HitWindows = new TestHitWindows();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         private void bindEvents(DrawableOsuHitObject drawableObject)
         {
             drawableObject.HitObject.PositionBindable.BindValueChanged(_ => scheduleRefresh());
-            drawableObject.HitObject.DefaultsApplied += scheduleRefresh;
+            drawableObject.HitObject.DefaultsApplied += _ => scheduleRefresh();
         }
 
         private void scheduleRefresh()

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             samplesBindable.CollectionChanged += (_, __) => loadSamples();
 
             updateState(ArmedState.Idle, true);
-            onDefaultsApplied();
+            apply(HitObject);
         }
 
         private void loadSamples()
@@ -175,7 +175,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
             AddInternal(Samples);
         }
 
-        private void onDefaultsApplied() => apply(HitObject);
+        private void onDefaultsApplied(HitObject hitObject)
+        {
+            apply(hitObject);
+        }
 
         private void apply(HitObject hitObject)
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
     [Cached(typeof(DrawableHitObject))]
     public abstract class DrawableHitObject : SkinReloadableDrawable
     {
+        public event Action<DrawableHitObject> DefaultsApplied;
+
         public readonly HitObject HitObject;
 
         /// <summary>
@@ -178,6 +180,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         private void onDefaultsApplied(HitObject hitObject)
         {
             apply(hitObject);
+            DefaultsApplied?.Invoke(this);
         }
 
         private void apply(HitObject hitObject)

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// Invoked after <see cref="ApplyDefaults"/> has completed on this <see cref="HitObject"/>.
         /// </summary>
-        public event Action DefaultsApplied;
+        public event Action<HitObject> DefaultsApplied;
 
         public readonly Bindable<double> StartTimeBindable = new BindableDouble();
 
@@ -124,7 +124,7 @@ namespace osu.Game.Rulesets.Objects
             foreach (var h in nestedHitObjects)
                 h.ApplyDefaults(controlPointInfo, difficulty);
 
-            DefaultsApplied?.Invoke();
+            DefaultsApplied?.Invoke(this);
         }
 
         protected virtual void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -16,17 +16,23 @@ namespace osu.Game.Rulesets.UI.Scrolling
     {
         private readonly IBindable<double> timeRange = new BindableDouble();
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
+        private readonly Dictionary<DrawableHitObject, Cached> hitObjectInitialStateCache = new Dictionary<DrawableHitObject, Cached>();
 
         [Resolved]
         private IScrollingInfo scrollingInfo { get; set; }
 
-        private readonly LayoutValue initialStateCache = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo);
+        // Responds to changes in the layout. When the layout is changes, all hit object states must be recomputed.
+        private readonly LayoutValue layoutCache = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo);
+
+        // A combined cache across all hit object states to reduce per-update iterations.
+        // When invalidated, one or more (but not necessarily all) hitobject states must be re-validated.
+        private readonly Cached combinedObjCache = new Cached();
 
         public ScrollingHitObjectContainer()
         {
             RelativeSizeAxes = Axes.Both;
 
-            AddLayout(initialStateCache);
+            AddLayout(layoutCache);
         }
 
         [BackgroundDependencyLoader]
@@ -35,13 +41,14 @@ namespace osu.Game.Rulesets.UI.Scrolling
             direction.BindTo(scrollingInfo.Direction);
             timeRange.BindTo(scrollingInfo.TimeRange);
 
-            direction.ValueChanged += _ => initialStateCache.Invalidate();
-            timeRange.ValueChanged += _ => initialStateCache.Invalidate();
+            direction.ValueChanged += _ => layoutCache.Invalidate();
+            timeRange.ValueChanged += _ => layoutCache.Invalidate();
         }
 
         public override void Add(DrawableHitObject hitObject)
         {
-            initialStateCache.Invalidate();
+            combinedObjCache.Invalidate();
+            hitObject.DefaultsApplied += onDefaultsApplied;
             base.Add(hitObject);
         }
 
@@ -51,8 +58,10 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
             if (result)
             {
-                initialStateCache.Invalidate();
+                combinedObjCache.Invalidate();
                 hitObjectInitialStateCache.Remove(hitObject);
+
+                hitObject.DefaultsApplied -= onDefaultsApplied;
             }
 
             return result;
@@ -60,10 +69,24 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
         public override void Clear(bool disposeChildren = true)
         {
+            foreach (var h in Objects)
+                h.DefaultsApplied -= onDefaultsApplied;
+
             base.Clear(disposeChildren);
 
-            initialStateCache.Invalidate();
+            combinedObjCache.Invalidate();
             hitObjectInitialStateCache.Clear();
+        }
+
+        private void onDefaultsApplied(DrawableHitObject drawableObject)
+        {
+            // The cache may not exist if the hitobject state hasn't been computed yet (e.g. if the hitobject was added + defaults applied in the same frame).
+            // In such a case, combinedObjCache will take care of updating the hitobject.
+            if (hitObjectInitialStateCache.TryGetValue(drawableObject, out var objCache))
+            {
+                combinedObjCache.Invalidate();
+                objCache.Invalidate();
+            }
         }
 
         private float scrollLength;
@@ -72,11 +95,19 @@ namespace osu.Game.Rulesets.UI.Scrolling
         {
             base.Update();
 
-            if (!initialStateCache.IsValid)
+            if (!layoutCache.IsValid)
             {
                 foreach (var cached in hitObjectInitialStateCache.Values)
                     cached.Invalidate();
+                combinedObjCache.Invalidate();
 
+                scrollingInfo.Algorithm.Reset();
+
+                layoutCache.Validate();
+            }
+
+            if (!combinedObjCache.IsValid)
+            {
                 switch (direction.Value)
                 {
                     case ScrollingDirection.Up:
@@ -89,15 +120,21 @@ namespace osu.Game.Rulesets.UI.Scrolling
                         break;
                 }
 
-                scrollingInfo.Algorithm.Reset();
-
                 foreach (var obj in Objects)
                 {
+                    if (!hitObjectInitialStateCache.TryGetValue(obj, out var objCache))
+                        objCache = hitObjectInitialStateCache[obj] = new Cached();
+
+                    if (objCache.IsValid)
+                        return;
+
                     computeLifetimeStartRecursive(obj);
                     computeInitialStateRecursive(obj);
+
+                    objCache.Validate();
                 }
 
-                initialStateCache.Validate();
+                combinedObjCache.Validate();
             }
         }
 
@@ -108,8 +145,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
             foreach (var obj in hitObject.NestedHitObjects)
                 computeLifetimeStartRecursive(obj);
         }
-
-        private readonly Dictionary<DrawableHitObject, Cached> hitObjectInitialStateCache = new Dictionary<DrawableHitObject, Cached>();
 
         private double computeOriginAdjustedLifetimeStart(DrawableHitObject hitObject)
         {
@@ -142,12 +177,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
         // Cant use AddOnce() since the delegate is re-constructed every invocation
         private void computeInitialStateRecursive(DrawableHitObject hitObject) => hitObject.Schedule(() =>
         {
-            if (!hitObjectInitialStateCache.TryGetValue(hitObject, out var cached))
-                cached = hitObjectInitialStateCache[hitObject] = new Cached();
-
-            if (cached.IsValid)
-                return;
-
             if (hitObject.HitObject is IHasEndTime e)
             {
                 switch (direction.Value)
@@ -171,8 +200,6 @@ namespace osu.Game.Rulesets.UI.Scrolling
                 // Nested hitobjects don't need to scroll, but they do need accurate positions
                 updatePosition(obj, hitObject.HitObject.StartTime);
             }
-
-            cached.Validate();
         });
 
         protected override void UpdateAfterChildrenLife()

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
                         objCache = hitObjectInitialStateCache[obj] = new Cached();
 
                     if (objCache.IsValid)
-                        return;
+                        continue;
 
                     computeLifetimeStartRecursive(obj);
                     computeInitialStateRecursive(obj);

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
         [Resolved]
         private IScrollingInfo scrollingInfo { get; set; }
 
-        // Responds to changes in the layout. When the layout is changes, all hit object states must be recomputed.
+        // Responds to changes in the layout. When the layout changes, all hit object states must be recomputed.
         private readonly LayoutValue layoutCache = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo);
 
         // A combined cache across all hit object states to reduce per-update iterations.

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -197,6 +198,25 @@ namespace osu.Game.Screens.Edit
 
             startTimeBindables.Remove(hitObject);
             HitObjectRemoved?.Invoke(hitObject);
+
+            updateHitObject(null, true);
+        }
+
+        /// <summary>
+        /// Clears all <see cref="HitObjects"/> from this <see cref="EditorBeatmap"/>.
+        /// </summary>
+        public void Clear()
+        {
+            var removed = HitObjects.ToList();
+
+            mutableHitObjects.Clear();
+
+            foreach (var b in startTimeBindables)
+                b.Value.UnbindAll();
+            startTimeBindables.Clear();
+
+            foreach (var h in removed)
+                HitObjectRemoved?.Invoke(h);
 
             updateHitObject(null, true);
         }


### PR DESCRIPTION
The biggest change of importance is to `ScrollingHitObjectContainer.cs`. It has 3 invalidations:

1. An invalidation based on layout (e.g. screen size changing).
    * This invalidates both (2) and (3).
2. An invalidation based on any hitobject changing (addition, removal, and now `ApplyDefaults`).
    * If this is invalidated, it can be assumed that _at least_ one of (3) is also invalidated.
3. A per-hitobject state invalidation.

The use of (2) is simply as a performance measure, otherwise the SHOC would have to iterate through all hitobjects every frame to see if it needs to recompute the state of any.