### PR TITLE
Make default skin cursor more visible against bright backgrounds

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -5,7 +5,9 @@ using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing.Input;
+using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Screens.Play;
@@ -24,9 +26,34 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
+        private Drawable background;
+
         public TestSceneGameplayCursor()
         {
             gameplayBeatmap = new GameplayBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
+
+            AddStep("change background colour", () =>
+            {
+                background?.Expire();
+
+                Add(background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Depth = float.MaxValue,
+                    Colour = new Colour4(RNG.NextSingle(), RNG.NextSingle(), RNG.NextSingle(), 1)
+                });
+            });
+
+            AddSliderStep("circle size", 0f, 10f, 0f, val =>
+            {
+                config.Set(OsuSetting.AutoCursorSize, true);
+                gameplayBeatmap.BeatmapInfo.BaseDifficulty.CircleSize = val;
+                Scheduler.AddOnce(recreate);
+            });
+
+            AddStep("test cursor container", recreate);
+
+            void recreate() => SetContents(() => new OsuInputManager(new OsuRuleset().RulesetInfo) { Child = new OsuCursorContainer() });
         }
 
         [TestCase(1, 1)]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -87,6 +87,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             public MovingCursorInputManager()
             {
                 UseParentInput = false;
+                ShowVisualCursorGuide = false;
             }
 
             protected override void Update()

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -69,16 +69,27 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private class ClickingCursorContainer : OsuCursorContainer
         {
+            private bool pressed;
+
+            public bool Pressed
+            {
+                set
+                {
+                    if (value == pressed)
+                        return;
+
+                    pressed = value;
+                    if (value)
+                        OnPressed(OsuAction.LeftButton);
+                    else
+                        OnReleased(OsuAction.LeftButton);
+                }
+            }
+
             protected override void Update()
             {
                 base.Update();
-
-                double currentTime = Time.Current;
-
-                if (((int)(currentTime / 1000)) % 2 == 0)
-                    OnPressed(OsuAction.LeftButton);
-                else
-                    OnReleased(OsuAction.LeftButton);
+                Pressed = ((int)(Time.Current / 1000)) % 2 == 0;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
@@ -59,10 +59,10 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         {
             if (!cursorExpand) return;
 
-            expandTarget.ScaleTo(released_scale).ScaleTo(pressed_scale, 100, Easing.OutQuad);
+            expandTarget.ScaleTo(released_scale).ScaleTo(pressed_scale, 400, Easing.OutElasticHalf);
         }
 
-        public void Contract() => expandTarget.ScaleTo(released_scale, 100, Easing.OutQuad);
+        public void Contract() => expandTarget.ScaleTo(released_scale, 400, Easing.OutQuad);
 
         private class DefaultCursor : OsuCursorSprite
         {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
@@ -115,24 +115,22 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                                     },
                                 },
                             },
-                            new CircularContainer
-                            {
-                                Origin = Anchor.Centre,
-                                Anchor = Anchor.Centre,
-                                RelativeSizeAxes = Axes.Both,
-                                Scale = new Vector2(0.1f),
-                                Masking = true,
-                                Children = new Drawable[]
-                                {
-                                    new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                    },
-                                },
-                            },
-                        }
-                    }
+                        },
+                    },
+                    new Circle
+                    {
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Scale = new Vector2(0.14f),
+                        Colour = new Color4(34, 93, 204, 255),
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Type = EdgeEffectType.Glow,
+                            Radius = 8,
+                            Colour = Color4.White,
+                        },
+                    },
                 };
             }
         }

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -30,7 +30,9 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private readonly Drawable cursorTrail;
 
-        public Bindable<float> CursorScale = new BindableFloat(1);
+        public IBindable<float> CursorScale => cursorScale;
+
+        private readonly Bindable<float> cursorScale = new BindableFloat(1);
 
         private Bindable<float> userCursorScale;
         private Bindable<bool> autoCursorScale;
@@ -68,13 +70,13 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             autoCursorScale = config.GetBindable<bool>(OsuSetting.AutoCursorSize);
             autoCursorScale.ValueChanged += _ => calculateScale();
 
-            CursorScale.ValueChanged += e =>
+            CursorScale.BindValueChanged(e =>
             {
                 var newScale = new Vector2(e.NewValue);
 
                 ActiveCursor.Scale = newScale;
                 cursorTrail.Scale = newScale;
-            };
+            }, true);
 
             calculateScale();
         }
@@ -95,7 +97,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                 scale *= GetScaleForCircleSize(beatmap.BeatmapInfo.BaseDifficulty.CircleSize);
             }
 
-            CursorScale.Value = scale;
+            cursorScale.Value = scale;
 
             var newScale = new Vector2(scale);
 

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.UI
         private OsuClickToResumeCursor clickToResumeCursor;
 
         private OsuCursorContainer localCursorContainer;
-        private Bindable<float> localCursorScale;
+        private IBindable<float> localCursorScale;
 
         public override CursorContainer LocalCursor => State.Value == Visibility.Visible ? localCursorContainer : null;
 


### PR DESCRIPTION
- Adds a dark colour to the centre (similar to stable) to make the default cursor more usable.
- Fixes cursor scale potentially not being read (only happens in tests).
- Fixes cursor tests not correctly showing transforms due to calling `OnPressed`/`OnReleased` too often.
- Adds tests against random background colours (and user input driven tests).
- [x] Depends on https://github.com/ppy/osu-framework/pull/3706

This is not a final design, just a temporary usability improvement until we have a more definitive cursor design.