### PR TITLE
Fix inconsistency between this and osu-performance

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -78,7 +78,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             if (mods.Any(m => m is ModHidden))
             {
-                value *= 1.05 + 0.075 * (10.0 - Math.Min(10.0, Attributes.ApproachRate)); // 7.5% for each AR below 10
                 // Hiddens gives almost nothing on max approach rate, and more the lower it is
                 if (approachRate <= 10.0)
                     value *= 1.05 + 0.075 * (10.0 - approachRate); // 7.5% for each AR below 10


### PR DESCRIPTION
The bonus value for HD is given twice here (probably a merge issue). The correct bonus is currently used on stable: https://github.com/ppy/osu-performance/blob/736515a0347ba909d5ac303df7051b600f6655be/src/performance/catch/CatchScore.cpp#L68