### PR TITLE
Add shortcut to go home

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Escape, GlobalAction.Back),
             new KeyBinding(InputKey.ExtraMouseButton1, GlobalAction.Back),
 
+            new KeyBinding(new[] { InputKey.Alt, InputKey.Home }, GlobalAction.Home),
+
             new KeyBinding(InputKey.Up, GlobalAction.SelectPrevious),
             new KeyBinding(InputKey.Down, GlobalAction.SelectNext),
 
@@ -152,5 +154,8 @@ namespace osu.Game.Input.Bindings
 
         [Description("Next Selection")]
         SelectNext,
+
+        [Description("Home")]
+        Home,
     }
 }

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -62,6 +62,7 @@ namespace osu.Game.Overlays.Toolbar
         protected ConstrainedIconContainer IconContainer;
         protected SpriteText DrawableText;
         protected Box HoverBackground;
+        private readonly Box FlashBackground;
         private readonly FillFlowContainer tooltipContainer;
         private readonly SpriteText tooltip1;
         private readonly SpriteText tooltip2;
@@ -78,7 +79,14 @@ namespace osu.Game.Overlays.Toolbar
                 HoverBackground = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = OsuColour.Gray(80).Opacity(0),
+                    Colour = OsuColour.Gray(80).Opacity(180),
+                    Blending = BlendingParameters.Additive,
+                    Alpha = 0,
+                },
+                FlashBackground = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Transparent,
                     Blending = BlendingParameters.Additive,
                 },
                 Flow = new FillFlowContainer
@@ -138,21 +146,21 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override bool OnClick(ClickEvent e)
         {
-            HoverBackground.FlashColour(Color4.White.Opacity(100), 500, Easing.OutQuint);
+            FlashBackground.FlashColour(Color4.White.Opacity(100), 500, Easing.OutQuint);
             tooltipContainer.FadeOut(100);
             return base.OnClick(e);
         }
 
         protected override bool OnHover(HoverEvent e)
         {
-            HoverBackground.FadeColour(OsuColour.Gray(80).Opacity(180), 200);
+            HoverBackground.FadeIn(200);
             tooltipContainer.FadeIn(100);
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            HoverBackground.FadeColour(OsuColour.Gray(80).Opacity(0), 200);
+            HoverBackground.FadeOut(200);
             tooltipContainer.FadeOut(100);
         }
     }

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays.Toolbar
         protected ConstrainedIconContainer IconContainer;
         protected SpriteText DrawableText;
         protected Box HoverBackground;
-        private readonly Box FlashBackground;
+        private readonly Box flashBackground;
         private readonly FillFlowContainer tooltipContainer;
         private readonly SpriteText tooltip1;
         private readonly SpriteText tooltip2;
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.Toolbar
                     Blending = BlendingParameters.Additive,
                     Alpha = 0,
                 },
-                FlashBackground = new Box
+                flashBackground = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
                     Colour = Color4.Transparent,
@@ -146,7 +146,7 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override bool OnClick(ClickEvent e)
         {
-            FlashBackground.FlashColour(Color4.White.Opacity(100), 500, Easing.OutQuint);
+            flashBackground.FlashColour(Color4.White.Opacity(100), 500, Easing.OutQuint);
             tooltipContainer.FadeOut(100);
             return base.OnClick(e);
         }

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -86,7 +86,8 @@ namespace osu.Game.Overlays.Toolbar
                 flashBackground = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Transparent,
+                    Alpha = 0,
+                    Colour = Color4.White.Opacity(100),
                     Blending = BlendingParameters.Additive,
                 },
                 Flow = new FillFlowContainer
@@ -146,7 +147,7 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override bool OnClick(ClickEvent e)
         {
-            flashBackground.FlashColour(Color4.White.Opacity(100), 500, Easing.OutQuint);
+            flashBackground.FadeOutFromOne(800, Easing.OutQuint);
             tooltipContainer.FadeOut(100);
             return base.OnClick(e);
         }

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -78,9 +78,8 @@ namespace osu.Game.Overlays.Toolbar
                 HoverBackground = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = OsuColour.Gray(80).Opacity(180),
+                    Colour = OsuColour.Gray(80).Opacity(0),
                     Blending = BlendingParameters.Additive,
-                    Alpha = 0,
                 },
                 Flow = new FillFlowContainer
                 {
@@ -146,14 +145,14 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override bool OnHover(HoverEvent e)
         {
-            HoverBackground.FadeIn(200);
+            HoverBackground.FadeColour(OsuColour.Gray(80).Opacity(180), 200);
             tooltipContainer.FadeIn(100);
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            HoverBackground.FadeOut(200);
+            HoverBackground.FadeColour(OsuColour.Gray(80).Opacity(0), 200);
             tooltipContainer.FadeOut(100);
         }
     }

--- a/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
@@ -2,16 +2,33 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Bindings;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    public class ToolbarHomeButton : ToolbarButton
+    public class ToolbarHomeButton : ToolbarButton, IKeyBindingHandler<GlobalAction>
     {
         public ToolbarHomeButton()
         {
             Icon = FontAwesome.Solid.Home;
             TooltipMain = "Home";
             TooltipSub = "Return to the main menu";
+        }
+
+        public bool OnPressed(GlobalAction action)
+        {
+            if (action == GlobalAction.Home)
+            {
+                Click();
+                return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(GlobalAction action)
+        {
         }
     }
 }


### PR DESCRIPTION
The shortcut (<kbd>Alt</kbd>+<kbd>Home</kbd>) is used in most browsers.

[Reference](https://en.wikipedia.org/wiki/Table_of_keyboard_shortcuts):

![image](https://user-images.githubusercontent.com/35318437/84601519-8ec50e00-ae35-11ea-9554-b91fa15e233c.png)

Not sure if the second commit is right, visually it looks the same though. `HoverBackground`'s alpha needs to be > 0 for `OnClick`'s `FlashColour` to be visible when not hovered, so I changed `Opacity` instead.