### PR TITLE
Exclude misses and empty window hits from unstable rate calculations

### DIFF
--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             var unstableRate = new UnstableRate(events);
 
-            Assert.IsTrue(Precision.AlmostEquals(0, unstableRate.Value));
+            Assert.AreEqual(0, unstableRate.Value);
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
+
+namespace osu.Game.Tests.NonVisual.Ranking
+{
+    [TestFixture]
+    public class UnstableRateTest
+    {
+        [Test]
+        public void TestDistributedHits()
+        {
+            var events = Enumerable.Range(-5, 11)
+                                   .Select(t => new HitEvent(t - 5, HitResult.Great, new HitObject(), null, null));
+
+            var unstableRate = new UnstableRate(events);
+
+            Assert.IsTrue(Precision.AlmostEquals(unstableRate.Value, 10 * Math.Sqrt(10)));
+        }
+
+        [Test]
+        public void TestMissesAndEmptyWindows()
+        {
+            var events = new[]
+            {
+                new HitEvent(-100, HitResult.Miss, new HitObject(), null, null),
+                new HitEvent(0, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(200, HitResult.Meh, new HitObject { HitWindows = HitWindows.Empty }, null, null),
+            };
+
+            var unstableRate = new UnstableRate(events);
+
+            Assert.IsTrue(Precision.AlmostEquals(0, unstableRate.Value));
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
@@ -59,12 +59,19 @@ namespace osu.Game.Screens.Ranking.Statistics
     /// </summary>
     public class SimpleStatisticItem<TValue> : SimpleStatisticItem
     {
+        private TValue value;
+
         /// <summary>
         /// The statistic's value to be displayed.
         /// </summary>
         public new TValue Value
         {
-            set => base.Value = DisplayValue(value);
+            get => value;
+            set
+            {
+                this.value = value;
+                base.Value = DisplayValue(value);
+            }
         }
 
         /// <summary>

--- a/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
+++ b/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
@@ -20,7 +20,8 @@ namespace osu.Game.Screens.Ranking.Statistics
         public UnstableRate(IEnumerable<HitEvent> hitEvents)
             : base("Unstable Rate")
         {
-            var timeOffsets = hitEvents.Select(ev => ev.TimeOffset).ToArray();
+            var timeOffsets = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result != HitResult.Miss)
+                                       .Select(ev => ev.TimeOffset).ToArray();
             Value = 10 * standardDeviation(timeOffsets);
         }
 


### PR DESCRIPTION
Companion piece to #10015.

# Summary

For parity with the distribution graph, exclude misses and hits with empty windows from being factored into unstable rate calculation.

The calculation part was not tested before - it is now with some straightforward non-visual tests.

# Remarks

Also exposed a getter in `SimpleStatisticItem<T>` - might come in handy with future simple statistic items, I'd say.