### PR TITLE
Fix MusicController raising track changed event twice

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -279,6 +279,10 @@ namespace osu.Game.Overlays
 
         private void changeBeatmap(WorkingBeatmap newWorking)
         {
+            // The provided beatmap is same as current, no need to do any changes.
+            if (newWorking == current)
+                return;
+
             var lastWorking = current;
 
             TrackChangeDirection direction = TrackChangeDirection.None;

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -279,7 +279,8 @@ namespace osu.Game.Overlays
 
         private void changeBeatmap(WorkingBeatmap newWorking)
         {
-            // If the provided beatmap is same as current, then there is no need to do any changes.
+            // This method can potentially be triggered multiple times as it is eagerly fired in next() / prev() to ensure correct execution order
+            // (changeBeatmap must be called before consumers receive the bindable changed event, which is not the case when called from the bindable itself).
             if (newWorking == current)
                 return;
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -279,7 +279,7 @@ namespace osu.Game.Overlays
 
         private void changeBeatmap(WorkingBeatmap newWorking)
         {
-            // The provided beatmap is same as current, no need to do any changes.
+            // If the provided beatmap is same as current, then there is no need to do any changes.
             if (newWorking == current)
                 return;
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Overlays
         private void changeBeatmap(WorkingBeatmap newWorking)
         {
             // This method can potentially be triggered multiple times as it is eagerly fired in next() / prev() to ensure correct execution order
-            // (changeBeatmap must be called before consumers receive the bindable changed event, which is not the case when called from the bindable itself).
+            // (changeBeatmap must be called before consumers receive the bindable changed event, which is not the case when the local beatmap bindable is updated directly).
             if (newWorking == current)
                 return;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10055

`changeBeatmap()` could be called a second time on the same beatmap on performing `prev()` or `next()` due to the below lines:
https://github.com/ppy/osu/blob/ebed7d09e3412206660666a3231b406e4550206d/osu.Game/Overlays/MusicController.cs#L325-L328

This is guarding against doing that to avoid double `TrackChanged` event raises, and since the `queuedDirection` is flushed on the first time, the second raise would take `TrackChangeDirection.None` with it, therefore causing the background transitions to not happen as in the linked issue which this PR fixes.

This is tested at once in #10063 (`TestSceneMusicActionHandling`) as that test scene actually depends on this issue being fixed therefore covering it.