### PR TITLE
Add support for SpinnerFrequencyModulate skin config option 

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -85,8 +85,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         private SkinnableSound spinningSample;
-        private const float SPINNING_SAMPLE_INITIAL_FREQUENCY = 1.0f;
-        private const float SPINNING_SAMPLE_MODULATED_BASE_FREQUENCY = 0.5f;
+        private const float spinning_sample_initial_frequency = 1.0f;
+        private const float spinning_sample_modulated_base_frequency = 0.5f;
 
         protected override void LoadSamples()
         {
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 {
                     Volume = { Value = 0 },
                     Looping = true,
-                    Frequency = { Value = SPINNING_SAMPLE_INITIAL_FREQUENCY }
+                    Frequency = { Value = spinning_sample_initial_frequency }
                 });
             }
         }
@@ -233,7 +233,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 RotationTracker.Tracking = !Result.HasResult && (OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
 
             if (spinningSample != null && spinnerFrequencyModulate)
-                spinningSample.Frequency.Value = SPINNING_SAMPLE_MODULATED_BASE_FREQUENCY + Progress;
+                spinningSample.Frequency.Value = spinning_sample_modulated_base_frequency + Progress;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -104,6 +104,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 {
                     Volume = { Value = 0 },
                     Looping = true,
+                    Frequency = { Value = 1.0f }
                 });
             }
         }
@@ -228,8 +229,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (HandleUserInput)
                 RotationTracker.Tracking = !Result.HasResult && (OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
 
-            if (spinningSample != null)
-                spinningSample.Frequency.Value = spinnerFrequencyModulate ? 0.5f + Progress : 0.5f;
+            if (spinningSample != null && spinnerFrequencyModulate)
+                spinningSample.Frequency.Value = 0.5f + Progress;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         private SkinnableSound spinningSample;
-        private const float SPINNING_SAMPLE_INITAL_FREQUENCY = 1.0f;
+        private const float SPINNING_SAMPLE_INITIAL_FREQUENCY = 1.0f;
         private const float SPINNING_SAMPLE_MODULATED_BASE_FREQUENCY = 0.5f;
 
         protected override void LoadSamples()
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 {
                     Volume = { Value = 0 },
                     Looping = true,
-                    Frequency = { Value = SPINNING_SAMPLE_INITAL_FREQUENCY }
+                    Frequency = { Value = SPINNING_SAMPLE_INITIAL_FREQUENCY }
                 });
             }
         }
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, ISkinSource skin)
+        private void load(OsuColour colours)
         {
             positionBindable.BindValueChanged(pos => Position = pos.NewValue);
             positionBindable.BindTo(HitObject.PositionBindable);
@@ -179,6 +179,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override void ApplySkin(ISkinSource skin, bool allowFallback)
         {
+            base.ApplySkin(skin, allowFallback);
             spinnerFrequencyModulate = skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.SpinnerFrequencyModulate)?.Value ?? true;
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         private SkinnableSound spinningSample;
+        private const float SPINNING_SAMPLE_INITAL_FREQUENCY = 1.0f;
+        private const float SPINNING_SAMPLE_MODULATED_BASE_FREQUENCY = 0.5f;
 
         protected override void LoadSamples()
         {
@@ -104,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 {
                     Volume = { Value = 0 },
                     Looping = true,
-                    Frequency = { Value = 1.0f }
+                    Frequency = { Value = SPINNING_SAMPLE_INITAL_FREQUENCY }
                 });
             }
         }
@@ -230,7 +232,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 RotationTracker.Tracking = !Result.HasResult && (OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
 
             if (spinningSample != null && spinnerFrequencyModulate)
-                spinningSample.Frequency.Value = 0.5f + Progress;
+                spinningSample.Frequency.Value = SPINNING_SAMPLE_MODULATED_BASE_FREQUENCY + Progress;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Skinning;
@@ -30,6 +31,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly SpinnerBonusDisplay bonusDisplay;
 
         private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
+
+        private bool spinnerFrequencyModulate;
 
         public DrawableSpinner(Spinner s)
             : base(s)
@@ -165,10 +168,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, ISkinSource skin)
         {
             positionBindable.BindValueChanged(pos => Position = pos.NewValue);
             positionBindable.BindTo(HitObject.PositionBindable);
+            spinnerFrequencyModulate = skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.SpinnerFrequencyModulate)?.Value ?? true;
         }
 
         /// <summary>
@@ -221,8 +225,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 RotationTracker.Tracking = !Result.HasResult && (OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
 
             if (spinningSample != null)
-                // todo: implement SpinnerFrequencyModulate
-                spinningSample.Frequency.Value = 0.5f + Progress;
+                spinningSample.Frequency.Value = spinnerFrequencyModulate ? 0.5f + Progress : 0.5f;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -172,6 +172,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             positionBindable.BindValueChanged(pos => Position = pos.NewValue);
             positionBindable.BindTo(HitObject.PositionBindable);
+        }
+
+        protected override void ApplySkin(ISkinSource skin, bool allowFallback)
+        {
             spinnerFrequencyModulate = skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.SpinnerFrequencyModulate)?.Value ?? true;
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         CursorExpand,
         CursorRotate,
         HitCircleOverlayAboveNumber,
-        HitCircleOverlayAboveNumer // Some old skins will have this typo
+        HitCircleOverlayAboveNumer, // Some old skins will have this typo
+		SpinnerFrequencyModulate
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         CursorExpand,
         CursorRotate,
         HitCircleOverlayAboveNumber,
-        HitCircleOverlayAboveNumer, // Some old skins will have this typo
+		HitCircleOverlayAboveNumer, // Some old skins will have this typo
 		SpinnerFrequencyModulate
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         CursorExpand,
         CursorRotate,
         HitCircleOverlayAboveNumber,
-		HitCircleOverlayAboveNumer, // Some old skins will have this typo
-		SpinnerFrequencyModulate
+        HitCircleOverlayAboveNumer, // Some old skins will have this typo
+        SpinnerFrequencyModulate
     }
 }


### PR DESCRIPTION
Closes #9738.
VSCode helpfully tried to turn it back into tabs when I tried to put spaces instead so that's the reason for the double commit, squash if you wish.