### PR TITLE
Marginally improve spinner visuals

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void testSingle(float circleSize, bool auto = false)
         {
-            var spinner = new Spinner { StartTime = Time.Current + 1000, EndTime = Time.Current + 4000 };
+            var spinner = new Spinner { StartTime = Time.Current + 2000, EndTime = Time.Current + 5000 };
 
             spinner.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = circleSize });
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -147,15 +147,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (Progress >= 1 && !Disc.Complete)
             {
                 Disc.Complete = true;
-
-                const float duration = 200;
-
-                Disc.FadeAccent(completeColour, duration);
-
-                Background.FadeAccent(completeColour.Darken(1), duration);
-
-                circle.FadeColour(completeColour, duration);
-                glow.FadeColour(completeColour, duration);
+                transformFillColour(completeColour, 200);
             }
 
             if (userTriggered || Time.Current < Spinner.EndTime)
@@ -208,18 +200,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             using (BeginDelayedSequence(HitObject.TimePreempt / 2, true))
             {
-                float phaseOneScale = Spinner.Scale * 0.8f;
+                float phaseOneScale = Spinner.Scale * 0.7f;
 
-                circleContainer.ScaleTo(phaseOneScale, HitObject.TimePreempt / 2f, Easing.OutQuint);
+                circleContainer.ScaleTo(phaseOneScale, HitObject.TimePreempt / 4, Easing.OutQuint);
 
                 mainContainer
-                    .ScaleTo(phaseOneScale * circle.DrawHeight / DrawHeight * 1.4f, HitObject.TimePreempt / 2, Easing.OutElasticHalf)
-                    .RotateTo(25, HitObject.TimePreempt + Spinner.Duration);
+                    .ScaleTo(phaseOneScale * circle.DrawHeight / DrawHeight * 1.5f, HitObject.TimePreempt / 4, Easing.OutQuint)
+                    .RotateTo((float)(25 * Spinner.Duration / 2000), HitObject.TimePreempt + Spinner.Duration);
 
                 using (BeginDelayedSequence(HitObject.TimePreempt / 2, true))
                 {
-                    circleContainer.ScaleTo(Spinner.Scale * 1.4f, 400, Easing.OutQuint);
-                    mainContainer.ScaleTo(Spinner.Scale, 400, Easing.OutQuint);
+                    circleContainer.ScaleTo(Spinner.Scale, 400, Easing.OutQuint);
+                    mainContainer.ScaleTo(1, 400, Easing.OutQuint);
                 }
             }
         }
@@ -228,18 +220,33 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateStateTransforms(state);
 
-            var sequence = this.Delay(Spinner.Duration).FadeOut(160);
-
-            switch (state)
+            using (BeginDelayedSequence(Spinner.Duration, true))
             {
-                case ArmedState.Hit:
-                    sequence.ScaleTo(Scale * 1.2f, 320, Easing.Out);
-                    break;
+                this.FadeOut(160);
 
-                case ArmedState.Miss:
-                    sequence.ScaleTo(Scale * 0.8f, 320, Easing.In);
-                    break;
+                switch (state)
+                {
+                    case ArmedState.Hit:
+                        transformFillColour(completeColour, 0);
+                        this.ScaleTo(Scale * 1.2f, 320, Easing.Out);
+                        mainContainer.RotateTo(mainContainer.Rotation + 180, 320);
+                        break;
+
+                    case ArmedState.Miss:
+                        this.ScaleTo(Scale * 0.8f, 320, Easing.In);
+                        break;
+                }
             }
