### PR TITLE
Changed DatabasedKeyBinding to use string instead of int for action storage

### DIFF
--- a/osu.Game/Database/OsuDbContext.cs
+++ b/osu.Game/Database/OsuDbContext.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Database
             modelBuilder.Entity<SkinInfo>().HasIndex(b => b.DeletePending);
 
             modelBuilder.Entity<DatabasedKeyBinding>().HasIndex(b => new { b.RulesetID, b.Variant });
-            modelBuilder.Entity<DatabasedKeyBinding>().HasIndex(b => b.IntAction);
+            modelBuilder.Entity<DatabasedKeyBinding>().HasIndex(b => b.StringAction);
 
             modelBuilder.Entity<DatabasedSetting>().HasIndex(b => new { b.RulesetID, b.Variant });
 

--- a/osu.Game/Input/Bindings/DatabasedKeyBinding.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBinding.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using osu.Framework.Input.Bindings;
 using osu.Game.Database;
@@ -24,10 +25,12 @@ namespace osu.Game.Input.Bindings
         }
 
         [Column("Action")]
-        public int IntAction
+        public string StringAction
         {
-            get => (int)Action;
+            get => Action.ToString();
             set => Action = value;
         }
+
+        public override T GetAction<T>() => (T)Enum.Parse(typeof(T), StringAction);
     }
 }

--- a/osu.Game/Input/KeyBindingStore.cs
+++ b/osu.Game/Input/KeyBindingStore.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Input
                 // compare counts in database vs defaults
                 foreach (var group in defaults.GroupBy(k => k.Action))
                 {
-                    int count = Query(rulesetId, variant).Count(k => (int)k.Action == (int)group.Key);
+                    int count = Query(rulesetId, variant).Count(k => k.Action == group.Key);
                     int aimCount = group.Count();
 
                     if (aimCount <= count)

--- a/osu.Game/Migrations/20200711205230_KeyBindingDBUpgrade.cs
+++ b/osu.Game/Migrations/20200711205230_KeyBindingDBUpgrade.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace osu.Game.Migrations
+{
+    public partial class KeyBindingDBUpgrade : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn("KeyBinding", "Action", action =>
+            {
+                // don't think there is a way to do this without having access to a previous state of the keybinding enums or whatever they're using
+            });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
+++ b/osu.Game/Migrations/OsuDbContextModelSnapshot.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Migrations
                     b.Property<int>("ID")
                         .ValueGeneratedOnAdd();
 
-                    b.Property<int>("IntAction")
+                    b.Property<string>("StringAction")
                         .HasColumnName("Action");
 
                     b.Property<string>("KeysString")
@@ -263,7 +263,7 @@ namespace osu.Game.Migrations
 
                     b.HasKey("ID");
 
-                    b.HasIndex("IntAction");
+                    b.HasIndex("StringAction");
 
                     b.HasIndex("RulesetID", "Variant");
 

--- a/osu.Game/Overlays/KeyBinding/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/KeyBinding/KeyBindingsSubsection.cs
@@ -38,10 +38,10 @@ namespace osu.Game.Overlays.KeyBinding
 
             foreach (var defaultGroup in Defaults.GroupBy(d => d.Action))
             {
-                int intKey = (int)defaultGroup.Key;
+                string stringKey = defaultGroup.Key.ToString();
 
                 // one row per valid action.
-                Add(new KeyBindingRow(defaultGroup.Key, bindings.Where(b => ((int)b.Action).Equals(intKey)))
+                Add(new KeyBindingRow(defaultGroup.Key, bindings.Where(b => b.StringAction.Equals(stringKey, System.StringComparison.Ordinal)))
                 {
                     AllowMainMouseButtons = Ruleset != null,
                     Defaults = defaultGroup.Select(d => d.KeyCombination)


### PR DESCRIPTION
Allows #9517 to move the enum value up to ensure logical order.
Also this might break everything and is not quite ready yet as the migration is missing, thus I am opening this PR as a draft first.
If this concept is completely out of line feel free to close this completely.
At least I really had fun getting into the osu code and exploring various concepts of c# :)