### PR TITLE
Refactor editor snapping logic and add osu!mania beat snapping support

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
@@ -15,7 +15,6 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Tests.Visual;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Tests
@@ -56,8 +55,6 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         protected override void AddHitObject(DrawableHitObject hitObject) => column.Add((DrawableManiaHitObject)hitObject);
 
-        public Column ColumnAt(Vector2 screenSpacePosition) => column;
-
-        public int TotalColumns => 1;
+        public ManiaPlayfield Playfield => null;
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Timing;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.UI;
@@ -41,6 +42,14 @@ namespace osu.Game.Rulesets.Mania.Tests
                 AccentColour = Color4.OrangeRed,
                 Clock = new FramedClock(new StopwatchClock()), // No scroll
             });
+        }
+
+        protected override SnapResult SnapForBlueprint(PlacementBlueprint blueprint)
+        {
+            var time = column.TimeAtScreenSpacePosition(InputManager.CurrentState.Mouse.Position);
+            var pos = column.ScreenSpacePositionAtTime(time);
+
+            return new ManiaSnapResult(pos, time, column);
         }
 
         protected override Container CreateHitObjectContainer() => new ScrollingTestContainer(ScrollingDirection.Down) { RelativeSizeAxes = Axes.Both };

--- a/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
@@ -49,8 +49,6 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         public Column ColumnAt(Vector2 screenSpacePosition) => column;
 
-        public Vector2 ScreenSpacePositionAtTime(double time, Column column = null) => Vector2.Zero;
-
         public int TotalColumns => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaPlacementBlueprintTestScene.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         public Column ColumnAt(Vector2 screenSpacePosition) => column;
 
+        public Vector2 ScreenSpacePositionAtTime(double time, Column column = null) => Vector2.Zero;
+
         public int TotalColumns => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaSelectionBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaSelectionBlueprintTestScene.cs
@@ -7,7 +7,6 @@ using osu.Framework.Timing;
 using osu.Game.Rulesets.Mania.Edit;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Tests.Visual;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Tests
@@ -18,11 +17,9 @@ namespace osu.Game.Rulesets.Mania.Tests
         [Cached(Type = typeof(IAdjustableClock))]
         private readonly IAdjustableClock clock = new StopwatchClock();
 
