### PR TITLE
Fix regression in android build parsing behaviour

### DIFF
--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -38,7 +38,6 @@ namespace osu.Android
                     }
                     else
                     {
-
 #pragma warning disable CS0618 // Type or member is obsolete
                         // this is required else older SDKs will report missing method exception.
                         versionName = packageInfo.VersionCode.ToString();

--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -33,6 +33,7 @@ namespace osu.Android
                     if (Build.VERSION.SdkInt >= BuildVersionCodes.P)
                     {
                         versionName = packageInfo.LongVersionCode.ToString();
+                        // ensure we only read the trailing portion of long (the part we are interested in).
                         versionName = versionName.Substring(versionName.Length - 9);
                     }
                     else

--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Android.App;
+using Android.OS;
 using osu.Game;
 using osu.Game.Updater;
 
@@ -18,9 +19,32 @@ namespace osu.Android
 
                 try
                 {
-                    // todo: needs checking before play store redeploy.
-                    string versionName = packageInfo.VersionName;
-                    // undo play store version garbling
+                    // We store the osu! build number in the "VersionCode" field to better support google play releases.
+                    // If we were to use the main build number, it would require a new submission each time (similar to TestFlight).
+                    // In order to do this, we should split it up and pad the numbers to still ensure sequential increase over time.
+                    //
+                    // We also need to be aware that older SDK versions store this as a 32bit int.
+                    //
+                    // Basic conversion format (as done in Fastfile): 2020.606.0 -> 202006060
+
+                    // https://stackoverflow.com/questions/52977079/android-sdk-28-versioncode-in-packageinfo-has-been-deprecated
+                    string versionName = string.Empty;
+
+                    if (Build.VERSION.SdkInt >= BuildVersionCodes.P)
+                    {
+                        versionName = packageInfo.LongVersionCode.ToString();
+                        versionName = versionName.Substring(versionName.Length - 9);
+                    }
+                    else
+                    {
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                        // this is required else older SDKs will report missing method exception.
+                        versionName = packageInfo.VersionCode.ToString();
+#pragma warning restore CS0618 // Type or member is obsolete
+                    }
+
+                    // undo play store version garbling (as mentioned above).
                     return new Version(int.Parse(versionName.Substring(0, 4)), int.Parse(versionName.Substring(4, 4)), int.Parse(versionName.Substring(8, 1)));
                 }
                 catch


### PR DESCRIPTION
The previous change made was not tested, and badly regressed the ability to read android build numbers. It has been a while since I've looked into why we did things the way we did, so I made a note of documenting inline.

The pain point is that we need to keep the obsoleted (in version 28) method call in order to support older android SDK versions (which are still recent enough that we do want to support, for instance my test device is running version 24 but still runs osu! 60fps with no issues).

Closes https://github.com/ppy/osu/issues/9183.