### PR TITLE
Fix being able to press enter to create matches

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSettingsOverlay.cs
@@ -69,6 +69,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 settings.NameField.Current.Value = expected_name;
                 settings.DurationField.Current.Value = expectedDuration;
+                Room.Playlist.Add(new PlaylistItem { Beatmap = { Value = CreateBeatmap(Ruleset.Value).BeatmapInfo } });
 
                 roomManager.CreateRequested = r =>
                 {
@@ -89,6 +90,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("setup", () =>
             {
+                Room.Name.Value = "Test Room";
+                Room.Playlist.Add(new PlaylistItem { Beatmap = { Value = CreateBeatmap(Ruleset.Value).BeatmapInfo } });
+
                 fail = true;
                 roomManager.CreateRequested = _ => !fail;
             });

--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -133,7 +133,6 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                                     {
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,
-                                                                        OnCommit = (sender, text) => apply(),
                                                                     },
                                                                 },
                                                                 new Section("Duration")
@@ -196,7 +195,6 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,
                                                                         ReadOnly = true,
-                                                                        OnCommit = (sender, text) => apply()
                                                                     },
                                                                 },
                                                                 new Section("Password (optional)")
@@ -207,7 +205,6 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,
                                                                         ReadOnly = true,
-                                                                        OnCommit = (sender, text) => apply()
                                                                     },
                                                                 },
                                                             },
@@ -331,6 +328,9 @@ namespace osu.Game.Screens.Multi.Match.Components
 
             private void apply()
             {
+                if (!ApplyButton.Enabled.Value)
+                    return;
+
                 hideError();
 
                 RoomName.Value = NameField.Text;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9056

Left over from the time when playlists didn't really exist. Disables all enter controls and adds a safeguard to `apply()` just in case.