+        }
+
+        private void transformFillColour(Colour4 colour, double duration)
+        {
+            Disc.FadeAccent(colour, duration);
+
+            Background.FadeAccent(colour.Darken(1), duration);
+
+            circle.FadeColour(colour, duration);
+            glow.FadeColour(colour, duration);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 circleContainer.ScaleTo(phaseOneScale, HitObject.TimePreempt / 4, Easing.OutQuint);
 
                 mainContainer
-                    .ScaleTo(phaseOneScale * circle.DrawHeight / DrawHeight * 1.5f, HitObject.TimePreempt / 4, Easing.OutQuint)
+                    .ScaleTo(phaseOneScale * circle.DrawHeight / DrawHeight * 1.6f, HitObject.TimePreempt / 4, Easing.OutQuint)
                     .RotateTo((float)(25 * Spinner.Duration / 2000), HitObject.TimePreempt + Spinner.Duration);
 
                 using (BeginDelayedSequence(HitObject.TimePreempt / 2, true))

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     {
                         Background = new SpinnerBackground
                         {
-                            Alpha = 0.6f,
+                            Alpha = 1f,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             Background.AccentColour = normalColour;
 
-            completeColour = colours.YellowLight.Opacity(0.75f);
+            completeColour = colours.YellowLight;
 
             Disc.AccentColour = fillColour;
             circle.Colour = colours.BlueDark;
@@ -152,8 +152,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
                 Disc.FadeAccent(completeColour, duration);
 
-                Background.FadeAccent(completeColour, duration);
-                Background.FadeOut(duration);
+                Background.FadeAccent(completeColour.Darken(1), duration);
 
                 circle.FadeColour(completeColour, duration);
                 glow.FadeColour(completeColour, duration);
@@ -204,14 +203,25 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateInitialTransforms();
 
-            circleContainer.ScaleTo(Spinner.Scale * 0.3f);
-            circleContainer.ScaleTo(Spinner.Scale, HitObject.TimePreempt / 1.4f, Easing.OutQuint);
+            circleContainer.ScaleTo(0);
+            mainContainer.ScaleTo(0);
 
-            mainContainer
-                .ScaleTo(0)
-                .ScaleTo(Spinner.Scale * circle.DrawHeight / DrawHeight * 1.4f, HitObject.TimePreempt - 150, Easing.OutQuint)
-                .Then()
-                .ScaleTo(1, 500, Easing.OutQuint);
+            using (BeginDelayedSequence(HitObject.TimePreempt / 2, true))
+            {
+                float phaseOneScale = Spinner.Scale * 0.8f;
+
+                circleContainer.ScaleTo(phaseOneScale, HitObject.TimePreempt / 2f, Easing.OutQuint);
+
+                mainContainer
+                    .ScaleTo(phaseOneScale * circle.DrawHeight / DrawHeight * 1.4f, HitObject.TimePreempt / 2, Easing.OutElasticHalf)
+                    .RotateTo(25, HitObject.TimePreempt + Spinner.Duration);
+
+                using (BeginDelayedSequence(HitObject.TimePreempt / 2, true))
+                {
+                    circleContainer.ScaleTo(Spinner.Scale * 1.4f, 400, Easing.OutQuint);
+                    mainContainer.ScaleTo(Spinner.Scale, 400, Easing.OutQuint);
+                }
+            }
         }
 
         protected override void UpdateStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -93,7 +93,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     {
                         Background = new SpinnerBackground
                         {
-                            Alpha = 1f,
+                            Disc =
+                            {
+                                Alpha = 0f,
+                            },
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },
@@ -125,10 +128,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private void load(OsuColour colours)
         {
             normalColour = baseColour;
+            completeColour = colours.YellowLight;
 
             Background.AccentColour = normalColour;
-
-            completeColour = colours.YellowLight;
+            Ticks.AccentColour = normalColour;
 
             Disc.AccentColour = fillColour;
             circle.Colour = colours.BlueDark;
@@ -244,6 +247,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Disc.FadeAccent(colour, duration);
 
             Background.FadeAccent(colour.Darken(1), duration);
+            Ticks.FadeAccent(colour, duration);
 
             circle.FadeColour(colour, duration);
             glow.FadeColour(colour, duration);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBackground.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBackground.cs
@@ -12,14 +12,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class SpinnerBackground : CircularContainer, IHasAccentColour
     {
-        private readonly Box disc;
+        public readonly Box Disc;
 
         public Color4 AccentColour
         {
-            get => disc.Colour;
+            get => Disc.Colour;
             set
             {
-                disc.Colour = value;
+                Disc.Colour = value;
 
                 EdgeEffect = new EdgeEffectParameters
                 {
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Children = new Drawable[]
             {
-                disc = new Box
+                Disc = new Box
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBackground.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBackground.cs
@@ -1,25 +1,25 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osuTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class SpinnerBackground : CircularContainer, IHasAccentColour
     {
-        protected Box Disc;
+        private readonly Box disc;
 
         public Color4 AccentColour
         {
-            get => Disc.Colour;
+            get => disc.Colour;
             set
             {
-                Disc.Colour = value;
+                disc.Colour = value;
 
                 EdgeEffect = new EdgeEffectParameters
                 {
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Children = new Drawable[]
             {
-                Disc = new Box
+                disc = new Box
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerTicks.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerTicks.cs
@@ -33,11 +33,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                     RelativePositionAxes = Axes.Both,
                     Masking = true,
                     CornerRadius = 5,
-                    Size = new Vector2(65, 10),
+                    Size = new Vector2(60, 10),
                     Origin = Anchor.Centre,
                     Position = new Vector2(
-                        0.5f + MathF.Sin(i / count * 2 * MathF.PI) / 2 * 0.86f,
-                        0.5f + MathF.Cos(i / count * 2 * MathF.PI) / 2 * 0.86f
+                        0.5f + MathF.Sin(i / count * 2 * MathF.PI) / 2 * 0.83f,
+                        0.5f + MathF.Cos(i / count * 2 * MathF.PI) / 2 * 0.83f
                     ),
                     Rotation = -i / count * 360 + 90,
                     Children = new[]

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerTicks.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerTicks.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -9,10 +10,11 @@ using osu.Framework.Graphics.Effects;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
-    public class SpinnerTicks : Container
+    public class SpinnerTicks : Container, IHasAccentColour
     {
         public SpinnerTicks()
         {
@@ -26,14 +28,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             {
                 Add(new Container
                 {
-                    Colour = Color4.Black,
-                    Alpha = 0.2f,
-                    EdgeEffect = new EdgeEffectParameters
-                    {
-                        Type = EdgeEffectType.Glow,
-                        Radius = 20,
-                        Colour = Color4.Gray.Opacity(0.2f),
-                    },
+                    Alpha = 0.4f,
+                    Blending = BlendingParameters.Additive,
                     RelativePositionAxes = Axes.Both,
                     Masking = true,
                     CornerRadius = 5,
@@ -52,6 +48,26 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                         }
                     }
                 });
+            }
+        }
+
+        public Color4 AccentColour
+        {
+            get => Colour;
+            set
+            {
+                Colour = value;
+
+                foreach (var c in Children.OfType<Container>())
+                {
+                    c.EdgeEffect =
+                        new EdgeEffectParameters
+                        {
+                            Type = EdgeEffectType.Glow,
+                            Radius = 20,
+                            Colour = value.Opacity(0.8f),
+                        };
+                }
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerTicks.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerTicks.cs
@@ -20,24 +20,24 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             Anchor = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;
 
-            const float count = 18;
+            const float count = 8;
 
             for (float i = 0; i < count; i++)
             {
                 Add(new Container
                 {
                     Colour = Color4.Black,
-                    Alpha = 0.4f,
+                    Alpha = 0.2f,
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
-                        Radius = 10,
+                        Radius = 20,
                         Colour = Color4.Gray.Opacity(0.2f),
                     },
                     RelativePositionAxes = Axes.Both,
                     Masking = true,
                     CornerRadius = 5,
-                    Size = new Vector2(60, 10),
+                    Size = new Vector2(65, 10),
                     Origin = Anchor.Centre,
                     Position = new Vector2(
                         0.5f + MathF.Sin(i / count * 2 * MathF.PI) / 2 * 0.86f,


### PR DESCRIPTION
Note that this isn't supposed to be a final solution, just an iterative improvement aimed at making spinners feel less ugly and a bit more reactive.

- Added a constant passive spin
- Reduced "ticks" count but made more visible
- Removed fill background
- Ensure it's spinning when disappearing on a successful hit
- Fixed colour fading back to blue on successful hit
- Improved animation code quality slightly

Next step is to add skinning, which may change the structure further.

Against light:
![2020-07-20 17 53 18](https://user-images.githubusercontent.com/191335/87919521-dda83800-cab2-11ea-9901-ade58da75872.gif)

Against dark:

![2020-07-20 17 57 14](https://user-images.githubusercontent.com/191335/87919593-fe708d80-cab2-11ea-8d45-34f4b2abaefe.gif)
