### PR TITLE
Fix catch not applying HR offset correctly

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchBeatmapConversionTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchBeatmapConversionTest.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [TestCase("hardrock-stream", new[] { typeof(CatchModHardRock) })]
         [TestCase("hardrock-repeat-slider", new[] { typeof(CatchModHardRock) })]
         [TestCase("hardrock-spinner", new[] { typeof(CatchModHardRock) })]
+        [TestCase("right-bound-hr-offset", new[] { typeof(CatchModHardRock) })]
         public new void Test(string name, params Type[] mods) => base.Test(name, mods);
 
         protected override IEnumerable<ConvertValue> CreateConvertValue(HitObject hitObject)

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             if (amount > 0)
             {
                 // Clamp to the right bound
-                if (position + amount < 1)
+                if (position + amount < CatchPlayfield.WIDTH)
                     position += amount;
             }
             else

--- a/osu.Game.Rulesets.Catch/Resources/Testing/Beatmaps/right-bound-hr-offset-expected-conversion.json
+++ b/osu.Game.Rulesets.Catch/Resources/Testing/Beatmaps/right-bound-hr-offset-expected-conversion.json
@@ -1,0 +1,17 @@
+{
+    "Mappings": [{
+            "StartTime": 3368,
+            "Objects": [{
+                "StartTime": 3368,
+                "Position": 374
+            }]
+        },
+        {
+            "StartTime": 3501,
+            "Objects": [{
+                "StartTime": 3501,
+                "Position": 446
+            }]
+        }
+    ]
+}

--- a/osu.Game.Rulesets.Catch/Resources/Testing/Beatmaps/right-bound-hr-offset.osu
+++ b/osu.Game.Rulesets.Catch/Resources/Testing/Beatmaps/right-bound-hr-offset.osu
@@ -1,0 +1,20 @@
+osu file format v14
+
+[General]
+StackLeniency: 0.7
+Mode: 2
+
+[Difficulty]
+HPDrainRate:6
+CircleSize:4
+OverallDifficulty:9.6
+ApproachRate:9.6
+SliderMultiplier:1.9
+SliderTickRate:1
+
+[TimingPoints]
+2169,266.666666666667,4,2,1,70,1,0
+
+[HitObjects]
+374,60,3368,1,0,0:0:0:0:
+410,146,3501,1,2,0:1:0:0:


### PR DESCRIPTION
Regression from https://github.com/ppy/osu/pull/9421
Found on https://osu.ppy.sh/beatmapsets/944317#fruits/2106490

If a diffcalc deploy hasn't happened since the above PR was merged, this does not need sr/pp recalcs.