-        private readonly Column column;
-
         protected ManiaSelectionBlueprintTestScene()
         {
-            Add(column = new Column(0)
+            Add(new Column(0)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -31,8 +28,6 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
         }
 
-        public Column ColumnAt(Vector2 screenSpacePosition) => column;
-
-        public int TotalColumns => 1;
+        public ManiaPlayfield Playfield => null;
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaSelectionBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaSelectionBlueprintTestScene.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         public Column ColumnAt(Vector2 screenSpacePosition) => column;
 
+        public Vector2 ScreenSpacePositionAtTime(double time, Column column = null) => Vector2.Zero;
+
         public int TotalColumns => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaSelectionBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaSelectionBlueprintTestScene.cs
@@ -33,8 +33,6 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         public Column ColumnAt(Vector2 screenSpacePosition) => column;
 
-        public Vector2 ScreenSpacePositionAtTime(double time, Column column = null) => Vector2.Zero;
-
         public int TotalColumns => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep("move mouse downwards", () =>
             {
-                InputManager.MoveMouseTo(lastObject, new Vector2(0, lastObject.ScreenSpaceDrawQuad.Height * 2));
+                InputManager.MoveMouseTo(lastObject, new Vector2(0, lastObject.ScreenSpaceDrawQuad.Height * 4));
                 InputManager.ReleaseButton(MouseButton.Left);
             });
 
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep("move mouse upwards", () =>
             {
-                InputManager.MoveMouseTo(lastObject, new Vector2(0, -lastObject.ScreenSpaceDrawQuad.Height * 2));
+                InputManager.MoveMouseTo(lastObject, new Vector2(0, -lastObject.ScreenSpaceDrawQuad.Height * 4));
                 InputManager.ReleaseButton(MouseButton.Left);
             });
 

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaHitObjectComposer.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         public void TestDragOffscreenSelectionVerticallyUpScroll()
         {
             DrawableHitObject lastObject = null;
+            double originalTime = 0;
             Vector2 originalPosition = Vector2.Zero;
 
             setScrollStep(ScrollingDirection.Up);
@@ -49,6 +50,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             AddStep("seek to last object", () =>
             {
                 lastObject = this.ChildrenOfType<DrawableHitObject>().Single(d => d.HitObject == composer.EditorBeatmap.HitObjects.Last());
+                originalTime = lastObject.HitObject.StartTime;
                 Clock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
             });
 
@@ -64,19 +66,20 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep("move mouse downwards", () =>
             {
-                InputManager.MoveMouseTo(lastObject, new Vector2(0, 20));
+                InputManager.MoveMouseTo(lastObject, new Vector2(0, lastObject.ScreenSpaceDrawQuad.Height * 2));
                 InputManager.ReleaseButton(MouseButton.Left);
             });
 
             AddAssert("hitobjects not moved columns", () => composer.EditorBeatmap.HitObjects.All(h => ((ManiaHitObject)h).Column == 0));
             AddAssert("hitobjects moved downwards", () => lastObject.DrawPosition.Y - originalPosition.Y > 0);
-            AddAssert("hitobjects not moved too far", () => lastObject.DrawPosition.Y - originalPosition.Y < 50);
+            AddAssert("hitobject has moved time", () => lastObject.HitObject.StartTime == originalTime + 125);
         }
 
         [Test]
         public void TestDragOffscreenSelectionVerticallyDownScroll()
         {
             DrawableHitObject lastObject = null;
+            double originalTime = 0;
             Vector2 originalPosition = Vector2.Zero;
 
             setScrollStep(ScrollingDirection.Down);
@@ -84,6 +87,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             AddStep("seek to last object", () =>
             {
                 lastObject = this.ChildrenOfType<DrawableHitObject>().Single(d => d.HitObject == composer.EditorBeatmap.HitObjects.Last());
+                originalTime = lastObject.HitObject.StartTime;
                 Clock.Seek(composer.EditorBeatmap.HitObjects.Last().StartTime);
             });
 
@@ -99,13 +103,13 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddStep("move mouse upwards", () =>
             {
-                InputManager.MoveMouseTo(lastObject, new Vector2(0, -20));
+                InputManager.MoveMouseTo(lastObject, new Vector2(0, -lastObject.ScreenSpaceDrawQuad.Height * 2));
                 InputManager.ReleaseButton(MouseButton.Left);
             });
 
             AddAssert("hitobjects not moved columns", () => composer.EditorBeatmap.HitObjects.All(h => ((ManiaHitObject)h).Column == 0));
             AddAssert("hitobjects moved upwards", () => originalPosition.Y - lastObject.DrawPosition.Y > 0);
-            AddAssert("hitobjects not moved too far", () => originalPosition.Y - lastObject.DrawPosition.Y < 50);
+            AddAssert("hitobject has moved time", () => lastObject.HitObject.StartTime == originalTime + 125);
         }
 
         [Test]
@@ -207,7 +211,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 };
 
                 for (int i = 0; i < 10; i++)
-                    EditorBeatmap.Add(new Note { StartTime = 100 * i });
+                    EditorBeatmap.Add(new Note { StartTime = 125 * i });
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -74,8 +74,11 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
             }
             else
             {
-                headPiece.Width = tailPiece.Width = SnappedWidth;
-                headPiece.X = tailPiece.X = SnappedMousePosition.X;
+                if (result is ManiaSnapResult maniaResult)
+                {
+                    headPiece.Width = tailPiece.Width = maniaResult.Column.DrawWidth;
+                    headPiece.X = tailPiece.X = ToLocalSpace(result.ScreenSpacePosition).X;
+                }
 
                 if (result.Time is double startTime)
                     originalStartTime = HitObject.StartTime = startTime;

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Mania.Objects;
 using osuTK;
@@ -59,23 +60,25 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
         private double originalStartTime;
 
-        public override void UpdatePosition(Vector2 screenSpacePosition)
+        public override void UpdatePosition(SnapResult result)
         {
-            base.UpdatePosition(screenSpacePosition);
+            base.UpdatePosition(result);
 
             if (PlacementActive)
             {
-                var endTime = TimeAt(screenSpacePosition);
-
-                HitObject.StartTime = endTime < originalStartTime ? endTime : originalStartTime;
-                HitObject.Duration = Math.Abs(endTime - originalStartTime);
+                if (result.Time is double endTime)
+                {
+                    HitObject.StartTime = endTime < originalStartTime ? endTime : originalStartTime;
+                    HitObject.Duration = Math.Abs(endTime - originalStartTime);
+                }
             }
             else
             {
                 headPiece.Width = tailPiece.Width = SnappedWidth;
                 headPiece.X = tailPiece.X = SnappedMousePosition.X;
 
-                originalStartTime = HitObject.StartTime = TimeAt(screenSpacePosition);
+                if (result.Time is double startTime)
+                    originalStartTime = HitObject.StartTime = startTime;
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -20,6 +20,9 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         private readonly EditNotePiece headPiece;
         private readonly EditNotePiece tailPiece;
 
+        [Resolved]
+        private IManiaHitObjectComposer composer { get; set; }
+
         public HoldNotePlacementBlueprint()
             : base(new HoldNote())
         {
@@ -39,8 +42,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
             if (Column != null)
             {
-                headPiece.Y = positionAt(HitObject.StartTime);
-                tailPiece.Y = positionAt(HitObject.EndTime);
+                headPiece.Y = Parent.ToLocalSpace(composer.ScreenSpacePositionAtTime(HitObject.StartTime, Column)).Y;
+                tailPiece.Y = Parent.ToLocalSpace(composer.ScreenSpacePositionAtTime(HitObject.EndTime, Column)).Y;
             }
 
             var topPosition = new Vector2(headPiece.DrawPosition.X, Math.Min(headPiece.DrawPosition.Y, tailPiece.DrawPosition.Y));
@@ -85,22 +88,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
                 if (result.Time is double startTime)
                     originalStartTime = HitObject.StartTime = startTime;
             }
-        }
-
-        [Resolved]
-        private IScrollingInfo scrollingInfo { get; set; }
-
-        private float positionAt(double time)
-        {
-            var pos = scrollingInfo.Algorithm.PositionAt(time,
-                EditorClock.CurrentTime,
-                scrollingInfo.TimeRange.Value,
-                Column.HitObjectContainer.DrawHeight);
-
-            if (scrollingInfo.Direction.Value == ScrollingDirection.Down)
-                pos = Column.HitObjectContainer.DrawHeight - pos;
-
-            return Column.HitObjectContainer.ToSpaceOfOtherDrawable(new Vector2(0, pos), Parent).Y;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -8,7 +8,6 @@ using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Input;
 
@@ -42,8 +41,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
             if (Column != null)
             {
-                headPiece.Y = Parent.ToLocalSpace(composer.ScreenSpacePositionAtTime(HitObject.StartTime, Column)).Y;
-                tailPiece.Y = Parent.ToLocalSpace(composer.ScreenSpacePositionAtTime(HitObject.EndTime, Column)).Y;
+                headPiece.Y = Parent.ToLocalSpace(Column.ScreenSpacePositionAtTime(HitObject.StartTime, Column)).Y;
+                tailPiece.Y = Parent.ToLocalSpace(Column.ScreenSpacePositionAtTime(HitObject.EndTime, Column)).Y;
             }
 
             var topPosition = new Vector2(headPiece.DrawPosition.X, Math.Min(headPiece.DrawPosition.Y, tailPiece.DrawPosition.Y));

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Input;
 
@@ -37,8 +39,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
             if (Column != null)
             {
-                headPiece.Y = PositionAt(HitObject.StartTime);
-                tailPiece.Y = PositionAt(HitObject.EndTime);
+                headPiece.Y = positionAt(HitObject.StartTime);
+                tailPiece.Y = positionAt(HitObject.EndTime);
             }
 
             var topPosition = new Vector2(headPiece.DrawPosition.X, Math.Min(headPiece.DrawPosition.Y, tailPiece.DrawPosition.Y));
@@ -83,6 +85,22 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
                 if (result.Time is double startTime)
                     originalStartTime = HitObject.StartTime = startTime;
             }
+        }
+
+        [Resolved]
+        private IScrollingInfo scrollingInfo { get; set; }
+
+        private float positionAt(double time)
+        {
+            var pos = scrollingInfo.Algorithm.PositionAt(time,
+                EditorClock.CurrentTime,
+                scrollingInfo.TimeRange.Value,
+                Column.HitObjectContainer.DrawHeight);
+
+            if (scrollingInfo.Direction.Value == ScrollingDirection.Down)
+                pos = Column.HitObjectContainer.DrawHeight - pos;
+
+            return Column.HitObjectContainer.ToSpaceOfOtherDrawable(new Vector2(0, pos), Parent).Y;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -41,8 +41,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
             if (Column != null)
             {
-                headPiece.Y = Parent.ToLocalSpace(Column.ScreenSpacePositionAtTime(HitObject.StartTime, Column)).Y;
-                tailPiece.Y = Parent.ToLocalSpace(Column.ScreenSpacePositionAtTime(HitObject.EndTime, Column)).Y;
+                headPiece.Y = Parent.ToLocalSpace(Column.ScreenSpacePositionAtTime(HitObject.StartTime)).Y;
+                tailPiece.Y = Parent.ToLocalSpace(Column.ScreenSpacePositionAtTime(HitObject.EndTime)).Y;
             }
 
             var topPosition = new Vector2(headPiece.DrawPosition.X, Math.Min(headPiece.DrawPosition.Y, tailPiece.DrawPosition.Y));

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNoteSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNoteSelectionBlueprint.cs
@@ -77,6 +77,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
         public override Quad SelectionQuad => ScreenSpaceDrawQuad;
 
-        public override Vector2 SelectionPoint => DrawableObject.Head.ScreenSpaceDrawQuad.Centre;
+        public override Vector2 ScreenSpaceSelectionPoint => DrawableObject.Head.ScreenSpaceDrawQuad.Centre;
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -34,9 +34,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         protected float SnappedWidth { get; private set; }
 
         [Resolved]
-        private IManiaHitObjectComposer composer { get; set; }
-
-        [Resolved]
         private IScrollingInfo scrollingInfo { get; set; }
 
         protected ManiaPlacementBlueprint(T hitObject)
@@ -61,7 +58,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         public override void UpdatePosition(SnapResult result)
         {
             if (!PlacementActive)
-                Column = ColumnAt(result.ScreenSpacePosition);
+                Column = (result as ManiaSnapResult)?.Column;
 
             if (Column == null) return;
 
@@ -84,9 +81,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
             return hitObjectToMousePosition(Column.HitObjectContainer.ToSpaceOfOtherDrawable(new Vector2(0, pos), Parent)).Y;
         }
-
-        protected Column ColumnAt(Vector2 screenSpacePosition)
-            => composer.ColumnAt(screenSpacePosition);
 
         /// <summary>
         /// Converts a mouse position to a hitobject position.

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Objects;
@@ -11,8 +10,7 @@ using osuTK.Input;
 
 namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 {
-    public abstract class ManiaPlacementBlueprint<T> : PlacementBlueprint,
-                                                       IRequireHighFrequencyMousePosition // the playfield could be moving behind us
+    public abstract class ManiaPlacementBlueprint<T> : PlacementBlueprint
         where T : ManiaHitObject
     {
         protected new T HitObject => (T)base.HitObject;

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -23,16 +23,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
         protected Column Column;
 
-        /// <summary>
-        /// The current mouse position, snapped to the closest column.
-        /// </summary>
-        protected Vector2 SnappedMousePosition { get; private set; }
-
-        /// <summary>
-        /// The width of the closest column to the current mouse position.
-        /// </summary>
-        protected float SnappedWidth { get; private set; }
-
         [Resolved]
         private IScrollingInfo scrollingInfo { get; set; }
 
@@ -59,14 +49,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         {
             if (!PlacementActive)
                 Column = (result as ManiaSnapResult)?.Column;
-
-            if (Column == null) return;
-
-            SnappedWidth = Column.DrawWidth;
-
-            // Snap to the column
-            var parentPos = Parent.ToLocalSpace(Column.ToScreenSpace(new Vector2(Column.DrawWidth / 2, 0)));
-            SnappedMousePosition = new Vector2(parentPos.X, Parent.ToLocalSpace(result.ScreenSpacePosition).Y);
         }
 
         protected float PositionAt(double time)
@@ -80,30 +62,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
                 pos = Column.HitObjectContainer.DrawHeight - pos;
 
             return hitObjectToMousePosition(Column.HitObjectContainer.ToSpaceOfOtherDrawable(new Vector2(0, pos), Parent)).Y;
-        }
-
-        /// <summary>
-        /// Converts a mouse position to a hitobject position.
-        /// </summary>
-        /// <remarks>
-        /// Blueprints are centred on the mouse position, such that the hitobject position is anchored at the top or bottom of the blueprint depending on the scroll direction.
-        /// </remarks>
-        /// <param name="mousePosition">The mouse position.</param>
-        /// <returns>The resulting hitobject position, acnhored at the top or bottom of the blueprint depending on the scroll direction.</returns>
-        private Vector2 mouseToHitObjectPosition(Vector2 mousePosition)
-        {
-            switch (scrollingInfo.Direction.Value)
-            {
-                case ScrollingDirection.Up:
-                    mousePosition.Y -= DefaultNotePiece.NOTE_HEIGHT / 2;
-                    break;
-
-                case ScrollingDirection.Down:
-                    mousePosition.Y += DefaultNotePiece.NOTE_HEIGHT / 2;
-                    break;
-            }
-
-            return mousePosition;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
                 return base.OnMouseDown(e);
 
             HitObject.Column = Column.Index;
-            BeginPlacement(TimeAt(e.ScreenSpaceMousePosition), true);
+            BeginPlacement(true);
             return true;
         }
 

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -58,10 +58,10 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
             return true;
         }
 
-        public override void UpdatePosition(Vector2 screenSpacePosition)
+        public override void UpdatePosition(SnapResult result)
         {
             if (!PlacementActive)
-                Column = ColumnAt(screenSpacePosition);
+                Column = ColumnAt(result.ScreenSpacePosition);
 
             if (Column == null) return;
 
@@ -69,26 +69,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
             // Snap to the column
             var parentPos = Parent.ToLocalSpace(Column.ToScreenSpace(new Vector2(Column.DrawWidth / 2, 0)));
-            SnappedMousePosition = new Vector2(parentPos.X, Parent.ToLocalSpace(screenSpacePosition).Y);
-        }
-
-        protected double TimeAt(Vector2 screenSpacePosition)
-        {
-            if (Column == null)
-                return 0;
-
-            var hitObjectContainer = Column.HitObjectContainer;
-
-            // If we're scrolling downwards, a position of 0 is actually further away from the hit target
-            // so we need to flip the vertical coordinate in the hitobject container's space
-            var hitObjectPos = mouseToHitObjectPosition(Column.HitObjectContainer.ToLocalSpace(screenSpacePosition)).Y;
-            if (scrollingInfo.Direction.Value == ScrollingDirection.Down)
-                hitObjectPos = hitObjectContainer.DrawHeight - hitObjectPos;
-
-            return scrollingInfo.Algorithm.TimeAt(hitObjectPos,
-                EditorClock.CurrentTime,
-                scrollingInfo.TimeRange.Value,
-                hitObjectContainer.DrawHeight);
+            SnappedMousePosition = new Vector2(parentPos.X, Parent.ToLocalSpace(result.ScreenSpacePosition).Y);
         }
 
         protected float PositionAt(double time)

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -1,16 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Mania.UI;
-using osu.Game.Rulesets.UI.Scrolling;
-using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Mania.Edit.Blueprints
@@ -22,9 +18,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         protected new T HitObject => (T)base.HitObject;
 
         protected Column Column;
-
-        [Resolved]
-        private IScrollingInfo scrollingInfo { get; set; }
 
         protected ManiaPlacementBlueprint(T hitObject)
             : base(hitObject)
@@ -49,40 +42,6 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         {
             if (!PlacementActive)
                 Column = (result as ManiaSnapResult)?.Column;
-        }
-
-        protected float PositionAt(double time)
-        {
-            var pos = scrollingInfo.Algorithm.PositionAt(time,
-                EditorClock.CurrentTime,
-                scrollingInfo.TimeRange.Value,
-                Column.HitObjectContainer.DrawHeight);
-
-            if (scrollingInfo.Direction.Value == ScrollingDirection.Down)
-                pos = Column.HitObjectContainer.DrawHeight - pos;
-
-            return hitObjectToMousePosition(Column.HitObjectContainer.ToSpaceOfOtherDrawable(new Vector2(0, pos), Parent)).Y;
-        }
-
-        /// <summary>
-        /// Converts a hitobject position to a mouse position.
-        /// </summary>
-        /// <param name="hitObjectPosition">The hitobject position.</param>
-        /// <returns>The resulting mouse position, anchored at the centre of the hitobject.</returns>
-        private Vector2 hitObjectToMousePosition(Vector2 hitObjectPosition)
-        {
-            switch (scrollingInfo.Direction.Value)
-            {
-                case ScrollingDirection.Up:
-                    hitObjectPosition.Y += DefaultNotePiece.NOTE_HEIGHT / 2;
-                    break;
-
-                case ScrollingDirection.Down:
-                    hitObjectPosition.Y -= DefaultNotePiece.NOTE_HEIGHT / 2;
-                    break;
-            }
-
-            return hitObjectPosition;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -17,7 +17,20 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
     {
         protected new T HitObject => (T)base.HitObject;
 
-        protected Column Column;
+        private Column column;
+
+        public Column Column
+        {
+            get => column;
+            set
+            {
+                if (value == column)
+                    return;
+
+                column = value;
+                HitObject.Column = column.Index;
+            }
+        }
 
         protected ManiaPlacementBlueprint(T hitObject)
             : base(hitObject)
@@ -31,9 +44,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
                 return false;
 
             if (Column == null)
-                return base.OnMouseDown(e);
+                return false;
 
-            HitObject.Column = Column.Index;
             BeginPlacement(true);
             return true;
         }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 
         public override void UpdatePosition(SnapResult result)
         {
+            base.UpdatePosition(result);
+
             if (!PlacementActive)
                 Column = (result as ManiaSnapResult)?.Column;
         }

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/NotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/NotePlacementBlueprint.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints.Components;
 using osu.Game.Rulesets.Mania.Objects;
 using osuTK.Input;
@@ -11,22 +12,25 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
 {
     public class NotePlacementBlueprint : ManiaPlacementBlueprint<Note>
     {
+        private readonly EditNotePiece piece;
+
         public NotePlacementBlueprint()
             : base(new Note())
         {
-            Origin = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
 
-            AutoSizeAxes = Axes.Y;
-
-            InternalChild = new EditNotePiece { RelativeSizeAxes = Axes.X };
+            InternalChild = piece = new EditNotePiece { Origin = Anchor.Centre };
         }
 
-        protected override void Update()
+        public override void UpdatePosition(SnapResult result)
         {
-            base.Update();
+            base.UpdatePosition(result);
 
-            Width = SnappedWidth;
-            Position = SnappedMousePosition;
+            if (result is ManiaSnapResult maniaResult)
+            {
+                piece.Width = maniaResult.Column.DrawWidth;
+                piece.Position = ToLocalSpace(result.ScreenSpacePosition);
+            }
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Mania/Edit/IManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/IManiaHitObjectComposer.cs
@@ -2,14 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mania.UI;
-using osuTK;
 
 namespace osu.Game.Rulesets.Mania.Edit
 {
     public interface IManiaHitObjectComposer
     {
-        Column ColumnAt(Vector2 screenSpacePosition);
-
-        int TotalColumns { get; }
+        ManiaPlayfield Playfield { get; }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/IManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/IManiaHitObjectComposer.cs
@@ -10,8 +10,6 @@ namespace osu.Game.Rulesets.Mania.Edit
     {
         Column ColumnAt(Vector2 screenSpacePosition);
 
-        Vector2 ScreenSpacePositionAtTime(double time, Column column = null);
-
         int TotalColumns { get; }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/IManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/IManiaHitObjectComposer.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Rulesets.Mania.Edit
     {
         Column ColumnAt(Vector2 screenSpacePosition);
 
+        Vector2 ScreenSpacePositionAtTime(double time, Column column = null);
+
         int TotalColumns { get; }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
@@ -44,26 +45,31 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         public int TotalColumns => Playfield.TotalColumns;
 
-        public override (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time)
+        public override (Vector2 position, double time) SnapPositionToValidTime(Vector2 position)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
         {
             var hoc = Playfield.GetColumn(0).HitObjectContainer;
 
-            float targetPosition = hoc.ToLocalSpace(ToScreenSpace(position)).Y;
+            Vector2 targetPosition = hoc.ToLocalSpace(screenSpacePosition);
 
             if (drawableRuleset.ScrollingInfo.Direction.Value == ScrollingDirection.Down)
             {
                 // We're dealing with screen coordinates in which the position decreases towards the centre of the screen resulting in an increase in start time.
                 // The scrolling algorithm instead assumes a top anchor meaning an increase in time corresponds to an increase in position,
                 // so when scrolling downwards the coordinates need to be flipped.
-                targetPosition = hoc.DrawHeight - targetPosition;
+                targetPosition.Y = hoc.DrawHeight - targetPosition.Y;
             }
 
-            double targetTime = drawableRuleset.ScrollingInfo.Algorithm.TimeAt(targetPosition,
+            double targetTime = drawableRuleset.ScrollingInfo.Algorithm.TimeAt(targetPosition.Y,
                 EditorClock.CurrentTime,
                 drawableRuleset.ScrollingInfo.TimeRange.Value,
                 hoc.DrawHeight);
 
-            return base.GetSnappedPosition(position, targetTime);
+            return (targetPosition, targetTime);
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -72,11 +72,17 @@ namespace osu.Game.Rulesets.Mania.Edit
 
             targetTime = BeatSnapProvider.SnapTime(targetTime);
 
-            var localPos = new Vector2(
+            localPosition = new Vector2(
                 hoc.DrawWidth / 2,
                 scrollInfo.Algorithm.PositionAt(targetTime, EditorClock.CurrentTime, scrollInfo.TimeRange.Value, hoc.DrawHeight));
 
-            return new ManiaSnapResult(hoc.ToScreenSpace(localPos), BeatSnapProvider.SnapTime(targetTime), column);
+            if (scrollInfo.Direction.Value == ScrollingDirection.Down)
+            {
+                // reapply the above.
+                localPosition.Y = hoc.DrawHeight - localPosition.Y;
+            }
+
+            return new ManiaSnapResult(hoc.ToScreenSpace(localPosition), BeatSnapProvider.SnapTime(targetTime), column);
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -26,13 +26,6 @@ namespace osu.Game.Rulesets.Mania.Edit
         {
         }
 
-        /// <summary>
-        /// Retrieves the column that intersects a screen-space position.
-        /// </summary>
-        /// <param name="screenSpacePosition">The screen-space position.</param>
-        /// <returns>The column which intersects with <paramref name="screenSpacePosition"/>.</returns>
-        public Column ColumnAt(Vector2 screenSpacePosition) => drawableRuleset.GetColumnByPosition(screenSpacePosition);
-
         private DependencyContainer dependencies;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -42,11 +35,9 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         public IScrollingInfo ScrollingInfo => drawableRuleset.ScrollingInfo;
 
-        public int TotalColumns => Playfield.TotalColumns;
-
         public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
         {
-            var column = ColumnAt(screenSpacePosition);
+            var column = Playfield.GetColumnByPosition(screenSpacePosition);
 
             if (column == null)
                 return new SnapResult(screenSpacePosition, null);

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Mania.Edit
             targetTime = BeatSnapProvider.SnapTime(targetTime);
 
             // convert back to screen space
-            screenSpacePosition = column.ScreenSpacePositionAtTime(targetTime, column);
+            screenSpacePosition = column.ScreenSpacePositionAtTime(targetTime);
 
             return new ManiaSnapResult(screenSpacePosition, targetTime, column);
         }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Mania.Edit
                 drawableRuleset.ScrollingInfo.TimeRange.Value,
                 hoc.DrawHeight);
 
-            return new SnapResult(targetPosition, targetTime);
+            return new SnapResult(screenSpacePosition, targetTime);
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -103,15 +103,4 @@ namespace osu.Game.Rulesets.Mania.Edit
             new HoldNoteCompositionTool()
         };
     }
-
-    public class ManiaSnapResult : SnapResult
-    {
-        public readonly Column Column;
-
-        public ManiaSnapResult(Vector2 screenSpacePosition, double time, Column column)
-            : base(screenSpacePosition, time)
-        {
-            Column = column;
-        }
-    }
 }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
@@ -45,12 +44,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         public int TotalColumns => Playfield.TotalColumns;
 
-        public override (Vector2 position, double time) SnapPositionToValidTime(Vector2 position)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
+        public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
         {
             var hoc = Playfield.GetColumn(0).HitObjectContainer;
 
@@ -69,7 +63,7 @@ namespace osu.Game.Rulesets.Mania.Edit
                 drawableRuleset.ScrollingInfo.TimeRange.Value,
                 hoc.DrawHeight);
 
-            return (targetPosition, targetTime);
+            return new SnapResult(targetPosition, targetTime);
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -55,7 +55,9 @@ namespace osu.Game.Rulesets.Mania.Edit
 
             Vector2 localPosition = hoc.ToLocalSpace(screenSpacePosition);
 
-            if (drawableRuleset.ScrollingInfo.Direction.Value == ScrollingDirection.Down)
+            var scrollInfo = drawableRuleset.ScrollingInfo;
+
+            if (scrollInfo.Direction.Value == ScrollingDirection.Down)
             {
                 // We're dealing with screen coordinates in which the position decreases towards the centre of the screen resulting in an increase in start time.
                 // The scrolling algorithm instead assumes a top anchor meaning an increase in time corresponds to an increase in position,
@@ -63,19 +65,18 @@ namespace osu.Game.Rulesets.Mania.Edit
                 localPosition.Y = hoc.DrawHeight - localPosition.Y;
             }
 
-            double targetTime = drawableRuleset.ScrollingInfo.Algorithm.TimeAt(localPosition.Y,
+            double targetTime = scrollInfo.Algorithm.TimeAt(localPosition.Y,
                 EditorClock.CurrentTime,
-                drawableRuleset.ScrollingInfo.TimeRange.Value,
+                scrollInfo.TimeRange.Value,
                 hoc.DrawHeight);
 
             targetTime = BeatSnapProvider.SnapTime(targetTime);
 
-            screenSpacePosition.Y = hoc.ToScreenSpace(
-                new Vector2(0, drawableRuleset.ScrollingInfo.Algorithm.PositionAt(targetTime, EditorClock.CurrentTime, drawableRuleset.ScrollingInfo.TimeRange.Value,
-                    hoc.DrawHeight))
-            ).Y;
+            var localPos = new Vector2(
+                hoc.DrawWidth / 2,
+                scrollInfo.Algorithm.PositionAt(targetTime, EditorClock.CurrentTime, scrollInfo.TimeRange.Value, hoc.DrawHeight));
 
-            return new ManiaSnapResult(screenSpacePosition, BeatSnapProvider.SnapTime(targetTime), column);
+            return new ManiaSnapResult(hoc.ToScreenSpace(localPos), BeatSnapProvider.SnapTime(targetTime), column);
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -72,25 +72,9 @@ namespace osu.Game.Rulesets.Mania.Edit
             targetTime = BeatSnapProvider.SnapTime(targetTime);
 
             // convert back to screen space
-            screenSpacePosition = ScreenSpacePositionAtTime(targetTime, column);
+            screenSpacePosition = column.ScreenSpacePositionAtTime(targetTime, column);
 
             return new ManiaSnapResult(screenSpacePosition, targetTime, column);
-        }
-
-        public Vector2 ScreenSpacePositionAtTime(double time, Column column = null)
-        {
-            var hoc = (column ?? Playfield.GetColumn(0)).HitObjectContainer;
-            var scrollInfo = drawableRuleset.ScrollingInfo;
-
-            var pos = scrollInfo.Algorithm.PositionAt(time, EditorClock.CurrentTime, scrollInfo.TimeRange.Value, hoc.DrawHeight);
-
-            if (scrollInfo.Direction.Value == ScrollingDirection.Down)
-            {
-                // as explained above
-                pos = hoc.DrawHeight - pos;
-            }
-
-            return hoc.ToScreenSpace(new Vector2(hoc.DrawWidth / 2, pos));
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -51,22 +51,7 @@ namespace osu.Game.Rulesets.Mania.Edit
             if (column == null)
                 return new SnapResult(screenSpacePosition, null);
 
-            var hoc = column.HitObjectContainer;
-
-            // convert to local space of column so we can snap and fetch correct location.
-            Vector2 localPosition = hoc.ToLocalSpace(screenSpacePosition);
-
-            var scrollInfo = drawableRuleset.ScrollingInfo;
-
-            if (scrollInfo.Direction.Value == ScrollingDirection.Down)
-            {
-                // We're dealing with screen coordinates in which the position decreases towards the centre of the screen resulting in an increase in start time.
-                // The scrolling algorithm instead assumes a top anchor meaning an increase in time corresponds to an increase in position,
-                // so when scrolling downwards the coordinates need to be flipped.
-                localPosition.Y = hoc.DrawHeight - localPosition.Y;
-            }
-
-            double targetTime = scrollInfo.Algorithm.TimeAt(localPosition.Y, EditorClock.CurrentTime, scrollInfo.TimeRange.Value, hoc.DrawHeight);
+            double targetTime = column.TimeAtScreenSpacePosition(screenSpacePosition);
 
             // apply beat snapping
             targetTime = BeatSnapProvider.SnapTime(targetTime);

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -46,19 +46,22 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
         {
-            var hoc = Playfield.GetColumn(0).HitObjectContainer;
+            var hoc = ColumnAt(screenSpacePosition)?.HitObjectContainer;
 
-            Vector2 targetPosition = hoc.ToLocalSpace(screenSpacePosition);
+            if (hoc == null)
+                return new SnapResult(screenSpacePosition, null);
+
+            Vector2 localPosition = hoc.ToLocalSpace(screenSpacePosition);
 
             if (drawableRuleset.ScrollingInfo.Direction.Value == ScrollingDirection.Down)
             {
                 // We're dealing with screen coordinates in which the position decreases towards the centre of the screen resulting in an increase in start time.
                 // The scrolling algorithm instead assumes a top anchor meaning an increase in time corresponds to an increase in position,
                 // so when scrolling downwards the coordinates need to be flipped.
-                targetPosition.Y = hoc.DrawHeight - targetPosition.Y;
+                localPosition.Y = hoc.DrawHeight - localPosition.Y;
             }
 
-            double targetTime = drawableRuleset.ScrollingInfo.Algorithm.TimeAt(targetPosition.Y,
+            double targetTime = drawableRuleset.ScrollingInfo.Algorithm.TimeAt(localPosition.Y,
                 EditorClock.CurrentTime,
                 drawableRuleset.ScrollingInfo.TimeRange.Value,
                 hoc.DrawHeight);

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -46,10 +46,12 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
         {
-            var hoc = ColumnAt(screenSpacePosition)?.HitObjectContainer;
+            var column = ColumnAt(screenSpacePosition);
 
-            if (hoc == null)
+            if (column == null)
                 return new SnapResult(screenSpacePosition, null);
+
+            var hoc = column.HitObjectContainer;
 
             Vector2 localPosition = hoc.ToLocalSpace(screenSpacePosition);
 
@@ -73,7 +75,7 @@ namespace osu.Game.Rulesets.Mania.Edit
                     hoc.DrawHeight))
             ).Y;
 
-            return new SnapResult(screenSpacePosition, BeatSnapProvider.SnapTime(targetTime));
+            return new ManiaSnapResult(screenSpacePosition, BeatSnapProvider.SnapTime(targetTime), column);
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
@@ -93,5 +95,16 @@ namespace osu.Game.Rulesets.Mania.Edit
             new NoteCompositionTool(),
             new HoldNoteCompositionTool()
         };
+    }
+
+    public class ManiaSnapResult : SnapResult
+    {
+        public readonly Column Column;
+
+        public ManiaSnapResult(Vector2 screenSpacePosition, double time, Column column)
+            : base(screenSpacePosition, time)
+        {
+            Column = column;
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -63,7 +63,14 @@ namespace osu.Game.Rulesets.Mania.Edit
                 drawableRuleset.ScrollingInfo.TimeRange.Value,
                 hoc.DrawHeight);
 
-            return new SnapResult(screenSpacePosition, targetTime);
+            targetTime = BeatSnapProvider.SnapTime(targetTime);
+
+            screenSpacePosition.Y = hoc.ToScreenSpace(
+                new Vector2(0, drawableRuleset.ScrollingInfo.Algorithm.PositionAt(targetTime, EditorClock.CurrentTime, drawableRuleset.ScrollingInfo.TimeRange.Value,
+                    hoc.DrawHeight))
+            ).Y;
+
+            return new SnapResult(screenSpacePosition, BeatSnapProvider.SnapTime(targetTime));
         }
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)

--- a/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         private void performColumnMovement(int lastColumn, MoveSelectionEvent moveEvent)
         {
-            var currentColumn = composer.ColumnAt(moveEvent.ScreenSpacePosition);
+            var currentColumn = composer.Playfield.GetColumnByPosition(moveEvent.ScreenSpacePosition);
             if (currentColumn == null)
                 return;
 
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Mania.Edit
                     maxColumn = obj.Column;
             }
 
-            columnDelta = Math.Clamp(columnDelta, -minColumn, composer.TotalColumns - 1 - maxColumn);
+            columnDelta = Math.Clamp(columnDelta, -minColumn, composer.Playfield.TotalColumns - 1 - maxColumn);
 
             foreach (var obj in SelectedHitObjects.OfType<ManiaHitObject>())
                 obj.Column += columnDelta;

--- a/osu.Game.Rulesets.Mania/Edit/ManiaSnapResult.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaSnapResult.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Mania.UI;
+using osuTK;
+
+namespace osu.Game.Rulesets.Mania.Edit
+{
+    public class ManiaSnapResult : SnapResult
+    {
+        public readonly Column Column;
+
+        public ManiaSnapResult(Vector2 screenSpacePosition, double time, Column column)
+            : base(screenSpacePosition, time)
+        {
+            Column = column;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -140,5 +140,18 @@ namespace osu.Game.Rulesets.Mania.UI
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
             // This probably shouldn't exist as is, but the columns in the stage are separated by a 1px border
             => DrawRectangle.Inflate(new Vector2(Stage.COLUMN_SPACING / 2, 0)).Contains(ToLocalSpace(screenSpacePos));
+
+        public Vector2 ScreenSpacePositionAtTime(double time, Column column = null)
+        {
+            var pos = ScrollingInfo.Algorithm.PositionAt(time, Time.Current, ScrollingInfo.TimeRange.Value, HitObjectContainer.DrawHeight);
+
+            if (ScrollingInfo.Direction.Value == ScrollingDirection.Down)
+            {
+                // as explained above
+                pos = HitObjectContainer.DrawHeight - pos;
+            }
+
+            return HitObjectContainer.ToScreenSpace(new Vector2(HitObjectContainer.DrawWidth / 2, pos));
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -190,29 +190,5 @@ namespace osu.Game.Rulesets.Mania.UI
 
             return ScrollingInfo.Algorithm.TimeAt(localPosition.Y, Time.Current, ScrollingInfo.TimeRange.Value, HitObjectContainer.DrawHeight);
         }
-
-        /// <summary>
-        /// Converts a mouse position to a hitobject position.
-        /// </summary>
-        /// <remarks>
-        /// Blueprints are centred on the mouse position, such that the hitobject position is anchored at the top or bottom of the blueprint depending on the scroll direction.
-        /// </remarks>
-        /// <param name="mousePosition">The mouse position.</param>
-        /// <returns>The resulting hitobject position, acnhored at the top or bottom of the blueprint depending on the scroll direction.</returns>
-        private Vector2 mouseToHitObjectPosition(Vector2 mousePosition)
-        {
-            switch (ScrollingInfo.Direction.Value)
-            {
-                case ScrollingDirection.Up:
-                    mousePosition.Y -= DefaultNotePiece.NOTE_HEIGHT / 2;
-                    break;
-
-                case ScrollingDirection.Down:
-                    mousePosition.Y += DefaultNotePiece.NOTE_HEIGHT / 2;
-                    break;
-            }
-
-            return mousePosition;
-        }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -142,7 +142,10 @@ namespace osu.Game.Rulesets.Mania.UI
             // This probably shouldn't exist as is, but the columns in the stage are separated by a 1px border
             => DrawRectangle.Inflate(new Vector2(Stage.COLUMN_SPACING / 2, 0)).Contains(ToLocalSpace(screenSpacePos));
 
-        public Vector2 ScreenSpacePositionAtTime(double time, Column column = null)
+        /// <summary>
+        /// Given a time, return the screen space position within this column.
+        /// </summary>
+        public Vector2 ScreenSpacePositionAtTime(double time)
         {
             var pos = ScrollingInfo.Algorithm.PositionAt(time, Time.Current, ScrollingInfo.TimeRange.Value, HitObjectContainer.DrawHeight);
 
@@ -166,6 +169,9 @@ namespace osu.Game.Rulesets.Mania.UI
             return HitObjectContainer.ToScreenSpace(new Vector2(HitObjectContainer.DrawWidth / 2, pos));
         }
 
+        /// <summary>
+        /// Given a position in screen space, return the time within this column.
+        /// </summary>
         public double TimeAtScreenSpacePosition(Vector2 screenSpacePosition)
         {
             // convert to local space of column so we can snap and fetch correct location.

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -153,5 +153,21 @@ namespace osu.Game.Rulesets.Mania.UI
 
             return HitObjectContainer.ToScreenSpace(new Vector2(HitObjectContainer.DrawWidth / 2, pos));
         }
+
+        public double TimeAtScreenSpacePosition(Vector2 screenSpacePosition)
+        {
+            // convert to local space of column so we can snap and fetch correct location.
+            Vector2 localPosition = HitObjectContainer.ToLocalSpace(screenSpacePosition);
+
+            if (ScrollingInfo.Direction.Value == ScrollingDirection.Down)
+            {
+                // We're dealing with screen coordinates in which the position decreases towards the centre of the screen resulting in an increase in start time.
+                // The scrolling algorithm instead assumes a top anchor meaning an increase in time corresponds to an increase in position,
+                // so when scrolling downwards the coordinates need to be flipped.
+                localPosition.Y = HitObjectContainer.DrawHeight - localPosition.Y;
+            }
+
+            return ScrollingInfo.Algorithm.TimeAt(localPosition.Y, Time.Current, ScrollingInfo.TimeRange.Value, HitObjectContainer.DrawHeight);
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -23,7 +23,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
-using osuTK;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
@@ -107,13 +106,6 @@ namespace osu.Game.Rulesets.Mania.UI
         }
 
         private void updateTimeRange() => TimeRange.Value = configTimeRange.Value * speedAdjustmentTrack.AggregateTempo.Value * speedAdjustmentTrack.AggregateFrequency.Value;
-
-        /// <summary>
-        /// Retrieves the column that intersects a screen-space position.
-        /// </summary>
-        /// <param name="screenSpacePosition">The screen-space position.</param>
-        /// <returns>The column which intersects with <paramref name="screenSpacePosition"/>.</returns>
-        public Column GetColumnByPosition(Vector2 screenSpacePosition) => Playfield.GetColumnByPosition(screenSpacePosition);
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new ManiaPlayfieldAdjustmentContainer();
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuDistanceSnapGrid.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Cached]
         private readonly BindableBeatDivisor beatDivisor = new BindableBeatDivisor();
 
-        [Cached(typeof(IDistanceSnapProvider))]
+        [Cached(typeof(IPositionSnapProvider))]
         private readonly SnapProvider snapProvider = new SnapProvider();
 
         private TestOsuDistanceSnapGrid grid;
@@ -172,9 +172,11 @@ namespace osu.Game.Rulesets.Osu.Tests
             }
         }
 
-        private class SnapProvider : IDistanceSnapProvider
+        private class SnapProvider : IPositionSnapProvider
         {
-            public (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time) => (position, time);
+            public (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) => (position, 0);
+
+            public (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition) => (screenSpacePosition, 0);
 
             public float GetBeatSnapDistanceAt(double referenceTime) => (float)beat_length;
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuDistanceSnapGrid.cs
@@ -174,9 +174,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private class SnapProvider : IPositionSnapProvider
         {
-            public (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) => (position, 0);
-
-            public (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition) => (screenSpacePosition, 0);
+            public SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition) => new SnapResult(screenSpacePosition, 0);
 
             public float GetBeatSnapDistanceAt(double referenceTime) => (float)beat_length;
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -5,7 +5,6 @@ using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
 using osu.Game.Rulesets.Osu.Objects;
-using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
@@ -40,6 +39,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
             return base.OnMouseDown(e);
         }
 
-        public override void UpdatePosition(Vector2 screenSpacePosition) => HitObject.Position = ToLocalSpace(screenSpacePosition);
+        public override void UpdatePosition(SnapResult result) => HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -39,6 +39,10 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
             return base.OnMouseDown(e);
         }
 
-        public override void UpdatePosition(SnapResult result) => HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
+        public override void UpdatePosition(SnapResult result)
+        {
+            base.UpdatePosition(result);
+            HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -162,8 +162,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (ControlPoint == slider.Path.ControlPoints[0])
             {
                 // Special handling for the head control point - the position of the slider changes which means the snapped position and time have to be taken into account
-                var result = snapProvider?.SnapScreenSpacePositionToValidTime(e.MousePosition);
-                Vector2 movementDelta = (result?.ScreenSpacePosition ?? e.MousePosition) - slider.Position;
+                var result = snapProvider?.SnapScreenSpacePositionToValidTime(e.ScreenSpaceMousePosition);
+
+                Vector2 movementDelta = Parent.ToLocalSpace(result?.ScreenSpacePosition ?? e.ScreenSpaceMousePosition) - slider.Position;
 
                 slider.Position += movementDelta;
                 slider.StartTime = result?.Time ?? slider.StartTime;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         private IEditorChangeHandler changeHandler { get; set; }
 
         [Resolved(CanBeNull = true)]
-        private IDistanceSnapProvider snapProvider { get; set; }
+        private IPositionSnapProvider snapProvider { get; set; }
 
         [Resolved]
         private OsuColour colours { get; set; }
@@ -162,7 +162,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (ControlPoint == slider.Path.ControlPoints[0])
             {
                 // Special handling for the head control point - the position of the slider changes which means the snapped position and time have to be taken into account
-                (Vector2 snappedPosition, double snappedTime) = snapProvider?.GetSnappedPosition(e.MousePosition, slider.StartTime) ?? (e.MousePosition, slider.StartTime);
+                (Vector2 snappedPosition, double snappedTime) = snapProvider?.SnapScreenSpacePositionToValidTime(e.MousePosition) ?? (e.MousePosition, slider.StartTime);
                 Vector2 movementDelta = snappedPosition - slider.Position;
 
                 slider.Position += movementDelta;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -162,11 +162,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (ControlPoint == slider.Path.ControlPoints[0])
             {
                 // Special handling for the head control point - the position of the slider changes which means the snapped position and time have to be taken into account
-                (Vector2 snappedPosition, double snappedTime) = snapProvider?.SnapScreenSpacePositionToValidTime(e.MousePosition) ?? (e.MousePosition, slider.StartTime);
-                Vector2 movementDelta = snappedPosition - slider.Position;
+                var result = snapProvider?.SnapScreenSpacePositionToValidTime(e.MousePosition);
+                Vector2 movementDelta = (result?.ScreenSpacePosition ?? e.MousePosition) - slider.Position;
 
                 slider.Position += movementDelta;
-                slider.StartTime = snappedTime;
+                slider.StartTime = result?.Time ?? slider.StartTime;
 
                 // Since control points are relative to the position of the slider, they all need to be offset backwards by the delta
                 for (int i = 1; i < slider.Path.ControlPoints.Count; i++)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -67,13 +67,13 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             inputManager = GetContainingInputManager();
         }
 
-        public override void UpdatePosition(Vector2 screenSpacePosition)
+        public override void UpdatePosition(SnapResult result)
         {
             switch (state)
             {
                 case PlacementState.Initial:
                     BeginPlacement();
-                    HitObject.Position = ToLocalSpace(screenSpacePosition);
+                    HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
                     break;
 
                 case PlacementState.Body:

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -69,6 +69,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         public override void UpdatePosition(SnapResult result)
         {
+            base.UpdatePosition(result);
+
             switch (state)
             {
                 case PlacementState.Initial:

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             new OsuMenuItem("Add control point", MenuItemType.Standard, () => addControlPoint(rightClickPosition)),
         };
 
-        public override Vector2 SelectionPoint => ((DrawableSlider)DrawableObject).HeadCircle.ScreenSpaceDrawQuad.Centre;
+        public override Vector2 ScreenSpaceSelectionPoint => ((DrawableSlider)DrawableObject).HeadCircle.ScreenSpaceDrawQuad.Centre;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => BodyPiece.ReceivePositionalInputAt(screenSpacePos);
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -8,7 +8,6 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
-using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
@@ -61,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
             return true;
         }
 
-        public override void UpdatePosition(Vector2 screenSpacePosition)
+        public override void UpdatePosition(SnapResult result)
         {
         }
     }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -59,9 +59,5 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
 
             return true;
         }
-
-        public override void UpdatePosition(SnapResult result)
-        {
-        }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -153,9 +153,7 @@ namespace osu.Game.Tests.Visual.Editing
 
         private class SnapProvider : IPositionSnapProvider
         {
-            public (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) => (position, 0);
-
-            public (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition) => (screenSpacePosition, 0);
+            public SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition) => new SnapResult(screenSpacePosition, 0);
 
             public float GetBeatSnapDistanceAt(double referenceTime) => 10;
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Cached(typeof(EditorBeatmap))]
         private readonly EditorBeatmap editorBeatmap;
 
-        [Cached(typeof(IDistanceSnapProvider))]
+        [Cached(typeof(IPositionSnapProvider))]
         private readonly SnapProvider snapProvider = new SnapProvider();
 
         public TestSceneDistanceSnapGrid()
@@ -151,9 +151,11 @@ namespace osu.Game.Tests.Visual.Editing
                 => (Vector2.Zero, 0);
         }
 
-        private class SnapProvider : IDistanceSnapProvider
+        private class SnapProvider : IPositionSnapProvider
         {
-            public (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time) => (position, time);
+            public (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) => (position, 0);
+
+            public (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition) => (screenSpacePosition, 0);
 
             public float GetBeatSnapDistanceAt(double referenceTime) => 10;
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -245,7 +245,8 @@ namespace osu.Game.Rulesets.Edit
         {
             EditorBeatmap.PlacementObject.Value = hitObject;
 
-            hitObject.StartTime = SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position).time;
+            if (SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position).Time is double time)
+                hitObject.StartTime = time;
         }
 
         public void EndPlacement(HitObject hitObject, bool commit)
@@ -264,11 +265,13 @@ namespace osu.Game.Rulesets.Edit
 
         public void Delete(HitObject hitObject) => EditorBeatmap.Remove(hitObject);
 
-        public override (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) =>
-            distanceSnapGrid?.GetSnappedPosition(position) ?? (position, 0);
+        public override SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
+        {
+            if (distanceSnapGrid == null) return new SnapResult(screenSpacePosition, null);
 
-        public override (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
-            => SnapPositionToValidTime(drawableRulesetWrapper.Playfield.ToLocalSpace(screenSpacePosition));
+            (Vector2 pos, double time) = distanceSnapGrid.GetSnappedPosition(distanceSnapGrid.ToLocalSpace(screenSpacePosition));
+            return new SnapResult(distanceSnapGrid.ToScreenSpace(pos), time);
+        }
 
         public override float GetBeatSnapDistanceAt(double referenceTime)
         {
@@ -326,9 +329,7 @@ namespace osu.Game.Rulesets.Edit
         [CanBeNull]
         protected virtual DistanceSnapGrid CreateDistanceSnapGrid([NotNull] IEnumerable<HitObject> selectedHitObjects) => null;
 
-        public abstract (Vector2 position, double time) SnapPositionToValidTime(Vector2 position);
-
-        public abstract (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition);
+        public abstract SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition);
 
         public abstract float GetBeatSnapDistanceAt(double referenceTime);
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -244,8 +244,6 @@ namespace osu.Game.Rulesets.Edit
         public void BeginPlacement(HitObject hitObject)
         {
             EditorBeatmap.PlacementObject.Value = hitObject;
-
-            hitObject.StartTime = SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position).Time ?? EditorClock.CurrentTime;
         }
 
         public void EndPlacement(HitObject hitObject, bool commit)

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -245,8 +245,7 @@ namespace osu.Game.Rulesets.Edit
         {
             EditorBeatmap.PlacementObject.Value = hitObject;
 
-            if (distanceSnapGrid != null)
-                hitObject.StartTime = GetSnappedPosition(distanceSnapGrid.ToLocalSpace(inputManager.CurrentState.Mouse.Position), hitObject.StartTime).time;
+            hitObject.StartTime = SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position).time;
         }
 
         public void EndPlacement(HitObject hitObject, bool commit)
@@ -265,7 +264,11 @@ namespace osu.Game.Rulesets.Edit
 
         public void Delete(HitObject hitObject) => EditorBeatmap.Remove(hitObject);
 
-        public override (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time) => distanceSnapGrid?.GetSnappedPosition(position) ?? (position, time);
+        public override (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) =>
+            distanceSnapGrid?.GetSnappedPosition(position) ?? (position, 0);
+
+        public override (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition)
+            => SnapPositionToValidTime(drawableRulesetWrapper.Playfield.ToLocalSpace(screenSpacePosition));
 
         public override float GetBeatSnapDistanceAt(double referenceTime)
         {
@@ -297,8 +300,8 @@ namespace osu.Game.Rulesets.Edit
     }
 
     [Cached(typeof(HitObjectComposer))]
-    [Cached(typeof(IDistanceSnapProvider))]
-    public abstract class HitObjectComposer : CompositeDrawable, IDistanceSnapProvider
+    [Cached(typeof(IPositionSnapProvider))]
+    public abstract class HitObjectComposer : CompositeDrawable, IPositionSnapProvider
     {
         internal HitObjectComposer()
         {
@@ -323,7 +326,9 @@ namespace osu.Game.Rulesets.Edit
         [CanBeNull]
         protected virtual DistanceSnapGrid CreateDistanceSnapGrid([NotNull] IEnumerable<HitObject> selectedHitObjects) => null;
 
-        public abstract (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time);
+        public abstract (Vector2 position, double time) SnapPositionToValidTime(Vector2 position);
+
+        public abstract (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition);
 
         public abstract float GetBeatSnapDistanceAt(double referenceTime);
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -245,8 +245,7 @@ namespace osu.Game.Rulesets.Edit
         {
             EditorBeatmap.PlacementObject.Value = hitObject;
 
-            if (SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position).Time is double time)
-                hitObject.StartTime = time;
+            hitObject.StartTime = SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position).Time ?? EditorClock.CurrentTime;
         }
 
         public void EndPlacement(HitObject hitObject, bool commit)

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Edit
         private IAdjustableClock adjustableClock { get; set; }
 
         [Resolved]
-        private IBeatSnapProvider beatSnapProvider { get; set; }
+        protected IBeatSnapProvider BeatSnapProvider { get; private set; }
 
         protected ComposeBlueprintContainer BlueprintContainer { get; private set; }
 
@@ -278,27 +278,27 @@ namespace osu.Game.Rulesets.Edit
         public override float GetBeatSnapDistanceAt(double referenceTime)
         {
             DifficultyControlPoint difficultyPoint = EditorBeatmap.ControlPointInfo.DifficultyPointAt(referenceTime);
-            return (float)(100 * EditorBeatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier * difficultyPoint.SpeedMultiplier / beatSnapProvider.BeatDivisor);
+            return (float)(100 * EditorBeatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier * difficultyPoint.SpeedMultiplier / BeatSnapProvider.BeatDivisor);
         }
 
         public override float DurationToDistance(double referenceTime, double duration)
         {
-            double beatLength = beatSnapProvider.GetBeatLengthAtTime(referenceTime);
+            double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
             return (float)(duration / beatLength * GetBeatSnapDistanceAt(referenceTime));
         }
 
         public override double DistanceToDuration(double referenceTime, float distance)
         {
-            double beatLength = beatSnapProvider.GetBeatLengthAtTime(referenceTime);
+            double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
             return distance / GetBeatSnapDistanceAt(referenceTime) * beatLength;
         }
 
         public override double GetSnappedDurationFromDistance(double referenceTime, float distance)
-            => beatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime) - referenceTime;
+            => BeatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime) - referenceTime;
 
         public override float GetSnappedDistanceFromDistance(double referenceTime, float distance)
         {
-            var snappedEndTime = beatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime);
+            var snappedEndTime = BeatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime);
 
             return DurationToDistance(referenceTime, snappedEndTime - referenceTime);
         }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -269,7 +269,9 @@ namespace osu.Game.Rulesets.Edit
         {
             if (distanceSnapGrid == null) return new SnapResult(screenSpacePosition, null);
 
+            // TODO: move distance snap grid to OsuHitObjectComposer.
             (Vector2 pos, double time) = distanceSnapGrid.GetSnappedPosition(distanceSnapGrid.ToLocalSpace(screenSpacePosition));
+
             return new SnapResult(distanceSnapGrid.ToScreenSpace(pos), time);
         }
 

--- a/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
@@ -53,23 +53,4 @@ namespace osu.Game.Rulesets.Edit
         /// <returns>A value that represents <paramref name="distance"/> snapped to the closest beat of the timing point.</returns>
         float GetSnappedDistanceFromDistance(double referenceTime, float distance);
     }
