### PR TITLE
Fix potential crash if disposing a DrawableStoryboardSample twice

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -76,6 +76,8 @@ namespace osu.Game.Storyboards.Drawables
         protected override void Dispose(bool isDisposing)
         {
             Channel?.Stop();
+            Channel = null;
+
             base.Dispose(isDisposing);
         }
     }


### PR DESCRIPTION
I believe this can only happen in tests, so didn't feel it needs test coverage.