### PR TITLE
Fix osu!catch dropping fruit appearing above the plate instead of behind

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 Origin = Anchor.TopLeft,
             };
 
-            InternalChildren = new Drawable[]
+            InternalChildren = new []
             {
                 explodingFruitContainer,
                 CatcherArea.MovableCatcher.CaughtFruitContainer.CreateProxy(),

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Catch.UI
             InternalChildren = new[]
             {
                 explodingFruitContainer,
-                CatcherArea.MovableCatcher.CaughtFruitContainer.CreateProxy(),
+                CatcherArea.MovableCatcher.CreateProxiedContent(),
                 HitObjectContainer,
                 CatcherArea
             };

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -35,22 +35,25 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfield(BeatmapDifficulty difficulty, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation)
         {
-            Container explodingFruitContainer;
+            var explodingFruitContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+            };
+
+            CatcherArea = new CatcherArea(difficulty)
+            {
+                CreateDrawableRepresentation = createDrawableRepresentation,
+                ExplodingFruitTarget = explodingFruitContainer,
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.TopLeft,
+            };
 
             InternalChildren = new Drawable[]
             {
-                explodingFruitContainer = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
-                CatcherArea = new CatcherArea(difficulty)
-                {
-                    CreateDrawableRepresentation = createDrawableRepresentation,
-                    ExplodingFruitTarget = explodingFruitContainer,
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.TopLeft,
-                },
-                HitObjectContainer
+                explodingFruitContainer,
+                CatcherArea.MovableCatcher.CaughtFruitContainer.CreateProxy(),
+                HitObjectContainer,
+                CatcherArea
             };
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 Origin = Anchor.TopLeft,
             };
 
