### PR TITLE
Improve visibility of toolbar tooltips against bright backgrounds

### DIFF
--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -118,9 +118,9 @@ namespace osu.Game.Overlays.Toolbar
                         RelativeSizeAxes = Axes.X,
                         Anchor = Anchor.BottomLeft,
                         Alpha = 0,
-                        Height = 90,
+                        Height = 100,
                         Colour = ColourInfo.GradientVertical(
-                            OsuColour.Gray(0.1f).Opacity(0.5f), OsuColour.Gray(0.1f).Opacity(0)),
+                            OsuColour.Gray(0).Opacity(0.9f), OsuColour.Gray(0).Opacity(0)),
                     },
                 };
             }


### PR DESCRIPTION
Either this needs to happen, or the music controller needs to be in front of the toolbar. And I think we already decided it should be behind so I went with this for now.

Before:

![image](https://user-images.githubusercontent.com/191335/90361848-2cd58e80-e09a-11ea-9fd1-6d6f2a031d27.png)

![image](https://user-images.githubusercontent.com/191335/90361868-36f78d00-e09a-11ea-95cd-380f02f2d16a.png)

After:

![image](https://user-images.githubusercontent.com/191335/90361800-0fa0c000-e09a-11ea-94d1-5d003a70f7b9.png)

![image](https://user-images.githubusercontent.com/191335/90361814-16c7ce00-e09a-11ea-9bc0-423be95c8669.png)
