### PR TITLE
Use static instances in all fallback ControlPoint lookups to reduce allocations

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -64,14 +64,14 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         /// <param name="time">The time to find the difficulty control point at.</param>
         /// <returns>The difficulty control point.</returns>
-        public DifficultyControlPoint DifficultyPointAt(double time) => binarySearchWithFallback(DifficultyPoints, time);
+        public DifficultyControlPoint DifficultyPointAt(double time) => binarySearchWithFallback(DifficultyPoints, time, DifficultyControlPoint.DEFAULT);
 
         /// <summary>
         /// Finds the effect control point that is active at <paramref name="time"/>.
         /// </summary>
         /// <param name="time">The time to find the effect control point at.</param>
         /// <returns>The effect control point.</returns>
-        public EffectControlPoint EffectPointAt(double time) => binarySearchWithFallback(EffectPoints, time);
+        public EffectControlPoint EffectPointAt(double time) => binarySearchWithFallback(EffectPoints, time, EffectControlPoint.DEFAULT);
 
         /// <summary>
         /// Finds the sound control point that is active at <paramref name="time"/>.
@@ -92,21 +92,21 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         [JsonIgnore]
         public double BPMMaximum =>
-            60000 / (TimingPoints.OrderBy(c => c.BeatLength).FirstOrDefault() ?? new TimingControlPoint()).BeatLength;
+            60000 / (TimingPoints.OrderBy(c => c.BeatLength).FirstOrDefault() ?? TimingControlPoint.DEFAULT).BeatLength;
 
         /// <summary>
         /// Finds the minimum BPM represented by any timing control point.
         /// </summary>
         [JsonIgnore]
         public double BPMMinimum =>
-            60000 / (TimingPoints.OrderByDescending(c => c.BeatLength).FirstOrDefault() ?? new TimingControlPoint()).BeatLength;
+            60000 / (TimingPoints.OrderByDescending(c => c.BeatLength).FirstOrDefault() ?? TimingControlPoint.DEFAULT).BeatLength;
 
         /// <summary>
         /// Finds the mode BPM (most common BPM) represented by the control points.
         /// </summary>
         [JsonIgnore]
         public double BPMMode =>
-            60000 / (TimingPoints.GroupBy(c => c.BeatLength).OrderByDescending(grp => grp.Count()).FirstOrDefault()?.FirstOrDefault() ?? new TimingControlPoint()).BeatLength;
+            60000 / (TimingPoints.GroupBy(c => c.BeatLength).OrderByDescending(grp => grp.Count()).FirstOrDefault()?.FirstOrDefault() ?? TimingControlPoint.DEFAULT).BeatLength;
 
         /// <summary>
         /// Remove all <see cref="ControlPointGroup"/>s and return to a pristine state.
@@ -170,12 +170,12 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         /// <param name="list">The list to search.</param>
         /// <param name="time">The time to find the control point at.</param>
-        /// <param name="prePoint">The control point to use when <paramref name="time"/> is before any control points. If null, a new control point will be constructed.</param>
+        /// <param name="fallback">The control point to use when <paramref name="time"/> is before any control points.</param>
         /// <returns>The active control point at <paramref name="time"/>, or a fallback <see cref="ControlPoint"/> if none found.</returns>
