### PR TITLE
Unify number types in performance calculators

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -52,8 +52,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             // Longer maps are worth more
             double lengthBonus =
-                0.95f + 0.3f * Math.Min(1.0f, numTotalHits / 2500.0f) +
-                (numTotalHits > 2500 ? (float)Math.Log10(numTotalHits / 2500.0f) * 0.475f : 0.0f);
+                0.95 + 0.3 * Math.Min(1.0, numTotalHits / 2500.0) +
+                (numTotalHits > 2500 ? Math.Log10(numTotalHits / 2500.0) * 0.475 : 0.0);
 
             // Longer maps are worth more
             value *= lengthBonus;
@@ -65,14 +65,14 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             if (Attributes.MaxCombo > 0)
                 value *= Math.Min(Math.Pow(Score.MaxCombo, 0.8) / Math.Pow(Attributes.MaxCombo, 0.8), 1.0);
 
-            float approachRate = (float)Attributes.ApproachRate;
-            float approachRateFactor = 1.0f;
-            if (approachRate > 9.0f)
-                approachRateFactor += 0.1f * (approachRate - 9.0f); // 10% for each AR above 9
-            if (approachRate > 10.0f)
-                approachRateFactor += 0.1f * (approachRate - 10.0f); // Additional 10% at AR 11, 30% total
-            else if (approachRate < 8.0f)
-                approachRateFactor += 0.025f * (8.0f - approachRate); // 2.5% for each AR below 8
+            double approachRate = Attributes.ApproachRate;
+            double approachRateFactor = 1.0;
+            if (approachRate > 9.0)
+                approachRateFactor += 0.1 * (approachRate - 9.0); // 10% for each AR above 9
+            if (approachRate > 10.0)
+                approachRateFactor += 0.1 * (approachRate - 10.0); // Additional 10% at AR 11, 30% total
+            else if (approachRate < 8.0)
+                approachRateFactor += 0.025 * (8.0 - approachRate); // 2.5% for each AR below 8
 
             value *= approachRateFactor;
 
@@ -80,10 +80,10 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             {
                 value *= 1.05 + 0.075 * (10.0 - Math.Min(10.0, Attributes.ApproachRate)); // 7.5% for each AR below 10
                 // Hiddens gives almost nothing on max approach rate, and more the lower it is
-                if (approachRate <= 10.0f)
-                    value *= 1.05f + 0.075f * (10.0f - approachRate); // 7.5% for each AR below 10
-                else if (approachRate > 10.0f)
-                    value *= 1.01f + 0.04f * (11.0f - Math.Min(11.0f, approachRate)); // 5% at AR 10, 1% at AR 11
+                if (approachRate <= 10.0)
+                    value *= 1.05 + 0.075 * (10.0 - approachRate); // 7.5% for each AR below 10
+                else if (approachRate > 10.0)
+                    value *= 1.01 + 0.04 * (11.0 - Math.Min(11.0, approachRate)); // 5% at AR 10, 1% at AR 11
             }
 
             if (mods.Any(m => m is ModFlashlight))
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             return value;
         }
 
-        private float accuracy() => totalHits() == 0 ? 0 : Math.Clamp((float)totalSuccessfulHits() / totalHits(), 0, 1);
+        private double accuracy() => totalHits() == 0 ? 0 : Math.Clamp((double)totalSuccessfulHits() / totalHits(), 0, 1);
         private int totalHits() => tinyTicksHit + ticksHit + fruitsHit + misses + tinyTicksMissed;
         private int totalSuccessfulHits() => tinyTicksHit + ticksHit + fruitsHit;
         private int totalComboHits() => misses + ticksHit + fruitsHit;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             return accuracyValue;
         }
 
-        private double totalHits => countGreat + countGood + countMeh + countMiss;
-        private double totalSuccessfulHits => countGreat + countGood + countMeh;
+        private int totalHits => countGreat + countGood + countMeh + countMiss;
+        private int totalSuccessfulHits => countGreat + countGood + countMeh;
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -181,7 +181,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             int amountHitObjectsWithAccuracy = countHitCircles;
 
             if (amountHitObjectsWithAccuracy > 0)
-                betterAccuracyPercentage = ((countGreat - (totalHits - amountHitObjectsWithAccuracy)) * 6 + countGood * 2 + countMeh) / (amountHitObjectsWithAccuracy * 6);
+                betterAccuracyPercentage = ((countGreat - (totalHits - amountHitObjectsWithAccuracy)) * 6 + countGood * 2 + countMeh) / (double)(amountHitObjectsWithAccuracy * 6);
             else
                 betterAccuracyPercentage = 0;
 


### PR DESCRIPTION
Catch: introduced in #6974 , regressed when resolving conflict in #8934 .
Total hits in osu: not caught, but other rulesets and source in osu-performance uses int for it.