### PR TITLE
Move graphics from TournamentGameBase to TournamentGame

### DIFF
--- a/osu.Game.Tournament.Tests/TournamentTestBrowser.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestBrowser.cs
@@ -19,9 +19,6 @@ namespace osu.Game.Tournament.Tests
                 Depth = 10
             }, AddInternal);
 
-            MenuCursorContainer.Cursor.AlwaysPresent = true;
-            MenuCursorContainer.Cursor.Alpha = 0;
-
             // Have to construct this here, rather than in the constructor, because
             // we depend on some dependencies to be loaded within OsuGameBase.load().
             Add(new TestBrowser());

--- a/osu.Game.Tournament.Tests/TournamentTestBrowser.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestBrowser.cs
@@ -19,6 +19,9 @@ namespace osu.Game.Tournament.Tests
                 Depth = 10
             }, AddInternal);
 
+            MenuCursorContainer.Cursor.AlwaysPresent = true;
+            MenuCursorContainer.Cursor.Alpha = 0;
+
             // Have to construct this here, rather than in the constructor, because
             // we depend on some dependencies to be loaded within OsuGameBase.load().
             Add(new TestBrowser());

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -1,11 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Drawing;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Colour;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Tournament.Models;
+using osu.Game.Graphics;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Tournament
@@ -21,17 +29,94 @@ namespace osu.Game.Tournament
         public static readonly Color4 ELEMENT_FOREGROUND_COLOUR = Color4Extensions.FromHex("#000");
 
         public static readonly Color4 TEXT_COLOUR = Color4Extensions.FromHex("#fff");
+        private Drawable heightWarning;
+        private Bindable<Size> windowSize;
+
+        [BackgroundDependencyLoader]
+        private void load(FrameworkConfigManager frameworkConfig)
+        {
+            windowSize = frameworkConfig.GetBindable<Size>(FrameworkSetting.WindowedSize);
+            windowSize.BindValueChanged(size => ScheduleAfterChildren(() =>
+            {
+                var minWidth = (int)(size.NewValue.Height / 768f * TournamentSceneManager.REQUIRED_WIDTH) - 1;
+
+                heightWarning.Alpha = size.NewValue.Width < minWidth ? 1 : 0;
+            }), true);
+
+            AddRange(new[]
+            {
+                new Container
+                {
+                    CornerRadius = 10,
+                    Depth = float.MinValue,
+                    Position = new Vector2(5),
+                    Masking = true,
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = OsuColour.Gray(0.2f),
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new TourneyButton
+                        {
+                            Text = "Save Changes",
+                            Width = 140,
+                            Height = 50,
+                            Padding = new MarginPadding
+                            {
+                                Top = 10,
+                                Left = 10,
+                            },
+                            Margin = new MarginPadding
+                            {
+                                Right = 10,
+                                Bottom = 10,
+                            },
+                            Action = SaveChanges,
+                        },
+                    }
+                },
+                heightWarning = new Container
+                {
+                    Masking = true,
+                    CornerRadius = 5,
+                    Depth = float.MinValue,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = Color4.Red,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new TournamentSpriteText
+                        {
+                            Text = "Please make the window wider",
+                            Font = OsuFont.Torus.With(weight: FontWeight.Bold),
+                            Colour = Color4.White,
+                            Padding = new MarginPadding(20)
+                        }
+                    }
+                },
+                new OsuContextMenuContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new TournamentSceneManager()
+                }
+            });
+        }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            Add(new OsuContextMenuContainer
-            {
-                RelativeSizeAxes = Axes.Both,
-                Child = new TournamentSceneManager()
-            });
-
+            MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display
             // we don't want to show the menu cursor as it would appear on stream output.
             MenuCursorContainer.Cursor.Alpha = 0;
         }

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -111,15 +111,5 @@ namespace osu.Game.Tournament
                 }
             });
         }