-        private T binarySearchWithFallback<T>(IReadOnlyList<T> list, double time, T prePoint = null)
+        private T binarySearchWithFallback<T>(IReadOnlyList<T> list, double time, T fallback)
             where T : ControlPoint, new()
         {
-            return binarySearch(list, time) ?? prePoint ?? new T();
+            return binarySearch(list, time) ?? fallback;
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -78,14 +78,14 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         /// <param name="time">The time to find the sound control point at.</param>
         /// <returns>The sound control point.</returns>
-        public SampleControlPoint SamplePointAt(double time) => binarySearchWithFallback(SamplePoints, time, SamplePoints.Count > 0 ? SamplePoints[0] : null);
+        public SampleControlPoint SamplePointAt(double time) => binarySearchWithFallback(SamplePoints, time, SamplePoints.Count > 0 ? SamplePoints[0] : SampleControlPoint.DEFAULT);
 
         /// <summary>
         /// Finds the timing control point that is active at <paramref name="time"/>.
         /// </summary>
         /// <param name="time">The time to find the timing control point at.</param>
         /// <returns>The timing control point.</returns>
-        public TimingControlPoint TimingPointAt(double time) => binarySearchWithFallback(TimingPoints, time, TimingPoints.Count > 0 ? TimingPoints[0] : null);
+        public TimingControlPoint TimingPointAt(double time) => binarySearchWithFallback(TimingPoints, time, TimingPoints.Count > 0 ? TimingPoints[0] : TimingControlPoint.DEFAULT);
 
         /// <summary>
         /// Finds the maximum BPM represented by any timing control point.

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// <param name="fallback">The control point to use when <paramref name="time"/> is before any control points.</param>
         /// <returns>The active control point at <paramref name="time"/>, or a fallback <see cref="ControlPoint"/> if none found.</returns>
         private T binarySearchWithFallback<T>(IReadOnlyList<T> list, double time, T fallback)
-            where T : ControlPoint, new()
+            where T : ControlPoint
         {
             return binarySearch(list, time) ?? fallback;
         }

--- a/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
@@ -7,6 +7,11 @@ namespace osu.Game.Beatmaps.ControlPoints
 {
     public class DifficultyControlPoint : ControlPoint
     {
+        public static readonly DifficultyControlPoint DEFAULT = new DifficultyControlPoint
+        {
+            SpeedMultiplierBindable = { Disabled = true },
+        };
+
         /// <summary>
         /// The speed multiplier at this control point.
         /// </summary>

--- a/osu.Game/Beatmaps/ControlPoints/EffectControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/EffectControlPoint.cs
@@ -7,6 +7,12 @@ namespace osu.Game.Beatmaps.ControlPoints
 {
     public class EffectControlPoint : ControlPoint
     {
+        public static readonly EffectControlPoint DEFAULT = new EffectControlPoint
+        {
+            KiaiModeBindable = { Disabled = true },
+            OmitFirstBarLineBindable = { Disabled = true }
+        };
+
         /// <summary>
         /// Whether the first bar line of this control point is ignored.
         /// </summary>

--- a/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
@@ -10,6 +10,12 @@ namespace osu.Game.Beatmaps.ControlPoints
     {
         public const string DEFAULT_BANK = "normal";
 
+        public static readonly SampleControlPoint DEFAULT = new SampleControlPoint
+        {
+            SampleBankBindable = { Disabled = true },
+            SampleVolumeBindable = { Disabled = true }
+        };
+
         /// <summary>
         /// The default sample bank at this control point.
         /// </summary>

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -20,8 +20,11 @@ namespace osu.Game.Beatmaps.ControlPoints
 
         public static readonly TimingControlPoint DEFAULT = new TimingControlPoint
         {
-            BeatLength = default_beat_length,
-            BeatLengthBindable = { Disabled = true },
+            BeatLengthBindable =
+            {
+                Value = default_beat_length,
+                Disabled = true
+            },
             TimeSignatureBindable = { Disabled = true }
         };
 

--- a/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/TimingControlPoint.cs
@@ -14,6 +14,18 @@ namespace osu.Game.Beatmaps.ControlPoints
         public readonly Bindable<TimeSignatures> TimeSignatureBindable = new Bindable<TimeSignatures>(TimeSignatures.SimpleQuadruple) { Default = TimeSignatures.SimpleQuadruple };
 
         /// <summary>
+        /// Default length of a beat in milliseconds. Used whenever there is no beatmap or track playing.
+        /// </summary>
+        private const double default_beat_length = 60000.0 / 60.0;
+
+        public static readonly TimingControlPoint DEFAULT = new TimingControlPoint
+        {
+            BeatLength = default_beat_length,
+            BeatLengthBindable = { Disabled = true },
+            TimeSignatureBindable = { Disabled = true }
+        };
+
+        /// <summary>
         /// The time signature at this control point.
         /// </summary>
         public TimeSignatures TimeSignature

--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -43,14 +43,6 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         public double MinimumBeatLength { get; set; }
 
-        /// <summary>
-        /// Default length of a beat in milliseconds. Used whenever there is no beatmap or track playing.
-        /// </summary>
-        private const double default_beat_length = 60000.0 / 60.0;
-
-        private TimingControlPoint defaultTiming;
-        private EffectControlPoint defaultEffect;
-
         protected bool IsBeatSyncedWithTrack { get; private set; }
 
         protected override void Update()
@@ -81,8 +73,8 @@ namespace osu.Game.Graphics.Containers
             if (timingPoint == null || !IsBeatSyncedWithTrack)
             {
                 currentTrackTime = Clock.CurrentTime;
-                timingPoint = defaultTiming;
-                effectPoint = defaultEffect;
+                timingPoint = TimingControlPoint.DEFAULT;
+                effectPoint = EffectControlPoint.DEFAULT;
             }
 
             double beatLength = timingPoint.BeatLength / Divisor;
@@ -116,17 +108,6 @@ namespace osu.Game.Graphics.Containers
         private void load(IBindable<WorkingBeatmap> beatmap)
         {
             Beatmap.BindTo(beatmap);
-
-            defaultTiming = new TimingControlPoint
-            {
-                BeatLength = default_beat_length,
-            };
-
-            defaultEffect = new EffectControlPoint
-            {
-                KiaiMode = false,
-                OmitFirstBarLine = false
-            };
         }
 
         protected virtual void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/87843493-ff0cf680-c8ef-11ea-8556-1dca0423cc4c.png)

After:

![image](https://user-images.githubusercontent.com/191335/87843267-15b24e00-c8ee-11ea-8733-54859e67abf4.png)

I know we want to make these kinds of static 100% safe, but this is the best we can do in this context without larger changes (I think the disabled flag makes it very unlikely to ever cause issue).