### PR TITLE
Fix taiko sample mapping for strong hits

### DIFF
--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -171,30 +171,6 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
 
                     bool isRim = samples.Any(isRimDefinition);
 
-                    if (isRim)
-                    {
-                        // consume then remove the rim definition sample types.
-                        var updatedSamples = samples.Where(s => !isRimDefinition(s)).ToList();
-
-                        // strong + rim always maps to whistle.
-                        if (strong)
-                        {
-                            for (var i = 0; i < updatedSamples.Count; i++)
-                            {
-                                var s = samples[i];
-
-                                if (s.Name != HitSampleInfo.HIT_FINISH)
-                                    continue;
-
-                                var sClone = s.Clone();
-                                sClone.Name = HitSampleInfo.HIT_WHISTLE;
-                                updatedSamples[i] = sClone;
-                            }
-                        }
-
-                        samples = updatedSamples;
-                    }
-
                     yield return new Hit
                     {
                         StartTime = obj.StartTime,

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -167,13 +167,39 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
 
                 default:
                 {
-                    bool isRim = samples.Any(s => s.Name == HitSampleInfo.HIT_CLAP || s.Name == HitSampleInfo.HIT_WHISTLE);
+                    bool isRimDefinition(HitSampleInfo s) => s.Name == HitSampleInfo.HIT_CLAP || s.Name == HitSampleInfo.HIT_WHISTLE;
+
+                    bool isRim = samples.Any(isRimDefinition);
+
+                    if (isRim)
+                    {
+                        // consume then remove the rim definition sample types.
+                        var updatedSamples = samples.Where(s => !isRimDefinition(s)).ToList();
+
+                        // strong + rim always maps to whistle.
+                        if (strong)
+                        {
+                            for (var i = 0; i < updatedSamples.Count; i++)
+                            {
+                                var s = samples[i];
+
+                                if (s.Name != HitSampleInfo.HIT_FINISH)
+                                    continue;
+
+                                var sClone = s.Clone();
+                                sClone.Name = HitSampleInfo.HIT_WHISTLE;
+                                updatedSamples[i] = sClone;
+                            }
+                        }
+
+                        samples = updatedSamples;
+                    }
 
                     yield return new Hit
                     {
                         StartTime = obj.StartTime,
                         Type = isRim ? HitType.Rim : HitType.Centre,
-                        Samples = obj.Samples,
+                        Samples = samples,
                         IsStrong = strong
                     };
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Graphics;
+using osu.Game.Audio;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
@@ -46,6 +48,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override SkinnableDrawable CreateMainPiece() => HitObject.Type == HitType.Centre
             ? new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.CentreHit), _ => new CentreHitCirclePiece(), confineMode: ConfineMode.ScaleToFit)
             : new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.RimHit), _ => new RimHitCirclePiece(), confineMode: ConfineMode.ScaleToFit);
+
+        protected override IEnumerable<HitSampleInfo> GetSamples()
+        {
+            // normal and claps are always handled by the drum (see DrumSampleMapping).
+            return HitObject.Samples.Where(s => s.Name != HitSampleInfo.HIT_NORMAL && s.Name != HitSampleInfo.HIT_CLAP);
+        }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -52,7 +52,32 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override IEnumerable<HitSampleInfo> GetSamples()
         {
             // normal and claps are always handled by the drum (see DrumSampleMapping).
-            return HitObject.Samples.Where(s => s.Name != HitSampleInfo.HIT_NORMAL && s.Name != HitSampleInfo.HIT_CLAP);
+            var samples = HitObject.Samples.Where(s => s.Name != HitSampleInfo.HIT_NORMAL && s.Name != HitSampleInfo.HIT_CLAP);
+
+            if (HitObject.Type == HitType.Rim && HitObject.IsStrong)
+            {
+                // strong + rim always maps to whistle.
+                // TODO: this should really be in the legacy decoder, but can't be because legacy encoding parity would be broken.
+                // when we add a taiko editor, this is probably not going to play nice.
+
+                var corrected = samples.ToList();
+
+                for (var i = 0; i < corrected.Count; i++)
+                {
+                    var s = corrected[i];
+
+                    if (s.Name != HitSampleInfo.HIT_FINISH)
+                        continue;
+
+                    var sClone = s.Clone();
+                    sClone.Name = HitSampleInfo.HIT_WHISTLE;
+                    corrected[i] = sClone;
+                }
+
+                return corrected;
+            }
+
+            return samples;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -165,8 +165,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             return base.CreateNestedHitObject(hitObject);
         }
 
-        // Normal and clap samples are handled by the drum
-        protected override IEnumerable<HitSampleInfo> GetSamples() => HitObject.Samples.Where(s => s.Name != HitSampleInfo.HIT_NORMAL && s.Name != HitSampleInfo.HIT_CLAP);
+        // Most osu!taiko hitsounds are managed by the drum (see DrumSampleMapping).
+        protected override IEnumerable<HitSampleInfo> GetSamples() => Enumerable.Empty<HitSampleInfo>();
 
         protected abstract SkinnableDrawable CreateMainPiece();
 


### PR DESCRIPTION
In stable the mapping for taiko object types is defined as follows:

```
Hit types:

Normal -> Normal
Whistle -> Rim
Clap -> Rim
Finish -> Strong

Hit sounds:

strong => Finish
strong+rim => Whistle
```

Normal and clap are always played separately from hitobjects by the drum.

I've changed the logic to do the correct sample mapping in the `TaikoBeatmapConverter`, so we can better define and provide editor support for all sound combinations in the future, but left the normal/clap to the drum for simplicity/sanity reasons.

Testing shows the following:

```
# for Normal hitobject definition
Stable:     Normal 
master:     Normal
this pr:    Normal

# for Whistle hitobject definition
Stable:     Clap 
master:     Clap,Whistle
this pr:    Clap

# for Finish hitobject definition
Stable:     Normal,Finish
master:     Normal,Normal,Finish
this pr:    Normal,Normal,Finish

Clap
Stable:     Clap 
master:     Clap
this pr:    Clap

# for Whistle+Finish hitobject definition
Stable:     Whistle,Clap
master:     Clap,Finish,Whistle,Clap
this pr:    Clap,Whistle,Clap

# for Clap+Finish hitobject definition
Stable:     Whistle,Clap
master:     Clap,Finish,Clap
this pr:    Clap,Whistle,Clap
```

Note that the double playbacks of Clap/Normal are a separate issue which I will be investigating (the drum needs to avoid overlapping playbacks for double hits on strongs.)

Closes https://github.com/ppy/osu/issues/8955


