### PR TITLE
Fix chat history not being loaded for multiplayer matches

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -246,7 +246,12 @@ namespace osu.Game.Tests.Visual.Online
             {
                 ((BindableList<Channel>)ChannelManager.AvailableChannels).AddRange(channels);
 
-                Child = ChatOverlay = new TestChatOverlay { RelativeSizeAxes = Axes.Both, };
+                InternalChildren = new Drawable[]
+                {
+                    ChannelManager,
+                    ChatOverlay = new TestChatOverlay { RelativeSizeAxes = Axes.Both, },
+                };
+
                 ChatOverlay.Show();
             }
         }

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -358,6 +358,13 @@ namespace osu.Game.Online.Chat
             {
                 switch (channel.Type)
                 {
+                    case ChannelType.Multiplayer:
+                        // join is implicit. happens when you join a multiplayer game.
+                        // this will probably change in the future.
+                        channel.Joined.Value = true;
+                        joinChannel(channel, fetchInitialMessages);
+                        return channel;
+
                     case ChannelType.Private:
                         // can't do this yet.
                         break;

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -93,12 +93,6 @@ namespace osu.Game.Online.Chat
         {
             if (!(e.NewValue is ChannelSelectorTabItem.ChannelSelectorTabChannel))
                 JoinChannel(e.NewValue);
-
-            if (e.NewValue?.MessagesLoaded == false)
-            {
-                // let's fetch a small number of messages to bring us up-to-date with the backlog.
-                fetchInitalMessages(e.NewValue);
-            }
         }
 
         /// <summary>
@@ -240,7 +234,6 @@ namespace osu.Game.Online.Chat
                     }
 
                     JoinChannel(channel);
-                    CurrentChannel.Value = channel;
                     break;
 
                 case "help":
@@ -275,7 +268,7 @@ namespace osu.Game.Online.Chat
 
                     // join any channels classified as "defaults"
                     if (joinDefaults && defaultChannels.Any(c => c.Equals(channel.Name, StringComparison.OrdinalIgnoreCase)))
-                        JoinChannel(ch);
+                        joinChannel(ch);
                 }
             };
             req.Failure += error =>
@@ -296,7 +289,7 @@ namespace osu.Game.Online.Chat
         /// <param name="channel">The channel </param>
         private void fetchInitalMessages(Channel channel)
         {
-            if (channel.Id <= 0) return;
+            if (channel.Id <= 0 || channel.MessagesLoaded) return;
 
             var fetchInitialMsgReq = new GetMessagesRequest(channel);
             fetchInitialMsgReq.Success += messages =>
@@ -351,9 +344,10 @@ namespace osu.Game.Online.Chat
         /// Joins a channel if it has not already been joined.
         /// </summary>
         /// <param name="channel">The channel to join.</param>
-        /// <param name="alreadyJoined">Whether the channel has already been joined server-side. Will skip a join request.</param>
         /// <returns>The joined channel. Note that this may not match the parameter channel as it is a backed object.</returns>
-        public Channel JoinChannel(Channel channel, bool alreadyJoined = false)
+        public Channel JoinChannel(Channel channel) => joinChannel(channel, true);
+
+        private Channel joinChannel(Channel channel, bool fetchInitialMessages = false)
         {
             if (channel == null) return null;
 
@@ -362,20 +356,28 @@ namespace osu.Game.Online.Chat
             // ensure we are joined to the channel
             if (!channel.Joined.Value)
             {
-                if (alreadyJoined)
-                    channel.Joined.Value = true;
-                else
+                switch (channel.Type)
                 {
-                    switch (channel.Type)
-                    {
-                        case ChannelType.Public:
-                            var req = new JoinChannelRequest(channel, api.LocalUser.Value);
-                            req.Success += () => JoinChannel(channel, true);
-                            req.Failure += ex => LeaveChannel(channel);
-                            api.Queue(req);
-                            return channel;
-                    }
+                    case ChannelType.Private:
+                        // can't do this yet.
+                        break;
+
+                    default:
+                        var req = new JoinChannelRequest(channel, api.LocalUser.Value);
+                        req.Success += () =>
+                        {
+                            channel.Joined.Value = true;
+                            joinChannel(channel, fetchInitialMessages);
+                        };
+                        req.Failure += ex => LeaveChannel(channel);
+                        api.Queue(req);
+                        return channel;
                 }
+            }
+            else
+            {
+                if (fetchInitialMessages)
+                    fetchInitalMessages(channel);
             }
 
             if (CurrentChannel.Value == null)
@@ -420,7 +422,8 @@ namespace osu.Game.Online.Chat
                     foreach (var channel in updates.Presence)
                     {
                         // we received this from the server so should mark the channel already joined.
-                        JoinChannel(channel, true);
+                        channel.Joined.Value = true;
+                        joinChannel(channel);
                     }
 
                     //todo: handle left channels


### PR DESCRIPTION
The lazy load logic for `fetchInitialMessages` was relying on the channel becoming the `ChannelManager`'s `CurrentChannel`, which it doesn't for external chat displays.

Closes https://github.com/ppy/osu/issues/9181. Also tidies things up a bit (not sure why there was an extra pathway/state for `alreadyJoined`.. nothing seems to break with this change).