### PR TITLE
Fix catch hyper dash colour defaults not being set correctly

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -285,8 +285,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private void runHyperDashStateTransition(bool hyperDashing)
         {
-            trails.HyperDashTrailsColour = hyperDashColour;
-            trails.EndGlowSpritesColour = hyperDashEndGlowColour;
             updateTrailVisibility();
 
             if (hyperDashing)
@@ -402,6 +400,9 @@ namespace osu.Game.Rulesets.Catch.UI
             hyperDashEndGlowColour =
                 skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashAfterImage)?.Value ??
                 hyperDashColour;
+
+            trails.HyperDashTrailsColour = hyperDashColour;
+            trails.EndGlowSpritesColour = hyperDashEndGlowColour;
 
             runHyperDashStateTransition(HyperDashing);
         }

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly Container<CatcherTrailSprite> hyperDashTrails;
         private readonly Container<CatcherTrailSprite> endGlowSprites;
 
-        private Color4 hyperDashTrailsColour;
+        private Color4 hyperDashTrailsColour = Catcher.DEFAULT_HYPER_DASH_COLOUR;
 
         public Color4 HyperDashTrailsColour
         {
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Catch.UI
             }
         }
 
-        private Color4 endGlowSpritesColour;
+        private Color4 endGlowSpritesColour = Catcher.DEFAULT_HYPER_DASH_COLOUR;
 
         public Color4 EndGlowSpritesColour
         {

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     return;
 
                 hyperDashTrailsColour = value;
-                hyperDashTrails.FadeColour(hyperDashTrailsColour, Catcher.HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
+                hyperDashTrails.Colour = hyperDashTrailsColour;
             }
         }
 
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     return;
 
                 endGlowSpritesColour = value;
-                endGlowSprites.FadeColour(endGlowSpritesColour, Catcher.HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
+                endGlowSprites.Colour = endGlowSpritesColour;
             }
         }
 


### PR DESCRIPTION
As the defaults were not set, if a skin happened to specify 0,0,0,0 it would be ignored due to the early returns in property setters.

- Closes #9918.