### PR TITLE
Display a play's performance points on the results screen

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -472,6 +472,16 @@ namespace osu.Game.Screens.Play
             else
                 score.User = api.LocalUser.Value;
 
+            try
+            {
+                var performanceCalculator = ruleset?.CreatePerformanceCalculator(Beatmap.Value, score);
+                var totalPp = performanceCalculator?.Calculate(new Dictionary<string, double>());
+                score.PP = totalPp;
+            }
+            catch (Exception)
+            {
+            }
+
             ScoreProcessor.PopulateScore(score);
 
             return score;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -474,12 +474,13 @@ namespace osu.Game.Screens.Play
 
             try
             {
-                var performanceCalculator = ruleset?.CreatePerformanceCalculator(Beatmap.Value, score);
-                var totalPp = performanceCalculator?.Calculate(new Dictionary<string, double>());
+                var performanceCalculator = ruleset.CreatePerformanceCalculator(Beatmap.Value, score);
+                var totalPp = performanceCalculator?.Calculate(null);
                 score.PP = totalPp;
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                Logger.Log($"Failed to calculate performance points: {e}", LoggingTarget.Runtime, LogLevel.Debug);
             }
 
             ScoreProcessor.PopulateScore(score);


### PR DESCRIPTION
# Summary

Closes #8587

- This adds performance point calculation to `Player` using `PerformanceCalculators` so `ScoreInfo`s now get their pp field populated, and the pp shows on the results screen. 

Only "drawback" is that it won't display for older scores set before this PR.

## Testing

No tests for this as quite hard to test as it is.
Manual testings shows it to work as expected.

---

I have been thinking about actually moving the pp calculation to Results screen to do the pp calculation "on-demand" in background and show it on the results pp counter rather than calculating once and persisting it to database (potentially requiring to recalculate the whole database in case of a change in the pp algorithm) but this may not be the direction to go with.