### PR TITLE
Reduce spinner tick and bonus score

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 // multipled by 2 to nullify the score multiplier. (autoplay mod selected)
                 var totalScore = ((ScoreExposedPlayer)Player).ScoreProcessor.TotalScore.Value * 2;
-                return totalScore == (int)(drawableSpinner.Disc.CumulativeRotation / 360) * 100;
+                return totalScore == (int)(drawableSpinner.Disc.CumulativeRotation / 360) * 10;
             });
 
             addSeekStep(0);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 // multipled by 2 to nullify the score multiplier. (autoplay mod selected)
                 var totalScore = ((ScoreExposedPlayer)Player).ScoreProcessor.TotalScore.Value * 2;
-                return totalScore == (int)(drawableSpinner.Disc.CumulativeRotation / 360) * 10;
+                return totalScore == (int)(drawableSpinner.Disc.CumulativeRotation / 360) * SpinnerTick.SCORE_PER_TICK;
             });
 
             addSeekStep(0);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 return;
 
             displayedCount = count;
-            bonusCounter.Text = $"{1000 * count}";
+            bonusCounter.Text = $"{SpinnerBonusTick.SCORE_PER_TICK * count}";
             bonusCounter.FadeOutFromOne(1500);
             bonusCounter.ScaleTo(1.5f).Then().ScaleTo(1f, 1000, Easing.OutQuint);
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
@@ -9,6 +9,8 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SpinnerBonusTick : SpinnerTick
     {
+        public new const int SCORE_PER_TICK = 50;
+
         public SpinnerBonusTick()
         {
             Samples.Add(new HitSampleInfo { Name = "spinnerbonus" });
@@ -18,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerBonusTickJudgement : OsuSpinnerTickJudgement
         {
-            protected override int NumericResultFor(HitResult result) => 50;
+            protected override int NumericResultFor(HitResult result) => SCORE_PER_TICK;
 
             protected override double HealthIncreaseFor(HitResult result) => base.HealthIncreaseFor(result) * 2;
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerBonusTickJudgement : OsuSpinnerTickJudgement
         {
-            protected override int NumericResultFor(HitResult result) => 1100;
+            protected override int NumericResultFor(HitResult result) => 50;
 
             protected override double HealthIncreaseFor(HitResult result) => base.HealthIncreaseFor(result) * 2;
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         {
             public override bool AffectsCombo => false;
 
-            protected override int NumericResultFor(HitResult result) => 100;
+            protected override int NumericResultFor(HitResult result) => 10;
 
             protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.6 * base.HealthIncreaseFor(result) : 0;
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
@@ -9,6 +9,8 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SpinnerTick : OsuHitObject
     {
+        public const int SCORE_PER_TICK = 10;
+
         public override Judgement CreateJudgement() => new OsuSpinnerTickJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
@@ -17,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         {
             public override bool AffectsCombo => false;
 
-            protected override int NumericResultFor(HitResult result) => 10;
+            protected override int NumericResultFor(HitResult result) => SCORE_PER_TICK;
 
             protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.6 * base.HealthIncreaseFor(result) : 0;
         }


### PR DESCRIPTION
We're not yet sure on the final usage of bonus score (and how it will affect ranking), but for now the original "100 per spin, 1100 per bonus spin" slider scoring was far too high and allowed spinning to outweigh the accuracy component.

We could also consider scaling back the maximum spin count as a countermeasure for this, but let's start by dialing back scoring.

These are values I found felt quite good (and in line with other bonus scoring) but I'm open to changing them with valid reasoning / example.

- Closes https://github.com/ppy/osu/issues/9667