### PR TITLE
Use full catcher width for hyperdash calculation

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             for (int i = 0; i < 9; i++)
             {
                 int count = i + 1;
-                AddUntilStep("wait for next hyperdash", () => hyperDashCount == count);
+                AddUntilStep("wait for next hyperdash", () => hyperDashCount >= count);
             }
         }
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
@@ -22,21 +22,38 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Test]
         public void TestHyperDash()
         {
-            AddAssert("First note is hyperdash", () => Beatmap.Value.Beatmap.HitObjects[0] is Fruit f && f.HyperDash);
-            AddUntilStep("wait for right movement", () => getCatcher().Scale.X > 0); // don't check hyperdashing as it happens too fast.
-
-            AddUntilStep("wait for left movement", () => getCatcher().Scale.X < 0);
-
-            for (int i = 0; i < 3; i++)
+            AddStep("reset count", () =>
             {
-                AddUntilStep("wait for right hyperdash", () => getCatcher().Scale.X > 0 && getCatcher().HyperDashing);
-                AddUntilStep("wait for left hyperdash", () => getCatcher().Scale.X < 0 && getCatcher().HyperDashing);
-            }
+                inHyperDash = false;
+                hyperDashCount = 0;
+            });
 
-            AddUntilStep("wait for right hyperdash", () => getCatcher().Scale.X > 0 && getCatcher().HyperDashing);
+            AddAssert("First note is hyperdash", () => Beatmap.Value.Beatmap.HitObjects[0] is Fruit f && f.HyperDash);
+
+            for (int i = 0; i < 9; i++)
+            {
+                int count = i + 1;
+                AddUntilStep("wait for next hyperdash", () => hyperDashCount == count);
+            }
         }
 
-        private Catcher getCatcher() => Player.ChildrenOfType<CatcherArea>().First().MovableCatcher;
+        private int hyperDashCount;
+        private bool inHyperDash;
+
+        protected override void Update()
+        {
+            var catcher = Player.ChildrenOfType<CatcherArea>().FirstOrDefault()?.MovableCatcher;
+
+            if (catcher == null)
+                return;
+
+            if (catcher.HyperDashing != inHyperDash)
+            {
+                inHyperDash = catcher.HyperDashing;
+                if (catcher.HyperDashing)
+                    hyperDashCount++;
+            }
+        }
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
         {

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs
@@ -212,6 +212,12 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
             objectWithDroplets.Sort((h1, h2) => h1.StartTime.CompareTo(h2.StartTime));
 
             double halfCatcherWidth = Catcher.CalculateCatchWidth(beatmap.BeatmapInfo.BaseDifficulty) / 2;
+
+            // Todo: This is wrong. osu!stable calculated hyperdashes using the full catcher size, excluding the margins.
+            // This should theoretically cause impossible scenarios, but practically, likely due to the size of the playfield, it doesn't seem possible.
+            // For now, to bring gameplay (and diffcalc!) completely in-line with stable, this code also uses the full catcher size.
+            halfCatcherWidth /= Catcher.ALLOWED_CATCH_RANGE;
+
             int lastDirection = 0;
             double lastExcess = halfCatcherWidth;
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// The width of the catcher which can receive fruit. Equivalent to "catchMargin" in osu-stable.
         /// </summary>
-        private const float allowed_catch_range = 0.8f;
+        public const float ALLOWED_CATCH_RANGE = 0.8f;
 
         /// <summary>
         /// The drawable catcher for <see cref="CurrentState"/>.
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         /// <param name="scale">The scale of the catcher.</param>
         internal static float CalculateCatchWidth(Vector2 scale)
-            => CatcherArea.CATCHER_SIZE * Math.Abs(scale.X) * allowed_catch_range;
+            => CatcherArea.CATCHER_SIZE * Math.Abs(scale.X) * ALLOWED_CATCH_RANGE;
 
         /// <summary>
         /// Calculates the width of the area used for attempting catches in gameplay.


### PR DESCRIPTION
More than anything, I'm looking for discussion here. This can be replicated on https://osu.ppy.sh/beatmapsets/511538#fruits/1087385, which is a hdash-less map on stable.

I've tried to make a failure scenario happen, but I can't seem to. Since everyone seems to want this to happen, maybe we should just do it until a later point in time (beatmap v128+) where we use the 80% area instead?

This requires a re-diffcalc.