### PR TITLE
Replace poo icon at disclaimer screen

### DIFF
--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Menu
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Icon = FontAwesome.Solid.Poo,
+                    Icon = FontAwesome.Solid.Flask,
                     Size = new Vector2(icon_size),
                     Y = icon_y,
                 },


### PR DESCRIPTION
It was a placeholder as I couldn't find a more appropriate font-awesome icon, but due to way-too-many complaints about the poo I found a better one.