### PR TITLE
Fix pause/play operation sometimes displaying incorrectly on OSD

### DIFF
--- a/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
+++ b/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
@@ -33,9 +33,11 @@ namespace osu.Game.Overlays.Music
             switch (action)
             {
                 case GlobalAction.MusicPlay:
-                    if (musicController.TogglePause())
-                        onScreenDisplay?.Display(new MusicActionToast(musicController.IsPlaying ? "Play track" : "Pause track"));
+                    // use previous state as TogglePause may not update the track's state immediately (state update is run on the audio thread see https://github.com/ppy/osu/issues/9880#issuecomment-674668842)
+                    bool wasPlaying = musicController.IsPlaying;
 
+                    if (musicController.TogglePause())
+                        onScreenDisplay?.Display(new MusicActionToast(wasPlaying ? "Pause track" : "Play track"));
                     return true;
 
                 case GlobalAction.MusicNext:


### PR DESCRIPTION
Offers a local fix for https://github.com/ppy/osu/issues/9880.

- [x] Depends on https://github.com/ppy/osu/pull/10063

We may want to apply this and take more time to consider whether the framework requires a change (it's likely not a simple one to apply and requires localising "playing" state away from bass, which may or may not be something we want).