### PR TITLE
Fix gameplay clock not correctly reporting elapsed time

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneGameplayClockContainer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Gameplay
+{
+    public class TestSceneGameplayClockContainer : OsuTestScene
+    {
+        [Test]
+        public void TestStartThenElapsedTime()
+        {
+            GameplayClockContainer gcc = null;
+
+            AddStep("create container", () => Add(gcc = new GameplayClockContainer(CreateWorkingBeatmap(new OsuRuleset().RulesetInfo), Array.Empty<Mod>(), 0)));
+            AddStep("start track", () => gcc.Start());
+            AddUntilStep("elapsed greater than zero", () => gcc.GameplayClock.ElapsedFrameTime > 0);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Screens.Play
         {
             // we always want to apply the same real-time offset, so it should be adjusted by the difference in playback rate (from realtime) to achieve this.
             // base implementation already adds offset at 1.0 rate, so we only add the difference from that here.
-            public override double CurrentTime => base.CurrentTime + Offset * (1 - Rate);
+            public override double CurrentTime => base.CurrentTime + Offset * (Rate - 1);
 
             public HardwareCorrectionOffsetClock(IClock source, bool processSource = true)
                 : base(source, processSource)

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -251,8 +251,9 @@ namespace osu.Game.Screens.Play
 
         private class HardwareCorrectionOffsetClock : FramedOffsetClock
         {
-            // we always want to apply the same real-time offset, so it should be adjusted by the playback rate to achieve this.
-            public override double CurrentTime => SourceTime + Offset * Rate;
+            // we always want to apply the same real-time offset, so it should be adjusted by the difference in playback rate (from realtime) to achieve this.
+            // base implementation already adds offset at 1.0 rate, so we only add the difference from that here.
+            public override double CurrentTime => base.CurrentTime + Offset * (1 - Rate);
 
             public HardwareCorrectionOffsetClock(IClock source, bool processSource = true)
                 : base(source, processSource)


### PR DESCRIPTION
Due to the way CurrentTime was implemented (ignoring the base value), elapsed time would not correctly propagate up the clock stack. This changes the approach to be able to use the base value while still applying the real-time adjust offset.

Fixes the part of #8145 where storyboard samples fail to play.