### PR TITLE
Allow disabling SkipOverlay through AllowGameplayOverlays.

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play;
@@ -16,7 +16,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     [TestFixture]
     public class TestSceneSkipOverlay : OsuManualInputManagerTestScene
     {
-        private SkipOverlay skip;
+        private TestSkipOverlay skip;
         private int requestCount;
 
         private double increment;
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    skip = new SkipOverlay(skip_time)
+                    skip = new TestSkipOverlay(skip_time)
                     {
                         RequestSkip = () =>
                         {
@@ -56,19 +56,19 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestFadeOnIdle()
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(Vector2.Zero));
-            AddUntilStep("fully visible", () => skip.Children.First().Alpha == 1);
-            AddUntilStep("wait for fade", () => skip.Children.First().Alpha < 1);
+            AddUntilStep("fully visible", () => skip.OverlayContents.Alpha == 1);
+            AddUntilStep("wait for fade", () => skip.OverlayContents.Alpha < 1);
 
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
-            AddUntilStep("fully visible", () => skip.Children.First().Alpha == 1);
-            AddUntilStep("wait for fade", () => skip.Children.First().Alpha < 1);
+            AddUntilStep("fully visible", () => skip.OverlayContents.Alpha == 1);
+            AddUntilStep("wait for fade", () => skip.OverlayContents.Alpha < 1);
         }
 
         [Test]
         public void TestClickableAfterFade()
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
-            AddUntilStep("wait for fade", () => skip.Children.First().Alpha == 0);
+            AddUntilStep("wait for fade", () => skip.OverlayContents.Alpha == 0);
             AddStep("click", () => InputManager.Click(MouseButton.Left));
             checkRequestCount(1);
         }
@@ -105,13 +105,23 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
             AddStep("button down", () => InputManager.PressButton(MouseButton.Left));
-            AddUntilStep("wait for overlay disappear", () => !skip.IsPresent);
-            AddAssert("ensure button didn't disappear", () => skip.Children.First().Alpha > 0);
+            AddUntilStep("wait for overlay disappear", () => !skip.Child.IsPresent);
+            AddAssert("ensure button didn't disappear", () => skip.OverlayContents.Alpha > 0);
             AddStep("button up", () => InputManager.ReleaseButton(MouseButton.Left));
             checkRequestCount(0);
         }
 
         private void checkRequestCount(int expected) =>
             AddAssert($"request count is {expected}", () => requestCount == expected);
+
+        private class TestSkipOverlay : SkipOverlay
+        {
+            public TestSkipOverlay(double startTime)
+                : base(startTime)
+            {
+            }
+
+            public Drawable OverlayContents => (Child as Container).Child;
+        }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
             }
 
-            public Drawable OverlayContents => (Child as Container).Child;
+            public Drawable OverlayContents => (Child as Container)?.Child;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -56,19 +56,19 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestFadeOnIdle()
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(Vector2.Zero));
-            AddUntilStep("fully visible", () => skip.OverlayContents.Alpha == 1);
-            AddUntilStep("wait for fade", () => skip.OverlayContents.Alpha < 1);
+            AddUntilStep("fully visible", () => skip.FadingContent.Alpha == 1);
+            AddUntilStep("wait for fade", () => skip.FadingContent.Alpha < 1);
 
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
-            AddUntilStep("fully visible", () => skip.OverlayContents.Alpha == 1);
-            AddUntilStep("wait for fade", () => skip.OverlayContents.Alpha < 1);
+            AddUntilStep("fully visible", () => skip.FadingContent.Alpha == 1);
+            AddUntilStep("wait for fade", () => skip.FadingContent.Alpha < 1);
         }
 
         [Test]
         public void TestClickableAfterFade()
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
-            AddUntilStep("wait for fade", () => skip.OverlayContents.Alpha == 0);
+            AddUntilStep("wait for fade", () => skip.FadingContent.Alpha == 0);
             AddStep("click", () => InputManager.Click(MouseButton.Left));
             checkRequestCount(1);
         }
@@ -105,8 +105,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
             AddStep("button down", () => InputManager.PressButton(MouseButton.Left));
-            AddUntilStep("wait for overlay disappear", () => !skip.OverlayContents.IsPresent);
-            AddAssert("ensure button didn't disappear", () => skip.OverlayContents.Alpha > 0);
+            AddUntilStep("wait for overlay disappear", () => !skip.OverlayContent.IsPresent);
+            AddAssert("ensure button didn't disappear", () => skip.FadingContent.Alpha > 0);
             AddStep("button up", () => InputManager.ReleaseButton(MouseButton.Left));
             checkRequestCount(0);
         }
