### PR TITLE
Rename drag blueprint selection method for discoverability

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             AddRangeInternal(new[]
             {
-                DragBox = CreateDragBox(select),
+                DragBox = CreateDragBox(selectBlueprintsFromDragRectangle),
                 selectionHandler,
                 SelectionBlueprints = CreateSelectionBlueprintContainer(),
                 selectionHandler.CreateProxy(),
@@ -326,7 +326,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Select all masks in a given rectangle selection area.
         /// </summary>
         /// <param name="rect">The rectangle to perform a selection on in screen-space coordinates.</param>
-        private void select(RectangleF rect)
+        private void selectBlueprintsFromDragRectangle(RectangleF rect)
         {
             foreach (var blueprint in SelectionBlueprints)
             {


### PR DESCRIPTION
I've failed to find this selection code path multiple times, having drag in the name would help a lot.