### PR TITLE
Fix crash when same ruleset loaded more than once

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -191,6 +191,11 @@ namespace osu.Game.Rulesets
             if (loadedAssemblies.ContainsKey(assembly))
                 return;
 
+            // the same assembly may be loaded twice in the same AppDomain (currently a thing in certain Rider versions https://youtrack.jetbrains.com/issue/RIDER-48799).
+            // as a failsafe, also compare by FullName.
+            if (loadedAssemblies.Any(a => a.Key.FullName == assembly.FullName))
+                return;
+
             try
             {
                 loadedAssemblies[assembly] = assembly.GetTypes().First(t => t.IsPublic && t.IsSubclassOf(typeof(Ruleset)));


### PR DESCRIPTION
If the same ruleset assembly was present more than once in the current AppDomain, the game would crash. We recently saw this in Rider EAP9. While this behaviour may change going forward, this is a good safety measure regardless.