### PR TITLE
Change multiplayer tests to have null room by default

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomInfo.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomInfo.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            Room.CopyFrom(new Room());
+            Room = new Room();
 
             Child = new RoomInfo
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchBeatmapDetailArea.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchBeatmapDetailArea.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            Room.Playlist.Clear();
+            Room = new Room();
 
             Child = new MatchBeatmapDetailArea
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchHeader.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchHeader.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
     {
         public TestSceneMatchHeader()
         {
+            Room = new Room();
             Room.Playlist.Add(new PlaylistItem
             {
                 Beatmap =

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchLeaderboard.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Online.API;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.Multi.Match.Components;
 using osu.Game.Users;
 using osuTK;
@@ -18,7 +19,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public TestSceneMatchLeaderboard()
         {
-            Room.RoomID.Value = 3;
+            Room = new Room { RoomID = { Value = 3 } };
 
             Add(new MatchLeaderboard
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSongSelect.cs
@@ -14,6 +14,7 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Multi.Components;
@@ -95,7 +96,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            Room.Playlist.Clear();
+            Room = new Room();
         });
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMatchSubScreen.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            Room.CopyFrom(new Room());
+            Room = new Room();
         });
 
         [SetUpSteps]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneOverlinedParticipants.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneOverlinedParticipants.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.Multi.Components;
 using osuTK;
 
@@ -12,10 +13,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
     {
         protected override bool UseOnlineAPI => true;
 
-        public TestSceneOverlinedParticipants()
+        [SetUp]
+        public void Setup() => Schedule(() =>
         {
-            Room.RoomID.Value = 7;
-        }
+            Room = new Room { RoomID = { Value = 7 } };
+        });
 
         [Test]
         public void TestHorizontalLayout()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneOverlinedPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneOverlinedPlaylist.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public TestSceneOverlinedPlaylist()
         {
+            Room = new Room { RoomID = { Value = 7 } };
+
             for (int i = 0; i < 10; i++)
             {
                 Room.Playlist.Add(new PlaylistItem

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneParticipantsList.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.Multi.Components;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -10,10 +12,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
     {
         protected override bool UseOnlineAPI => true;
 
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Room = new Room { RoomID = { Value = 7 } };
+        });
+
         public TestSceneParticipantsList()
         {
-            Room.RoomID.Value = 7;
-
             Add(new ParticipantsList { RelativeSizeAxes = Axes.Both });
         }
     }

--- a/osu.Game/Tests/Visual/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/MultiplayerTestScene.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Tests.Visual
     public abstract class MultiplayerTestScene : ScreenTestScene
     {
         [Cached]
-        private readonly Bindable<Room> currentRoom = new Bindable<Room>(new Room());
+        private readonly Bindable<Room> currentRoom = new Bindable<Room>();
 
         protected Room Room
         {


### PR DESCRIPTION
Since the lounge has a null room by default, I think this works better. Also removes unnecessary `CopyFrom` logic.