### PR TITLE
Allow providing custom sprite text for RollingCounter<T>

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoreCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoreCounter.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 Origin = Anchor.TopRight,
                 Anchor = Anchor.TopRight,
-                TextSize = 40,
                 Margin = new MarginPadding(20),
             };
             Add(score);
@@ -30,7 +29,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Origin = Anchor.BottomLeft,
                 Anchor = Anchor.BottomLeft,
                 Margin = new MarginPadding(10),
-                TextSize = 40,
             };
             Add(comboCounter);
 

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchScoreDisplay.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
@@ -127,20 +128,27 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
         private class MatchScoreCounter : ScoreCounter
         {
+            private OsuSpriteText displayedSpriteText;
+
             public MatchScoreCounter()
             {
                 Margin = new MarginPadding { Top = bar_height, Horizontal = 10 };
-
-                Winning = false;
-
-                DisplayedCountSpriteText.Spacing = new Vector2(-6);
             }
 
             public bool Winning
             {
-                set => DisplayedCountSpriteText.Font = value
+                set => displayedSpriteText.Font = value
                     ? OsuFont.Torus.With(weight: FontWeight.Bold, size: 50, fixedWidth: true)
                     : OsuFont.Torus.With(weight: FontWeight.Regular, size: 40, fixedWidth: true);
+            }
+
+            protected override OsuSpriteText CreateSpriteText()
+            {
+                displayedSpriteText = base.CreateSpriteText();
+                displayedSpriteText.Spacing = new Vector2(-6);
+                Winning = false;
+
+                return displayedSpriteText;
             }
         }
     }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchScoreDisplay.cs
@@ -137,19 +137,20 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
             public bool Winning
             {
-                set => displayedSpriteText.Font = value
+                set => updateFont(value);
+            }
+
+            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
+            {
+                displayedSpriteText = s;
+                displayedSpriteText.Spacing = new Vector2(-6);
+                updateFont(false);
+            });
+
+            private void updateFont(bool winning)
+                => displayedSpriteText.Font = winning
                     ? OsuFont.Torus.With(weight: FontWeight.Bold, size: 50, fixedWidth: true)
                     : OsuFont.Torus.With(weight: FontWeight.Regular, size: 40, fixedWidth: true);
-            }
-
-            protected override OsuSpriteText CreateSpriteText()
-            {
-                displayedSpriteText = base.CreateSpriteText();
-                displayedSpriteText.Spacing = new Vector2(-6);
-                Winning = false;
-
-                return displayedSpriteText;
-            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/PercentageCounter.cs
+++ b/osu.Game/Graphics/UserInterface/PercentageCounter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Utils;
 
@@ -28,7 +29,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours) => AccentColour = colours.BlueLighter;
+        private void load(OsuColour colours) => Colour = colours.BlueLighter;
 
         protected override string FormatCount(double count) => count.FormatAccuracy();
 
@@ -38,11 +39,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         protected override OsuSpriteText CreateSpriteText()
-        {
-            var spriteText = base.CreateSpriteText();
-            spriteText.Font = spriteText.Font.With(fixedWidth: true);
-            return spriteText;
-        }
+            => base.CreateSpriteText().With(s => s.Font = s.Font.With(size: 20f, fixedWidth: true));
 
         public override void Increment(double amount)
         {

--- a/osu.Game/Graphics/UserInterface/PercentageCounter.cs
+++ b/osu.Game/Graphics/UserInterface/PercentageCounter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Utils;
 
 namespace osu.Game.Graphics.UserInterface
@@ -23,7 +24,6 @@ namespace osu.Game.Graphics.UserInterface
 
         public PercentageCounter()
         {
-            DisplayedCountSpriteText.Font = DisplayedCountSpriteText.Font.With(fixedWidth: true);
             Current.Value = DisplayedCount = 1.0f;
         }
 
@@ -35,6 +35,13 @@ namespace osu.Game.Graphics.UserInterface
         protected override double GetProportionalDuration(double currentValue, double newValue)
         {
             return Math.Abs(currentValue - newValue) * RollingDuration * 100.0f;
+        }
+
+        protected override OsuSpriteText CreateSpriteText()
+        {
+            var spriteText = base.CreateSpriteText();
+            spriteText.Font = spriteText.Font.With(fixedWidth: true);
+            return spriteText;
         }
 
         public override void Increment(double amount)

--- a/osu.Game/Graphics/UserInterface/RollingCounter.cs
+++ b/osu.Game/Graphics/UserInterface/RollingCounter.cs
@@ -9,11 +9,10 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public abstract class RollingCounter<T> : Container, IHasAccentColour
+    public abstract class RollingCounter<T> : Container
         where T : struct, IEquatable<T>
     {
         /// <summary>
@@ -59,38 +58,6 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         public abstract void Increment(T amount);
-
-        private float textSize = 40f;
-
-        public float TextSize
-        {
-            get => displayedCountSpriteText?.Font.Size ?? textSize;
-            set
-            {
-                if (TextSize == value)
-                    return;
-
-                textSize = value;
-                if (displayedCountSpriteText != null)
-                    displayedCountSpriteText.Font = displayedCountSpriteText.Font.With(size: value);
-            }
-        }
-
-        private Color4 accentColour;
-
-        public Color4 AccentColour
-        {
-            get => displayedCountSpriteText?.Colour ?? accentColour;
-            set
-            {
-                if (AccentColour == value)
-                    return;
-
-                accentColour = value;
-                if (displayedCountSpriteText != null)
-                    displayedCountSpriteText.Colour = value;
-            }
-        }
 
         /// <summary>
         /// Skeleton of a numeric counter which value rolls over time.
@@ -185,8 +152,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected virtual OsuSpriteText CreateSpriteText() => new OsuSpriteText
         {
-            Font = OsuFont.Numeric.With(size: textSize),
-            Colour = accentColour,
+            Font = OsuFont.Numeric.With(size: 40f),
         };
     }
 }

