### PR TITLE
Adjust key binding panel tests to not rely on row indices

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -68,22 +68,22 @@ namespace osu.Game.Tests.Visual.Settings
         [Test]
         public void TestClearButtonOnBindings()
         {
-            KeyBindingRow backBindingRow = null;
+            KeyBindingRow multiBindingRow = null;
 
-            AddStep("click back binding row", () =>
+            AddStep("click first row with two bindings", () =>
             {
-                backBindingRow = panel.ChildrenOfType<KeyBindingRow>().ElementAt(10);
-                InputManager.MoveMouseTo(backBindingRow);
+                multiBindingRow = panel.ChildrenOfType<KeyBindingRow>().First(row => row.Defaults.Count() > 1);
+                InputManager.MoveMouseTo(multiBindingRow);
                 InputManager.Click(MouseButton.Left);
             });
 
             clickClearButton();
 
-            AddAssert("first binding cleared", () => string.IsNullOrEmpty(backBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First().Text.Text));
+            AddAssert("first binding cleared", () => string.IsNullOrEmpty(multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First().Text.Text));
 
             AddStep("click second binding", () =>
             {
-                var target = backBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1);
+                var target = multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1);
 
                 InputManager.MoveMouseTo(target);
                 InputManager.Click(MouseButton.Left);
@@ -91,13 +91,13 @@ namespace osu.Game.Tests.Visual.Settings
 
             clickClearButton();
 
-            AddAssert("second binding cleared", () => string.IsNullOrEmpty(backBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1).Text.Text));
+            AddAssert("second binding cleared", () => string.IsNullOrEmpty(multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1).Text.Text));
 
             void clickClearButton()
             {
                 AddStep("click clear button", () =>
                 {
-                    var clearButton = backBindingRow.ChildrenOfType<KeyBindingRow.ClearButton>().Single();
+                    var clearButton = multiBindingRow.ChildrenOfType<KeyBindingRow.ClearButton>().Single();
 
                     InputManager.MoveMouseTo(clearButton);
                     InputManager.Click(MouseButton.Left);
@@ -108,20 +108,20 @@ namespace osu.Game.Tests.Visual.Settings
         [Test]
         public void TestClickRowSelectsFirstBinding()
         {
-            KeyBindingRow backBindingRow = null;
+            KeyBindingRow multiBindingRow = null;
 
-            AddStep("click back binding row", () =>
+            AddStep("click first row with two bindings", () =>
             {
-                backBindingRow = panel.ChildrenOfType<KeyBindingRow>().ElementAt(10);
-                InputManager.MoveMouseTo(backBindingRow);
+                multiBindingRow = panel.ChildrenOfType<KeyBindingRow>().First(row => row.Defaults.Count() > 1);
+                InputManager.MoveMouseTo(multiBindingRow);
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("first binding selected", () => backBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First().IsBinding);
+            AddAssert("first binding selected", () => multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First().IsBinding);
 
             AddStep("click second binding", () =>
             {
-                var target = backBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1);
+                var target = multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(1);
 
                 InputManager.MoveMouseTo(target);
                 InputManager.Click(MouseButton.Left);
@@ -129,12 +129,12 @@ namespace osu.Game.Tests.Visual.Settings
 
             AddStep("click back binding row", () =>
             {
-                backBindingRow = panel.ChildrenOfType<KeyBindingRow>().ElementAt(10);
-                InputManager.MoveMouseTo(backBindingRow);
+                multiBindingRow = panel.ChildrenOfType<KeyBindingRow>().ElementAt(10);
+                InputManager.MoveMouseTo(multiBindingRow);
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("first binding selected", () => backBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First().IsBinding);
+            AddAssert("first binding selected", () => multiBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().First().IsBinding);
         }
     }
 }


### PR DESCRIPTION
As seen in #9948.

# Summary

Tests for the key binding panel added in #9633 were prone to accidental regressions upon adding new bindings, as if the newly added binding happened to be before the hard-coded 10 index, the resulting offset could result in a test failure (e.g. if after the shift the binding at index 10 had one default instead of two).

Resolve by always picking the first available binding with two defaults for the test.