### PR TITLE
Clean up HitEvents after use to avoid near-permanent memory retention

### DIFF
--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -252,6 +252,12 @@ namespace osu.Game.Rulesets.Scoring
             HighestCombo.Value = 0;
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            hitEvents.Clear();
+        }
+
         /// <summary>
         /// Retrieve a score populated with data for the current play this processor is responsible for.
         /// </summary>
@@ -269,7 +275,7 @@ namespace osu.Game.Rulesets.Scoring
             foreach (var result in Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r > HitResult.None && hitWindows.IsHitResultAllowed(r)))
                 score.Statistics[result] = GetStatistic(result);
 
-            score.HitEvents = new List<HitEvent>(hitEvents);
+            score.HitEvents = hitEvents;
         }
 
         /// <summary>


### PR DESCRIPTION
This is not a permanent fix, just a hotfix to alleviate the issue.

- Resolves https://github.com/ppy/osu/issues/9521