### PR TITLE
Fix potential crash when trying to ensure music is playing

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Overlays
                 if (beatmap.Disabled)
                     return;
 
-                next();
+                NextTrack();
             }
             else if (!IsPlaying)
             {
@@ -217,6 +217,9 @@ namespace osu.Game.Overlays
         /// <returns>The <see cref="PreviousTrackResult"/> that indicate the decided action.</returns>
         private PreviousTrackResult prev()
         {
+            if (beatmap.Disabled)
+                return PreviousTrackResult.None;
+
             var currentTrackPosition = current?.Track.CurrentTime;
 
             if (currentTrackPosition >= restart_cutoff_point)
@@ -248,6 +251,9 @@ namespace osu.Game.Overlays
 
         private bool next()
         {
+            if (beatmap.Disabled)
+                return false;
+
             queuedDirection = TrackChangeDirection.Next;
 
             var playable = BeatmapSets.SkipWhile(i => i.ID != current.BeatmapSetInfo.ID).ElementAtOrDefault(1) ?? BeatmapSets.FirstOrDefault();


### PR DESCRIPTION
Came up while running unrelated tests.

```
osu.Game.Tests.Visual.Navigation.TestSceneScreenNavigation.TestMenuMakesMusic

TearDown : System.InvalidOperationException : BeatmapSets should not be accessed before the music controller is loaded.
--TearDown
   at osu.Game.Overlays.MusicController.get_BeatmapSets() in /Users/dean/Projects/osu/osu.Game/Overlays/MusicController.cs:line 36
   at osu.Game.Overlays.MusicController.next() in /Users/dean/Projects/osu/osu.Game/Overlays/MusicController.cs:line 253
   at osu.Game.Overlays.MusicController.EnsurePlayingSomething() in /Users/dean/Projects/osu/osu.Game/Overlays/MusicController.cs:line 152
   at osu.Game.Screens.Menu.MainMenu.OnResuming(IScreen last) in /Users/dean/Projects/osu/osu.Game/Screens/Menu/MainMenu.cs:line 263
   at osu.Framework.Screens.ScreenStack.resumeFrom(IScreen source)
   at osu.Framework.Screens.ScreenStack.exitFrom(IScreen source, Boolean shouldFireExitEvent, Boolean shouldFireResumeEvent)
   at osu.Framework.Screens.ScreenStack.Exit(IScreen source)
   at osu.Framework.Screens.creenExtensions.Exit(IScreen screen)
   at osu.Game.Tests.Visual.Navigation.TestSceneScreenNavigation.<>c__DisplayClass7_0.<TestMenuMakesMusic>b__4() in /Users/dean/Projects/osu/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs:line 86
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location where exception was thrown ---
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 335
   at osu.Framework.Testing.TestScene.RunTests()
```