### PR TITLE
Use CacheAs for caching game-wide components

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -91,7 +91,7 @@ namespace osu.Game
 
         protected BackButton BackButton;
 
-        protected SettingsPanel Settings;
+        protected SettingsOverlay Settings;
 
         private VolumeOverlay volume;
         private OsuLogo osuLogo;
@@ -767,11 +767,17 @@ namespace osu.Game
 
         private Task asyncLoadStream;
 
+        /// <summary>
+        /// Schedules loading the provided <paramref name="d"/> in a single file.
+        /// </summary>
+        /// <param name="d">The component to load.</param>
+        /// <param name="add">The method to invoke for adding the component.</param>
+        /// <param name="cache">Whether to cache the component as type <typeparamref name="T"/> into the game dependencies before any scheduling.</param>
         private T loadComponentSingleFile<T>(T d, Action<T> add, bool cache = false)
             where T : Drawable
         {
             if (cache)
-                dependencies.Cache(d);
+                dependencies.CacheAs(d);
 
             if (d is OverlayContainer overlay)
                 overlays.Add(overlay);


### PR DESCRIPTION
This pull request switches out Cache with CacheAs inside the loadComponentSingleFile method.
As it's probably more appropriate and correct to cache the component as one shared base type for virtual protected instantiation methods (CreateXXX()), like done in #8965 with caching UpdateManager with the type as-is instantiated by CreateUpdateManager().