### PR TITLE
Seek to start of placed object, not end

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Rulesets.Edit
             {
                 EditorBeatmap.Add(hitObject);
 
-                adjustableClock.Seek(hitObject.GetEndTime());
+                adjustableClock.Seek(hitObject.StartTime);
             }
 
             showGridFor(Enumerable.Empty<HitObject>());

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -257,7 +257,8 @@ namespace osu.Game.Rulesets.Edit
             {
                 EditorBeatmap.Add(hitObject);
 
-                adjustableClock.Seek(hitObject.StartTime);
+                if (adjustableClock.CurrentTime < hitObject.StartTime)
+                    adjustableClock.Seek(hitObject.StartTime);
             }
 
             showGridFor(Enumerable.Empty<HitObject>());


### PR DESCRIPTION
Discussed IRL as a definite usability improvement. I've also made it only seek if the seek is in a forwards direction, which seems to feel better.

Still need some kind of motion to see the final UX of this, but definitely an improvement IMO.