### PR TITLE
Fix memory leak due to undisposed drawables

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -129,6 +129,9 @@ namespace osu.Game.Screens.Select
 
         protected List<DrawableCarouselItem> Items = new List<DrawableCarouselItem>();
 
+        // Stores all the items ever created for disposal purposes.
+        private readonly HashSet<DrawableCarouselItem> allItems = new HashSet<DrawableCarouselItem>();
+
         private CarouselRoot root;
 
         public BeatmapCarousel()
@@ -571,7 +574,7 @@ namespace osu.Game.Screens.Select
             }
 
             // aggressively dispose "off-screen" items to reduce GC pressure.
-            foreach (var i in Items)
+            foreach (var i in allItems)
                 i.Dispose();
         }
 
@@ -625,6 +628,8 @@ namespace osu.Game.Screens.Select
         private void updateItems()
         {
             Items = root.Drawables.ToList();
+            foreach (var item in Items)
+                allItems.Add(item);
 
             yPositions.Clear();
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9049
Fixes https://github.com/ppy/osu/issues/8992
Possibly (fixes) https://github.com/ppy/osu/issues/7218

I hope this is a temporary fix. We will probably have a better way to do this in the future - whether via realm or otherwise perhaps by implementing some sort of pseudo-`BindableList` that can lead to the removal of the `ItemAdded`/`ItemRemoved` events altogether.

### Explanation

`TopLocalRank` binds to `ScoreManager.ItemAdded` and unbinds correctly in `Dispose()`. But this only works if the `Drawable` itself is disposed, which occurs via one of two processes:
1. Via the draw hierarchy, if the `DrawableCarouselBeatmap` is visible on the screen and hasn't been removed due to `BeatmapCarousel`'s optimisations: https://github.com/ppy/osu/blob/87e501d4ba2422f2c14851902ffd925bd6b8582a/osu.Game/Screens/Select/BeatmapCarousel.cs#L490
2. Via the eager disposal in `BeatmapCarousel.Dispose()`, if the `DrawableCarouselBeatmap` was added to the `Items` list: https://github.com/ppy/osu/blob/87e501d4ba2422f2c14851902ffd925bd6b8582a/osu.Game/Screens/Select/BeatmapCarousel.cs#L574-L575

Unfortunately, this is a case where neither of the above was true, because the `Items` list gets re-created quite a lot (e.g. when selecting a new item): https://github.com/ppy/osu/blob/87e501d4ba2422f2c14851902ffd925bd6b8582a/osu.Game/Screens/Select/BeatmapCarousel.cs#L627 and this list does _not_ contain items that are not present (e.g. alpha=0 due to being offscreen): https://github.com/ppy/osu/blob/87e501d4ba2422f2c14851902ffd925bd6b8582a/osu.Game/Screens/Select/Carousel/CarouselItem.cs#L28
If an item had previously had its `Drawable` representation created and previously loaded a `TopLocalRank` but wasn't added to the `Items` list on the next refresh, then it would exist as this sort of hidden object that would bypass both the above `Disposal()` pathways. Finalisation wouldn't occur because of external references to it. This would actually in-turn keep quite a large reference tree through dependency containers - even up to `SongSelect` itself since it's cached.

## Solution

At first I thought I could implement `IDisposable` on `CarouselItem` (the non-disposable model), however that isn't sufficient since beatmap sets can be removed altogether from `BeatmapCarousel` via the `BeatmapManager` events.

So instead I'm storing all `Drawable`s ever created into a `HashSet` and forcing a disposal on them, which seems like the intention of the original code anyway.