### PR TITLE
Add hyper droplets

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -20,12 +20,13 @@ namespace osu.Game.Rulesets.Catch.Tests
             foreach (FruitVisualRepresentation rep in Enum.GetValues(typeof(FruitVisualRepresentation)))
                 AddStep($"show {rep}", () => SetContents(() => createDrawable(rep)));
 
-            AddStep("show droplet", () => SetContents(createDrawableDroplet));
-
+            AddStep("show droplet", () => SetContents(() => createDrawableDroplet()));
             AddStep("show tiny droplet", () => SetContents(createDrawableTinyDroplet));
 
             foreach (FruitVisualRepresentation rep in Enum.GetValues(typeof(FruitVisualRepresentation)))
                 AddStep($"show hyperdash {rep}", () => SetContents(() => createDrawable(rep, true)));
+
+            AddStep("show hyperdash droplet", () => SetContents(() => createDrawableDroplet(true)));
         }
 
         private Drawable createDrawableTinyDroplet()
@@ -46,11 +47,12 @@ namespace osu.Game.Rulesets.Catch.Tests
             };
         }
 
-        private Drawable createDrawableDroplet()
+        private Drawable createDrawableDroplet(bool hyperdash = false)
         {
             var droplet = new TestCatchDroplet
             {
                 Scale = 1.5f,
+                HyperDashTarget = hyperdash ? new Banana() : null
             };
 
             return new DrawableDroplet(droplet)

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -30,9 +30,8 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private Drawable createDrawableTinyDroplet()
         {
-            var droplet = new TinyDroplet
+            var droplet = new TestCatchTinyDroplet
             {
-                StartTime = Clock.CurrentTime,
                 Scale = 1.5f,
             };
 
@@ -49,9 +48,8 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private Drawable createDrawableDroplet()
         {
-            var droplet = new Droplet
+            var droplet = new TestCatchDroplet
             {
-                StartTime = Clock.CurrentTime,
                 Scale = 1.5f,
             };
 
@@ -94,6 +92,22 @@ namespace osu.Game.Rulesets.Catch.Tests
             }
 
             public override FruitVisualRepresentation VisualRepresentation { get; }
+        }
+
+        public class TestCatchDroplet : Droplet
+        {
+            public TestCatchDroplet()
+            {
+                StartTime = 1000000000000;
+            }
+        }
+
+        public class TestCatchTinyDroplet : TinyDroplet
+        {
+            public TestCatchTinyDroplet()
+            {
+                StartTime = 1000000000000;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             createObjects(() => new Fruit { X = right_x });
             createObjects(() => new TestJuiceStream(left_x), 1);
 
-            beatmap.ControlPointInfo.Add(7900, new TimingControlPoint
+            beatmap.ControlPointInfo.Add(startTime, new TimingControlPoint
             {
                 BeatLength = 50
             });

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects;
@@ -31,6 +32,8 @@ namespace osu.Game.Rulesets.Catch.Tests
                 AddUntilStep("wait for right hyperdash", () => getCatcher().Scale.X > 0 && getCatcher().HyperDashing);
                 AddUntilStep("wait for left hyperdash", () => getCatcher().Scale.X < 0 && getCatcher().HyperDashing);
             }
+
+            AddUntilStep("wait for right hyperdash", () => getCatcher().Scale.X > 0 && getCatcher().HyperDashing);
         }
 
         private Catcher getCatcher() => Player.ChildrenOfType<CatcherArea>().First().MovableCatcher;
@@ -45,6 +48,8 @@ namespace osu.Game.Rulesets.Catch.Tests
                     BaseDifficulty = new BeatmapDifficulty { CircleSize = 3.6f }
                 }
             };
+
+            beatmap.ControlPointInfo.Add(0, new TimingControlPoint());
 
             // Should produce a hyper-dash (edge case test)
             beatmap.HitObjects.Add(new Fruit { StartTime = 1816, X = 56, NewCombo = true });
@@ -62,6 +67,20 @@ namespace osu.Game.Rulesets.Catch.Tests
             createObjects(() => new Fruit { X = left_x });
             createObjects(() => new Fruit { X = right_x });
             createObjects(() => new TestJuiceStream(left_x), 1);
