### PR TITLE
Reduce redundant difficulty re-calculations

### DIFF
--- a/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    [TestFixture]
+    public class BeatmapDifficultyManagerTest
+    {
+        [Test]
+        public void TestKeyEqualsWithDifferentModInstances()
+        {
+            var key1 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+
+            Assert.That(key1, Is.EqualTo(key2));
+        }
+
+        [Test]
+        public void TestKeyEqualsWithDifferentModOrder()
+        {
+            var key1 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHidden(), new OsuModHardRock() });
+
+            Assert.That(key1, Is.EqualTo(key2));
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Beatmaps
             updateScheduler?.Dispose();
         }
 
-        private readonly struct DifficultyCacheLookup : IEquatable<DifficultyCacheLookup>
+        public readonly struct DifficultyCacheLookup : IEquatable<DifficultyCacheLookup>
         {
             public readonly int BeatmapId;
             public readonly int RulesetId;
@@ -267,7 +267,7 @@ namespace osu.Game.Beatmaps
             public bool Equals(DifficultyCacheLookup other)
                 => BeatmapId == other.BeatmapId
                    && RulesetId == other.RulesetId
-                   && Mods.SequenceEqual(other.Mods);
+                   && Mods.Select(m => m.Acronym).SequenceEqual(other.Mods.Select(m => m.Acronym));
 
             public override int GetHashCode()
             {

--- a/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
@@ -89,8 +89,14 @@ namespace osu.Game.Beatmaps
             if (tryGetExisting(beatmapInfo, rulesetInfo, mods, out var existing, out var key))
                 return existing;
 
-            return await Task.Factory.StartNew(() => computeDifficulty(key, beatmapInfo, rulesetInfo), cancellationToken,
-                TaskCreationOptions.HideScheduler | TaskCreationOptions.RunContinuationsAsynchronously, updateScheduler);
+            return await Task.Factory.StartNew(() =>
+            {
+                // Computation may have finished in a previous task.
+                if (tryGetExisting(beatmapInfo, rulesetInfo, mods, out existing, out _))
+                    return existing;
+
+                return computeDifficulty(key, beatmapInfo, rulesetInfo);
+            }, cancellationToken, TaskCreationOptions.HideScheduler | TaskCreationOptions.RunContinuationsAsynchronously, updateScheduler);
         }
 
         /// <summary>


### PR DESCRIPTION
Only noticed this because I'm querying beatmap difficulty a lot in an upcoming PR.

Two changes:
1. Querying the difficulty again in the async context. My upcoming changes query the beatmap difficulty some 50 times simultaneously, which would enqueue an equal number of computations on maps like https://osu.ppy.sh/beatmapsets/29157#osu/156352 that don't complete fast enough.
2. Fixing the `Equals()` comparison. In a similar vein to the above, I'm querying the beatmap difficulty many times with different instances of the same mods.