### PR TITLE
Fix 1M score being possible with only GREATs in mania

### DIFF
--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -25,8 +25,10 @@ namespace osu.Game.Rulesets.Mania.Judgements
                     return 200;
 
                 case HitResult.Great:
-                case HitResult.Perfect:
                     return 300;
+
+                case HitResult.Perfect:
+                    return 320;
             }
         }
     }


### PR DESCRIPTION
I think this is from a time when standardised scoring wasn't really implemented yet, where the concept of combo and accuracy numeric scores were different.

This is a bit harsher than SV2 mania which only awards 305 for PERFECT but I don't see this as a bad thing especially since mania players care more about accuracy than combo.