### PR TITLE
Separate "pause sample on gameplay pause" logic to a specific GameplaySkinnableSound class

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Tracking.BindValueChanged(updateSlidingSample);
         }
 
-        private SkinnableSound slidingSample;
+        private GameplaySkinnableSound slidingSample;
 
         protected override void LoadSamples()
         {
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 var clone = HitObject.SampleControlPoint.ApplyTo(firstSample);
                 clone.Name = "sliderslide";
 
-                AddInternal(slidingSample = new SkinnableSound(clone)
+                AddInternal(slidingSample = new GameplaySkinnableSound(clone)
                 {
                     Looping = true
                 });

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             isSpinning.BindValueChanged(updateSpinningSample);
         }
 
-        private SkinnableSound spinningSample;
+        private GameplaySkinnableSound spinningSample;
 
         private const float minimum_volume = 0.0001f;
 
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 var clone = HitObject.SampleControlPoint.ApplyTo(firstSample);
                 clone.Name = "spinnerspin";
 
-                AddInternal(spinningSample = new SkinnableSound(clone)
+                AddInternal(spinningSample = new GameplaySkinnableSound(clone)
                 {
                     Volume = { Value = minimum_volume },
                     Looping = true,

--- a/osu.Game.Rulesets.Taiko/Audio/DrumSampleContainer.cs
+++ b/osu.Game.Rulesets.Taiko/Audio/DrumSampleContainer.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Rulesets.Taiko.Audio
             }
         }
 
-        private SkinnableSound addSound(HitSampleInfo hitSampleInfo, double lifetimeStart, double lifetimeEnd)
+        private GameplaySkinnableSound addSound(HitSampleInfo hitSampleInfo, double lifetimeStart, double lifetimeEnd)
         {
-            var drawable = new SkinnableSound(hitSampleInfo)
+            var drawable = new GameplaySkinnableSound(hitSampleInfo)
             {
                 LifetimeStart = lifetimeStart,
                 LifetimeEnd = lifetimeEnd
@@ -57,8 +57,8 @@ namespace osu.Game.Rulesets.Taiko.Audio
 
         public class DrumSample
         {
-            public SkinnableSound Centre;
-            public SkinnableSound Rim;
+            public GameplaySkinnableSound Centre;
+            public GameplaySkinnableSound Rim;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySkinnableSound.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySkinnableSound.cs
@@ -15,12 +15,12 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    public class TestSceneSkinnableSound : OsuTestScene
+    public class TestSceneGameplaySkinnableSound : OsuTestScene
     {
         [Cached]
         private GameplayClock gameplayClock = new GameplayClock(new FramedClock());
 
-        private SkinnableSound skinnableSound;
+        private GameplaySkinnableSound skinnableSound;
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 {
                     Clock = gameplayClock,
                     RelativeSizeAxes = Axes.Both,
-                    Child = skinnableSound = new SkinnableSound(new SampleInfo("normal-sliderslide"))
+                    Child = skinnableSound = new GameplaySkinnableSound(new SampleInfo("normal-sliderslide"))
                 },
             };
         });

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -52,10 +52,10 @@ namespace osu.Game.Rulesets.Mods
 
         public class NightcoreBeatContainer : BeatSyncedContainer
         {
-            private SkinnableSound hatSample;
-            private SkinnableSound clapSample;
-            private SkinnableSound kickSample;
-            private SkinnableSound finishSample;
+            private GameplaySkinnableSound hatSample;
+            private GameplaySkinnableSound clapSample;
+            private GameplaySkinnableSound kickSample;
+            private GameplaySkinnableSound finishSample;
 
             private int? firstBeat;
 
@@ -69,10 +69,10 @@ namespace osu.Game.Rulesets.Mods
             {
                 InternalChildren = new Drawable[]
                 {
-                    hatSample = new SkinnableSound(new SampleInfo("nightcore-hat")),
-                    clapSample = new SkinnableSound(new SampleInfo("nightcore-clap")),
-                    kickSample = new SkinnableSound(new SampleInfo("nightcore-kick")),
-                    finishSample = new SkinnableSound(new SampleInfo("nightcore-finish")),
+                    hatSample = new GameplaySkinnableSound(new SampleInfo("nightcore-hat")),
+                    clapSample = new GameplaySkinnableSound(new SampleInfo("nightcore-clap")),
+                    kickSample = new GameplaySkinnableSound(new SampleInfo("nightcore-kick")),
+                    finishSample = new GameplaySkinnableSound(new SampleInfo("nightcore-finish")),
                 };
             }
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </summary>
         public readonly Bindable<Color4> AccentColour = new Bindable<Color4>(Color4.Gray);
 
-        protected SkinnableSound Samples { get; private set; }
+        protected GameplaySkinnableSound Samples { get; private set; }
 
         public virtual IEnumerable<HitSampleInfo> GetSamples() => HitObject.Samples;
 
@@ -176,7 +176,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
                                                     + $" This is an indication that {nameof(HitObject.ApplyDefaults)} has not been invoked on {this}.");
             }
 
-            Samples = new SkinnableSound(samples.Select(s => HitObject.SampleControlPoint.ApplyTo(s)));
+            Samples = new GameplaySkinnableSound(samples.Select(s => HitObject.SampleControlPoint.ApplyTo(s)));
             AddInternal(Samples);
         }
 

--- a/osu.Game/Screens/Play/ComboEffects.cs
+++ b/osu.Game/Screens/Play/ComboEffects.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Play
     {
         private readonly ScoreProcessor processor;
 
-        private SkinnableSound comboBreakSample;
+        private GameplaySkinnableSound comboBreakSample;
 
         private Bindable<bool> alwaysPlay;
         private bool firstTime = true;
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Play
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            InternalChild = comboBreakSample = new SkinnableSound(new SampleInfo("combobreak"));
+            InternalChild = comboBreakSample = new GameplaySkinnableSound(new SampleInfo("combobreak"));
             alwaysPlay = config.GetBindable<bool>(OsuSetting.AlwaysPlayFirstComboBreak);
         }
 

--- a/osu.Game/Skinning/GameplaySkinnableSound.cs
+++ b/osu.Game/Skinning/GameplaySkinnableSound.cs
@@ -29,11 +29,11 @@ namespace osu.Game.Skinning
 
         private IBindable<bool> gameplayPaused;
 
-        [BackgroundDependencyLoader]
+        [BackgroundDependencyLoader(true)]
         private void load(GameplayClock gameplayClock)
         {
-            gameplayPaused = gameplayClock.IsPaused.GetBoundCopy();
-            gameplayPaused.BindValueChanged(paused =>
+            gameplayPaused = gameplayClock?.IsPaused.GetBoundCopy();
+            gameplayPaused?.BindValueChanged(paused =>
             {
                 if (requestedPlaying)
                 {

--- a/osu.Game/Skinning/GameplaySkinnableSound.cs
+++ b/osu.Game/Skinning/GameplaySkinnableSound.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Audio;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// Represents a <see cref="SkinnableSound"/> that pauses its samples and resumes them based on the cached <see cref="GameplayClock"/>'s state.
+    /// </summary>
+    // todo: there should be a sample store cached adjusted to follow the gameplay clock's rate instead, but that requires https://github.com/ppy/osu-framework/issues/2760 first.
+    public class GameplaySkinnableSound : SkinnableSound
+    {
+        private bool requestedPlaying;
+
+        public GameplaySkinnableSound(ISampleInfo hitSamples)
+            : base(hitSamples)
+        {
+        }
+
+        public GameplaySkinnableSound(IEnumerable<ISampleInfo> hitSamples)
+            : base(hitSamples)
+        {
+        }
+
+        private IBindable<bool> gameplayPaused;
+
+        [BackgroundDependencyLoader]
+        private void load(GameplayClock gameplayClock)
+        {
+            gameplayPaused = gameplayClock.IsPaused.GetBoundCopy();
+            gameplayPaused.BindValueChanged(paused =>
+            {
+                if (requestedPlaying)
+                {
+                    if (paused.NewValue)
+                        base.Stop();
+                    // it's not easy to know if a sample has finished playing (to end).
+                    // to keep things simple only resume playing looping samples.
+                    else if (Looping)
+                        base.Play();
+                }
+            });
+        }
+
+        public override void Play()
+        {
+            requestedPlaying = true;
+            base.Play();
+        }
+
+        public override void Stop()
+        {
+            requestedPlaying = false;
+            base.Stop();
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/ppy/osu/issues/9739 is silently fixed as the issue was about another sample channel created and the old one left playing in the background without any control from the game (which is the reason there's another pause loop playing even when resuming), but this PR resolves the entire issue from ever happening again (another playback being invoked while resuming). Closes #9739 

---

Code-side, a better fix that would get rid of this logic would be to cache a sample store somewhere at a `DrawableRuleset` level adjusting it to match the gameplay clock's rate, but would require https://github.com/ppy/osu-framework/issues/2760 to be fixed first. (added a todo comment for that)

Had to permit null if gameplay clock is not cached to DI, due to some tests failing because of it (`TestSceneNightcoreBeatContainer`)

Not testable as the existing tests are correct enough, this is only splitting the logic to avoid this issue ever happening again.