@@ -121,7 +121,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
             }
 
-            public Drawable OverlayContents => (InternalChild as Container)?.Child;
+            public Drawable OverlayContent => InternalChild;
+
+            public Drawable FadingContent => (OverlayContent as Container)?.Child;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkipOverlay.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("move mouse", () => InputManager.MoveMouseTo(skip.ScreenSpaceDrawQuad.Centre));
             AddStep("button down", () => InputManager.PressButton(MouseButton.Left));
-            AddUntilStep("wait for overlay disappear", () => !skip.Child.IsPresent);
+            AddUntilStep("wait for overlay disappear", () => !skip.OverlayContents.IsPresent);
             AddAssert("ensure button didn't disappear", () => skip.OverlayContents.Alpha > 0);
             AddStep("button up", () => InputManager.ReleaseButton(MouseButton.Left));
             checkRequestCount(0);
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
             }
 
-            public Drawable OverlayContents => (Child as Container)?.Child;
+            public Drawable OverlayContents => (InternalChild as Container)?.Child;
         }
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -83,6 +83,8 @@ namespace osu.Game.Screens.Play
 
         private BreakTracker breakTracker;
 
+        private SkipOverlay skipOverlay;
+
         protected ScoreProcessor ScoreProcessor { get; private set; }
 
         protected HealthProcessor HealthProcessor { get; private set; }
@@ -189,6 +191,8 @@ namespace osu.Game.Screens.Play
                 HUDOverlay.ShowHud.Value = false;
                 HUDOverlay.ShowHud.Disabled = true;
                 BreakOverlay.Hide();
+                skipOverlay.Disabled = true;
+                skipOverlay.Hide();
             }
 
             DrawableRuleset.HasReplayLoaded.BindValueChanged(_ => updatePauseOnFocusLostState(), true);
@@ -290,7 +294,7 @@ namespace osu.Game.Screens.Play
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre
                 },
-                new SkipOverlay(DrawableRuleset.GameplayStartTime)
+                skipOverlay = new SkipOverlay(DrawableRuleset.GameplayStartTime)
                 {
                     RequestSkip = GameplayClockContainer.Skip
                 },

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -191,7 +191,6 @@ namespace osu.Game.Screens.Play
                 HUDOverlay.ShowHud.Value = false;
                 HUDOverlay.ShowHud.Disabled = true;
                 BreakOverlay.Hide();
-                skipOverlay.Disabled = true;
                 skipOverlay.Hide();
             }
 

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -24,7 +24,7 @@ using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Play
 {
-    public class SkipOverlay : Container, IKeyBindingHandler<GlobalAction>
+    public class SkipOverlay : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
         private readonly double startTime;
 
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.Play
         [BackgroundDependencyLoader(true)]
         private void load(OsuColour colours)
         {
-            Child = buttonContainer = new ButtonContainer
+            InternalChild = buttonContainer = new ButtonContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = fadeContainer = new FadeContainer

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private GameplayClock gameplayClock { get; set; }
 
+        public bool Disabled { get; set; }
+
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         /// <summary>
@@ -105,7 +107,8 @@ namespace osu.Game.Screens.Play
             button.Action = () => RequestSkip?.Invoke();
             displayTime = gameplayClock.CurrentTime;
 
-            Show();
+            if (!Disabled)
+                Show();
         }
 
         protected override void PopIn() => this.FadeIn(fade_time);
@@ -121,7 +124,7 @@ namespace osu.Game.Screens.Play
             remainingTimeBox.Width = (float)Interpolation.Lerp(remainingTimeBox.Width, progress, Math.Clamp(Time.Elapsed / 40, 0, 1));
 
             button.Enabled.Value = progress > 0;
-            State.Value = progress > 0 ? Visibility.Visible : Visibility.Hidden;
+            State.Value = progress > 0 && !Disabled ? Visibility.Visible : Visibility.Hidden;
         }
 
         protected override bool OnMouseMove(MouseMoveEvent e)


### PR DESCRIPTION
Forgot to include SkipOverlay in previous PR; thus opening this as a follow-up.

# Summary

- This allows to disable the display of `SkipOverlay` through `DrawableRuleset.AllowGameplayOverlays` property.