### PR TITLE
Allow GracefullyExit() to not presist on exiting

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -131,7 +131,7 @@ namespace osu.Desktop.Updater
                     Activated = () =>
                     {
                         updateManager.PrepareUpdateAsync()
-                                     .ContinueWith(_ => updateManager.Schedule(() => game.GracefullyExit()));
+                                     .ContinueWith(_ => updateManager.Schedule(() => game.GracefullyExit(true)));
                         return true;
                     }
                 };

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -934,14 +934,14 @@ namespace osu.Game
 
         /// <summary>
         /// Use to programatically exit the game as if the user was triggering via alt-f4.
-        /// Will keep persisting until an exit occurs (exit may be blocked multiple times).
         /// </summary>
-        public void GracefullyExit()
+        /// <param name="repeatExit">Whether to keep presisting until an exit occurs (exit may be blocked multiple times).</param>
+        public void GracefullyExit(bool repeatExit = false)
         {
             if (!OnExiting())
                 Exit();
-            else
-                Scheduler.AddDelayed(GracefullyExit, 2000);
+            else if (repeatExit)
+                Scheduler.AddDelayed(() => GracefullyExit(true), 2000);
         }
 
         protected override void UpdateAfterChildren()


### PR DESCRIPTION
Useful when testing blocking exits.