### PR TITLE
Show precise number tooltip of leaderboard score rank when 1000 or higher

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -350,7 +350,7 @@ namespace osu.Game.Online.Leaderboards
         {
             public RankLabel(int? rank)
             {
-                TooltipText = rank == null || rank < 1000 ? null : $"{rank}";
+                TooltipText = rank == null || rank < 1000 ? null : $"#{rank:N0}";
 
                 Child = new OsuSpriteText
                 {

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -82,20 +82,10 @@ namespace osu.Game.Online.Leaderboards
 
             Children = new Drawable[]
             {
-                new Container
+                new RankLabel(rank)
                 {
                     RelativeSizeAxes = Axes.Y,
                     Width = rank_width,
-                    Children = new[]
-                    {
-                        new OsuSpriteText
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Font = OsuFont.GetFont(size: 20, italics: true),
-                            Text = rank == null ? "-" : rank.Value.ToMetric(decimals: rank < 100000 ? 1 : 0),
-                        },
-                    },
                 },
                 content = new Container
                 {
@@ -354,6 +344,24 @@ namespace osu.Game.Online.Leaderboards
                     },
                 };
             }
+        }
+
+        private class RankLabel : Container, IHasTooltip
+        {
+            public RankLabel(int? rank)
+            {
+                TooltipText = rank == null || rank < 1000 ? null : $"{rank}";
+
+                Child = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Font = OsuFont.GetFont(size: 20, italics: true),
+                    Text = rank == null ? "-" : rank.Value.ToMetric(decimals: rank < 100000 ? 1 : 0),
+                };
+            }
+
+            public string TooltipText { get; }
         }
 
         public class LeaderboardScoreStatistic

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -350,7 +350,8 @@ namespace osu.Game.Online.Leaderboards
         {
             public RankLabel(int? rank)
             {
-                TooltipText = rank == null || rank < 1000 ? null : $"#{rank:N0}";
+                if (rank >= 1000)
+                    TooltipText = $"#{rank:N0}";
 
                 Child = new OsuSpriteText
                 {


### PR DESCRIPTION
Seems to be a good UX improvement.

![image](https://user-images.githubusercontent.com/35318437/90472801-38df4180-e0d6-11ea-8461-3510eb3e7d8f.png)
