### PR TITLE
Fix snapped distances potentially exceeding the source distance

### DIFF
--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -169,17 +169,17 @@ namespace osu.Game.Tests.Editing
         [Test]
         public void GetSnappedDistanceFromDistance()
         {
-            assertSnappedDistance(50, 100);
+            assertSnappedDistance(50, 0);
             assertSnappedDistance(100, 100);
-            assertSnappedDistance(150, 200);
+            assertSnappedDistance(150, 100);
             assertSnappedDistance(200, 200);
-            assertSnappedDistance(250, 300);
+            assertSnappedDistance(250, 200);
 
             AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier = 2);
 
             assertSnappedDistance(50, 0);
-            assertSnappedDistance(100, 200);
-            assertSnappedDistance(150, 200);
+            assertSnappedDistance(100, 0);
+            assertSnappedDistance(150, 0);
             assertSnappedDistance(200, 200);
             assertSnappedDistance(250, 200);
 
@@ -190,8 +190,8 @@ namespace osu.Game.Tests.Editing
             });
 
             assertSnappedDistance(50, 0);
-            assertSnappedDistance(100, 200);
-            assertSnappedDistance(150, 200);
+            assertSnappedDistance(100, 0);
+            assertSnappedDistance(150, 0);
             assertSnappedDistance(200, 200);
             assertSnappedDistance(250, 200);
             assertSnappedDistance(400, 400);

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -293,7 +293,13 @@ namespace osu.Game.Rulesets.Edit
 
         public override float GetSnappedDistanceFromDistance(double referenceTime, float distance)
         {
-            var snappedEndTime = BeatSnapProvider.SnapTime(referenceTime + DistanceToDuration(referenceTime, distance), referenceTime);
+            double actualDuration = referenceTime + DistanceToDuration(referenceTime, distance);
+
+            double snappedEndTime = BeatSnapProvider.SnapTime(actualDuration, referenceTime);
+
+            // we don't want to exceed the actual duration and snap to a point in the future.
+            if (snappedEndTime > actualDuration)
+                snappedEndTime -= BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
 
             return DurationToDistance(referenceTime, snappedEndTime - referenceTime);
         }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -25,7 +25,7 @@ using osu.Game.Screens.Edit.Components.RadioButtons;
 using osu.Game.Screens.Edit.Compose;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
-using Key = osuTK.Input.Key;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -297,9 +297,12 @@ namespace osu.Game.Rulesets.Edit
 
             double snappedEndTime = BeatSnapProvider.SnapTime(actualDuration, referenceTime);
 
+            double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
+
             // we don't want to exceed the actual duration and snap to a point in the future.
-            if (snappedEndTime > actualDuration)
-                snappedEndTime -= BeatSnapProvider.GetBeatLengthAtTime(referenceTime);
+            // as we are snapping to beat length via SnapTime (which will round-to-nearest), check for snapping in the forward direction and reverse it.
+            if (snappedEndTime > actualDuration + 1)
+                snappedEndTime -= beatLength;
 
             return DurationToDistance(referenceTime, snappedEndTime - referenceTime);
         }

--- a/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IPositionSnapProvider.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Rulesets.Edit
 
         /// <summary>
         /// Converts an unsnapped distance to a snapped distance.
+        /// The returned distance will always be floored (as to never exceed the provided <paramref name="distance"/>.
         /// </summary>
         /// <param name="referenceTime">The time of the timing point which <paramref name="distance"/> resides in.</param>
         /// <param name="distance">The distance to convert.</param>


### PR DESCRIPTION
This results in slider placement including "excess" length, where the curve is not applied to the placed path. This is generally not what we want.

I considered adding a bool parameter (or enum) to change the floor/rounding mode, but on further examination I think this is what we always expect from this function.

Before:

![2020-08-25 19 00 57](https://user-images.githubusercontent.com/191335/91161167-5aa77c80-e705-11ea-850b-853eb9843047.gif)

After:

![2020-08-25 18 59 26](https://user-images.githubusercontent.com/191335/91161060-32b81900-e705-11ea-9945-b75218989698.gif)
