### PR TITLE
Fix local online cache database not being used when offline / logged out

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
@@ -48,9 +48,6 @@ namespace osu.Game.Beatmaps
 
             public Task UpdateAsync(BeatmapSetInfo beatmapSet, CancellationToken cancellationToken)
             {
-                if (api?.State != APIState.Online)
-                    return Task.CompletedTask;
-
                 LogForModel(beatmapSet, "Performing online lookups...");
                 return Task.WhenAll(beatmapSet.Beatmaps.Select(b => UpdateAsync(beatmapSet, b, cancellationToken)).ToArray());
             }

--- a/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Beatmaps
 
             // todo: expose this when we need to do individual difficulty lookups.
             protected Task UpdateAsync(BeatmapSetInfo beatmapSet, BeatmapInfo beatmap, CancellationToken cancellationToken)
-                => Task.Factory.StartNew(() => lookup(beatmapSet, beatmap), cancellationToken, TaskCreationOptions.HideScheduler, updateScheduler);
+                => Task.Factory.StartNew(() => lookup(beatmapSet, beatmap), cancellationToken, TaskCreationOptions.HideScheduler | TaskCreationOptions.RunContinuationsAsynchronously, updateScheduler);
 
             private void lookup(BeatmapSetInfo set, BeatmapInfo beatmap)
             {


### PR DESCRIPTION
API state check is already done further in the lookup (before the actual online request)

https://github.com/ppy/osu/blob/e0d9e70404fd5beabf944d886cfe7544d5aad907/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs#L67-L68