### PR TITLE
Exactly reproduce osu!stable skin colour alphas

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Skinning
 {
@@ -61,7 +62,12 @@ namespace osu.Game.Rulesets.Catch.Skinning
             switch (lookup)
             {
                 case CatchSkinColour colour:
-                    return Source.GetConfig<SkinCustomColourLookup, TValue>(new SkinCustomColourLookup(colour));
+                    var result = (Bindable<Color4>)Source.GetConfig<SkinCustomColourLookup, TValue>(new SkinCustomColourLookup(colour));
+                    if (result == null)
+                        return null;
+
+                    result.Value = result.Value.ToLegacyColour();
+                    return (IBindable<TValue>)result;
             }
 
             return Source.GetConfig<TLookup, TValue>(lookup);

--- a/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Catch.Skinning
                     if (result == null)
                         return null;
 
-                    result.Value = result.Value.ToLegacyColour();
+                    result.Value = LegacyColourCompatibility.DisallowZeroAlpha(result.Value);
                     return (IBindable<TValue>)result;
             }
 

--- a/osu.Game.Rulesets.Catch/Skinning/LegacyFruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/LegacyFruitPiece.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Catch.Skinning
         {
             base.LoadComplete();
 
-            accentColour.BindValueChanged(colour => colouredSprite.Colour = colour.NewValue.ToLegacyColour(), true);
+            accentColour.BindValueChanged(colour => colouredSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue), true);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Skinning/LegacyFruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/LegacyFruitPiece.cs
@@ -40,7 +40,6 @@ namespace osu.Game.Rulesets.Catch.Skinning
                 colouredSprite = new Sprite
                 {
                     Texture = skin.GetTexture(lookupName),
-                    Colour = drawableObject.AccentColour.Value,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
@@ -76,7 +75,7 @@ namespace osu.Game.Rulesets.Catch.Skinning
         {
             base.LoadComplete();
 
-            accentColour.BindValueChanged(colour => colouredSprite.Colour = colour.NewValue, true);
+            accentColour.BindValueChanged(colour => colouredSprite.Colour = colour.NewValue.ToLegacyColour(), true);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
@@ -58,14 +58,20 @@ namespace osu.Game.Rulesets.Mania.Skinning
 
             InternalChildren = new Drawable[]
             {
-                new Box { RelativeSizeAxes = Axes.Both }.WithLegacyColour(backgroundColour),
+                LegacyColourCompatibility.ApplyWithDoubledAlpha(new Box
+                {
+                    RelativeSizeAxes = Axes.Both
+                }, backgroundColour),
                 new Container
                 {
                     RelativeSizeAxes = Axes.Y,
                     Width = leftLineWidth,
                     Scale = new Vector2(0.740f, 1),
                     Alpha = hasLeftLine ? 1 : 0,
-                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithLegacyColour(lineColour)
+                    Child = LegacyColourCompatibility.ApplyWithDoubledAlpha(new Box
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    }, lineColour)
                 },
                 new Container
                 {
@@ -75,7 +81,10 @@ namespace osu.Game.Rulesets.Mania.Skinning
                     Width = rightLineWidth,
                     Scale = new Vector2(0.740f, 1),
                     Alpha = hasRightLine ? 1 : 0,
-                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithLegacyColour(lineColour)
+                    Child = LegacyColourCompatibility.ApplyWithDoubledAlpha(new Box
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    }, lineColour)
                 },
                 lightContainer = new Container
                 {
@@ -86,7 +95,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
                     {
                         Anchor = Anchor.BottomCentre,
                         Origin = Anchor.BottomCentre,
-                        Colour = lightColour.ToLegacyColour(),
+                        Colour = LegacyColourCompatibility.DisallowZeroAlpha(lightColour),
                         Texture = skin.GetTexture(lightImage),
                         RelativeSizeAxes = Axes.X,
                         Width = 1,

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
@@ -58,14 +58,14 @@ namespace osu.Game.Rulesets.Mania.Skinning
 
             InternalChildren = new Drawable[]
             {
-                new Box { RelativeSizeAxes = Axes.Both }.WithInitialColour(backgroundColour),
+                new Box { RelativeSizeAxes = Axes.Both }.WithLegacyColour(backgroundColour),
                 new Container
                 {
                     RelativeSizeAxes = Axes.Y,
                     Width = leftLineWidth,
                     Scale = new Vector2(0.740f, 1),
                     Alpha = hasLeftLine ? 1 : 0,
-                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithInitialColour(lineColour)
+                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithLegacyColour(lineColour)
                 },
                 new Container
                 {
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
                     Width = rightLineWidth,
                     Scale = new Vector2(0.740f, 1),
                     Alpha = hasRightLine ? 1 : 0,
-                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithInitialColour(lineColour)
+                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithLegacyColour(lineColour)
                 },
                 lightContainer = new Container
                 {

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
@@ -58,28 +58,24 @@ namespace osu.Game.Rulesets.Mania.Skinning
 
             InternalChildren = new Drawable[]
             {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = backgroundColour
-                },
-                new Box
+                new Box { RelativeSizeAxes = Axes.Both }.WithInitialColour(backgroundColour),
+                new Container
                 {
                     RelativeSizeAxes = Axes.Y,
                     Width = leftLineWidth,
                     Scale = new Vector2(0.740f, 1),
-                    Colour = lineColour,
-                    Alpha = hasLeftLine ? 1 : 0
+                    Alpha = hasLeftLine ? 1 : 0,
+                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithInitialColour(lineColour)
                 },
-                new Box
+                new Container
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
                     RelativeSizeAxes = Axes.Y,
                     Width = rightLineWidth,
                     Scale = new Vector2(0.740f, 1),
-                    Colour = lineColour,
-                    Alpha = hasRightLine ? 1 : 0
+                    Alpha = hasRightLine ? 1 : 0,
+                    Child = new Box { RelativeSizeAxes = Axes.Both }.WithInitialColour(lineColour)
                 },
                 lightContainer = new Container
                 {
@@ -90,7 +86,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
                     {
                         Anchor = Anchor.BottomCentre,
                         Origin = Anchor.BottomCentre,
-                        Colour = lightColour,
+                        Colour = lightColour.ToLegacyColour(),
                         Texture = skin.GetTexture(lightImage),
                         RelativeSizeAxes = Axes.X,
                         Width = 1,

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyHitTarget.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyHitTarget.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
                         Anchor = Anchor.CentreLeft,
                         RelativeSizeAxes = Axes.X,
                         Height = 1,
-                        Colour = lineColour,
+                        Colour = lineColour.ToLegacyColour(),
                         Alpha = showJudgementLine ? 0.9f : 0
                     }
                 }

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyHitTarget.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyHitTarget.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
                         Anchor = Anchor.CentreLeft,
                         RelativeSizeAxes = Axes.X,
                         Height = 1,
-                        Colour = lineColour.ToLegacyColour(),
+                        Colour = LegacyColourCompatibility.DisallowZeroAlpha(lineColour),
                         Alpha = showJudgementLine ? 0.9f : 0
                     }
                 }

--- a/osu.Game.Rulesets.Mania/Skinning/LegacyStageBackground.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyStageBackground.cs
@@ -108,37 +108,38 @@ namespace osu.Game.Rulesets.Mania.Skinning
 
                 InternalChildren = new Drawable[]
                 {
-                    new Container
+                    LegacyColourCompatibility.ApplyWithDoubledAlpha(new Box
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Child = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = backgroundColour
-                        },
-                    },
+                        RelativeSizeAxes = Axes.Both
+                    }, backgroundColour),
                     new HitTargetInsetContainer
                     {
                         RelativeSizeAxes = Axes.Both,
                         Children = new[]
                         {
-                            new Box
+                            new Container
                             {
                                 RelativeSizeAxes = Axes.Y,
                                 Width = leftLineWidth,
                                 Scale = new Vector2(0.740f, 1),
-                                Colour = lineColour,
-                                Alpha = hasLeftLine ? 1 : 0
+                                Alpha = hasLeftLine ? 1 : 0,
+                                Child = LegacyColourCompatibility.ApplyWithDoubledAlpha(new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both
+                                }, lineColour)
                             },
-                            new Box
+                            new Container
                             {
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
                                 RelativeSizeAxes = Axes.Y,
                                 Width = rightLineWidth,
                                 Scale = new Vector2(0.740f, 1),
-                                Colour = lineColour,
-                                Alpha = hasRightLine ? 1 : 0
+                                Alpha = hasRightLine ? 1 : 0,
+                                Child = LegacyColourCompatibility.ApplyWithDoubledAlpha(new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both
+                                }, lineColour)
                             },
                         }
                     }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
