### PR TITLE
Update mania scroll speed range to match stable

### DIFF
--- a/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Mania.Configuration
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
         {
             new TrackedSetting<double>(ManiaRulesetSetting.ScrollTime,
-                v => new SettingDescription(v, "Scroll Speed", $"{(int)Math.Round(13720.0 / v)} ({v}ms)"))
+                v => new SettingDescription(v, "Scroll Speed", $"{(int)Math.Round(DrawableManiaRuleset.MAX_TIME_RANGE / v)} ({v}ms)"))
         };
     }
 

--- a/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Mania.Configuration
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
         {
             new TrackedSetting<double>(ManiaRulesetSetting.ScrollTime,
-                v => new SettingDescription(v, "Scroll Speed", $"{(int)Math.Round(DrawableManiaRuleset.MAX_TIME_RANGE / v)} ({v}ms)"))
+                v => new SettingDescription(v, "Scroll Speed", $"{(int)Math.Round(13720.0 / v)} ({v}ms)"))
         };
     }
 

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// The maximum time range. This occurs at a <see cref="relativeTimeRange"/> of 1.
         /// </summary>
-        public const double MAX_TIME_RANGE = 6000;
+        public const double MAX_TIME_RANGE = 13720;
 
         protected new ManiaPlayfield Playfield => (ManiaPlayfield)base.Playfield;
 

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// The minimum time range. This occurs at a <see cref="relativeTimeRange"/> of 40.
         /// </summary>
-        public const double MIN_TIME_RANGE = 150;
+        public const double MIN_TIME_RANGE = 340;
 
         /// <summary>
         /// The maximum time range. This occurs at a <see cref="relativeTimeRange"/> of 1.


### PR DESCRIPTION
Resolves #9868.

Using `DrawableManiaRuleset.MAX_TIME_RANGE` to calculate mania's scroll speed resolves to a value unlike osu!stable's.