### PR TITLE
Added statistic in mania ruleset for key counts

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         {
             int notes = HitObjects.Count(s => s is Note);
             int holdnotes = HitObjects.Count(s => s is HoldNote);
+            string keys = string.Join(", ", Stages.Select(g => g.Columns).Distinct().ToList().OrderByDescending(g => g).Select(g => g + "K"));
 
             return new[]
             {
@@ -50,6 +51,12 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                     Content = holdnotes.ToString(),
                     Icon = FontAwesome.Regular.Circle
                 },
+                new BeatmapStatistic
+                {
+                    Name = @"Key Count",
+                    Content = keys,
+                    Icon = FontAwesome.Regular.Circle
+                }
             };
         }
     }


### PR DESCRIPTION
Currently there is no way to tell the key count for a mania beatmap without playing the map. This PR adds the the count as a statistic in the statistics wedge at the left.

![image](https://user-images.githubusercontent.com/40352447/90467641-8dc88b00-e0c9-11ea-8597-412842c2d174.png)
