### PR TITLE
Exclude hit objects with an EmptyHitWindow from being considered in TimingDistributionGraph

### DIFF
--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="hitEvents">The <see cref="HitEvent"/>s to display the timing distribution of.</param>
         public HitEventTimingDistributionGraph(IReadOnlyList<HitEvent> hitEvents)
         {
-            this.hitEvents = hitEvents;
+            this.hitEvents = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows)).ToList();
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
HitObjects with `EmptyHitWindow`s should not be considered in the statistics graph.

This also prevents hitobjects like Mania's Holds (which is not judged, but wraps two other judged objects), Slider repeats, ticks, and so on from artificially inflating the number of 0ms in the graph, making it inaccurate.

Before:
![image](https://user-images.githubusercontent.com/12001167/85987591-6259e600-ba20-11ea-89dd-388008c190e8.png)
After:
![image](https://user-images.githubusercontent.com/12001167/85987710-93d2b180-ba20-11ea-9d35-a261f29592a4.png)

