### PR TITLE
Show a loading spinner on multiplayer lounge loads

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
@@ -141,6 +141,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
             }
 
             public readonly BindableList<Room> Rooms = new BindableList<Room>();
+
+            public Bindable<bool> InitialRoomsReceived { get; } = new Bindable<bool>(true);
+
             IBindableList<Room> IRoomManager.Rooms => Rooms;
 
             public void CreateRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null) => Rooms.Add(room);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSettingsOverlay.cs
@@ -133,6 +133,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 remove { }
             }
 
+            public Bindable<bool> InitialRoomsReceived { get; } = new Bindable<bool>(true);
+
             public IBindableList<Room> Rooms { get; } = null;
 
             public void CreateRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSubScreen.cs
@@ -93,6 +93,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 remove => throw new NotImplementedException();
             }
 
+            public Bindable<bool> InitialRoomsReceived { get; } = new Bindable<bool>(true);
+
             public IBindableList<Room> Rooms { get; } = new BindableList<Room>();
 
             public void CreateRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)

--- a/osu.Game/Screens/Multi/IRoomManager.cs
+++ b/osu.Game/Screens/Multi/IRoomManager.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Screens.Multi
         event Action RoomsUpdated;
 
         /// <summary>
+        /// Whether an initial listing of rooms has been received.
+        /// </summary>
+        Bindable<bool> InitialRoomsReceived { get; }
+
+        /// <summary>
         /// All the active <see cref="Room"/>s.
         /// </summary>
         IBindableList<Room> Rooms { get; }

--- a/osu.Game/Screens/Multi/RoomManager.cs
+++ b/osu.Game/Screens/Multi/RoomManager.cs
@@ -25,6 +25,9 @@ namespace osu.Game.Screens.Multi
         public event Action RoomsUpdated;
 
         private readonly BindableList<Room> rooms = new BindableList<Room>();
+
+        public Bindable<bool> InitialRoomsReceived { get; } = new Bindable<bool>();
+
         public IBindableList<Room> Rooms => rooms;
 
         public double TimeBetweenListingPolls
@@ -62,7 +65,11 @@ namespace osu.Game.Screens.Multi
 
             InternalChildren = new Drawable[]
             {
-                listingPollingComponent = new ListingPollingComponent { RoomsReceived = onListingReceived },
+                listingPollingComponent = new ListingPollingComponent
+                {
+                    InitialRoomsReceived = { BindTarget = InitialRoomsReceived },
+                    RoomsReceived = onListingReceived
+                },
                 selectionPollingComponent = new SelectionPollingComponent { RoomReceived = onSelectedRoomReceived }
             };
         }
@@ -262,6 +269,8 @@ namespace osu.Game.Screens.Multi
         {
             public Action<List<Room>> RoomsReceived;
 
+            public readonly Bindable<bool> InitialRoomsReceived = new Bindable<bool>();
+
             [Resolved]
             private IAPIProvider api { get; set; }
 
@@ -273,6 +282,8 @@ namespace osu.Game.Screens.Multi
             {
                 currentFilter.BindValueChanged(_ =>
                 {
+                    InitialRoomsReceived.Value = false;
+
                     if (IsLoaded)
                         PollImmediately();
                 });
@@ -292,6 +303,7 @@ namespace osu.Game.Screens.Multi
 
                 pollReq.Success += result =>
                 {
+                    InitialRoomsReceived.Value = true;
                     RoomsReceived?.Invoke(result);
                     tcs.SetResult(true);
                 };


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/9138

Think it's good enough without showing a "no open rooms" text - the spinner disappears.