### PR TITLE
Fix spinner test failures

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -97,12 +97,12 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep("retrieve cumulative disc rotation", () => finalCumulativeTrackerRotation = drawableSpinner.RotationTracker.CumulativeRotation);
 
             addSeekStep(2500);
-            AddUntilStep("disc rotation rewound",
+            AddAssert("disc rotation rewound",
                 // we want to make sure that the rotation at time 2500 is in the same direction as at time 5000, but about half-way in.
                 // due to the exponential damping applied we're allowing a larger margin of error of about 10%
                 // (5% relative to the final rotation value, but we're half-way through the spin).
                 () => Precision.AlmostEquals(drawableSpinner.RotationTracker.Rotation, finalTrackerRotation / 2, trackerRotationTolerance));
-            AddUntilStep("symbol rotation rewound",
+            AddAssert("symbol rotation rewound",
                 () => Precision.AlmostEquals(spinnerSymbol.Rotation, finalSpinnerSymbolRotation / 2, spinnerSymbolRotationTolerance));
             AddAssert("is cumulative rotation rewound",
                 // cumulative rotation is not damped, so we're treating it as the "ground truth" and allowing a comparatively smaller margin of error.


### PR DESCRIPTION
Resolves spinner rewind test failures.

# Summary

The recent spinner PR caused reproducible test failures on the tests that checked the rotation after rewind. The failure itself was related to switching a lerp to a damp with a quite high exponentiation base of 0.99. This meant that the rotation values were further off from the expected ones than before, at the cost of the rotation being less rigid and more momentum-based.

This PR changes the tolerance values in failing test cases to be relative to the marginal values instead of absolute, therefore allowing for more tolerance when checking the value. This means that the rotation value might not necessarily be 100% correct, but I don't think it matters for it to be correct rather than *feel* okay, which I think the current one does (it kind of works like a ~300ms transform right now). The value that we really care about correctness-wise (cumulative rotation, as it affects scoring) is not damped and therefore needs no adjustment.

The reason why the wait steps had no effect is that the seeks prevent time from elapsing, and therefore the rotation stays frozen. This is consistent with every other gameplay element, so I'd say it's expected behaviour.

# Remarks

I went back and forth on whether to lower the damp, but decided against it. If you think that would be better then I'll close.

[Here's a spreadsheet](https://docs.google.com/spreadsheets/d/14enVlvJ2DfqAstUPtk9MSWyJOzgDJxBdgLhTR6ER2Yc/edit?usp=sharing) that shows how the current damp works. Probably the most sketchy-looking case is in the "backward to halfway" sheet but I think it's ok.