### PR TITLE
Fix taiko scroller not correctly adhering to gameplay time movement

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.427.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.512.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2020.511.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoScroller.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
+using osu.Framework.Timing;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning;
@@ -12,11 +13,28 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 {
     public class TestSceneTaikoScroller : TaikoSkinnableTestScene
     {
+        private readonly ManualClock clock = new ManualClock();
+
+        private bool reversed;
+
         public TestSceneTaikoScroller()
         {
-            AddStep("Load scroller", () => SetContents(() => new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoScroller), _ => Empty())));
+            AddStep("Load scroller", () => SetContents(() =>
+                new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoScroller), _ => Empty())
+                {
+                    Clock = new FramedClock(clock)
+                }));
             AddToggleStep("Toggle passing", passing => this.ChildrenOfType<LegacyTaikoScroller>().ForEach(s => s.LastResult.Value =
                 new JudgementResult(null, new Judgement()) { Type = passing ? HitResult.Perfect : HitResult.Miss }));
+
+            AddToggleStep("toggle playback direction", reversed => this.reversed = reversed);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            clock.CurrentTime += (reversed ? -1 : 1) * Clock.ElapsedFrameTime;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoScroller.cs
@@ -22,7 +22,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             AddStep("Load scroller", () => SetContents(() =>
                 new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoScroller), _ => Empty())
                 {
-                    Clock = new FramedClock(clock)
+                    Clock = new FramedClock(clock),
+                    Height = 0.4f,
                 }));
             AddToggleStep("Toggle passing", passing => this.ChildrenOfType<LegacyTaikoScroller>().ForEach(s => s.LastResult.Value =
                 new JudgementResult(null, new Judgement()) { Type = passing ? HitResult.Perfect : HitResult.Miss }));

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 {
     public class LegacyTaikoScroller : CompositeDrawable
     {
+        public Bindable<JudgementResult> LastResult = new Bindable<JudgementResult>();
+
         public LegacyTaikoScroller()
         {
             RelativeSizeAxes = Axes.Both;
@@ -50,21 +52,16 @@ namespace osu.Game.Rulesets.Taiko.Skinning
             }, true);
         }
 
-        public Bindable<JudgementResult> LastResult = new Bindable<JudgementResult>();
-
         protected override void Update()
         {
             base.Update();
-
-            bool wideEnough() =>
-                InternalChildren.Any()
-                && InternalChildren.First().ScreenSpaceDrawQuad.Width * InternalChildren.Count >= ScreenSpaceDrawQuad.Width * 2;
 
             // store X before checking wide enough so if we perform layout there is no positional discrepancy.
             float currentX = (InternalChildren?.FirstOrDefault()?.X ?? 0) - (float)Clock.ElapsedFrameTime * 0.1f;
 
             // ensure we have enough sprites
-            while (!wideEnough())
+            if (!InternalChildren.Any()
+                || InternalChildren.First().ScreenSpaceDrawQuad.Width * InternalChildren.Count < ScreenSpaceDrawQuad.Width * 2)
                 AddInternal(new ScrollerSprite { Passing = passing });
 
             var first = InternalChildren.First();

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
@@ -17,6 +17,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 {
     public class LegacyTaikoScroller : CompositeDrawable
     {
+        [Resolved(canBeNull: true)]
+        private GameplayClock gameplayClock { get; set; }
+
         public LegacyTaikoScroller()
         {
             RelativeSizeAxes = Axes.Both;
@@ -63,7 +66,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                 foreach (var sprite in InternalChildren)
                 {
                     // add the x coordinates and perform re-layout on all sprites as spacing may change with gameplay scale.
-                    sprite.X = additiveX ??= sprite.X - (float)Time.Elapsed * 0.1f;
+                    sprite.X = additiveX ??= sprite.X - (float)(gameplayClock ?? Clock).ElapsedFrameTime * 0.1f;
 
                     additiveX += sprite.DrawWidth - 1;
 

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
@@ -64,13 +64,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning
             float currentX = (InternalChildren?.FirstOrDefault()?.X ?? 0) - (float)Clock.ElapsedFrameTime * 0.1f;
 
             // ensure we have enough sprites
-            if (!wideEnough())
-            {
-                ClearInternal();
-
-                while (!wideEnough())
-                    AddInternal(new ScrollerSprite { Passing = passing });
-            }
+            while (!wideEnough())
+                AddInternal(new ScrollerSprite { Passing = passing });
 
             var first = InternalChildren.First();
             var last = InternalChildren.Last();

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
             {
                 // add the x coordinates and perform re-layout on all sprites as spacing may change with gameplay scale.
                 sprite.X = currentX;
-                currentX += sprite.DrawWidth - 1;
+                currentX += sprite.DrawWidth;
             }
 
             if (first.ScreenSpaceDrawQuad.TopLeft.X >= ScreenSpaceDrawQuad.TopLeft.X)

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             new BarLineGenerator<BarLine>(Beatmap).BarLines.ForEach(bar => Playfield.Add(bar.Major ? new DrawableBarLineMajor(bar) : new DrawableBarLine(bar)));
 
-            AddInternal(scroller = new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoScroller), _ => Empty())
+            FrameStableComponents.Add(scroller = new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoScroller), _ => Empty())
             {
                 RelativeSizeAxes = Axes.X,
                 Depth = float.MaxValue

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Framework" Version="2020.511.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.427.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.512.0" />
     <PackageReference Include="Sentry" Version="2.1.1" />
     <PackageReference Include="SharpCompress" Version="0.25.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.511.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.427.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.512.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8995
- Adds forgotten resources bump to make the scroller actually appear for default skin

More of a large change than I hoped for, but I think this method reads better. Maybe.