### PR TITLE
Hide the game-wide cursor on touch input

### DIFF
--- a/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Graphics.Cursor
         {
             base.Update();
 
-            var lastMouseSource = GetContainingInputManager().CurrentState.Mouse.LastSource;
+            var lastMouseSource = inputManager.CurrentState.Mouse.LastSource;
             bool hasValidInput = lastMouseSource != null && !(lastMouseSource is ISourcedFromTouch);
 
             if (!hasValidInput || !CanShowCursor)

--- a/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
+using osu.Framework.Input.StateChanges;
 
 namespace osu.Game.Graphics.Cursor
 {
@@ -47,7 +48,10 @@ namespace osu.Game.Graphics.Cursor
         {
             base.Update();
 
-            if (!CanShowCursor)
+            var lastMouseSource = GetContainingInputManager().CurrentState.Mouse.LastSource;
+            bool hasValidInput = lastMouseSource != null && !(lastMouseSource is ISourcedFromTouch);
+
+            if (!hasValidInput || !CanShowCursor)
             {
                 currentTarget?.Cursor?.Hide();
                 currentTarget = null;


### PR DESCRIPTION
I looked at fixing this locally on the `LoadingLayer` and while it is possible, this makes more sense.

Closes https://github.com/ppy/osu/issues/10046.
Closes https://github.com/ppy/osu/issues/7437.

Tested on iOS simulator only, but should be ample based on simplicity of implementation.