### PR TITLE
Make perfect mod ignore all non-combo-affecting hitobjects

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModPerfect.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModPerfect.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
         public void TestDroplet(bool shouldMiss) => CreateHitObjectTest(new HitObjectTestData(new Droplet { StartTime = 1000 }), shouldMiss);
 
         // We only care about testing misses, hits are tested via JuiceStream
-        [TestCase(true)]
+        [TestCase(false)]
         public void TestTinyDroplet(bool shouldMiss) => CreateHitObjectTest(new HitObjectTestData(new TinyDroplet { StartTime = 1000 }), shouldMiss);
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModPerfect.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModPerfect.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Catch.Judgements;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModPerfect : ModPerfect
     {
-        protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
-            => !(result.Judgement is CatchBananaJudgement)
-               && base.FailCondition(healthProcessor, result);
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 
             assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Idle);
             assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Fail);
-            assertStateAfterResult(new JudgementResult(new DrumRoll(), new TaikoDrumRollJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Fail);
+            assertStateAfterResult(new JudgementResult(new DrumRoll(), new TaikoDrumRollJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Idle);
             assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Good }, TaikoMascotAnimationState.Idle);
         }
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             };
 
         [Test]
-        public void TestSpinnerDoesNotFail()
+        public void TestSpinnerDoesFail()
         {
             bool judged = false;
             AddStep("Setup judgements", () =>
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 Player.ScoreProcessor.NewJudgement += b => judged = true;
             });
             AddUntilStep("swell judged", () => judged);
-            AddAssert("not failed", () => !Player.HasFailed);
+            AddAssert("failed", () => Player.HasFailed);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollJudgement.cs
@@ -7,8 +7,6 @@ namespace osu.Game.Rulesets.Taiko.Judgements
 {
     public class TaikoDrumRollJudgement : TaikoJudgement
     {
-        public override bool AffectsCombo => false;
-
         protected override double HealthIncreaseFor(HitResult result)
         {
             // Drum rolls can be ignored with no health penalty

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoSwellJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoSwellJudgement.cs
@@ -7,8 +7,6 @@ namespace osu.Game.Rulesets.Taiko.Judgements
 {
     public class TaikoSwellJudgement : TaikoJudgement
     {
-        public override bool AffectsCombo => false;
-
         protected override double HealthIncreaseFor(HitResult result)
         {
             switch (result)

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Mods
 
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
             => !(result.Judgement is IgnoreJudgement)
+               && result.Judgement.AffectsCombo
                && result.Type != result.Judgement.MaxResult;
     }
 }


### PR DESCRIPTION
As per discord discussion, this seems to make more sense from a consistency perspective.

Community response seems roughly positive ([70-30](https://twitter.com/ppy/status/1285478489848602624) but no real feedback to advocate reason for not making the change). Probably don't merge until we get some more feedback, just throwing this up for review/dependency reasons.