### PR TITLE
Make hold note ticks affect combo score rather than bonus

### DIFF
--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
@@ -7,8 +7,6 @@ namespace osu.Game.Rulesets.Mania.Judgements
 {
     public class HoldNoteTickJudgement : ManiaJudgement
     {
-        public override bool AffectsCombo => false;
-
         protected override int NumericResultFor(HitResult result) => 20;
 
         protected override double HealthIncreaseFor(HitResult result)


### PR DESCRIPTION
Since they're required to hit, it makes sense to count them as combo score. This will make mania scores max out at 1mil as expected.