### PR TITLE
Adjust mania scoring to be 95% based on accuracy

### DIFF
--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mania.Judgements
                     return 300;
 
                 case HitResult.Perfect:
-                    return 320;
+                    return 350;
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -7,9 +7,9 @@ namespace osu.Game.Rulesets.Mania.Scoring
 {
     internal class ManiaScoreProcessor : ScoreProcessor
     {
-        protected override double DefaultAccuracyPortion => 0.8;
+        protected override double DefaultAccuracyPortion => 0.95;
 
-        protected override double DefaultComboPortion => 0.2;
+        protected override double DefaultComboPortion => 0.05;
 
         public override HitWindows CreateHitWindows() => new ManiaHitWindows();
     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9683

---

- Changed to 95:5 accuracy to combo ratio.
- Increased PERFECT score reward from 320 to 350.