### PR TITLE
Add timeshift beatmap checksum validation

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -602,6 +602,8 @@ namespace osu.Game.Tests.Beatmaps.IO
                     Beatmap beatmapToUpdate = (Beatmap)manager.GetWorkingBeatmap(setToUpdate.Beatmaps.First(b => b.RulesetID == 0)).Beatmap;
                     BeatmapSetFileInfo fileToUpdate = setToUpdate.Files.First(f => beatmapToUpdate.BeatmapInfo.Path.Contains(f.Filename));
 
+                    string oldMd5Hash = beatmapToUpdate.BeatmapInfo.MD5Hash;
+
                     using (var stream = new MemoryStream())
                     {
                         using (var writer = new StreamWriter(stream, Encoding.UTF8, 1024, true))
@@ -624,6 +626,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     Beatmap updatedBeatmap = (Beatmap)manager.GetWorkingBeatmap(manager.QueryBeatmap(b => b.ID == beatmapToUpdate.BeatmapInfo.ID)).Beatmap;
                     Assert.That(updatedBeatmap.HitObjects.Count, Is.EqualTo(1));
                     Assert.That(updatedBeatmap.HitObjects[0].StartTime, Is.EqualTo(5000));
+                    Assert.That(updatedBeatmap.BeatmapInfo.MD5Hash, Is.Not.EqualTo(oldMd5Hash));
                 }
                 finally
                 {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSubScreen.cs
@@ -5,7 +5,9 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Bindables;
+using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -29,13 +31,19 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Cached(typeof(IRoomManager))]
         private readonly TestRoomManager roomManager = new TestRoomManager();
 
-        [Resolved]
-        private BeatmapManager beatmaps { get; set; }
-
-        [Resolved]
-        private RulesetStore rulesets { get; set; }
+        private BeatmapManager manager;
+        private RulesetStore rulesets;
 
         private TestMatchSubScreen match;
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host, AudioManager audio)
+        {
+            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
+            Dependencies.Cache(manager = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, host, Beatmap.Default));
+
+            manager.Import(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapSet).Wait();
+        }
 
         [SetUp]
         public void Setup() => Schedule(() =>
@@ -75,9 +83,48 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("first playlist item selected", () => match.SelectedItem.Value == Room.Playlist[0]);
         }
 
+        [Test]
+        public void TestBeatmapUpdatedOnReImport()
+        {
+            BeatmapSetInfo importedSet = null;
+
+            AddStep("import altered beatmap", () =>
+            {
+                var beatmap = new TestBeatmap(new OsuRuleset().RulesetInfo);
+                beatmap.BeatmapInfo.BaseDifficulty.CircleSize = 1;
+
+                importedSet = manager.Import(beatmap.BeatmapInfo.BeatmapSet).Result;
+            });
+
+            AddStep("load room", () =>
+            {
+                Room.Name.Value = "my awesome room";
+                Room.Host.Value = new User { Id = 2, Username = "peppy" };
+                Room.Playlist.Add(new PlaylistItem
+                {
+                    Beatmap = { Value = importedSet.Beatmaps[0] },
+                    Ruleset = { Value = new OsuRuleset().RulesetInfo }
+                });
+            });
+
+            AddStep("create room", () =>
+            {
+                InputManager.MoveMouseTo(match.ChildrenOfType<MatchSettingsOverlay.CreateRoomButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("match has altered beatmap", () => match.Beatmap.Value.Beatmap.BeatmapInfo.BaseDifficulty.CircleSize == 1);
+
+            AddStep("re-import original beatmap", () => manager.Import(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo.BeatmapSet).Wait());
+
+            AddAssert("match has original beatmap", () => match.Beatmap.Value.Beatmap.BeatmapInfo.BaseDifficulty.CircleSize != 1);
+        }
+
         private class TestMatchSubScreen : MatchSubScreen
         {
             public new Bindable<PlaylistItem> SelectedItem => base.SelectedItem;
+
+            public new Bindable<WorkingBeatmap> Beatmap => base.Beatmap;
 
             public TestMatchSubScreen(Room room)
                 : base(room)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -215,7 +215,7 @@ namespace osu.Game.Beatmaps
 
             foreach (var info in item.Beatmaps)
             {
-                var file = item.Files.FirstOrDefault(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase))?.FileInfo.StoragePath;
+                var file = item.Files.SingleOrDefault(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase))?.FileInfo.StoragePath;
 
                 using (var stream = Files.Store.GetStream(file))
                     info.MD5Hash = stream.ComputeMD5Hash();

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -201,7 +201,9 @@ namespace osu.Game.Beatmaps
                 using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                     new LegacyBeatmapEncoder(beatmapContent).Encode(sw);
 
-                stream.Seek(0, SeekOrigin.Begin);
+                var attachedInfo = setInfo.Beatmaps.Single(b => b.ID == info.ID);
+                var md5Hash = stream.ComputeMD5Hash();
+                attachedInfo.MD5Hash = md5Hash;
 
                 UpdateFile(setInfo, setInfo.Files.Single(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase)), stream);
             }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -201,6 +201,8 @@ namespace osu.Game.Beatmaps
                 using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                     new LegacyBeatmapEncoder(beatmapContent).Encode(sw);
 
+                stream.Seek(0, SeekOrigin.Begin);
+
                 UpdateFile(setInfo, setInfo.Files.Single(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase)), stream);
             }
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -201,16 +201,25 @@ namespace osu.Game.Beatmaps
                 using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                     new LegacyBeatmapEncoder(beatmapContent).Encode(sw);
 
