### PR TITLE
Update class exclusion for dynamic compilation

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.904.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.904.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.907.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -21,13 +21,11 @@ using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using System;
-using osu.Framework.Testing;
 using osu.Game.Rulesets.Catch.Skinning;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch
 {
-    [ExcludeFromDynamicCompile]
     public class CatchRuleset : Ruleset, ILegacyRuleset
     {
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableCatchRuleset(this, beatmap, mods);

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Testing;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Replays.Types;
@@ -35,7 +34,6 @@ using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets.Mania
 {
-    [ExcludeFromDynamicCompile]
     public class ManiaRuleset : Ruleset, ILegacyRuleset
     {
         /// <summary>

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -30,14 +30,12 @@ using osu.Game.Scoring;
 using osu.Game.Skinning;
 using System;
 using System.Linq;
-using osu.Framework.Testing;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Statistics;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets.Osu
 {
-    [ExcludeFromDynamicCompile]
     public class OsuRuleset : Ruleset, ILegacyRuleset
     {
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableOsuRuleset(this, beatmap, mods);

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -22,7 +22,6 @@ using osu.Game.Rulesets.Taiko.Scoring;
 using osu.Game.Scoring;
 using System;
 using System.Linq;
-using osu.Framework.Testing;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Taiko.Edit;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -32,7 +31,6 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko
 {
-    [ExcludeFromDynamicCompile]
     public class TaikoRuleset : Ruleset, ILegacyRuleset
     {
         public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new DrawableTaikoRuleset(this, beatmap, mods);

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Scoring;
+using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using Newtonsoft.Json;
+using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.IO.Serialization;
 using osu.Game.Rulesets;
@@ -14,6 +15,7 @@ using osu.Game.Scoring;
 
 namespace osu.Game.Beatmaps
 {
+    [ExcludeFromDynamicCompile]
     [Serializable]
     public class BeatmapInfo : IEquatable<BeatmapInfo>, IJsonSerializable, IHasPrimaryKey
     {

--- a/osu.Game/Beatmaps/BeatmapMetadata.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadata.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using Newtonsoft.Json;
+using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Users;
 
 namespace osu.Game.Beatmaps
 {
+    [ExcludeFromDynamicCompile]
     [Serializable]
     public class BeatmapMetadata : IEquatable<BeatmapMetadata>, IHasPrimaryKey
     {

--- a/osu.Game/Beatmaps/BeatmapSetInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfo.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
+using osu.Framework.Testing;
 using osu.Game.Database;
 
 namespace osu.Game.Beatmaps
 {
+    [ExcludeFromDynamicCompile]
     public class BeatmapSetInfo : IHasPrimaryKey, IHasFiles<BeatmapSetFileInfo>, ISoftDelete, IEquatable<BeatmapSetInfo>
     {
         public int ID { get; set; }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -13,6 +13,7 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
 using osu.Framework.Statistics;
+using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Types;
@@ -22,6 +23,7 @@ using osu.Game.Storyboards;
 
 namespace osu.Game.Beatmaps
 {
+    [ExcludeFromDynamicCompile]
     public abstract class WorkingBeatmap : IWorkingBeatmap
     {
         public readonly BeatmapInfo BeatmapInfo;

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -6,6 +6,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
 using osu.Framework.Extensions;
 using osu.Framework.Platform;
+using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Select;
@@ -13,6 +14,7 @@ using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Configuration
 {
+    [ExcludeFromDynamicCompile]
     public class OsuConfigManager : IniConfigManager<OsuSetting>
     {
         protected override void InitialiseDefaults()

--- a/osu.Game/Input/GameIdleTracker.cs
+++ b/osu.Game/Input/GameIdleTracker.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input;
+
+namespace osu.Game.Input
+{
+    public class GameIdleTracker : IdleTracker
+    {
+        private InputManager inputManager;
+
+        public GameIdleTracker(int time)
+            : base(time)
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            inputManager = GetContainingInputManager();
+        }
+
+        protected override bool AllowIdle => inputManager.FocusedDrawable == null;
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -718,24 +718,6 @@ namespace osu.Game
                 overlayContent.ChangeChildDepth(overlay, (float)-Clock.CurrentTime);
         }
 
-        public class GameIdleTracker : IdleTracker
-        {
-            private InputManager inputManager;
-
-            public GameIdleTracker(int time)
-                : base(time)
-            {
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-                inputManager = GetContainingInputManager();
-            }
-
-            protected override bool AllowIdle => inputManager.FocusedDrawable == null;
-        }
-
         private void forwardLoggedErrorsToNotifications()
         {
             int recentLogCount = 0;
@@ -990,11 +972,5 @@ namespace osu.Game
             if (newScreen == null)
                 Exit();
         }
-    }
-
-    public enum ScorePresentType
-    {
-        Results,
-        Gameplay
     }
 }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.UI;
@@ -18,6 +19,7 @@ namespace osu.Game.Rulesets.Mods
     /// <summary>
     /// The base class for gameplay modifiers.
     /// </summary>
+    [ExcludeFromDynamicCompile]
     public abstract class Mod : IMod, IJsonSerializable
     {
         /// <summary>

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -23,10 +23,12 @@ using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Users;
 using JetBrains.Annotations;
+using osu.Framework.Testing;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets
 {
+    [ExcludeFromDynamicCompile]
     public abstract class Ruleset
     {
         public RulesetInfo RulesetInfo { get; internal set; }

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -5,9 +5,11 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Newtonsoft.Json;
+using osu.Framework.Testing;
 
 namespace osu.Game.Rulesets
 {
+    [ExcludeFromDynamicCompile]
     public class RulesetInfo : IEquatable<RulesetInfo>
     {
         public int? ID { get; set; }

--- a/osu.Game/Screens/ScorePresentType.cs
+++ b/osu.Game/Screens/ScorePresentType.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Screens
+{
+    public enum ScorePresentType
+    {
+        Results,
+        Gameplay
+    }
+}

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -30,6 +30,7 @@ using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Visual
 {
+    [ExcludeFromDynamicCompile]
     public abstract class OsuTestScene : TestScene
     {
         protected Bindable<WorkingBeatmap> Beatmap { get; private set; }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.904.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.907.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.904.0" />
     <PackageReference Include="Sentry" Version="2.1.6" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.904.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.907.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.904.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
@@ -80,7 +80,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.904.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.907.0" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/3775

- [x] Depends on https://github.com/ppy/osu-framework/pull/3865 to achieve the results I've listed below.

```
Master:

- Working:
    - TestSceneDialogOverlay -> TestDialogOverlay
- Not working:
    - TestSceneDrawableDrumRoll (taiko) -> LegacyDrumRoll
    - TestSceneEditor (taiko) -> TaikoSelectionHandler
    - TestSceneEditor (taiko) -> DrawableDrumRoll
    - TestSceneEditor (taiko) -> TaikoBlueprintContainer
    - TestSceneEditor (taiko) -> TaikoSelectionBlueprint
    - TestSceneEditor (taiko) -> ComposeBlueprintContainer
    - TestSceneEditor (taiko) -> BlueprintContainer
    - TestSceneEditor (taiko) -> OverlaySelectionBlueprint
    - TestSceneTimelineBlueprintContainer -> BlueprintContainer
    - TestSceneTimelineBlueprintContainer -> TimelineBlueprintContainer
    - TestSceneBeatmapInfoWedge -> BeatmapInfoWedge
    - TestSceneCollectionSettingsDialog -> CollectionSettingsDialog (dialog in game rather than in test, simple DialogOverlay relationship)

---

Master without taiko exclude:

- Working:
    - TestSceneDrawableDrumRoll (taiko) -> LegacyDrumRoll
    - TestSceneEditor (taiko) -> TaikoSelectionHandler
    - TestSceneEditor (taiko) -> DrawableDrumRoll
    - TestSceneEditor (taiko) -> TaikoBlueprintContainer
    - TestSceneEditor (taiko) -> TaikoSelectionBlueprint
    - TestSceneDialogOverlay -> TestDialogOverlay
- Not working:
    - TestSceneEditor (taiko) -> ComposeBlueprintContainer
    - TestSceneEditor (taiko) -> BlueprintContainer
    - TestSceneEditor (taiko) -> OverlaySelectionBlueprint
    - TestSceneTimelineBlueprintContainer -> BlueprintContainer
    - TestSceneTimelineBlueprintContainer -> TimelineBlueprintContainer
    - TestSceneBeatmapInfoWedge -> BeatmapInfoWedge
    - TestSceneCollectionSettingsDialog -> CollectionSettingsDialog (dialog in game rather than in test, simple DialogOverlay relationship)

---

This branch:

- Working:
    - TestSceneDrawableDrumRoll (taiko) -> LegacyDrumRoll
    - TestSceneEditor (taiko) -> TaikoSelectionHandler
    - TestSceneEditor (taiko) -> DrawableDrumRoll
    - TestSceneEditor (taiko) -> TaikoBlueprintContainer
    - TestSceneEditor (taiko) -> TaikoSelectionBlueprint
    - TestSceneDialogOverlay -> TestDialogOverlay
    - TestSceneTimelineBlueprintContainer -> BlueprintContainer
    - TestSceneTimelineBlueprintContainer -> TimelineBlueprintContainer
    - TestSceneBeatmapInfoWedge -> BeatmapInfoWedge
    - TestSceneCollectionSettingsDialog -> CollectionSettingsDialog (dialog in game rather than in test, simple DialogOverlay relationship)
- Not working:
    - TestSceneEditor (taiko) -> ComposeBlueprintContainer
    - TestSceneEditor (taiko) -> BlueprintContainer
    - TestSceneEditor (taiko) -> OverlaySelectionBlueprint
```

I expect similar for other rulesets, the exclusions were completely wrong.