### PR TITLE
Add pooling for mania judgements

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -15,6 +15,10 @@ namespace osu.Game.Rulesets.Mania.UI
         {
         }
 
+        public DrawableManiaJudgement()
+        {
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
@@ -33,8 +34,8 @@ namespace osu.Game.Rulesets.Mania.UI
         public IReadOnlyList<Column> Columns => columnFlow.Children;
         private readonly FillFlowContainer<Column> columnFlow;
 
-        public Container<DrawableManiaJudgement> Judgements => judgements;
         private readonly JudgementContainer<DrawableManiaJudgement> judgements;
+        private readonly DrawablePool<DrawableManiaJudgement> judgementPool;
 
         private readonly Drawable barLineContainer;
         private readonly Container topLevelContainer;
@@ -63,6 +64,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             InternalChildren = new Drawable[]
             {
+                judgementPool = new DrawablePool<DrawableManiaJudgement>(2),
                 new Container
                 {
                     Anchor = Anchor.TopCentre,
@@ -208,12 +210,14 @@ namespace osu.Game.Rulesets.Mania.UI
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 
-            judgements.Clear();
-            judgements.Add(new DrawableManiaJudgement(result, judgedObject)
+            judgements.Clear(false);
+            judgements.Add(judgementPool.Get(j =>
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-            });
+                j.Apply(result, judgedObject);
+
+                j.Anchor = Anchor.Centre;
+                j.Origin = Anchor.Centre;
+            }));
         }
 
         protected override void Update()


### PR DESCRIPTION
Keeping it simple for now. I believe even pooling might be excessive here but only because of the transform - it might look better to not fade-in the text every time, so a singular instance might be preferable.

Can do that in the future though, this preserves current logic.