### PR TITLE
Fix possible exceptions in performance calculators

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -4,12 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
-using osu.Game.Scoring.Legacy;
 
 namespace osu.Game.Rulesets.Catch.Difficulty
 {
@@ -34,11 +34,11 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         {
             mods = Score.Mods;
 
-            fruitsHit = Score?.GetCount300() ?? Score.Statistics[HitResult.Perfect];
-            ticksHit = Score?.GetCount100() ?? 0;
-            tinyTicksHit = Score?.GetCount50() ?? 0;
-            tinyTicksMissed = Score?.GetCountKatu() ?? 0;
-            misses = Score.Statistics[HitResult.Miss];
+            fruitsHit = Score.Statistics.GetOrDefault(HitResult.Perfect);
+            ticksHit = Score.Statistics.GetOrDefault(HitResult.LargeTickHit);
+            tinyTicksHit = Score.Statistics.GetOrDefault(HitResult.SmallTickHit);
+            tinyTicksMissed = Score.Statistics.GetOrDefault(HitResult.SmallTickMiss);
+            misses = Score.Statistics.GetOrDefault(HitResult.Miss);
 
             // Don't count scores made with supposedly unranked mods
             if (mods.Any(m => !m.Ranked))

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -37,12 +38,12 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         {
             mods = Score.Mods;
             scaledScore = Score.TotalScore;
-            countPerfect = Score.Statistics[HitResult.Perfect];
-            countGreat = Score.Statistics[HitResult.Great];
-            countGood = Score.Statistics[HitResult.Good];
-            countOk = Score.Statistics[HitResult.Ok];
-            countMeh = Score.Statistics[HitResult.Meh];
-            countMiss = Score.Statistics[HitResult.Miss];
+            countPerfect = Score.Statistics.GetOrDefault(HitResult.Perfect);
+            countGreat = Score.Statistics.GetOrDefault(HitResult.Great);
+            countGood = Score.Statistics.GetOrDefault(HitResult.Good);
+            countOk = Score.Statistics.GetOrDefault(HitResult.Ok);
+            countMeh = Score.Statistics.GetOrDefault(HitResult.Meh);
+            countMiss = Score.Statistics.GetOrDefault(HitResult.Miss);
 
             if (mods.Any(m => !m.Ranked))
                 return 0;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -45,10 +46,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             mods = Score.Mods;
             accuracy = Score.Accuracy;
             scoreMaxCombo = Score.MaxCombo;
-            countGreat = Score.Statistics[HitResult.Great];
-            countGood = Score.Statistics[HitResult.Good];
-            countMeh = Score.Statistics[HitResult.Meh];
-            countMiss = Score.Statistics[HitResult.Miss];
+            countGreat = Score.Statistics.GetOrDefault(HitResult.Great);
+            countGood = Score.Statistics.GetOrDefault(HitResult.Good);
+            countMeh = Score.Statistics.GetOrDefault(HitResult.Meh);
+            countMiss = Score.Statistics.GetOrDefault(HitResult.Miss);
 
             // Don't count scores made with supposedly unranked mods
             if (mods.Any(m => !m.Ranked))

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -31,10 +32,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         public override double Calculate(Dictionary<string, double> categoryDifficulty = null)
         {
             mods = Score.Mods;
-            countGreat = Score.Statistics[HitResult.Great];
-            countGood = Score.Statistics[HitResult.Good];
-            countMeh = Score.Statistics[HitResult.Meh];
-            countMiss = Score.Statistics[HitResult.Miss];
+            countGreat = Score.Statistics.GetOrDefault(HitResult.Great);
+            countGood = Score.Statistics.GetOrDefault(HitResult.Good);
+            countMeh = Score.Statistics.GetOrDefault(HitResult.Meh);
+            countMiss = Score.Statistics.GetOrDefault(HitResult.Miss);
 
             // Don't count scores made with supposedly unranked mods
             if (mods.Any(m => !m.Ranked))


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.item?view=netcore-3.1#System_Collections_Generic_Dictionary_2_Item__0_

> If the specified key is not found, a get operation throws a KeyNotFoundException.