### PR TITLE
Fix display start time in sequential scroll algorithm 

### DIFF
--- a/osu.Game.Tests/ScrollAlgorithms/SequentialScrollTest.cs
+++ b/osu.Game.Tests/ScrollAlgorithms/SequentialScrollTest.cs
@@ -29,8 +29,22 @@ namespace osu.Game.Tests.ScrollAlgorithms
         [Test]
         public void TestDisplayStartTime()
         {
-            // Sequential scroll algorithm approximates the start time
-            // This should be fixed in the future
+            // easy cases - time range adjusted for velocity fits within control point duration
+            Assert.AreEqual(2500, algorithm.GetDisplayStartTime(5000, 0, 2500, 1)); // 5000 - (2500 / 1)
+            Assert.AreEqual(13750, algorithm.GetDisplayStartTime(15000, 0, 2500, 1)); // 15000 - (2500 / 2)
+            Assert.AreEqual(20000, algorithm.GetDisplayStartTime(25000, 0, 2500, 1)); // 25000 - (2500 / 0.5)
+
+            // hard case - time range adjusted for velocity exceeds control point duration
+
+            // 1st multiplier point takes 10000 / 2500 = 4 scroll lengths
+            // 2nd multiplier point takes 10000 / (2500 / 2) = 8 scroll lengths
+            // 3rd multiplier point takes 2500 / (2500 * 2) = 0.5 scroll lengths up to hitobject start
+
+            // absolute position of the hitobject = 1000 * (4 + 8 + 0.5) = 12500
+            // minus one scroll length allowance = 12500 - 1000 = 11500 = 11.5 [scroll lengths]
+            // therefore the start time lies within the second multiplier point (because 11.5 < 4 + 8)
+            // its exact time position is = 10000 + 7.5 * (2500 / 2) = 19375
+            Assert.AreEqual(19375, algorithm.GetDisplayStartTime(22500, 0, 2500, 1000));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
@@ -78,19 +78,18 @@ namespace osu.Game.Tests.Visual.Gameplay
                 }
             };
 
-            setUpHitObjects();
+            hitObjectSpawnDelegate?.Cancel();
         });
 
