### PR TITLE
Fix LoadingSpinner not always playing fade in animation

### DIFF
--- a/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingSpinner.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Graphics.UserInterface
     {
         private readonly SpriteIcon spinner;
 
+        protected override bool StartHidden => true;
+
         protected Container MainContents;
 
         public const float TRANSITION_DURATION = 500;


### PR DESCRIPTION
Noticed while reviewing timeshift results screen (where the appearance was very abrupt).

Before:

![image](https://user-images.githubusercontent.com/191335/84465615-71b40200-acb2-11ea-97b1-cf63492da636.gif)


After:

![image](https://user-images.githubusercontent.com/191335/84465647-85f7ff00-acb2-11ea-8c1e-827dac9e8f7d.gif)
