### PR TITLE
Start track after seeking if it was not paused explicitly

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -129,7 +129,11 @@ namespace osu.Game.Overlays
             seekDelegate = Schedule(() =>
             {
                 if (!beatmap.Disabled)
+                {
                     current?.Track.Seek(position);
+                    if (!IsUserPaused)
+                        current?.Track.Start();
+                }
             });
         }
 


### PR DESCRIPTION
resolves #9398 
The idea is that the track should be paused only if it was explicitly paused by the user before seeking.