### PR TITLE
Fix defaults not being applied correctly to blueprints after StartTime is changed

### DIFF
--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Rulesets.Edit
 
         private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
 
+        private Bindable<double> startTimeBindable;
+
         [Resolved]
         private IPlacementHandler placementHandler { get; set; }
 
@@ -55,7 +57,8 @@ namespace osu.Game.Rulesets.Edit
 
             EditorClock = clock;
 
-            ApplyDefaultsToHitObject();
+            startTimeBindable = HitObject.StartTimeBindable.GetBoundCopy();
+            startTimeBindable.BindValueChanged(_ => ApplyDefaultsToHitObject(), true);
         }
 
         /// <summary>


### PR DESCRIPTION
- Closes #9085

Sliders now change velocity when they are moved to a new control point, for instance:

![image](https://user-images.githubusercontent.com/191335/82673850-65252680-9c7d-11ea-81d3-7a5f855e266a.gif)