-
-    public class SnapResult
-    {
-        /// <summary>
-        /// The screen space position, potentially altered for snapping.
-        /// </summary>
-        public Vector2 ScreenSpacePosition;
-
-        /// <summary>
-        /// The resultant time for snapping, if a value could be attained.
-        /// </summary>
-        public double? Time;
-
-        public SnapResult(Vector2 screenSpacePosition, double? time)
-        {
-            ScreenSpacePosition = screenSpacePosition;
-            Time = time;
-        }
-    }
 }

--- a/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
@@ -5,9 +5,16 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Edit
 {
-    public interface IDistanceSnapProvider
+    public interface IPositionSnapProvider
     {
-        (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time);
+        /// <summary>
+        /// Given a position (local to the provider), find a valid time snap
+        /// </summary>
+        /// <param name="position">The local position to be snapped.</param>
+        /// <returns>The time and position post-snapping.</returns>
+        (Vector2 position, double time) SnapPositionToValidTime(Vector2 position);
+
+        (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition);
 
         /// <summary>
         /// Retrieves the distance between two points within a timing point that are one beat length apart.

--- a/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
@@ -8,13 +8,11 @@ namespace osu.Game.Rulesets.Edit
     public interface IPositionSnapProvider
     {
         /// <summary>
-        /// Given a position (local to the provider), find a valid time snap
+        /// Given a position, find a valid time snap.
         /// </summary>
-        /// <param name="position">The local position to be snapped.</param>
+        /// <param name="screenSpacePosition">The screen-space position to be snapped.</param>
         /// <returns>The time and position post-snapping.</returns>
-        (Vector2 position, double time) SnapPositionToValidTime(Vector2 position);
-
-        (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition);
+        SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition);
 
         /// <summary>
         /// Retrieves the distance between two points within a timing point that are one beat length apart.
@@ -54,5 +52,24 @@ namespace osu.Game.Rulesets.Edit
         /// <param name="distance">The distance to convert.</param>
         /// <returns>A value that represents <paramref name="distance"/> snapped to the closest beat of the timing point.</returns>
         float GetSnappedDistanceFromDistance(double referenceTime, float distance);
+    }
+
+    public class SnapResult
+    {
+        /// <summary>
+        /// The screen space position, potentially altered for snapping.
+        /// </summary>
+        public Vector2 ScreenSpacePosition;
+
+        /// <summary>
+        /// The resultant time for snapping, if a value could be attained.
+        /// </summary>
+        public double? Time;
+
+        public SnapResult(Vector2 screenSpacePosition, double? time)
+        {
+            ScreenSpacePosition = screenSpacePosition;
+            Time = time;
+        }
     }
 }

