### PR TITLE
Disable CA2225 warning regarding operator overloads

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -192,3 +192,6 @@ dotnet_diagnostic.IDE0052.severity = silent
 dotnet_diagnostic.IDE0067.severity = none
 dotnet_diagnostic.IDE0068.severity = none
 dotnet_diagnostic.IDE0069.severity = none
+
+#Disable operator overloads requiring alternate named methods
+dotnet_diagnostic.CA2225.severity = none


### PR DESCRIPTION
CA2225 requires overloaded operators to have matching alternate methods.  As discussed in Discord, we don't currently want this.

https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2225?view=vs-2019
