### PR TITLE
Extract abstract hitobject sample test class

### DIFF
--- a/osu.Game.Tests/Gameplay/HitObjectSampleTest.cs
+++ b/osu.Game.Tests/Gameplay/HitObjectSampleTest.cs
@@ -16,7 +16,6 @@ using osu.Game.IO;
 using osu.Game.Rulesets;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
-using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual;
 using osu.Game.Users;
 
@@ -24,6 +23,8 @@ namespace osu.Game.Tests.Gameplay
 {
     public abstract class HitObjectSampleTest : PlayerTestScene
     {
+        protected abstract IResourceStore<byte[]> Resources { get; }
+
         private readonly SkinInfo userSkinInfo = new SkinInfo();
 
         private readonly BeatmapInfo beatmapInfo = new BeatmapInfo
@@ -61,7 +62,7 @@ namespace osu.Game.Tests.Gameplay
 
                 AddStep($"load {filename}", () =>
                 {
-                    using (var reader = new LineBufferedReader(TestResources.OpenResource($"SampleLookups/{filename}")))
+                    using (var reader = new LineBufferedReader(Resources.GetStream($"Resources/SampleLookups/{filename}")))
                         currentTestBeatmap = Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
                 });
             });

--- a/osu.Game.Tests/Gameplay/HitObjectSampleTest.cs
+++ b/osu.Game.Tests/Gameplay/HitObjectSampleTest.cs
@@ -1,0 +1,183 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.IO.Stores;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.IO;
+using osu.Game.Rulesets;
+using osu.Game.Skinning;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Resources;
+using osu.Game.Tests.Visual;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.Gameplay
+{
+    public abstract class HitObjectSampleTest : PlayerTestScene
+    {
+        private readonly SkinInfo userSkinInfo = new SkinInfo();
+
+        private readonly BeatmapInfo beatmapInfo = new BeatmapInfo
+        {
+            BeatmapSet = new BeatmapSetInfo(),
+            Metadata = new BeatmapMetadata
+            {
+                Author = User.SYSTEM_USER
+            }
+        };
+
+        private readonly TestResourceStore userSkinResourceStore = new TestResourceStore();
+        private readonly TestResourceStore beatmapSkinResourceStore = new TestResourceStore();
+        private SkinSourceDependencyContainer dependencies;
+        private IBeatmap currentTestBeatmap;
+        protected override bool HasCustomSteps => true;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+            => new DependencyContainer(dependencies = new SkinSourceDependencyContainer(base.CreateChildDependencies(parent)));
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => currentTestBeatmap;
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
+            => new TestWorkingBeatmap(beatmapInfo, beatmapSkinResourceStore, beatmap, storyboard, Clock, Audio);
+
+        protected void CreateTestWithBeatmap(string filename)
+        {
+            CreateTest(() =>
+            {
+                AddStep("clear performed lookups", () =>
+                {
+                    userSkinResourceStore.PerformedLookups.Clear();
+                    beatmapSkinResourceStore.PerformedLookups.Clear();
+                });
+
+                AddStep($"load {filename}", () =>
+                {
+                    using (var reader = new LineBufferedReader(TestResources.OpenResource($"SampleLookups/{filename}")))
+                        currentTestBeatmap = Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
+                });
+            });
+        }
+
+        protected void SetupSkins(string beatmapFile, string userFile)
+        {
+            AddStep("setup skins", () =>
+            {
+                userSkinInfo.Files = new List<SkinFileInfo>
+                {
+                    new SkinFileInfo
+                    {
+                        Filename = userFile,
+                        FileInfo = new IO.FileInfo { Hash = userFile }
+                    }
+                };
+
+                beatmapInfo.BeatmapSet.Files = new List<BeatmapSetFileInfo>
+                {
+                    new BeatmapSetFileInfo
+                    {
+                        Filename = beatmapFile,
+                        FileInfo = new IO.FileInfo { Hash = beatmapFile }
+                    }
+                };
+
+                // Need to refresh the cached skin source to refresh the skin resource store.
+                dependencies.SkinSource = new SkinProvidingContainer(new LegacySkin(userSkinInfo, userSkinResourceStore, Audio));
+            });
+        }
+
+        protected void AssertBeatmapLookup(string name) => AddAssert($"\"{name}\" looked up from beatmap skin",
+            () => !userSkinResourceStore.PerformedLookups.Contains(name) && beatmapSkinResourceStore.PerformedLookups.Contains(name));
+
+        protected void AssertUserLookup(string name) => AddAssert($"\"{name}\" looked up from user skin",
+            () => !beatmapSkinResourceStore.PerformedLookups.Contains(name) && userSkinResourceStore.PerformedLookups.Contains(name));
+
+        protected class SkinSourceDependencyContainer : IReadOnlyDependencyContainer
+        {
+            public ISkinSource SkinSource;
+
+            private readonly IReadOnlyDependencyContainer fallback;
+
+            public SkinSourceDependencyContainer(IReadOnlyDependencyContainer fallback)
+            {
+                this.fallback = fallback;
+            }
+
+            public object Get(Type type)
+            {
+                if (type == typeof(ISkinSource))
+                    return SkinSource;
+
+                return fallback.Get(type);
+            }
+
+            public object Get(Type type, CacheInfo info)
+            {
+                if (type == typeof(ISkinSource))
+                    return SkinSource;
+
+                return fallback.Get(type, info);
+            }
+
+            public void Inject<T>(T instance) where T : class
+            {
+                // Never used directly
+            }
+        }
+
+        protected class TestResourceStore : IResourceStore<byte[]>
+        {
+            public readonly List<string> PerformedLookups = new List<string>();
+
+            public byte[] Get(string name)
+            {
+                markLookup(name);
+                return Array.Empty<byte>();
+            }
+
+            public Task<byte[]> GetAsync(string name)
+            {
+                markLookup(name);
+                return Task.FromResult(Array.Empty<byte>());
+            }
+
+            public Stream GetStream(string name)
+            {
+                markLookup(name);
+                return new MemoryStream();
+            }
+
+            private void markLookup(string name) => PerformedLookups.Add(name.Substring(name.LastIndexOf(Path.DirectorySeparatorChar) + 1));
+
+            public IEnumerable<string> GetAvailableResources() => Enumerable.Empty<string>();
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private class TestWorkingBeatmap : ClockBackedTestWorkingBeatmap
+        {
+            private readonly BeatmapInfo skinBeatmapInfo;
+            private readonly IResourceStore<byte[]> resourceStore;
+
+            public TestWorkingBeatmap(BeatmapInfo skinBeatmapInfo, IResourceStore<byte[]> resourceStore, IBeatmap beatmap, Storyboard storyboard, IFrameBasedClock referenceClock, AudioManager audio,
+                                      double length = 60000)
+                : base(beatmap, storyboard, referenceClock, audio, length)
+            {
+                this.skinBeatmapInfo = skinBeatmapInfo;
+                this.resourceStore = resourceStore;
+            }
+
+            protected override ISkin GetSkin() => new LegacyBeatmapSkin(skinBeatmapInfo, resourceStore, AudioManager);
+        }
+    }
+}

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
@@ -1,52 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
-using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
-using osu.Framework.Timing;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.Formats;
-using osu.Game.IO;
 using osu.Game.Rulesets;
-using osu.Game.Skinning;
-using osu.Game.Storyboards;
-using osu.Game.Tests.Resources;
-using osu.Game.Tests.Visual.Gameplay;
-using osu.Game.Users;
+using osu.Game.Rulesets.Osu;
 
 namespace osu.Game.Tests.Gameplay
 {
     [HeadlessTest]
-    public class TestSceneHitObjectSamples : OsuPlayerTestScene
+    public class TestSceneHitObjectSamples : HitObjectSampleTest
     {
-        private readonly SkinInfo userSkinInfo = new SkinInfo();
-
-        private readonly BeatmapInfo beatmapInfo = new BeatmapInfo
-        {
-            BeatmapSet = new BeatmapSetInfo(),
-            Metadata = new BeatmapMetadata
-            {
-                Author = User.SYSTEM_USER
-            }
-        };
-
-        private readonly TestResourceStore userSkinResourceStore = new TestResourceStore();
-        private readonly TestResourceStore beatmapSkinResourceStore = new TestResourceStore();
-
-        protected override bool HasCustomSteps => true;
-
-        private SkinSourceDependencyContainer dependencies;
-
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-            => new DependencyContainer(dependencies = new SkinSourceDependencyContainer(base.CreateChildDependencies(parent)));
+        protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
 
         /// <summary>
         /// Tests that a hitobject which provides no custom sample set retrieves samples from the user skin.
@@ -56,11 +21,11 @@ namespace osu.Game.Tests.Gameplay
         {
             const string expected_sample = "normal-hitnormal";
 
-            setupSkins(expected_sample, expected_sample);
+            SetupSkins(expected_sample, expected_sample);
 
-            createTestWithBeatmap("hitobject-skin-sample.osu");
+            CreateTestWithBeatmap("hitobject-skin-sample.osu");
 
-            assertUserLookup(expected_sample);
+            AssertUserLookup(expected_sample);
         }
 
         /// <summary>
@@ -71,11 +36,11 @@ namespace osu.Game.Tests.Gameplay
         {
             const string expected_sample = "normal-hitnormal";
 
-            setupSkins(expected_sample, expected_sample);
+            SetupSkins(expected_sample, expected_sample);
 
-            createTestWithBeatmap("hitobject-beatmap-sample.osu");
+            CreateTestWithBeatmap("hitobject-beatmap-sample.osu");
 
-            assertBeatmapLookup(expected_sample);
+            AssertBeatmapLookup(expected_sample);
         }
 
         /// <summary>
@@ -86,11 +51,11 @@ namespace osu.Game.Tests.Gameplay
         {
             const string expected_sample = "normal-hitnormal";
 
-            setupSkins(null, expected_sample);
+            SetupSkins(null, expected_sample);
 
-            createTestWithBeatmap("hitobject-beatmap-sample.osu");
+            CreateTestWithBeatmap("hitobject-beatmap-sample.osu");
 
-            assertUserLookup(expected_sample);
+            AssertUserLookup(expected_sample);
         }
 
         /// <summary>
@@ -102,11 +67,11 @@ namespace osu.Game.Tests.Gameplay
         [TestCase("normal-hitnormal")]
         public void TestDefaultCustomSampleFromBeatmap(string expectedSample)
         {
-            setupSkins(expectedSample, expectedSample);
+            SetupSkins(expectedSample, expectedSample);
 
-            createTestWithBeatmap("hitobject-beatmap-custom-sample.osu");
+            CreateTestWithBeatmap("hitobject-beatmap-custom-sample.osu");
 
-            assertBeatmapLookup(expectedSample);
+            AssertBeatmapLookup(expectedSample);
         }
 
         /// <summary>
@@ -118,11 +83,11 @@ namespace osu.Game.Tests.Gameplay
         [TestCase("normal-hitnormal")]
         public void TestDefaultCustomSampleFromUserSkinFallback(string expectedSample)
         {
-            setupSkins(string.Empty, expectedSample);
+            SetupSkins(string.Empty, expectedSample);
 
-            createTestWithBeatmap("hitobject-beatmap-custom-sample.osu");
+            CreateTestWithBeatmap("hitobject-beatmap-custom-sample.osu");
 
-            assertUserLookup(expectedSample);
+            AssertUserLookup(expectedSample);
         }
 
         /// <summary>
@@ -133,11 +98,11 @@ namespace osu.Game.Tests.Gameplay
         {
             const string expected_sample = "hit_1.wav";
 
-            setupSkins(expected_sample, expected_sample);
+            SetupSkins(expected_sample, expected_sample);
 
-            createTestWithBeatmap("file-beatmap-sample.osu");
+            CreateTestWithBeatmap("file-beatmap-sample.osu");
 
-            assertBeatmapLookup(expected_sample);
+            AssertBeatmapLookup(expected_sample);
         }
 
         /// <summary>
@@ -148,11 +113,11 @@ namespace osu.Game.Tests.Gameplay
         {
             const string expected_sample = "normal-hitnormal";
 
-            setupSkins(expected_sample, expected_sample);
+            SetupSkins(expected_sample, expected_sample);
 
-            createTestWithBeatmap("controlpoint-skin-sample.osu");
+            CreateTestWithBeatmap("controlpoint-skin-sample.osu");
 
-            assertUserLookup(expected_sample);
+            AssertUserLookup(expected_sample);
         }
 
         /// <summary>
@@ -163,11 +128,11 @@ namespace osu.Game.Tests.Gameplay
         {
             const string expected_sample = "normal-hitnormal";
 
-            setupSkins(expected_sample, expected_sample);
+            SetupSkins(expected_sample, expected_sample);
 
-            createTestWithBeatmap("controlpoint-beatmap-sample.osu");
+            CreateTestWithBeatmap("controlpoint-beatmap-sample.osu");
 
-            assertBeatmapLookup(expected_sample);
+            AssertBeatmapLookup(expected_sample);
         }
 
         /// <summary>
@@ -177,11 +142,11 @@ namespace osu.Game.Tests.Gameplay
         [TestCase("normal-hitnormal")]
         public void TestControlPointCustomSampleFromBeatmap(string sampleName)
         {
-            setupSkins(sampleName, sampleName);
+            SetupSkins(sampleName, sampleName);
 
-            createTestWithBeatmap("controlpoint-beatmap-custom-sample.osu");
+            CreateTestWithBeatmap("controlpoint-beatmap-custom-sample.osu");
 
-            assertBeatmapLookup(sampleName);
+            AssertBeatmapLookup(sampleName);
         }
 
         /// <summary>
@@ -192,149 +157,11 @@ namespace osu.Game.Tests.Gameplay
         {
             const string expected_sample = "normal-hitnormal3";
 
-            setupSkins(expected_sample, expected_sample);
+            SetupSkins(expected_sample, expected_sample);
 
-            createTestWithBeatmap("hitobject-beatmap-custom-sample-override.osu");
+            CreateTestWithBeatmap("hitobject-beatmap-custom-sample-override.osu");
 
-            assertBeatmapLookup(expected_sample);
-        }
-
-        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => currentTestBeatmap;
-
-        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
-            => new TestWorkingBeatmap(beatmapInfo, beatmapSkinResourceStore, beatmap, storyboard, Clock, Audio);
-
-        private IBeatmap currentTestBeatmap;
-
-        private void createTestWithBeatmap(string filename)
-        {
-            CreateTest(() =>
-            {
-                AddStep("clear performed lookups", () =>
-                {
-                    userSkinResourceStore.PerformedLookups.Clear();
-                    beatmapSkinResourceStore.PerformedLookups.Clear();
-                });
-
-                AddStep($"load {filename}", () =>
-                {
-                    using (var reader = new LineBufferedReader(TestResources.OpenResource($"SampleLookups/{filename}")))
-                        currentTestBeatmap = Decoder.GetDecoder<Beatmap>(reader).Decode(reader);
-                });
-            });
-        }
-
-        private void setupSkins(string beatmapFile, string userFile)
-        {
-            AddStep("setup skins", () =>
-            {
-                userSkinInfo.Files = new List<SkinFileInfo>
-                {
-                    new SkinFileInfo
-                    {
-                        Filename = userFile,
-                        FileInfo = new IO.FileInfo { Hash = userFile }
-                    }
-                };
-
-                beatmapInfo.BeatmapSet.Files = new List<BeatmapSetFileInfo>
-                {
-                    new BeatmapSetFileInfo
-                    {
-                        Filename = beatmapFile,
-                        FileInfo = new IO.FileInfo { Hash = beatmapFile }
-                    }
-                };
-
-                // Need to refresh the cached skin source to refresh the skin resource store.
-                dependencies.SkinSource = new SkinProvidingContainer(new LegacySkin(userSkinInfo, userSkinResourceStore, Audio));
-            });
-        }
-
-        private void assertBeatmapLookup(string name) => AddAssert($"\"{name}\" looked up from beatmap skin",
-            () => !userSkinResourceStore.PerformedLookups.Contains(name) && beatmapSkinResourceStore.PerformedLookups.Contains(name));
-
-        private void assertUserLookup(string name) => AddAssert($"\"{name}\" looked up from user skin",
-            () => !beatmapSkinResourceStore.PerformedLookups.Contains(name) && userSkinResourceStore.PerformedLookups.Contains(name));
-
-        private class SkinSourceDependencyContainer : IReadOnlyDependencyContainer
-        {
-            public ISkinSource SkinSource;
-
-            private readonly IReadOnlyDependencyContainer fallback;
-
-            public SkinSourceDependencyContainer(IReadOnlyDependencyContainer fallback)
-            {
-                this.fallback = fallback;
-            }
-
-            public object Get(Type type)
-            {
-                if (type == typeof(ISkinSource))
-                    return SkinSource;
-
-                return fallback.Get(type);
-            }
-
-            public object Get(Type type, CacheInfo info)
-            {
-                if (type == typeof(ISkinSource))
-                    return SkinSource;
-
-                return fallback.Get(type, info);
-            }
-
-            public void Inject<T>(T instance) where T : class
-            {
-                // Never used directly
-            }
-        }
-
-        private class TestResourceStore : IResourceStore<byte[]>
-        {
-            public readonly List<string> PerformedLookups = new List<string>();
-
-            public byte[] Get(string name)
-            {
-                markLookup(name);
-                return Array.Empty<byte>();
-            }
-
-            public Task<byte[]> GetAsync(string name)
-            {
-                markLookup(name);
-                return Task.FromResult(Array.Empty<byte>());
-            }
-
-            public Stream GetStream(string name)
-            {
-                markLookup(name);
-                return new MemoryStream();
-            }
-
-            private void markLookup(string name) => PerformedLookups.Add(name.Substring(name.LastIndexOf(Path.DirectorySeparatorChar) + 1));
-
-            public IEnumerable<string> GetAvailableResources() => Enumerable.Empty<string>();
-
-            public void Dispose()
-            {
-            }
-        }
-
-        private class TestWorkingBeatmap : ClockBackedTestWorkingBeatmap
-        {
-            private readonly BeatmapInfo skinBeatmapInfo;
-            private readonly IResourceStore<byte[]> resourceStore;
-
-            public TestWorkingBeatmap(BeatmapInfo skinBeatmapInfo, IResourceStore<byte[]> resourceStore, IBeatmap beatmap, Storyboard storyboard, IFrameBasedClock referenceClock, AudioManager audio,
-                                      double length = 60000)
-                : base(beatmap, storyboard, referenceClock, audio, length)
-            {
-                this.skinBeatmapInfo = skinBeatmapInfo;
-                this.resourceStore = resourceStore;
-            }
-
-            protected override ISkin GetSkin() => new LegacyBeatmapSkin(skinBeatmapInfo, resourceStore, AudioManager);
+            AssertBeatmapLookup(expected_sample);
         }
     }
 }

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Gameplay
 {
@@ -12,6 +14,7 @@ namespace osu.Game.Tests.Gameplay
     public class TestSceneHitObjectSamples : HitObjectSampleTest
     {
         protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
+        protected override IResourceStore<byte[]> Resources => TestResources.GetStore();
 
         /// <summary>
         /// Tests that a hitobject which provides no custom sample set retrieves samples from the user skin.

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
@@ -6,6 +6,7 @@ using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Gameplay

--- a/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
+++ b/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
@@ -19,7 +19,7 @@ using osu.Game.Storyboards;
 using osu.Game.Tests.Visual;
 using osu.Game.Users;
 
-namespace osu.Game.Tests.Gameplay
+namespace osu.Game.Tests.Beatmaps
 {
     public abstract class HitObjectSampleTest : PlayerTestScene
     {

--- a/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
+++ b/osu.Game/Tests/Beatmaps/HitObjectSampleTest.cs
@@ -40,14 +40,14 @@ namespace osu.Game.Tests.Beatmaps
         private readonly TestResourceStore beatmapSkinResourceStore = new TestResourceStore();
         private SkinSourceDependencyContainer dependencies;
         private IBeatmap currentTestBeatmap;
-        protected override bool HasCustomSteps => true;
+        protected sealed override bool HasCustomSteps => true;
 
-        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        protected sealed override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             => new DependencyContainer(dependencies = new SkinSourceDependencyContainer(base.CreateChildDependencies(parent)));
 
-        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => currentTestBeatmap;
+        protected sealed override IBeatmap CreateBeatmap(RulesetInfo ruleset) => currentTestBeatmap;
 
-        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
+        protected sealed override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
             => new TestWorkingBeatmap(beatmapInfo, beatmapSkinResourceStore, beatmap, storyboard, Clock, Audio);
 
         protected void CreateTestWithBeatmap(string filename)
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Beatmaps
         protected void AssertUserLookup(string name) => AddAssert($"\"{name}\" looked up from user skin",
             () => !beatmapSkinResourceStore.PerformedLookups.Contains(name) && userSkinResourceStore.PerformedLookups.Contains(name));
 
-        protected class SkinSourceDependencyContainer : IReadOnlyDependencyContainer
+        private class SkinSourceDependencyContainer : IReadOnlyDependencyContainer
         {
             public ISkinSource SkinSource;
 
@@ -134,7 +134,7 @@ namespace osu.Game.Tests.Beatmaps
             }
         }
 
-        protected class TestResourceStore : IResourceStore<byte[]>
+        private class TestResourceStore : IResourceStore<byte[]>
         {
             public readonly List<string> PerformedLookups = new List<string>();
 


### PR DESCRIPTION
Step 2 towards addressing ppy/osu#8595.

# Summary

To add tests for the mania-specific handling of layered hit sounds, I needed a way to switch the ruleset. The previously-existing `TestSceneHitObjectSamples` was 99% of what I needed, but used `OsuRuleset`.

Seeing that I needed another class anyway, I decided to do things "by the book" and follow the path of `BeatmapConversionTest` *et al.*, by splitting the necessary glue code to a superclass (which got moved to `osu.Game`, to the `Testing` namespace), and then subclassing the existing test to leverage it.

# Remarks

I did not move `TestSceneHitObjectSamples` to the osu! ruleset test project, as the existing test cases are general enough to remain in the main one. This should continue to be the case once the actual implementation of layered hit sounds lands.

Some care had to be taken when it comes to the resource handling, as the end goal was to reuse `HitObjectSampleTest` in the mania test project with its local resources, hence the abstract `Resources`.

This will probably review horribly, which is why I split this. Commit-by-commit might be better.