### PR TITLE
Fix osu!catch relax mod

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                     {
                         X = CatchPlayfield.CENTER_X,
                         StartTime = 750,
-                        Path = new SliderPath(PathType.Linear, new Vector2[] { Vector2.Zero, Vector2.UnitY * 200 })
+                        Path = new SliderPath(PathType.Linear, new[] { Vector2.Zero, Vector2.UnitY * 200 })
                     }
                 }
             }
@@ -64,12 +64,15 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 case 0:
                     InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre);
                     break;
+
                 case 1:
                     InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.BottomLeft);
                     break;
+
                 case 2:
                     InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.BottomRight);
                     break;
+
                 case 3:
                     InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre);
                     break;

--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Mods;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Mods
+{
+    public class TestSceneCatchModRelax : ModTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
+
+        [Test]
+        public void TestModRelax() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModRelax(),
+            Autoplay = false,
+            PassCondition = () =>
+            {
+                var playfield = this.ChildrenOfType<CatchPlayfield>().Single();
+                InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre);
+
+                return Player.ScoreProcessor.Combo.Value > 0;
+            },
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Fruit
+                    {
+                        X = CatchPlayfield.CENTER_X
+                    }
+                }
+            }
+        });
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
@@ -10,7 +10,9 @@ using osu.Game.Rulesets.Catch.Mods;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Tests.Visual;
+using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Tests.Mods
 {
@@ -23,23 +25,57 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
         {
             Mod = new CatchModRelax(),
             Autoplay = false,
-            PassCondition = () =>
-            {
-                var playfield = this.ChildrenOfType<CatchPlayfield>().Single();
-                InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre);
-
-                return Player.ScoreProcessor.Combo.Value > 0;
-            },
+            PassCondition = passCondition,
             Beatmap = new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
                     new Fruit
                     {
-                        X = CatchPlayfield.CENTER_X
+                        X = CatchPlayfield.CENTER_X,
+                        StartTime = 0
+                    },
+                    new Fruit
+                    {
+                        X = 0,
+                        StartTime = 250
+                    },
+                    new Fruit
+                    {
+                        X = CatchPlayfield.WIDTH,
+                        StartTime = 500
+                    },
+                    new JuiceStream
+                    {
+                        X = CatchPlayfield.CENTER_X,
+                        StartTime = 750,
+                        Path = new SliderPath(PathType.Linear, new Vector2[] { Vector2.Zero, Vector2.UnitY * 200 })
                     }
                 }
             }
         });
+
+        private bool passCondition()
+        {
+            var playfield = this.ChildrenOfType<CatchPlayfield>().Single();
+
+            switch (Player.ScoreProcessor.Combo.Value)
+            {
+                case 0:
+                    InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre);
+                    break;
+                case 1:
+                    InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.BottomLeft);
+                    break;
+                case 2:
+                    InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.BottomRight);
+                    break;
+                case 3:
+                    InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre);
+                    break;
+            }
+
+            return Player.ScoreProcessor.Combo.Value >= 6;
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModRelax.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 
             protected override bool OnMouseMove(MouseMoveEvent e)
             {
-                catcher.UpdatePosition(e.MousePosition.X / DrawSize.X);
+                catcher.UpdatePosition(e.MousePosition.X / DrawSize.X * CatchPlayfield.WIDTH);
                 return base.OnMouseMove(e);
             }
         }


### PR DESCRIPTION
The catcher no moving in Relax mod.
```cs
protected override bool OnMouseMove(MouseMoveEvent e)
{
    catcher.UpdatePosition(e.MousePosition.X / DrawSize.X * CatchPlayfield.WIDTH);
    return base.OnMouseMove(e);
}
```

The catcher without `CatchPlayfield.WIDTH` move between 0 and 1, but the playfield size is `CatchPlayfield.WIDTH` (512).