### PR TITLE
Allow pausing gameplay via middle mouse button

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Input.Bindings
 
         [Description("Toggle notifications")]
         ToggleNotifications,
-        
+
         [Description("Pause")]
         PauseGameplay,
     }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.Tilde }, GlobalAction.QuickExit),
             new KeyBinding(new[] { InputKey.Control, InputKey.Plus }, GlobalAction.IncreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.Control, InputKey.Minus }, GlobalAction.DecreaseScrollSpeed),
+            new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
         };
 
         public IEnumerable<KeyBinding> AudioControlKeyBindings => new[]
@@ -157,5 +158,8 @@ namespace osu.Game.Input.Bindings
 
         [Description("Home")]
         Home,
+
+        [Description("Pause")]
+        PauseGameplay,
     }
 }

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -265,6 +265,7 @@ namespace osu.Game.Screens.Play.HUD
                 switch (action)
                 {
                     case GlobalAction.Back:
+                    case GlobalAction.PauseGameplay:
                         AbortConfirm();
                         break;
                 }

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Screens.Play.HUD
                 switch (action)
                 {
                     case GlobalAction.Back:
-                    case GlobalAction.PauseGameplay:
+                    case GlobalAction.PauseGameplay: // in the future this behaviour will differ for replays etc.
                         if (!pendingAnimation)
                             BeginConfirm();
                         return true;

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -251,6 +251,7 @@ namespace osu.Game.Screens.Play.HUD
                 switch (action)
                 {
                     case GlobalAction.Back:
+                    case GlobalAction.PauseGameplay:
                         if (!pendingAnimation)
                             BeginConfirm();
                         return true;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/9531

Note that for the moment this just triggers standard "quit" behaviour (for cases like replays). This can change in the future once we have the ability to pause replays as well, but having the binding in place earlier is favourable IMO.