### PR TITLE
Adjust project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/ppy/osu/badge)](https://www.codefactor.io/repository/github/ppy/osu)
 [![dev chat](https://discordapp.com/api/guilds/188630481301012481/widget.png?style=shield)](https://discord.gg/ppy)
 
-Rhythm is just a *click* away. The future of [osu!](https://osu.ppy.sh) and the beginning of an open era! Commonly known by the codename *osu!lazer*. Pew pew.
+A free-to-win rhythm game. Rhythm is just a *click* away!
+
+The future of [osu!](https://osu.ppy.sh) and the beginning of an open era! Commonly known by the codename *osu!lazer*. Pew pew.
 
 ## Status
 

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Description>click the circles. to the beat.</Description>
+    <Description>A free-to-win rhythm game. Rhythm is just a *click* away!</Description>
     <AssemblyName>osu!</AssemblyName>
     <Title>osu!lazer</Title>
     <Product>osu!lazer</Product>

--- a/osu.Desktop/osu.nuspec
+++ b/osu.Desktop/osu.nuspec
@@ -9,8 +9,7 @@
         <projectUrl>https://osu.ppy.sh/</projectUrl>
         <iconUrl>https://puu.sh/tYyXZ/9a01a5d1b0.ico</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>click the circles. to the beat.</description>
-        <summary>click the circles.</summary>
+        <description>A free-to-win rhythm game. Rhythm is just a *click* away!</description>
         <releaseNotes>testing</releaseNotes>
         <copyright>Copyright (c) 2020 ppy Pty Ltd</copyright>
         <language>en-AU</language>


### PR DESCRIPTION
One part of #9875.

# Summary

As suggested in the introduction, add a baseline introduction first sentence to the README to describe what we're doing here better. Phrasing partially borrowed from [the home page](https://osu.ppy.sh/home) (although not word-for-word - I well realise that *the bestest free-to-win rhythm game* is tongue-in-cheek but I'm not sure all incoming readers would, too). Will change to that on request.

# Remarks

Project descriptions in `.csproj`s also updated in line as they were pretty old (last touched back in ~2017). `<summary>` got deleted from `.nuspec` as upon looking at docs to tell how it differs from `<description>` [it is being deprecated](https://docs.microsoft.com/en-us/nuget/reference/nuspec#summary).