### PR TITLE
Adjust legacy skin spinners fade in time to match osu-stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -79,8 +79,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             var spinner = (Spinner)drawableSpinner.HitObject;
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt / 2, true))
-                this.FadeInFromZero(spinner.TimePreempt / 2);
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
+                this.FadeInFromZero(spinner.TimeFadeIn / 2);
 
             fixedMiddle.FadeColour(Color4.White);
             using (BeginAbsoluteSequence(spinner.StartTime, true))

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -85,8 +85,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             var spinner = drawableSpinner.HitObject;
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt / 2, true))
-                this.FadeInFromZero(spinner.TimePreempt / 2);
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
+                this.FadeInFromZero(spinner.TimeFadeIn / 2);
         }
 
         protected override void Update()


### PR DESCRIPTION
Matches stable 1:1 for legacy skins. I've left lazer default as it is because changing to use the shorter apperance looks bad. This will probably change as we proceed with the redesign of the default skin.