### PR TITLE
Hide non-alive selection blueprints by default

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/OsuSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/OsuSelectionBlueprint.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
     {
         protected new T HitObject => (T)DrawableObject.HitObject;
 
+        protected override bool AlwaysShowWhenSelected => true;
+
         protected OsuSelectionBlueprint(DrawableHitObject drawableObject)
             : base(drawableObject)
         {

--- a/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
@@ -15,7 +15,12 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         public readonly DrawableHitObject DrawableObject;
 
-        protected override bool ShouldBeAlive => (DrawableObject.IsAlive && DrawableObject.IsPresent) || State == SelectionState.Selected;
+        /// <summary>
+        /// Whether the blueprint should be shown even when the <see cref="DrawableObject"/> is not alive.
+        /// </summary>
+        protected virtual bool AlwaysShowWhenSelected => false;
+
+        protected override bool ShouldBeAlive => (DrawableObject.IsAlive && DrawableObject.IsPresent) || (AlwaysShowWhenSelected && State == SelectionState.Selected);
 
         protected OverlaySelectionBlueprint(DrawableHitObject drawableObject)
             : base(drawableObject.HitObject)


### PR DESCRIPTION
This is expected behaviour in all but osu! ruleset (anything where objects are moving off-screen with time). I think it's a better default to hide them, and fixes issues in mania/taiko where the object's lifetime may be reached while the blueprint is still on screen.

Before:

![image](https://user-images.githubusercontent.com/191335/82978609-f0a50b80-a01f-11ea-8c14-43a277d37b1e.gif)

After:

![image](https://user-images.githubusercontent.com/191335/82978683-1df1b980-a020-11ea-9527-e11497147568.gif)
