### PR TITLE
Fix toolbar not respecting current overlay activation mode

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -4,8 +4,10 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets;
 using osuTK.Input;
@@ -15,7 +17,7 @@ namespace osu.Game.Tests.Visual.Menus
     [TestFixture]
     public class TestSceneToolbar : OsuManualInputManagerTestScene
     {
-        private Toolbar toolbar;
+        private TestToolbar toolbar;
 
         [Resolved]
         private RulesetStore rulesets { get; set; }
@@ -23,7 +25,7 @@ namespace osu.Game.Tests.Visual.Menus
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            Child = toolbar = new Toolbar { State = { Value = Visibility.Visible } };
+            Child = toolbar = new TestToolbar { State = { Value = Visibility.Visible } };
         });
 
         [Test]
@@ -71,6 +73,27 @@ namespace osu.Game.Tests.Visual.Menus
 
                 AddUntilStep("ruleset switched", () => rulesetSelector.Current.Value.Equals(expected));
             }
+        }
+
+        [TestCase(OverlayActivation.All)]
+        [TestCase(OverlayActivation.Disabled)]
+        public void TestRespectsOverlayActivation(OverlayActivation mode)
+        {
+            AddStep($"set activation mode to {mode}", () => toolbar.OverlayActivationMode.Value = mode);
+            AddStep("hide toolbar", () => toolbar.Hide());
+            AddStep("try to show toolbar", () => toolbar.Show());
+
+            if (mode == OverlayActivation.Disabled)
+                AddUntilStep("toolbar still hidden", () => toolbar.Visibility == Visibility.Hidden);
+            else
+                AddAssert("toolbar is visible", () => toolbar.Visibility == Visibility.Visible);
+        }
+
+        public class TestToolbar : Toolbar
+        {
+            public new Bindable<OverlayActivation> OverlayActivationMode => base.OverlayActivationMode;
+
+            public Visibility Visibility => State.Value;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -84,16 +84,14 @@ namespace osu.Game.Tests.Visual.Menus
             AddStep("try to show toolbar", () => toolbar.Show());
 
             if (mode == OverlayActivation.Disabled)
-                AddUntilStep("toolbar still hidden", () => toolbar.Visibility == Visibility.Hidden);
+                AddUntilStep("toolbar still hidden", () => toolbar.State.Value == Visibility.Hidden);
             else
-                AddAssert("toolbar is visible", () => toolbar.Visibility == Visibility.Visible);
+                AddAssert("toolbar is visible", () => toolbar.State.Value == Visibility.Visible);
         }
 
         public class TestToolbar : Toolbar
         {
             public new Bindable<OverlayActivation> OverlayActivationMode => base.OverlayActivationMode;
-
-            public Visibility Visibility => State.Value;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Visual.Menus
             AddStep("try to show toolbar", () => toolbar.Show());
 
             if (mode == OverlayActivation.Disabled)
-                AddUntilStep("toolbar still hidden", () => toolbar.State.Value == Visibility.Hidden);
+                AddAssert("toolbar still hidden", () => toolbar.State.Value == Visibility.Hidden);
             else
                 AddAssert("toolbar is visible", () => toolbar.State.Value == Visibility.Visible);
         }

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.Toolbar
 
         private const double transition_time = 500;
 
-        private readonly Bindable<OverlayActivation> overlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
+        protected readonly Bindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
         // Toolbar components like RulesetSelector should receive keyboard input events even when the toolbar is hidden.
         public override bool PropagateNonPositionalInputSubTree => true;
@@ -89,14 +89,8 @@ namespace osu.Game.Overlays.Toolbar
             // Bound after the selector is added to the hierarchy to give it a chance to load the available rulesets
             rulesetSelector.Current.BindTo(parentRuleset);
 
-            State.ValueChanged += visibility =>
-            {
-                if (overlayActivationMode.Value == OverlayActivation.Disabled)
-                    Hide();
-            };
-
             if (osuGame != null)
-                overlayActivationMode.BindTo(osuGame.OverlayActivationMode);
+                OverlayActivationMode.BindTo(osuGame.OverlayActivationMode);
         }
 
         public class ToolbarBackground : Container
@@ -135,6 +129,17 @@ namespace osu.Game.Overlays.Toolbar
             {
                 gradientBackground.FadeOut(transition_time, Easing.OutQuint);
             }
+        }
+
+        protected override void UpdateState(ValueChangedEvent<Visibility> state)
+        {
+            if (state.NewValue == Visibility.Visible && OverlayActivationMode.Value == OverlayActivation.Disabled)
+            {
+                State.Value = Visibility.Hidden;
+                return;
+            }
+
+            base.UpdateState(state);
         }
 
         protected override void PopIn()


### PR DESCRIPTION
This was observed while reviewing #9766

# Summary

This attempts to fix the toolbar not respecting the current overlay activation mode and being toggleable even though the current overlay activation mode doesn't permit it (== Disabled).

The logic previously in place for this turned out to not even be working since it was missing a schedule call. Even when it was fixed, it would allow unwanted transitions, making the toolbar potentially visible for a very few moments.

This moves the check of the current overlay activation state inside `UpdateState()` to prevent the toolbar from displaying when not allowed. A test also has been added.