### PR TITLE
Add padding to mania column borders to match stable

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyColumnBackground.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 using osuTK;
@@ -20,8 +21,11 @@ namespace osu.Game.Rulesets.Mania.Skinning
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
         private readonly bool isLastColumn;
 
+        private Container borderLineContainer;
         private Container lightContainer;
         private Sprite light;
+
+        private float hitPosition;
 
         public LegacyColumnBackground(bool isLastColumn)
         {
@@ -44,6 +48,9 @@ namespace osu.Game.Rulesets.Mania.Skinning
             bool hasRightLine = rightLineWidth > 0 && skin.GetConfig<LegacySkinConfiguration.LegacySetting, decimal>(LegacySkinConfiguration.LegacySetting.Version)?.Value >= 2.4m
                                 || isLastColumn;
 
+            hitPosition = GetColumnSkinConfig<float>(skin, LegacyManiaSkinConfigurationLookups.HitPosition)?.Value
+                          ?? Stage.HIT_TARGET_POSITION;
+
             float lightPosition = GetColumnSkinConfig<float>(skin, LegacyManiaSkinConfigurationLookups.LightPosition)?.Value
                                   ?? 0;
 
@@ -63,23 +70,30 @@ namespace osu.Game.Rulesets.Mania.Skinning
                     RelativeSizeAxes = Axes.Both,
                     Colour = backgroundColour
                 },
-                new Box
+                borderLineContainer = new Container
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    Width = leftLineWidth,
-                    Scale = new Vector2(0.740f, 1),
-                    Colour = lineColour,
-                    Alpha = hasLeftLine ? 1 : 0
-                },
-                new Box
-                {
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.TopRight,
-                    RelativeSizeAxes = Axes.Y,
-                    Width = rightLineWidth,
-                    Scale = new Vector2(0.740f, 1),
-                    Colour = lineColour,
-                    Alpha = hasRightLine ? 1 : 0
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Y,
+                            Width = leftLineWidth,
+                            Scale = new Vector2(0.740f, 1),
+                            Colour = lineColour,
+                            Alpha = hasLeftLine ? 1 : 0
+                        },
+                        new Box
+                        {
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            RelativeSizeAxes = Axes.Y,
+                            Width = rightLineWidth,
+                            Scale = new Vector2(0.740f, 1),
+                            Colour = lineColour,
+                            Alpha = hasRightLine ? 1 : 0
+                        }
+                    }
                 },
                 lightContainer = new Container
                 {
@@ -109,11 +123,15 @@ namespace osu.Game.Rulesets.Mania.Skinning
             {
                 lightContainer.Anchor = Anchor.TopCentre;
                 lightContainer.Scale = new Vector2(1, -1);
+
+                borderLineContainer.Padding = new MarginPadding { Top = hitPosition };
             }
             else
             {
                 lightContainer.Anchor = Anchor.BottomCentre;
                 lightContainer.Scale = Vector2.One;
+
+                borderLineContainer.Padding = new MarginPadding { Bottom = hitPosition };
             }
         }
 


### PR DESCRIPTION
Resolves #9547.

# Summary

As can be seen from the screenshots attached to the aforementioned issue, on legacy skins on stable column borders aren't drawn on the entire height of the screen - they stop at the hit position.

To resolve, apply padding locally to the relevant border boxes. The effect of this change can be seen on [this video](https://drive.google.com/file/d/1178k5i3cbx8Tk1153jp2GSALjgCVdZOB/view?usp=sharing), and also in visual tests:

| `master` | this PR |
| :-: | :-: |
| ![before](https://user-images.githubusercontent.com/20418176/90922468-566d1d80-e3ec-11ea-9c47-3d6b46f6ae92.PNG) | ![after](https://user-images.githubusercontent.com/20418176/90922483-5b31d180-e3ec-11ea-9ff0-8067391bb917.PNG) |

Note that the above screenshots aren't still 100% accurate, due to the fact that (among other issues) `mania-stage-hint` is still drawn for individual columns instead of for the entire stage at once, but that is out of scope of this particular change and tracked at #9500.

# Remarks

After too much time spent thinking I decided to keep this one simple (no proxying, no complications, just a singular local padding application). A possible gripe with that way of doing things is that the fallback lookup of `HitPosition` is now duplicated in here and in `HitObjectArea`:

https://github.com/ppy/osu/blob/56480d16654ec2455bc17c3fa09f2a68606e52d0/osu.Game.Rulesets.Mania/UI/Components/HitObjectArea.cs#L49-L51

but unsure how much of a deal this is. Will split into an extension method/move to `ManiaLegacySkinTransformer` on request, but honestly it felt like a bit of an over-engineer (and I recall similar objections being raised in other skinning PRs before).