### PR TITLE
Fix editor crash on saving more than once

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -231,7 +231,7 @@ namespace osu.Game.Beatmaps
         /// <param name="beatmapSkin">The beatmap <see cref="ISkin"/> content to write, null if to be omitted.</param>
         public void Save(BeatmapInfo info, IBeatmap beatmapContent, ISkin beatmapSkin = null)
         {
-            var setInfo = QueryBeatmapSet(s => s.Beatmaps.Any(b => b.ID == info.ID));
+            var setInfo = info.BeatmapSet;
 
             using (var stream = new MemoryStream())
             {


### PR DESCRIPTION
I'm fixing this in the simplest way possible as this kind of issue is specific to EF core, which may cease to exist quite soon. Turns out the re-retrieval of the beatmap set causes concurrency confusion and wasn't actually needed in my final iteration of the new beatmap logic.

Closes #10091 