### PR TITLE
Add a back button to sub screens in the Tournament Client

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingEditorScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingEditorScreen.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             var match = CreateSampleMatch();
 
-            Add(new SeedingEditorScreen(match.Team1.Value)
+            Add(new SeedingEditorScreen(match.Team1.Value, new TeamEditorScreen())
             {
                 Width = 0.85f // create room for control panel
             });

--- a/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
@@ -25,6 +25,13 @@ namespace osu.Game.Tournament.Screens.Editors
 
         protected override BindableList<SeedingResult> Storage => team.SeedingResults;
 
+        [Resolved(canBeNull: true)]
+        private TournamentSceneManager sceneManager { get; set; }
+
+        protected override bool IsSubScreen => true;
+
+        protected override System.Type ParentScreen => typeof(TeamEditorScreen);
+
         public SeedingEditorScreen(TournamentTeam team)
         {
             this.team = team;

--- a/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
@@ -28,11 +28,8 @@ namespace osu.Game.Tournament.Screens.Editors
         [Resolved(canBeNull: true)]
         private TournamentSceneManager sceneManager { get; set; }
 
-        protected override bool IsSubScreen => true;
-
-        protected override System.Type ParentScreen => typeof(TeamEditorScreen);
-
-        public SeedingEditorScreen(TournamentTeam team)
+        public SeedingEditorScreen(TournamentTeam team, TournamentScreen parentScreen)
+            : base(parentScreen)
         {
             this.team = team;
         }

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tournament.Screens.Editors
             });
         }
 
-        protected override TeamRow CreateDrawable(TournamentTeam model) => new TeamRow(model);
+        protected override TeamRow CreateDrawable(TournamentTeam model) => new TeamRow(model, this);
 
         private void addAllCountries()
         {
@@ -63,7 +63,7 @@ namespace osu.Game.Tournament.Screens.Editors
             [Resolved]
             private LadderInfo ladderInfo { get; set; }
 
-            public TeamRow(TournamentTeam team)
+            public TeamRow(TournamentTeam team, TournamentScreen parent)
             {
                 Model = team;
 
@@ -154,7 +154,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 Text = "Edit seeding results",
                                 Action = () =>
                                 {
-                                    sceneManager?.SetScreen(new SeedingEditorScreen(team));
+                                    sceneManager?.SetScreen(new SeedingEditorScreen(team, parent));
                                 }
                             },
                         }

--- a/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
@@ -33,13 +33,15 @@ namespace osu.Game.Tournament.Screens.Editors
 
         protected ControlPanel ControlPanel;
 
-        protected virtual bool IsSubScreen => false;
-
-        protected virtual System.Type ParentScreen { get; set; }
-
+        private readonly TournamentScreen parentScreen;
         private BackButton backButton;
 
-        private System.Action backAction => () => sceneManager?.SetScreen(ParentScreen);
+        private System.Action backAction => () => sceneManager?.SetScreen(parentScreen.GetType());
+
+        protected TournamentEditorScreen(TournamentScreen parentScreen = null)
+        {
+            this.parentScreen = parentScreen;
+        }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -51,7 +53,7 @@ namespace osu.Game.Tournament.Screens.Editors
                 Origin = Anchor.BottomLeft,
                 Action = () =>
                 {
-                    if (IsSubScreen)
+                    if (parentScreen != null)
                         backAction.Invoke();
                 }
             };
@@ -98,7 +100,7 @@ namespace osu.Game.Tournament.Screens.Editors
                 }
             });
 
-            if (IsSubScreen)
+            if (parentScreen != null)
                 backButton.Show();
 
             Storage.CollectionChanged += (_, args) =>

--- a/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
@@ -70,13 +70,13 @@ namespace osu.Game.Tournament.Screens.Editors
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    Padding = new MarginPadding { Bottom = backButton.Height },
                     Child = flow = new FillFlowContainer<TDrawable>
                     {
                         Direction = FillDirection.Vertical,
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Spacing = new Vector2(20)
+                        Spacing = new Vector2(20),
+                        Padding = new MarginPadding { Bottom = backButton.Height * 2 },
                     },
                 },
                 backButton,

--- a/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
@@ -44,6 +44,18 @@ namespace osu.Game.Tournament.Screens.Editors
         [BackgroundDependencyLoader]
         private void load()
         {
+            BackButton.Receptor receptor = new BackButton.Receptor();
+            backButton = new BackButton(receptor)
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                Action = () =>
+                {
+                    if (IsSubScreen)
+                        backAction.Invoke();
+                }
+            };
+
             AddRangeInternal(new Drawable[]
             {
                 new Box
@@ -56,6 +68,7 @@ namespace osu.Game.Tournament.Screens.Editors
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
+                    Padding = new MarginPadding { Bottom = backButton.Height },
                     Child = flow = new FillFlowContainer<TDrawable>
                     {
                         Direction = FillDirection.Vertical,
@@ -64,6 +77,7 @@ namespace osu.Game.Tournament.Screens.Editors
                         Spacing = new Vector2(20)
                     },
                 },
+                backButton,
                 ControlPanel = new ControlPanel
                 {
                     Children = new Drawable[]
@@ -85,17 +99,7 @@ namespace osu.Game.Tournament.Screens.Editors
             });
 
             if (IsSubScreen)
-            {
-                BackButton.Receptor receptor = new BackButton.Receptor();
-                backButton = new BackButton(receptor)
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    Action = () => { backAction.Invoke(); }
-                };
-                AddInternal(backButton);
                 backButton.Show();