@@ -59,7 +59,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
                         hitCircleSprite = new Sprite
                         {
                             Texture = getTextureWithFallback(string.Empty),
-                            Colour = drawableObject.AccentColour.Value,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },
@@ -107,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
             base.LoadComplete();
 
             state.BindValueChanged(updateState, true);
-            accentColour.BindValueChanged(colour => hitCircleSprite.Colour = colour.NewValue, true);
+            accentColour.BindValueChanged(colour => hitCircleSprite.Colour = colour.NewValue.ToLegacyColour(), true);
             indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
             base.LoadComplete();
 
             state.BindValueChanged(updateState, true);
-            accentColour.BindValueChanged(colour => hitCircleSprite.Colour = colour.NewValue.ToLegacyColour(), true);
+            accentColour.BindValueChanged(colour => hitCircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue), true);
             indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     Texture = skin.GetTexture("sliderb-nd"),
                     Colour = new Color4(5, 5, 5, 255),
                 },
-                animationContent.WithInitialColour(ballColour).With(d =>
+                animationContent.WithLegacyColour(ballColour).With(d =>
                 {
                     d.Anchor = Anchor.Centre;
                     d.Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin, DrawableHitObject drawableObject)
         {
-            animationContent.Colour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBall)?.Value ?? Color4.White;
+            var ballColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBall)?.Value ?? Color4.White;
 
             InternalChildren = new[]
             {
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     Texture = skin.GetTexture("sliderb-nd"),
                     Colour = new Color4(5, 5, 5, 255),
                 },
-                animationContent.With(d =>
+                animationContent.WithInitialColour(ballColour).With(d =>
                 {
                     d.Anchor = Anchor.Centre;
                     d.Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
@@ -39,11 +39,11 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     Texture = skin.GetTexture("sliderb-nd"),
                     Colour = new Color4(5, 5, 5, 255),
                 },
-                animationContent.WithLegacyColour(ballColour).With(d =>
+                LegacyColourCompatibility.ApplyWithDoubledAlpha(animationContent.With(d =>
                 {
                     d.Anchor = Anchor.Centre;
                     d.Origin = Anchor.Centre;
-                }),
+                }), ballColour),
                 layerSpec = new Sprite
                 {
                     Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyCirclePiece.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         private void updateAccentColour()
         {
-            backgroundLayer.Colour = accentColour.ToLegacyColour();
+            backgroundLayer.Colour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyCirclePiece.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         private void updateAccentColour()
         {
-            backgroundLayer.Colour = accentColour;
+            backgroundLayer.Colour = accentColour.ToLegacyColour();
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
@@ -76,9 +76,11 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         private void updateAccentColour()
         {
-            headCircle.AccentColour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
-            body.Colour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
-            end.Colour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
+            var colour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
+
+            headCircle.AccentColour = colour;
+            body.Colour = colour;
+            end.Colour = colour;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
@@ -76,9 +76,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         private void updateAccentColour()
         {
-            headCircle.AccentColour = accentColour;
-            body.Colour = accentColour;
-            end.Colour = accentColour;
+            headCircle.AccentColour = accentColour.ToLegacyColour();
+            body.Colour = accentColour.ToLegacyColour();
+            end.Colour = accentColour.ToLegacyColour();
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyDrumRoll.cs
@@ -76,9 +76,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         private void updateAccentColour()
         {
-            headCircle.AccentColour = accentColour.ToLegacyColour();
-            body.Colour = accentColour.ToLegacyColour();
-            end.Colour = accentColour.ToLegacyColour();
+            headCircle.AccentColour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
+            body.Colour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
+            end.Colour = LegacyColourCompatibility.DisallowZeroAlpha(accentColour);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHit.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHit.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Game.Skinning;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Skinning
@@ -18,9 +19,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
         [BackgroundDependencyLoader]
         private void load()
         {
-            AccentColour = component == TaikoSkinComponents.CentreHit
+            AccentColour = (component == TaikoSkinComponents.CentreHit
                 ? new Color4(235, 69, 44, 255)
-                : new Color4(67, 142, 172, 255);
+                : new Color4(67, 142, 172, 255)).ToLegacyColour();
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHit.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHit.cs
@@ -19,9 +19,10 @@ namespace osu.Game.Rulesets.Taiko.Skinning
         [BackgroundDependencyLoader]
         private void load()
         {
-            AccentColour = (component == TaikoSkinComponents.CentreHit
-                ? new Color4(235, 69, 44, 255)
-                : new Color4(67, 142, 172, 255)).ToLegacyColour();
+            AccentColour = LegacyColourCompatibility.DisallowZeroAlpha(
+                component == TaikoSkinComponents.CentreHit
+                    ? new Color4(235, 69, 44, 255)
+                    : new Color4(67, 142, 172, 255));
         }
     }
 }

--- a/osu.Game.Tests/Resources/skin-zero-alpha-colour.ini
+++ b/osu.Game.Tests/Resources/skin-zero-alpha-colour.ini
@@ -1,5 +1,0 @@
-[General]
-Version: latest
-
-[Colours]
-Combo1: 255,255,255,0

--- a/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacySkinDecoderTest.cs
@@ -108,15 +108,5 @@ namespace osu.Game.Tests.Skins
             using (var stream = new LineBufferedReader(resStream))
                 Assert.That(decoder.Decode(stream).LegacyVersion, Is.EqualTo(1.0m));
         }
-
-        [Test]
-        public void TestDecodeColourWithZeroAlpha()
-        {
-            var decoder = new LegacySkinDecoder();
-
-            using (var resStream = TestResources.OpenResource("skin-zero-alpha-colour.ini"))
-            using (var stream = new LineBufferedReader(resStream))
-                Assert.That(decoder.Decode(stream).ComboColours[0].A, Is.EqualTo(1.0f));
-        }
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -104,10 +104,6 @@ namespace osu.Game.Beatmaps.Formats
             try
             {
                 byte alpha = split.Length == 4 ? byte.Parse(split[3]) : (byte)255;
-
-                if (alpha == 0)
-                    alpha = 255;
-
                 colour = new Color4(byte.Parse(split[0]), byte.Parse(split[1]), byte.Parse(split[2]), alpha);
             }
             catch

--- a/osu.Game/Skinning/LegacyColourCompatibility.cs
+++ b/osu.Game/Skinning/LegacyColourCompatibility.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osuTK.Graphics;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// Compatibility methods to convert osu!stable colours to osu!lazer-compatible ones. Should be used for legacy skins only.
+    /// </summary>
+    public static class LegacyColourCompatibility
+    {
+        /// <summary>
+        /// Forces an alpha of 1 if a given <see cref="Color4"/> is fully transparent.
+        /// </summary>
+        /// <remarks>
+        /// This is equivalent to setting colour post-constructor in osu!stable.
+        /// </remarks>
+        /// <param name="colour">The <see cref="Color4"/> to disallow zero alpha on.</param>
+        /// <returns>The resultant <see cref="Color4"/>.</returns>
+        public static Color4 DisallowZeroAlpha(Color4 colour)
+        {
+            if (colour.A == 0)
+                colour.A = 1;
+            return colour;
+        }
+
+        /// <summary>
+        /// Applies a <see cref="Color4"/> to a <see cref="Drawable"/>, doubling the alpha value into the <see cref="Drawable.Alpha"/> property.
+        /// </summary>
+        /// <remarks>
+        /// This is equivalent to setting colour in the constructor in osu!stable.
+        /// </remarks>
+        /// <param name="drawable">The <see cref="Drawable"/> to apply the colour to.</param>
+        /// <param name="colour">The <see cref="Color4"/> to apply.</param>
+        /// <returns>The given <paramref name="drawable"/>.</returns>
+        public static T ApplyWithDoubledAlpha<T>(T drawable, Color4 colour)
+            where T : Drawable
+        {
+            drawable.Alpha = colour.A;
+            drawable.Colour = DisallowZeroAlpha(colour);
+            return drawable;
+        }
+    }
+}

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -82,10 +82,10 @@ namespace osu.Game.Skinning
         /// <remarks>
         /// Beware: Any existing value in <see cref="Drawable.Alpha"/> is overwritten.
         /// </remarks>
-        /// <param name="drawable">The <see cref="Drawable"/> to set the "InitialColour" of.</param>
+        /// <param name="drawable">The <see cref="Drawable"/> to set the colour of.</param>
         /// <param name="colour">The <see cref="Color4"/> to set.</param>
         /// <returns>The given <see cref="Drawable"/>.</returns>
-        public static T WithInitialColour<T>(this T drawable, Color4 colour)
+        public static T WithLegacyColour<T>(this T drawable, Color4 colour)
             where T : Drawable
         {
             drawable.Alpha = colour.A;

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -63,6 +63,11 @@ namespace osu.Game.Skinning
             }
         }
 
+        /// <summary>
+        /// The resultant colour after setting a post-constructor colour in osu!stable.
+        /// </summary>
+        /// <param name="colour">The <see cref="Color4"/> to convert.</param>
+        /// <returns>The converted <see cref="Color4"/>.</returns>
         public static Color4 ToLegacyColour(this Color4 colour)
         {
             if (colour.A == 0)
@@ -70,6 +75,16 @@ namespace osu.Game.Skinning
             return colour;
         }
 
+        /// <summary>
+        /// Equivalent of setting a colour in the constructor in osu!stable.
+        /// Doubles the alpha channel into <see cref="Drawable.Alpha"/> and uses <see cref="ToLegacyColour"/> to set <see cref="Drawable.Colour"/>.
+        /// </summary>
+        /// <remarks>
+        /// Beware: Any existing value in <see cref="Drawable.Alpha"/> is overwritten.
+        /// </remarks>
+        /// <param name="drawable">The <see cref="Drawable"/> to set the "InitialColour" of.</param>
+        /// <param name="colour">The <see cref="Color4"/> to set.</param>
+        /// <returns>The given <see cref="Drawable"/>.</returns>
         public static T WithInitialColour<T>(this T drawable, Color4 colour)
             where T : Drawable
         {

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osuTK.Graphics;
 using static osu.Game.Skinning.LegacySkinConfiguration;
 
 namespace osu.Game.Skinning
@@ -60,6 +61,21 @@ namespace osu.Game.Skinning
                     yield return texture;
                 }
             }
+        }
+
+        public static Color4 ToLegacyColour(this Color4 colour)
+        {
+            if (colour.A == 0)
+                colour.A = 1;
+            return colour;
+        }
+
+        public static T WithInitialColour<T>(this T drawable, Color4 colour)
+            where T : Drawable
+        {
+            drawable.Alpha = colour.A;
+            drawable.Colour = ToLegacyColour(colour);
+            return drawable;
         }
 
         public class SkinnableTextureAnimation : TextureAnimation

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osuTK.Graphics;
 using static osu.Game.Skinning.LegacySkinConfiguration;
 
 namespace osu.Game.Skinning
@@ -61,36 +60,6 @@ namespace osu.Game.Skinning
                     yield return texture;
                 }
             }
