### PR TITLE
Fix osu!catch playfield bounds not matching expectations

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfieldAdjustmentContainer.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Rulesets.Catch.UI
 {
     public class CatchPlayfieldAdjustmentContainer : PlayfieldAdjustmentContainer
     {
+        private const float playfield_size_adjust = 0.8f;
+
         protected override Container<Drawable> Content => content;
         private readonly Container content;
 
@@ -18,7 +20,7 @@ namespace osu.Game.Rulesets.Catch.UI
             Anchor = Anchor.TopCentre;
             Origin = Anchor.TopCentre;
 
-            Size = new Vector2(0.86f); // matches stable's vertical offset for catcher plate
+            Size = new Vector2(playfield_size_adjust);
 
             InternalChild = new Container
             {

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfieldAdjustmentContainer.cs
@@ -17,8 +17,12 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfieldAdjustmentContainer()
         {
-            Anchor = Anchor.TopCentre;
-            Origin = Anchor.TopCentre;
+            // because we are using centre anchor/origin, we will need to limit visibility in the future
+            // to ensure tall windows do not get a readability advantage.
+            // it may be possible to bake the catch-specific offsets (-100..340 mentioned below) into new values
+            // which are compatible with TopCentre alignment.
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
 
             Size = new Vector2(playfield_size_adjust);
 
@@ -29,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 RelativeSizeAxes = Axes.Both,
                 FillMode = FillMode.Fit,
                 FillAspectRatio = 4f / 3,
-                Child = content = new ScalingContainer { RelativeSizeAxes = Axes.Both }
+                Child = content = new ScalingContainer { RelativeSizeAxes = Axes.Both, }
             };
         }
 
@@ -42,8 +46,14 @@ namespace osu.Game.Rulesets.Catch.UI
             {
                 base.Update();
 
+                // in stable, fruit fall vertically from -100 to 340.
+                // to emulate this, we want to make our playfield 440 gameplay pixels high.
+                // we then offset it -100 vertically in the position set below.
+                const float stable_v_offset_ratio = 440 / 384f;
+
                 Scale = new Vector2(Parent.ChildSize.X / CatchPlayfield.WIDTH);
-                Size = Vector2.Divide(Vector2.One, Scale);
+                Position = new Vector2(0, -100 * stable_v_offset_ratio + Scale.X);
+                Size = Vector2.Divide(new Vector2(1, stable_v_offset_ratio), Scale);
             }
         }
     }


### PR DESCRIPTION
- Playfield was scaled using 0.86f, not 0.8f (cross-check with `OsuPlayfieldAdjustmentContainer`). Changing this fixes horizontal sizing.
- After changing to 0.8f, the vertical alignment did not match correctly. I ported over stable's method, which is using a playfield range of -100..340 instead of the standard 0..384 (see the `FruitCircle` transform for reference, in osu-stable codebase)
- Closes #8221

Note: below visual is not what I used to make these changes, and only provided as a rough reference. I was going by actual size data so it should be 1:1 now.

![2020-08-20 19 14 37](https://user-images.githubusercontent.com/191335/90758160-8ac3d980-e319-11ea-9ee7-b77bc05af3a6.gif)

A few things I'm not 100% on, but can be fixed as follow-up if/when necessary:
- The catcher looks visually smaller on lazer, but the difference is <2% and that can be fixed separately (is not affected by this PR). It may just be sprite resizing differences.
- In stable, the playfield is offset more from the top than the bottom of the screen (this goes for osu! mode too). It's doing a vertical offset from screen-top of `(parentHeight - playfieldHeight) * 4 / 3`, so 3/4 of the spacing is at that top while 1/4 is at the bottom. I don't believe we're doing that anywhere in lazer (correct me if i've missed it), so I'm not sure why vertical alignment is correct without making this change.
