### PR TITLE
Fix notification redirecting to the old log folder when game installation has been migrated to another location

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -767,7 +767,7 @@ namespace osu.Game
                         Text = "Subsequent messages have been logged. Click to view log files.",
                         Activated = () =>
                         {
-                            Host.Storage.GetStorageForDirectory("logs").OpenInNativeExplorer();
+                            Storage.GetStorageForDirectory("logs").OpenInNativeExplorer();
                             return true;
                         }
                     }));


### PR DESCRIPTION
I came accross this while importing scores from stable. Maybe a leftover dating from the time `OsuStorage` was implemented.

Game would previously open the "old" (default) storage location for logs when game data directory was migrated elsewhere.