-        }
-
-        /// <summary>
-        /// The resultant colour after setting a post-constructor colour in osu!stable.
-        /// </summary>
-        /// <param name="colour">The <see cref="Color4"/> to convert.</param>
-        /// <returns>The converted <see cref="Color4"/>.</returns>
-        public static Color4 ToLegacyColour(this Color4 colour)
-        {
-            if (colour.A == 0)
-                colour.A = 1;
-            return colour;
-        }
-
-        /// <summary>
-        /// Equivalent of setting a colour in the constructor in osu!stable.
-        /// Doubles the alpha channel into <see cref="Drawable.Alpha"/> and uses <see cref="ToLegacyColour"/> to set <see cref="Drawable.Colour"/>.
-        /// </summary>
-        /// <remarks>
-        /// Beware: Any existing value in <see cref="Drawable.Alpha"/> is overwritten.
-        /// </remarks>
-        /// <param name="drawable">The <see cref="Drawable"/> to set the colour of.</param>
-        /// <param name="colour">The <see cref="Color4"/> to set.</param>
-        /// <returns>The given <see cref="Drawable"/>.</returns>
-        public static T WithLegacyColour<T>(this T drawable, Color4 colour)
-            where T : Drawable
-        {
-            drawable.Alpha = colour.A;
-            drawable.Colour = ToLegacyColour(colour);
-            return drawable;
         }
 
         public class SkinnableTextureAnimation : TextureAnimation


