### PR TITLE
Extract base legacy skin transformer

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchSkinColourDecodingTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchSkinColourDecodingTest.cs
@@ -17,7 +17,8 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             var store = new NamespacedResourceStore<byte[]>(new DllResourceStore(GetType().Assembly), "Resources/special-skin");
             var rawSkin = new TestLegacySkin(new SkinInfo { Name = "special-skin" }, store);
-            var skin = new CatchLegacySkinTransformer(rawSkin);
+            var skinSource = new SkinProvidingContainer(rawSkin);
+            var skin = new CatchLegacySkinTransformer(skinSource);
 
             Assert.AreEqual(new Color4(232, 185, 35, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value);
             Assert.AreEqual(new Color4(232, 74, 35, 255), skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value);

--- a/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
@@ -2,26 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Humanizer;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Audio;
 using osu.Game.Skinning;
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Skinning
 {
-    public class CatchLegacySkinTransformer : ISkin
+    public class CatchLegacySkinTransformer : LegacySkinTransformer
     {
-        private readonly ISkin source;
-
-        public CatchLegacySkinTransformer(ISkin source)
+        public CatchLegacySkinTransformer(ISkinSource source)
+            : base(source)
         {
-            this.source = source;
         }
 
-        public Drawable GetDrawableComponent(ISkinComponent component)
+        public override Drawable GetDrawableComponent(ISkinComponent component)
         {
             if (!(component is CatchSkinComponent catchSkinComponent))
                 return null;
@@ -61,19 +56,15 @@ namespace osu.Game.Rulesets.Catch.Skinning
             return null;
         }
 
-        public Texture GetTexture(string componentName) => source.GetTexture(componentName);
-
-        public SampleChannel GetSample(ISampleInfo sample) => source.GetSample(sample);
-
-        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
+        public override IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
         {
             switch (lookup)
             {
                 case CatchSkinColour colour:
-                    return source.GetConfig<SkinCustomColourLookup, TValue>(new SkinCustomColourLookup(colour));
+                    return Source.GetConfig<SkinCustomColourLookup, TValue>(new SkinCustomColourLookup(colour));
             }
 
-            return source.GetConfig<TLookup, TValue>(lookup);
+            return Source.GetConfig<TLookup, TValue>(lookup);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/ManiaLegacySkinTransformer.cs
@@ -3,11 +3,8 @@
 
 using System;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Textures;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Skinning;
@@ -15,9 +12,8 @@ using System.Collections.Generic;
 
 namespace osu.Game.Rulesets.Mania.Skinning
 {
-    public class ManiaLegacySkinTransformer : ISkin
+    public class ManiaLegacySkinTransformer : LegacySkinTransformer
     {
-        private readonly ISkin source;
         private readonly ManiaBeatmap beatmap;
 
         /// <summary>
@@ -59,23 +55,23 @@ namespace osu.Game.Rulesets.Mania.Skinning
         private Lazy<bool> hasKeyTexture;
 
         public ManiaLegacySkinTransformer(ISkinSource source, IBeatmap beatmap)
+            : base(source)
         {
-            this.source = source;
             this.beatmap = (ManiaBeatmap)beatmap;
 
-            source.SourceChanged += sourceChanged;
+            Source.SourceChanged += sourceChanged;
             sourceChanged();
         }
 
         private void sourceChanged()
         {
-            isLegacySkin = new Lazy<bool>(() => source.GetConfig<LegacySkinConfiguration.LegacySetting, decimal>(LegacySkinConfiguration.LegacySetting.Version) != null);
-            hasKeyTexture = new Lazy<bool>(() => source.GetAnimation(
+            isLegacySkin = new Lazy<bool>(() => Source.GetConfig<LegacySkinConfiguration.LegacySetting, decimal>(LegacySkinConfiguration.LegacySetting.Version) != null);
+            hasKeyTexture = new Lazy<bool>(() => Source.GetAnimation(
                 this.GetManiaSkinConfig<string>(LegacyManiaSkinConfigurationLookups.KeyImage, 0)?.Value
                 ?? "mania-key1", true, true) != null);
         }
 
-        public Drawable GetDrawableComponent(ISkinComponent component)
+        public override Drawable GetDrawableComponent(ISkinComponent component)
         {
             switch (component)
             {
@@ -133,16 +129,12 @@ namespace osu.Game.Rulesets.Mania.Skinning
             return this.GetAnimation(filename, true, true);
         }
 
-        public Texture GetTexture(string componentName) => source.GetTexture(componentName);
-
-        public SampleChannel GetSample(ISampleInfo sample) => source.GetSample(sample);
-
-        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
+        public override IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
         {
             if (lookup is ManiaSkinConfigurationLookup maniaLookup)
-                return source.GetConfig<LegacyManiaSkinConfigurationLookup, TValue>(new LegacyManiaSkinConfigurationLookup(beatmap.TotalColumns, maniaLookup.Lookup, maniaLookup.TargetColumn));
+                return Source.GetConfig<LegacyManiaSkinConfigurationLookup, TValue>(new LegacyManiaSkinConfigurationLookup(beatmap.TotalColumns, maniaLookup.Lookup, maniaLookup.TargetColumn));
 
-            return source.GetConfig<TLookup, TValue>(lookup);
+            return Source.GetConfig<TLookup, TValue>(lookup);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -2,20 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Audio;
 using osu.Game.Skinning;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Skinning
 {
-    public class OsuLegacySkinTransformer : ISkin
+    public class OsuLegacySkinTransformer : LegacySkinTransformer
     {
-        private readonly ISkin source;
-
         private Lazy<bool> hasHitCircle;
 
         /// <summary>
@@ -26,19 +21,18 @@ namespace osu.Game.Rulesets.Osu.Skinning
         public const float LEGACY_CIRCLE_RADIUS = 64 - 5;
 
         public OsuLegacySkinTransformer(ISkinSource source)
+            : base(source)
         {
-            this.source = source;
-
-            source.SourceChanged += sourceChanged;
+            Source.SourceChanged += sourceChanged;
             sourceChanged();
         }
 
         private void sourceChanged()
         {
-            hasHitCircle = new Lazy<bool>(() => source.GetTexture("hitcircle") != null);
+            hasHitCircle = new Lazy<bool>(() => Source.GetTexture("hitcircle") != null);
         }
 
-        public Drawable GetDrawableComponent(ISkinComponent component)
+        public override Drawable GetDrawableComponent(ISkinComponent component)
         {
             if (!(component is OsuSkinComponent osuComponent))
                 return null;
@@ -85,13 +79,13 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     return null;
 
                 case OsuSkinComponents.Cursor:
-                    if (source.GetTexture("cursor") != null)
+                    if (Source.GetTexture("cursor") != null)
                         return new LegacyCursor();
 
                     return null;
 
                 case OsuSkinComponents.CursorTrail:
-                    if (source.GetTexture("cursortrail") != null)
+                    if (Source.GetTexture("cursortrail") != null)
                         return new LegacyCursorTrail();
 
                     return null;
@@ -102,7 +96,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
                     return !hasFont(font)
                         ? null
-                        : new LegacySpriteText(source, font)
+                        : new LegacySpriteText(Source, font)
                         {
                             // stable applies a blanket 0.8x scale to hitcircle fonts
                             Scale = new Vector2(0.8f),
@@ -113,16 +107,12 @@ namespace osu.Game.Rulesets.Osu.Skinning
             return null;
         }
 
-        public Texture GetTexture(string componentName) => source.GetTexture(componentName);
-
-        public SampleChannel GetSample(ISampleInfo sample) => source.GetSample(sample);
-
-        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
+        public override IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup)
         {
             switch (lookup)
             {
                 case OsuSkinColour colour:
-                    return source.GetConfig<SkinCustomColourLookup, TValue>(new SkinCustomColourLookup(colour));
+                    return Source.GetConfig<SkinCustomColourLookup, TValue>(new SkinCustomColourLookup(colour));
 
                 case OsuSkinConfiguration osuLookup:
                     switch (osuLookup)
@@ -136,16 +126,16 @@ namespace osu.Game.Rulesets.Osu.Skinning
                         case OsuSkinConfiguration.HitCircleOverlayAboveNumber:
                             // See https://osu.ppy.sh/help/wiki/Skinning/skin.ini#%5Bgeneral%5D
                             // HitCircleOverlayAboveNumer (with typo) should still be supported for now.
-                            return source.GetConfig<OsuSkinConfiguration, TValue>(OsuSkinConfiguration.HitCircleOverlayAboveNumber) ??
-                                   source.GetConfig<OsuSkinConfiguration, TValue>(OsuSkinConfiguration.HitCircleOverlayAboveNumer);
+                            return Source.GetConfig<OsuSkinConfiguration, TValue>(OsuSkinConfiguration.HitCircleOverlayAboveNumber) ??
+                                   Source.GetConfig<OsuSkinConfiguration, TValue>(OsuSkinConfiguration.HitCircleOverlayAboveNumer);
                     }
 
                     break;
             }
 
-            return source.GetConfig<TLookup, TValue>(lookup);
+            return Source.GetConfig<TLookup, TValue>(lookup);
         }
 
-        private bool hasFont(string fontName) => source.GetTexture($"{fontName}-0") != null;
+        private bool hasFont(string fontName) => Source.GetTexture($"{fontName}-0") != null;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -6,23 +6,20 @@ using System.Collections.Generic;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Skinning
 {
-    public class TaikoLegacySkinTransformer : ISkin
+    public class TaikoLegacySkinTransformer : LegacySkinTransformer
     {
-        private readonly ISkinSource source;
-
         public TaikoLegacySkinTransformer(ISkinSource source)
+            : base(source)
         {
-            this.source = source;
         }
 
-        public Drawable GetDrawableComponent(ISkinComponent component)
+        public override Drawable GetDrawableComponent(ISkinComponent component)
         {
             if (!(component is TaikoSkinComponent taikoComponent))
                 return null;
@@ -100,7 +97,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                     return null;
             }
 
-            return source.GetDrawableComponent(component);
+            return Source.GetDrawableComponent(component);
         }
 
         private string getHitName(TaikoSkinComponents component)
@@ -120,11 +117,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
             throw new ArgumentOutOfRangeException(nameof(component), "Invalid result type");
         }
 
-        public Texture GetTexture(string componentName) => source.GetTexture(componentName);
+        public override SampleChannel GetSample(ISampleInfo sampleInfo) => Source.GetSample(new LegacyTaikoSampleInfo(sampleInfo));
 
-        public SampleChannel GetSample(ISampleInfo sampleInfo) => source.GetSample(new LegacyTaikoSampleInfo(sampleInfo));
-
-        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => source.GetConfig<TLookup, TValue>(lookup);
+        public override IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => Source.GetConfig<TLookup, TValue>(lookup);
 
         private class LegacyTaikoSampleInfo : ISampleInfo
         {

--- a/osu.Game/Skinning/LegacySkinTransformer.cs
+++ b/osu.Game/Skinning/LegacySkinTransformer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Audio;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// Transformer used to handle support of legacy features for individual rulesets.
+    /// </summary>
+    public abstract class LegacySkinTransformer : ISkin
+    {
+        /// <summary>
+        /// Source of the <see cref="ISkin"/> which is being transformed.
+        /// </summary>
+        protected ISkinSource Source { get; }
+
+        protected LegacySkinTransformer(ISkinSource source)
+        {
+            Source = source;
+        }
+
+        public abstract Drawable GetDrawableComponent(ISkinComponent component);
+
+        public Texture GetTexture(string componentName) => Source.GetTexture(componentName);
+
+        public virtual SampleChannel GetSample(ISampleInfo sampleInfo) => Source.GetSample(sampleInfo);
+
+        public abstract IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup);
+    }
+}


### PR DESCRIPTION
Step 3 towards addressing #8595.

- [x] Depends on #9333.

# Summary

Once I took the direction of handling layered hit sounds in legacy skin transformers, it became apparent that two rulesets (namely osu! and osu!catch) would be sharing the same non-trivial logic in `GetSample()` (which is, play non-layered samples always, and layered samples only if the skin option isn't explicitly turned off - otherwise return a virtual channel).

Up until now skin transformers had a very similar interface (by the virtue of adhering to `ISkin`), but there wasn't really much reason to unify them in any way; even though they had the same implementation of `GetTexture`, it was just proxying.

To avoid duplication when handling layered hitsounds, this PR extracts a base legacy skin transformer, to which the "standard" (2/4 rulesets) layered sample handling logic can be applied, and which any ruleset can override at its leisure (which taiko already does and mania will also do).

# Remarks

I am quite unsure of this change, code-wise. Aside from being a refactoring to a major visual part which makes me uneasy (although it *should* be fine and I proofread it several times, for however little that is worth), if I was writing this code on a personal project, I would have probably gone for composition over inheritance, but that seems non-idiomatic in the codebase here, so I'm mostly trying to follow suit.

Step 4 to add layered hit sounds looks very close to ready and likely to be the last - I've [pushed the branch with what I have right now](https://github.com/bdach/osu/compare/base-legacy-skin-transformer...bdach:layered-hit-sounds), but I'd like to give it one more evening of scrutiny before I PR it (possibly with more tests) as there is a surprising number of edge-cases to consider. I figure all three changes introduced thus far should stand on their own as to their usefulness.