### PR TITLE
Fix hit lighting setting not having any effect if toggled during gameplay

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             showResult(HitResult.Great);
 
             AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
+            AddAssert("judgement body immediately visible",
+                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.JudgementBody.Alpha == 1));
             AddAssert("hit lighting hidden",
                 () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.Lighting.Alpha == 0));
         }
@@ -55,6 +57,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             showResult(HitResult.Great);
 
             AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
+            AddAssert("judgement body not immediately visible",
+                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.JudgementBody.Alpha > 0 && judgement.JudgementBody.Alpha < 1));
             AddAssert("hit lighting shown",
                 () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.Lighting.Alpha > 0));
         }
@@ -102,6 +106,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private class TestDrawableOsuJudgement : DrawableOsuJudgement
         {
             public new SkinnableSprite Lighting => base.Lighting;
+            public new Container JudgementBody => base.JudgementBody;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -4,62 +4,104 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
+using osu.Framework.Testing;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
     public class TestSceneDrawableJudgement : OsuSkinnableTestScene
     {
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
+        private readonly List<DrawablePool<TestDrawableOsuJudgement>> pools;
+
         public TestSceneDrawableJudgement()
         {
-            var pools = new List<DrawablePool<DrawableOsuJudgement>>();
+            pools = new List<DrawablePool<TestDrawableOsuJudgement>>();
 
             foreach (HitResult result in Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Skip(1))
+                showResult(result);
+        }
+
+        [Test]
+        public void TestHitLightingDisabled()
+        {
+            AddStep("hit lighting disabled", () => config.Set(OsuSetting.HitLighting, false));
+
+            showResult(HitResult.Great);
+
+            AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
+            AddAssert("hit lighting hidden",
+                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.Lighting.Alpha == 0));
+        }
+
+        [Test]
+        public void TestHitLightingEnabled()
+        {
+            AddStep("hit lighting enabled", () => config.Set(OsuSetting.HitLighting, true));
+
+            showResult(HitResult.Great);
+
+            AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
+            AddAssert("hit lighting shown",
+                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.Lighting.Alpha > 0));
+        }
+
+        private void showResult(HitResult result)
+        {
+            AddStep("Show " + result.GetDescription(), () =>
             {
-                AddStep("Show " + result.GetDescription(), () =>
+                int poolIndex = 0;
+
+                SetContents(() =>
                 {
-                    int poolIndex = 0;
+                    DrawablePool<TestDrawableOsuJudgement> pool;
 
-                    SetContents(() =>
+                    if (poolIndex >= pools.Count)
+                        pools.Add(pool = new DrawablePool<TestDrawableOsuJudgement>(1));
+                    else
                     {
-                        DrawablePool<DrawableOsuJudgement> pool;
+                        pool = pools[poolIndex];
 
-                        if (poolIndex >= pools.Count)
-                            pools.Add(pool = new DrawablePool<DrawableOsuJudgement>(1));
-                        else
+                        // We need to make sure neither the pool nor the judgement get disposed when new content is set, and they both share the same parent.
+                        ((Container)pool.Parent).Clear(false);
+                    }
+
+                    var container = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
                         {
-                            pool = pools[poolIndex];
-
-                            // We need to make sure neither the pool nor the judgement get disposed when new content is set, and they both share the same parent.
-                            ((Container)pool.Parent).Clear(false);
-                        }
-
-                        var container = new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Children = new Drawable[]
+                            pool,
+                            pool.Get(j => j.Apply(new JudgementResult(new HitObject(), new Judgement()) { Type = result }, null)).With(j =>
                             {
-                                pool,
-                                pool.Get(j => j.Apply(new JudgementResult(new HitObject(), new Judgement()) { Type = result }, null)).With(j =>
-                                {
-                                    j.Anchor = Anchor.Centre;
-                                    j.Origin = Anchor.Centre;
-                                })
-                            }
-                        };
+                                j.Anchor = Anchor.Centre;
+                                j.Origin = Anchor.Centre;
+                            })
+                        }
+                    };
 
-                        poolIndex++;
-                        return container;
-                    });
+                    poolIndex++;
+                    return container;
                 });
