### PR TITLE
Load nested hitobjects during map load

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -129,9 +129,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
             LoadSamples();
         }
 
-        protected override void LoadComplete()
+        protected override void LoadAsyncComplete()
         {
-            base.LoadComplete();
+            base.LoadAsyncComplete();
 
             HitObject.DefaultsApplied += onDefaultsApplied;
 
@@ -148,6 +148,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
             samplesBindable.CollectionChanged += (_, __) => LoadSamples();
 
             apply(HitObject);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
 
             updateState(ArmedState.Idle, true);
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9659

1. Loads nested hitobjects, samples, etc, asynchronously.
Note that does increase memory usage even in osu!, but I think we want this anyway and save memory usage for DHO pooling.
2. Even after the above, I still had a stutter which was caused by multiple `computeInitialState`s running.
From: 
![Screenshot_2020-07-24_19-17-15](https://user-images.githubusercontent.com/1329837/88382971-8c66b400-cde4-11ea-8e50-0a14c7399ee8.png)
To:
![Screenshot_2020-07-24_19-29-57](https://user-images.githubusercontent.com/1329837/88382988-91c3fe80-cde4-11ea-95e9-482b2935077c.png)