--- a/osu.Game/Graphics/UserInterface/RollingCounter.cs
+++ b/osu.Game/Graphics/UserInterface/RollingCounter.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Graphics.UserInterface
         private void load()
         {
             displayedCountSpriteText = CreateSpriteText();
-            displayedCountSpriteText.Text = FormatCount(displayedCount);
+            displayedCountSpriteText.Text = FormatCount(DisplayedCount);
             Child = displayedCountSpriteText;
         }
 

--- a/osu.Game/Graphics/UserInterface/ScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/ScoreCounter.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours) => AccentColour = colours.BlueLighter;
+        private void load(OsuColour colours) => Colour = colours.BlueLighter;
 
         protected override double GetProportionalDuration(double currentValue, double newValue)
         {
@@ -50,11 +50,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         protected override OsuSpriteText CreateSpriteText()
-        {
-            var spriteText = base.CreateSpriteText();
-            spriteText.Font = spriteText.Font.With(fixedWidth: true);
-            return spriteText;
-        }
+            => base.CreateSpriteText().With(s => s.Font = s.Font.With(fixedWidth: true));
 
         public override void Increment(double amount)
         {

--- a/osu.Game/Graphics/UserInterface/ScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/ScoreCounter.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -24,7 +25,6 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="leading">How many leading zeroes the counter will have.</param>
         public ScoreCounter(uint leading = 0)
         {
-            DisplayedCountSpriteText.Font = DisplayedCountSpriteText.Font.With(fixedWidth: true);
             LeadingZeroes = leading;
         }
 
@@ -47,6 +47,13 @@ namespace osu.Game.Graphics.UserInterface
             }
 
             return ((long)count).ToString(format);
+        }
+
+        protected override OsuSpriteText CreateSpriteText()
+        {
+            var spriteText = base.CreateSpriteText();
+            spriteText.Font = spriteText.Font.With(fixedWidth: true);
+            return spriteText;
         }
 
         public override void Increment(double amount)

--- a/osu.Game/Graphics/UserInterface/SimpleComboCounter.cs
+++ b/osu.Game/Graphics/UserInterface/SimpleComboCounter.cs
@@ -3,6 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -19,7 +21,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours) => AccentColour = colours.BlueLighter;
+        private void load(OsuColour colours) => Colour = colours.BlueLighter;
 
         protected override string FormatCount(int count)
         {
@@ -35,5 +37,8 @@ namespace osu.Game.Graphics.UserInterface
         {
             Current.Value += amount;
         }
+
+        protected override OsuSpriteText CreateSpriteText()
+            => base.CreateSpriteText().With(s => s.Font = s.Font.With(size: 20f));
     }
 }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -232,7 +232,6 @@ namespace osu.Game.Screens.Play
 
         protected virtual RollingCounter<double> CreateAccuracyCounter() => new PercentageCounter
         {
-            TextSize = 20,
             BypassAutoSizeAxes = Axes.X,
             Anchor = Anchor.TopLeft,
             Origin = Anchor.TopRight,
@@ -241,14 +240,12 @@ namespace osu.Game.Screens.Play
 
         protected virtual ScoreCounter CreateScoreCounter() => new ScoreCounter(6)
         {
-            TextSize = 40,
             Anchor = Anchor.TopCentre,
             Origin = Anchor.TopCentre,
         };
 
         protected virtual RollingCounter<int> CreateComboCounter() => new SimpleComboCounter
         {
-            TextSize = 20,
             BypassAutoSizeAxes = Axes.X,
             Anchor = Anchor.TopRight,
             Origin = Anchor.TopLeft,

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osu.Game.Utils;
@@ -43,16 +44,18 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
 
             protected override Easing RollingEasing => AccuracyCircle.ACCURACY_TRANSFORM_EASING;
 
-            public Counter()
-            {
-                DisplayedCountSpriteText.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
-                DisplayedCountSpriteText.Spacing = new Vector2(-2, 0);
-            }
-
             protected override string FormatCount(double count) => count.FormatAccuracy();
 
             public override void Increment(double amount)
                 => Current.Value += amount;
+
+            protected override OsuSpriteText CreateSpriteText()
+            {
+                var spriteText = base.CreateSpriteText();
+                spriteText.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
+                spriteText.Spacing = new Vector2(-2, 0);
+                return spriteText;
+            }
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
@@ -49,13 +49,11 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
             public override void Increment(double amount)
                 => Current.Value += amount;
 
-            protected override OsuSpriteText CreateSpriteText()
+            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
             {
-                var spriteText = base.CreateSpriteText();
-                spriteText.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
-                spriteText.Spacing = new Vector2(-2, 0);
-                return spriteText;
-            }
+                s.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
+                s.Spacing = new Vector2(-2, 0);
+            });
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osuTK;
@@ -43,10 +44,12 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
 
             protected override Easing RollingEasing => AccuracyCircle.ACCURACY_TRANSFORM_EASING;
 