-                var attachedInfo = setInfo.Beatmaps.Single(b => b.ID == info.ID);
-                var md5Hash = stream.ComputeMD5Hash();
-                attachedInfo.MD5Hash = md5Hash;
-
                 UpdateFile(setInfo, setInfo.Files.Single(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase)), stream);
             }
 
             var working = workingCache.FirstOrDefault(w => w.BeatmapInfo?.ID == info.ID);
             if (working != null)
                 workingCache.Remove(working);
+        }
+
+        protected override void PreUpdate(BeatmapSetInfo item)
+        {
+            base.PreUpdate(item);
+
+            foreach (var info in item.Beatmaps)
+            {
+                var file = item.Files.FirstOrDefault(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase))?.FileInfo.StoragePath;
+
+                using (var stream = Files.Store.GetStream(file))
+                    info.MD5Hash = stream.ComputeMD5Hash();
+            }
         }
 
         private readonly WeakList<WorkingBeatmap> workingCache = new WeakList<WorkingBeatmap>();

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -203,25 +203,19 @@ namespace osu.Game.Beatmaps
 
                 stream.Seek(0, SeekOrigin.Begin);
 
-                UpdateFile(setInfo, setInfo.Files.Single(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase)), stream);
+                using (ContextFactory.GetForWrite())
+                {
+                    var beatmapInfo = setInfo.Beatmaps.Single(b => b.ID == info.ID);
+                    beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
+
+                    stream.Seek(0, SeekOrigin.Begin);
+                    UpdateFile(setInfo, setInfo.Files.Single(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase)), stream);
+                }
             }
 
             var working = workingCache.FirstOrDefault(w => w.BeatmapInfo?.ID == info.ID);
             if (working != null)
                 workingCache.Remove(working);
-        }
-
-        protected override void PreUpdate(BeatmapSetInfo item)
-        {
-            base.PreUpdate(item);
-
-            foreach (var info in item.Beatmaps)
-            {
-                var file = item.Files.SingleOrDefault(f => string.Equals(f.Filename, info.Path, StringComparison.OrdinalIgnoreCase))?.FileInfo.StoragePath;
-
-                using (var stream = Files.Store.GetStream(file))
-                    info.MD5Hash = stream.ComputeMD5Hash();
-            }
         }
 
         private readonly WeakList<WorkingBeatmap> workingCache = new WeakList<WorkingBeatmap>();

--- a/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_WorkingBeatmap.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Beatmaps
                 }
             }
 
-            private string getPathForFile(string filename) => BeatmapSetInfo.Files.FirstOrDefault(f => string.Equals(f.Filename, filename, StringComparison.OrdinalIgnoreCase))?.FileInfo.StoragePath;
+            private string getPathForFile(string filename) => BeatmapSetInfo.Files.SingleOrDefault(f => string.Equals(f.Filename, filename, StringComparison.OrdinalIgnoreCase))?.FileInfo.StoragePath;
 
             private TextureStore textureStore;
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -430,8 +430,18 @@ namespace osu.Game.Database
             {
                 item.Hash = computeHash(item);
 
+                PreUpdate(item);
+
                 ModelStore.Update(item);
             }
