### PR TITLE
Fix HP drain around bonus judgements and catch bananas

### DIFF
--- a/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
                     return 0;
 
                 case HitResult.Perfect:
-                    return 0.01;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.75;
             }
         }
 

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -114,7 +114,9 @@ namespace osu.Game.Rulesets.Scoring
         protected override void ApplyResultInternal(JudgementResult result)
         {
             base.ApplyResultInternal(result);
-            healthIncreases.Add((result.HitObject.GetEndTime() + result.TimeOffset, GetHealthIncreaseFor(result)));
+
+            if (!result.Judgement.IsBonus)
+                healthIncreases.Add((result.HitObject.GetEndTime() + result.TimeOffset, GetHealthIncreaseFor(result)));
         }
 
         protected override void Reset(bool storeResults)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9513

Two fixes here:
1. Assuming 0 bonus judgements are hit. Meaning that the time delta between two surrounding combo objects is used to determine the drain rate, rather than time delta between bonus objects (imagine 30% hp being reached between each non-disjoint set):
    ```
        combo ---- bonus ---- bonus ---- combo
    curr:    ^^^^^^     ^^^^^^     ^^^^^^
    new :    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ```
2. Increasing the HP gain of bananas. This affects mostly the start / end of maps which don't have two surrounding combo objects. This shouldn't be too low otherwise it can be overpowered by the drain rate (based on combo objects).