### PR TITLE
Fix avatar in score panel being unclickable when statistics panel is visible

### DIFF
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -79,6 +79,11 @@ namespace osu.Game.Screens.Ranking
                                 RelativeSizeAxes = Axes.Both,
                                 Children = new Drawable[]
                                 {
+                                    statisticsPanel = new StatisticsPanel
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Score = { BindTarget = SelectedScore }
+                                    },
                                     scorePanelList = new ScorePanelList
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -88,11 +93,6 @@ namespace osu.Game.Screens.Ranking
                                     detachedPanelContainer = new Container<ScorePanel>
                                     {
                                         RelativeSizeAxes = Axes.Both
-                                    },
-                                    statisticsPanel = new StatisticsPanel
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Score = { BindTarget = SelectedScore }
                                     },
                                 }
                             }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9402.

Didn't see a visual difference with the depth change.