### PR TITLE
Fix multi screen test crashing

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
@@ -14,7 +14,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             Screens.Multi.Multiplayer multi = new Screens.Multi.Multiplayer();
 
-            AddStep(@"show", () => LoadScreen(multi));
+            AddStep("show", () => LoadScreen(multi));
+            AddUntilStep("wait for loaded", () => multi.IsLoaded);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiScreen.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Overlays;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -9,6 +11,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
     public class TestSceneMultiScreen : ScreenTestScene
     {
         protected override bool UseOnlineAPI => true;
+
+        [Cached]
+        private MusicController musicController { get; set; } = new MusicController();
 
         public TestSceneMultiScreen()
         {


### PR DESCRIPTION
As seen in #9933 ([CI build result](https://ci.appveyor.com/project/peppy/osu/builds/34767670/tests)).

Crash due to missing dependency. Would actually crash without fail in test browser, presumably didn't fail on CI due to the ctor step completing too fast before the crash could take place. Should no longer be possible to have it silently fail due to the added until step.