### PR TITLE
Always show newly presented overlay at front

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -702,6 +702,9 @@ namespace osu.Game
                     if (state.NewValue == Visibility.Hidden) return;
 
                     singleDisplayOverlays.Where(o => o != overlay).ForEach(o => o.Hide());
+
+                    if (!overlay.IsPresent)
+                        overlayContent.ChangeChildDepth(overlay, (float)-Clock.CurrentTime);
                 };
             }
 


### PR DESCRIPTION
This feels much better. Does not change order if the overlay to be shown
is not yet completely hidden.

- Closes #9815.