### PR TITLE
Fix pause menu selection not resetting on visibility change

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
@@ -272,7 +272,21 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("Overlay is closed", () => pauseOverlay.State.Value == Visibility.Hidden);
         }
 
+        [Test]
+        public void TestSelectionResetOnVisibilityChange()
+        {
+            showOverlay();
+            AddStep("Select last button", () => InputManager.Key(Key.Up));
+
+            hideOverlay();
+            showOverlay();
+
+            AddAssert("No button selected",
+                () => pauseOverlay.Buttons.All(button => !button.Selected.Value));
+        }
+
         private void showOverlay() => AddStep("Show overlay", () => pauseOverlay.Show());
+        private void hideOverlay() => AddStep("Hide overlay", () => pauseOverlay.Hide());
 
         private DialogButton getButton(int index) => pauseOverlay.Buttons.Skip(index).First();
 

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Play
 
         public abstract string Description { get; }
 
-        protected internal FillFlowContainer<DialogButton> InternalButtons;
+        protected ButtonContainer InternalButtons;
         public IReadOnlyList<DialogButton> Buttons => InternalButtons;
 
         private FillFlowContainer retryCounterContainer;
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Play
         {
             RelativeSizeAxes = Axes.Both;
 
-            State.ValueChanged += s => selectionIndex = -1;
+            State.ValueChanged += s => InternalButtons.Deselect();
         }
 
         [BackgroundDependencyLoader]
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Play
                                 }
                             }
                         },
-                        InternalButtons = new FillFlowContainer<DialogButton>
+                        InternalButtons = new ButtonContainer
                         {
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
@@ -186,40 +186,16 @@ namespace osu.Game.Screens.Play
             InternalButtons.Add(button);
         }
 
-        private int selectionIndex = -1;
-
-        private void setSelected(int value)
-        {
-            if (selectionIndex == value)
-                return;
-
-            // Deselect the previously-selected button
-            if (selectionIndex != -1)
-                InternalButtons[selectionIndex].Selected.Value = false;
-
-            selectionIndex = value;
-
-            // Select the newly-selected button
-            if (selectionIndex != -1)
-                InternalButtons[selectionIndex].Selected.Value = true;
-        }
-
         public bool OnPressed(GlobalAction action)
         {
             switch (action)
             {
                 case GlobalAction.SelectPrevious:
-                    if (selectionIndex == -1 || selectionIndex == 0)
-                        setSelected(InternalButtons.Count - 1);
-                    else
-                        setSelected(selectionIndex - 1);
+                    InternalButtons.SelectPrevious();
                     return true;
 
                 case GlobalAction.SelectNext:
-                    if (selectionIndex == -1 || selectionIndex == InternalButtons.Count - 1)
-                        setSelected(0);
-                    else
-                        setSelected(selectionIndex + 1);
+                    InternalButtons.SelectNext();
                     return true;
 
                 case GlobalAction.Back:
@@ -241,9 +217,9 @@ namespace osu.Game.Screens.Play
         private void buttonSelectionChanged(DialogButton button, bool isSelected)
         {
             if (!isSelected)
-                setSelected(-1);
+                InternalButtons.Deselect();
             else
-                setSelected(InternalButtons.IndexOf(button));
+                InternalButtons.Select(button);
         }
 
         private void updateRetryCount()
@@ -275,6 +251,46 @@ namespace osu.Game.Screens.Play
                     Font = OsuFont.GetFont(size: 18),
                 }
             };
+        }
+
+        protected class ButtonContainer : FillFlowContainer<DialogButton>
+        {
+            private int selectedIndex = -1;
+
+            private void setSelected(int value)
+            {
+                if (selectedIndex == value)
+                    return;
+
+                // Deselect the previously-selected button
+                if (selectedIndex != -1)
+                    this[selectedIndex].Selected.Value = false;
+
+                selectedIndex = value;
+
+                // Select the newly-selected button
+                if (selectedIndex != -1)
+                    this[selectedIndex].Selected.Value = true;
+            }
+
+            public void SelectNext()
+            {
+                if (selectedIndex == -1 || selectedIndex == Count - 1)
+                    setSelected(0);
+                else
+                    setSelected(selectedIndex + 1);
+            }
+
+            public void SelectPrevious()
+            {
+                if (selectedIndex == -1 || selectedIndex == 0)
+                    setSelected(Count - 1);
+                else
+                    setSelected(selectedIndex - 1);
+            }
+
+            public void Deselect() => setSelected(-1);
+            public void Select(DialogButton button) => setSelected(IndexOf(button));
         }
 
         private class Button : DialogButton


### PR DESCRIPTION
Resolves #9856.

# Summary

This is actually a pretty old regression from back in December (#7149). The following changes in `GameplayMenuOverlay` were applied:

* the private property backing field `_selectionIndex` was renamed to `selectionIndex`,
* the private property `selectionIndex` was removed in favour of having reads come from `selectionIndex` (which is now a field) and writes through `setSelection`.

However, the following write access to `selectionIndex` was missed:

https://github.com/ppy/osu/blob/d42a4e943ab1d158cbbbda99fa61709bf1c23154/osu.Game/Screens/Play/GameplayMenuOverlay.cs#L62

and because `selectionIndex` changed from a setter with side effects to a dumb property, the behaviour changed.

The fix is a refactor of the entire button container to encapsulate the index better. A visual test has also been added to cover the regression in the future.

# Remarks

Initially I was just going to fix the one access but realised the overall interface kinda sucks and being able to mistakenly set the index without the side effects is bad, so I went a bit more enterprise:tm:. I sort of think it makes the code look nice though, so maybe not all that bad.

I dropped some `internal` access modifiers since we don't like those (dynamic compilation).