+        }
+
+        /// <summary>
+        /// Perform any final actions before the update to database executes.
+        /// </summary>
+        /// <param name="item">The <typeparamref name="TModel"/> that is being updated.</param>
+        protected virtual void PreUpdate(TModel item)
+        {
         }
 
         /// <summary>

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -429,19 +429,8 @@ namespace osu.Game.Database
             using (ContextFactory.GetForWrite())
             {
                 item.Hash = computeHash(item);
-
-                PreUpdate(item);
-
                 ModelStore.Update(item);
             }
-        }
-
-        /// <summary>
-        /// Perform any final actions before the update to database executes.
-        /// </summary>
-        /// <param name="item">The <typeparamref name="TModel"/> that is being updated.</param>
-        protected virtual void PreUpdate(TModel item)
-        {
         }
 
         /// <summary>

--- a/osu.Game/Online/API/APIPlaylistBeatmap.cs
+++ b/osu.Game/Online/API/APIPlaylistBeatmap.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Online.API
+{
+    public class APIPlaylistBeatmap : APIBeatmap
+    {
+        [JsonProperty("checksum")]
+        public string Checksum { get; set; }
+
+        public override BeatmapInfo ToBeatmap(RulesetStore rulesets)
+        {
+            var b = base.ToBeatmap(rulesets);
+            b.MD5Hash = Checksum;
+            return b;
+        }
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"max_combo")]
         private int? maxCombo { get; set; }
 
-        public BeatmapInfo ToBeatmap(RulesetStore rulesets)
+        public virtual BeatmapInfo ToBeatmap(RulesetStore rulesets)
         {
             var set = BeatmapSet?.ToBeatmapSet(rulesets);
 

--- a/osu.Game/Online/Multiplayer/PlaylistItem.cs
+++ b/osu.Game/Online/Multiplayer/PlaylistItem.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 
@@ -37,7 +36,7 @@ namespace osu.Game.Online.Multiplayer
         public readonly BindableList<Mod> RequiredMods = new BindableList<Mod>();
 
         [JsonProperty("beatmap")]
-        private APIBeatmap apiBeatmap { get; set; }
+        private APIPlaylistBeatmap apiBeatmap { get; set; }
 
         private APIMod[] allowedModsBacking;
 

--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -433,7 +433,7 @@ namespace osu.Game.Screens.Multi.Match.Components
             }
         }
 
