### PR TITLE
Compensate for track playback rate when calculating spinner spin rate and completion

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -121,19 +121,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         public void TestRotationDirection([Values(true, false)] bool clockwise)
         {
             if (clockwise)
-            {
-                AddStep("flip replay", () =>
-                {
-                    var drawableRuleset = this.ChildrenOfType<DrawableOsuRuleset>().Single();
-                    var score = drawableRuleset.ReplayScore;
-                    var scoreWithFlippedReplay = new Score
-                    {
-                        ScoreInfo = score.ScoreInfo,
-                        Replay = flipReplay(score.Replay)
-                    };
-                    drawableRuleset.SetReplayScore(scoreWithFlippedReplay);
-                });
-            }
+                transformReplay(flip);
 
             addSeekStep(5000);
 
@@ -141,7 +129,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("spinner symbol direction correct", () => clockwise ? spinnerSymbol.Rotation > 0 : spinnerSymbol.Rotation < 0);
         }
 
-        private Replay flipReplay(Replay scoreReplay) => new Replay
+        private Replay flip(Replay scoreReplay) => new Replay
         {
             Frames = scoreReplay
                      .Frames
@@ -202,6 +190,18 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddUntilStep("wait for seek to finish", () => Precision.AlmostEquals(time, Player.DrawableRuleset.FrameStableClock.CurrentTime, 100));
         }
+
+        private void transformReplay(Func<Replay, Replay> replayTransformation) => AddStep("set replay", () =>
+        {
+            var drawableRuleset = this.ChildrenOfType<DrawableOsuRuleset>().Single();
+            var score = drawableRuleset.ReplayScore;
+            var transformedScore = new Score
+            {
+                ScoreInfo = score.ScoreInfo,
+                Replay = replayTransformation.Invoke(score.Replay)
+            };
+            drawableRuleset.SetReplayScore(transformedScore);
+        });
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
         {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -70,11 +70,11 @@ namespace osu.Game.Rulesets.Osu.Tests
                 trackerRotationTolerance = Math.Abs(drawableSpinner.RotationTracker.Rotation * 0.1f);
             });
             AddAssert("is disc rotation not almost 0", () => !Precision.AlmostEquals(drawableSpinner.RotationTracker.Rotation, 0, 100));
-            AddAssert("is disc rotation absolute not almost 0", () => !Precision.AlmostEquals(drawableSpinner.RotationTracker.CumulativeRotation, 0, 100));
+            AddAssert("is disc rotation absolute not almost 0", () => !Precision.AlmostEquals(drawableSpinner.RotationTracker.RateAdjustedRotation, 0, 100));
 
             addSeekStep(0);
             AddAssert("is disc rotation almost 0", () => Precision.AlmostEquals(drawableSpinner.RotationTracker.Rotation, 0, trackerRotationTolerance));
-            AddAssert("is disc rotation absolute almost 0", () => Precision.AlmostEquals(drawableSpinner.RotationTracker.CumulativeRotation, 0, 100));
+            AddAssert("is disc rotation absolute almost 0", () => Precision.AlmostEquals(drawableSpinner.RotationTracker.RateAdjustedRotation, 0, 100));
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 finalSpinnerSymbolRotation = spinnerSymbol.Rotation;
                 spinnerSymbolRotationTolerance = Math.Abs(finalSpinnerSymbolRotation * 0.05f);
             });
