### PR TITLE
Improve quality of song select beatmap wedge

### DIFF
--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -155,7 +155,6 @@ namespace osu.Game.Screens.Select
                 var metadata = beatmapInfo.Metadata ?? beatmap.BeatmapSetInfo?.Metadata ?? new BeatmapMetadata();
 
                 CacheDrawnFrameBuffer = true;
-                RedrawOnScale = false;
 
                 RelativeSizeAxes = Axes.Both;
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/9305

It doesn't look to be drawing too much anyway... I considered moving the buffered container to only the background, but the BC wrapping everything still needs to exist anyway otherwise there'd be weirdness during the fadeout transition when changing wedges (details fade out and background peeks through).