### PR TITLE
Fix chat name backgrounds not dimming

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -114,21 +115,26 @@ namespace osu.Game.Overlays.Chat
                         Colour = Color4.Black.Opacity(0.3f),
                         Type = EdgeEffectType.Shadow,
                     },
-                    // Drop shadow effect
                     Child = new Container
                     {
                         AutoSizeAxes = Axes.Both,
+                        Y = 3,
                         Masking = true,
                         CornerRadius = 4,
-                        EdgeEffect = new EdgeEffectParameters
+                        Children = new Drawable[]
                         {
-                            Radius = 1,
-                            Colour = Color4Extensions.FromHex(message.Sender.Colour),
-                            Type = EdgeEffectType.Shadow,
-                        },
-                        Padding = new MarginPadding { Left = 3, Right = 3, Bottom = 1, Top = -3 },
-                        Y = 3,
-                        Child = username,
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4Extensions.FromHex(message.Sender.Colour),
+                            },
+                            new Container
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Padding = new MarginPadding { Left = 4, Right = 4, Bottom = 1, Top = -2 },
+                                Child = username
+                            }
+                        }
                     }
                 };
             }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9504

Master:
![Screenshot_2020-07-16_15-00-38](https://user-images.githubusercontent.com/1329837/87633162-d4972e00-c775-11ea-8b53-67ebbd4633d9.png)

This PR:
![Screenshot_2020-07-16_15-02-25](https://user-images.githubusercontent.com/1329837/87633174-d82ab500-c775-11ea-9b28-e2b31f590803.png)

The differences are minor enough to be indistinguishable to me in a blind test.