### PR TITLE
Fix editor double-click incorrectly firing when clicks target different hitobjects

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -121,14 +121,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return e.Button == MouseButton.Left;
         }
 
+        private SelectionBlueprint clickedBlueprint;
+
         protected override bool OnClick(ClickEvent e)
         {
             if (e.Button == MouseButton.Right)
                 return false;
 
+            // store for double-click handling
+            clickedBlueprint = selectionHandler.SelectedBlueprints.FirstOrDefault(b => b.IsHovered);
+
             // Deselection should only occur if no selected blueprints are hovered
             // A special case for when a blueprint was selected via this click is added since OnClick() may occur outside the hitobject and should not trigger deselection
-            if (endClickSelection() || selectionHandler.SelectedBlueprints.Any(b => b.IsHovered))
+            if (endClickSelection() || clickedBlueprint != null)
                 return true;
 
             deselectAll();
@@ -140,9 +145,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (e.Button == MouseButton.Right)
                 return false;
 
-            SelectionBlueprint clickedBlueprint = selectionHandler.SelectedBlueprints.FirstOrDefault(b => b.IsHovered);
-
-            if (clickedBlueprint == null)
+            // ensure the blueprint which was hovered for the first click is still the hovered blueprint.
+            if (clickedBlueprint == null || selectionHandler.SelectedBlueprints.FirstOrDefault(b => b.IsHovered) != clickedBlueprint)
                 return false;
 
             editorClock?.SeekTo(clickedBlueprint.HitObject.StartTime);


### PR DESCRIPTION
before:
![2020-07-17 17 06 00](https://user-images.githubusercontent.com/191335/87763713-2b713600-c850-11ea-8f0d-c9c13fb64d22.gif)
after:
![2020-07-17 17 04 55](https://user-images.githubusercontent.com/191335/87763704-290edc00-c850-11ea-977f-eb93fcb1b4d7.gif)