### PR TITLE
Fix reversing scroll direction not always behaving as expected

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSeekSnapping.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSeekSnapping.cs
@@ -175,13 +175,13 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("Time = 50", () => Clock.CurrentTime == 50);
             AddStep("Seek(49.999)", () => Clock.Seek(49.999));
             AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
-            AddAssert("Time = 50", () => Clock.CurrentTime == 50);
+            AddAssert("Time = 100", () => Clock.CurrentTime == 100);
             AddStep("Seek(99)", () => Clock.Seek(99));
             AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
             AddAssert("Time = 100", () => Clock.CurrentTime == 100);
             AddStep("Seek(99.999)", () => Clock.Seek(99.999));
             AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
-            AddAssert("Time = 100", () => Clock.CurrentTime == 100);
+            AddAssert("Time = 100", () => Clock.CurrentTime == 150);
             AddStep("Seek(174)", () => Clock.Seek(174));
             AddStep("SeekForward, Snap", () => Clock.SeekForward(true));
             AddAssert("Time = 175", () => Clock.CurrentTime == 175);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -275,11 +275,22 @@ namespace osu.Game.Screens.Edit
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            scrollAccumulation += (e.ScrollDelta.X + e.ScrollDelta.Y) * (e.IsPrecise ? 0.1 : 1);
+            const double precision = 1;
 
-            const int precision = 1;
+            double scrollComponent = e.ScrollDelta.X + e.ScrollDelta.Y;
 
-            while (Math.Abs(scrollAccumulation) > precision)
+            double scrollDirection = Math.Sign(scrollComponent);
+
+            // this is a special case to handle the "pivot" scenario.
+            // if we are precise scrolling in one direction then change our mind and scroll backwards,
+            // the existing accumulation should be applied in the inverse direction to maintain responsiveness.
+            if (Math.Sign(scrollAccumulation) != scrollDirection)
+                scrollAccumulation = scrollDirection * (precision - Math.Abs(scrollAccumulation));
+
+            scrollAccumulation += scrollComponent * (e.IsPrecise ? 0.1 : 1);
+
+            // because we are doing snapped seeking, we need to add up precise scrolls until they accumulate to an arbitrary cut-off.
+            while (Math.Abs(scrollAccumulation) >= precision)
             {
                 if (scrollAccumulation > 0)
                     seek(e, -1);

--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -118,9 +118,14 @@ namespace osu.Game.Screens.Edit
 
             seekTime = timingPoint.Time + closestBeat * seekAmount;
 
+            // limit forward seeking to only up to the next timing point's start time.
+            var nextTimingPoint = ControlPointInfo.TimingPoints.FirstOrDefault(t => t.Time > timingPoint.Time);
+            if (seekTime > nextTimingPoint?.Time)
+                seekTime = nextTimingPoint.Time;
+
             // Due to the rounding above, we may end up on the current beat. This will effectively cause 0 seeking to happen, but we don't want this.
             // Instead, we'll go to the next beat in the direction when this is the case
-            if (Precision.AlmostEquals(current, seekTime, 1))
+            if (Precision.AlmostEquals(current, seekTime, 0.5f))
             {
                 closestBeat += direction > 0 ? 1 : -1;
                 seekTime = timingPoint.Time + closestBeat * seekAmount;
@@ -128,10 +133,6 @@ namespace osu.Game.Screens.Edit
 
             if (seekTime < timingPoint.Time && timingPoint != ControlPointInfo.TimingPoints.First())
                 seekTime = timingPoint.Time;
-
-            var nextTimingPoint = ControlPointInfo.TimingPoints.FirstOrDefault(t => t.Time > timingPoint.Time);
-            if (seekTime > nextTimingPoint?.Time)
-                seekTime = nextTimingPoint.Time;
 
             // Ensure the sought point is within the boundaries
             seekTime = Math.Clamp(seekTime, 0, TrackLength);

--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Screens.Edit
 
             // Due to the rounding above, we may end up on the current beat. This will effectively cause 0 seeking to happen, but we don't want this.
             // Instead, we'll go to the next beat in the direction when this is the case
-            if (Precision.AlmostEquals(current, seekTime))
+            if (Precision.AlmostEquals(current, seekTime, 1))
             {
                 closestBeat += direction > 0 ? 1 : -1;
                 seekTime = timingPoint.Time + closestBeat * seekAmount;


### PR DESCRIPTION
This fixes two similar issues:

- Using left and right arrows in the editor can someone (still) get stuck on the first reverse direction press. This was due to the `AlmostEquals` check not being lenient enough.
- Scrolling with precise scroll didn't feel good when reversing direction due to the completed portion of the "precision" tick not being counted for the inverse movement. This would result in a large movement requirement before the seek started to feel responsive again.

Added some more documentation around this code since it is a bit custom.

Previously:

![2020-07-17 16 47 57](https://user-images.githubusercontent.com/191335/87762007-5c03a080-c84d-11ea-8b0c-7fd07c6418dd.gif)

Note "sticking" behaviour when reversing direction while fractionally close to the snap point.


Now:

![2020-07-17 16 48 47](https://user-images.githubusercontent.com/191335/87762086-7d648c80-c84d-11ea-9b07-28cd4796a239.gif)
