### PR TITLE
Load menu backgrounds via LargeTextureStore to reduce memory usage

### DIFF
--- a/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Graphics.Backgrounds
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(LargeTextureStore textures)
         {
             Sprite.Texture = Beatmap?.Background ?? textures.Get(fallbackTextureName);
         }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/3824 (to actually be noticeable)

Given that the default menu backgrounds are 16mb in memory each (for 6 or 7 backgrounds) this helps greatly with reducing memory usage.

There's one remaining issue – with `IntroTriangles` two backgrounds are loaded into memory on startup, but I will address that separately as it's a bit hard to solve.