### PR TITLE
Re-namespace multiplayer requests and responses

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTimeshiftResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTimeshiftResultsScreen.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Scoring;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneTimeshiftResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneTimeshiftResultsScreen.cs
@@ -64,11 +64,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void bindHandler(double delay = 0)
         {
-            var roomScores = new List<RoomScore>();
+            var roomScores = new List<MultiplayerScore>();
 
             for (int i = 0; i < 10; i++)
             {
-                roomScores.Add(new RoomScore
+                roomScores.Add(new MultiplayerScore
                 {
                     ID = i,
                     Accuracy = 0.9 - 0.01 * i,

--- a/osu.Game/Online/Multiplayer/APICreatedRoom.cs
+++ b/osu.Game/Online/Multiplayer/APICreatedRoom.cs
@@ -2,9 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Newtonsoft.Json;
-using osu.Game.Online.Multiplayer;
 
-namespace osu.Game.Online.API.Requests.Responses
+namespace osu.Game.Online.Multiplayer
 {
     public class APICreatedRoom : Room
     {

--- a/osu.Game/Online/Multiplayer/APIPlaylistBeatmap.cs
+++ b/osu.Game/Online/Multiplayer/APIPlaylistBeatmap.cs
@@ -6,7 +6,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 
-namespace osu.Game.Online.API
+namespace osu.Game.Online.Multiplayer
 {
     public class APIPlaylistBeatmap : APIBeatmap
     {

--- a/osu.Game/Online/Multiplayer/APIScoreToken.cs
+++ b/osu.Game/Online/Multiplayer/APIScoreToken.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json;
 
-namespace osu.Game.Online.API.Requests.Responses
+namespace osu.Game.Online.Multiplayer
 {
     public class APIScoreToken
     {

--- a/osu.Game/Online/Multiplayer/CreateRoomRequest.cs
+++ b/osu.Game/Online/Multiplayer/CreateRoomRequest.cs
@@ -2,16 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Net.Http;
+using Newtonsoft.Json;
 using osu.Framework.IO.Network;
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.API;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
-    public class PartRoomRequest : APIRequest
+    public class CreateRoomRequest : APIRequest<APICreatedRoom>
     {
         private readonly Room room;
 
-        public PartRoomRequest(Room room)
+        public CreateRoomRequest(Room room)
         {
             this.room = room;
         }
@@ -19,10 +20,15 @@ namespace osu.Game.Online.API.Requests
         protected override WebRequest CreateWebRequest()
         {
             var req = base.CreateWebRequest();
-            req.Method = HttpMethod.Delete;
+
+            req.ContentType = "application/json";
+            req.Method = HttpMethod.Post;
+
+            req.AddRaw(JsonConvert.SerializeObject(room));
+
             return req;
         }
 
-        protected override string Target => $"rooms/{room.RoomID.Value}/users/{User.Id}";
+        protected override string Target => "rooms";
     }
 }

--- a/osu.Game/Online/Multiplayer/CreateRoomScoreRequest.cs
+++ b/osu.Game/Online/Multiplayer/CreateRoomScoreRequest.cs
@@ -3,9 +3,9 @@
 
 using System.Net.Http;
 using osu.Framework.IO.Network;
-using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.API;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
     public class CreateRoomScoreRequest : APIRequest<APIScoreToken>
     {

--- a/osu.Game/Online/Multiplayer/GetRoomPlaylistScoresRequest.cs
+++ b/osu.Game/Online/Multiplayer/GetRoomPlaylistScoresRequest.cs
@@ -3,8 +3,9 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Game.Online.API;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
     public class GetRoomPlaylistScoresRequest : APIRequest<RoomPlaylistScores>
     {

--- a/osu.Game/Online/Multiplayer/GetRoomPlaylistScoresRequest.cs
+++ b/osu.Game/Online/Multiplayer/GetRoomPlaylistScoresRequest.cs
@@ -24,6 +24,6 @@ namespace osu.Game.Online.Multiplayer
     public class RoomPlaylistScores
     {
         [JsonProperty("scores")]
-        public List<RoomScore> Scores { get; set; }
+        public List<MultiplayerScore> Scores { get; set; }
     }
 }

--- a/osu.Game/Online/Multiplayer/GetRoomRequest.cs
+++ b/osu.Game/Online/Multiplayer/GetRoomRequest.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.API;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
     public class GetRoomRequest : APIRequest<Room>
     {

--- a/osu.Game/Online/Multiplayer/GetRoomScoresRequest.cs
+++ b/osu.Game/Online/Multiplayer/GetRoomScoresRequest.cs
@@ -2,9 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
     public class GetRoomScoresRequest : APIRequest<List<APIUserScoreAggregate>>
     {

--- a/osu.Game/Online/Multiplayer/GetRoomsRequest.cs
+++ b/osu.Game/Online/Multiplayer/GetRoomsRequest.cs
@@ -4,10 +4,10 @@
 using System.Collections.Generic;
 using Humanizer;
 using osu.Framework.IO.Network;
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.API;
 using osu.Game.Screens.Multi.Lounge.Components;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
     public class GetRoomsRequest : APIRequest<List<Room>>
     {

--- a/osu.Game/Online/Multiplayer/JoinRoomRequest.cs
+++ b/osu.Game/Online/Multiplayer/JoinRoomRequest.cs
@@ -2,18 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Net.Http;
-using Newtonsoft.Json;
 using osu.Framework.IO.Network;
-using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.API;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
-    public class CreateRoomRequest : APIRequest<APICreatedRoom>
+    public class JoinRoomRequest : APIRequest
     {
         private readonly Room room;
 
-        public CreateRoomRequest(Room room)
+        public JoinRoomRequest(Room room)
         {
             this.room = room;
         }
@@ -21,15 +19,10 @@ namespace osu.Game.Online.API.Requests
         protected override WebRequest CreateWebRequest()
         {
             var req = base.CreateWebRequest();
-
-            req.ContentType = "application/json";
-            req.Method = HttpMethod.Post;
-
-            req.AddRaw(JsonConvert.SerializeObject(room));
-
+            req.Method = HttpMethod.Put;
             return req;
         }
 
-        protected override string Target => "rooms";
+        protected override string Target => $"rooms/{room.RoomID.Value}/users/{User.Id}";
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerScore.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerScore.cs
@@ -14,7 +14,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Online.Multiplayer
 {
-    public class RoomScore
+    public class MultiplayerScore
     {
         [JsonProperty("id")]
         public int ID { get; set; }

--- a/osu.Game/Online/Multiplayer/PartRoomRequest.cs
+++ b/osu.Game/Online/Multiplayer/PartRoomRequest.cs
@@ -3,15 +3,15 @@
 
 using System.Net.Http;
 using osu.Framework.IO.Network;
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.API;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
-    public class JoinRoomRequest : APIRequest
+    public class PartRoomRequest : APIRequest
     {
         private readonly Room room;
 
-        public JoinRoomRequest(Room room)
+        public PartRoomRequest(Room room)
         {
             this.room = room;
         }
@@ -19,7 +19,7 @@ namespace osu.Game.Online.API.Requests
         protected override WebRequest CreateWebRequest()
         {
             var req = base.CreateWebRequest();
-            req.Method = HttpMethod.Put;
+            req.Method = HttpMethod.Delete;
             return req;
         }
 

--- a/osu.Game/Online/Multiplayer/RoomScore.cs
+++ b/osu.Game/Online/Multiplayer/RoomScore.cs
@@ -6,13 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.API;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Users;
 
-namespace osu.Game.Online.API
+namespace osu.Game.Online.Multiplayer
 {
     public class RoomScore
     {

--- a/osu.Game/Online/Multiplayer/SubmitRoomScoreRequest.cs
+++ b/osu.Game/Online/Multiplayer/SubmitRoomScoreRequest.cs
@@ -9,7 +9,7 @@ using osu.Game.Scoring;
 
 namespace osu.Game.Online.Multiplayer
 {
-    public class SubmitRoomScoreRequest : APIRequest<RoomScore>
+    public class SubmitRoomScoreRequest : APIRequest<MultiplayerScore>
     {
         private readonly int scoreId;
         private readonly int roomId;

--- a/osu.Game/Online/Multiplayer/SubmitRoomScoreRequest.cs
+++ b/osu.Game/Online/Multiplayer/SubmitRoomScoreRequest.cs
@@ -4,9 +4,10 @@
 using System.Net.Http;
 using Newtonsoft.Json;
 using osu.Framework.IO.Network;
+using osu.Game.Online.API;
 using osu.Game.Scoring;
 
-namespace osu.Game.Online.API.Requests
+namespace osu.Game.Online.Multiplayer
 {
     public class SubmitRoomScoreRequest : APIRequest<RoomScore>
     {

--- a/osu.Game/Screens/Multi/Match/Components/MatchLeaderboard.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchLeaderboard.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Online.Multiplayer;

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -10,7 +10,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;

--- a/osu.Game/Screens/Multi/Ranking/TimeshiftResultsScreen.cs
+++ b/osu.Game/Screens/Multi/Ranking/TimeshiftResultsScreen.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;

--- a/osu.Game/Screens/Multi/RoomManager.cs
+++ b/osu.Game/Screens/Multi/RoomManager.cs
@@ -14,7 +14,6 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Online;
 using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Multi.Lounge.Components;


### PR DESCRIPTION
As discussed in discord, putting everything inside the `Online/Multiplayer` namespace. At the same time, I've renamed `RoomScore` to `MultiplayerScore` to match [osu!web naming](https://github.com/ppy/osu-web/blob/2f1c50b135abba49020259f9d51fee57a14d27a9/resources/docs/source/includes/_structures.md).