### PR TITLE
Move title specification for settings groups to constructor

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplaySettingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplaySettingsOverlay.cs
@@ -48,7 +48,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private class ExampleContainer : PlayerSettingsGroup
         {
-            protected override string Title => @"example";
+            public ExampleContainer()
+                : base("example")
+            {
+            }
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
@@ -20,8 +20,6 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
     {
         private const int padding = 10;
 
-        protected override string Title => @"ladder";
-
         private SettingsDropdown<TournamentRound> roundDropdown;
         private PlayerCheckbox losersCheckbox;
         private DateTextBox dateTimeBox;
@@ -33,6 +31,11 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
         [Resolved]
         private LadderInfo ladderInfo { get; set; }
+
+        public LadderEditorSettings()
+            : base("ladder")
+        {
+        }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Rulesets/Edit/ToolboxGroup.cs
+++ b/osu.Game/Rulesets/Edit/ToolboxGroup.cs
@@ -8,9 +8,8 @@ namespace osu.Game.Rulesets.Edit
 {
     public class ToolboxGroup : PlayerSettingsGroup
     {
-        protected override string Title => "toolbox";
-
         public ToolboxGroup()
+            : base("toolbox")
         {
             RelativeSizeAxes = Axes.X;
             Width = 1;

--- a/osu.Game/Screens/Play/PlayerSettings/CollectionSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/CollectionSettings.cs
@@ -10,7 +10,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public class CollectionSettings : PlayerSettingsGroup
     {
-        protected override string Title => @"collections";
+        public CollectionSettings()
+            : base("collections")
+        {
+        }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/Play/PlayerSettings/DiscussionSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/DiscussionSettings.cs
@@ -10,7 +10,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public class DiscussionSettings : PlayerSettingsGroup
     {
-        protected override string Title => @"discussions";
+        public DiscussionSettings()
+            : base("discussions")
+        {
+        }
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
@@ -9,11 +9,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public class InputSettings : PlayerSettingsGroup
     {
-        protected override string Title => "Input settings";
-
         private readonly PlayerCheckbox mouseButtonsCheckbox;
 
         public InputSettings()
+            : base("Input Settings")
         {
             Children = new Drawable[]
             {

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -13,8 +13,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
     {
         private const int padding = 10;
 
-        protected override string Title => @"playback";
-
         public readonly Bindable<double> UserPlaybackRate = new BindableDouble(1)
         {
             Default = 1,
@@ -28,6 +26,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private readonly OsuSpriteText multiplierText;
 
         public PlaybackSettings()
+            : base("playback")
         {
             Children = new Drawable[]
             {

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsGroup.cs
@@ -17,11 +17,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public abstract class PlayerSettingsGroup : Container
     {
-        /// <summary>
-        /// The title to be displayed in the header of this group.
-        /// </summary>
-        protected abstract string Title { get; }
-
         private const float transition_duration = 250;
         private const int container_width = 270;
         private const int border_thickness = 2;
@@ -58,7 +53,11 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         private Color4 expandedColour;
 
-        protected PlayerSettingsGroup()
+        /// <summary>
+        /// Create a new instance.
+        /// </summary>
+        /// <param name="title">The title to be displayed in the header of this group.</param>
+        protected PlayerSettingsGroup(string title)
         {
             AutoSizeAxes = Axes.Y;
             Width = container_width;
@@ -95,7 +94,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                 {
                                     Origin = Anchor.CentreLeft,
                                     Anchor = Anchor.CentreLeft,
-                                    Text = Title.ToUpperInvariant(),
+                                    Text = title.ToUpperInvariant(),
                                     Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 17),
                                     Margin = new MarginPadding { Left = 10 },
                                 },

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -10,8 +10,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public class VisualSettings : PlayerSettingsGroup
     {
-        protected override string Title => "Visual settings";
-
         private readonly PlayerSliderBar<double> dimSliderBar;
         private readonly PlayerSliderBar<double> blurSliderBar;
         private readonly PlayerCheckbox showStoryboardToggle;
@@ -19,6 +17,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private readonly PlayerCheckbox beatmapHitsoundsToggle;
 
         public VisualSettings()
+            : base("Visual Settings")
         {
             Children = new Drawable[]
             {


### PR DESCRIPTION
Using an abstract property was awkward for this as it is being consumed in the underlying constructor but could not be dynamically set in time from a derived class.