-
-        protected override void LoadComplete()
-        {
-            MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display
-
-            // we don't want to show the menu cursor as it would appear on stream output.
-            MenuCursorContainer.Cursor.Alpha = 0;
-
-            base.LoadComplete();
-        }
     }
 }

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -114,11 +114,12 @@ namespace osu.Game.Tournament
 
         protected override void LoadComplete()
         {
-            base.LoadComplete();
-
             MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display
+
             // we don't want to show the menu cursor as it would appear on stream output.
             MenuCursorContainer.Cursor.Alpha = 0;
+
+            base.LoadComplete();
         }
     }
 }

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -20,7 +20,7 @@ using osuTK.Input;
 namespace osu.Game.Tournament
 {
     [Cached(typeof(TournamentGameBase))]
-    public abstract class TournamentGameBase : OsuGameBase
+    public class TournamentGameBase : OsuGameBase
     {
         private const string bracket_filename = "bracket.json";
 

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -228,6 +228,15 @@ namespace osu.Game.Tournament
 
             API.Queue(req);
         }
+        protected override void LoadComplete()
+        {
+            MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display
+
+            // we don't want to show the menu cursor as it would appear on stream output.
+            MenuCursorContainer.Cursor.Alpha = 0;
+
+            base.LoadComplete();
+        }
 
         protected virtual void SaveChanges()
         {

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -2,28 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Configuration;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics;
 using osu.Game.Online.API.Requests;
 using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
 using osu.Game.Users;
-using osuTK;
-using osuTK.Graphics;
 using osuTK.Input;
 
 namespace osu.Game.Tournament
@@ -40,11 +31,7 @@ namespace osu.Game.Tournament
         private TournamentStorage tournamentStorage;
 
         private DependencyContainer dependencies;
-
-        private Bindable<Size> windowSize;
         private FileBasedIPC ipc;
-
-        private Drawable heightWarning;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -52,7 +39,7 @@ namespace osu.Game.Tournament
         }
 
         [BackgroundDependencyLoader]
-        private void load(Storage storage, FrameworkConfigManager frameworkConfig)
+        private void load(Storage storage)
         {
             Resources.AddStore(new DllResourceStore(typeof(TournamentGameBase).Assembly));
 
@@ -62,83 +49,12 @@ namespace osu.Game.Tournament
 
             this.storage = storage;
 
-            windowSize = frameworkConfig.GetBindable<Size>(FrameworkSetting.WindowedSize);
-            windowSize.BindValueChanged(size => ScheduleAfterChildren(() =>
-            {
-                var minWidth = (int)(size.NewValue.Height / 768f * TournamentSceneManager.REQUIRED_WIDTH) - 1;
-
-                heightWarning.Alpha = size.NewValue.Width < minWidth ? 1 : 0;
-            }), true);
-
             readBracket();
 
             ladder.CurrentMatch.Value = ladder.Matches.FirstOrDefault(p => p.Current.Value);
 
             dependencies.CacheAs<MatchIPCInfo>(ipc = new FileBasedIPC());
             Add(ipc);
-
-            AddRange(new[]
-            {
-                new Container
-                {
-                    CornerRadius = 10,
-                    Depth = float.MinValue,
-                    Position = new Vector2(5),
-                    Masking = true,
-                    AutoSizeAxes = Axes.Both,
-                    Anchor = Anchor.BottomRight,
-                    Origin = Anchor.BottomRight,
-                    Children = new Drawable[]
-                    {
-                        new Box
-                        {
-                            Colour = OsuColour.Gray(0.2f),
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        new TourneyButton
-                        {
-                            Text = "Save Changes",
-                            Width = 140,
-                            Height = 50,
-                            Padding = new MarginPadding
-                            {
-                                Top = 10,
-                                Left = 10,
-                            },
-                            Margin = new MarginPadding
-                            {
-                                Right = 10,
-                                Bottom = 10,
-                            },
-                            Action = SaveChanges,
-                        },
-                    }
-                },
-                heightWarning = new Container
-                {
-                    Masking = true,
-                    CornerRadius = 5,
-                    Depth = float.MinValue,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    AutoSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
-                        new Box
-                        {
-                            Colour = Color4.Red,
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        new TournamentSpriteText
-                        {
-                            Text = "Please make the window wider",
-                            Font = OsuFont.Torus.With(weight: FontWeight.Bold),
-                            Colour = Color4.White,
-                            Padding = new MarginPadding(20)
-                        }
-                    }
-                },
-            });
         }
 
         private void readBracket()
@@ -311,14 +227,6 @@ namespace osu.Game.Tournament
             };
 
             API.Queue(req);
-        }
-
-        protected override void LoadComplete()
-        {
-            MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display
-            MenuCursorContainer.Cursor.Alpha = 0;
-
-            base.LoadComplete();
         }
 
         protected virtual void SaveChanges()

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -228,6 +228,7 @@ namespace osu.Game.Tournament
 
             API.Queue(req);
         }
+
         protected override void LoadComplete()
         {
             MenuCursorContainer.Cursor.AlwaysPresent = true; // required for tooltip display


### PR DESCRIPTION
Right now `TournamentGameBase` also adds all the user interface elements on startup. In this PR I have moved all the user interface related code inside `TournamentGameBase` to `TournamentGame` to match the relationship that `OsuGameBase` and `OsuGame` have.

Afaik `OsuGameBase` does not add any drawables to the screen, so this PR is supposed to achieve the same goal, but for the tournament side. 

This allows for headless tests to be created for the Tournament Client as well. 