-        private class CreateRoomButton : TriangleButton
+        public class CreateRoomButton : TriangleButton
         {
             public CreateRoomButton()
             {

--- a/osu.Game/Screens/Multi/Match/Components/ReadyButton.cs
+++ b/osu.Game/Screens/Multi/Match/Components/ReadyButton.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
@@ -52,24 +53,14 @@ namespace osu.Game.Screens.Multi.Match.Components
 
         private void updateSelectedItem(PlaylistItem item)
         {
-            hasBeatmap = false;
-
-            int? beatmapId = SelectedItem.Value?.Beatmap.Value?.OnlineBeatmapID;
-            if (beatmapId == null)
-                return;
-
-            hasBeatmap = beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == beatmapId) != null;
+            hasBeatmap = findBeatmap(expr => beatmaps.QueryBeatmap(expr));
         }
 
         private void beatmapUpdated(ValueChangedEvent<WeakReference<BeatmapSetInfo>> weakSet)
         {
             if (weakSet.NewValue.TryGetTarget(out var set))
             {
-                int? beatmapId = SelectedItem.Value?.Beatmap.Value?.OnlineBeatmapID;
-                if (beatmapId == null)
-                    return;
-
-                if (set.Beatmaps.Any(b => b.OnlineBeatmapID == beatmapId))
+                if (findBeatmap(expr => set.Beatmaps.AsQueryable().FirstOrDefault(expr)))
                     Schedule(() => hasBeatmap = true);
             }
         }
@@ -78,13 +69,20 @@ namespace osu.Game.Screens.Multi.Match.Components
         {
             if (weakSet.NewValue.TryGetTarget(out var set))
             {
-                int? beatmapId = SelectedItem.Value?.Beatmap.Value?.OnlineBeatmapID;
-                if (beatmapId == null)
-                    return;
-
-                if (set.Beatmaps.Any(b => b.OnlineBeatmapID == beatmapId))
+                if (findBeatmap(expr => set.Beatmaps.AsQueryable().FirstOrDefault(expr)))
                     Schedule(() => hasBeatmap = false);
             }
+        }
+
+        private bool findBeatmap(Func<Expression<Func<BeatmapInfo, bool>>, BeatmapInfo> expression)
+        {
+            int? beatmapId = SelectedItem.Value?.Beatmap.Value?.OnlineBeatmapID;
+            string checksum = SelectedItem.Value?.Beatmap.Value?.MD5Hash;
+
+            if (beatmapId == null || checksum == null)
+                return false;
+
+            return expression(b => b.OnlineBeatmapID == beatmapId && b.MD5Hash == checksum) != null;
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -207,6 +207,8 @@ namespace osu.Game.Screens.Multi.Match
                 Ruleset.Value = item.Ruleset.Value;
         }
 
+        private void beatmapUpdated(ValueChangedEvent<WeakReference<BeatmapSetInfo>> weakSet) => Schedule(updateWorkingBeatmap);
+
         private void updateWorkingBeatmap()
         {
             var beatmap = SelectedItem.Value?.Beatmap.Value;
@@ -215,17 +217,6 @@ namespace osu.Game.Screens.Multi.Match
             var localBeatmap = beatmap == null ? null : beatmapManager.QueryBeatmap(b => b.OnlineBeatmapID == beatmap.OnlineBeatmapID);
 
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
-        }
-
-        private void beatmapUpdated(ValueChangedEvent<WeakReference<BeatmapSetInfo>> weakSet)
-        {
-            Schedule(() =>
-            {
-                if (Beatmap.Value != beatmapManager.DefaultBeatmap)
-                    return;
-
-                updateWorkingBeatmap();
-            });
         }
 
         private void onStart()

--- a/osu.Game/Tests/Beatmaps/TestBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestBeatmap.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.IO;
 using osu.Game.Rulesets;
@@ -43,9 +45,24 @@ namespace osu.Game.Tests.Beatmaps
         private static Beatmap createTestBeatmap()
         {
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(test_beatmap_data)))
-            using (var reader = new LineBufferedReader(stream))
-                return Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
+            {
+                using (var reader = new LineBufferedReader(stream))
+                {
+                    var b = Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
+
+                    b.BeatmapInfo.MD5Hash = test_beatmap_hash.Value.md5;
+                    b.BeatmapInfo.Hash = test_beatmap_hash.Value.sha2;
+
+                    return b;
+                }
+            }
         }
+
+        private static readonly Lazy<(string md5, string sha2)> test_beatmap_hash = new Lazy<(string md5, string sha2)>(() =>
+        {
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(test_beatmap_data)))
+                return (stream.ComputeMD5Hash(), stream.ComputeSHA2Hash());
+        });
 
         private const string test_beatmap_data = @"osu file format v14
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/9132

A few changes here:

1. I've added an all-encompassing `PreUpdate()` method that follows the `PreImport()` signature for this task. I imagine this method to be used in the future to queue up diffcalc re-computations, etc.
2. The download button does a second local query against the beatmap checksum. This is done this way because `DownloadTrackingComponent` only knows about the parenting `TModel` (beatmap set) and `ArchiveModelManager<TModel>`. I think maybe we'll want to extract this logic out, but doing so is quite a large refactoring which I'll save for a further PR.
3. `MatchSubScreen` now always re-queries for the working beatmap when a change happens on the `BeatmapManager`. `Save()` removes the working beatmap from the cache and expects consumers to re-query for the updated beatmap. If the current beatmap isn't changed, the cache will still be hot and the re-query should be pretty much instantaneous.
4. `TestBeatmap` now populates MD5 + SHA2 hashes for testability.

Tested:
- Entering room, downloading updated beatmap, playing the downloaded version.
- Creating a room, downloading updated beatmap (because we send a `beatmap_id` and receive back a `checksum`).