-        private void setUpHitObjects()
+        private void setUpHitObjects() => AddStep("set up hit objects", () =>
         {
             scrollContainers.ForEach(c => c.ControlPoints.Add(new MultiplierControlPoint(0)));
 
             for (int i = spawn_rate / 2; i <= time_range; i += spawn_rate)
                 addHitObject(Time.Current + i);
 
-            hitObjectSpawnDelegate?.Cancel();
             hitObjectSpawnDelegate = Scheduler.AddDelayed(() => addHitObject(Time.Current + time_range), spawn_rate, true);
-        }
+        });
 
         private IList<MultiplierControlPoint> testControlPoints => new List<MultiplierControlPoint>
         {
@@ -102,6 +101,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestScrollAlgorithms()
         {
+            setUpHitObjects();
+
             AddStep("constant scroll", () => setScrollAlgorithm(ScrollVisualisationMethod.Constant));
             AddStep("overlapping scroll", () => setScrollAlgorithm(ScrollVisualisationMethod.Overlapping));
             AddStep("sequential scroll", () => setScrollAlgorithm(ScrollVisualisationMethod.Sequential));
@@ -114,6 +115,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestConstantScrollLifetime()
         {
+            setUpHitObjects();
+
             AddStep("set constant scroll", () => setScrollAlgorithm(ScrollVisualisationMethod.Constant));
             // scroll container time range must be less than the rate of spawning hitobjects
             // otherwise the hitobjects will spawn already partly visible on screen and look wrong
@@ -123,14 +126,40 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestSequentialScrollLifetime()
         {
+            setUpHitObjects();
+
             AddStep("set sequential scroll", () => setScrollAlgorithm(ScrollVisualisationMethod.Sequential));
             AddStep("set time range", () => scrollContainers.ForEach(c => c.TimeRange = time_range / 2.0));
             AddStep("add control points", () => addControlPoints(testControlPoints, Time.Current));
         }
 
         [Test]
+        public void TestSlowSequentialScroll()
+        {
+            AddStep("set sequential scroll", () => setScrollAlgorithm(ScrollVisualisationMethod.Sequential));
+            AddStep("set time range", () => scrollContainers.ForEach(c => c.TimeRange = time_range));
+            AddStep("add control points", () => addControlPoints(
+                new List<MultiplierControlPoint>
+                {
+                    new MultiplierControlPoint { Velocity = 0.1 }
+                },
+                Time.Current + time_range));
+
+            // All of the hit objects added below should be immediately visible on screen
+            AddStep("add hit objects", () =>
+            {
+                for (int i = 0; i < 20; ++i)
+                {
+                    addHitObject(Time.Current + time_range * (2 + 0.1 * i));
+                }
+            });
+        }
+
+        [Test]
         public void TestOverlappingScrollLifetime()
         {
+            setUpHitObjects();
+
             AddStep("set overlapping scroll", () => setScrollAlgorithm(ScrollVisualisationMethod.Overlapping));
             AddStep("set time range", () => scrollContainers.ForEach(c => c.TimeRange = time_range / 2.0));
             AddStep("add control points", () => addControlPoints(testControlPoints, Time.Current));

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
@@ -16,6 +16,7 @@ using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Timing;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
@@ -221,7 +222,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private class TestDrawableControlPoint : DrawableHitObject<HitObject>
         {
             public TestDrawableControlPoint(ScrollingDirection direction, double time)
-                : base(new HitObject { StartTime = time })
+                : base(new HitObject { StartTime = time, HitWindows = HitWindows.Empty })
             {
                 Origin = Anchor.Centre;
 
@@ -252,7 +253,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private class TestDrawableHitObject : DrawableHitObject<HitObject>
         {
             public TestDrawableHitObject(double time)
-                : base(new HitObject { StartTime = time })
+                : base(new HitObject { StartTime = time, HitWindows = HitWindows.Empty })
             {
                 Origin = Anchor.Custom;
                 OriginPosition = new Vector2(75 / 4.0f);

--- a/osu.Game/Rulesets/UI/Scrolling/Algorithms/SequentialScrollAlgorithm.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/Algorithms/SequentialScrollAlgorithm.cs
@@ -22,8 +22,7 @@ namespace osu.Game.Rulesets.UI.Scrolling.Algorithms
 
         public double GetDisplayStartTime(double originTime, float offset, double timeRange, float scrollLength)
         {
-            double adjustedTime = TimeAt(-offset, originTime, timeRange, scrollLength);
-            return adjustedTime - timeRange - 1000;
+            return TimeAt(-(scrollLength + offset), originTime, timeRange, scrollLength);
         }
 
         public float GetLength(double startTime, double endTime, double timeRange, float scrollLength)


### PR DESCRIPTION
Resolves #8826.

# Summary

As reported in the issue thread, some especially slow-scrolling sections of mania maps would look wrong due to hitobjects appearing in the middle of the scrolling container. This in turn was caused, [as mentioned in the issue](https://github.com/ppy/osu/issues/8826#issuecomment-617520244), by the sequential scroll algorithm making a quite arbitrary choice of the lifetime start time of hitobjects:

https://github.com/ppy/osu/blob/230435b5a365ed8011f80c02b6d89d3a8bb75104/osu.Game/Rulesets/UI/Scrolling/Algorithms/SequentialScrollAlgorithm.cs#L25-L26

Note that the subtractions to `adjustedTime` do not take into account multiplier points at all. If the actual time range at some point in the map is bigger than `timeRange + 1000` due to having a very low multiplier applied, then the lifetime start time would be too late.

The proposed resolution is quite simple, but took me some time to arrive at. Keeping in mind the invariant that objects at both ends of the scrolling container are separated by exactly `scrollLength` and the fact that there is no overlap, we can apply the same technique used to adjust for origin position, and leverage `TimeAt` to do the necessary calculation for us, by passing the negated scroll length to it.

Internally `TimeAt` then accounts for all of the multiplier control points and their effects on the time range, by calculating the absolute position of the hitobject, then subtracting the scroll length and finally reapplying control points one by one.

In other words, given that the start time of the hitobject is its time at the near edge of the scrolling container, we apply a *spatial* offset equal to the length of the scroll to make sure it starts being visible at its far edge, which then `TimeAt` automagically turns into the correct time value.

In addition to the fix, this PR contains unit tests that check the values returned by `GetDisplayStartTime` after this change with a moderately verbose explanation of the math, and also a visual test scene which demonstrates the incorrect behaviour at 24d898c and the correct one at 6f388b7.

Here are some videos for visual comparison purposes:

* the added visual test case ([before](https://streamable.com/rbj648), [after](https://streamable.com/eveo2j)),
* gameplay of map reported as affected ([Ninja Re Bang Bang - Kyary Pamyu Pamyu by ecafree2](https://osu.ppy.sh/beatmapsets/372942#mania/1728348) - [before](https://streamable.com/mkphau), [after](https://streamable.com/uk7h8r)).

# Remarks

The `ScrollingHitObjects` test scene has actually regressed with c06db5a due to the following check:

https://github.com/ppy/osu/blob/0997886df6b093c576252257e779fb116d912dbb/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L260-L261

As the drawable hit objects used for the test specified no hit windows (defaulting to `null`), they would expire immediately upon creation and therefore never show. I've added empty hit windows to them as I see it the easiest and most hassle-free resolution.

The unit tests for `GetDisplayStartTime` do not cover the offset path, as it just boils down to the same thing as the normal path.

I'm reasonably certain that this lifetime is as tight as as can be, but of course more pairs of eyes are definitely needed here as this technically relaxes the lifetime specifications.