### PR TITLE
Fix colours with 0 alpha being invisible in legacy skins

### DIFF
--- a/osu.Game.Tests/Resources/skin-zero-alpha-colour.ini
+++ b/osu.Game.Tests/Resources/skin-zero-alpha-colour.ini
@@ -1,0 +1,5 @@
+[General]
+Version: latest
+
+[Colours]
+Combo1: 255,255,255,0

--- a/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
@@ -108,5 +108,15 @@ namespace osu.Game.Tests.Skins
             using (var stream = new LineBufferedReader(resStream))
                 Assert.That(decoder.Decode(stream).LegacyVersion, Is.EqualTo(1.0m));
         }
+
+        [Test]
+        public void TestDecodeColourWithZeroAlpha()
+        {
+            var decoder = new LegacySkinDecoder();
+
+            using (var resStream = TestResources.OpenResource("skin-zero-alpha-colour.ini"))
+            using (var stream = new LineBufferedReader(resStream))
+                Assert.That(decoder.Decode(stream).ComboColours[0].A, Is.EqualTo(1.0f));
+        }
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -103,7 +103,12 @@ namespace osu.Game.Beatmaps.Formats
 
             try
             {
-                colour = new Color4(byte.Parse(split[0]), byte.Parse(split[1]), byte.Parse(split[2]), split.Length == 4 ? byte.Parse(split[3]) : (byte)255);
+                byte alpha = split.Length == 4 ? byte.Parse(split[3]) : (byte)255;
+
+                if (alpha == 0)
+                    alpha = 255;
+
+                colour = new Color4(byte.Parse(split[0]), byte.Parse(split[1]), byte.Parse(split[2]), alpha);
             }
             catch
             {

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Skinning
             if (!source.CustomColours.TryGetValue(lookup, out var col))
                 return null;
 
-            if (col.A == 0)
+            if (col.A <= 0 || col.A >= 255)
                 col.A = 1;
 
             return new Bindable<Color4>(col);

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Skinning
             if (!source.CustomColours.TryGetValue(lookup, out var col))
                 return null;
 
-            if (col.A <= 0 || col.A >= 255)
+            if (col.A <= 0 || col.A >= 1)
                 col.A = 1;
 
             return new Bindable<Color4>(col);

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -271,7 +271,15 @@ namespace osu.Game.Skinning
         }
 
         private IBindable<Color4> getCustomColour(IHasCustomColours source, string lookup)
-            => source.CustomColours.TryGetValue(lookup, out var col) ? new Bindable<Color4>(col) : null;
+        {
+            if (!source.CustomColours.TryGetValue(lookup, out var col))
+                return null;
+
+            if (col.A == 0)
+                col.A = 1;
+
+            return new Bindable<Color4>(col);
+        }
 
         private IBindable<string> getManiaImage(LegacyManiaSkinConfiguration source, string lookup)
             => source.ImageLookups.TryGetValue(lookup, out var image) ? new Bindable<string>(image) : null;

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -271,15 +271,7 @@ namespace osu.Game.Skinning
         }
 
         private IBindable<Color4> getCustomColour(IHasCustomColours source, string lookup)
-        {
-            if (!source.CustomColours.TryGetValue(lookup, out var col))
-                return null;
-
-            if (col.A <= 0 || col.A >= 1)
-                col.A = 1;
-
-            return new Bindable<Color4>(col);
-        }
+            => source.CustomColours.TryGetValue(lookup, out var col) ? new Bindable<Color4>(col) : null;
 
         private IBindable<string> getManiaImage(LegacyManiaSkinConfiguration source, string lookup)
             => source.ImageLookups.TryGetValue(lookup, out var image) ? new Bindable<string>(image) : null;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9306

For some reason stable ignores the alpha of colours with `A <= 0` and `A >= 255`. ¯\\_(ツ)_/¯