### PR TITLE
Fix beatmap covers not being unloaded in most overlays

### DIFF
--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapSetCover.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapSetCover.cs
@@ -67,19 +67,18 @@ namespace osu.Game.Beatmaps.Drawables
 
             if (beatmapSet != null)
             {
-                BeatmapSetCover cover;
-
-                Add(displayedCover = new DelayedLoadWrapper(
-                    cover = new BeatmapSetCover(beatmapSet, coverType)
+                Add(displayedCover = new DelayedLoadUnloadWrapper(() =>
+                {
+                    var cover = new BeatmapSetCover(beatmapSet, coverType)
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.Both,
                         FillMode = FillMode.Fill,
-                    })
-                );
-
-                cover.OnLoadComplete += d => d.FadeInFromZero(400, Easing.Out);
+                    };
+                    cover.OnLoadComplete += d => d.FadeInFromZero(400, Easing.Out);
+                    return cover;
+                }));
             }
         }
     }


### PR DESCRIPTION
Eventually we'll probably want something smarter than this, but for the time being this helps stop runaway memory usage. Most noticeable in Beatmap Listing.