### PR TITLE
Restore key repeat functionality to the song select carousel

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -17,11 +17,12 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
     [TestFixture]
-    public class TestSceneBeatmapCarousel : OsuTestScene
+    public class TestSceneBeatmapCarousel : OsuManualInputManagerTestScene
     {
         private TestBeatmapCarousel carousel;
         private RulesetStore rulesets;
@@ -37,6 +38,43 @@ namespace osu.Game.Tests.Visual.SongSelect
         private void load(RulesetStore rulesets)
         {
             this.rulesets = rulesets;
+        }
+
+        [Test]
+        public void TestKeyRepeat()
+        {
+            loadBeatmaps();
+            advanceSelection(false);
+
+            AddStep("press down arrow", () => InputManager.PressKey(Key.Down));
+
+            BeatmapInfo selection = null;
+
+            checkSelectionIterating(true);
+
+            AddStep("press up arrow", () => InputManager.PressKey(Key.Up));
+
+            checkSelectionIterating(true);
+
+            AddStep("release down arrow", () => InputManager.ReleaseKey(Key.Down));
+
+            checkSelectionIterating(true);
+
+            AddStep("release up arrow", () => InputManager.ReleaseKey(Key.Up));
+
+            checkSelectionIterating(false);
+
+            void checkSelectionIterating(bool isIterating)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    AddStep("store selection", () => selection = carousel.SelectedBeatmap);
+                    if (isIterating)
+                        AddUntilStep("selection changed", () => carousel.SelectedBeatmap != selection);
+                    else
+                        AddUntilStep("selection not changed", () => carousel.SelectedBeatmap == selection);
+                }
+            }
         }
 
         [Test]

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -279,9 +279,6 @@ namespace osu.Game.Screens.Select
         /// <param name="skipDifficulties">Whether to skip individual difficulties and only increment over full groups.</param>
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
-            if (selectedBeatmap == null)
-                return;
-
             if (beatmapSets.All(s => s.Filtered.Value))
                 return;
 
@@ -305,6 +302,9 @@ namespace osu.Game.Screens.Select
 
         private void selectNextDifficulty(int direction)
         {
+            if (selectedBeatmap == null)
+                return;
+
             var unfilteredDifficulties = selectedBeatmapSet.Children.Where(s => !s.Filtered.Value).ToList();
 
             int index = unfilteredDifficulties.IndexOf(selectedBeatmap);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -279,6 +279,9 @@ namespace osu.Game.Screens.Select
         /// <param name="skipDifficulties">Whether to skip individual difficulties and only increment over full groups.</param>
         public void SelectNext(int direction = 1, bool skipDifficulties = true)
         {
+            if (selectedBeatmap == null)
+                return;
+
             if (beatmapSets.All(s => s.Filtered.Value))
                 return;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -19,6 +19,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
+using osu.Game.Extensions;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Input.Bindings;
@@ -527,7 +528,7 @@ namespace osu.Game.Screens.Select
             endRepeatSelection();
 
             lastRepeatSource = source;
-            Scheduler.Add(repeatDelegate = new ScheduledDelegate(action, Time.Current, repeat_interval));
+            Scheduler.Add(repeatDelegate = this.BeginKeyRepeat(Scheduler, action));
         }
 
         private void endRepeatSelection(object source = null)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -452,20 +452,37 @@ namespace osu.Game.Screens.Select
         /// </summary>
         public void ScrollToSelected() => scrollPositionCache.Invalidate();
 
+        #region Key / button selection logic
+
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             switch (e.Key)
             {
                 case Key.Left:
-                    SelectNext(-1, true);
+                    if (!e.Repeat)
+                        beginRepeatSelection(() => SelectNext(-1, true), e.Key);
                     return true;
 
                 case Key.Right:
-                    SelectNext(1, true);
+                    if (!e.Repeat)
+                        beginRepeatSelection(() => SelectNext(1, true), e.Key);
                     return true;
             }
 
             return false;
+        }
+
+        protected override void OnKeyUp(KeyUpEvent e)
+        {
+            switch (e.Key)
+            {
+                case Key.Left:
+                case Key.Right:
+                    endRepeatSelection(e.Key);
+                    break;
+            }
+
+            base.OnKeyUp(e);
         }
 
         public bool OnPressed(GlobalAction action)
@@ -473,11 +490,11 @@ namespace osu.Game.Screens.Select
             switch (action)
             {
                 case GlobalAction.SelectNext:
-                    SelectNext(1, false);
+                    beginRepeatSelection(() => SelectNext(1, false), action);
                     return true;
 
                 case GlobalAction.SelectPrevious:
-                    SelectNext(-1, false);
+                    beginRepeatSelection(() => SelectNext(-1, false), action);
                     return true;
             }
 
@@ -486,7 +503,45 @@ namespace osu.Game.Screens.Select
 
         public void OnReleased(GlobalAction action)
         {
+            switch (action)
+            {
+                case GlobalAction.SelectNext:
+                case GlobalAction.SelectPrevious:
+                    endRepeatSelection(action);
+                    break;
+            }
         }
+
+        private const double repeat_interval = 120;
+
+        private ScheduledDelegate repeatDelegate;
+        private object lastRepeatSource;
+
+        /// <summary>
+        /// Begin repeating the specified selection action.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        /// <param name="source">The source of the action. Used in conjunction with <see cref="endRepeatSelection"/> to only cancel the correct action (most recently pressed key).</param>
+        private void beginRepeatSelection(Action action, object source)
+        {
+            endRepeatSelection();
+
+            lastRepeatSource = source;
+            Scheduler.Add(repeatDelegate = new ScheduledDelegate(action, Time.Current, repeat_interval));
+        }
+
+        private void endRepeatSelection(object source = null)
+        {
+            // only the most recent source should be able to cancel the current action.
+            if (source != null && !EqualityComparer<object>.Default.Equals(lastRepeatSource, source))
+                return;
+
+            repeatDelegate?.Cancel();
+            repeatDelegate = null;
+            lastRepeatSource = null;
+        }
+
+        #endregion
 
         protected override void Update()
         {

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -526,7 +526,7 @@ namespace osu.Game.Screens.Select
             endRepeatSelection();
 
             lastRepeatSource = source;
-            Scheduler.Add(repeatDelegate = this.BeginKeyRepeat(Scheduler, action));
+            repeatDelegate = this.BeginKeyRepeat(Scheduler, action);
         }
 
         private void endRepeatSelection(object source = null)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -513,8 +513,6 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private const double repeat_interval = 120;
-
         private ScheduledDelegate repeatDelegate;
         private object lastRepeatSource;
 


### PR DESCRIPTION
Was lost when custom binding support was added.

Closes https://github.com/ppy/osu/issues/8379