### PR TITLE
Fix running osu.Game.Benchmarks

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkBeatmapParsing.cs
+++ b/osu.Game.Benchmarks/BenchmarkBeatmapParsing.cs
@@ -8,7 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.IO;
 using osu.Game.IO.Archives;
-using osu.Game.Resources;
+using osu.Game.Tests.Resources;
 
 namespace osu.Game.Benchmarks
 {
@@ -18,8 +18,8 @@ namespace osu.Game.Benchmarks
 
         public override void SetUp()
         {
-            using (var resources = new DllResourceStore(OsuResources.ResourceAssembly))
-            using (var archive = resources.GetStream("Beatmaps/241526 Soleily - Renatus.osz"))
+            using (var resources = new DllResourceStore(typeof(TestResources).Assembly))
+            using (var archive = resources.GetStream($"Resources/Archives/241526 Soleily - Renatus.osz"))
             using (var reader = new ZipArchiveReader(archive))
                 reader.GetStream("Soleily - Renatus (Gamu) [Insane].osu").CopyTo(beatmapStream);
         }

--- a/osu.Game.Benchmarks/BenchmarkBeatmapParsing.cs
+++ b/osu.Game.Benchmarks/BenchmarkBeatmapParsing.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Benchmarks
         public override void SetUp()
         {
             using (var resources = new DllResourceStore(typeof(TestResources).Assembly))
-            using (var archive = resources.GetStream($"Resources/Archives/241526 Soleily - Renatus.osz"))
+            using (var archive = resources.GetStream("Resources/Archives/241526 Soleily - Renatus.osz"))
             using (var reader = new ZipArchiveReader(archive))
                 reader.GetStream("Soleily - Renatus (Gamu) [Insane].osu").CopyTo(beatmapStream);
         }

--- a/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj
+++ b/osu.Game.Benchmarks/osu.Game.Benchmarks.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\osu.Game.Tests\osu.Game.Tests.csproj" />
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
It was crashing crashing since ppy/osu-resources#86.
Not sure if this is the right approach, but with this PR the benchmark is running again.