### PR TITLE
Avoid disabling a host-level bindable from osu! code

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -19,7 +19,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private readonly BindableBool rawInputToggle = new BindableBool();
         private Bindable<double> sensitivityBindable = new BindableDouble();
         private Bindable<string> ignoredInputHandler;
-        private SensitivitySetting sensitivity;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager osuConfig, FrameworkConfigManager config)
@@ -38,7 +37,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     LabelText = "Raw input",
                     Bindable = rawInputToggle
                 },
-                sensitivity = new SensitivitySetting
+                new SensitivitySetting
                 {
                     LabelText = "Cursor sensitivity",
                     Bindable = sensitivityBindable

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -17,12 +17,20 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         protected override string Header => "Mouse";
 
         private readonly BindableBool rawInputToggle = new BindableBool();
+        private Bindable<double> sensitivityBindable = new BindableDouble();
         private Bindable<string> ignoredInputHandler;
         private SensitivitySetting sensitivity;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager osuConfig, FrameworkConfigManager config)
         {
+            var configSensitivity = config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
+
+            // use local bindable to avoid changing enabled state of game host's bindable.
+            sensitivityBindable = configSensitivity.GetUnboundCopy();
+            configSensitivity.BindValueChanged(val => sensitivityBindable.Value = val.NewValue);
+            sensitivityBindable.BindValueChanged(val => configSensitivity.Value = val.NewValue);
+
             Children = new Drawable[]
             {
                 new SettingsCheckbox
@@ -33,7 +41,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 sensitivity = new SensitivitySetting
                 {
                     LabelText = "Cursor sensitivity",
-                    Bindable = config.GetBindable<double>(FrameworkSetting.CursorSensitivity)
+                    Bindable = sensitivityBindable
                 },
                 new SettingsCheckbox
                 {
@@ -60,7 +68,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
             {
                 rawInputToggle.Disabled = true;
-                sensitivity.Bindable.Disabled = true;
+                sensitivityBindable.Disabled = true;
             }
             else
             {

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     bool raw = !handler.NewValue.Contains("Raw");
                     rawInputToggle.Value = raw;
-                    sensitivity.Bindable.Disabled = !raw;
+                    sensitivityBindable.Disabled = !raw;
                 };
 
                 ignoredInputHandler.TriggerChange();


### PR DESCRIPTION
- Closes #8753.

I had a look at a few different approaches to fixing this problem, but this seems like the path of least resistance (least likely to break in the future).

Other alternatives I assessed:
- Exposing `OsuGameTestScene` for consumption by templates
- Reimplementing similar local storage logic in template projects

Both may fix this one instance but would require updates in all template based projects and the same issue may surface elsewhere if we aren't careful.