--- a/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Edit
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => DrawableObject.ReceivePositionalInputAt(screenSpacePos);
 
-        public override Vector2 SelectionPoint => DrawableObject.ScreenSpaceDrawQuad.Centre;
+        public override Vector2 ScreenSpaceSelectionPoint => DrawableObject.ScreenSpaceDrawQuad.Centre;
 
         public override Quad SelectionQuad => DrawableObject.ScreenSpaceDrawQuad;
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -64,9 +64,7 @@ namespace osu.Game.Rulesets.Edit
         /// <param name="commitStart">Whether this call is committing a value for HitObject.StartTime and continuing with further adjustments.</param>
         protected void BeginPlacement(bool commitStart = false)
         {
-            // applies snapping to above time
             placementHandler.BeginPlacement(HitObject);
-
             PlacementActive |= commitStart;
         }
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -61,12 +61,9 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// Signals that the placement of <see cref="HitObject"/> has started.
         /// </summary>
-        /// <param name="startTime">The start time of <see cref="HitObject"/> at the placement point. If null, the current clock time is used.</param>
         /// <param name="commitStart">Whether this call is committing a value for HitObject.StartTime and continuing with further adjustments.</param>
-        protected void BeginPlacement(double? startTime = null, bool commitStart = false)
+        protected void BeginPlacement(bool commitStart = false)
         {
-            HitObject.StartTime = startTime ?? EditorClock.CurrentTime;
-
             // applies snapping to above time
             placementHandler.BeginPlacement(HitObject);
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -66,7 +66,10 @@ namespace osu.Game.Rulesets.Edit
         protected void BeginPlacement(double? startTime = null, bool commitStart = false)
         {
             HitObject.StartTime = startTime ?? EditorClock.CurrentTime;
+
+            // applies snapping to above time
             placementHandler.BeginPlacement(HitObject);
+
             PlacementActive |= commitStart;
         }
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -10,6 +10,7 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose;
 using osuTK;
 
@@ -83,11 +84,18 @@ namespace osu.Game.Rulesets.Edit
             PlacementActive = false;
         }
 
