### PR TITLE
Fix overlay sound effects playing when open requested while disabled

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -103,6 +103,8 @@ namespace osu.Game.Graphics.Containers
         {
         }
 
+        private bool playedPopInSound;
+
         protected override void UpdateState(ValueChangedEvent<Visibility> state)
         {
             switch (state.NewValue)
@@ -115,11 +117,18 @@ namespace osu.Game.Graphics.Containers
                     }
 
                     samplePopIn?.Play();
+                    playedPopInSound = true;
+
                     if (BlockScreenWideMouse && DimMainContent) game?.AddBlockingOverlay(this);
                     break;
 
                 case Visibility.Hidden:
-                    samplePopOut?.Play();
+                    if (playedPopInSound)
+                    {
+                        samplePopOut?.Play();
+                        playedPopInSound = false;
+                    }
+
                     if (BlockScreenWideMouse) game?.RemoveBlockingOverlay(this);
                     break;
             }

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -112,6 +112,7 @@ namespace osu.Game.Graphics.Containers
                 case Visibility.Visible:
                     if (OverlayActivationMode.Value == OverlayActivation.Disabled)
                     {
+                        // todo: visual/audible feedback that this operation could not complete.
                         State.Value = Visibility.Hidden;
                         return;
                     }


### PR DESCRIPTION
Closes #10096.

We probably want an "error" sound and some visual messaging to let the user know why the operation failed, going forward.