### PR TITLE
Fix color and underline of tab control checkboxes when initially checked

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabControlCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControlCheckbox.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Graphics.UserInterface
     {
         private readonly Box box;
         private readonly SpriteText text;
-        private readonly SpriteIcon icon;
 
         private Color4? accentColour;
 
@@ -46,6 +45,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public OsuTabControlCheckbox()
         {
+            SpriteIcon icon;
+
             AutoSizeAxes = Axes.Both;
 
             Children = new Drawable[]

--- a/osu.Game/Graphics/UserInterface/OsuTabControlCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControlCheckbox.cs
@@ -32,12 +32,6 @@ namespace osu.Game.Graphics.UserInterface
             {
                 accentColour = value;
 
-                if (Current.Value)
-                {
-                    text.Colour = AccentColour;
-                    icon.Colour = AccentColour;
-                }
-
                 updateFade();
             }
         }
@@ -89,6 +83,8 @@ namespace osu.Game.Graphics.UserInterface
             {
                 icon.Icon = selected.NewValue ? FontAwesome.Regular.CheckCircle : FontAwesome.Regular.Circle;
                 text.Font = text.Font.With(weight: selected.NewValue ? FontWeight.Bold : FontWeight.Medium);
+
+                updateFade();
             };
         }
 
@@ -115,8 +111,8 @@ namespace osu.Game.Graphics.UserInterface
 
         private void updateFade()
         {
-            box.FadeTo(IsHovered ? 1 : 0, transition_length, Easing.OutQuint);
-            text.FadeColour(IsHovered ? Color4.White : AccentColour, transition_length, Easing.OutQuint);
+            box.FadeTo(Current.Value || IsHovered ? 1 : 0, transition_length, Easing.OutQuint);
+            text.FadeColour(Current.Value || IsHovered ? Color4.White : AccentColour, transition_length, Easing.OutQuint);
         }
     }
 }


### PR DESCRIPTION
After going to song select with show converted beatmaps enabled:

| Before | After |
| --- | --- |
| ![dotnet_cE9oVCb6mq](https://user-images.githubusercontent.com/35318437/87237105-c6789480-c3a6-11ea-887f-3ede1a0e0d5d.png) | ![dotnet_ZkYdW942Rr](https://user-images.githubusercontent.com/35318437/87237107-cbd5df00-c3a6-11ea-8632-59ee37e5e8e4.png) |

The `updateFade` addition after value changed is actually a side change for when the setting is changed elsewhere. It is needed because on hover won't happen.