### PR TITLE
Fix juice streams sometimes playing double hitsounds

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
@@ -38,7 +40,11 @@ namespace osu.Game.Rulesets.Catch.Tests
                         new Vector2(width, 0)
                     }),
                     StartTime = i * 2000,
-                    NewCombo = i % 8 == 0
+                    NewCombo = i % 8 == 0,
+                    Samples = new List<HitSampleInfo>(new[]
+                    {
+                        new HitSampleInfo { Bank = "normal", Name = "hitnormal", Volume = 100 }
+                    })
                 });
             }
 

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -28,6 +28,11 @@ namespace osu.Game.Rulesets.Catch.Objects
         }
 
         /// <summary>
+        /// Whether this object can be placed on the catcher's plate.
+        /// </summary>
+        public virtual bool CanBePlated => false;
+
+        /// <summary>
         /// A random offset applied to <see cref="X"/>, set by the <see cref="CatchBeatmapProcessor"/>.
         /// </summary>
         internal float XOffset { get; set; }
@@ -98,6 +103,14 @@ namespace osu.Game.Rulesets.Catch.Objects
         }
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+    }
+
+    /// <summary>
+    /// Represents a single object that can be caught by the catcher.
+    /// </summary>
+    public abstract class PalpableCatchHitObject : CatchHitObject
+    {
+        public override bool CanBePlated => true;
     }
 
     public enum FruitVisualRepresentation

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -15,14 +15,14 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public abstract class PalpableCatchHitObject<TObject> : DrawableCatchHitObject<TObject>
+    public abstract class PalpableDrawableCatchHitObject<TObject> : DrawableCatchHitObject<TObject>
         where TObject : CatchHitObject
     {
         public override bool CanBePlated => true;
 
         protected Container ScaleContainer { get; private set; }
 
-        protected PalpableCatchHitObject(TObject hitObject)
+        protected PalpableDrawableCatchHitObject(TObject hitObject)
             : base(hitObject)
         {
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -16,10 +16,8 @@ using osuTK.Graphics;
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public abstract class PalpableDrawableCatchHitObject<TObject> : DrawableCatchHitObject<TObject>
-        where TObject : CatchHitObject
+        where TObject : PalpableCatchHitObject
     {
-        public override bool CanBePlated => true;
-
         protected Container ScaleContainer { get; private set; }
 
         protected PalpableDrawableCatchHitObject(TObject hitObject)
@@ -65,9 +63,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
     public abstract class DrawableCatchHitObject : DrawableHitObject<CatchHitObject>
     {
-        public virtual bool CanBePlated => false;
-
-        public virtual bool StaysOnPlate => CanBePlated;
+        public virtual bool StaysOnPlate => HitObject.CanBePlated;
 
         public float DisplayRadius => DrawSize.X / 2 * Scale.X * HitObject.Scale;
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -9,7 +9,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableDroplet : PalpableCatchHitObject<Droplet>
+    public class DrawableDroplet : PalpableDrawableCatchHitObject<Droplet>
     {
         public override bool StaysOnPlate => false;
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -8,7 +8,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableFruit : PalpableCatchHitObject<Fruit>
+    public class DrawableFruit : PalpableDrawableCatchHitObject<Fruit>
     {
         public DrawableFruit(Fruit h)
             : base(h)

--- a/osu.Game.Rulesets.Catch/Objects/Droplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Droplet.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Judgements;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
-    public class Droplet : CatchHitObject
+    public class Droplet : PalpableCatchHitObject
     {
         public override Judgement CreateJudgement() => new CatchDropletJudgement();
     }

--- a/osu.Game.Rulesets.Catch/Objects/Fruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Fruit.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Judgements;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
-    public class Fruit : CatchHitObject
+    public class Fruit : PalpableCatchHitObject
     {
         public override Judgement CreateJudgement() => new CatchJudgement();
     }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -216,6 +216,9 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <returns>Whether the catch is possible.</returns>
         public bool AttemptCatch(CatchHitObject fruit)
         {
+            if (!fruit.CanBePlated)
+                return false;
+
             var halfCatchWidth = catchWidth * 0.5f;
 
             // this stuff wil disappear once we move fruit to non-relative coordinate space in the future.

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     lastPlateableFruit.OnLoadComplete += _ => action();
             }
 
-            if (result.IsHit && fruit.CanBePlated)
+            if (result.IsHit && fruit.HitObject.CanBePlated)
             {
                 // create a new (cloned) fruit to stay on the plate. the original is faded out immediately.
                 var caughtFruit = (DrawableCatchHitObject)CreateDrawableRepresentation?.Invoke(fruit.HitObject);


### PR DESCRIPTION
Resolves #8266.

# Summary

Sporadically, some catch hitsounds at the end of juice streams would sound really loud in comparison to the rest of the map. This behaviour was not consistent and would vary from stream to stream.

The reason for the doubling up was that in some cases, both the ending `DrawableFruit` and the `DrawableJuiceStream` would play their samples. This, in turn, was caused by the fact that `Catcher` could actually catch `DrawableJuiceStream`s, but not in a way you would suspect. If by the end of the stream the catcher is in a position that would have captured *the stream's first fruit*, it would register a hit on the juice stream:

https://github.com/ppy/osu/blob/02678c04d59986ae555db2a817ad7ea18dea8395/osu.Game.Rulesets.Catch/UI/Catcher.cs#L217-L231

This does nothing in terms of scoring, because `DrawableJuiceStream` has an `IgnoreJudgement` on it, but [it *does* fire `ApplyResult`](https://github.com/ppy/osu/blob/02678c04d59986ae555db2a817ad7ea18dea8395/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs#L92-L93), which in turn causes sample playback to happen in the [base `DrawableHitObject` itself](https://github.com/ppy/osu/blob/02678c04d59986ae555db2a817ad7ea18dea8395/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L267-L268).

This in fact means that not only the end sample could play twice, it could [also play when it shouldn't if the catcher was where the stream started](https://drive.google.com/file/d/1CUWMnOr7CTwxSxjNPGfA8ruOsSwkqeCL/view?usp=sharing) - and this would apply to banana showers as well, I'm pretty sure.

Now, as for the fix... There's about a dozen ways you could program this if you wanted. The way I'm proposing comes from the fact that after some thinking I decided that distinguishing whether a hit object is palpable or not on the drawable level is too high up; that same distinction should apply to the data/domain level. Therefore, I changed the hierarchy of catch hit objects as follows:

```
CatchHitObject
  JuiceStream
  BananaShower
  PalpableCatchHitObject
    Fruit
    Droplet
```

and adjusted the drawable hierarchy to match. This way, the fix at 9546fbb makes semantic sense, at least to me; if the object can't be caught, don't try to catch it, therefore don't make it a hit, therefore never play hit samples for it.

Here's a pair of videos showing the effects of this in actual gameplay:

* [before](https://drive.google.com/file/d/1WTzcdUl-92kE2Mqb5e5qtjhQK1p_8muH/view?usp=sharing),
* [after](https://drive.google.com/file/d/1hObTEymWz46_Slxk8IPcFrxXollLQgOe/view?usp=sharing).

# Remarks

There is a *semblance* of a test here, but a flimsy one (as in you have to run it yourself and know what to listen for to be able to tell if there's breakage). I can't figure out a good way to test this. I could test that all juice streams end in a miss, but that would be a pretty WTF assertion to write... Suggestions welcome.

Unsure if the fix is too enterprise™️. In my thinking the `HitObject` layer is supposed to represent gameplay as data, and it makes sense to me that you would distinguish palpable and non-palpable objects there. Maybe you prefer the simpler variants like sticking a conditional on there. I dunno, there's honestly too many possible ways out.