### PR TITLE
Fix correct filter criteria not being applied to beatmap carousel if beatmaps take too long to load

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             loadBeatmaps();
 
-            AddStep("select last", () => carousel.SelectBeatmap(carousel.BeatmapSets.First().Beatmaps.First()));
+            AddStep("select first", () => carousel.SelectBeatmap(carousel.BeatmapSets.First().Beatmaps.First()));
             waitForSelection(1, 1);
 
             advanceSelection(direction: 1, diff: true);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -80,9 +80,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestRecommendedSelection()
         {
-            loadBeatmaps();
+            loadBeatmaps(carouselAdjust: carousel => carousel.GetRecommendedBeatmap = beatmaps => beatmaps.LastOrDefault());
 
-            AddStep("set recommendation function", () => carousel.GetRecommendedBeatmap = beatmaps => beatmaps.LastOrDefault());
+            AddStep("select last", () => carousel.SelectBeatmap(carousel.BeatmapSets.Last().Beatmaps.Last()));
 
             // check recommended was selected
             advanceSelection(direction: 1, diff: false);
@@ -114,7 +114,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             loadBeatmaps();
 
-            advanceSelection(direction: 1, diff: false);
+            AddStep("select last", () => carousel.SelectBeatmap(carousel.BeatmapSets.First().Beatmaps.First()));
             waitForSelection(1, 1);
 
             advanceSelection(direction: 1, diff: true);
@@ -707,9 +707,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             checkVisibleItemCount(true, 15);
         }
 
-        private void loadBeatmaps(List<BeatmapSetInfo> beatmapSets = null, Func<FilterCriteria> initialCriteria = null)
+        private void loadBeatmaps(List<BeatmapSetInfo> beatmapSets = null, Func<FilterCriteria> initialCriteria = null, Action<BeatmapCarousel> carouselAdjust = null)
         {
-            createCarousel();
+            createCarousel(carouselAdjust);
 
             if (beatmapSets == null)
             {
@@ -730,17 +730,21 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("Wait for load", () => changed);
         }
 
-        private void createCarousel(Container target = null)
+        private void createCarousel(Action<BeatmapCarousel> carouselAdjust = null, Container target = null)
         {
             AddStep("Create carousel", () =>
             {
                 selectedSets.Clear();
                 eagerSelectedIDs.Clear();
 
-                (target ?? this).Child = carousel = new TestBeatmapCarousel
+                carousel = new TestBeatmapCarousel
                 {
                     RelativeSizeAxes = Axes.Both,
                 };
+
+                carouselAdjust?.Invoke(carousel);
+
+                (target ?? this).Child = carousel;
             });
         }
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Screens.Select
             itemsCache.Invalidate();
             scrollPositionCache.Invalidate();
 
-            // the filter criteria may have changed since the above filter operation.
+            // apply any pending filter operation that may have been delayed (see applyActiveCriteria's scheduling behaviour when BeatmapSetsLoaded is false).
             FlushPendingFilterOperations();
 
             // Run on late scheduler want to ensure this runs after all pending UpdateBeatmapSet / RemoveBeatmapSet operations are run.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/9408.

The case here was `FilterControl` loading before `loadBeatmapSets` completes. `SongSelect` would do a non-debounced filter application

https://github.com/ppy/osu/blob/57cfdb82ce47965e1f3654c8460e4be296a0715c/osu.Game/Screens/Select/SongSelect.cs#L307-L310

but this is cancelled at 

https://github.com/ppy/osu/blob/57cfdb82ce47965e1f3654c8460e4be296a0715c/osu.Game/Screens/Select/BeatmapCarousel.cs#L430

That was the only filter application pathway.

This change ensure the filter is always applied at the end of the load process, and only applied once (via checking the `BeatmapSetsLoaded` flag). You may jump to the conclusion that this isn't thread safe (what happens if the `FilterControl` applies the filter *after* the added Flush call?), but it will actually work correctly due to the filter *always* being scheduled until `BeatmapSetsLoaded` is true.

I make this change reluctantly, but I have tested quite thoroughly. Not too easy to write test coverage (open to suggestion, maybe converting the async part to a `protected virtual` and add a semaphore?), but to test locally the reported bug, add a `Thread.Sleep(10000)` in `loadBeatmapSets` before the `root = newRoot` line.