### PR TITLE
Add distance snap toggle (and support for future arbitrary composer toggles)

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -38,6 +39,13 @@ namespace osu.Game.Rulesets.Osu.Edit
             new SpinnerCompositionTool()
         };
 
+        private readonly BindableBool distanceSnapToggle = new BindableBool(true) { Description = "Distance Snap" };
+
+        protected override IEnumerable<BindableBool> Toggles => new[]
+        {
+            distanceSnapToggle
+        };
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -45,6 +53,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             EditorBeatmap.SelectedHitObjects.CollectionChanged += (_, __) => updateDistanceSnapGrid();
             EditorBeatmap.PlacementObject.ValueChanged += _ => updateDistanceSnapGrid();
+            distanceSnapToggle.ValueChanged += _ => updateDistanceSnapGrid();
         }
 
         protected override ComposeBlueprintContainer CreateBlueprintContainer(IEnumerable<DrawableHitObject> hitObjects)
@@ -87,6 +96,10 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             distanceSnapGridContainer.Clear();
             distanceSnapGridCache.Invalidate();
+            distanceSnapGrid = null;
+
+            if (!distanceSnapToggle.Value)
+                return;
 
             switch (BlueprintContainer.CurrentTool)
             {

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Rulesets.Edit
                             Name = "Sidebar",
                             RelativeSizeAxes = Axes.Both,
                             Padding = new MarginPadding { Right = 10 },
+                            Spacing = new Vector2(10),
                             Children = new Drawable[]
                             {
                                 new ToolboxGroup("toolbox") { Child = toolboxCollection = new RadioButtonCollection { RelativeSizeAxes = Axes.X } },

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
@@ -13,6 +14,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
@@ -94,7 +96,15 @@ namespace osu.Game.Rulesets.Edit
                             Padding = new MarginPadding { Right = 10 },
                             Children = new Drawable[]
                             {
-                                new ToolboxGroup { Child = toolboxCollection = new RadioButtonCollection { RelativeSizeAxes = Axes.X } }
+                                new ToolboxGroup("toolbox") { Child = toolboxCollection = new RadioButtonCollection { RelativeSizeAxes = Axes.X } },
+                                new ToolboxGroup("toggles")
+                                {
+                                    ChildrenEnumerable = Toggles.Select(b => new SettingsCheckbox
+                                    {
+                                        Bindable = b,
+                                        LabelText = b?.Description ?? "unknown"
+                                    })
+                                }
                             }
                         },
                         new Container
@@ -155,6 +165,12 @@ namespace osu.Game.Rulesets.Edit
         /// A "select" tool is automatically added as the first tool.
         /// </remarks>
         protected abstract IReadOnlyList<HitObjectCompositionTool> CompositionTools { get; }
+
+        /// <summary>
+        /// A collection of toggles which will be displayed to the user.
+        /// The display name will be decided by <see cref="Bindable{T}.Description"/>.
+        /// </summary>
+        protected virtual IEnumerable<BindableBool> Toggles => Enumerable.Empty<BindableBool>();
 
         /// <summary>
         /// Construct a relevant blueprint container. This will manage hitobject selection/placement input handling and display logic.

--- a/osu.Game/Rulesets/Edit/ToolboxGroup.cs
+++ b/osu.Game/Rulesets/Edit/ToolboxGroup.cs
@@ -8,8 +8,8 @@ namespace osu.Game.Rulesets.Edit
 {
     public class ToolboxGroup : PlayerSettingsGroup
     {
-        public ToolboxGroup()
-            : base("toolbox")
+        public ToolboxGroup(string title)
+            : base(title)
         {
             RelativeSizeAxes = Axes.X;
             Width = 1;


### PR DESCRIPTION
Adds a toggle for distance snap, as well as facilities for rulesets to add/display arbitrary toggles. We may need to expand this into a class definition in the future, rather than just a bindable list, but this is a good starting point.

![2020-09-09 19 18 09](https://user-images.githubusercontent.com/191335/92586464-39cc5300-f2d1-11ea-88a0-f4bb9043b6af.gif)

- [x] Depends on https://github.com/ppy/osu/pull/10100