### PR TITLE
Fix results screen crashing for beatmaps with no online ID

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -36,12 +36,14 @@ namespace osu.Game.Tests.Visual.Ranking
                 Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo);
         }
 
-        private TestSoloResults createResultsScreen() => new TestSoloResults(new TestScoreInfo(new OsuRuleset().RulesetInfo));
+        private TestResultsScreen createResultsScreen() => new TestResultsScreen(new TestScoreInfo(new OsuRuleset().RulesetInfo));
+
+        private UnrankedSoloResultsScreen createUnrankedSoloResultsScreen() => new UnrankedSoloResultsScreen(new TestScoreInfo(new OsuRuleset().RulesetInfo));
 
         [Test]
         public void ResultsWithoutPlayer()
         {
-            TestSoloResults screen = null;
+            TestResultsScreen screen = null;
             OsuScreenStack stack;
 
             AddStep("load results", () =>
@@ -60,9 +62,19 @@ namespace osu.Game.Tests.Visual.Ranking
         [Test]
         public void ResultsWithPlayer()
         {
-            TestSoloResults screen = null;
+            TestResultsScreen screen = null;
 
             AddStep("load results", () => Child = new TestResultsContainer(screen = createResultsScreen()));
+            AddUntilStep("wait for loaded", () => screen.IsLoaded);
+            AddAssert("retry overlay present", () => screen.RetryOverlay != null);
+        }
+
+        [Test]
+        public void ResultsForUnranked()
+        {
+            UnrankedSoloResultsScreen screen = null;
+
+            AddStep("load results", () => Child = new TestResultsContainer(screen = createUnrankedSoloResultsScreen()));
             AddUntilStep("wait for loaded", () => screen.IsLoaded);
             AddAssert("retry overlay present", () => screen.RetryOverlay != null);
         }
@@ -86,13 +98,32 @@ namespace osu.Game.Tests.Visual.Ranking
             }
         }
 
-        private class TestSoloResults : ResultsScreen
+        private class TestResultsScreen : ResultsScreen
         {
             public HotkeyRetryOverlay RetryOverlay;
 
-            public TestSoloResults(ScoreInfo score)
+            public TestResultsScreen(ScoreInfo score)
                 : base(score)
             {
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                RetryOverlay = InternalChildren.OfType<HotkeyRetryOverlay>().SingleOrDefault();
+            }
+        }
+
+        private class UnrankedSoloResultsScreen : SoloResultsScreen
+        {
+            public HotkeyRetryOverlay RetryOverlay;
+
+            public UnrankedSoloResultsScreen(ScoreInfo score)
+                : base(score)
+            {
+                Score.Beatmap.OnlineBeatmapID = 0;
+                Score.Beatmap.Status = BeatmapSetOnlineStatus.Pending;
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -141,17 +141,14 @@ namespace osu.Game.Screens.Ranking
         {
             base.LoadComplete();
 
-            if (Score.Beatmap.OnlineBeatmapID != null && Score.Beatmap.Status > BeatmapSetOnlineStatus.Pending)
+            var req = FetchScores(scores => Schedule(() =>
             {
-                var req = FetchScores(scores => Schedule(() =>
-                {
-                    foreach (var s in scores)
-                        panels.AddScore(s);
-                }));
+                foreach (var s in scores)
+                    panels.AddScore(s);
+            }));
 
-                if (req != null)
-                    api.Queue(req);
-            }
+            if (req != null)
+                api.Queue(req);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
@@ -140,7 +141,7 @@ namespace osu.Game.Screens.Ranking
         {
             base.LoadComplete();
 
-            if (Score.Beatmap.OnlineBeatmapID != null)
+            if (Score.Beatmap.OnlineBeatmapID != null && Score.Beatmap.Status > BeatmapSetOnlineStatus.Pending)
             {
                 var req = FetchScores(scores => Schedule(() =>
                 {

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -140,14 +140,17 @@ namespace osu.Game.Screens.Ranking
         {
             base.LoadComplete();
 
-            var req = FetchScores(scores => Schedule(() =>
+            if (Score.Beatmap.OnlineBeatmapID != null)
             {
-                foreach (var s in scores)
-                    panels.AddScore(s);
-            }));
+                var req = FetchScores(scores => Schedule(() =>
+                {
+                    foreach (var s in scores)
+                        panels.AddScore(s);
+                }));
 
-            if (req != null)
-                api.Queue(req);
+                if (req != null)
+                    api.Queue(req);
+            }
         }
 
         /// <summary>

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Rulesets;
@@ -24,6 +25,9 @@ namespace osu.Game.Screens.Ranking
 
         protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
         {
+            if (Score.Beatmap.OnlineBeatmapID == null || Score.Beatmap.Status <= BeatmapSetOnlineStatus.Pending)
+                return null;
+
             var req = new GetScoresRequest(Score.Beatmap, Score.Ruleset);
             req.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => s.OnlineScoreID != Score.OnlineScoreID).Select(s => s.CreateScoreInfo(rulesets)));
             return req;


### PR DESCRIPTION
Likely regressed in #9086 

Logic taken from `ScoresRequest.getScores()`