### PR TITLE
Hide misses from timing distribution graph

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -35,6 +35,18 @@ namespace osu.Game.Tests.Visual.Ranking
             createTest(new List<HitEvent>());
         }
 
+        [Test]
+        public void TestMissesDontShow()
+        {
+            createTest(Enumerable.Range(0, 100).Select(i =>
+            {
+                if (i % 2 == 0)
+                    return new HitEvent(0, HitResult.Perfect, new HitCircle(), new HitCircle(), null);
+
+                return new HitEvent(30, HitResult.Miss, new HitCircle(), new HitCircle(), null);
+            }).ToList());
+        }
+
         private void createTest(List<HitEvent> events) => AddStep("create test", () =>
         {
             Children = new Drawable[]

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="hitEvents">The <see cref="HitEvent"/>s to display the timing distribution of.</param>
         public HitEventTimingDistributionGraph(IReadOnlyList<HitEvent> hitEvents)
         {
-            this.hitEvents = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows)).ToList();
+            this.hitEvents = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result != HitResult.Miss).ToList();
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Doesn't make sense to show them in the first place as they aren't user triggered.

Closes https://github.com/ppy/osu/issues/9748.
