### PR TITLE
Eliminate floating point inaccuracies when generating bar lines

### DIFF
--- a/osu.Game.Tests/NonVisual/BarLineGeneratorTest.cs
+++ b/osu.Game.Tests/NonVisual/BarLineGeneratorTest.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Tests.NonVisual
+{
+    public class BarLineGeneratorTest
+    {
+        [Test]
+        public void TestRoundingErrorCompensation()
+        {
+            // The aim of this test is to make sure bar line generation compensates for floating-point errors.
+            // The premise of the test is that we have a single timing point that should result in bar lines
+            // that start at a time point that is a whole number every seventh beat.
+
+            // The fact it's every seventh beat is important - it's a number indivisible by 2, which makes
+            // it susceptible to rounding inaccuracies. In fact this was originally spotted in cases of maps
+            // that met exactly this criteria.
+
+            const int beat_length_numerator = 2000;
+            const int beat_length_denominator = 7;
+            const TimeSignatures signature = TimeSignatures.SimpleQuadruple;
+
+            var beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitObject { StartTime = 0 },
+                    new HitObject { StartTime = 120_000 }
+                },
+                ControlPointInfo = new ControlPointInfo()
+            };
+
+            beatmap.ControlPointInfo.Add(0, new TimingControlPoint
+            {
+                BeatLength = (double)beat_length_numerator / beat_length_denominator,
+                TimeSignature = signature
+            });
+
+            var barLines = new BarLineGenerator<BarLine>(beatmap).BarLines;
+
+            for (int i = 0; i * beat_length_denominator < barLines.Count; i++)
+            {
+                var barLine = barLines[i * beat_length_denominator];
+                var expectedTime = beat_length_numerator * (int)signature * i;
+
+                // every seventh bar's start time should be at least greater than the whole number we expect.
+                // It cannot be less, as that can affect overlapping scroll algorithms
+                // (the previous timing point might be chosen incorrectly if this is not the case)
+                Assert.GreaterOrEqual(barLine.StartTime, expectedTime);
+
+                // on the other side, make sure we don't stray too far from the expected time either.
+                Assert.IsTrue(Precision.AlmostEquals(barLine.StartTime, expectedTime));
+
+                // check major/minor lines for good measure too
+                Assert.AreEqual(i % (int)signature == 0, barLine.Major);
+            }
+        }
+
+        private class BarLine : IBarLine
+        {
+            public double StartTime { get; set; }
+            public bool Major { get; set; }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Objects/BarLineGenerator.cs
+++ b/osu.Game/Rulesets/Objects/BarLineGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Utils;
@@ -46,6 +47,16 @@ namespace osu.Game.Rulesets.Objects
 
                 for (double t = currentTimingPoint.Time; Precision.DefinitelyBigger(endTime, t); t += barLength, currentBeat++)
                 {
+                    var roundedTime = Math.Round(t, MidpointRounding.AwayFromZero);
+
+                    // in the case of some bar lengths, rounding errors can cause t to be slightly less than
+                    // the expected whole number value due to floating point inaccuracies.
+                    // if this is the case, apply rounding.
+                    if (Precision.AlmostEquals(t, roundedTime))
+                    {
+                        t = roundedTime;
+                    }
+
                     BarLines.Add(new TBarLine
                     {
                         StartTime = t,


### PR DESCRIPTION
Resolves #8749.

# Summary

After investigating the beatmaps reported as affected, it turned out that bar line generation was impacted by floating-point inaccuracies. In the cases pointed out by users, the start time of the generated bar lines was marginally smaller than the start time of the timing control points that affected the overlapping scroll:

| Beatmap | Timing control point start time [m:s.ms] | Timing control point start time [ms] | Bar line start time [ms] |
| :- | -: | -: | -: |
| [Aether Realm - The Sun, The Moon, The Stars [Echoes from the Past]](https://osu.ppy.sh/beatmapsets/1042815#taiko/2179670) | 10:04.842 | 604842 | 604841.999999995 |
| [Celldweller - End of an Empire [Inner Oni]](https://osu.ppy.sh/beatmapsets/1107086#taiko/2313837) | 01:17.846 | 77146 | 77145.9999999999 |
| [Arcaea Sound Team against. ETIA. - Singularity VVVIP [If You CCCAN]](https://osu.ppy.sh/beatmapsets/1139960#taiko/2381084) | 01:17.330 | 77330 | 77329.9999999999 |
| [ESTi - HELIX (Edit ver.) [Inner Oni]](https://osu.ppy.sh/beatmapsets/625729#taiko/1584721) | 01:19.533 | 79533 | 79532.999999999985 |
| [ZYTOKINE - Missing Opus feat. cold kiss [Magnum Opus]](https://osu.ppy.sh/beatmapsets/737090#taiko/1555538) | 02:01.337 | 121337 | 121336.9999999997 |

To resolve, for each bar line generated round its start time to the nearest integer and apply precision to determine if its start time is close enough. If it is, then discard the fractional value in favour of the whole number, which should be exactly precise as long as it fits on 53 bits.

Here are some screenshots showing the results of this fix on beatmaps affected:

| Beatmap | `master` | this PR |
| :- | :-: | :-: |
| [Arcaea Sound Team against. ETIA. - Singularity VVVIP [If You CCCAN]](https://osu.ppy.sh/beatmapsets/1139960#taiko/2381084) | ![osu_2020-05-17_21-26-08](https://user-images.githubusercontent.com/20418176/82159463-83aaac80-988e-11ea-8540-6e63b02feef1.jpg) | ![osu_2020-05-17_22-06-22](https://user-images.githubusercontent.com/20418176/82159467-8c9b7e00-988e-11ea-9a6c-7d2e9f7f6d0d.jpg) |
| [ESTi - HELIX (Edit ver.) [Inner Oni]](https://osu.ppy.sh/beatmapsets/625729#taiko/1584721) | ![osu_2020-05-17_21-28-15](https://user-images.githubusercontent.com/20418176/82159484-a63cc580-988e-11ea-966f-bf80f2622622.jpg) | ![osu_2020-05-17_22-07-29](https://user-images.githubusercontent.com/20418176/82159489-ae950080-988e-11ea-80e4-9fda41713280.jpg) |
| [ZYTOKINE - Missing Opus feat. cold kiss [Magnum Opus]](https://osu.ppy.sh/beatmapsets/737090#taiko/1555538) | ![osu_2020-05-17_21-28-59](https://user-images.githubusercontent.com/20418176/82159492-b654a500-988e-11ea-88b9-88f4ef039af0.jpg) | ![osu_2020-05-17_22-08-17](https://user-images.githubusercontent.com/20418176/82159494-bc4a8600-988e-11ea-9c32-7a22c9149d2e.jpg) |

# Remarks

As somewhat of a "fun" fact, when I looked at the bar line start times generated, I started noticing number patterns of `...142857142...` in the decimal expansions of the bar line start times.

You might have seen something like that somewhere before - it's the decimal expansion of fractions with a denominator of 7, which cycle:

```
1/7 = 0.1428571428571429...
2/7 = 0.2857142857142857...
3/7 = 0.4285714285714286...
4/7 = 0.5714285714285714...
5/7 = 0.7142857142857143...
6/7 = 0.8571428571428571...
```

In fact all affected beatmaps had at least one timing point with a beat length that would be a result of division by 7. This allowed me to add a test case for this that covers the case of such maps.

The issue isn't however something unique to the number 7, as it just has to do with infinite fractional expansions (whether in base 2, or base 10). The fix should cover all possible cases for reasonable divisors, but if this ever comes up again in some other case, then tuning the tolerance in the precision check should suffice.

Not sure if you'll agree to the performance implications of this, but as a personal opinion I consider this the cleanest fix logic-wise.