### PR TITLE
Add loading spinner while editor screen loads

### DIFF
--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK.Graphics;
@@ -32,6 +33,8 @@ namespace osu.Game.Screens.Edit
 
             Container mainContent;
 
+            LoadingSpinner spinner;
+
             Children = new Drawable[]
             {
                 mainContent = new Container
@@ -43,6 +46,10 @@ namespace osu.Game.Screens.Edit
                         Horizontal = horizontal_margins,
                         Top = vertical_margins + timeline_height,
                         Bottom = vertical_margins
+                    },
+                    Child = spinner = new LoadingSpinner(true)
+                    {
+                        State = { Value = Visibility.Visible },
                     },
                 },
                 new Container
@@ -87,9 +94,10 @@ namespace osu.Game.Screens.Edit
                     }
                 },
             };
-
             LoadComponentAsync(CreateMainContent(), content =>
             {
+                spinner.State.Value = Visibility.Hidden;
+
                 mainContent.Add(content);
                 content.FadeInFromZero(300, Easing.OutQuint);
 


### PR DESCRIPTION
Compose screen can take upwards of 30 seconds to load (osu!mania) so let's at least tell the user something is happening for now.