### PR TITLE
Fix spinner spinning in the wrong direction

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 if (auto && !userTriggered && Time.Current > Spinner.StartTime + Spinner.Duration / 2 && Progress < 1)
                 {
                     // force completion only once to not break human interaction
-                    Disc.RotationAbsolute = Spinner.SpinsRequired * 360;
+                    Disc.CumulativeRotation = Spinner.SpinsRequired * 360;
                     auto = false;
                 }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -58,11 +58,11 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             addSeekStep(5000);
             AddAssert("is disc rotation not almost 0", () => !Precision.AlmostEquals(drawableSpinner.Disc.Rotation, 0, 100));
-            AddAssert("is disc rotation absolute not almost 0", () => !Precision.AlmostEquals(drawableSpinner.Disc.RotationAbsolute, 0, 100));
+            AddAssert("is disc rotation absolute not almost 0", () => !Precision.AlmostEquals(drawableSpinner.Disc.CumulativeRotation, 0, 100));
 
             addSeekStep(0);
             AddAssert("is disc rotation almost 0", () => Precision.AlmostEquals(drawableSpinner.Disc.Rotation, 0, 100));
-            AddAssert("is disc rotation absolute almost 0", () => Precision.AlmostEquals(drawableSpinner.Disc.RotationAbsolute, 0, 100));
+            AddAssert("is disc rotation absolute almost 0", () => Precision.AlmostEquals(drawableSpinner.Disc.CumulativeRotation, 0, 100));
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             addSeekStep(5000);
             AddStep("retrieve disc relative rotation", () => finalRelativeDiscRotation = drawableSpinner.Disc.Rotation);
-            AddStep("retrieve disc absolute rotation", () => finalAbsoluteDiscRotation = drawableSpinner.Disc.RotationAbsolute);
+            AddStep("retrieve disc absolute rotation", () => finalAbsoluteDiscRotation = drawableSpinner.Disc.CumulativeRotation);
             AddStep("retrieve spinner symbol rotation", () => finalSpinnerSymbolRotation = spinnerSymbol.Rotation);
 
             addSeekStep(2500);
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("is symbol rotation almost same",
                 () => Precision.AlmostEquals(spinnerSymbol.Rotation, finalSpinnerSymbolRotation, 100));
             AddAssert("is disc rotation absolute almost same",
-                () => Precision.AlmostEquals(drawableSpinner.Disc.RotationAbsolute, finalAbsoluteDiscRotation, 100));
+                () => Precision.AlmostEquals(drawableSpinner.Disc.CumulativeRotation, finalAbsoluteDiscRotation, 100));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             positionBindable.BindTo(HitObject.PositionBindable);
         }
 
-        public float Progress => Math.Clamp(Disc.RotationAbsolute / 360 / Spinner.SpinsRequired, 0, 1);
+        public float Progress => Math.Clamp(Disc.CumulativeRotation / 360 / Spinner.SpinsRequired, 0, 1);
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
@@ -191,7 +191,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             circle.Rotation = Disc.Rotation;
             Ticks.Rotation = Disc.Rotation;
-            SpmCounter.SetRotation(Disc.RotationAbsolute);
+            SpmCounter.SetRotation(Disc.CumulativeRotation);
 
             float relativeCircleScale = Spinner.Scale * circle.DrawHeight / mainContainer.DrawHeight;
             float targetScale = relativeCircleScale + (1 - relativeCircleScale) * Progress;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             float targetScale = relativeCircleScale + (1 - relativeCircleScale) * Progress;
             Disc.Scale = new Vector2((float)Interpolation.Lerp(Disc.Scale.X, targetScale, Math.Clamp(Math.Abs(Time.Elapsed) / 100, 0, 1)));
 
-            symbol.Rotation = (float)Interpolation.Lerp(symbol.Rotation, Disc.RotationAbsolute / 2, Math.Clamp(Math.Abs(Time.Elapsed) / 40, 0, 1));
+            symbol.Rotation = (float)Interpolation.Lerp(symbol.Rotation, Disc.Rotation / 2, Math.Clamp(Math.Abs(Time.Elapsed) / 40, 0, 1));
         }
 
         protected override void UpdateInitialTransforms()
@@ -206,9 +206,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             circleContainer.ScaleTo(Spinner.Scale * 0.3f);
             circleContainer.ScaleTo(Spinner.Scale, HitObject.TimePreempt / 1.4f, Easing.OutQuint);