+        [Resolved(canBeNull: true)]
+        private IFrameBasedClock editorClock { get; set; }
+
         /// <summary>
         /// Updates the position of this <see cref="PlacementBlueprint"/> to a new screen-space position.
         /// </summary>
         /// <param name="snapResult">The snap result information.</param>
-        public abstract void UpdatePosition(SnapResult snapResult);
+        public virtual void UpdatePosition(SnapResult snapResult)
+        {
+            if (!PlacementActive)
+                HitObject.StartTime = snapResult.Time ?? editorClock?.CurrentTime ?? Time.Current;
+        }
 
         /// <summary>
         /// Invokes <see cref="Objects.HitObject.ApplyDefaults(ControlPointInfo,BeatmapDifficulty)"/>,

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -10,7 +10,6 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose;
 using osuTK;
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -86,8 +86,8 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// Updates the position of this <see cref="PlacementBlueprint"/> to a new screen-space position.
         /// </summary>
-        /// <param name="screenSpacePosition">The screen-space position.</param>
-        public abstract void UpdatePosition(Vector2 screenSpacePosition);
+        /// <param name="snapResult">The snap result information.</param>
+        public abstract void UpdatePosition(SnapResult snapResult);
 
         /// <summary>
         /// Invokes <see cref="Objects.HitObject.ApplyDefaults(ControlPointInfo,BeatmapDifficulty)"/>,

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// The screen-space point that causes this <see cref="OverlaySelectionBlueprint"/> to be selected.
         /// </summary>
