### PR TITLE
Fix potentially incorrect zoom level getting set on very short audio

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }, true);
         }
 
-        private float getZoomLevelForVisibleMilliseconds(double milliseconds) => (float)(track.Length / milliseconds);
+        private float getZoomLevelForVisibleMilliseconds(double milliseconds) => Math.Max(1, (float)(track.Length / milliseconds));
 
         /// <summary>
         /// The timeline's scroll position in the last frame.


### PR DESCRIPTION
Tracks that are only seconds long could potentially crash due to exceeding supported bounds of `ZoomableScrollContainer`:

https://github.com/ppy/osu/blob/bb97e9632cd05c65bb826cabc7fff4e2b078e1d5/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs#L54-L55

https://github.com/ppy/osu/blob/bb97e9632cd05c65bb826cabc7fff4e2b078e1d5/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs#L74-L75

Closes #8742
