### PR TITLE
Allow SelectionHandler to provide custom context menu items without local hover check

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -244,14 +244,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #region Context Menu
 
-        public virtual MenuItem[] ContextMenuItems
+        public MenuItem[] ContextMenuItems
         {
             get
             {
                 if (!selectedBlueprints.Any(b => b.IsHovered))
                     return Array.Empty<MenuItem>();
 
-                var items = new List<MenuItem>
+                var items = new List<MenuItem>();
+
+                items.AddRange(GetContextMenuItemsForSelection(selectedBlueprints));
+
+                if (selectedBlueprints.Count == 1)
+                    items.AddRange(selectedBlueprints[0].ContextMenuItems);
+
+                items.AddRange(new[]
                 {
                     new OsuMenuItem("Sound")
                     {
@@ -263,14 +270,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         }
                     },
                     new OsuMenuItem("Delete", MenuItemType.Destructive, deleteSelected),
-                };
-
-                if (selectedBlueprints.Count == 1)
-                    items.AddRange(selectedBlueprints[0].ContextMenuItems);
+                });
 
                 return items.ToArray();
             }
         }
+
+        /// <summary>
+        /// Provide context menu items relevant to current selection. Calling base is not required.
+        /// </summary>
+        /// <param name="selection">The current selection.</param>
+        /// <returns>The relevant menu items.</returns>
+        protected virtual IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint> selection)
+            => Enumerable.Empty<MenuItem>();
 
         private MenuItem createHitSampleMenuItem(string name, string sampleName)
         {


### PR DESCRIPTION
Previous virtual method would require each implementation to do the validity checks. Luckily, wasn't being used yet.

As a future change, the context menu will likely need to be moved to the `DragBox` for visual reasons, but just going to fix this for now.