### PR TITLE
Fix applied platform/user offsets being incorrect when rate adjust mods are active

### DIFF
--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -78,10 +78,10 @@ namespace osu.Game.Screens.Play
 
             // Lazer's audio timings in general doesn't match stable. This is the result of user testing, albeit limited.
             // This only seems to be required on windows. We need to eventually figure out why, with a bit of luck.
-            platformOffsetClock = new FramedOffsetClock(adjustableClock) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
+            platformOffsetClock = new HardwareCorrectionOffsetClock(adjustableClock) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
 
             // the final usable gameplay clock with user-set offsets applied.
-            userOffsetClock = new FramedOffsetClock(platformOffsetClock);
+            userOffsetClock = new HardwareCorrectionOffsetClock(platformOffsetClock);
 
             // the clock to be exposed via DI to children.
             GameplayClock = new GameplayClock(userOffsetClock);
@@ -246,6 +246,17 @@ namespace osu.Game.Screens.Play
             {
                 track.ResetSpeedAdjustments();
                 speedAdjustmentsApplied = false;
+            }
+        }
+
+        private class HardwareCorrectionOffsetClock : FramedOffsetClock
+        {
+            // we always want to apply the same real-time offset, so it should be adjusted by the playback rate to achieve this.
+            public override double CurrentTime => SourceTime + Offset * Rate;
+
+            public HardwareCorrectionOffsetClock(IClock source, bool processSource = true)
+                : base(source, processSource)
+            {
             }
         }
     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8774

Offsets and adjustments are hard.

Simplest way to understand this: UO and platform adjustments are made to account for constant delays in audio hardware or drivers. Because we are adjusting the playback rate relative to real time, we cannot apply these offsets in the same rate-adjusted timeline without accounting for this rate adjustment (making the offsets equivalent real-time values).

I believe this may also potentially be the issue mappers were having in stable when timing at 25%, reporting that the offset was off by roughly `WINDOWS_PLATFORM_OFFSET` amount.