### PR TITLE
Make toolbar opaque

### DIFF
--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -28,9 +28,6 @@ namespace osu.Game.Overlays.Toolbar
 
         private const double transition_time = 500;
 
-        private const float alpha_hovering = 0.8f;
-        private const float alpha_normal = 0.6f;
-
         private readonly Bindable<OverlayActivation> overlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         // Toolbar components like RulesetSelector should receive keyboard input events even when the toolbar is hidden.
@@ -103,7 +100,6 @@ namespace osu.Game.Overlays.Toolbar
 
         public class ToolbarBackground : Container
         {
-            private readonly Box solidBackground;
             private readonly Box gradientBackground;
 
             public ToolbarBackground()
@@ -111,11 +107,10 @@ namespace osu.Game.Overlays.Toolbar
                 RelativeSizeAxes = Axes.Both;
                 Children = new Drawable[]
                 {
-                    solidBackground = new Box
+                    new Box
                     {
                         RelativeSizeAxes = Axes.Both,
                         Colour = OsuColour.Gray(0.1f),
-                        Alpha = alpha_normal,
                     },
                     gradientBackground = new Box
                     {
@@ -131,14 +126,12 @@ namespace osu.Game.Overlays.Toolbar
 
             protected override bool OnHover(HoverEvent e)
             {
-                solidBackground.FadeTo(alpha_hovering, transition_time, Easing.OutQuint);
                 gradientBackground.FadeIn(transition_time, Easing.OutQuint);
                 return true;
             }
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
-                solidBackground.FadeTo(alpha_normal, transition_time, Easing.OutQuint);
                 gradientBackground.FadeOut(transition_time, Easing.OutQuint);
             }
         }

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Overlays.Toolbar
         protected override void PopIn()
         {
             this.MoveToY(0, transition_time, Easing.OutQuint);
-            this.FadeIn(transition_time / 2, Easing.OutQuint);
+            this.FadeIn(transition_time / 4, Easing.OutQuint);
         }
 
         protected override void PopOut()
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.Toolbar
             userButton.StateContainer?.Hide();
 
             this.MoveToY(-DrawSize.Y, transition_time, Easing.OutQuint);
-            this.FadeOut(transition_time);
+            this.FadeOut(transition_time, Easing.InQuint);
         }
     }
 }


### PR DESCRIPTION
- Closes #6710

This is the general direction we're going with future designs. Just applying this now because it makes a lot of screens feel much better (multiplayer lobby / match, song select etc. where there are elements
adjacent to the bar which cause the transparency to feel a bit awkward).