### PR TITLE
Add support to disable user cancelling on progress notifications

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -162,30 +162,26 @@ namespace osu.Game.Overlays.Notifications
 
         public class NotificationCloseButton : OsuClickableContainer
         {
-            private readonly ShakeContainer shakeContainer;
-
             private Color4 hoverColour;
 
             public NotificationCloseButton()
             {
                 Colour = OsuColour.Gray(0.2f);
 
-                Children = new[]
+                SpriteIcon icon;
+                Child = icon = new SpriteIcon
                 {
-                    shakeContainer = new ShakeContainer
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Child = new SpriteIcon
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Icon = FontAwesome.Solid.TimesCircle,
-                            RelativeSizeAxes = Axes.Both,
-                        }
-                    }
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = FontAwesome.Solid.TimesCircle,
+                    RelativeSizeAxes = Axes.Both,
                 };
 
-                Enabled.ValueChanged += _ => updateState();
+                Enabled.ValueChanged += e =>
+                {
+                    // Hide the button internally to avoid conflicting with notification hovering logic.
+                    icon.FadeTo(e.NewValue ? 1 : 0, 120);
+                };
             }
 
             [BackgroundDependencyLoader]
@@ -194,49 +190,16 @@ namespace osu.Game.Overlays.Notifications
                 hoverColour = colours.Yellow;
             }
 
-            /// <summary>
-            /// Fades the button in (if not visible), shakes it, then fades it back to its original alpha.
-            /// </summary>
-            public void FadeAndShake()
-            {
-                FinishTransforms(true);
-
-                var original = Alpha;
-
-                this.FadeIn(250, Easing.OutExpo)
-                    .Schedule(() => shakeContainer.Shake()).Then()
-                    .FadeTo(original, 250, Easing.InExpo);
-            }
-
             protected override bool OnHover(HoverEvent e)
             {
-                updateState();
+                this.FadeColour(hoverColour, 200);
                 return base.OnHover(e);
             }
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
-                updateState();
+                this.FadeColour(OsuColour.Gray(0.2f), 200);
                 base.OnHoverLost(e);
-            }
-
-            protected override bool OnClick(ClickEvent e)
-            {
-                if (!Enabled.Value)
-                    shakeContainer.Shake();
-
-                return base.OnClick(e);
-            }
-
-            private void updateState()
-            {
-                if (!Enabled.Value)
-                {
-                    this.FadeColour(OsuColour.Gray(0.8f), 200);
-                    return;
-                }
-
-                this.FadeColour(IsHovered ? hoverColour : OsuColour.Gray(0.2f), 200);
             }
         }
 

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -194,6 +194,20 @@ namespace osu.Game.Overlays.Notifications
                 hoverColour = colours.Yellow;
             }
 
+            /// <summary>
+            /// Fades the button in (if not visible), shakes it, then fades it back to its original alpha.
+            /// </summary>
+            public void FadeAndShake()
+            {
+                FinishTransforms(true);
+
+                var original = Alpha;
+
+                this.FadeIn(250, Easing.OutExpo)
+                    .Schedule(() => shakeContainer.Shake()).Then()
+                    .FadeTo(original, 250, Easing.InExpo);
+            }
+
             protected override bool OnHover(HoverEvent e)
             {
                 updateState();

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -188,13 +187,11 @@ namespace osu.Game.Overlays.Notifications
                 case ProgressNotificationState.Active:
                 case ProgressNotificationState.Queued:
                     if (!cancellable)
-                    {
-                        CloseButton.FadeAndShake();
                         return;
-                    }
 
                     if (CancelRequested?.Invoke() != false)
                         State = ProgressNotificationState.Cancelled;
+
                     break;
             }
         }


### PR DESCRIPTION
Gives better UX for progress notifications tracking tasks that cannot be cancelled, instead of silently finishing the task regardless of the notification state (currently happening with `SquirrelUpdateManager`, to be fixed in a follow-up PR):

![](https://im7.ezgif.com/tmp/ezgif-7-053d550e810d.gif)

- Design is open for feedback, currently following what most disabled buttons do afaik.