-            }
+            });
+        }
+
+        private class TestDrawableOsuJudgement : DrawableOsuJudgement
+        {
+            public new SkinnableSprite Lighting => base.Lighting;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -20,6 +20,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private Bindable<Color4> lightingColour;
 
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
         public DrawableOsuJudgement(JudgementResult result, DrawableHitObject judgedObject)
             : base(result, judgedObject)
         {
@@ -30,18 +33,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load()
         {
-            if (config.Get<bool>(OsuSetting.HitLighting))
+            AddInternal(Lighting = new SkinnableSprite("lighting")
             {
-                AddInternal(Lighting = new SkinnableSprite("lighting")
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Blending = BlendingParameters.Additive,
-                    Depth = float.MaxValue
-                });
-            }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Blending = BlendingParameters.Additive,
+                Depth = float.MaxValue,
+                Alpha = 0
+            });
         }
 
         public override void Apply(JudgementResult result, DrawableHitObject judgedObject)
@@ -61,19 +62,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             lightingColour?.UnbindAll();
 
-            if (Lighting != null)
-            {
-                Lighting.ResetAnimation();
+            Lighting.ResetAnimation();
 
-                if (JudgedObject != null)
-                {
-                    lightingColour = JudgedObject.AccentColour.GetBoundCopy();
-                    lightingColour.BindValueChanged(colour => Lighting.Colour = Result.Type == HitResult.Miss ? Color4.Transparent : colour.NewValue, true);
-                }
-                else
-                {
-                    Lighting.Colour = Color4.White;
-                }
+            if (JudgedObject != null)
+            {
+                lightingColour = JudgedObject.AccentColour.GetBoundCopy();
+                lightingColour.BindValueChanged(colour => Lighting.Colour = Result.Type == HitResult.Miss ? Color4.Transparent : colour.NewValue, true);
+            }
+            else
+            {
+                Lighting.Colour = Color4.White;
             }
         }
 