### PR DESCRIPTION
PRing mostly for comments for now, because I'm not super sure this is the direction we should go in and I'm wondering how people would feel about this.

---

tl;dr: In stable,
1. Setting colour via ctor also transfers the alpha to the sprite's alpha value. This results in alpha doubling at draw time.
2. Setting a fully-transparent colour at any point discards the alpha value of the colour. This is what https://github.com/ppy/osu/pull/9369 intended to fix, but didn't address (1).

---

Slight discrepancies can be seen between master and stable, which this fixes. For example using my skin (https://drive.google.com/file/d/19BwcK6fj5PTQY0fwi02-s3F9vrAvPPjR/view?usp=sharing), stable completely hides the column line colours, but lazer displays them at full opacity. This is because an alpha=0 colour is set in the ctor, which transfers that value into the sprite alpha property that's used even if the colour's alpha is discarded.
By extension, this fixes the first issue in https://github.com/ppy/osu/issues/9500.

There's two methods here:
1. `WithLegacyColour(Drawable, Color4)` - This emulates what the ctor in stable does. (1) from above.
2. `ToLegacyColour(Color4)` - This applies the alpha discard, and is used for cases where the colour is set _post_ ctor. (2) from above.

I haven't done a super deep regression test, though I think I've covered usages of legacy colours.