### PR TITLE
Fix score panel not receiving input in some places

### DIFF
--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -243,5 +243,10 @@ namespace osu.Game.Screens.Ranking
 
             return true;
         }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+            => base.ReceivePositionalInputAt(screenSpacePos)
+               || topLayerContainer.ReceivePositionalInputAt(screenSpacePos)
+               || middleLayerContainer.ReceivePositionalInputAt(screenSpacePos);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9178

The score panel layout is going to change in the near future so I think this is ok for now. Based on flyte's newest designs, what's currently the "top" layer is going to be more like a "behind" layer and expand in both directions vertically, rather than the two layers sliding out from one another.

That future structure alone will make this logic a lot cleaner.