@@ -81,7 +79,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override void ApplyHitAnimations()
         {
-            if (Lighting != null)
+            if (config.Get<bool>(OsuSetting.HitLighting))
             {
                 JudgementBody.FadeIn().Delay(FadeInDuration).FadeOut(400);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -75,17 +75,26 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        protected override double FadeOutDelay => Lighting == null ? base.FadeOutDelay : 1400;
+        private double fadeOutDelay;
+        protected override double FadeOutDelay => fadeOutDelay;
 
         protected override void ApplyHitAnimations()
         {
-            if (config.Get<bool>(OsuSetting.HitLighting))
+            bool hitLightingEnabled = config.Get<bool>(OsuSetting.HitLighting);
+
+            if (hitLightingEnabled)
             {
                 JudgementBody.FadeIn().Delay(FadeInDuration).FadeOut(400);
 
                 Lighting.ScaleTo(0.8f).ScaleTo(1.2f, 600, Easing.Out);
                 Lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);
             }
+            else
+            {
+                JudgementBody.Alpha = 1;
+            }
+
+            fadeOutDelay = hitLightingEnabled ? 1400 : base.FadeOutDelay;
 
             JudgementText?.TransformSpacingTo(Vector2.Zero).Then().TransformSpacingTo(new Vector2(14, 0), 1800, Easing.OutQuint);
             base.ApplyHitAnimations();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -16,7 +16,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableOsuJudgement : DrawableJudgement
     {
-        private SkinnableSprite lighting;
+        protected SkinnableSprite Lighting;
+
         private Bindable<Color4> lightingColour;
 
         public DrawableOsuJudgement(JudgementResult result, DrawableHitObject judgedObject)
@@ -33,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             if (config.Get<bool>(OsuSetting.HitLighting))
             {
-                AddInternal(lighting = new SkinnableSprite("lighting")
+                AddInternal(Lighting = new SkinnableSprite("lighting")
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -60,32 +61,32 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             lightingColour?.UnbindAll();
 
-            if (lighting != null)
+            if (Lighting != null)
             {
-                lighting.ResetAnimation();
+                Lighting.ResetAnimation();
 
                 if (JudgedObject != null)
                 {
                     lightingColour = JudgedObject.AccentColour.GetBoundCopy();
-                    lightingColour.BindValueChanged(colour => lighting.Colour = Result.Type == HitResult.Miss ? Color4.Transparent : colour.NewValue, true);
+                    lightingColour.BindValueChanged(colour => Lighting.Colour = Result.Type == HitResult.Miss ? Color4.Transparent : colour.NewValue, true);
                 }
                 else
                 {
-                    lighting.Colour = Color4.White;
+                    Lighting.Colour = Color4.White;
                 }
             }
         }
 
-        protected override double FadeOutDelay => lighting == null ? base.FadeOutDelay : 1400;
+        protected override double FadeOutDelay => Lighting == null ? base.FadeOutDelay : 1400;
 
         protected override void ApplyHitAnimations()
         {
-            if (lighting != null)
+            if (Lighting != null)
             {
                 JudgementBody.FadeIn().Delay(FadeInDuration).FadeOut(400);
 
-                lighting.ScaleTo(0.8f).ScaleTo(1.2f, 600, Easing.Out);
-                lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);
+                Lighting.ScaleTo(0.8f).ScaleTo(1.2f, 600, Easing.Out);
+                Lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);
             }
 
             JudgementText?.TransformSpacingTo(Vector2.Zero).Then().TransformSpacingTo(new Vector2(14, 0), 1800, Easing.OutQuint);

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -130,11 +130,16 @@ namespace osu.Game.Rulesets.Judgements
             if (type == currentDrawableType)
                 return;
 
-            InternalChild = JudgementBody = new Container
+            // sub-classes might have added their own children that would be removed here if .InternalChild was used.
+            if (JudgementBody != null)
+                RemoveInternal(JudgementBody);
+
+            AddInternal(JudgementBody = new Container
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
+                Depth = -float.MaxValue,
                 Child = bodyDrawable = new SkinnableDrawable(new GameplaySkinComponent<HitResult>(type), _ => JudgementText = new OsuSpriteText
                 {
                     Text = type.GetDescription().ToUpperInvariant(),
@@ -142,7 +147,7 @@ namespace osu.Game.Rulesets.Judgements
                     Colour = colours.ForHitResult(type),
                     Scale = new Vector2(0.85f, 1),
                 }, confineMode: ConfineMode.NoScaling)
-            };
+            });
 
             currentDrawableType = type;
         }

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -139,7 +139,6 @@ namespace osu.Game.Rulesets.Judgements
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-                Depth = -float.MaxValue,
                 Child = bodyDrawable = new SkinnableDrawable(new GameplaySkinComponent<HitResult>(type), _ => JudgementText = new OsuSpriteText
                 {
                     Text = type.GetDescription().ToUpperInvariant(),


### PR DESCRIPTION
This broke with #9431; finally got around to finishing it.

# Summary

With introduction of pooling, switching the hit lighting setting mid-gameplay got broken on the osu! ruleset, as the judgements were no longer created and loaded on-demand. This brings back support for toggling that setting mid-gameplay, by always adding the hit lighting to the hierarchy regardless of setting value, and determining if it should be shown at the point of `ApplyHitAnimations()`.

To be extra sure, I checked allocations on [Centipede](https://osu.ppy.sh/beatmapsets/150945) (one playthrough of the map per configuration, on a fresh lazer run), and this is what I got:

| | `master` | this PR |
| :- | :-: | :-: |
| lighting off | ![image](https://user-images.githubusercontent.com/20418176/88578401-cafca880-d048-11ea-9074-830a218f2de1.png) | ![image](https://user-images.githubusercontent.com/20418176/88578407-cdf79900-d048-11ea-98c1-1e25e2908375.png) |
| lighting on | ![image](https://user-images.githubusercontent.com/20418176/88578431-d8b22e00-d048-11ea-8ae0-7c83b0fe058c.png) | ![image](https://user-images.githubusercontent.com/20418176/88578417-d2bc4d00-d048-11ea-93e3-46759821b361.png) |

There is a bit of a hit, especially in the case if hit lighting is off (see the allocations in `load()`), but I suppose that (a) it is the price to pay for having that setting work during gameplay and (b) it's a test on possibly *the* benchmark map for osu!, so considering that I don't think those allocs are that egregious.

Additionally hit lighting is now covered with tests.

# Remarks

The reason for storing a reference to `OsuConfigManager` and reading directly from it instead of getting a bindable and subscribing to `BindValueChanged()` is to prevent firing a lot of callbacks when not necessary. (I also prefer the way that it lets the existing lighting animations play out instead of interrupting them.)

There are unfortunately a few satellite changes in here. They are all a result of attempting to write tests, upon which I found a couple of breakages (namely the fact that the lighting would get removed from the hierarchy if the judgement was reused, which is addressed in 5fc7039, and then that always creating the lighting broke the pre-existing fade duration logic, which is addressed in 7ad3101). Not sure if you'll agree with the way I opted to resolve them.

This is sort of the part where the downsides of pooling are starting to show - at the cost of getting pooling and eager initialisation, we get state and state-related bugs like the aforementioned ones. I suppose this again is another intrinsic cost of trying to optimise in this way.