### PR TITLE
Fix storyboard video playback when not starting at beginning of beatmap

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -55,10 +55,11 @@ namespace osu.Game.Storyboards.Drawables
 
             if (video == null) return;
 
-            video.PlaybackPosition = Clock.CurrentTime - Video.StartTime;
-
-            using (video.BeginAbsoluteSequence(0))
+            using (video.BeginAbsoluteSequence(Video.StartTime))
+            {
+                Schedule(() => video.PlaybackPosition = Time.Current - Video.StartTime);
                 video.FadeIn(500);
+            }
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/9561

I started adding a test but it seems like we will need a test resource with video to make it work properly. Not sure I'm ready to put in the time required to make that work right now, maybe next regression?