### PR TITLE
Fix some web requests retrieving the user too early

### DIFF
--- a/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
+++ b/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
@@ -8,7 +8,6 @@ using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Tests.Visual;
-using osu.Game.Users;
 
 namespace osu.Game.Tests.Online
 {
@@ -55,7 +54,7 @@ namespace osu.Game.Tests.Online
             AddStep("fire request", () =>
             {
                 gotResponse = false;
-                request = new LeaveChannelRequest(new Channel(), new User());
+                request = new LeaveChannelRequest(new Channel());
                 request.Success += () => gotResponse = true;
                 API.Queue(request);
             });
@@ -74,7 +73,7 @@ namespace osu.Game.Tests.Online
             AddStep("fire request", () =>
             {
                 gotResponse = false;
-                request = new LeaveChannelRequest(new Channel(), new User());
+                request = new LeaveChannelRequest(new Channel());
                 request.Success += () => gotResponse = true;
                 API.Perform(request);
             });
@@ -93,7 +92,7 @@ namespace osu.Game.Tests.Online
             AddStep("fire request", () =>
             {
                 gotResponse = false;
-                request = new LeaveChannelRequest(new Channel(), new User());
+                request = new LeaveChannelRequest(new Channel());
                 request.Success += () => gotResponse = true;
                 API.PerformAsync(request);
             });

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -5,6 +5,7 @@ using System;
 using Newtonsoft.Json;
 using osu.Framework.IO.Network;
 using osu.Framework.Logging;
+using osu.Game.Users;
 
 namespace osu.Game.Online.API
 {
@@ -62,6 +63,11 @@ namespace osu.Game.Online.API
         protected WebRequest WebRequest;
 
         /// <summary>
+        /// The currently logged in user. Note that this will only be populated during <see cref="Perform"/>.
+        /// </summary>
+        protected User User { get; private set; }
+
+        /// <summary>
         /// Invoked on successful completion of an API request.
         /// This will be scheduled to the API's internal scheduler (run on update thread automatically).
         /// </summary>
@@ -86,6 +92,7 @@ namespace osu.Game.Online.API
             }
 
             API = apiAccess;
+            User = apiAccess.LocalUser.Value;
 
             if (checkAndScheduleFailure())
                 return;

--- a/osu.Game/Online/API/Requests/JoinChannelRequest.cs
+++ b/osu.Game/Online/API/Requests/JoinChannelRequest.cs
@@ -4,19 +4,16 @@
 using System.Net.Http;
 using osu.Framework.IO.Network;
 using osu.Game.Online.Chat;
-using osu.Game.Users;
 
 namespace osu.Game.Online.API.Requests
 {
     public class JoinChannelRequest : APIRequest
     {
         private readonly Channel channel;
-        private readonly User user;
 
-        public JoinChannelRequest(Channel channel, User user)
+        public JoinChannelRequest(Channel channel)
         {
             this.channel = channel;
-            this.user = user;
         }
 
         protected override WebRequest CreateWebRequest()
@@ -26,6 +23,6 @@ namespace osu.Game.Online.API.Requests
             return req;
         }
 
-        protected override string Target => $@"chat/channels/{channel.Id}/users/{user.Id}";
+        protected override string Target => $@"chat/channels/{channel.Id}/users/{User.Id}";
     }
 }

--- a/osu.Game/Online/API/Requests/JoinRoomRequest.cs
+++ b/osu.Game/Online/API/Requests/JoinRoomRequest.cs
@@ -4,19 +4,16 @@
 using System.Net.Http;
 using osu.Framework.IO.Network;
 using osu.Game.Online.Multiplayer;
-using osu.Game.Users;
 
 namespace osu.Game.Online.API.Requests
 {
     public class JoinRoomRequest : APIRequest
     {
         private readonly Room room;
-        private readonly User user;
 
-        public JoinRoomRequest(Room room, User user)
+        public JoinRoomRequest(Room room)
         {
             this.room = room;
-            this.user = user;
         }
 
         protected override WebRequest CreateWebRequest()
@@ -26,6 +23,6 @@ namespace osu.Game.Online.API.Requests
             return req;
         }
 
-        protected override string Target => $"rooms/{room.RoomID.Value}/users/{user.Id}";
+        protected override string Target => $"rooms/{room.RoomID.Value}/users/{User.Id}";
     }
 }

