### PR TITLE
Improve music fade on game exit

### DIFF
--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -126,6 +126,12 @@ namespace osu.Game.Screens.Menu
 
             double fadeOutTime = exit_delay;
 
+            var track = musicController.CurrentTrack;
+
+            // ensure the track doesn't change or loop as we are exiting.
+            track.Looping = false;
+            Beatmap.Disabled = true;
+
             // we also handle the exit transition.
             if (MenuVoice.Value)
             {
@@ -134,16 +140,16 @@ namespace osu.Game.Screens.Menu
                 // if playing the outro voice, we have more time to have fun with the background track.
                 // initially fade to almost silent then ramp out over the remaining time.
                 const double initial_fade = 200;
-                musicController.CurrentTrack
-                               .VolumeTo(0.03f, initial_fade).Then()
-                               .VolumeTo(0, fadeOutTime - initial_fade, Easing.In);
+                track
+                    .VolumeTo(0.03f, initial_fade).Then()
+                    .VolumeTo(0, fadeOutTime - initial_fade, Easing.In);
             }
             else
             {
                 fadeOutTime = 500;
 
                 // if outro voice is turned off, just do a simple fade out.
-                musicController.CurrentTrack.VolumeTo(0, fadeOutTime, Easing.Out);
+                track.VolumeTo(0, fadeOutTime, Easing.Out);
             }
 
             //don't want to fade out completely else we will stop running updates.

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -46,8 +46,6 @@ namespace osu.Game.Screens.Menu
 
         protected ITrack Track { get; private set; }
 
-        private readonly BindableDouble exitingVolumeFade = new BindableDouble(1);
-
         private const int exit_delay = 3000;
 
         private SampleChannel seeya;
@@ -127,17 +125,29 @@ namespace osu.Game.Screens.Menu
             this.FadeIn(300);
 
             double fadeOutTime = exit_delay;
+
             // we also handle the exit transition.
             if (MenuVoice.Value)
+            {
                 seeya.Play();
+
+                // if playing the outro voice, we have more time to have fun with the background track.
+                // initially fade to almost silent then ramp out over the remaining time.
+                const double initial_fade = 200;
+                musicController.CurrentTrack
+                               .VolumeTo(0.03f, initial_fade).Then()
+                               .VolumeTo(0, fadeOutTime - initial_fade, Easing.In);
+            }
             else
+            {
                 fadeOutTime = 500;
 
-            audio.AddAdjustment(AdjustableProperty.Volume, exitingVolumeFade);
-            this.TransformBindableTo(exitingVolumeFade, 0, fadeOutTime).OnComplete(_ => this.Exit());
+                // if outro voice is turned off, just do a simple fade out.
+                musicController.CurrentTrack.VolumeTo(0, fadeOutTime, Easing.Out);
+            }
 
             //don't want to fade out completely else we will stop running updates.
-            Game.FadeTo(0.01f, fadeOutTime);
+            Game.FadeTo(0.01f, fadeOutTime).OnComplete(_ => this.Exit());
 
             base.OnResuming(last);
         }


### PR DESCRIPTION
- Fades music much faster, similar to stable. can still hear an echo of the music over the remaining fade time.
- Handles no voice and voice scenarios better
- Ensures track doesn't change or loop during outro
- [~] Loosely depends on https://github.com/ppy/osu-resources/pull/112 (but not really necessary in that order)