### PR TITLE
Do not attempt to complete spinners that are too short in autoplay

### DIFF
--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -154,9 +154,9 @@ namespace osu.Game.Rulesets.Osu.Replays
             // The startPosition for the slider should not be its .Position, but the point on the circle whose tangent crosses the current cursor position
             // We also modify spinnerDirection so it spins in the direction it enters the spin circle, to make a smooth transition.
             // TODO: Shouldn't the spinner always spin in the same direction?
-            if (h is Spinner)
+            if (h is Spinner spinner)
             {
-                if ((h as Spinner).Duration == 0)
+                if (spinner.Duration < reactionTime)
                     return;
 
                 calcSpinnerStartPosAndDirection(((OsuReplayFrame)Frames[^1]).Position, out startPosition, out spinnerDirection);

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -156,6 +156,9 @@ namespace osu.Game.Rulesets.Osu.Replays
             // TODO: Shouldn't the spinner always spin in the same direction?
             if (h is Spinner)
             {
+                if ((h as Spinner).Duration == 0)
+                    return;
+
                 calcSpinnerStartPosAndDirection(((OsuReplayFrame)Frames[^1]).Position, out startPosition, out spinnerDirection);
 
                 Vector2 spinCentreOffset = SPINNER_CENTRE - ((OsuReplayFrame)Frames[^1]).Position;

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -156,7 +156,8 @@ namespace osu.Game.Rulesets.Osu.Replays
             // TODO: Shouldn't the spinner always spin in the same direction?
             if (h is Spinner spinner)
             {
-                if (spinner.Duration < reactionTime)
+                // spinners with 0 spins required will auto-complete - don't bother
+                if (spinner.SpinsRequired == 0)
                     return;
 
                 calcSpinnerStartPosAndDirection(((OsuReplayFrame)Frames[^1]).Position, out startPosition, out spinnerDirection);


### PR DESCRIPTION
Resolves #10011 

Intentional low duration spinners will most likely have the `Duration` of `0`. Seems like adding a simple `Duration` check is enough to solve this problem.