### PR TITLE
Fix seeding numbers being unreadable due to design changes

### DIFF
--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -203,13 +203,14 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                                         new Box
                                         {
                                             RelativeSizeAxes = Axes.Both,
-                                            Colour = TournamentGame.TEXT_COLOUR,
+                                            Colour = TournamentGame.ELEMENT_BACKGROUND_COLOUR,
                                         },
                                         new TournamentSpriteText
                                         {
                                             Anchor = Anchor.Centre,
                                             Origin = Anchor.Centre,
                                             Text = seeding.ToString("#,0"),
+                                            Colour = TournamentGame.ELEMENT_FOREGROUND_COLOUR
                                         },
                                     }
                                 },


### PR DESCRIPTION
Before:

![dotnet_2020-07-08_03-29-41](https://user-images.githubusercontent.com/803255/86863389-5bd80800-c0cb-11ea-8026-31e0e0e08a48.png)

After: 
![dotnet_2020-07-08_03-29-29](https://user-images.githubusercontent.com/803255/86863401-61355280-c0cb-11ea-953a-1f4cf9bb6ab8.png)

The two colours previously being used were both white. This also makes the colouring consistent with `TournamentSpriteTextWithBackground`

Edit: just noticed my commit text says it the other way around, oops.
