### PR TITLE
Improve messaging when timeshift token retrieval fails

### DIFF
--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Multi.Play
             {
                 failed = true;
 
-                Logger.Error(e, "Failed to retrieve a score submission token.");
+                Logger.Error(e, "Failed to retrieve a score submission token.\n\nThis may happen if you are not running an official release of osu! (ie. you are self-compiling).");
 
                 Schedule(() =>
                 {

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Multi.Play
             {
                 failed = true;
 
-                Logger.Error(e, "Failed to retrieve a score submission token.\n\nThis may happen if you are not running an official release of osu! (ie. you are self-compiling).");
+                Logger.Error(e, "Failed to retrieve a score submission token.\n\nThis may happen if you are running an old or non-official release of osu! (ie. you are self-compiling).");
 
                 Schedule(() =>
                 {


### PR DESCRIPTION
Obviously not a final solution, but should better help self-compiling
(or unofficial package) users better understand why this is happening.

- Closes #9813