### PR TITLE
Add osu!catch banana catching sounds

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.727.1" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.731.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2020.730.1" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using osu.Game.Audio;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Judgements;
 
@@ -8,8 +10,27 @@ namespace osu.Game.Rulesets.Catch.Objects
 {
     public class Banana : Fruit
     {
+        /// <summary>
+        /// Index of banana in current shower.
+        /// </summary>
+        public int BananaIndex;
+
         public override FruitVisualRepresentation VisualRepresentation => FruitVisualRepresentation.Banana;
 
         public override Judgement CreateJudgement() => new CatchBananaJudgement();
+
+        private static readonly List<HitSampleInfo> samples = new List<HitSampleInfo> { new BananaHitSampleInfo() };
+
+        public Banana()
+        {
+            Samples = samples;
+        }
+
+        private class BananaHitSampleInfo : HitSampleInfo
+        {
+            private static string[] lookupNames { get; } = { "metronomelow", "catch-banana" };
+
+            public override IEnumerable<string> LookupNames => lookupNames;
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
@@ -30,15 +30,21 @@ namespace osu.Game.Rulesets.Catch.Objects
             if (spacing <= 0)
                 return;
 
-            for (double i = StartTime; i <= EndTime; i += spacing)
+            double time = StartTime;
+            int i = 0;
+
+            while (time <= EndTime)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 AddNested(new Banana
                 {
-                    Samples = Samples,
-                    StartTime = i
+                    StartTime = time,
+                    BananaIndex = i,
                 });
+
+                time += spacing;
+                i++;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -40,6 +40,13 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             float getRandomAngle() => 180 * (RNG.NextSingle() * 2 - 1);
         }
 
+        public override void PlaySamples()
+        {
+            base.PlaySamples();
+            if (Samples != null)
+                Samples.Frequency.Value = 0.77f + ((Banana)HitObject).BananaIndex * 0.006f;
+        }
+
         private Color4 getBananaColour()
         {
             switch (RNG.Next(0, 3))

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Framework" Version="2020.730.1" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.727.1" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.731.0" />
     <PackageReference Include="Sentry" Version="2.1.5" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.730.1" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.727.1" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2020.731.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-resources/pull/110
- Uses new "catch-banana" but falls back to legacy "metronomelow" for compatibility.

Not sure if we want to add bank support. Shouldn't be a huge reach, but also was not previously supported and has never been requested.