-        public virtual Vector2 SelectionPoint => ScreenSpaceDrawQuad.Centre;
+        public virtual Vector2 ScreenSpaceSelectionPoint => ScreenSpaceDrawQuad.Centre;
 
         /// <summary>
         /// The screen-space quad that outlines this <see cref="OverlaySelectionBlueprint"/> for selections.

--- a/osu.Game/Rulesets/Edit/SnapResult.cs
+++ b/osu.Game/Rulesets/Edit/SnapResult.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osuTK;
+
+namespace osu.Game.Rulesets.Edit
+{
+    /// <summary>
+    /// The result of a position/time snapping process.
+    /// </summary>
+    public class SnapResult
+    {
+        /// <summary>
+        /// The screen space position, potentially altered for snapping.
+        /// </summary>
+        public Vector2 ScreenSpacePosition;
+
+        /// <summary>
+        /// The resultant time for snapping, if a value could be attained.
+        /// </summary>
+        public double? Time;
+
+        public SnapResult(Vector2 screenSpacePosition, double? time)
+        {
+            ScreenSpacePosition = screenSpacePosition;
+            Time = time;
+        }
+    }
+}

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingPlayfield.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingPlayfield.cs
@@ -15,12 +15,12 @@ namespace osu.Game.Rulesets.UI.Scrolling
         protected readonly IBindable<ScrollingDirection> Direction = new Bindable<ScrollingDirection>();
 
         [Resolved]
