### PR TITLE
Fix invalid accuracy calculation during replay decoding

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
@@ -11,6 +12,7 @@ using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Game.Tests.Resources;
 
@@ -35,6 +37,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
                 Assert.AreEqual(829_931, score.ScoreInfo.TotalScore);
                 Assert.AreEqual(3, score.ScoreInfo.MaxCombo);
+                Assert.IsTrue(Precision.AlmostEquals(0.8889, score.ScoreInfo.Accuracy, 0.0001));
+                Assert.AreEqual(ScoreRank.B, score.ScoreInfo.Rank);
 
                 Assert.That(score.Replay.Frames, Is.Not.Empty);
             }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -13,7 +13,6 @@ using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Replays;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Users;
 using SharpCompress.Compressors.LZMA;
 
@@ -123,12 +122,12 @@ namespace osu.Game.Scoring.Legacy
 
         protected void CalculateAccuracy(ScoreInfo score)
         {
-            score.Statistics.TryGetValue(HitResult.Miss, out int countMiss);
-            score.Statistics.TryGetValue(HitResult.Meh, out int count50);
-            score.Statistics.TryGetValue(HitResult.Good, out int count100);
-            score.Statistics.TryGetValue(HitResult.Great, out int count300);
-            score.Statistics.TryGetValue(HitResult.Perfect, out int countGeki);
-            score.Statistics.TryGetValue(HitResult.Ok, out int countKatu);
+            int countMiss = score.GetCountMiss() ?? 0;
+            int count50 = score.GetCount50() ?? 0;
+            int count100 = score.GetCount100() ?? 0;
+            int count300 = score.GetCount300() ?? 0;
+            int countGeki = score.GetCountGeki() ?? 0;
+            int countKatu = score.GetCountKatu() ?? 0;
 
             switch (score.Ruleset.ID)
             {


### PR DESCRIPTION
Found in #9993 (yak level: 2)

- [x] Depends on #9993 for the test case.

# Summary

While writing the test case for #9993 and covering accuracy calculation correctness I noticed that the results were off, due to seemingly confusing 200s and 100s. This is replicable in the game itself without any intervention, by importing an online score and then looking at it locally. [Here's a video demonstrating this](https://drive.google.com/file/d/1qvRvcBGnpYryAR4NUvjDKAxc_JSLTKEL/view?usp=sharing); note the accuracy dropping from 99.95% on the online score to 99.89% on the local score.

The mix-up is here:

https://github.com/ppy/osu/blob/93a9994bcde096576dee8a1d06fbc099d29eb1b2/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs#L126-L131

Here's a reference table for mania [based on `LegacyScoreExtensions`](https://github.com/ppy/osu/blob/e8aebada3c707909dda8a51cf59c7710c3cf0575/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs) which are used [earlier in the decoding process](https://github.com/ppy/osu/blob/93a9994bcde096576dee8a1d06fbc099d29eb1b2/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs#L54-L59) to keep track:

| numerical value | lazer name | stable name |
| :-: | :- | :- |
| 300/305/350 | `HitResult.Perfect` | `countGeki` |
| 300 | `HitResult.Great` | `count300` |
| 200 | `HitResult.Good` | `countKatu` |
| 100 | `HitResult.Ok` | `count100` |
| 50 | `HitResult.Meh` | `count50` |
| 0 | `HitResult.Miss` | `count0` |

As you can see, 200s and 100s are mixed up. Note that in other modes `HitResult.Good` *is* worth 100, therefore just swapping them will break other rulesets.

Resolve by using `LegacyScoreExtensions`' getter methods instead of manually scraping from `score.Statistics`.

# Remarks

Fixing this allows to expand the coverage of legacy score decoding to cover accuracy (at least for mania).

More testing of decoding overall is something that could be improved upon, but given this quite is a detour already I'm not sure it's something I'd want to commit to right now. I will expand the coverage on request to cover other game modes, however, probably in a separate pull.