-            InternalChildren = new []
+            InternalChildren = new[]
             {
                 explodingFruitContainer,
                 CatcherArea.MovableCatcher.CaughtFruitContainer.CreateProxy(),

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -46,6 +46,12 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public Container ExplodingFruitTarget;
 
+        public Container<DrawableHitObject> CaughtFruitContainer { get; } = new Container<DrawableHitObject>
+        {
+            Anchor = Anchor.TopCentre,
+            Origin = Anchor.BottomCentre,
+        };
+
         [NotNull]
         private readonly Container trailsTarget;
 
@@ -83,8 +89,6 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private readonly float catchWidth;
 
-        private Container<DrawableHitObject> caughtFruit;
-
         private CatcherSprite catcherIdle;
         private CatcherSprite catcherKiai;
         private CatcherSprite catcherFail;
@@ -118,11 +122,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             InternalChildren = new Drawable[]
             {
-                caughtFruit = new Container<DrawableHitObject>
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.BottomCentre,
-                },
+                CaughtFruitContainer,
                 catcherIdle = new CatcherSprite(CatcherAnimationState.Idle)
                 {
                     Anchor = Anchor.TopCentre,
@@ -176,7 +176,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             const float allowance = 10;
 
-            while (caughtFruit.Any(f =>
+            while (CaughtFruitContainer.Any(f =>
                 f.LifetimeEnd == double.MaxValue &&
                 Vector2Extensions.Distance(f.Position, fruit.Position) < (ourRadius + (theirRadius = f.DrawSize.X / 2 * f.Scale.X)) / (allowance / 2)))
             {
@@ -187,7 +187,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             fruit.X = Math.Clamp(fruit.X, -CatcherArea.CATCHER_SIZE / 2, CatcherArea.CATCHER_SIZE / 2);
 
-            caughtFruit.Add(fruit);
+            CaughtFruitContainer.Add(fruit);
 
             AddInternal(new HitExplosion(fruit)
             {
@@ -342,7 +342,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public void Drop()
         {
-            foreach (var f in caughtFruit.ToArray())
+            foreach (var f in CaughtFruitContainer.ToArray())
                 Drop(f);
         }
 
@@ -351,7 +351,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public void Explode()
         {
-            foreach (var f in caughtFruit.ToArray())
+            foreach (var f in CaughtFruitContainer.ToArray())
                 Explode(f);
         }
 
@@ -450,9 +450,9 @@ namespace osu.Game.Rulesets.Catch.UI
             if (ExplodingFruitTarget != null)
             {
                 fruit.Anchor = Anchor.TopLeft;
-                fruit.Position = caughtFruit.ToSpaceOfOtherDrawable(fruit.DrawPosition, ExplodingFruitTarget);
+                fruit.Position = CaughtFruitContainer.ToSpaceOfOtherDrawable(fruit.DrawPosition, ExplodingFruitTarget);
 
-                if (!caughtFruit.Remove(fruit))
+                if (!CaughtFruitContainer.Remove(fruit))
                     // we may have already been removed by a previous operation (due to the weird OnLoadComplete scheduling).
                     // this avoids a crash on potentially attempting to Add a fruit to ExplodingFruitTarget twice.
                     return;

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public Container ExplodingFruitTarget;
 
-        public Container<DrawableHitObject> CaughtFruitContainer { get; } = new Container<DrawableHitObject>
+        private Container<DrawableHitObject> caughtFruitContainer { get; } = new Container<DrawableHitObject>
         {
             Anchor = Anchor.TopCentre,
             Origin = Anchor.BottomCentre,
@@ -122,7 +122,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             InternalChildren = new Drawable[]
             {
-                CaughtFruitContainer,
+                caughtFruitContainer,
                 catcherIdle = new CatcherSprite(CatcherAnimationState.Idle)
                 {
                     Anchor = Anchor.TopCentre,
@@ -144,6 +144,12 @@ namespace osu.Game.Rulesets.Catch.UI
 
             updateCatcher();
         }
+
+        /// <summary>
+        /// Creates proxied content to be displayed beneath hitobjects.
+        /// </summary>
+        /// <returns></returns>
+        public Drawable CreateProxiedContent() => caughtFruitContainer.CreateProxy();
 
         /// <summary>
         /// Calculates the scale of the catcher based off the provided beatmap difficulty.
@@ -176,7 +182,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             const float allowance = 10;
 
-            while (CaughtFruitContainer.Any(f =>
+            while (caughtFruitContainer.Any(f =>
                 f.LifetimeEnd == double.MaxValue &&
                 Vector2Extensions.Distance(f.Position, fruit.Position) < (ourRadius + (theirRadius = f.DrawSize.X / 2 * f.Scale.X)) / (allowance / 2)))
             {
@@ -187,7 +193,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             fruit.X = Math.Clamp(fruit.X, -CatcherArea.CATCHER_SIZE / 2, CatcherArea.CATCHER_SIZE / 2);
 
-            CaughtFruitContainer.Add(fruit);
+            caughtFruitContainer.Add(fruit);
 
             AddInternal(new HitExplosion(fruit)
             {
@@ -342,7 +348,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public void Drop()
         {
-            foreach (var f in CaughtFruitContainer.ToArray())
+            foreach (var f in caughtFruitContainer.ToArray())
                 Drop(f);
         }
 
@@ -351,7 +357,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public void Explode()
         {
-            foreach (var f in CaughtFruitContainer.ToArray())
+            foreach (var f in caughtFruitContainer.ToArray())
                 Explode(f);
         }
 
@@ -450,9 +456,9 @@ namespace osu.Game.Rulesets.Catch.UI
             if (ExplodingFruitTarget != null)
             {
                 fruit.Anchor = Anchor.TopLeft;
-                fruit.Position = CaughtFruitContainer.ToSpaceOfOtherDrawable(fruit.DrawPosition, ExplodingFruitTarget);
+                fruit.Position = caughtFruitContainer.ToSpaceOfOtherDrawable(fruit.DrawPosition, ExplodingFruitTarget);
 
-                if (!CaughtFruitContainer.Remove(fruit))
+                if (!caughtFruitContainer.Remove(fruit))
                     // we may have already been removed by a previous operation (due to the weird OnLoadComplete scheduling).
                     // this avoids a crash on potentially attempting to Add a fruit to ExplodingFruitTarget twice.
                     return;

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -148,7 +148,6 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Creates proxied content to be displayed beneath hitobjects.
         /// </summary>
-        /// <returns></returns>
         public Drawable CreateProxiedContent() => caughtFruitContainer.CreateProxy();
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public Func<CatchHitObject, DrawableHitObject<CatchHitObject>> CreateDrawableRepresentation;
 
+        public readonly Catcher MovableCatcher;
+
         public Container ExplodingFruitTarget
         {
             set => MovableCatcher.ExplodingFruitTarget = value;
@@ -104,7 +106,5 @@ namespace osu.Game.Rulesets.Catch.UI
             if (state?.CatcherX != null)
                 MovableCatcher.X = state.CatcherX.Value;
         }
-
-        protected internal readonly Catcher MovableCatcher;
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/7938

I was considering changing `ExplodingFruitTarget` to also user proxying, but turns out that's not what we want due to it no tracking the catcher position.