### PR TITLE
Reduce mania's HP drain by 20%

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Rulesets.Mania
 
         public override ScoreProcessor CreateScoreProcessor() => new ManiaScoreProcessor();
 
+        public override HealthProcessor CreateHealthProcessor(double drainStartTime) => new DrainingHealthProcessor(drainStartTime, 0.2);
+
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new ManiaBeatmapConverter(beatmap, this);
 
         public override PerformanceCalculator CreatePerformanceCalculator(WorkingBeatmap beatmap, ScoreInfo score) => new ManiaPerformanceCalculator(this, beatmap, score);

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Rulesets.Scoring
         private double gameplayEndTime;
 
         private readonly double drainStartTime;
+        private readonly double drainLenience;
 
         private readonly List<(double time, double health)> healthIncreases = new List<(double, double)>();
         private double targetMinimumHealth;
@@ -55,9 +56,14 @@ namespace osu.Game.Rulesets.Scoring
         /// Creates a new <see cref="DrainingHealthProcessor"/>.
         /// </summary>
         /// <param name="drainStartTime">The time after which draining should begin.</param>
-        public DrainingHealthProcessor(double drainStartTime)
+        /// <param name="drainLenience">A lenience to apply to the default drain rate.<br />
+        /// A value of 0 uses the default drain rate.<br />
+        /// A value of 0.5 halves the drain rate.<br />
+        /// A value of 1 completely removes drain.</param>
+        public DrainingHealthProcessor(double drainStartTime, double drainLenience = 0)
         {
             this.drainStartTime = drainStartTime;
+            this.drainLenience = drainLenience;
         }
 
         protected override void Update()
@@ -95,6 +101,8 @@ namespace osu.Game.Rulesets.Scoring
             )));
 
             targetMinimumHealth = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.DrainRate, min_health_target, mid_health_target, max_health_target);
+            targetMinimumHealth += drainLenience * (1 - targetMinimumHealth);
+            targetMinimumHealth = Math.Min(1, targetMinimumHealth);
 
             base.ApplyBeatmap(beatmap);
         }

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -101,8 +101,12 @@ namespace osu.Game.Rulesets.Scoring
             )));
 
             targetMinimumHealth = BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.DrainRate, min_health_target, mid_health_target, max_health_target);
+
+            // Add back a portion of the amount of HP to be drained, depending on the lenience requested.
             targetMinimumHealth += drainLenience * (1 - targetMinimumHealth);
-            targetMinimumHealth = Math.Min(1, targetMinimumHealth);
+
+            // Ensure the target HP is within an acceptable range.
+            targetMinimumHealth = Math.Clamp(targetMinimumHealth, 0, 1);
 
             base.ApplyBeatmap(beatmap);
         }


### PR DESCRIPTION
Since stable didn't have any HP drain, mania mappers ramped up the HP drain rate to be harsh via misses.
So I've just uniformly reduced the HP drain by 20% at all levels for now, hoping it'll be enough. This changes the mappings of `(95%, 70%, 30%)` at `(OD0, OD5, OD10)` respectively to `(96%, 76%, 44%)`.