### PR TITLE
Replace further spinner transforms with manual lerp

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -14,6 +14,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Ranking;
 
@@ -193,9 +194,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             SpmCounter.SetRotation(Disc.RotationAbsolute);
 
             float relativeCircleScale = Spinner.Scale * circle.DrawHeight / mainContainer.DrawHeight;
-            Disc.ScaleTo(relativeCircleScale + (1 - relativeCircleScale) * Progress, 200, Easing.OutQuint);
+            float targetScale = relativeCircleScale + (1 - relativeCircleScale) * Progress;
+            Disc.Scale = new Vector2((float)Interpolation.Lerp(Disc.Scale.X, targetScale, Math.Clamp(Math.Abs(Time.Elapsed) / 100, 0, 1)));
 
-            symbol.RotateTo(Disc.Rotation / 2, 500, Easing.OutQuint);
+            symbol.Rotation = (float)Interpolation.Lerp(symbol.Rotation, Disc.Rotation / 2, Math.Clamp(Math.Abs(Time.Elapsed) / 40, 0, 1));
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             float targetScale = relativeCircleScale + (1 - relativeCircleScale) * Progress;
             Disc.Scale = new Vector2((float)Interpolation.Lerp(Disc.Scale.X, targetScale, Math.Clamp(Math.Abs(Time.Elapsed) / 100, 0, 1)));
 
-            symbol.Rotation = (float)Interpolation.Lerp(symbol.Rotation, Disc.Rotation / 2, Math.Clamp(Math.Abs(Time.Elapsed) / 40, 0, 1));
+            symbol.Rotation = (float)Interpolation.Lerp(symbol.Rotation, Disc.RotationAbsolute / 2, Math.Clamp(Math.Abs(Time.Elapsed) / 40, 0, 1));
         }
 
         protected override void UpdateInitialTransforms()


### PR DESCRIPTION
Resolves #8367 again (hopefully for the last time).

# Summary

This is the same fix as #8394 (replacing transforms with non-zero duration that would start queueing up and taking up more and more of update frame time with manual lerps) in the places that got overlooked.

Video demonstrations of the change:

* [before](https://streamable.com/obthsu) (note update time increases on `DrawableSpinner` and `SpriteIcon`),
* [after](https://streamable.com/ff5mx4).

Both videos taken on a debug build, with frame limiter off. Results might not be fully accurate as running with frame limiter off triggers thermal throttling on my box sometimes so can't guarantee they were taken with identical parameters in that sense, but the difference in behaviour exhibited is visible and should be reproducible.

# Remarks

Lerp value for the symbol stolen off #8394; value for the disc scale is proportionally scaled (200 is to 500 what 1/100 is to 1/40).

@Azureharp Would appreciate it if you could test this to make sure the issue doesn't have to be re-opened a third time.