### PR TITLE
Add support for storyboard overlay layer

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 var storyboard = decoder.Decode(stream);
 
                 Assert.IsTrue(storyboard.HasDrawable);
-                Assert.AreEqual(5, storyboard.Layers.Count());
+                Assert.AreEqual(6, storyboard.Layers.Count());
 
                 StoryboardLayer background = storyboard.Layers.FirstOrDefault(l => l.Depth == 3);
                 Assert.IsNotNull(background);
@@ -55,6 +55,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.IsTrue(foreground.VisibleWhenFailing);
                 Assert.IsTrue(foreground.VisibleWhenPassing);
                 Assert.AreEqual("Foreground", foreground.Name);
+
+                StoryboardLayer overlay = storyboard.Layers.FirstOrDefault(l => l.Depth == int.MinValue);
+                Assert.IsNotNull(overlay);
+                Assert.IsEmpty(overlay.Elements);
+                Assert.IsTrue(overlay.VisibleWhenFailing);
+                Assert.IsTrue(overlay.VisibleWhenPassing);
+                Assert.AreEqual("Overlay", overlay.Name);
 
                 int spriteCount = background.Elements.Count(x => x.GetType() == typeof(StoryboardSprite));
                 int animationCount = background.Elements.Count(x => x.GetType() == typeof(StoryboardAnimation));

--- a/osu.Game/Beatmaps/Legacy/LegacyStoryLayer.cs
+++ b/osu.Game/Beatmaps/Legacy/LegacyStoryLayer.cs
@@ -9,6 +9,7 @@ namespace osu.Game.Beatmaps.Legacy
         Fail = 1,
         Pass = 2,
         Foreground = 3,
-        Video = 4
+        Overlay = 4,
+        Video = 5
     }
 }

--- a/osu.Game/Screens/Play/DimmableStoryboard.cs
+++ b/osu.Game/Screens/Play/DimmableStoryboard.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.Containers;
 using osu.Game.Storyboards;
 using osu.Game.Storyboards.Drawables;
@@ -13,6 +14,8 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public class DimmableStoryboard : UserDimContainer
     {
+        public Container OverlayLayerContainer;
+
         private readonly Storyboard storyboard;
         private DrawableStoryboard drawableStoryboard;
 
@@ -24,6 +27,8 @@ namespace osu.Game.Screens.Play
         [BackgroundDependencyLoader]
         private void load()
         {
+            Add(OverlayLayerContainer = new Container());
+
             initializeStoryboard(false);
         }
 
@@ -46,9 +51,15 @@ namespace osu.Game.Screens.Play
             drawableStoryboard = storyboard.CreateDrawable();
 
             if (async)
-                LoadComponentAsync(drawableStoryboard, Add);
+                LoadComponentAsync(drawableStoryboard, onStoryboardCreated);
             else
-                Add(drawableStoryboard);
+                onStoryboardCreated(drawableStoryboard);
+        }
+
+        private void onStoryboardCreated(DrawableStoryboard storyboard)
+        {
+            Add(storyboard);
+            OverlayLayerContainer.Add(storyboard.OverlayLayer.CreateProxy());
         }
     }
 }

