### PR TITLE
Add cinema mod selection shortcut to song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -31,6 +31,7 @@ using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Users;
 using osuTK.Input;
+using osu.Game.Overlays.Mods;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
@@ -589,6 +590,65 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestCinemaViaCtrlShiftEnter()
+        {
+            addRulesetImportStep(0);
+
+            createSongSelect();
+
+            AddStep("press ctrl+shit+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.PressKey(Key.Enter);
+
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+                InputManager.ReleaseKey(Key.Enter);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("cinema enabled", () => songSelect.Mods.Value.FirstOrDefault() is ModCinema);
+
+            AddUntilStep("wait for return to ss", () => songSelect.IsCurrentScreen());
+
+            AddAssert("mod disabled", () => songSelect.Mods.Value.Count == 0);
+        }
+
+        [Test]
+        public void TestAutoplayWithCtrlShiftEnter()
+        {
+            addRulesetImportStep(0);
+
+            createSongSelect();
+
+            AddStep("select autoplay", () =>
+            {
+                songSelect.ModSelect.SelectTypes(new[] { typeof(ModAutoplay) });
+            });
+
+            AddStep("press ctrl+shit+enter", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.PressKey(Key.Enter);
+
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+                InputManager.ReleaseKey(Key.Enter);
+            });
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
+
+            AddAssert("only cinema enabled", () => songSelect.Mods.Value.FirstOrDefault() is ModCinema && songSelect.Mods.Value.Count == 1);
+
+            AddUntilStep("wait for return to ss", () => songSelect.IsCurrentScreen());
+
+            AddAssert("mod disabled", () => songSelect.Mods.Value.Count == 0);
+        }
+
+        [Test]
         public void TestHideSetSelectsCorrectBeatmap()
         {
             int? previousID = null;
@@ -929,6 +989,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             public WorkingBeatmap CurrentBeatmap => Beatmap.Value;
             public WorkingBeatmap CurrentBeatmapDetailsBeatmap => BeatmapDetails.Beatmap;
             public new BeatmapCarousel Carousel => base.Carousel;
+
+            public new ModSelectOverlay ModSelect => base.ModSelect;
 
             public new void PresentScore(ScoreInfo score) => base.PresentScore(score);
 

--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -128,7 +128,8 @@ namespace osu.Game.Overlays.Mods
         /// Select one or more mods in this section and deselects all other ones.
         /// </summary>
         /// <param name="modTypes">The types of <see cref="Mod"/>s which should be selected.</param>
-        public void SelectTypes(IEnumerable<Type> modTypes)
+        /// <param name="deselect">Whether to deselect mods not present in <paramref name="modTypes"/></param>
+        public void SelectTypes(IEnumerable<Type> modTypes, bool deselect = true)
         {
             foreach (var button in buttons)
             {
@@ -136,7 +137,7 @@ namespace osu.Game.Overlays.Mods
 
                 if (i >= 0)
                     button.SelectAt(i);
-                else
+                else if (deselect)
                     button.Deselect();
             }
         }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -336,6 +336,14 @@ namespace osu.Game.Overlays.Mods
             refreshSelectedMods();
         }
 
+        public void SelectTypes(Type[] modTypes)
+        {
+            if (modTypes.Length == 0) return;
+
+            foreach (var section in ModSectionsContainer.Children)
+                section.SelectTypes(modTypes, false);
+        }
+
         /// <summary>
         /// Deselect one or more mods.
         /// </summary>


### PR DESCRIPTION
# Summary

Closes #9221

- Adds the cinema mod selection shortcut to song select <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd>
- A notification similar to what was implemented in #9168 will be displayed if the user attempts to start a beatmap using a ruleset which hasn't an available cinema mod.

## Testing
~~Again no automatic testing as it is quite hard to automate.
However, manual testing shows it works as expected.~~

See `TestScenePlaySongSelect` test scene.