-            }
 
             Storage.CollectionChanged += (_, args) =>
             {

--- a/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
@@ -46,18 +46,6 @@ namespace osu.Game.Tournament.Screens.Editors
         [BackgroundDependencyLoader]
         private void load()
         {
-            BackButton.Receptor receptor = new BackButton.Receptor();
-            backButton = new BackButton(receptor)
-            {
-                Anchor = Anchor.BottomLeft,
-                Origin = Anchor.BottomLeft,
-                Action = () =>
-                {
-                    if (parentScreen != null)
-                        backAction.Invoke();
-                }
-            };
-
             AddRangeInternal(new Drawable[]
             {
                 new Box
@@ -76,10 +64,8 @@ namespace osu.Game.Tournament.Screens.Editors
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Spacing = new Vector2(20),
-                        Padding = new MarginPadding { Bottom = backButton.Height * 2 },
                     },
                 },
-                backButton,
                 ControlPanel = new ControlPanel
                 {
                     Children = new Drawable[]
@@ -101,7 +87,21 @@ namespace osu.Game.Tournament.Screens.Editors
             });
 
             if (parentScreen != null)
-                backButton.Show();
+            {
+                AddInternal(backButton = new BackButton(new BackButton.Receptor())
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    State = { Value = Visibility.Visible },
+                    Action = () =>
+                    {
+                        if (parentScreen != null)
+                            backAction.Invoke();
+                    }
+                });
+
+                flow.Padding = new MarginPadding { Bottom = backButton.Height * 2 };
+            }
 
             Storage.CollectionChanged += (_, args) =>
             {
@@ -126,7 +126,7 @@ namespace osu.Game.Tournament.Screens.Editors
             switch (action)
             {
                 case GlobalAction.Back:
-                    backAction.Invoke();
+                    backAction?.Invoke();
                     return true;
             }
 

--- a/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
@@ -10,8 +10,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Input.Bindings;
-using osu.Framework.Input.Bindings;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays.Settings;
@@ -20,7 +18,7 @@ using osuTK;
 
 namespace osu.Game.Tournament.Screens.Editors
 {
-    public abstract class TournamentEditorScreen<TDrawable, TModel> : TournamentScreen, IProvideVideo, IKeyBindingHandler<GlobalAction>
+    public abstract class TournamentEditorScreen<TDrawable, TModel> : TournamentScreen, IProvideVideo
         where TDrawable : Drawable, IModelBacked<TModel>
         where TModel : class, new()
     {
@@ -35,8 +33,6 @@ namespace osu.Game.Tournament.Screens.Editors
 
         private readonly TournamentScreen parentScreen;
         private BackButton backButton;
-
-        private System.Action backAction => () => sceneManager?.SetScreen(parentScreen.GetType());
 
         protected TournamentEditorScreen(TournamentScreen parentScreen = null)
         {
@@ -88,16 +84,12 @@ namespace osu.Game.Tournament.Screens.Editors
 
             if (parentScreen != null)
             {
-                AddInternal(backButton = new BackButton(new BackButton.Receptor())
+                AddInternal(backButton = new BackButton
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     State = { Value = Visibility.Visible },
-                    Action = () =>
-                    {
-                        if (parentScreen != null)
-                            backAction.Invoke();
-                    }
+                    Action = () => sceneManager?.SetScreen(parentScreen.GetType())
                 });
 
                 flow.Padding = new MarginPadding { Bottom = backButton.Height * 2 };
@@ -119,22 +111,6 @@ namespace osu.Game.Tournament.Screens.Editors
 
             foreach (var model in Storage)
                 flow.Add(CreateDrawable(model));
-        }
-
-        public bool OnPressed(GlobalAction action)
-        {
-            switch (action)
-            {
-                case GlobalAction.Back:
-                    backAction?.Invoke();
-                    return true;
-            }
-
-            return false;
-        }
-
-        public void OnReleased(GlobalAction action)
-        {
         }
 
         protected abstract TDrawable CreateDrawable(TModel model);

--- a/osu.Game/Graphics/UserInterface/BackButton.cs
+++ b/osu.Game/Graphics/UserInterface/BackButton.cs
@@ -16,10 +16,8 @@ namespace osu.Game.Graphics.UserInterface
 
         private readonly TwoLayerButton button;
 
-        public BackButton(Receptor receptor)
+        public BackButton(Receptor receptor = null)
         {
-            receptor.OnBackPressed = () => button.Click();
-
             Size = TwoLayerButton.SIZE_EXTENDED;
 
             Child = button = new TwoLayerButton
@@ -30,6 +28,10 @@ namespace osu.Game.Graphics.UserInterface
                 Icon = OsuIcon.LeftCircle,
                 Action = () => Action?.Invoke()
             };
+
+            Add(receptor ??= new Receptor());
+
+            receptor.OnBackPressed = () => button.Click();
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Closes #9038 

This also handles the input of Esc so it goes back to the parent screen. 

Included are two screenshots: 

![dotnet_2020-05-16_04-06-12](https://user-images.githubusercontent.com/803255/82107806-ab80ff80-972a-11ea-93f7-3346ca7c4903.png)

![dotnet_2020-05-16_04-06-15](https://user-images.githubusercontent.com/803255/82107811-b20f7700-972a-11ea-9d07-81b0bda966fc.png)

Note that there's a padding on the ScrollContainer to compensate for the back button, so that all the items stay accessible.