-            public Counter()
+            protected override OsuSpriteText CreateSpriteText()
             {
-                DisplayedCountSpriteText.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
-                DisplayedCountSpriteText.Spacing = new Vector2(-2, 0);
+                var spriteText = base.CreateSpriteText();
+                spriteText.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
+                spriteText.Spacing = new Vector2(-2, 0);
+                return spriteText;
             }
 
             public override void Increment(int amount)

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
@@ -44,13 +44,11 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
 
             protected override Easing RollingEasing => AccuracyCircle.ACCURACY_TRANSFORM_EASING;
 
-            protected override OsuSpriteText CreateSpriteText()
+            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
             {
-                var spriteText = base.CreateSpriteText();
-                spriteText.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
-                spriteText.Spacing = new Vector2(-2, 0);
-                return spriteText;
-            }
+                s.Font = OsuFont.Torus.With(size: 20, fixedWidth: true);
+                s.Spacing = new Vector2(-2, 0);
+            });
 
             public override void Increment(int amount)
                 => Current.Value += amount;

--- a/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
+++ b/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
@@ -28,16 +28,14 @@ namespace osu.Game.Screens.Ranking.Expanded
 
         protected override string FormatCount(long count) => count.ToString("N0");
 
-        protected override OsuSpriteText CreateSpriteText()
+        protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
         {
-            var spriteText = base.CreateSpriteText();
-            spriteText.Anchor = Anchor.TopCentre;
-            spriteText.Origin = Anchor.TopCentre;
+            s.Anchor = Anchor.TopCentre;
+            s.Origin = Anchor.TopCentre;
 
-            spriteText.Font = OsuFont.Torus.With(size: 60, weight: FontWeight.Light, fixedWidth: true);
-            spriteText.Spacing = new Vector2(-5, 0);
-            return spriteText;
-        }
+            s.Font = OsuFont.Torus.With(size: 60, weight: FontWeight.Light, fixedWidth: true);
+            s.Spacing = new Vector2(-5, 0);
+        });
 
         public override void Increment(long amount)
             => Current.Value += amount;

--- a/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
+++ b/osu.Game/Screens/Ranking/Expanded/TotalScoreCounter.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osuTK;
@@ -23,14 +24,20 @@ namespace osu.Game.Screens.Ranking.Expanded
             // Todo: AutoSize X removed here due to https://github.com/ppy/osu-framework/issues/3369
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
-            DisplayedCountSpriteText.Anchor = Anchor.TopCentre;
-            DisplayedCountSpriteText.Origin = Anchor.TopCentre;
-
-            DisplayedCountSpriteText.Font = OsuFont.Torus.With(size: 60, weight: FontWeight.Light, fixedWidth: true);
-            DisplayedCountSpriteText.Spacing = new Vector2(-5, 0);
         }
 
         protected override string FormatCount(long count) => count.ToString("N0");
+
+        protected override OsuSpriteText CreateSpriteText()
+        {
+            var spriteText = base.CreateSpriteText();
+            spriteText.Anchor = Anchor.TopCentre;
+            spriteText.Origin = Anchor.TopCentre;
+
+            spriteText.Font = OsuFont.Torus.With(size: 60, weight: FontWeight.Light, fixedWidth: true);
+            spriteText.Spacing = new Vector2(-5, 0);
+            return spriteText;
+        }
 
         public override void Increment(long amount)
             => Current.Value += amount;


### PR DESCRIPTION
Required for catch-specific combo counter as it uses `RollingCounter<T>`, and the sprite text of the counter for legacy skins must be a `LegacySpriteText` of course.