### PR TITLE
Implement basic support for osu!mania special style

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaColumnTypeTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaColumnTypeTest.cs
@@ -31,11 +31,40 @@ namespace osu.Game.Rulesets.Mania.Tests
             ColumnType.Even,
             ColumnType.Odd
         }, 7)]
-        public void Test(IEnumerable<ColumnType> expected, int columns)
+        public void TestNormal(IEnumerable<ColumnType> expected, int columns)
         {
             var definition = new StageDefinition
             {
                 Columns = columns
+            };
+            var results = getResults(definition);
+            Assert.AreEqual(expected, results);
+        }
+
+        [TestCase(new[]
+        {
+            ColumnType.Special,
+            ColumnType.Odd,
+            ColumnType.Even,
+            ColumnType.Odd,
+            ColumnType.Even,
+            ColumnType.Odd,
+            ColumnType.Even,
+            ColumnType.Odd
+        }, 8)]
+        [TestCase(new[]
+        {
+            ColumnType.Odd,
+            ColumnType.Even,
+            ColumnType.Even,
+            ColumnType.Odd
+        }, 4)]
+        public void TestSpecial(IEnumerable<ColumnType> expected, int columns)
+        {
+            var definition = new StageDefinition
+            {
+                Columns = columns,
+                SpecialStyle = true
             };
             var results = getResults(definition);
             Assert.AreEqual(expected, results);

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         private const int max_notes_for_density = 7;
 
         public int TargetColumns;
+        public bool SpecialStyle;
         public bool Dual;
         public readonly bool IsForCurrentRuleset;
 
@@ -64,6 +65,8 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                 else
                     TargetColumns = Math.Max(4, Math.Min((int)roundedOverallDifficulty + 1, 7));
             }
+
+            SpecialStyle = beatmap.BeatmapInfo.SpecialStyle;
         }
 
         public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasXPosition);
@@ -80,10 +83,10 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
 
         protected override Beatmap<ManiaHitObject> CreateBeatmap()
         {
-            beatmap = new ManiaBeatmap(new StageDefinition { Columns = TargetColumns });
+            beatmap = new ManiaBeatmap(new StageDefinition { Columns = TargetColumns, SpecialStyle = SpecialStyle });
 
             if (Dual)
-                beatmap.Stages.Add(new StageDefinition { Columns = TargetColumns });
+                beatmap.Stages.Add(new StageDefinition { Columns = TargetColumns, SpecialStyle = SpecialStyle });
 
             return beatmap;
         }

--- a/osu.Game.Rulesets.Mania/Beatmaps/StageDefinition.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/StageDefinition.cs
@@ -17,11 +17,39 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         public int Columns;
 
         /// <summary>
+        /// Whether the SpecialStyle flag is set.
+        /// </summary>
+        public bool SpecialStyle;
+
+        /// <summary>
+        /// Whether this is a special style map.
+        /// </summary>
+        /// <remarks>
+        /// Aside from 6K and 8K, special style is almost never used in other
+        /// keymodes, so this function always gives false for non-6/8K modes.
+        /// This also matches stable behavior of only allowing configuration
+        /// of special style in 6/8K.
+        /// </remarks>
+        public bool UseSpecialStyle()
+        {
+            if (Columns != 6 && Columns != 8)
+                return false;
+
+            return SpecialStyle;
+        }
+
+        /// <summary>
         /// Whether the column index is a special column for this stage.
         /// </summary>
         /// <param name="column">The 0-based column index.</param>
         /// <returns>Whether the column is a special column.</returns>
-        public bool IsSpecialColumn(int column) => Columns % 2 == 1 && column == Columns / 2;
+        public bool IsSpecialColumn(int column)
+        {
+            if (UseSpecialStyle())
+                return column == 0;
+
+            return Columns % 2 == 1 && column == Columns / 2;
+        }
 
         /// <summary>
         /// Get the type of column given a column index.
@@ -33,7 +61,13 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             if (IsSpecialColumn(column))
                 return ColumnType.Special;
 
-            int distanceToEdge = Math.Min(column, (Columns - 1) - column);
+            int distanceToEdge;
+
+            if (UseSpecialStyle())
+                distanceToEdge = Math.Min(column + 1, (Columns - 1) - column);
+            else
+                distanceToEdge = Math.Min(column, (Columns - 1) - column);
+
             return distanceToEdge % 2 == 0 ? ColumnType.Odd : ColumnType.Even;
         }
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -21,8 +21,10 @@ namespace osu.Game.Rulesets.Mania.Mods
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
             var availableColumns = ((ManiaBeatmap)beatmap).TotalColumns;
+            var specialStyle = beatmap.BeatmapInfo.SpecialStyle;
 
-            beatmap.HitObjects.OfType<ManiaHitObject>().ForEach(h => h.Column = availableColumns - 1 - h.Column);
+            beatmap.HitObjects.OfType<ManiaHitObject>().ForEach(h =>
+                h.Column = specialStyle ? h.Column == 0 ? 0 : availableColumns - h.Column : availableColumns - 1 - h.Column);
         }
     }
 }


### PR DESCRIPTION
*Note: S refers to special column.*
- Closes #2203
- S column's position should be switchable
- Co-op maps should use S-keys keys-S layout, instead of S-keys S-keys
- Mirror should not suppress mirroring of S when special style flag is enabled on non-6K-or-8K maps