### PR TITLE
Dispose beatmap lookup task scheduler

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
@@ -183,6 +183,7 @@ namespace osu.Game.Beatmaps
             public void Dispose()
             {
                 cacheDownloadRequest?.Dispose();
+                updateScheduler?.Dispose();
             }
 
             [Serializable]


### PR DESCRIPTION
For a while now I've been unable to complete a full unit test run. In debugging I've found that one of the reasons is having 1000 threads running from all the online lookup task schedulers. Disposing the task scheduler joins all the threads to fix that.

There's still other problems, which are probably more linux-specific which https://github.com/ppy/osu-framework/pull/3700 will address - if the 0 device is freed the audio thread will get stuck on a Bass.ChannelPlay call.