+
+            beatmap.ControlPointInfo.Add(7900, new TimingControlPoint
+            {
+                BeatLength = 50
+            });
+
+            createObjects(() => new TestJuiceStream(left_x)
+            {
+                Path = new SliderPath(new[]
+                {
+                    new PathControlPoint(Vector2.Zero),
+                    new PathControlPoint(new Vector2(512, 0))
+                })
+            }, 1);
 
             return beatmap;
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
-using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
@@ -21,11 +20,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            ScaleContainer.Child = new SkinnableDrawable(new CatchSkinComponent(CatchSkinComponents.Droplet), _ => new Pulp
-            {
-                Size = Size / 4,
-                AccentColour = { BindTarget = AccentColour }
-            });
+            ScaleContainer.Child = new SkinnableDrawable(new CatchSkinComponent(CatchSkinComponents.Droplet), _ => new DropletPiece());
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DropletPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DropletPiece.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects.Drawables;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    public class DropletPiece : CompositeDrawable
+    {
+        public DropletPiece()
+        {
+            Size = new Vector2(CatchHitObject.OBJECT_RADIUS / 2);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableObject)
+        {
+            DrawableCatchHitObject drawableCatchObject = (DrawableCatchHitObject)drawableObject;
+            var hitObject = drawableCatchObject.HitObject;
+
+            InternalChild = new Pulp
+            {
+                // RelativeSizeAxes is not used since the edge effect uses Size.
+                Size = Size,
+                AccentColour = { BindTarget = drawableObject.AccentColour }
+            };
+
+            if (hitObject.HyperDash)
+            {
+                AddInternal(new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(2f),
+                    Depth = 1,
+                    Children = new Drawable[]
+                    {
+                        new Circle
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            BorderColour = Catcher.DEFAULT_HYPER_DASH_COLOUR,
+                            BorderThickness = 6,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    AlwaysPresent = true,
+                                    Alpha = 0.3f,
+                                    Blending = BlendingParameters.Additive,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR,
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DropletPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DropletPiece.cs
@@ -27,8 +27,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
             InternalChild = new Pulp
             {
-                // RelativeSizeAxes is not used since the edge effect uses Size.
-                Size = Size,
+                RelativeSizeAxes = Axes.Both,
                 AccentColour = { BindTarget = drawableObject.AccentColour }
             };
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/FruitPiece.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -21,10 +20,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public const float RADIUS_ADJUST = 1.1f;
 
         private Circle border;
-
         private CatchHitObject hitObject;
-
-        private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
         public FruitPiece()
         {
@@ -36,8 +32,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
             DrawableCatchHitObject drawableCatchObject = (DrawableCatchHitObject)drawableObject;
             hitObject = drawableCatchObject.HitObject;
-
-            accentColour.BindTo(drawableCatchObject.AccentColour);
 
             AddRangeInternal(new[]
             {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/Pulp.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/Pulp.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
             EdgeEffect = new EdgeEffectParameters
             {
                 Type = EdgeEffectType.Glow,
-                Radius = Size.X / 2,
+                Radius = DrawWidth / 2,
                 Colour = colour.NewValue.Darken(0.2f).Opacity(0.75f)
             };
         }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -229,8 +229,8 @@ namespace osu.Game.Rulesets.Catch.UI
                 catchObjectPosition >= catcherPosition - halfCatchWidth &&
                 catchObjectPosition <= catcherPosition + halfCatchWidth;
 
-            // only update hyperdash state if we are catching a fruit or a droplet (and not a tiny droplet).
-            if (!(fruit is Fruit || fruit is Droplet) || fruit is TinyDroplet) return validCatch;
+            // only update hyperdash state if we are catching not catching a tiny droplet.
+            if (fruit is TinyDroplet) return validCatch;
 
             if (validCatch && fruit.HyperDash)
             {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 catchObjectPosition >= catcherPosition - halfCatchWidth &&
                 catchObjectPosition <= catcherPosition + halfCatchWidth;
 
-            // only update hyperdash state if we are catching not catching a tiny droplet.
+            // only update hyperdash state if we are not catching a tiny droplet.
             if (fruit is TinyDroplet) return validCatch;
 
             if (validCatch && fruit.HyperDash)

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -226,9 +226,8 @@ namespace osu.Game.Rulesets.Catch.UI
                 catchObjectPosition >= catcherPosition - halfCatchWidth &&
                 catchObjectPosition <= catcherPosition + halfCatchWidth;
 
-            // only update hyperdash state if we are catching a fruit.
-            // exceptions are Droplets and JuiceStreams.
-            if (!(fruit is Fruit)) return validCatch;
+            // only update hyperdash state if we are catching a fruit or a droplet (and not a tiny droplet).
+            if (!(fruit is Fruit || fruit is Droplet) || fruit is TinyDroplet) return validCatch;
 
             if (validCatch && fruit.HyperDash)
             {


### PR DESCRIPTION
This was discovered on https://osu.ppy.sh/beatmapsets/822552#fruits/1723939 - droplets can be hyperfruit.

Not sure about the design but it's going to change soon already soooo... Preview: https://drive.google.com/file/d/1zcfDJGATarP88NQvDDpVYwnYY064B7C5/view?usp=sharing

The legacy skin already implemented the display logic, it's only the default skin that hadn't, and obviously gameplay also assumed it didn't exist.

I'm not super happy about the conditional, suggestions appreciated.

I've also kinda clobbered it into the existing `TestSceneHyperDash`, but I think this testscene should be rewritten in the future to test smaller scenarios. The fact that it overrides `CreateBeatmap` makes it extremely unwieldy to accurately test such scenarios.