### PR TITLE
Block screen suspend while gameplay is active

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -125,6 +125,8 @@ namespace osu.Game.Screens.Play
 
         private GameplayBeatmap gameplayBeatmap;
 
+        private ScreenSuspensionHandler screenSuspension;
+
         private DependencyContainer dependencies;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -179,6 +181,7 @@ namespace osu.Game.Screens.Play
             InternalChild = GameplayClockContainer = new GameplayClockContainer(Beatmap.Value, Mods.Value, DrawableRuleset.GameplayStartTime);
 
             AddInternal(gameplayBeatmap = new GameplayBeatmap(playableBeatmap));
+            AddInternal(screenSuspension = new ScreenSuspensionHandler(GameplayClockContainer));
 
             dependencies.CacheAs(gameplayBeatmap);
 
@@ -628,12 +631,16 @@ namespace osu.Game.Screens.Play
 
         public override void OnSuspending(IScreen next)
         {
+            screenSuspension?.Expire();
+
             fadeOut();
             base.OnSuspending(next);
         }
 
         public override bool OnExiting(IScreen next)
         {
+            screenSuspension?.Expire();
+
             if (completionProgressDelegate != null && !completionProgressDelegate.Cancelled && !completionProgressDelegate.Completed)
             {
                 // proceed to result screen if beatmap already finished playing

--- a/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
+++ b/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -29,6 +30,10 @@ namespace osu.Game.Screens.Play
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            // This is the only usage game-wide of suspension changes.
+            // Assert to ensure we don't accidentally forget this in the future.
+            Debug.Assert(host.AllowScreenSuspension.Value);
 
             isPaused = gameplayClockContainer.IsPaused.GetBoundCopy();
             isPaused.BindValueChanged(paused => host.AllowScreenSuspension.Value = paused.NewValue, true);

--- a/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
+++ b/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+
+namespace osu.Game.Screens.Play
+{
+    internal class ScreenSuspensionHandler : Component
+    {
+        private readonly GameplayClockContainer gameplayClockContainer;
+        private Bindable<bool> isPaused;
+
+        [Resolved]
+        private GameHost host { get; set; }
+
+        public ScreenSuspensionHandler(GameplayClockContainer gameplayClockContainer)
+        {
+            this.gameplayClockContainer = gameplayClockContainer;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            isPaused = gameplayClockContainer.IsPaused.GetBoundCopy();
+            isPaused.BindValueChanged(paused => host.AllowScreenSuspension.Value = paused.NewValue, true);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            isPaused?.UnbindAll();
+
+            if (host != null)
+                host.AllowScreenSuspension.Value = true;
+        }
+    }
+}

--- a/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
+++ b/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -8,7 +10,10 @@ using osu.Framework.Platform;
 
 namespace osu.Game.Screens.Play
 {
-    internal class ScreenSuspensionHandler : Component
+    /// <summary>
+    /// Ensures screen is not suspended / dimmed while gameplay is active.
+    /// </summary>
+    public class ScreenSuspensionHandler : Component
     {
         private readonly GameplayClockContainer gameplayClockContainer;
         private Bindable<bool> isPaused;
@@ -16,9 +21,9 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private GameHost host { get; set; }
 
-        public ScreenSuspensionHandler(GameplayClockContainer gameplayClockContainer)
+        public ScreenSuspensionHandler([NotNull] GameplayClockContainer gameplayClockContainer)
         {
-            this.gameplayClockContainer = gameplayClockContainer;
+            this.gameplayClockContainer = gameplayClockContainer ?? throw new ArgumentNullException(nameof(gameplayClockContainer));
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Adds very basic usage of framework-side implementation. Currently only supported on android and iOS. Wanted to get this in before we completely forget that the framework support exists for it.

- [x] Needs mobile device testing (will do this tomorrow)