-            AddStep("retrieve cumulative disc rotation", () => finalCumulativeTrackerRotation = drawableSpinner.RotationTracker.CumulativeRotation);
+            AddStep("retrieve cumulative disc rotation", () => finalCumulativeTrackerRotation = drawableSpinner.RotationTracker.RateAdjustedRotation);
 
             addSeekStep(2500);
             AddAssert("disc rotation rewound",
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 () => Precision.AlmostEquals(spinnerSymbol.Rotation, finalSpinnerSymbolRotation / 2, spinnerSymbolRotationTolerance));
             AddAssert("is cumulative rotation rewound",
                 // cumulative rotation is not damped, so we're treating it as the "ground truth" and allowing a comparatively smaller margin of error.
-                () => Precision.AlmostEquals(drawableSpinner.RotationTracker.CumulativeRotation, finalCumulativeTrackerRotation / 2, 100));
+                () => Precision.AlmostEquals(drawableSpinner.RotationTracker.RateAdjustedRotation, finalCumulativeTrackerRotation / 2, 100));
 
             addSeekStep(5000);
             AddAssert("is disc rotation almost same",
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("is symbol rotation almost same",
                 () => Precision.AlmostEquals(spinnerSymbol.Rotation, finalSpinnerSymbolRotation, spinnerSymbolRotationTolerance));
             AddAssert("is cumulative rotation almost same",
-                () => Precision.AlmostEquals(drawableSpinner.RotationTracker.CumulativeRotation, finalCumulativeTrackerRotation, 100));
+                () => Precision.AlmostEquals(drawableSpinner.RotationTracker.RateAdjustedRotation, finalCumulativeTrackerRotation, 100));
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 // multipled by 2 to nullify the score multiplier. (autoplay mod selected)
                 var totalScore = ((ScoreExposedPlayer)Player).ScoreProcessor.TotalScore.Value * 2;
-                return totalScore == (int)(drawableSpinner.RotationTracker.CumulativeRotation / 360) * SpinnerTick.SCORE_PER_TICK;
+                return totalScore == (int)(drawableSpinner.RotationTracker.RateAdjustedRotation / 360) * SpinnerTick.SCORE_PER_TICK;
             });
 
             addSeekStep(0);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     // these become implicitly hit.
                     return 1;
 
-                return Math.Clamp(RotationTracker.CumulativeRotation / 360 / Spinner.SpinsRequired, 0, 1);
+                return Math.Clamp(RotationTracker.RateAdjustedRotation / 360 / Spinner.SpinsRequired, 0, 1);
             }
         }
 
@@ -233,7 +233,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (!SpmCounter.IsPresent && RotationTracker.Tracking)
                 SpmCounter.FadeIn(HitObject.TimeFadeIn);
-            SpmCounter.SetRotation(RotationTracker.CumulativeRotation);
+            SpmCounter.SetRotation(RotationTracker.RateAdjustedRotation);
 
             updateBonusScore();
         }
@@ -245,7 +245,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (ticks.Count == 0)
                 return;
 
-            int spins = (int)(RotationTracker.CumulativeRotation / 360);
+            int spins = (int)(RotationTracker.RateAdjustedRotation / 360);
 
             if (spins < wholeSpins)
             {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         {
             get
             {
-                int rotations = (int)(drawableSpinner.RotationTracker.CumulativeRotation / 360);
+                int rotations = (int)(drawableSpinner.RotationTracker.RateAdjustedRotation / 360);
 
                 if (wholeRotationCount == rotations) return false;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerRotationTracker.cs
@@ -31,17 +31,28 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         public readonly BindableBool Complete = new BindableBool();
 
         /// <summary>
-        /// The total rotation performed on the spinner disc, disregarding the spin direction.
+        /// The total rotation performed on the spinner disc, disregarding the spin direction,
+        /// adjusted for the track's playback rate.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This value is always non-negative and is monotonically increasing with time
         /// (i.e. will only increase if time is passing forward, but can decrease during rewind).
+        /// </para>
+        /// <para>
+        /// The rotation from each frame is multiplied by the clock's current playback rate.
+        /// The reason this is done is to ensure that spinners give the same score and require the same number of spins
+        /// regardless of whether speed-modifying mods are applied.
+        /// </para>
         /// </remarks>
         /// <example>
-        /// If the spinner is spun 360 degrees clockwise and then 360 degrees counter-clockwise,
+        /// Assuming no speed-modifying mods are active,
+        /// if the spinner is spun 360 degrees clockwise and then 360 degrees counter-clockwise,
         /// this property will return the value of 720 (as opposed to 0 for <see cref="Drawable.Rotation"/>).
+        /// If Double Time is active instead (with a speed multiplier of 1.5x),
+        /// in the same scenario the property will return 720 * 1.5 = 1080.
         /// </example>
-        public float CumulativeRotation { get; private set; }
+        public float RateAdjustedRotation { get; private set; }
 
         /// <summary>
         /// Whether the spinning is spinning at a reasonable speed to be considered visually spinning.
@@ -113,7 +124,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             }
 
             currentRotation += angle;
-            CumulativeRotation += Math.Abs(angle) * Math.Sign(Clock.ElapsedFrameTime);
+            // rate has to be applied each frame, because it's not guaranteed to be constant throughout playback
+            // (see: ModTimeRamp)
+            RateAdjustedRotation += (float)(Math.Abs(angle) * Clock.Rate);
         }
     }
 }


