### PR TITLE
Apply temporary fix for tournament song bar disappearance

### DIFF
--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -77,6 +77,8 @@ namespace osu.Game.Tournament.Components
                 flow = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
+                    // Todo: This is a hack for https://github.com/ppy/osu-framework/issues/3617 since this container is at the very edge of the screen and potentially initially masked away.
+                    Height = 1,
                     AutoSizeAxes = Axes.Y,
                     LayoutDuration = 500,
                     LayoutEasing = Easing.OutQuint,


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9200

I have no good simple o!f-side solution to this. Have made a framework issue (https://github.com/ppy/osu-framework/issues/3617) but I want to take a long-needed look at the auto-size / update hierarchy to fix this, which is going to take some time.

It is semi-related to the issue causing the global statistics window to continuously create and not dispose drawables (lack of updates).