### PR TITLE
Fix fail graph crashes on some maps

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlaySuccessRate.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlaySuccessRate.cs
@@ -7,8 +7,10 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Screens.Select.Details;
@@ -70,6 +72,20 @@ namespace osu.Game.Tests.Visual.Online
                     Retries = Enumerable.Range(-2, 100).Select(_ => RNG.Next(10)).ToArray(),
                 }
             };
+        }
+
+        [Test]
+        public void TestOnlyFailMetrics()
+        {
+            AddStep("set beatmap", () => successRate.Beatmap = new BeatmapInfo
+            {
+                Metrics = new BeatmapMetrics
+                {
+                    Fails = Enumerable.Range(1, 100).ToArray(),
+                }
+            });
+            AddAssert("graph max values correct",
+                () => successRate.ChildrenOfType<BarGraph>().All(graph => graph.MaxValue == 100));
         }
 
         private class GraphExposingSuccessRate : SuccessRate

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlaySuccessRate.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlaySuccessRate.cs
@@ -88,6 +88,18 @@ namespace osu.Game.Tests.Visual.Online
                 () => successRate.ChildrenOfType<BarGraph>().All(graph => graph.MaxValue == 100));
         }
 
+        [Test]
+        public void TestEmptyMetrics()
+        {
+            AddStep("set beatmap", () => successRate.Beatmap = new BeatmapInfo
+            {
+                Metrics = new BeatmapMetrics()
+            });
+
+            AddAssert("graph max values correct",
+                () => successRate.ChildrenOfType<BarGraph>().All(graph => graph.MaxValue == 0));
+        }
+
         private class GraphExposingSuccessRate : SuccessRate
         {
             public new FailRetryGraph Graph => base.Graph;

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -236,7 +236,7 @@ namespace osu.Game.Screens.Select
         private void updateMetrics()
         {
             var hasRatings = beatmap?.BeatmapSet?.Metrics?.Ratings?.Any() ?? false;
-            var hasRetriesFails = (beatmap?.Metrics?.Retries?.Any() ?? false) && (beatmap?.Metrics.Fails?.Any() ?? false);
+            var hasRetriesFails = (beatmap?.Metrics?.Retries?.Any() ?? false) || (beatmap?.Metrics?.Fails?.Any() ?? false);
 
             if (hasRatings)
             {

--- a/osu.Game/Screens/Select/Details/FailRetryGraph.cs
+++ b/osu.Game/Screens/Select/Details/FailRetryGraph.cs
@@ -29,14 +29,28 @@ namespace osu.Game.Screens.Select.Details
 
                 var retries = Metrics?.Retries ?? Array.Empty<int>();
                 var fails = Metrics?.Fails ?? Array.Empty<int>();
+                var retriesAndFails = sumRetriesAndFails(retries, fails);
 
-                float maxValue = fails.Any() ? fails.Zip(retries, (fail, retry) => fail + retry).Max() : 0;
+                float maxValue = retriesAndFails.Any() ? retriesAndFails.Max() : 0;
                 failGraph.MaxValue = maxValue;
                 retryGraph.MaxValue = maxValue;
 
-                failGraph.Values = fails.Select(f => (float)f);
-                retryGraph.Values = retries.Zip(fails, (retry, fail) => retry + Math.Clamp(fail, 0, maxValue));
+                failGraph.Values = fails.Select(v => (float)v);
+                retryGraph.Values = retriesAndFails.Select(v => (float)v);
             }
+        }
+
+        private int[] sumRetriesAndFails(int[] retries, int[] fails)
+        {
+            var result = new int[Math.Max(retries.Length, fails.Length)];
+
+            for (int i = 0; i < retries.Length; ++i)
+                result[i] = retries[i];
+
+            for (int i = 0; i < fails.Length; ++i)
+                result[i] += fails[i];
+
+            return result;
         }
 
         public FailRetryGraph()


### PR DESCRIPTION
Resolves #9937.

# Summary

As mentioned in the issue thread, on some maps APIv2 returns only one of the two properties needed to display the fail graph (`fail` and `exit`; see [example API response on one map affected](https://gist.github.com/bdach/73cb6d790e53a7b588f0961c50506185)).

To fix, ensure correct behaviour if only one of the lists is present/empty, by doing a "manual" zip, which uses the longer sequence length instead of the shorter one as LINQ `.Zip()` does. This will practically coerce an empty/not present list to a list full of zeroes.

# Remarks

The choice to coerce as outlined above instead of entirely discarding the data is due to the fact that the data can still be correct even if not all present - in the response linked above, there are actual fail counts there, which will be visible in the beatmap details section now:

![osu_2020-08-24_21-46-15](https://user-images.githubusercontent.com/20418176/91089049-4a36c980-e653-11ea-9677-d21b052a3c44.jpg)

Unsure if this should be fixed on the infra side; see ppy/osu-web#6543 for discussion on that. I guess being fault tolerant client-side is useful anyway, [Postel's law](https://en.wikipedia.org/wiki/Robustness_principle) and all.

Test coverage included, for the lopsided and both-empty cases.