### PR TITLE
Check local availability of beatmap before disabling download buttons

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
@@ -50,13 +50,6 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         [BackgroundDependencyLoader(true)]
         private void load(OsuGame game, BeatmapManager beatmaps, OsuConfigManager osuConfig)
         {
-            if ((BeatmapSet.Value?.OnlineInfo?.Availability?.DownloadDisabled ?? false) && State.Value != DownloadState.LocallyAvailable)
-            {
-                button.Enabled.Value = false;
-                button.TooltipText = "this beatmap is currently not available for download.";
-                return;
-            }
-
             noVideoSetting = osuConfig.GetBindable<bool>(OsuSetting.PreferNoVideo);
 
             button.Action = () =>
@@ -81,6 +74,26 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                         break;
                 }
             };
+
+            State.BindValueChanged(state =>
+            {
+                switch (state.NewValue)
+                {
+                    case DownloadState.LocallyAvailable:
+                        button.Enabled.Value = true;
+                        button.TooltipText = string.Empty;
+                        break;
+
+                    default:
+                        if (BeatmapSet.Value?.OnlineInfo?.Availability?.DownloadDisabled ?? false)
+                        {
+                            button.Enabled.Value = false;
+                            button.TooltipText = "this beatmap is currently not available for download.";
+                        }
+
+                        break;
+                }
+            }, true);
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         [BackgroundDependencyLoader(true)]
         private void load(OsuGame game, BeatmapManager beatmaps, OsuConfigManager osuConfig)
         {
-            if (BeatmapSet.Value?.OnlineInfo?.Availability?.DownloadDisabled ?? false)
+            if ((BeatmapSet.Value?.OnlineInfo?.Availability?.DownloadDisabled ?? false) && State.Value != DownloadState.LocallyAvailable)
             {
                 button.Enabled.Value = false;
                 button.TooltipText = "this beatmap is currently not available for download.";

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -264,7 +264,7 @@ namespace osu.Game.Overlays.BeatmapSet
         {
             if (BeatmapSet.Value == null) return;
 
-            if (BeatmapSet.Value.OnlineInfo.Availability?.DownloadDisabled ?? false)
+            if ((BeatmapSet.Value.OnlineInfo.Availability?.DownloadDisabled ?? false) && State.Value != DownloadState.LocallyAvailable)
             {
                 downloadButtonsContainer.Clear();
                 return;


### PR DESCRIPTION
Fixes #8974

Download buttons are also used by the game to present the beatmap in song select. If you already have downloaded a beatmap that others no longer can, you should be able to use the download button to present said beatmap.

This PR adds a simple check of local availability for osu!direct and beatmap info overlay.