### PR TITLE
Ignore custom sample bank when performing sample lookups from user skin

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Resources/SampleLookups/taiko-hitobject-beatmap-custom-sample-bank.osu
+++ b/osu.Game.Rulesets.Taiko.Tests/Resources/SampleLookups/taiko-hitobject-beatmap-custom-sample-bank.osu
@@ -1,0 +1,10 @@
+osu file format v14
+
+[General]
+Mode: 1
+
+[TimingPoints]
+0,300,4,1,2,100,1,0
+
+[HitObjects]
+444,320,1000,5,0,0:0:0:0:

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoHitObjectSamples.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Reflection;
+using NUnit.Framework;
+using osu.Framework.IO.Stores;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TestSceneTaikoHitObjectSamples : HitObjectSampleTest
+    {
+        protected override Ruleset CreatePlayerRuleset() => new TaikoRuleset();
+
+        protected override IResourceStore<byte[]> Resources => new DllResourceStore(Assembly.GetAssembly(typeof(TestSceneTaikoHitObjectSamples)));
+
+        [TestCase("taiko-normal-hitnormal")]
+        [TestCase("normal-hitnormal")]
+        [TestCase("hitnormal")]
+        public void TestDefaultCustomSampleFromBeatmap(string expectedSample)
+        {
+            SetupSkins(expectedSample, expectedSample);
+
+            CreateTestWithBeatmap("taiko-hitobject-beatmap-custom-sample-bank.osu");
+
+            AssertBeatmapLookup(expectedSample);
+        }
+
+        [TestCase("taiko-normal-hitnormal")]
+        [TestCase("normal-hitnormal")]
+        [TestCase("hitnormal")]
+        public void TestDefaultCustomSampleFromUserSkinFallback(string expectedSample)
+        {
+            SetupSkins(string.Empty, expectedSample);
+
+            CreateTestWithBeatmap("taiko-hitobject-beatmap-custom-sample-bank.osu");
+
+            AssertUserLookup(expectedSample);
+        }
+
+        [TestCase("taiko-normal-hitnormal2")]
+        [TestCase("normal-hitnormal2")]
+        public void TestUserSkinLookupIgnoresSampleBank(string unwantedSample)
+        {
+            SetupSkins(string.Empty, unwantedSample);
+
+            CreateTestWithBeatmap("taiko-hitobject-beatmap-custom-sample-bank.osu");
+
+            AssertNoLookup(unwantedSample);
+        }
+    }
+}

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
@@ -82,12 +82,11 @@ namespace osu.Game.Tests.Gameplay
         }
 
         /// <summary>
-        /// Tests that a hitobject which provides a custom sample set of 2 retrieves the following samples from the user skin when the beatmap does not contain the sample:
-        /// normal-hitnormal2
+        /// Tests that a hitobject which provides a custom sample set of 2 retrieves the following samples from the user skin
+        /// (ignoring the custom sample set index) when the beatmap skin does not contain the sample:
         /// normal-hitnormal
         /// hitnormal
         /// </summary>
-        [TestCase("normal-hitnormal2")]
         [TestCase("normal-hitnormal")]
         [TestCase("hitnormal")]
         public void TestDefaultCustomSampleFromUserSkinFallback(string expectedSample)
@@ -97,6 +96,23 @@ namespace osu.Game.Tests.Gameplay
             CreateTestWithBeatmap("hitobject-beatmap-custom-sample.osu");
 
             AssertUserLookup(expectedSample);
+        }
+
+        /// <summary>
+        /// Tests that a hitobject which provides a custom sample set of 2 does not retrieve a normal-hitnormal2 sample from the user skin
+        /// if the beatmap skin does not contain the sample.
+        /// User skins in stable ignore the custom sample set index when performing lookups.
+        /// </summary>
+        [Test]
+        public void TestUserSkinLookupIgnoresSampleBank()
+        {
+            const string unwanted_sample = "normal-hitnormal2";
+
+            SetupSkins(string.Empty, unwanted_sample);
+
+            CreateTestWithBeatmap("hitobject-beatmap-custom-sample.osu");
+
+            AssertNoLookup(unwanted_sample);
         }
 
         /// <summary>
