### PR TITLE
Add dynamic compilation exclusion rules for ruleset types

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -21,11 +21,13 @@ using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using System;
+using osu.Framework.Testing;
 using osu.Game.Rulesets.Catch.Skinning;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch
 {
+    [ExcludeFromDynamicCompile]
     public class CatchRuleset : Ruleset, ILegacyRuleset
     {
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableCatchRuleset(this, beatmap, mods);

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Replays.Types;
@@ -34,6 +35,7 @@ using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets.Mania
 {
+    [ExcludeFromDynamicCompile]
     public class ManiaRuleset : Ruleset, ILegacyRuleset
     {
         /// <summary>

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -30,12 +30,14 @@ using osu.Game.Scoring;
 using osu.Game.Skinning;
 using System;
 using System.Linq;
+using osu.Framework.Testing;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Statistics;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets.Osu
 {
+    [ExcludeFromDynamicCompile]
     public class OsuRuleset : Ruleset, ILegacyRuleset
     {
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableOsuRuleset(this, beatmap, mods);

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -22,6 +22,7 @@ using osu.Game.Rulesets.Taiko.Scoring;
 using osu.Game.Scoring;
 using System;
 using System.Linq;
+using osu.Framework.Testing;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Taiko.Edit;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -31,6 +32,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko
 {
+    [ExcludeFromDynamicCompile]
     public class TaikoRuleset : Ruleset, ILegacyRuleset
     {
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableTaikoRuleset(this, beatmap, mods);


### PR DESCRIPTION
This regularly causes failures like this:

```
[runtime] 2020-07-10 04:08:04 [important]: Recompiling TestSceneGameplayCursor...
[runtime] 2020-07-10 04:08:05 [error]: Error with dynamic compilation!
[runtime] 2020-07-10 04:08:05 [error]: System.ArgumentNullException: Value cannot be null. (Parameter 'type')
[runtime] 2020-07-10 04:08:05 [error]: at System.Activator.CreateInstance(Type type, Boolean nonPublic, Boolean wrapExceptions)
[runtime] 2020-07-10 04:08:05 [error]: at System.Activator.CreateInstance(Type type)
[runtime] 2020-07-10 04:08:05 [error]: at osu.Game.Rulesets.RulesetInfo.CreateInstance() in /Users/dean/Projects/osu/osu.Game/Rulesets/RulesetInfo.cs:line 42
[runtime] 2020-07-10 04:08:05 [error]: at osu.Game.OsuGameBase.onRulesetChanged(ValueChangedEvent`1 r) in /Users/dean/Projects/osu/osu.Game/OsuGameBase.cs:line 264
[runtime] 2020-07-10 04:08:05 [error]: at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
[runtime] 2020-07-10 04:08:05 [error]: at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
[runtime] 2020-07-10 04:08:05 [error]: at osu.Framework.Bindables.Bindable`1.set_Value(T value)
[runtime] 2020-07-10 04:08:05 [error]: at osu.Game.Tests.Visual.OsuTestScene.load(RulesetStore rulesets) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 158
[runtime] 2020-07-10 04:08:05 [error]: --- End of stack trace from previous location where exception was thrown ---
```