### PR TITLE
Add pooling for mania hit explosions

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHitExplosion.cs
@@ -1,23 +1,27 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Mania.UI;
-using osu.Game.Skinning;
+using osu.Game.Rulesets.Objects;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Tests.Skinning
 {
     [TestFixture]
     public class TestSceneHitExplosion : ManiaSkinnableTestScene
     {
+        private readonly List<DrawablePool<PoolableHitExplosion>> hitExplosionPools = new List<DrawablePool<PoolableHitExplosion>>();
+
         public TestSceneHitExplosion()
         {
             int runcount = 0;
@@ -29,28 +33,40 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                 if (runcount % 15 > 12)
                     return;
 
-                CreatedDrawables.OfType<Container>().ForEach(c =>
+                int poolIndex = 0;
+
+                foreach (var c in CreatedDrawables.OfType<Container>())
                 {
-                    c.Add(new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.HitExplosion, 0),
-                        _ => new DefaultHitExplosion((runcount / 15) % 2 == 0 ? new Color4(94, 0, 57, 255) : new Color4(6, 84, 0, 255), runcount % 6 != 0)
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                        }));
-                });
+                    c.Add(hitExplosionPools[poolIndex].Get(e =>
+                    {
+                        e.Apply(new JudgementResult(new HitObject(), runcount % 6 == 0 ? new HoldNoteTickJudgement() : new ManiaJudgement()));
+
+                        e.Anchor = Anchor.Centre;
+                        e.Origin = Anchor.Centre;
+                    }));
+
+                    poolIndex++;
+                }
             }, 100);
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            SetContents(() => new ColumnTestContainer(0, ManiaAction.Key1)
+            SetContents(() =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativePositionAxes = Axes.Y,
-                Y = -0.25f,
-                Size = new Vector2(Column.COLUMN_WIDTH, DefaultNotePiece.NOTE_HEIGHT),
+                var pool = new DrawablePool<PoolableHitExplosion>(5);
+                hitExplosionPools.Add(pool);
+
+                return new ColumnTestContainer(0, ManiaAction.Key1)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativePositionAxes = Axes.Y,
+                    Y = -0.25f,
+                    Size = new Vector2(Column.COLUMN_WIDTH, DefaultNotePiece.NOTE_HEIGHT),
+                    Child = pool
+                };
             });
         }
     }

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
@@ -63,7 +64,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
                 explosion.Anchor = direction.NewValue == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
         }
 
