### PR TITLE
Remove padding from columns

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -79,7 +79,6 @@ namespace osu.Game.Rulesets.Mania.UI
                         columnFlow = new ColumnFlow<Column>(definition)
                         {
                             RelativeSizeAxes = Axes.Y,
-                            Padding = new MarginPadding { Left = COLUMN_SPACING, Right = COLUMN_SPACING },
                         },
                         new Container
                         {


### PR DESCRIPTION
The movement of background in https://github.com/ppy/osu/pull/9971 has made a pixel gap become more apparent with legacy skins.

Stable doesn't have this padding, and neither do flyte's new designs. So it's probably fine to remove it straight up.

Master before the above PR:
![Screenshot_2020-08-25_20-19-35](https://user-images.githubusercontent.com/1329837/91168424-93991e80-e710-11ea-80a8-5e97ba7f4d69.png)

Master after the above PR:
![image](https://user-images.githubusercontent.com/1329837/91172896-eaeebd00-e717-11ea-98aa-5e994f81bad4.png)

After this PR (+ https://github.com/ppy/osu/pull/9945 to fix column line colours):
![image](https://user-images.githubusercontent.com/1329837/91168567-cfcc7f00-e710-11ea-8c52-d429adae8be2.png)