### PR TITLE
Clean up song select filter control UI

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Graphics.UserInterface
     {
         private Color4 accentColour;
 
+        public const float HORIZONTAL_SPACING = 10;
+
         public virtual Color4 AccentColour
         {
             get => accentColour;
@@ -54,7 +56,7 @@ namespace osu.Game.Graphics.UserInterface
 
         public OsuTabControl()
         {
-            TabContainer.Spacing = new Vector2(10f, 0f);
+            TabContainer.Spacing = new Vector2(HORIZONTAL_SPACING, 0f);
 
             AddInternal(strip = new Box
             {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -116,6 +116,13 @@ namespace osu.Game.Screens.Select
                             Spacing = new Vector2(OsuTabControl<SortMode>.HORIZONTAL_SPACING, 0),
                             Children = new Drawable[]
                             {
+                                new OsuTabControlCheckbox
+                                {
+                                    Text = "Show converted",
+                                    Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.BottomRight,
+                                },
                                 sortTabs = new OsuTabControl<SortMode>
                                 {
                                     RelativeSizeAxes = Axes.X,

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -2,21 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osuTK;
-using osuTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
-using osu.Game.Graphics;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Screens.Select.Filter;
-using Container = osu.Framework.Graphics.Containers.Container;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Configuration;
-using osu.Game.Rulesets;
 using osu.Framework.Input.Events;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets;
+using osu.Game.Screens.Select.Filter;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Select
 {
@@ -26,9 +25,7 @@ namespace osu.Game.Screens.Select
 
         public Action<FilterCriteria> FilterChanged;
 
-        private readonly OsuTabControl<SortMode> sortTabs;
-
-        private readonly TabControl<GroupMode> groupTabs;
+        private OsuTabControl<SortMode> sortTabs;
 
         private Bindable<SortMode> sortMode;
 
@@ -56,19 +53,39 @@ namespace osu.Game.Screens.Select
             return criteria;
         }
 
-        private readonly SeekLimitedSearchTextBox searchTextBox;
+        private SeekLimitedSearchTextBox searchTextBox;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
-            base.ReceivePositionalInputAt(screenSpacePos) || groupTabs.ReceivePositionalInputAt(screenSpacePos) || sortTabs.ReceivePositionalInputAt(screenSpacePos);
+            base.ReceivePositionalInputAt(screenSpacePos) || sortTabs.ReceivePositionalInputAt(screenSpacePos);
 
-        public FilterControl()
+        [BackgroundDependencyLoader(permitNulls: true)]
+        private void load(OsuColour colours, IBindable<RulesetInfo> parentRuleset, OsuConfigManager config)
         {
+            config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConverted);
+            showConverted.ValueChanged += _ => updateCriteria();
+
+            config.BindWith(OsuSetting.DisplayStarsMinimum, minimumStars);
+            minimumStars.ValueChanged += _ => updateCriteria();
+
+            config.BindWith(OsuSetting.DisplayStarsMaximum, maximumStars);
+            maximumStars.ValueChanged += _ => updateCriteria();
+
+            ruleset.BindTo(parentRuleset);
+            ruleset.BindValueChanged(_ => updateCriteria());
+
+            sortMode = config.GetBindable<SortMode>(OsuSetting.SongSelectSortingMode);
+            groupMode = config.GetBindable<GroupMode>(OsuSetting.SongSelectGroupingMode);
+
+            groupMode.BindValueChanged(_ => updateCriteria());
+            sortMode.BindValueChanged(_ => updateCriteria());
+
             Children = new Drawable[]
             {
-                Background = new Box
+                new Box
                 {
                     Colour = Color4.Black,
                     Alpha = 0.8f,
+                    Width = 2,
                     RelativeSizeAxes = Axes.Both,
                 },
                 new Container
@@ -96,33 +113,28 @@ namespace osu.Game.Screens.Select
                             Direction = FillDirection.Horizontal,
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
+                            Spacing = new Vector2(OsuTabControl<SortMode>.HORIZONTAL_SPACING, 0),
                             Children = new Drawable[]
                             {
-                                groupTabs = new OsuTabControl<GroupMode>
-                                {
-                                    RelativeSizeAxes = Axes.X,
-                                    Height = 24,
-                                    Width = 0.5f,
-                                    AutoSort = true,
-                                },
-                                //spriteText = new OsuSpriteText
-                                //{
-                                //    Font = @"Exo2.0-Bold",
-                                //    Text = "Sort results by",
-                                //    Size = 14,
-                                //    Margin = new MarginPadding
-                                //    {
-                                //        Top = 5,
-                                //        Bottom = 5
-                                //    },
-                                //},
                                 sortTabs = new OsuTabControl<SortMode>
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     Width = 0.5f,
                                     Height = 24,
                                     AutoSort = true,
-                                }
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.BottomRight,
+                                    AccentColour = colours.GreenLight,
+                                    Current = { BindTarget = sortMode }
+                                },
+                                new OsuSpriteText
+                                {
+                                    Text = "Sort by",
+                                    Font = OsuFont.GetFont(size: 14),
+                                    Margin = new MarginPadding(5),
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.BottomRight,
+                                },
                             }
                         },
                     }
@@ -131,8 +143,7 @@ namespace osu.Game.Screens.Select
 
             searchTextBox.Current.ValueChanged += _ => FilterChanged?.Invoke(CreateCriteria());
 
-            groupTabs.PinItem(GroupMode.All);
-            groupTabs.PinItem(GroupMode.RecentlyPlayed);
+            updateCriteria();
         }
 
         public void Deactivate()
@@ -155,37 +166,6 @@ namespace osu.Game.Screens.Select
         private readonly Bindable<bool> showConverted = new Bindable<bool>();
         private readonly Bindable<double> minimumStars = new BindableDouble();
         private readonly Bindable<double> maximumStars = new BindableDouble();
-
-        public readonly Box Background;
-
-        [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(OsuColour colours, IBindable<RulesetInfo> parentRuleset, OsuConfigManager config)
-        {
-            sortTabs.AccentColour = colours.GreenLight;
-
-            config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConverted);
-            showConverted.ValueChanged += _ => updateCriteria();
-
-            config.BindWith(OsuSetting.DisplayStarsMinimum, minimumStars);
-            minimumStars.ValueChanged += _ => updateCriteria();
-
-            config.BindWith(OsuSetting.DisplayStarsMaximum, maximumStars);
-            maximumStars.ValueChanged += _ => updateCriteria();
-
-            ruleset.BindTo(parentRuleset);
-            ruleset.BindValueChanged(_ => updateCriteria());
-
-            sortMode = config.GetBindable<SortMode>(OsuSetting.SongSelectSortingMode);
-            groupMode = config.GetBindable<GroupMode>(OsuSetting.SongSelectGroupingMode);
-
-            sortTabs.Current.BindTo(sortMode);
-            groupTabs.Current.BindTo(groupMode);
-
-            groupMode.BindValueChanged(_ => updateCriteria());
-            sortMode.BindValueChanged(_ => updateCriteria());
-
-            updateCriteria();
-        }
 
         private void updateCriteria() => FilterChanged?.Invoke(CreateCriteria());
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -173,7 +173,6 @@ namespace osu.Game.Screens.Select
                             RelativeSizeAxes = Axes.X,
                             Height = FilterControl.HEIGHT,
                             FilterChanged = ApplyFilterToCarousel,
-                            Background = { Width = 2 },
                         },
                         new GridContainer // used for max width implementation
                         {


### PR DESCRIPTION
Until we have a design and structure in place for song select grouping, let's hide the controls for now. They were misleading as they did nothing (and it was hard to know whether they had any effect).

This also adds a "show converted" checkbox in the filter control for convenience. Saves having to go into settings to change this setting.