### PR TITLE
Fix mod selection not working with base types

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -1,23 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModFadeIn : Mod
+    public class ManiaModFadeIn : ManiaModHidden
     {
         public override string Name => "Fade In";
         public override string Acronym => "FI";
         public override IconUsage? Icon => OsuIcon.ModHidden;
-        public override ModType Type => ModType.DifficultyIncrease;
         public override string Description => @"Keys appear out of nowhere!";
-        public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
-        public override Type[] IncompatibleMods => new[] { typeof(ModFlashlight<ManiaHitObject>) };
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -13,6 +13,8 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
@@ -99,6 +101,12 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestManiaMods()
         {
             changeRuleset(3);
+
+            var mania = new ManiaRuleset();
+
+            testModsWithSameBaseType(
+                mania.GetAllMods().Single(m => m.GetType() == typeof(ManiaModFadeIn)),
+                mania.GetAllMods().Single(m => m.GetType() == typeof(ManiaModHidden)));
         }
 
         [Test]
@@ -195,6 +203,18 @@ namespace osu.Game.Tests.Visual.UserInterface
             selectPrevious(mod);
             AddWaitStep("wait for changing colour", 1);
             checkLabelColor(() => Color4.White);
+        }
+
+        private void testModsWithSameBaseType(Mod modA, Mod modB)
+        {
+            selectNext(modA);
+            checkSelected(modA);
+            selectNext(modB);
+            checkSelected(modB);
+
+            // Backwards
+            selectPrevious(modA);
+            checkSelected(modA);
         }
 
         private void selectNext(Mod mod) => AddStep($"left click {mod.Name}", () => modSelect.GetModButton(mod)?.SelectNext(1));

--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Overlays.Mods
         {
             foreach (var button in buttons)
             {
-                int i = Array.FindIndex(button.Mods, m => modTypes.Any(t => t.IsInstanceOfType(m)));
+                int i = Array.FindIndex(button.Mods, m => modTypes.Any(t => t == m.GetType()));
 
                 if (i >= 0)
                     button.SelectAt(i);


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/ppy/osu/pull/9538

I ported back the mod inheritance from the PR above. This is a case where we're trying to select `HD`, but since `FI : HD` and `FI` is the first visible button, `FI` is re-selected. I'd say it makes sense to do exact matching for mod selection, and keep `InstanceOfType` for deselection only.