### PR TITLE
Disallow catch-specific judgements in mania

### DIFF
--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHitWindows.cs
@@ -7,5 +7,20 @@ namespace osu.Game.Rulesets.Mania.Scoring
 {
     public class ManiaHitWindows : HitWindows
     {
+        public override bool IsHitResultAllowed(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Perfect:
+                case HitResult.Great:
+                case HitResult.Good:
+                case HitResult.Ok:
+                case HitResult.Meh:
+                case HitResult.Miss:
+                    return true;
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Resolves #9047.

# Summary

Regressed at #8934.

Due to `ManiaHitWindows` not directly overriding `IsHitResultAllowed` but instead [delegating to base](https://github.com/ppy/osu/blob/9003c069bb7d7214d05cfb12ce6f63efe4793f5f/osu.Game/Rulesets/Scoring/HitWindows.cs#L80), new hit result types introduced for the sake of new catch diffcalc started showing up in mania results.

Explicitly only allow the six hit results allowed for mania hitobjects.

# Remarks

No tests, as this shouldn't really regress again, but this exposes the fact that the current API is not safe in regard to extensibility. I thought a little bit about making `IsHitResultAllowed` abstract, but it's not an instant change, as it requires making the base `HitWindows` themselves abstract.

It wouldn't be breaking to any custom ruleset as far as I can see (all of the ones in the custom ruleset listing override `HitWindows` anyway... but not the template rulesets), but it does require direct instantiations of `HitWindows` in tests to be replaced (i.e. with `HitWindows.Empty`) and it also breaks beatmap serialisation due to the JSON deserialiser not being able to instantiate the abstract type, necessitating a new custom converter to resolve.

As such it's probably a separate PR and also one that I'd like to confirm is in line with the direction you want to take.