### PR TITLE
Use DrawableSample in SkinnableSound class

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Threading;
-using osu.Framework.Audio;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Types;
@@ -96,8 +95,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </remarks>
         protected virtual float SamplePlaybackPosition => 0.5f;
 
-        private readonly BindableDouble balanceAdjust = new BindableDouble();
-
         private BindableList<HitSampleInfo> samplesBindable;
         private Bindable<double> startTimeBindable;
         private Bindable<bool> userPositionalHitSounds;
@@ -173,7 +170,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Samples = new SkinnableSound(samples.Select(s => HitObject.SampleControlPoint.ApplyTo(s)));
-            Samples.AddAdjustment(AdjustableProperty.Balance, balanceAdjust);
             AddInternal(Samples);
         }
 
@@ -360,8 +356,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             const float balance_adjust_amount = 0.4f;
 
-            balanceAdjust.Value = balance_adjust_amount * (userPositionalHitSounds.Value ? SamplePlaybackPosition - 0.5f : 0);
-            Samples?.Play();
+            if (Samples != null)
+            {
+                Samples.Balance.Value = balance_adjust_amount * (userPositionalHitSounds.Value ? SamplePlaybackPosition - 0.5f : 0);
+                Samples.Play();
+            }
         }
 
         protected override void Update()

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -4,11 +4,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
 
 namespace osu.Game.Skinning
@@ -17,24 +17,31 @@ namespace osu.Game.Skinning
     {
         private readonly ISampleInfo[] hitSamples;
 
-        private List<(AdjustableProperty property, BindableDouble bindable)> adjustments;
-
-        private SampleChannel[] channels;
-
         [Resolved]
         private ISampleStore samples { get; set; }
+
+        public SkinnableSound(ISampleInfo hitSamples)
+            : this(new[] { hitSamples })
+        {
+        }
 
         public SkinnableSound(IEnumerable<ISampleInfo> hitSamples)
         {
             this.hitSamples = hitSamples.ToArray();
-        }
-
-        public SkinnableSound(ISampleInfo hitSamples)
-        {
-            this.hitSamples = new[] { hitSamples };
+            InternalChild = samplesContainer = new AudioContainer<DrawableSample>();
         }
 
         private bool looping;
+
+        private readonly AudioContainer<DrawableSample> samplesContainer;
+
+        public BindableNumber<double> Volume => samplesContainer.Volume;
+
+        public BindableNumber<double> Balance => samplesContainer.Balance;
+
+        public BindableNumber<double> Frequency => samplesContainer.Frequency;
+
+        public BindableNumber<double> Tempo => samplesContainer.Tempo;
 
         public bool Looping
         {
@@ -45,33 +52,23 @@ namespace osu.Game.Skinning
 
                 looping = value;
 
-                channels?.ForEach(c => c.Looping = looping);
+                samplesContainer.ForEach(c => c.Looping = looping);
             }
         }
 
-        public void Play() => channels?.ForEach(c => c.Play());
-
-        public void Stop() => channels?.ForEach(c => c.Stop());
-
-        public void AddAdjustment(AdjustableProperty type, BindableDouble adjustBindable)
+        public void Play() => samplesContainer.ForEach(c =>
         {
-            if (adjustments == null) adjustments = new List<(AdjustableProperty, BindableDouble)>();
+            if (c.AggregateVolume.Value > 0)
+                c.Play();
+        });
 
-            adjustments.Add((type, adjustBindable));
-            channels?.ForEach(c => c.AddAdjustment(type, adjustBindable));
-        }
-
-        public void RemoveAdjustment(AdjustableProperty type, BindableDouble adjustBindable)
-        {
-            adjustments?.Remove((type, adjustBindable));
-            channels?.ForEach(c => c.RemoveAdjustment(type, adjustBindable));
-        }
+        public void Stop() => samplesContainer.ForEach(c => c.Stop());
 
         public override bool IsPresent => Scheduler.HasPendingTasks;
 
         protected override void SkinChanged(ISkinSource skin, bool allowFallback)
         {
-            channels = hitSamples.Select(s =>
+            var channels = hitSamples.Select(s =>
             {
                 var ch = skin.GetSample(s);
 
@@ -88,27 +85,12 @@ namespace osu.Game.Skinning
                 {
                     ch.Looping = looping;
                     ch.Volume.Value = s.Volume / 100.0;
-
-                    if (adjustments != null)
-                    {
-                        foreach (var (property, bindable) in adjustments)
-                            ch.AddAdjustment(property, bindable);
-                    }
                 }
 
                 return ch;
-            }).Where(c => c != null).ToArray();
-        }
+            }).Where(c => c != null);
 
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (channels != null)
-            {
-                foreach (var c in channels)
-                    c.Dispose();
-            }
+            samplesContainer.ChildrenEnumerable = channels.Select(c => new DrawableSample(c));
         }
     }
 }


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/5317. I think we should get this change in as it *seems* like a better path forward. At very least it gives more attention to the drawable audio container implementations, which are currently not seeing much use.