### PR TITLE
Improve handling of missing intro beatmap / files

### DIFF
--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -41,9 +41,9 @@ namespace osu.Game.Screens.Menu
 
         protected IBindable<bool> MenuMusic { get; private set; }
 
-        private WorkingBeatmap introBeatmap;
+        private WorkingBeatmap initialBeatmap;
 
-        protected Track Track { get; private set; }
+        protected Track Track => initialBeatmap?.Track;
 
         private readonly BindableDouble exitingVolumeFade = new BindableDouble(1);
 
@@ -58,6 +58,11 @@ namespace osu.Game.Screens.Menu
         [Resolved]
         private AudioManager audio { get; set; }
 
+        /// <summary>
+        /// Whether the <see cref="Track"/> is provided by osu! resources, rather than a user beatmap.
+        /// </summary>
+        protected bool UsingThemedIntro { get; private set; }
+
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, SkinManager skinManager, BeatmapManager beatmaps, Framework.Game game)
         {
@@ -71,29 +76,45 @@ namespace osu.Game.Screens.Menu
 
             BeatmapSetInfo setInfo = null;
 
+            // if the user has requested not to play theme music, we should attempt to find a random beatmap from their collection.
             if (!MenuMusic.Value)
             {
                 var sets = beatmaps.GetAllUsableBeatmapSets(IncludedDetails.Minimal);
+
                 if (sets.Count > 0)
-                    setInfo = beatmaps.QueryBeatmapSet(s => s.ID == sets[RNG.Next(0, sets.Count - 1)].ID);
-            }
-
-            if (setInfo == null)
-            {
-                setInfo = beatmaps.QueryBeatmapSet(b => b.Hash == BeatmapHash);
-
-                if (setInfo == null)
                 {
-                    // we need to import the default menu background beatmap
-                    setInfo = beatmaps.Import(new ZipArchiveReader(game.Resources.GetStream($"Tracks/{BeatmapFile}"), BeatmapFile)).Result;
-
-                    setInfo.Protected = true;
-                    beatmaps.Update(setInfo);
+                    setInfo = beatmaps.QueryBeatmapSet(s => s.ID == sets[RNG.Next(0, sets.Count - 1)].ID);
+                    initialBeatmap = beatmaps.GetWorkingBeatmap(setInfo.Beatmaps[0]);
                 }
             }
 
-            introBeatmap = beatmaps.GetWorkingBeatmap(setInfo.Beatmaps[0]);
-            Track = introBeatmap.Track;
+            // we generally want a song to be playing on startup, so use the intro music even if a user has specified not to if no other track is available.
+            if (setInfo == null)
+            {
+                if (!loadThemedIntro())
+                {
+                    // if we detect that the theme track or beatmap is unavailable this is either first startup or things are in a bad state.
+                    // this could happen if a user has nuked their files store. for now, reimport to repair this.
+                    var import = beatmaps.Import(new ZipArchiveReader(game.Resources.GetStream($"Tracks/{BeatmapFile}"), BeatmapFile)).Result;
+                    import.Protected = true;
+                    beatmaps.Update(import);
+
+                    loadThemedIntro();
+                }
+            }
+
+            bool loadThemedIntro()
+            {
+                setInfo = beatmaps.QueryBeatmapSet(b => b.Hash == BeatmapHash);
+
+                if (setInfo != null)
+                {
+                    initialBeatmap = beatmaps.GetWorkingBeatmap(setInfo.Beatmaps[0]);
+                    UsingThemedIntro = !(Track is TrackVirtual);
+                }
+
+                return UsingThemedIntro;
+            }
         }
 
         public override void OnResuming(IScreen last)
@@ -119,7 +140,7 @@ namespace osu.Game.Screens.Menu
         public override void OnSuspending(IScreen next)
         {
             base.OnSuspending(next);
-            Track = null;
+            initialBeatmap = null;
         }
 
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenBlack();
@@ -127,7 +148,7 @@ namespace osu.Game.Screens.Menu
         protected void StartTrack()
         {
             // Only start the current track if it is the menu music. A beatmap's track is started when entering the Main Menu.
-            if (MenuMusic.Value)
+            if (UsingThemedIntro)
                 Track.Restart();
         }
 
@@ -141,8 +162,7 @@ namespace osu.Game.Screens.Menu
 
             if (!resuming)
             {
-                beatmap.Value = introBeatmap;
-                introBeatmap = null;
+                beatmap.Value = initialBeatmap;
 
                 logo.MoveTo(new Vector2(0.5f));
                 logo.ScaleTo(Vector2.One);

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -7,7 +7,6 @@ using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Audio.Track;
 using osu.Framework.Screens;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -47,7 +46,7 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (MenuVoice.Value && !MenuMusic.Value)
+            if (MenuVoice.Value && !UsingThemedIntro)
                 welcome = audio.Samples.Get(@"welcome");
         }
 
@@ -62,7 +61,7 @@ namespace osu.Game.Screens.Menu
                 LoadComponentAsync(new TrianglesIntroSequence(logo, background)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Clock = new FramedClock(MenuMusic.Value && !(Track is TrackVirtual) ? Track : null),
+                    Clock = new FramedClock(UsingThemedIntro ? Track : null),
                     LoadMenu = LoadMenu
                 }, t =>
                 {

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -7,6 +7,7 @@ using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Audio.Track;
 using osu.Framework.Screens;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -61,7 +62,7 @@ namespace osu.Game.Screens.Menu
                 LoadComponentAsync(new TrianglesIntroSequence(logo, background)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Clock = new FramedClock(MenuMusic.Value ? Track : null),
+                    Clock = new FramedClock(MenuMusic.Value && !(Track is TrackVirtual) ? Track : null),
                     LoadMenu = LoadMenu
                 }, t =>
                 {


### PR DESCRIPTION
Fixes [recurring reports](https://github.com/ppy/osu/issues?q=is%3Aissue+%22won%27t+start%22+is%3Aclosed) of lazer failing to start, usually due to user touching files they shouldn't.

- Fixes stall at intro screen if mp3 or beatmap files are missing (due to user deletion, usually)
- Fixes incorrect intro playback behaviour when user has disabled intro theme but also has no beatmaps
- Improves legibility of code, renamed "theme" specific lookups to separate from the case where the intro is using a user selection
- Fixes `WorkingBeatmap` cache not clearing on an underlying store change (would cause the implicit filestore reimport to not be used even on a second `GetWorkingBeatmap` call, because the `Track` was already resolved to a `TrackVirtual`)

Tests could be added for this with some degree of effort, but I also think this logic and process is going to change as we add more customisation going forward, so not sure how I feel about putting in the effort just yet. Manually tested all scenarios listed below:

- `rm client.db` -> imports from scratch
- `rm files/4/47/47b895484e7751f3ab429694ff6dbf21e774ab023e4f6c5b481476f04ff22f0f` (triangles mp3) -> uses existing but reimports missing files
- loading with menu theme disabled, with no beatmaps (both triangles and circles)
- loading with menu theme disabled, with beatmaps (both triangles and circles)

As an aside, the reason the `TrackVirtual` was stalling is that it has a length of 1000ms, which isn't enough for the intro to play out. Seems safest to avoid using it altogether rather than increase the length though.