### PR TITLE
Fix tracked bindable updates not getting cancelled correctly

### DIFF
--- a/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
@@ -146,6 +146,22 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
+        /// Creates a new <see cref="BindableStarDifficulty"/> and triggers an initial value update.
+        /// </summary>
+        /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> that star difficulty should correspond to.</param>
+        /// <param name="initialRulesetInfo">The initial <see cref="RulesetInfo"/> to get the difficulty with.</param>
+        /// <param name="initialMods">The initial <see cref="Mod"/>s to get the difficulty with.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> which stops updating the star difficulty for the given <see cref="BeatmapInfo"/>.</param>
+        /// <returns>The <see cref="BindableStarDifficulty"/>.</returns>
+        private BindableStarDifficulty createBindable([NotNull] BeatmapInfo beatmapInfo, [CanBeNull] RulesetInfo initialRulesetInfo, [CanBeNull] IEnumerable<Mod> initialMods,
+                                                      CancellationToken cancellationToken)
+        {
+            var bindable = new BindableStarDifficulty(beatmapInfo, cancellationToken);
+            updateBindable(bindable, initialRulesetInfo, initialMods, cancellationToken);
+            return bindable;
+        }
+
+        /// <summary>
         /// Updates the value of a <see cref="BindableStarDifficulty"/> with a given ruleset + mods.
         /// </summary>
         /// <param name="bindable">The <see cref="BindableStarDifficulty"/> to update.</param>
@@ -163,22 +179,6 @@ namespace osu.Game.Beatmaps
                         bindable.Value = t.Result;
                 });
             }, cancellationToken);
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="BindableStarDifficulty"/> and triggers an initial value update.
-        /// </summary>
-        /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> that star difficulty should correspond to.</param>
-        /// <param name="initialRulesetInfo">The initial <see cref="RulesetInfo"/> to get the difficulty with.</param>
-        /// <param name="initialMods">The initial <see cref="Mod"/>s to get the difficulty with.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> which stops updating the star difficulty for the given <see cref="BeatmapInfo"/>.</param>
-        /// <returns>The <see cref="BindableStarDifficulty"/>.</returns>
-        private BindableStarDifficulty createBindable([NotNull] BeatmapInfo beatmapInfo, [CanBeNull] RulesetInfo initialRulesetInfo, [CanBeNull] IEnumerable<Mod> initialMods,
-                                                      CancellationToken cancellationToken)
-        {
-            var bindable = new BindableStarDifficulty(beatmapInfo, cancellationToken);
-            updateBindable(bindable, initialRulesetInfo, initialMods, cancellationToken);
-            return bindable;
         }
 
         /// <summary>

--- a/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
@@ -137,10 +137,7 @@ namespace osu.Game.Beatmaps
             trackedUpdateCancellationSource = null;
 
             foreach (var c in linkedCancellationSources)
-            {
-                c.Cancel();
                 c.Dispose();
-            }
 
             linkedCancellationSources.Clear();
         }

--- a/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
@@ -136,10 +136,13 @@ namespace osu.Game.Beatmaps
             trackedUpdateCancellationSource?.Cancel();
             trackedUpdateCancellationSource = null;
 
-            foreach (var c in linkedCancellationSources)
-                c.Dispose();
+            if (linkedCancellationSources != null)
+            {
+                foreach (var c in linkedCancellationSources)
+                    c.Dispose();
 
-            linkedCancellationSources.Clear();
+                linkedCancellationSources.Clear();
+            }
         }
 
         /// <summary>
@@ -239,7 +242,7 @@ namespace osu.Game.Beatmaps
             base.Dispose(isDisposing);
 
             cancelTrackedBindableUpdate();
-            updateScheduler.Dispose();
+            updateScheduler?.Dispose();
         }
 
         private readonly struct DifficultyCacheLookup : IEquatable<DifficultyCacheLookup>

--- a/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
@@ -240,7 +240,9 @@ namespace osu.Game.Beatmaps
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
             cancelTrackedBindableUpdate();
+            updateScheduler.Dispose();
         }
 
         private readonly struct DifficultyCacheLookup : IEquatable<DifficultyCacheLookup>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9682

I've tried to write a test for this, but I haven't got it to fail on master since it's quite timing dependent...

In short, because the linked cancellation sources were being disposed, cancelling the `trackedUpdateCancellationSource` did not propagate to the linked sources and the updates therefore also didn't get cancelled.
To fix this I've stored the linked sources in a list that is disposed when the next request to update tracked bindables comes in.

I've also added a disposal of the `TaskScheduler` in this PR, to fix potentially having multiple schedulers running through multiple gamehost tests (similar to https://github.com/ppy/osu/pull/9470).