--- a/osu.Game/Screens/Play/DimmableStoryboard.cs
+++ b/osu.Game/Screens/Play/DimmableStoryboard.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public class DimmableStoryboard : UserDimContainer
     {
-        public Container OverlayLayerContainer;
+        public Container OverlayLayerContainer { get; private set; }
 
         private readonly Storyboard storyboard;
         private DrawableStoryboard drawableStoryboard;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -264,6 +264,7 @@ namespace osu.Game.Screens.Play
         {
             target.AddRange(new[]
             {
+                DimmableStoryboard.OverlayLayerContainer.CreateProxy(),
                 BreakOverlay = new BreakOverlay(working.Beatmap.BeatmapInfo.LetterboxInBreaks, ScoreProcessor)
                 {
                     Clock = DrawableRuleset.FrameStableClock,

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using System.Threading;
 using osuTK;
 using osu.Framework.Allocation;
@@ -71,6 +72,8 @@ namespace osu.Game.Storyboards.Drawables
                 Add(layer.CreateDrawable());
             }
         }
+
+        public DrawableStoryboardLayer OverlayLayer => Children.Single(layer => layer.Name == "Overlay");
 
         private void updateLayerVisibility()
         {

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -19,19 +19,26 @@ namespace osu.Game.Storyboards
 
         public double FirstEventTime => Layers.Min(l => l.Elements.FirstOrDefault()?.StartTime ?? 0);
 
+        /// <summary>
+        /// Depth of the currently front-most storyboard layer, excluding the overlay layer.
+        /// </summary>
+        private int minimumLayerDepth;
+
         public Storyboard()
         {
             layers.Add("Video", new StoryboardLayer("Video", 4, false));
             layers.Add("Background", new StoryboardLayer("Background", 3));
             layers.Add("Fail", new StoryboardLayer("Fail", 2) { VisibleWhenPassing = false, });
             layers.Add("Pass", new StoryboardLayer("Pass", 1) { VisibleWhenFailing = false, });
-            layers.Add("Foreground", new StoryboardLayer("Foreground", 0));
+            layers.Add("Foreground", new StoryboardLayer("Foreground", minimumLayerDepth = 0));
+
+            layers.Add("Overlay", new StoryboardLayer("Overlay", int.MinValue));
         }
 
         public StoryboardLayer GetLayer(string name)
         {
             if (!layers.TryGetValue(name, out var layer))
-                layers[name] = layer = new StoryboardLayer(name, layers.Values.Min(l => l.Depth) - 1);
+                layers[name] = layer = new StoryboardLayer(name, --minimumLayerDepth);
 
             return layer;
         }

--- a/osu.Game/Storyboards/StoryboardLayer.cs
+++ b/osu.Game/Storyboards/StoryboardLayer.cs
@@ -33,6 +33,6 @@ namespace osu.Game.Storyboards
         }
 
         public DrawableStoryboardLayer CreateDrawable()
-            => new DrawableStoryboardLayer(this) { Depth = Depth, };
+            => new DrawableStoryboardLayer(this) { Depth = Depth, Name = Name };
     }
 }


### PR DESCRIPTION
Resolves #8017.

# Summary

This PR allows for parsing and display of the storyboard overlay layer. It is pretty much identical to other storyboard layers, aside from the fact that it is always displayed front-most (and in front of the playfield, which includes hit objects).

The overlay layer will show regardless of whether the "Show storyboard" option is on at beatmap load, or it is enabled during gameplay - in which case it shows after the asynchronous load is complete - which takes a while in case of more complicated storyboards, but that's not a regression. The opacity of the layer will follow the user dim setting, as in the alpha of the overlay layer is the same as the rest of the storyboard, which as far as I can see is consistent with stable.

Here are a few screenshots of the feature in action:

| [Come And Get It (Razihel Remix) - Krewella (set by Plaudible, storyboard by Hokichi)](https://osu.ppy.sh/beatmapsets/803126) | [SPIDER NET WORK - CleanTears Remix - - Ayakura Mei (set and storyboard by -Tochi, 0% dim)](https://osu.ppy.sh/beatmapsets/941875) | [SPIDER NET WORK - CleanTears Remix - - Ayakura Mei (set and storyboard by -Tochi, ~90% dim)](https://osu.ppy.sh/beatmapsets/941875) |
| :-: | :-: | :-: |
| ![example1](https://user-images.githubusercontent.com/20418176/82366284-4707be00-9a12-11ea-9afa-717a95ab2bd5.png) | ![example2](https://user-images.githubusercontent.com/20418176/82366301-4bcc7200-9a12-11ea-84c8-5cd86c5404e3.png) | ![example3-dimmed](https://user-images.githubusercontent.com/20418176/82366318-525ae980-9a12-11ea-8c66-4d3b7e1242e4.png) |

Storyboard parsing tests have been extended to cover the new layer's attributes, but I haven't modified the `.osb` file, which had no objects in the overlay layer.

# Remarks

Hesitantly PRing this, as I'm not too sure of the content, but seeing that it's somewhat done and seems to work reasonably well... Due to the nature of this feature (it's an exception from a nice abstraction) it ends up having quite a few weird corners. I'll attempt to explain the reasoning but any of the kinks I'll yield on immediately if you have an idea that you'd consider better.

* I've opted to make the overlay layer have the minimum depth possible because I think it makes sense - it should always be the topmost layer even if it's not displayed inside of `Player` and proxied above playfield.
* When it comes to the exposition of the overlay layer, I didn't feel like passing a container down from `Player` was right as it goes against the flow of other things in there (`DrawableRuleset.Cursor`, `DrawableRuleset.ResumeOverlay`).
* Exposing just the overlay layer outwardly instead of providing a public by-name layer accessor was a conscious choice as to make the minimal change required and not overexpose things that we might regret exposing later. If you really wanted to, you could grab any layer anyway I guess, but having a public magic-string interface felt *off*, so this attempts to contain the scope of that.
* The double proxy is admittedly weird and done to accommodate the async storyboard load path. From a code perspective I prefer it from having `DimmableStoryboard` expose some sort of event and then `Player` having to subscribe to & handle it - more declarative that way? Reduces clutter in `Player`, for sure.

No visual tests included. I'm not sure the additions are very visually-testable (as in writing actual assertions that will test things isn't trivial, and I'm not sure if it's worth the effort).