### PR TITLE
Expose transform helpers in SkinnableSound

### DIFF
--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -7,8 +7,10 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Transforms;
 using osu.Game.Audio;
 
 namespace osu.Game.Skinning
@@ -42,6 +44,34 @@ namespace osu.Game.Skinning
         public BindableNumber<double> Frequency => samplesContainer.Frequency;
 
         public BindableNumber<double> Tempo => samplesContainer.Tempo;
+
+        /// <summary>
+        /// Smoothly adjusts <see cref="Volume"/> over time.
+        /// </summary>
+        /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+        public TransformSequence<DrawableAudioWrapper> VolumeTo(double newVolume, double duration = 0, Easing easing = Easing.None) =>
+            samplesContainer.VolumeTo(newVolume, duration, easing);
+
+        /// <summary>
+        /// Smoothly adjusts <see cref="Balance"/> over time.
+        /// </summary>
+        /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+        public TransformSequence<DrawableAudioWrapper> BalanceTo(double newBalance, double duration = 0, Easing easing = Easing.None) =>
+            samplesContainer.BalanceTo(newBalance, duration, easing);
+
+        /// <summary>
+        /// Smoothly adjusts <see cref="Frequency"/> over time.
+        /// </summary>
+        /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+        public TransformSequence<DrawableAudioWrapper> FrequencyTo(double newFrequency, double duration = 0, Easing easing = Easing.None) =>
+            samplesContainer.FrequencyTo(newFrequency, duration, easing);
+
+        /// <summary>
+        /// Smoothly adjusts <see cref="Tempo"/> over time.
+        /// </summary>
+        /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+        public TransformSequence<DrawableAudioWrapper> TempoTo(double newTempo, double duration = 0, Easing easing = Easing.None) =>
+            samplesContainer.TempoTo(newTempo, duration, easing);
 
         public bool Looping
         {


### PR DESCRIPTION
Can probably be localised to an interface framework-side but I think this is okay for now (such an interface doesn't exist right now so it's medium effort).