### PR TITLE
Make all toolbar tooltips lowercase

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingHeader.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingHeader.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.BeatmapListing
             public BeatmapListingTitle()
             {
                 Title = "beatmap listing";
-                Description = "Browse for new beatmaps";
+                Description = "browse for new beatmaps";
                 IconTexture = "Icons/Hexacons/beatmap";
             }
         }

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Overlays.Changelog
             public ChangelogHeaderTitle()
             {
                 Title = "changelog";
-                Description = "Track recent dev updates in the osu! ecosystem";
+                Description = "track recent dev updates in the osu! ecosystem";
                 IconTexture = "Icons/Hexacons/devtools";
             }
         }

--- a/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
+++ b/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Dashboard
             public DashboardTitle()
             {
                 Title = "dashboard";
-                Description = "View your friends and other information";
+                Description = "view your friends and other information";
                 IconTexture = "Icons/Hexacons/social";
             }
         }

--- a/osu.Game/Overlays/News/NewsHeader.cs
+++ b/osu.Game/Overlays/News/NewsHeader.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Overlays.News
             public NewsHeaderTitle()
             {
                 Title = "news";
-                Description = "Get up-to-date on community happenings";
+                Description = "get up-to-date on community happenings";
                 IconTexture = "Icons/Hexacons/news";
             }
         }

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -19,8 +19,8 @@ namespace osu.Game.Overlays
     public class NotificationOverlay : OsuFocusedOverlayContainer, INamedOverlayComponent
     {
         public string IconTexture => "Icons/Hexacons/notification";
-        public string Title => "Notifications";
-        public string Description => "Waiting for 'ya";
+        public string Title => "notifications";
+        public string Description => "waiting for 'ya";
 
         private const float width = 320;
 

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays
     {
         public string IconTexture => "Icons/Hexacons/music";
         public string Title => "now playing";
-        public string Description => "Manage the currently playing track";
+        public string Description => "manage the currently playing track";
 
         private const float player_height = 130;
         private const float transition_length = 800;

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Overlays.Rankings
             public RankingsTitle()
             {
                 Title = "ranking";
-                Description = "Find out who's the best right now";
+                Description = "find out who's the best right now";
                 IconTexture = "Icons/Hexacons/rankings";
             }
         }

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Overlays
     {
         public string IconTexture => "Icons/Hexacons/settings";
         public string Title => "settings";
-        public string Description => "Change the way osu! behaves";
+        public string Description => "change the way osu! behaves";
 
         protected override IEnumerable<SettingsSection> CreateSections() => new SettingsSection[]
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Overlays.Toolbar
         [BackgroundDependencyLoader]
         private void load()
         {
-            TooltipMain = "Home";
-            TooltipSub = "Return to the main menu";
+            TooltipMain = "home";
+            TooltipSub = "return to the main menu";
             SetIcon("Icons/Hexacons/home");
         }
     }

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays.Toolbar
             var rInstance = value.CreateInstance();
 
             ruleset.TooltipMain = rInstance.Description;
-            ruleset.TooltipSub = $"Play some {rInstance.Description}";
+            ruleset.TooltipSub = $"play some {rInstance.Description}";
             ruleset.SetIcon(rInstance.CreateIcon());
         }
 


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/10054

Wasn't easy to use string methods as I thought. Ruleset names which are proper nouns with variation in case (i.e. "Rush!", "osu!taiko", etc.) will get regressed if I used the humanizer method (`Transform(To.LowerCase)`) on `ToolbarButton`'s `ToolTip{Main/Sub}` property. Would need special cases for regular toolbar buttons, overlay toggle toolbar buttons, and ruleset toolbar buttons which will look ugly and complicate things.

As we are lowercasing, just lowercasing in code is fine for now.

Changes (apart from issue):
- Settings overlay (description is lowercased)
	![image](https://user-images.githubusercontent.com/35318437/92331548-598f1d00-f02c-11ea-82ef-c3fcb3f8fb11.png)