### PR TITLE
Fix dynamic compilation loading wrong ruleset versions

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -65,11 +65,15 @@ namespace osu.Game.Rulesets
             // the requesting assembly may be located out of the executable's base directory, thus requiring manual resolving of its dependencies.
             // this attempts resolving the ruleset dependencies on game core and framework assemblies by returning assemblies with the same assembly name
             // already loaded in the AppDomain.
-            foreach (var curAsm in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                if (asm.Name.Equals(curAsm.GetName().Name, StringComparison.Ordinal))
-                    return curAsm;
-            }
+            var domainAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                                          // Given name is always going to be equally-or-more qualified than the assembly name.
+                                          .Where(a => args.Name.Contains(a.GetName().Name, StringComparison.Ordinal))
+                                          // Pick the greatest assembly version.
+                                          .OrderBy(a => a.GetName().Version)
+                                          .LastOrDefault();
+
+            if (domainAssembly != null)
+                return domainAssembly;
 
             return loadedAssemblies.Keys.FirstOrDefault(a => a.FullName == asm.FullName);
         }

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -69,8 +69,8 @@ namespace osu.Game.Rulesets
                                           // Given name is always going to be equally-or-more qualified than the assembly name.
                                           .Where(a => args.Name.Contains(a.GetName().Name, StringComparison.Ordinal))
                                           // Pick the greatest assembly version.
-                                          .OrderBy(a => a.GetName().Version)
-                                          .LastOrDefault();
+                                          .OrderByDescending(a => a.GetName().Version)
+                                          .FirstOrDefault();
 
             if (domainAssembly != null)
                 return domainAssembly;


### PR DESCRIPTION
Resolves part 2 of https://github.com/ppy/osu-framework/issues/3775#issuecomment-666168195

Should be pretty obvious why this was occurring - the first assembly in the AppDomain is the lowest version.