### PR TITLE
JIT and GC optimization

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -11,6 +11,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Version>0.0.0</Version>
     <FileVersion>0.0.0</FileVersion>
+    <TieredCompilationQuickJit>false</TieredCompilationQuickJit>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>osu.Desktop.Program</StartupObject>


### PR DESCRIPTION
1. Disable QuickJIT for best quality code at first time
QuickJIT will generate degraded performance code at startup to decrease startup time, but it may lead to more stack space, more memory allocation and slower speed. And while re-JIT during runtime, the application may freeze for short-time which may lead to frame drop.

2. Use Background Server GC for lower GC latency
Background Server GC may increase memory consumption but it significantly reduces GC times and lead to lower GC latency, which is suitable for game scenario.