### PR TITLE
Fix possible nullref when unfocusing date text box in tourney

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneDateTextBox.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneDateTextBox.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Tests.Visual;
+using osu.Game.Tournament.Components;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tournament.Tests.Components
+{
+    public class TestSceneDateTextBox : OsuManualInputManagerTestScene
+    {
+        private DateTextBox textBox;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Child = textBox = new DateTextBox
+            {
+                Width = 0.3f
+            };
+        });
+
+        [Test]
+        public void TestCommitWithoutSettingBindable()
+        {
+            AddStep("click textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("unfocus", () =>
+            {
+                InputManager.MoveMouseTo(Vector2.Zero);
+                InputManager.Click(MouseButton.Left);
+            });
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/DateTextBox.cs
+++ b/osu.Game.Tournament/Components/DateTextBox.cs
@@ -22,11 +22,12 @@ namespace osu.Game.Tournament.Components
         }
 
         // hold a reference to the provided bindable so we don't have to in every settings section.
-        private Bindable<DateTimeOffset> bindable;
+        private Bindable<DateTimeOffset> bindable = new Bindable<DateTimeOffset>();
 
         public DateTextBox()
         {
             base.Bindable = new Bindable<string>();
+
             ((OsuTextBox)Control).OnCommit = (sender, newText) =>
             {
                 try


### PR DESCRIPTION
When text is committed without having selected a team.