### PR TITLE
Add component for displaying simple statistics on result screen

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneSimpleStatisticRow.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneSimpleStatisticRow.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using Humanizer;
+using NUnit.Framework;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
+using osu.Game.Screens.Ranking.Statistics;
+
+namespace osu.Game.Tests.Visual.Ranking
+{
+    public class TestSceneSimpleStatisticRow : OsuTestScene
+    {
+        private Container container;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Child = new Container
+            {
+                AutoSizeAxes = Axes.Y,
+                Width = 700,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4Extensions.FromHex("#333"),
+                    },
+                    container = new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding(20)
+                    }
+                }
+            };
+        });
+
+        [Test]
+        public void TestEmpty()
+        {
+            AddStep("create with no items",
+                () => container.Add(new SimpleStatisticRow(2, Enumerable.Empty<SimpleStatisticItem>())));
+        }
+
+        [Test]
+        public void TestManyItems(
+            [Values(1, 2, 3, 4, 12)] int itemCount,
+            [Values(1, 3, 5)] int columnCount)
+        {
+            AddStep($"create with {"item".ToQuantity(itemCount)}", () =>
+            {
+                var items = Enumerable.Range(1, itemCount)
+                                      .Select(i => new SimpleStatisticItem<int>($"Statistic #{i}")
+                                      {
+                                          Value = RNG.Next(100)
+                                      });
+
+                container.Add(new SimpleStatisticRow(columnCount, items));
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
@@ -1,0 +1,80 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Screens.Ranking.Statistics
+{
+    /// <summary>
+    /// Represents a simple statistic item (one that only needs textual display).
+    /// Richer visualisations should be done with <see cref="StatisticItem"/>s.
+    /// </summary>
+    public abstract class SimpleStatisticItem : Container
+    {
+        /// <summary>
+        /// The text to display as the statistic's value.
+        /// </summary>
+        protected string Value
+        {
+            set => this.value.Text = value;
+        }
+
+        private readonly OsuSpriteText value;
+
+        /// <summary>
+        /// Creates a new simple statistic item.
+        /// </summary>
+        /// <param name="name">The name of the statistic.</param>
+        protected SimpleStatisticItem(string name)
+        {
+            Name = name;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            AddRange(new[]
+            {
+                new OsuSpriteText
+                {
+                    Text = Name,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft
+                },
+                value = new OsuSpriteText
+                {
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    Font = OsuFont.Torus.With(weight: FontWeight.Bold)
+                }
+            });
+        }
+    }
+
+    /// <summary>
+    /// Strongly-typed generic specialisation for <see cref="SimpleStatisticItem"/>.
+    /// </summary>
+    public class SimpleStatisticItem<TValue> : SimpleStatisticItem
+    {
+        /// <summary>
+        /// The statistic's value to be displayed.
+        /// </summary>
+        public new TValue Value
+        {
+            set => base.Value = DisplayValue(value);
+        }
+
+        /// <summary>
+        /// Used to convert <see cref="Value"/> to a text representation.
+        /// Defaults to using <see cref="object.ToString"/>.
+        /// </summary>
+        protected virtual string DisplayValue(TValue value) => value.ToString();
+
+        public SimpleStatisticItem(string name)
+            : base(name)
+        {
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticRow.cs
@@ -1,0 +1,122 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Game.Screens.Ranking.Statistics
+{
+    /// <summary>
+    /// Represents a statistic row with simple statistics (ones that only need textual display).
+    /// Richer visualisations should be done with <see cref="StatisticRow"/>s and <see cref="StatisticItem"/>s.
+    /// </summary>
+    public class SimpleStatisticRow : CompositeDrawable
+    {
+        private readonly SimpleStatisticItem[] items;
+        private readonly int columnCount;
+
+        private FillFlowContainer[] columns;
+
+        /// <summary>
+        /// Creates a statistic row for the supplied <see cref="SimpleStatisticItem"/>s.
+        /// </summary>
+        /// <param name="columnCount">The number of columns to layout the <paramref name="items"/> into.</param>
+        /// <param name="items">The <see cref="SimpleStatisticItem"/>s to display in this row.</param>
+        public SimpleStatisticRow(int columnCount, IEnumerable<SimpleStatisticItem> items)
+        {
+            if (columnCount < 1)
+                throw new ArgumentOutOfRangeException(nameof(columnCount));
+
+            this.columnCount = columnCount;
+            this.items = items.ToArray();
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            columns = new FillFlowContainer[columnCount];
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new GridContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                RowDimensions = new[]
+                {
+                    new Dimension(GridSizeMode.AutoSize)
+                },
+                ColumnDimensions = createColumnDimensions().ToArray(),
+                Content = new[] { createColumns().ToArray() }
+            };
+
+            for (int i = 0; i < items.Length; ++i)
+                columns[i % columnCount].Add(items[i]);
+        }
+
+        private IEnumerable<Dimension> createColumnDimensions()
+        {
+            for (int column = 0; column < columnCount; ++column)
+            {
+                if (column > 0)
+                    yield return new Dimension(GridSizeMode.Absolute, 30);
+
+                yield return new Dimension();
+            }
+        }
+
+        private IEnumerable<Drawable> createColumns()
+        {
+            for (int column = 0; column < columnCount; ++column)
+            {
+                if (column > 0)
+                {
+                    yield return new Spacer
+                    {
+                        Alpha = items.Length > column ? 1 : 0
+                    };
+                }
+
+                yield return columns[column] = createColumn();
+            }
+        }
+
+        private FillFlowContainer createColumn() => new FillFlowContainer
+        {
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            Direction = FillDirection.Vertical
+        };
+
+        private class Spacer : CompositeDrawable
+        {
+            public Spacer()
+            {
+                RelativeSizeAxes = Axes.Both;
+                Padding = new MarginPadding { Vertical = 4 };
+
+                InternalChild = new CircularContainer
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 3,
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    CornerRadius = 2,
+                    Masking = true,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4Extensions.FromHex("#222")
+                    }
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
First step toward #8314.

# Summary

This PR adds a component that can be used on the results screen to present simple, textual statistics to the end user. The design follows the bottom-most visible component [shown here](https://user-images.githubusercontent.com/1329837/91057022-a86aa900-e661-11ea-8ee9-18fc2c21ef35.png).

The API allows users of this component to customise both the number of columns to lay out the statistics into, as well as control the formatting of the values passed in via the `DisplayValue()` virtual method.

The test scene attached demonstrates the usage of the component. [Here's a video showing what it looks like.](https://drive.google.com/file/d/1fbZ0XXgUd-5g6pZD0Yu3hCA44DMenpPQ/view?usp=sharing)

# Remarks

I'm PRing this separately for multiple reasons:

- this on its own is somewhat large and the design is mostly eyeballed, so I wanted to keep any potential issues with that separated from the rest,
- I'm unsure whether I haven't overengineered this with the customisation options (both felt very likely to be needed at some point and also relatively free),
- integration is still a bit away for two reasons:

  - The way statistic rows are done right now doesn't allow me to just drop in this component in there, as [`StatisticsPanel` is tightly coupled to `StatisticsRow`, which is tightly coupled to `StatisticsItem`](https://github.com/ppy/osu/blob/c21b1e358c55a03f74e7e02a74042ec7a25e2712/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs#L99-L119). I *could* add the new row alongside them in `StatisticsPanel` itself, but that feels like breaking the nice declarativeness of `CreateStatisticsForScore` somewhat. Right now I'm leaning toward decoupling via an `IStatisticsRow` interface which you could ask for a drawable representation of the row.
  - Then there's the actual computation of the UR. Current best idea is to have an `UnstableRate : SimpleStatisticsItem<double>` which receives hit events and does the computation during load.

  Both reasons are why I'm PRing the "safest" part first. Let me know if you have better ideas on how to proceed.

Naming is a bit ehh. Couldn't think of a better name (`TextualStatisticItem`?), so alternate suggestions welcome. Also thinking of renaming current `StatisticItem` to `DetailedStatisticItem` for added contrast.

The column creation is a tad hacky, but I don't think `GridContainer` has something like HTML `{row,col}span` to use for the spacers.