--- a/osu.Game/Online/API/Requests/LeaveChannelRequest.cs
+++ b/osu.Game/Online/API/Requests/LeaveChannelRequest.cs
@@ -4,19 +4,16 @@
 using System.Net.Http;
 using osu.Framework.IO.Network;
 using osu.Game.Online.Chat;
-using osu.Game.Users;
 
 namespace osu.Game.Online.API.Requests
 {
     public class LeaveChannelRequest : APIRequest
     {
         private readonly Channel channel;
-        private readonly User user;
 
-        public LeaveChannelRequest(Channel channel, User user)
+        public LeaveChannelRequest(Channel channel)
         {
             this.channel = channel;
-            this.user = user;
         }
 
         protected override WebRequest CreateWebRequest()
@@ -26,6 +23,6 @@ namespace osu.Game.Online.API.Requests
             return req;
         }
 
-        protected override string Target => $@"chat/channels/{channel.Id}/users/{user.Id}";
+        protected override string Target => $@"chat/channels/{channel.Id}/users/{User.Id}";
     }
 }

--- a/osu.Game/Online/API/Requests/PartRoomRequest.cs
+++ b/osu.Game/Online/API/Requests/PartRoomRequest.cs
@@ -4,19 +4,16 @@
 using System.Net.Http;
 using osu.Framework.IO.Network;
 using osu.Game.Online.Multiplayer;
-using osu.Game.Users;
 
 namespace osu.Game.Online.API.Requests
 {
     public class PartRoomRequest : APIRequest
     {
         private readonly Room room;
-        private readonly User user;
 
-        public PartRoomRequest(Room room, User user)
+        public PartRoomRequest(Room room)
         {
             this.room = room;
-            this.user = user;
         }
 
         protected override WebRequest CreateWebRequest()
@@ -26,6 +23,6 @@ namespace osu.Game.Online.API.Requests
             return req;
         }
 
-        protected override string Target => $"rooms/{room.RoomID.Value}/users/{user.Id}";
+        protected override string Target => $"rooms/{room.RoomID.Value}/users/{User.Id}";
     }
 }

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -381,7 +381,7 @@ namespace osu.Game.Online.Chat
                         break;
 
                     default:
-                        var req = new JoinChannelRequest(channel, api.LocalUser.Value);
+                        var req = new JoinChannelRequest(channel);
                         req.Success += () => joinChannel(channel, fetchInitialMessages);
                         req.Failure += ex => LeaveChannel(channel);
                         api.Queue(req);
@@ -410,7 +410,7 @@ namespace osu.Game.Online.Chat
 
             if (channel.Joined.Value)
             {
-                api.Queue(new LeaveChannelRequest(channel, api.LocalUser.Value));
+                api.Queue(new LeaveChannelRequest(channel));
                 channel.Joined.Value = false;
             }
         }

--- a/osu.Game/Screens/Multi/RoomManager.cs
+++ b/osu.Game/Screens/Multi/RoomManager.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Multi
         public void JoinRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)
         {
             currentJoinRoomRequest?.Cancel();
-            currentJoinRoomRequest = new JoinRoomRequest(room, api.LocalUser.Value);
+            currentJoinRoomRequest = new JoinRoomRequest(room);
 
             currentJoinRoomRequest.Success += () =>
             {
@@ -139,7 +139,7 @@ namespace osu.Game.Screens.Multi
             if (joinedRoom == null)
                 return;
 
-            api.Queue(new PartRoomRequest(joinedRoom, api.LocalUser.Value));
+            api.Queue(new PartRoomRequest(joinedRoom));
             joinedRoom = null;
         }
 


### PR DESCRIPTION
Chat requests were retrieving the `LocalUser` at `ctor` time, which is potentially too early (the login process could still be running).

This changes to flow to allow requests to source an up-to-date user reference at the point of making the request.

- Closes https://github.com/ppy/osu-stable-issues/issues/495