### PR TITLE
Increase coordinate parsing limits

### DIFF
--- a/osu.Game/Beatmaps/Formats/Parsing.cs
+++ b/osu.Game/Beatmaps/Formats/Parsing.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Beatmaps.Formats
     /// </summary>
     public static class Parsing
     {
-        public const int MAX_COORDINATE_VALUE = 65536;
+        public const int MAX_COORDINATE_VALUE = 131072;
 
         public const double MAX_PARSE_VALUE = int.MaxValue;
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/9342

Technically, we could forego these limits now that we have cancellable beatmap loads, but stable will need the same limit.

For @peppy , probably need to recompute SR of https://osu.ppy.sh/beatmapsets/944317#fruits/1972149 (from 5.89* to 6.04*).