### PR TITLE
Implement mania "KeysUnderNotes" skin config

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/LegacyKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/LegacyKeyArea.cs
@@ -65,6 +65,9 @@ namespace osu.Game.Rulesets.Mania.Skinning
 
             direction.BindTo(scrollingInfo.Direction);
             direction.BindValueChanged(onDirectionChanged, true);
+
+            if (GetColumnSkinConfig<bool>(skin, LegacyManiaSkinConfigurationLookups.KeysUnderNotes)?.Value ?? false)
+                Column.UnderlayElements.Add(CreateProxy());
         }
 
         private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)

--- a/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Skinning
         public float HitPosition = (480 - 402) * POSITION_SCALE_FACTOR;
         public float LightPosition = (480 - 413) * POSITION_SCALE_FACTOR;
         public bool ShowJudgementLine = true;
+        public bool KeysUnderNotes;
 
         public LegacyManiaSkinConfiguration(int keys)
         {

--- a/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
@@ -50,5 +50,6 @@ namespace osu.Game.Skinning
         Hit100,
         Hit50,
         Hit0,
+        KeysUnderNotes,
     }
 }

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -97,6 +97,10 @@ namespace osu.Game.Skinning
                         currentConfig.ShowJudgementLine = pair.Value == "1";
                         break;
 
+                    case "KeysUnderNotes":
+                        currentConfig.KeysUnderNotes = pair.Value == "1";
+                        break;
+
                     case "LightingNWidth":
                         parseArrayValue(pair.Value, currentConfig.ExplosionWidth);
                         break;

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -255,6 +255,9 @@ namespace osu.Game.Skinning
                 case LegacyManiaSkinConfigurationLookups.Hit300:
                 case LegacyManiaSkinConfigurationLookups.Hit300g:
                     return SkinUtils.As<TValue>(getManiaImage(existing, maniaLookup.Lookup.ToString()));
+
+                case LegacyManiaSkinConfigurationLookups.KeysUnderNotes:
+                    return SkinUtils.As<TValue>(new Bindable<bool>(existing.KeysUnderNotes));
             }
 
             return null;


### PR DESCRIPTION
Resolves one of the items in https://github.com/ppy/osu/issues/9500

Kinda hard to test this atm, because:
1. The skin instances are shared - if it's added to the special skin it'll affect all special skins, and
2. The mania skin test scenes don't usually add a column to the hierarchy, only keeping a column for reference purposes. This means that `KeysUnderNotes=1` would cause the keys to get proxied into the column and then disappear because the column itself isn't in the hierarchy.

Can be tested with arrow skins in particular: https://osu.ppy.sh/community/forums/topics/512453 (https://puu.sh/z7raA.osk)