### PR TITLE
Only fadeout beatmap metadata when it's visible and required

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -331,7 +331,7 @@ namespace osu.Game.Screens.Select
                 {
                     if (string.IsNullOrEmpty(value))
                     {
-                        this.FadeOut(transition_duration);
+                        this.Hide();
                         return;
                     }
 

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -331,7 +331,13 @@ namespace osu.Game.Screens.Select
                 {
                     if (string.IsNullOrEmpty(value))
                     {
-                        this.Hide();
+                        if (Height > 0)
+                        {
+                            this.FadeOut(transition_duration);
+                            return;
+                        }
+
+                        Hide();
                         return;
                     }
 


### PR DESCRIPTION
This fixes #9335.
When the title of Beatmap Details Metadata was empty, it would display the container and then fade it out, resulting in the bouncing animation.
Changing `this.FadeOut();` to `this.Hide();` was everything needed.