### PR TITLE
Disable user-cancelling in squirrel update notification

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -57,7 +57,7 @@ namespace osu.Desktop.Updater
 
                 if (notification == null)
                 {
-                    notification = new UpdateProgressNotification(this) { State = ProgressNotificationState.Active };
+                    notification = new UpdateProgressNotification(this) { State = ProgressNotificationState.Active, Cancellable = false };
                     Schedule(() => notificationOverlay.Post(notification));
                 }
 


### PR DESCRIPTION
- [ ] Depends on #9034 

Can be disabled for now until cancellation is supported in squirrel updating methods.