-        private IScrollingInfo scrollingInfo { get; set; }
+        protected IScrollingInfo ScrollingInfo { get; private set; }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Direction.BindTo(scrollingInfo.Direction);
+            Direction.BindTo(ScrollingInfo.Direction);
         }
 
         protected sealed override HitObjectContainer CreateHitObjectContainer() => new ScrollingHitObjectContainer();

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -405,16 +405,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
             Vector2 movePosition = movementBlueprintOriginalPosition.Value + e.ScreenSpaceMousePosition - e.ScreenSpaceMouseDownPosition;
 
             // Retrieve a snapped position.
-            (Vector2 snappedPosition, double snappedTime) = snapProvider.SnapScreenSpacePositionToValidTime(movePosition);
+            var result = snapProvider.SnapScreenSpacePositionToValidTime(movePosition);
 
             // Move the hitobjects.
-            if (!selectionHandler.HandleMovement(new MoveSelectionEvent(movementBlueprint, ToScreenSpace(snappedPosition))))
+            if (!selectionHandler.HandleMovement(new MoveSelectionEvent(movementBlueprint, result.ScreenSpacePosition)))
                 return true;
 
-            // Apply the start time at the newly snapped-to position
-            double offset = snappedTime - draggedObject.StartTime;
-            foreach (HitObject obj in selectionHandler.SelectedHitObjects)
-                obj.StartTime += offset;
+            if (result.Time.HasValue)
+            {
+                // Apply the start time at the newly snapped-to position
+                double offset = result.Time.Value - draggedObject.StartTime;
+                foreach (HitObject obj in selectionHandler.SelectedHitObjects)
+                    obj.StartTime += offset;
+            }
 
             return true;
         }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private readonly BindableList<HitObject> selectedHitObjects = new BindableList<HitObject>();
 
         [Resolved(canBeNull: true)]
-        private IDistanceSnapProvider snapProvider { get; set; }
+        private IPositionSnapProvider snapProvider { get; set; }
 
         protected BlueprintContainer()
         {
@@ -326,7 +326,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             foreach (var blueprint in SelectionBlueprints)
             {
-                if (blueprint.IsAlive && blueprint.IsPresent && rect.Contains(blueprint.SelectionPoint))
+                if (blueprint.IsAlive && blueprint.IsPresent && rect.Contains(blueprint.ScreenSpaceSelectionPoint))
                     blueprint.Select();
                 else
                     blueprint.Deselect();
@@ -384,7 +384,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // Movement is tracked from the blueprint of the earliest hitobject, since it only makes sense to distance snap from that hitobject
             movementBlueprint = selectionHandler.SelectedBlueprints.OrderBy(b => b.HitObject.StartTime).First();
-            movementBlueprintOriginalPosition = movementBlueprint.SelectionPoint; // todo: unsure if correct
+            movementBlueprintOriginalPosition = movementBlueprint.ScreenSpaceSelectionPoint; // todo: unsure if correct
         }
 
         /// <summary>
@@ -405,7 +405,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             Vector2 movePosition = movementBlueprintOriginalPosition.Value + e.ScreenSpaceMousePosition - e.ScreenSpaceMouseDownPosition;
 
             // Retrieve a snapped position.
-            (Vector2 snappedPosition, double snappedTime) = snapProvider.GetSnappedPosition(ToLocalSpace(movePosition), draggedObject.StartTime);
+            (Vector2 snappedPosition, double snappedTime) = snapProvider.SnapScreenSpacePositionToValidTime(movePosition);
 
             // Move the hitobjects.
             if (!selectionHandler.HandleMovement(new MoveSelectionEvent(movementBlueprint, ToScreenSpace(snappedPosition))))

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updatePlacementPosition(Vector2 screenSpacePosition)
         {
-            Vector2 snappedPlayfieldPosition = composer.SnapScreenSpacePositionToValidTime(screenSpacePosition).position;
+            Vector2 snappedPlayfieldPosition = composer.SnapScreenSpacePositionToValidTime(screenSpacePosition).ScreenSpacePosition;
 
             currentPlacement.UpdatePosition(ToScreenSpace(snappedPlayfieldPosition));
         }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -67,10 +67,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updatePlacementPosition(Vector2 screenSpacePosition)
         {
-            Vector2 snappedGridPosition = composer.GetSnappedPosition(ToLocalSpace(screenSpacePosition), 0).position;
-            Vector2 snappedScreenSpacePosition = ToScreenSpace(snappedGridPosition);
+            Vector2 snappedPlayfieldPosition = composer.SnapScreenSpacePositionToValidTime(screenSpacePosition).position;
 
-            currentPlacement.UpdatePosition(snappedScreenSpacePosition);
+            currentPlacement.UpdatePosition(ToScreenSpace(snappedPlayfieldPosition));
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -11,7 +11,6 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -65,9 +64,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             createPlacement();
         }
 
-        private void updatePlacementPosition(Vector2 screenSpacePosition)
+        private void updatePlacementPosition()
         {
-            var snapResult = composer.SnapScreenSpacePositionToValidTime(screenSpacePosition);
+            var snapResult = composer.SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position);
 
             currentPlacement.UpdatePosition(snapResult.ScreenSpacePosition);
         }
