### PR TITLE
Reposition taiko playfield closer to top of screen

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -13,18 +13,16 @@ namespace osu.Game.Rulesets.Taiko.UI
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
         private const float default_aspect = 16f / 9f;
 
-        public TaikoPlayfieldAdjustmentContainer()
-        {
-            Anchor = Anchor.CentreLeft;
-            Origin = Anchor.CentreLeft;
-        }
-
         protected override void Update()
         {
             base.Update();
 
             float aspectAdjust = Math.Clamp(Parent.ChildSize.X / Parent.ChildSize.Y, 0.4f, 4) / default_aspect;
             Size = new Vector2(1, default_relative_height * aspectAdjust);
+
+            // Position the taiko playfield exactly one playfield from the top of the screen.
+            RelativePositionAxes = Axes.Y;
+            Y = Size.Y;
         }
     }
 }


### PR DESCRIPTION
- [x] Loosely depends on #9003 
- Closes https://github.com/ppy/osu/issues/8994

Maybe considered a temporary measure. May change again when looking into https://github.com/ppy/osu/issues/5685 (see second screenshot).

![image](https://user-images.githubusercontent.com/191335/81648093-11d6fb00-9469-11ea-98a1-5b5b537d9b2c.png)

![image](https://user-images.githubusercontent.com/191335/81648100-17344580-9469-11ea-9384-2e5758e43ada.png)
