### PR TITLE
Fix incorrect default hitcircle font overlapping applied to legacy skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuLegacySkinTransformer.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
                 case OsuSkinComponents.HitCircleText:
                     var font = GetConfig<OsuSkinConfiguration, string>(OsuSkinConfiguration.HitCirclePrefix)?.Value ?? "default";
-                    var overlap = GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.HitCircleOverlap)?.Value ?? 0;
+                    var overlap = GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.HitCircleOverlap)?.Value ?? -2;
 
                     return !hasFont(font)
                         ? null


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/22781491/88515370-4718d100-cff4-11ea-9a00-e02fd8d8b356.png" width=250/> 
