### PR TITLE
Temporarily disable masking of tournament song bar

### DIFF
--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
@@ -66,6 +67,9 @@ namespace osu.Game.Tournament.Components
             }
         }
 
+        // Todo: This is a hack for https://github.com/ppy/osu-framework/issues/3617 since this container is at the very edge of the screen and potentially initially masked away.
+        protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => false;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -77,8 +81,6 @@ namespace osu.Game.Tournament.Components
                 flow = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
-                    // Todo: This is a hack for https://github.com/ppy/osu-framework/issues/3617 since this container is at the very edge of the screen and potentially initially masked away.
-                    Height = 1,
                     AutoSizeAxes = Axes.Y,
                     LayoutDuration = 500,
                     LayoutEasing = Easing.OutQuint,


### PR DESCRIPTION
Temporarily resolves #9200 (hopefully).

# Summary

The previous attempt to resolve this used the following hack:

https://github.com/ppy/osu/blob/a4254802c1355bdafe7895aa7851eb36b657b66c/osu.Game.Tournament/Components/SongBar.cs#L80-L82

As far as I can tell it didn't ever work. The reason why is the `AutoSize` set directly after the hard-coded height specification; because it was set *after* `Height`, `CompositeDrawable` just [silently discards that height and falls back to auto size mode](https://github.com/ppy/osu-framework/blob/446ee955a5dc4239bbda1030defbf27e57c4d308/osu.Framework/Graphics/Containers/CompositeDrawable.cs#L1687-L1694), and the `SongBar` gets masked away anyway.

As an alternative, disable masking on `SongBar` entirely.

# Remarks

There were other temporary solutions here, such as removing the `AutoSize` or removing `LayoutDuration`, but this felt like the most direct way to address the problem without changing behaviour.

As an aside, this only becomes a problem because the song bar's initial `Y` is slightly bigger than 720 in this particular case.