### PR TITLE
Improve usability of BPM modifying in timing setup view

### DIFF
--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -23,15 +23,8 @@ namespace osu.Game.Screens.Edit.Timing
         {
             Flow.AddRange(new Drawable[]
             {
-                bpmTextEntry = new BPMTextBox
-                {
-                    Bindable = new TimingControlPoint().BeatLengthBindable,
-                    Label = "BPM",
-                },
-                bpmSlider = new BPMSlider
-                {
-                    Bindable = new TimingControlPoint().BeatLengthBindable,
-                },
+                bpmTextEntry = new BPMTextBox(),
+                bpmSlider = new BPMSlider(),
                 timeSignature = new SettingsEnumDropdown<TimeSignatures>
                 {
                     LabelText = "Time Signature"
@@ -62,8 +55,12 @@ namespace osu.Game.Screens.Edit.Timing
 
         private class BPMTextBox : LabelledTextBox
         {
+            private readonly BindableNumber<double> beatLengthBindable = new TimingControlPoint().BeatLengthBindable;
+
             public BPMTextBox()
             {
+                Label = "BPM";
+
                 OnCommit += (val, isNew) =>
                 {
                     if (!isNew) return;
@@ -84,11 +81,9 @@ namespace osu.Game.Screens.Edit.Timing
 
                 beatLengthBindable.BindValueChanged(val =>
                 {
-                    Current.Value = beatLengthToBpm(val.NewValue).ToString();
-                });
+                    Current.Value = beatLengthToBpm(val.NewValue).ToString("N2");
+                }, true);
             }
-
-            private readonly BindableDouble beatLengthBindable = new BindableDouble();
 
             public Bindable<double> Bindable
             {
@@ -107,12 +102,12 @@ namespace osu.Game.Screens.Edit.Timing
             private const double sane_minimum = 60;
             private const double sane_maximum = 200;
 
-            private readonly BindableDouble beatLengthBindable = new BindableDouble();
+            private readonly BindableNumber<double> beatLengthBindable = new TimingControlPoint().BeatLengthBindable;
             private readonly BindableDouble bpmBindable = new BindableDouble();
 
             public BPMSlider()
             {
-                beatLengthBindable.BindValueChanged(beatLength => updateCurrent(beatLengthToBpm(beatLength.NewValue)));
+                beatLengthBindable.BindValueChanged(beatLength => updateCurrent(beatLengthToBpm(beatLength.NewValue)), true);
                 bpmBindable.BindValueChanged(bpm => bpmBindable.Default = beatLengthBindable.Value = beatLengthToBpm(bpm.NewValue));
 
                 base.Bindable = bpmBindable;

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Edit.Timing
         private class BPMSlider : SettingsSlider<double>
         {
             private const double sane_minimum = 60;
-            private const double sane_maximum = 200;
+            private const double sane_maximum = 240;
 
             private readonly BindableNumber<double> beatLengthBindable = new TimingControlPoint().BeatLengthBindable;
             private readonly BindableDouble bpmBindable = new BindableDouble();


### PR DESCRIPTION
Main goal here was to make the slider no longer display the full valid range, but instead a sane value range (60..240 now). Obviously this isn't the final control for adjusting BPM but at least it doesn't look stupid.

Also added a text entry control for BPM and cleaned up some weird bindable code along the way.

![2020-09-07 18 22 10](https://user-images.githubusercontent.com/191335/92371842-1cfc1800-f137-11ea-87c6-23dda82c0a6b.gif)

The slider bar will expand temporarily if a beatmap is opened with a higher/lower BPM.

![2020-09-07 18 23 01](https://user-images.githubusercontent.com/191335/92372019-546ac480-f137-11ea-9110-a466942b4114.gif)

