### PR TITLE
Add texture wrapping support to skinning, fix taiko and mania

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyBodyPiece.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -31,7 +32,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
             string imageName = GetColumnSkinConfig<string>(skin, LegacyManiaSkinConfigurationLookups.HoldNoteBodyImage)?.Value
                                ?? $"mania-note{FallbackColumnIndex}L";
 
-            sprite = skin.GetAnimation(imageName, true, true).With(d =>
+            sprite = skin.GetAnimation(imageName, WrapMode.ClampToEdge, WrapMode.ClampToEdge, true, true).With(d =>
             {
                 if (d == null)
                     return;

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyNotePiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyNotePiece.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Rulesets.UI.Scrolling;
@@ -92,7 +93,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
             string noteImage = GetColumnSkinConfig<string>(skin, lookup)?.Value
                                ?? $"mania-note{FallbackColumnIndex}{suffix}";
 
-            return skin.GetTexture(noteImage);
+            return skin.GetTexture(noteImage, WrapMode.ClampToEdge, WrapMode.ClampToEdge);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
@@ -8,6 +8,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Testing.Input;
 using osu.Game.Audio;
@@ -79,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             public Drawable GetDrawableComponent(ISkinComponent component) => throw new NotImplementedException();
 
-            public Texture GetTexture(string componentName)
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
             {
                 switch (componentName)
                 {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSkinFallbacks.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSkinFallbacks.cs
@@ -9,6 +9,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Timing;
@@ -131,7 +132,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 };
             }
 
-            public Texture GetTexture(string componentName) => null;
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => null;
 
             public SampleChannel GetSample(ISampleInfo sampleInfo) => null;
 

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Skinning;
@@ -34,13 +35,13 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreLeft,
                     RelativeSizeAxes = Axes.Both,
-                    Texture = skin.GetTexture("taiko-roll-end"),
+                    Texture = skin.GetTexture("taiko-roll-end", WrapMode.ClampToEdge, WrapMode.ClampToEdge),
                     FillMode = FillMode.Fit,
                 },
                 body = new Sprite
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Texture = skin.GetTexture("taiko-roll-middle"),
+                    Texture = skin.GetTexture("taiko-roll-middle", WrapMode.ClampToEdge, WrapMode.ClampToEdge),
                 },
                 headCircle = new LegacyCirclePiece
                 {

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectAccentColour.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectAccentColour.cs
@@ -8,6 +8,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Testing;
 using osu.Game.Audio;
@@ -118,7 +119,7 @@ namespace osu.Game.Tests.Gameplay
 
             public Drawable GetDrawableComponent(ISkinComponent component) => throw new NotImplementedException();
 
-            public Texture GetTexture(string componentName) => throw new NotImplementedException();
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => throw new NotImplementedException();
 
             public SampleChannel GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 

--- a/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinConfigurationLookup.cs
@@ -10,6 +10,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Testing;
 using osu.Game.Audio;
@@ -216,7 +217,7 @@ namespace osu.Game.Tests.Skins
 
             public Drawable GetDrawableComponent(ISkinComponent component) => skin.GetDrawableComponent(component);
 
-            public Texture GetTexture(string componentName) => skin.GetTexture(componentName);
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => skin.GetTexture(componentName, wrapModeS, wrapModeT);
 
             public SampleChannel GetSample(ISampleInfo sampleInfo) => skin.GetSample(sampleInfo);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableDrawable.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableDrawable.cs
@@ -10,6 +10,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
@@ -295,7 +296,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     }
                     : null;
 
-            public Texture GetTexture(string componentName) => throw new NotImplementedException();
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => throw new NotImplementedException();
 
             public SampleChannel GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 
@@ -306,7 +307,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             public Drawable GetDrawableComponent(ISkinComponent componentName) => new SecondarySourceBox();
 
-            public Texture GetTexture(string componentName) => throw new NotImplementedException();
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => throw new NotImplementedException();
 
             public SampleChannel GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 
@@ -318,7 +319,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             public Drawable GetDrawableComponent(ISkinComponent componentName) => new BaseSourceBox();
 
-            public Texture GetTexture(string componentName) => throw new NotImplementedException();
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => throw new NotImplementedException();
 
             public SampleChannel GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osuTK.Graphics;
@@ -21,7 +22,7 @@ namespace osu.Game.Skinning
 
         public override Drawable GetDrawableComponent(ISkinComponent component) => null;
 
-        public override Texture GetTexture(string componentName) => null;
+        public override Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => null;
 
         public override SampleChannel GetSample(ISampleInfo sampleInfo) => null;
 

--- a/osu.Game/Skinning/IAnimationTimeReference.cs
+++ b/osu.Game/Skinning/IAnimationTimeReference.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Timing;
 
 namespace osu.Game.Skinning
@@ -11,7 +12,7 @@ namespace osu.Game.Skinning
     /// </summary>
     /// <remarks>
     /// This should not be used to start an animation immediately at the current time.
-    /// To do so, use <see cref="LegacySkinExtensions.GetAnimation"/> with <code>startAtCurrentTime = true</code> instead.
+    /// To do so, use <see cref="LegacySkinExtensions.GetAnimation(ISkin, string, WrapMode, WrapMode, bool, bool, bool, string, bool, double?)"/> with <code>startAtCurrentTime = true</code> instead.
     /// </remarks>
     [Cached]
     public interface IAnimationTimeReference

--- a/osu.Game/Skinning/ISkin.cs
+++ b/osu.Game/Skinning/ISkin.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 
@@ -29,7 +30,17 @@ namespace osu.Game.Skinning
         /// <param name="componentName">The requested texture.</param>
         /// <returns>A matching texture, or null if unavailable.</returns>
         [CanBeNull]
-        Texture GetTexture(string componentName);
+        Texture GetTexture(string componentName) => GetTexture(componentName, default, default);
+
+        /// <summary>
+        /// Retrieve a <see cref="Texture"/>.
+        /// </summary>
+        /// <param name="componentName">The requested texture.</param>
+        /// <param name="wrapModeS">The texture wrap mode in horizontal direction.</param>
+        /// <param name="wrapModeT">The texture wrap mode in vertical direction.</param>
+        /// <returns>A matching texture, or null if unavailable.</returns>
+        [CanBeNull]
+        Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT);
 
         /// <summary>
         /// Retrieve a <see cref="SampleChannel"/>.

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -11,6 +11,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Game.Audio;
@@ -311,17 +312,17 @@ namespace osu.Game.Skinning
             return this.GetAnimation(component.LookupName, false, false);
         }
 