@@ -183,7 +199,7 @@ namespace osu.Game.Tests.Gameplay
             string[] expectedSamples =
             {
                 "normal-hitnormal2",
-                "normal-hitwhistle2"
+                "normal-hitwhistle" // user skin lookups ignore custom sample set index
             };
 
             SetupSkins(expectedSamples[0], expectedSamples[1]);

--- a/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneHitObjectSamples.cs
@@ -67,9 +67,11 @@ namespace osu.Game.Tests.Gameplay
         /// Tests that a hitobject which provides a custom sample set of 2 retrieves the following samples from the beatmap skin:
         /// normal-hitnormal2
         /// normal-hitnormal
+        /// hitnormal
         /// </summary>
         [TestCase("normal-hitnormal2")]
         [TestCase("normal-hitnormal")]
+        [TestCase("hitnormal")]
         public void TestDefaultCustomSampleFromBeatmap(string expectedSample)
         {
             SetupSkins(expectedSample, expectedSample);
@@ -83,9 +85,11 @@ namespace osu.Game.Tests.Gameplay
         /// Tests that a hitobject which provides a custom sample set of 2 retrieves the following samples from the user skin when the beatmap does not contain the sample:
         /// normal-hitnormal2
         /// normal-hitnormal
+        /// hitnormal
         /// </summary>
         [TestCase("normal-hitnormal2")]
         [TestCase("normal-hitnormal")]
+        [TestCase("hitnormal")]
         public void TestDefaultCustomSampleFromUserSkinFallback(string expectedSample)
         {
             SetupSkins(string.Empty, expectedSample);
@@ -145,6 +149,7 @@ namespace osu.Game.Tests.Gameplay
         /// </summary>
         [TestCase("normal-hitnormal2")]
         [TestCase("normal-hitnormal")]
+        [TestCase("hitnormal")]
         public void TestControlPointCustomSampleFromBeatmap(string sampleName)
         {
             SetupSkins(sampleName, sampleName);

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Skinning
     public class LegacyBeatmapSkin : LegacySkin
     {
         protected override bool AllowManiaSkin => false;
+        protected override bool UseCustomSampleBanks => true;
 
         public LegacyBeatmapSkin(BeatmapInfo beatmap, IResourceStore<byte[]> storage, AudioManager audioManager)
             : base(createSkinInfo(beatmap), new LegacySkinResourceStore<BeatmapSetFileInfo>(beatmap.BeatmapSet, storage), audioManager, beatmap.Path)

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -38,6 +38,12 @@ namespace osu.Game.Skinning
 
         protected virtual bool AllowManiaSkin => hasKeyTexture.Value;
 
+        /// <summary>
+        /// Whether this skin can use samples with a custom bank (custom sample set in stable terminology).
+        /// Added in order to match sample lookup logic from stable (in stable, only the beatmap skin could use samples with a custom sample bank).
+        /// </summary>
+        protected virtual bool UseCustomSampleBanks => false;
+
         public new LegacySkinConfiguration Configuration
         {
             get => base.Configuration as LegacySkinConfiguration;
@@ -337,7 +343,12 @@ namespace osu.Game.Skinning
 
         public override SampleChannel GetSample(ISampleInfo sampleInfo)
         {
-            foreach (var lookup in sampleInfo.LookupNames)
+            var lookupNames = sampleInfo.LookupNames;
+
+            if (sampleInfo is HitSampleInfo hitSample)
+                lookupNames = getLegacyLookupNames(hitSample);
+
+            foreach (var lookup in lookupNames)
             {
                 var sample = Samples?.Get(lookup);
 
@@ -360,6 +371,19 @@ namespace osu.Game.Skinning
             // Fall back to using the last piece for components coming from lazer (e.g. "Gameplay/osu/approachcircle" -> "approachcircle").
             string lastPiece = componentName.Split('/').Last();
             yield return componentName.StartsWith("Gameplay/taiko/") ? "taiko-" + lastPiece : lastPiece;
+        }
+
+        private IEnumerable<string> getLegacyLookupNames(HitSampleInfo hitSample)
+        {
+            var lookupNames = hitSample.LookupNames;
+
+            if (!UseCustomSampleBanks && !string.IsNullOrEmpty(hitSample.Suffix))
+                // for compatibility with stable, exclude the lookup names with the custom sample bank suffix, if they are not valid for use in this skin.
+                // using .EndsWith() is intentional as it ensures parity in all edge cases
+                // (see LegacyTaikoSampleInfo for an example of one - prioritising the taiko prefix should still apply, but the sample bank should not).
+                lookupNames = hitSample.LookupNames.Where(name => !name.EndsWith(hitSample.Suffix));
+
+            return lookupNames;
         }
     }
 }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -356,10 +356,6 @@ namespace osu.Game.Skinning
                     return sample;
             }
 
-            if (sampleInfo is HitSampleInfo hsi)
-                // Try fallback to non-bank samples.
-                return Samples?.Get(hsi.Name);
-
             return null;
         }
 
@@ -382,6 +378,11 @@ namespace osu.Game.Skinning
                 // using .EndsWith() is intentional as it ensures parity in all edge cases
                 // (see LegacyTaikoSampleInfo for an example of one - prioritising the taiko prefix should still apply, but the sample bank should not).
                 lookupNames = hitSample.LookupNames.Where(name => !name.EndsWith(hitSample.Suffix));
+
+            // also for compatibility, try falling back to non-bank samples (so-called "universal" samples) as the last resort.
+            // going forward specifying banks shall always be required, even for elements that wouldn't require it on stable,
+            // which is why this is done locally here.
+            lookupNames = lookupNames.Append(hitSample.Name);
 
             return lookupNames;
         }


### PR DESCRIPTION
Resolves #8928.

# Summary

As outlined in the issue thread, stable does not take into account the custom sample set/bank when looking up samples from the user skin, but does take it into account on the beatmap skin. To resolve, add a local check in `LegacySkin` to replicate behaviour.

In addition to the test cases attached, the following videos demonstrate the fail case with beatmap/user skin combination as reported in the issue:

* [stable](https://drive.google.com/file/d/14YWxgZoZM9xcOYSqzsptk_Il8aBQGxOG/view?usp=sharing) for reference,
* [`master`](https://drive.google.com/file/d/1G9ok1vAzqqJJPLjUZ9RgauHg41gIpMC7/view?usp=sharing),
* [this PR](https://drive.google.com/file/d/14BBxl7M_Dzh1Y-2NbRHTDKX9HHKRVtEK/view?usp=sharing).

# Remarks

The code differs slightly from what I posted in the issue. I have discarded [this commit](https://github.com/ppy/osu/commit/a4dba5910b9a3a022f0daccb5e91b3eda7fb170a) after reading [this old discussion](https://discordapp.com/channels/188630481301012481/188630652340404224/613972199442874368) that I wasn't around to witness yet, and kept the bank-less lookup local to `LegacySkin` too.

Additionally includes coverage for some untested parts of the lookup code (taiko lookups as well as bank-less ones). A careful reader might notice that the test cases for taiko aren't checking `{taiko-}?normal-hitnormal2`, and that is because, as it turns out, that is currently unsupported in lazer. Adding rudimentary support is easy enough, but, *unfortunately* there's another edge case there - stable skips those lookups on converted beatmaps, which I don't even know how to properly deal with right now.

I don't remember the last time I went back and forth on a branch as many times as this one. I hate this code but I don't really see a better way out; not sure if I left enough comments to explain the hackery. I'm sort of worried this will regress something I don't expect to, but I don't see a way out of that other than merging and dealing with potential reports later (which I will be looking out for and investigating/handling as soon as possible).