### PR TITLE
Allow drag selections to occur from outside the playfield

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -102,6 +102,7 @@ namespace osu.Game.Rulesets.Edit
                         {
                             Name = "Content",
                             RelativeSizeAxes = Axes.Both,
+                            Masking = true,
                             Children = new Drawable[]
                             {
                                 // layers below playfield

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private readonly BindableList<HitObject> selectedHitObjects = new BindableList<HitObject>();
 
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+
         [Resolved(canBeNull: true)]
         private IPositionSnapProvider snapProvider { get; set; }
 


### PR DESCRIPTION
Previously, you could not start a drag from outside the playfield, even though this is what is expected.

Now you can start a drag from anywhere in the content area.