-        public override Texture GetTexture(string componentName)
+        public override Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
         {
             foreach (var name in getFallbackNames(componentName))
             {
                 float ratio = 2;
-                var texture = Textures?.Get($"{name}@2x");
+                var texture = Textures?.Get($"{name}@2x", wrapModeS, wrapModeT);
 
                 if (texture == null)
                 {
                     ratio = 1;
-                    texture = Textures?.Get(name);
+                    texture = Textures?.Get(name, wrapModeS, wrapModeT);
                 }
 
                 if (texture == null)

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 
@@ -14,6 +15,11 @@ namespace osu.Game.Skinning
     public static class LegacySkinExtensions
     {
         public static Drawable GetAnimation(this ISkin source, string componentName, bool animatable, bool looping, bool applyConfigFrameRate = false, string animationSeparator = "-",
+                                            bool startAtCurrentTime = true, double? frameLength = null)
+            => source.GetAnimation(componentName, default, default, animatable, looping, applyConfigFrameRate, animationSeparator, startAtCurrentTime, frameLength);
+
+        public static Drawable GetAnimation(this ISkin source, string componentName, WrapMode wrapModeS, WrapMode wrapModeT, bool animatable, bool looping, bool applyConfigFrameRate = false,
+                                            string animationSeparator = "-",
                                             bool startAtCurrentTime = true, double? frameLength = null)
         {
             Texture texture;
@@ -38,7 +44,7 @@ namespace osu.Game.Skinning
             }
 
             // if an animation was not allowed or not found, fall back to a sprite retrieval.
-            if ((texture = source.GetTexture(componentName)) != null)
+            if ((texture = source.GetTexture(componentName, wrapModeS, wrapModeT)) != null)
                 return new Sprite { Texture = texture };
 
             return null;
@@ -47,7 +53,7 @@ namespace osu.Game.Skinning
             {
                 for (int i = 0; true; i++)
                 {
-                    if ((texture = source.GetTexture($"{componentName}{animationSeparator}{i}")) == null)
+                    if ((texture = source.GetTexture($"{componentName}{animationSeparator}{i}", wrapModeS, wrapModeT)) == null)
                         break;
 
                     yield return texture;

--- a/osu.Game/Skinning/LegacySkinTransformer.cs
+++ b/osu.Game/Skinning/LegacySkinTransformer.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Objects.Legacy;
@@ -27,7 +28,10 @@ namespace osu.Game.Skinning
 
         public abstract Drawable GetDrawableComponent(ISkinComponent component);
 
-        public Texture GetTexture(string componentName) => Source.GetTexture(componentName);
+        public Texture GetTexture(string componentName) => GetTexture(componentName, default, default);
+
+        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
+            => Source.GetTexture(componentName, wrapModeS, wrapModeT);
 
         public virtual SampleChannel GetSample(ISampleInfo sampleInfo)
         {

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 
@@ -20,7 +21,9 @@ namespace osu.Game.Skinning
 
         public abstract SampleChannel GetSample(ISampleInfo sampleInfo);
 
-        public abstract Texture GetTexture(string componentName);
+        public Texture GetTexture(string componentName) => GetTexture(componentName, default, default);
+
+        public abstract Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT);
 
         public abstract IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup);
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -13,6 +13,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
@@ -130,7 +131,7 @@ namespace osu.Game.Skinning
 
         public Drawable GetDrawableComponent(ISkinComponent component) => CurrentSkin.Value.GetDrawableComponent(component);
 
-        public Texture GetTexture(string componentName) => CurrentSkin.Value.GetTexture(componentName);
+        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => CurrentSkin.Value.GetTexture(componentName, wrapModeS, wrapModeT);
 
         public SampleChannel GetSample(ISampleInfo sampleInfo) => CurrentSkin.Value.GetSample(sampleInfo);
 

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 
@@ -47,13 +48,13 @@ namespace osu.Game.Skinning
             return fallbackSource?.GetDrawableComponent(component);
         }
 
-        public Texture GetTexture(string componentName)
+        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
         {
             Texture sourceTexture;
-            if (AllowTextureLookup(componentName) && (sourceTexture = skin?.GetTexture(componentName)) != null)
+            if (AllowTextureLookup(componentName) && (sourceTexture = skin?.GetTexture(componentName, wrapModeS, wrapModeT)) != null)
                 return sourceTexture;
 
-            return fallbackSource?.GetTexture(componentName);
+            return fallbackSource?.GetTexture(componentName, wrapModeS, wrapModeT);
         }
 
         public SampleChannel GetSample(ISampleInfo sampleInfo)

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
@@ -157,7 +158,7 @@ namespace osu.Game.Tests.Visual
                 this.extrapolateAnimations = extrapolateAnimations;
             }
 
-            public override Texture GetTexture(string componentName)
+            public override Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
             {
                 // extrapolate frames to test longer animations
                 if (extrapolateAnimations)
@@ -165,10 +166,10 @@ namespace osu.Game.Tests.Visual
                     var match = Regex.Match(componentName, "-([0-9]*)");
 
                     if (match.Length > 0 && int.TryParse(match.Groups[1].Value, out var number) && number < 60)
-                        return base.GetTexture(componentName.Replace($"-{number}", $"-{number % 2}"));
+                        return base.GetTexture(componentName.Replace($"-{number}", $"-{number % 2}"), wrapModeS, wrapModeT);
                 }
 
-                return base.GetTexture(componentName);
+                return base.GetTexture(componentName, wrapModeS, wrapModeT);
             }
         }
     }


### PR DESCRIPTION
I think this may be a breaking change for the karaoke ruleset (hopefully not but haven't tested), but I don't think there's a way around it.

Notable decisions I've made:
- Implemented interface method. Most use-cases will use the `ISkin` or `ISkinSource` interface.
- Exposed interface method from classes where it's likely to be used from the outside (`LegacySkinTransformer`, `Skin`).