-
-            Disc.RotateTo(-720);
-            symbol.RotateTo(-720);
 
             mainContainer
                 .ScaleTo(0)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerDisc.cs
@@ -74,6 +74,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         }
 
         /// <summary>
+        /// The total rotation performed on the spinner disc, disregarding the spin direction.
+        /// </summary>
+        /// <remarks>
+        /// This value is always non-negative and is monotonically increasing with time
+        /// (i.e. will only increase if time is passing forward, but can decrease during rewind).
+        /// </remarks>
+        /// <example>
+        /// If the spinner is spun 360 degrees clockwise and then 360 degrees counter-clockwise,
+        /// this property will return the value of 720 (as opposed to 0 for <see cref="Drawable.Rotation"/>).
+        /// </example>
+        public float RotationAbsolute;
+
+        /// <summary>
         /// Whether currently in the correct time range to allow spinning.
         /// </summary>
         private bool isSpinnableTime => spinner.StartTime <= Time.Current && spinner.EndTime > Time.Current;
@@ -88,7 +101,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         private float lastAngle;
         private float currentRotation;
-        public float RotationAbsolute;
         private int completeTick;
 
         private bool updateCompleteTick() => completeTick != (completeTick = (int)(RotationAbsolute / 360));

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerDisc.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         /// If the spinner is spun 360 degrees clockwise and then 360 degrees counter-clockwise,
         /// this property will return the value of 720 (as opposed to 0 for <see cref="Drawable.Rotation"/>).
         /// </example>
-        public float RotationAbsolute;
+        public float CumulativeRotation;
 
         /// <summary>
         /// Whether currently in the correct time range to allow spinning.
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         private float currentRotation;
         private int completeTick;
 
-        private bool updateCompleteTick() => completeTick != (completeTick = (int)(RotationAbsolute / 360));
+        private bool updateCompleteTick() => completeTick != (completeTick = (int)(CumulativeRotation / 360));
 
         private bool rotationTransferred;
 
@@ -161,7 +161,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             }
 
             currentRotation += angle;
-            RotationAbsolute += Math.Abs(angle) * Math.Sign(Clock.ElapsedFrameTime);
+            CumulativeRotation += Math.Abs(angle) * Math.Sign(Clock.ElapsedFrameTime);
         }
     }
 }


### PR DESCRIPTION
Resolves #9455.

# Summary

So, this one is entirely on me.

As mentioned in the issue thread I broke it in #9434 by using `RotationAbsolute`. As it turns out `Rotation` *was* the correct thing to use. The reason why the symbol would pause at rewind were these two lines:

https://github.com/ppy/osu/blob/d229993e5c727ff9c10328a1360ad776606053b2/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs#L210-L211

The lerps in `SpinnerDisc` and `DrawableSpinner` during rewind wouldn't interpolate within the range of (rotation from last frame, rotation in current frame). They would instead interpolate within the range of (-720, rotation in current frame). This is why the rotation would seemingly pause.

You could ask however, how is it that when I changed to `RotationAbsolute` it looked less wrong. See, when you test with autoplay, it spins *counter-clockwise*, which means negative `Rotation`.

* When using `Rotation`, the old code would lerp from -720 to a negative number, hence the spinner would barely move.
* When using `RotationAbsolute`, the old code would lerp from -720 to a *positive* number, twice as big in absolute value as `Rotation`, hence the spinner would rotate faster due to a wider interpolation range, but *still* slower than normal autoplay, which is wrong, as it should spin *faster* than normal autoplay in rewind.

To resolve, remove the two offending lines and revert to using `Rotation` correctly.

[Here's a video of the corrected behaviour](https://drive.google.com/file/d/1QDg52R3TeuCwlOk6FeV2zIHs8KB_Grsb/view?usp=sharing). Note: the manual slow testing in both directions and the speed changes with autoplay (when scrubbing forward or backward through the replay the spinner *always* moves faster regardless of direction). Due to capture frame rate that is not too visible on the video but should be very visible locally.

# Remarks

Using `RotationAbsolute` was my mistake as I misunderstood what it was. I won't bother with explaining of what I thought it was as it makes no sense, but I added xmldoc so that hopefully the next person doesn't make the same mistake.

I've added some new asserts and a test. They cover both the fact that the lerps were broken, and spinning the spinner in both directions. The latter is hacky in a sense but it works and is not that long so I figure we might as well have it.

I should really have taken more time and care to examine what was going on with the rotations pausing in the previous PR instead of just eyeballing it.