### PR TITLE
Fix some judgements potentially giving non-zero score for misses

### DIFF
--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Rulesets.Mania.Judgements
 {
     public class HoldNoteTickJudgement : ManiaJudgement
     {
-        protected override int NumericResultFor(HitResult result) => 20;
+        protected override int NumericResultFor(HitResult result) => result == MaxResult ? 20 : 0;
 
         protected override double HealthIncreaseFor(HitResult result)
         {

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerBonusTickJudgement : OsuSpinnerTickJudgement
         {
-            protected override int NumericResultFor(HitResult result) => SCORE_PER_TICK;
+            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SCORE_PER_TICK : 0;
 
             protected override double HealthIncreaseFor(HitResult result) => base.HealthIncreaseFor(result) * 2;
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         {
             public override bool AffectsCombo => false;
 
-            protected override int NumericResultFor(HitResult result) => SCORE_PER_TICK;
+            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SCORE_PER_TICK : 0;
 
             protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.6 * base.HealthIncreaseFor(result) : 0;
         }

--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Gameplay
+{
+    [HeadlessTest]
+    public class TestSceneScoreProcessor : OsuTestScene
+    {
+        [Test]
+        public void TestNoScoreIncreaseFromMiss()
+        {
+            var beatmap = new Beatmap<TestHitObject> { HitObjects = { new TestHitObject() } };
+
+            var scoreProcessor = new ScoreProcessor();
+            scoreProcessor.ApplyBeatmap(beatmap);
+
+            // Apply a miss judgement
+            scoreProcessor.ApplyResult(new JudgementResult(new TestHitObject(), new TestJudgement()) { Type = HitResult.Miss });
+
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(0.0));
+        }
+
+        private class TestHitObject : HitObject
+        {
+            public override Judgement CreateJudgement() => new TestJudgement();
+        }
+
+        private class TestJudgement : Judgement
+        {
+            protected override int NumericResultFor(HitResult result) => 100;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -133,17 +133,19 @@ namespace osu.Game.Rulesets.Scoring
                 }
             }
 
+            double scoreIncrease = result.Type == HitResult.Miss ? 0 : result.Judgement.NumericResultFor(result);
+
             if (result.Judgement.IsBonus)
             {
                 if (result.IsHit)
-                    bonusScore += result.Judgement.NumericResultFor(result);
+                    bonusScore += scoreIncrease;
             }
             else
             {
                 if (result.HasResult)
                     scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) + 1;
 
-                baseScore += result.Judgement.NumericResultFor(result);
+                baseScore += scoreIncrease;
                 rollingMaxBaseScore += result.Judgement.MaxNumericResult;
             }
 
@@ -169,17 +171,19 @@ namespace osu.Game.Rulesets.Scoring
             if (result.FailedAtJudgement)
                 return;
 
+            double scoreIncrease = result.Type == HitResult.Miss ? 0 : result.Judgement.NumericResultFor(result);
+
             if (result.Judgement.IsBonus)
             {
                 if (result.IsHit)
-                    bonusScore -= result.Judgement.NumericResultFor(result);
+                    bonusScore -= scoreIncrease;
             }
             else
             {
                 if (result.HasResult)
                     scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) - 1;
 
-                baseScore -= result.Judgement.NumericResultFor(result);
+                baseScore -= scoreIncrease;
                 rollingMaxBaseScore -= result.Judgement.MaxNumericResult;
             }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/9904

Ensured by `ScoreProcessor`, but updated the members anyway for potential external use (outside `ScoreProcessor`).