### PR TITLE
Fix crash after using Ctrl+Enter when current ruleset doesn't have an autoplay mod

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, Array.Empty<Mod>());
 
-            return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod().CreateReplayScore(beatmap));
+            return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod()?.CreateReplayScore(beatmap));
         }
 
         protected override void AddCheckSteps()

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -22,6 +22,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Users;
+using JetBrains.Annotations;
 
 namespace osu.Game.Rulesets
 {
@@ -100,6 +101,7 @@ namespace osu.Game.Rulesets
             return value;
         }
 
+        [CanBeNull]
         public ModAutoplay GetAutoplayMod() => GetAllMods().OfType<ModAutoplay>().FirstOrDefault();
 
         public virtual ISkin CreateLegacySkinProvider(ISkinSource source, IBeatmap beatmap) => null;

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets
             return value;
         }
 
-        public ModAutoplay GetAutoplayMod() => GetAllMods().OfType<ModAutoplay>().First();
+        public ModAutoplay GetAutoplayMod() => GetAllMods().OfType<ModAutoplay>().FirstOrDefault();
 
         public virtual ISkin CreateLegacySkinProvider(ISkinSource source, IBeatmap beatmap) => null;
 

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Select
         private bool removeAutoModOnResume;
         private OsuScreen player;
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private NotificationOverlay notifications { get; set; }
 
         public override bool AllowExternalScreenChange => true;
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.Select
 
                 if (autoType == null)
                 {
-                    notifications.Post(new SimpleNotification
+                    notifications?.Post(new SimpleNotification
                     {
                         Text = "The current ruleset doesn't have an autoplay mod avalaible!"
                     });

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -49,8 +49,11 @@ namespace osu.Game.Screens.Select
 
             if (removeAutoModOnResume)
             {
-                var autoType = Ruleset.Value.CreateInstance().GetAutoplayMod().GetType();
-                ModSelect.DeselectTypes(new[] { autoType }, true);
+                var autoType = Ruleset.Value.CreateInstance().GetAutoplayMod()?.GetType();
+
+                if (autoType != null)
+                    ModSelect.DeselectTypes(new[] { autoType }, true);
+
                 removeAutoModOnResume = false;
             }
         }
@@ -78,14 +81,17 @@ namespace osu.Game.Screens.Select
             if (GetContainingInputManager().CurrentState?.Keyboard.ControlPressed == true)
             {
                 var auto = Ruleset.Value.CreateInstance().GetAutoplayMod();
-                var autoType = auto.GetType();
+                var autoType = auto?.GetType();
 
-                var mods = Mods.Value;
-
-                if (mods.All(m => m.GetType() != autoType))
+                if (autoType != null)
                 {
-                    Mods.Value = mods.Append(auto).ToArray();
-                    removeAutoModOnResume = true;
+                    var mods = Mods.Value;
+
+                    if (mods.All(m => m.GetType() != autoType))
+                    {
+                        Mods.Value = mods.Append(auto).ToArray();
+                        removeAutoModOnResume = true;
+                    }
                 }
             }
 

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -7,6 +7,8 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
@@ -19,6 +21,9 @@ namespace osu.Game.Screens.Select
     {
         private bool removeAutoModOnResume;
         private OsuScreen player;
+
+        [Resolved]
+        private NotificationOverlay notifications { get; set; }
 
         public override bool AllowExternalScreenChange => true;
 
@@ -83,15 +88,21 @@ namespace osu.Game.Screens.Select
                 var auto = Ruleset.Value.CreateInstance().GetAutoplayMod();
                 var autoType = auto?.GetType();
 
-                if (autoType != null)
-                {
-                    var mods = Mods.Value;
+                var mods = Mods.Value;
 
-                    if (mods.All(m => m.GetType() != autoType))
+                if (autoType == null)
+                {
+                    notifications.Post(new SimpleNotification
                     {
-                        Mods.Value = mods.Append(auto).ToArray();
-                        removeAutoModOnResume = true;
-                    }
+                        Text = "The current ruleset doesn't have an autoplay mod avalaible!"
+                    });
+                    return false;
+                }
+
+                if (mods.All(m => m.GetType() != autoType))
+                {
+                    Mods.Value = mods.Append(auto).ToArray();
+                    removeAutoModOnResume = true;
                 }
             }
 


### PR DESCRIPTION
# Summary

This fixes a potential crash when using the <kbd>CTRL</kbd> <kbd>+</kbd>  <kbd>ENTER</kbd>  shortcut in Song selection to start a beatmap with the ruleset's autoplay mod when the current ruleset doesn't have one.