### PR TITLE
Fix beatmap-online-lookup-queue potentially throwing on OsuGameTestScene

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Beatmaps
     /// <summary>
     /// Handles the storage and retrieval of Beatmaps/WorkingBeatmaps.
     /// </summary>
-    public partial class BeatmapManager : DownloadableArchiveModelManager<BeatmapSetInfo, BeatmapSetFileInfo>
+    public partial class BeatmapManager : DownloadableArchiveModelManager<BeatmapSetInfo, BeatmapSetFileInfo>, IDisposable
     {
         /// <summary>
         /// Fired when a single difficulty has been hidden.
@@ -431,6 +431,11 @@ namespace osu.Game.Beatmaps
             double startTime = b.HitObjects.First().StartTime;
 
             return endTime - startTime;
+        }
+
+        public void Dispose()
+        {
+            onlineLookupQueue?.Dispose();
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Beatmaps
 {
     public partial class BeatmapManager
     {
-        private class BeatmapOnlineLookupQueue
+        private class BeatmapOnlineLookupQueue : IDisposable
         {
             private readonly IAPIProvider api;
             private readonly Storage storage;
@@ -178,6 +178,11 @@ namespace osu.Game.Beatmaps
                 }
 
                 return false;
+            }
+
+            public void Dispose()
+            {
+                cacheDownloadRequest?.Dispose();
             }
 
             [Serializable]

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -337,6 +337,7 @@ namespace osu.Game
         {
             base.Dispose(isDisposing);
             RulesetStore?.Dispose();
+            BeatmapManager?.Dispose();
 
             contextFactory.FlushConnections();
         }


### PR DESCRIPTION
This is happening because of test storages being recycled per-test-case, so requests have to be immediately aborted before any further steps are performed resulting in exceptions thrown (`DirectoryNotFoundException` from `File.Delete()`, etc...).

Disposing `FileWebRequest`s while they're downloading seems to be the best way to fix this, as it deletes the compressed cache file (internally from `FileWebRequest.Complete(abortWebException)`) and not invoke both `Failed` and `Finished`.