### PR TITLE
Fix mute button falling off the screen when UI scaling is used

### DIFF
--- a/osu.Game/Overlays/VolumeOverlay.cs
+++ b/osu.Game/Overlays/VolumeOverlay.cs
@@ -46,6 +46,13 @@ namespace osu.Game.Overlays
                     Width = 300,
                     Colour = ColourInfo.GradientHorizontal(Color4.Black.Opacity(0.75f), Color4.Black.Opacity(0))
                 },
+                muteButton = new MuteButton
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Margin = new MarginPadding(10),
+                    Current = { BindTarget = IsMuted }
+                },
                 new FillFlowContainer
                 {
                     Direction = FillDirection.Vertical,
@@ -56,19 +63,11 @@ namespace osu.Game.Overlays
                     Margin = new MarginPadding { Left = offset },
                     Children = new Drawable[]
                     {
-                        volumeMeterEffect = new VolumeMeter("EFFECTS", 125, colours.BlueDarker)
-                        {
-                            Margin = new MarginPadding { Top = 100 + MuteButton.HEIGHT } // to counter the mute button and re-center the volume meters
-                        },
+                        volumeMeterEffect = new VolumeMeter("EFFECTS", 125, colours.BlueDarker),
                         volumeMeterMaster = new VolumeMeter("MASTER", 150, colours.PinkDarker),
                         volumeMeterMusic = new VolumeMeter("MUSIC", 125, colours.BlueDarker),
-                        muteButton = new MuteButton
-                        {
-                            Margin = new MarginPadding { Top = 100 },
-                            Current = { BindTarget = IsMuted }
-                        }
                     }
-                },
+                }
             });
 
             volumeMeterMaster.Bindable.BindTo(audio.Volume);


### PR DESCRIPTION
- Closes #9028

lowest scale:
![image](https://user-images.githubusercontent.com/191335/82008011-95316000-96a6-11ea-87af-270d1dd884c4.png)

normal:
![image](https://user-images.githubusercontent.com/191335/82008033-a11d2200-96a6-11ea-9ef4-0fafff894940.png)

highest scale:
![image](https://user-images.githubusercontent.com/191335/82008114-cdd13980-96a6-11ea-80e4-e73a979f3da3.png)