-        public void Animate()
+        public void Animate(JudgementResult result)
         {
             (explosion as IFramedAnimation)?.GotoFrame(0);
 

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
@@ -6,13 +6,14 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 using osuTK;
 
 namespace osu.Game.Rulesets.Mania.Skinning
 {
-    public class LegacyHitExplosion : LegacyManiaColumnElement
+    public class LegacyHitExplosion : LegacyManiaColumnElement, IHitExplosion
     {
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
 
@@ -62,10 +63,8 @@ namespace osu.Game.Rulesets.Mania.Skinning
                 explosion.Anchor = direction.NewValue == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
         }
 
-        protected override void LoadComplete()
+        public void Animate()
         {
-            base.LoadComplete();
-
             explosion?.FadeInFromZero(80)
                      .Then().FadeOut(120);
         }

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyHitExplosion.cs
@@ -65,6 +65,8 @@ namespace osu.Game.Rulesets.Mania.Skinning
 
         public void Animate()
         {
+            (explosion as IFramedAnimation)?.GotoFrame(0);
+
             explosion?.FadeInFromZero(80)
                      .Then().FadeOut(120);
         }

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Rulesets.Mania.UI
             if (!result.IsHit || !judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 
-            HitObjectArea.Explosions.Add(hitExplosionPool.Get());
+            HitObjectArea.Explosions.Add(hitExplosionPool.Get(e => e.Apply(result)));
         }
 
         public bool OnPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -9,9 +9,9 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Input.Bindings;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.UI.Components;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
@@ -34,8 +34,8 @@ namespace osu.Game.Rulesets.Mania.UI
         public readonly Bindable<ManiaAction> Action = new Bindable<ManiaAction>();
 
         public readonly ColumnHitObjectArea HitObjectArea;
-
         internal readonly Container TopLevelContainer;
+        private readonly DrawablePool<PoolableHitExplosion> hitExplosionPool;
 
         public Container UnderlayElements => HitObjectArea.UnderlayElements;
 
@@ -53,6 +53,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             InternalChildren = new[]
             {
+                hitExplosionPool = new DrawablePool<PoolableHitExplosion>(5),
                 // For input purposes, the background is added at the highest depth, but is then proxied back below all other elements
                 background.CreateProxy(),
                 HitObjectArea = new ColumnHitObjectArea(Index, HitObjectContainer) { RelativeSizeAxes = Axes.Both },
@@ -108,15 +109,7 @@ namespace osu.Game.Rulesets.Mania.UI
             if (!result.IsHit || !judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 
-            var explosion = new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.HitExplosion, Index), _ =>
-                new DefaultHitExplosion(judgedObject.AccentColour.Value, judgedObject is DrawableHoldNoteTick))
-            {
-                RelativeSizeAxes = Axes.Both
-            };
-
-            HitObjectArea.Explosions.Add(explosion);
-
-            explosion.Delay(200).Expire(true);
+            HitObjectArea.Explosions.Add(hitExplosionPool.Get());
         }
 
         public bool OnPressed(ManiaAction action)

--- a/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Rulesets.Mania.UI
 {
     public class DefaultHitExplosion : CompositeDrawable, IHitExplosion
     {
+        private const float default_large_faint_size = 0.8f;
+
         public override bool RemoveWhenNotAlive => true;
 
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
@@ -54,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.UI
                     RelativeSizeAxes = Axes.Both,
                     Masking = true,
                     // we want our size to be very small so the glow dominates it.
-                    Size = new Vector2(0.8f),
+                    Size = new Vector2(default_large_faint_size),
                     Blending = BlendingParameters.Additive,
                     EdgeEffect = new EdgeEffectParameters
                     {
@@ -140,12 +142,17 @@ namespace osu.Game.Rulesets.Mania.UI
         public void Animate()
         {
             largeFaint
-                .ResizeTo(largeFaint.Size * new Vector2(5, 1), PoolableHitExplosion.DURATION, Easing.OutQuint)
+                .ResizeTo(default_large_faint_size)
+                .Then()
+                .ResizeTo(default_large_faint_size * new Vector2(5, 1), PoolableHitExplosion.DURATION, Easing.OutQuint)
                 .FadeOut(PoolableHitExplosion.DURATION * 2);
 
-            mainGlow1.ScaleTo(1.4f, PoolableHitExplosion.DURATION, Easing.OutQuint);
+            mainGlow1
+                .ScaleTo(1)
+                .Then()
+                .ScaleTo(1.4f, PoolableHitExplosion.DURATION, Easing.OutQuint);
 
-            this.FadeOut(PoolableHitExplosion.DURATION, Easing.Out);
+            this.FadeOutFromOne(PoolableHitExplosion.DURATION, Easing.Out);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/DefaultHitExplosion.cs
@@ -15,7 +15,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
-    public class DefaultHitExplosion : CompositeDrawable
+    public class DefaultHitExplosion : CompositeDrawable, IHitExplosion
     {
         public override bool RemoveWhenNotAlive => true;
 
@@ -123,21 +123,6 @@ namespace osu.Game.Rulesets.Mania.UI
             direction.BindValueChanged(onDirectionChanged, true);
         }
 
-        protected override void LoadComplete()
-        {
-            const double duration = 200;
-
-            base.LoadComplete();
-
-            largeFaint
-                .ResizeTo(largeFaint.Size * new Vector2(5, 1), duration, Easing.OutQuint)
-                .FadeOut(duration * 2);
-
-            mainGlow1.ScaleTo(1.4f, duration, Easing.OutQuint);
-
-            this.FadeOut(duration, Easing.Out);
-        }
-
         private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
         {
             if (direction.NewValue == ScrollingDirection.Up)
@@ -150,6 +135,17 @@ namespace osu.Game.Rulesets.Mania.UI
                 Anchor = Anchor.BottomCentre;
                 Y = -DefaultNotePiece.NOTE_HEIGHT / 2;
             }
+        }
+
+        public void Animate()
+        {
+            largeFaint
+                .ResizeTo(largeFaint.Size * new Vector2(5, 1), PoolableHitExplosion.DURATION, Easing.OutQuint)
+                .FadeOut(PoolableHitExplosion.DURATION * 2);
+
+            mainGlow1.ScaleTo(1.4f, PoolableHitExplosion.DURATION, Easing.OutQuint);
+
+            this.FadeOut(PoolableHitExplosion.DURATION, Easing.Out);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/IHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/IHitExplosion.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Mania.UI
+{
+    /// <summary>
+    /// Common interface for all hit explosion bodies.
+    /// </summary>
+    public interface IHitExplosion
+    {
+        /// <summary>
+        /// Begins animating this <see cref="IHitExplosion"/>.
+        /// </summary>
+        void Animate();
+    }
+}

--- a/osu.Game.Rulesets.Mania/UI/IHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/IHitExplosion.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Judgements;
+
 namespace osu.Game.Rulesets.Mania.UI
 {
     /// <summary>
@@ -11,6 +13,7 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// Begins animating this <see cref="IHitExplosion"/>.
         /// </summary>
-        void Animate();
+        /// <param name="result">The type of <see cref="JudgementResult"/> that caused this explosion.</param>
+        void Animate(JudgementResult result);
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/PoolableHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/PoolableHitExplosion.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Mania.UI
@@ -11,6 +12,8 @@ namespace osu.Game.Rulesets.Mania.UI
     public class PoolableHitExplosion : PoolableDrawable
     {
         public const double DURATION = 200;
+
+        public JudgementResult Result { get; private set; }
 
         [Resolved]
         private Column column { get; set; }
@@ -25,18 +28,22 @@ namespace osu.Game.Rulesets.Mania.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = skinnableExplosion = new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.HitExplosion, column.Index),
-                _ => new DefaultHitExplosion(column.AccentColour, false /*todo */))
+            InternalChild = skinnableExplosion = new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.HitExplosion, column.Index), _ => new DefaultHitExplosion())
             {
                 RelativeSizeAxes = Axes.Both
             };
+        }
+
+        public void Apply(JudgementResult result)
+        {
+            Result = result;
         }
 
         protected override void PrepareForUse()
         {
             base.PrepareForUse();
 
-            (skinnableExplosion?.Drawable as IHitExplosion)?.Animate();
+            (skinnableExplosion?.Drawable as IHitExplosion)?.Animate(Result);
 
             this.Delay(DURATION).Then().Expire();
         }

--- a/osu.Game.Rulesets.Mania/UI/PoolableHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/PoolableHitExplosion.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Mania.UI
+{
+    public class PoolableHitExplosion : PoolableDrawable
+    {
+        public const double DURATION = 200;
+
+        [Resolved]
+        private Column column { get; set; }
+
+        private SkinnableDrawable skinnableExplosion;
+
+        public PoolableHitExplosion()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = skinnableExplosion = new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.HitExplosion, column.Index),
+                _ => new DefaultHitExplosion(column.AccentColour, false /*todo */))
+            {
+                RelativeSizeAxes = Axes.Both
+            };
+        }
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+
+            (skinnableExplosion?.Drawable as IHitExplosion)?.Animate();
+
+            this.Delay(DURATION).Then().Expire();
+        }
+    }
+}


### PR DESCRIPTION
Initialised with 5 drawables per pool, one pool per column, with no upper limit (though around 10-15 per column is a viable upper limit).