### PR TITLE
Fix PlayerLoader test failures due to too many steps

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -71,7 +71,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("load dummy beatmap", () => ResetPlayer(false, () => SelectedMods.Value = new[] { new OsuModNightcore() }));
             AddUntilStep("wait for current", () => loader.IsCurrentScreen());
-            AddAssert("mod rate applied", () => Beatmap.Value.Track.Rate != 1);
             AddStep("exit loader", () => loader.Exit());
             AddUntilStep("wait for not current", () => !loader.IsCurrentScreen());
             AddAssert("player did not load", () => player == null);


### PR DESCRIPTION
Fixes local test failures in `TestEarlyExitBeforePlayerConstruction` by reducing the number of test steps before performing the null check. It seems like the construction was happening sooner than expected when loading completed immediately (ie. the induced delayed was being exceeded).

Have tested this headless on loop for a good 5 minutes with zero failures. Was previously failing 100% of the time locally for me.

The removed step is still tested in the next test in the file, so nothing lost here.