@@ -84,7 +83,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 removePlacement();
 
             if (currentPlacement != null)
-                updatePlacementPosition(inputManager.CurrentState.Mouse.Position);
+                updatePlacementPosition();
         }
 
         protected sealed override SelectionBlueprint CreateBlueprintFor(HitObject hitObject)
@@ -116,7 +115,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 placementBlueprintContainer.Child = currentPlacement = blueprint;
 
                 // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame
-                updatePlacementPosition(inputManager.CurrentState.Mouse.Position);
+                updatePlacementPosition();
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             var snapResult = composer.SnapScreenSpacePositionToValidTime(inputManager.CurrentState.Mouse.Position);
 
-            currentPlacement.UpdatePosition(snapResult.ScreenSpacePosition);
+            currentPlacement.UpdatePosition(snapResult);
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -67,9 +67,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updatePlacementPosition(Vector2 screenSpacePosition)
         {
-            Vector2 snappedPlayfieldPosition = composer.SnapScreenSpacePositionToValidTime(screenSpacePosition).ScreenSpacePosition;
+            var snapResult = composer.SnapScreenSpacePositionToValidTime(screenSpacePosition);
 
-            currentPlacement.UpdatePosition(ToScreenSpace(snappedPlayfieldPosition));
+            currentPlacement.UpdatePosition(snapResult.ScreenSpacePosition);
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected OsuColour Colours { get; private set; }
 
         [Resolved]
-        protected IDistanceSnapProvider SnapProvider { get; private set; }
+        protected IPositionSnapProvider SnapProvider { get; private set; }
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -181,11 +181,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private IBeatSnapProvider beatSnapProvider { get; set; }
 
-        public (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) =>
-            (position, beatSnapProvider.SnapTime(getTimeFromPosition(position)));
-
-        public (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 position) =>
-            (position, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(position))));
+        public SnapResult SnapScreenSpacePositionToValidTime(Vector2 position) =>
+            new SnapResult(position, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(position))));
 
         private double getTimeFromPosition(Vector2 localPosition) =>
             (localPosition.X / Content.DrawWidth) * track.Length;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -17,9 +17,9 @@ using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
-    [Cached(typeof(IDistanceSnapProvider))]
+    [Cached(typeof(IPositionSnapProvider))]
     [Cached]
-    public class Timeline : ZoomableScrollContainer, IDistanceSnapProvider
+    public class Timeline : ZoomableScrollContainer, IPositionSnapProvider
     {
         public readonly Bindable<bool> WaveformVisible = new Bindable<bool>();
         public readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
@@ -181,11 +181,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private IBeatSnapProvider beatSnapProvider { get; set; }
 
-        public double GetTimeFromScreenSpacePosition(Vector2 position)
-            => getTimeFromPosition(Content.ToLocalSpace(position));
-
-        public (Vector2 position, double time) GetSnappedPosition(Vector2 position, double time) =>
+        public (Vector2 position, double time) SnapPositionToValidTime(Vector2 position) =>
             (position, beatSnapProvider.SnapTime(getTimeFromPosition(position)));
+
+        public (Vector2 position, double time) SnapScreenSpacePositionToValidTime(Vector2 position) =>
+            (position, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(position))));
 
         private double getTimeFromPosition(Vector2 localPosition) =>
             (localPosition.X / Content.DrawWidth) * track.Length;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -181,8 +181,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private IBeatSnapProvider beatSnapProvider { get; set; }
 
-        public SnapResult SnapScreenSpacePositionToValidTime(Vector2 position) =>
-            new SnapResult(position, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(position))));
+        public SnapResult SnapScreenSpacePositionToValidTime(Vector2 screenSpacePosition) =>
+            new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(screenSpacePosition))));
 
         private double getTimeFromPosition(Vector2 localPosition) =>
             (localPosition.X / Content.DrawWidth) * track.Length;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
         }
 
-        public override Vector2 SelectionPoint => ScreenSpaceDrawQuad.TopLeft;
+        public override Vector2 ScreenSpaceSelectionPoint => ScreenSpaceDrawQuad.TopLeft;
 
         public class DragBar : Container
         {
@@ -275,7 +275,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 OnDragHandled?.Invoke(e);
 
-                var time = timeline.GetTimeFromScreenSpacePosition(e.ScreenSpaceMousePosition);
+                var time = timeline.SnapScreenSpacePositionToValidTime(e.ScreenSpaceMousePosition).time;
 
                 switch (hitObject)
                 {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -275,32 +275,33 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 OnDragHandled?.Invoke(e);
 
-                var time = timeline.SnapScreenSpacePositionToValidTime(e.ScreenSpaceMousePosition).time;
-
-                switch (hitObject)
+                if (timeline.SnapScreenSpacePositionToValidTime(e.ScreenSpaceMousePosition).Time is double time)
                 {
-                    case IHasRepeats repeatHitObject:
-                        // find the number of repeats which can fit in the requested time.
-                        var lengthOfOneRepeat = repeatHitObject.Duration / (repeatHitObject.RepeatCount + 1);
-                        var proposedCount = Math.Max(0, (int)((time - hitObject.StartTime) / lengthOfOneRepeat) - 1);
+                    switch (hitObject)
+                    {
+                        case IHasRepeats repeatHitObject:
+                            // find the number of repeats which can fit in the requested time.
+                            var lengthOfOneRepeat = repeatHitObject.Duration / (repeatHitObject.RepeatCount + 1);
+                            var proposedCount = Math.Max(0, (int)((time - hitObject.StartTime) / lengthOfOneRepeat) - 1);
 
-                        if (proposedCount == repeatHitObject.RepeatCount)
-                            return;
+                            if (proposedCount == repeatHitObject.RepeatCount)
+                                return;
 
-                        repeatHitObject.RepeatCount = proposedCount;
-                        break;
+                            repeatHitObject.RepeatCount = proposedCount;
+                            break;
 
-                    case IHasEndTime endTimeHitObject:
-                        var snappedTime = Math.Max(hitObject.StartTime, beatSnapProvider.SnapTime(time));
+                        case IHasEndTime endTimeHitObject:
+                            var snappedTime = Math.Max(hitObject.StartTime, beatSnapProvider.SnapTime(time));
 
-                        if (endTimeHitObject.EndTime == snappedTime)
-                            return;
+                            if (endTimeHitObject.EndTime == snappedTime)
+                                return;
 
-                        endTimeHitObject.EndTime = snappedTime;
-                        break;
+                            endTimeHitObject.EndTime = snappedTime;
+                            break;
+                    }
+
+                    beatmap.UpdateHitObject(hitObject);
                 }
-
-                beatmap.UpdateHitObject(hitObject);
             }
 
             protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -282,7 +282,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         case IHasRepeats repeatHitObject:
                             // find the number of repeats which can fit in the requested time.
                             var lengthOfOneRepeat = repeatHitObject.Duration / (repeatHitObject.RepeatCount + 1);
-                            var proposedCount = Math.Max(0, (int)((time - hitObject.StartTime) / lengthOfOneRepeat) - 1);
+                            var proposedCount = Math.Max(0, (int)Math.Round((time - hitObject.StartTime) / lengthOfOneRepeat) - 1);
 
                             if (proposedCount == repeatHitObject.RepeatCount)
                                 return;

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -71,8 +71,11 @@ namespace osu.Game.Tests.Visual
         {
             base.Update();
 
-            currentBlueprint.UpdatePosition(new SnapResult(InputManager.CurrentState.Mouse.Position, null));
+            currentBlueprint.UpdatePosition(SnapForBlueprint(currentBlueprint));
         }
+
+        protected virtual SnapResult SnapForBlueprint(PlacementBlueprint blueprint) =>
+            new SnapResult(InputManager.CurrentState.Mouse.Position, null);
 
         public override void Add(Drawable drawable)
         {
@@ -81,7 +84,7 @@ namespace osu.Game.Tests.Visual
             if (drawable is PlacementBlueprint blueprint)
             {
                 blueprint.Show();
-                blueprint.UpdatePosition(new SnapResult(InputManager.CurrentState.Mouse.Position, null));
+                blueprint.UpdatePosition(SnapForBlueprint(blueprint));
             }
         }
 

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual
         {
             base.Update();
 
-            currentBlueprint.UpdatePosition(InputManager.CurrentState.Mouse.Position);
+            currentBlueprint.UpdatePosition(new SnapResult(InputManager.CurrentState.Mouse.Position, null));
         }
 
         public override void Add(Drawable drawable)
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Visual
             if (drawable is PlacementBlueprint blueprint)
             {
                 blueprint.Show();
-                blueprint.UpdatePosition(InputManager.CurrentState.Mouse.Position);
+                blueprint.UpdatePosition(new SnapResult(InputManager.CurrentState.Mouse.Position, null));
             }
         }
 


### PR DESCRIPTION
PRing this in its current state as a proof of concept direction. This took quite a bit of thought and planning and I believe it is a good forward direction.

- [x] Fix broken tests (mania blueprint placement / selection)
- [x] Move `DistanceSnapGrid` to osu! ruleset (maybe in a follow-up PR)

Basic approach:

- Blueprints no longer do any kind of positional mapping and only deal with screen-space coordinates.
- Snapping, coordinate conversion etc. is done via `HitObjectComposer`
- New class `SnapResult` added to allow for more versatile results (sometimes we do not have a time to provide – the previous tuple structure was not flexible enough). This also allows for the column to be provided as part of the "snapping" algorithm.