### PR DESCRIPTION
Resolves #9821.

# Summary

As outlined in the issue thread, spinners would be affected by the playback rate of speed-changing mods, both in what was shown in the SPM counter, and in scoring. Both issues were caused by the fact that the `GameplayClock` operates in track time instead of real time, therefore buffing HT/DC and nerfing DT/NC.

Now, the reason *why* they were affected is subtle and different for each component:

* The SPM counter being broken was pretty straightforward; for calculating SPM, `SpinnerSpmCounter` uses `Time.Current`, which as mentioned before, uses track time and not real time.
* The reason why bonus scoring and `DrawableSpinner.Progress` were affected is subtler. `Spinner.SpinsRequired` relies on the duration of the spinner, which is only valid in nomod; calculating the number of spins required on that basis makes a difference when mods are applied, as the duration is either shorter or longer.

The proposed fix to both issues is to change `CumulativeRotation` into `RateAdjustedRotation`, which circumvents these issues by amplifying or damping the angle traversed by the cursor by the clock's current rate. This alleviates the issues, because:

* if the rate is below 1, in the game's perception this will "slow" the user's spinning rate, removing the buff,
* if the rate is above 1, in the game's perception this will make the spinning "faster", removing the nerf, and ensuring a level playing field.

Aside from the attached tests, the two following videos demonstrate the effects of this change:

* [before](https://drive.google.com/file/d/10oFxMM_zzBsMCEtbx41sXAUqXZlUdS22/view?usp=sharing),
* [after](https://drive.google.com/file/d/1raU3Eqsvc0N_9402-4NYtVUAFbI4iUMz/view?usp=sharing).

(Enclosed some footage of my wrist suffering on a full playthrough of the long Ievan Polkka spinner map, with Wind Up no less. Enjoy...?)

# Remarks

The way this was written might be seen as weird or hacky, but the issue is not very simple to go around.

I have considered introducing a `RateIndependentGameplayClock` or something of the sort, that would convert track time to real time for the spinner alone. However, this only fixes the SPM counter and not the scoring, as clocks are unaffected by the calculation of minimum spins required and maximum spins allowed, which are the basis for `Progress` and spinner bonus scoring respectively.

The reason why the rate is applied each frame and not just to the cumulative rotation itself in total is simple: `ModTimeRamp`. In that mod (and its derivatives), the total cumulative rotation at one time point can't just be multiplied by the current track rate, because that rate *changes* during gameplay. If you did that, then magically spinners would complete themselves quicker by the end. What is needed in this case is an integration of sorts (which is what multiplying by the current value every frame is supposed to do).

I'm well aware that `RateAdjustedRotation` is getting almost too opaque to understand. Suggestions how to make it more palatable are definitely welcome.

The actual `Rotation` of the spinner is untouched, for parity with stable (which doesn't slow down or speed up the actual rate of spinning of spinner sprites - it always reflects input 1:1).