### PR TITLE
Fix leaderboard loading spinner disappearing too early

### DIFF
--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -56,13 +56,14 @@ namespace osu.Game.Online.Leaderboards
                 scrollFlow?.FadeOut(fade_duration, Easing.OutQuint).Expire();
                 scrollFlow = null;
 
-                loading.Hide();
-
                 showScoresDelegate?.Cancel();
                 showScoresCancellationSource?.Cancel();
 
                 if (scores == null || !scores.Any())
+                {
+                    loading.Hide();
                     return;
+                }
 
                 // ensure placeholder is hidden when displaying scores
                 PlaceholderState = PlaceholderState.Successful;
@@ -84,6 +85,7 @@ namespace osu.Game.Online.Leaderboards
                     }
 
                     scrollContainer.ScrollTo(0f, false);
+                    loading.Hide();
                 }, (showScoresCancellationSource = new CancellationTokenSource()).Token));
             }
         }


### PR DESCRIPTION
Can be tested by placing a `Thread.Sleep()` inside `LeaderboardScore.load()` and observing that there's 0 scores shown with no spinner:
![Screenshot_2020-09-09_20-18-25](https://user-images.githubusercontent.com/1329837/92592000-d7c41b80-f2d9-11ea-80be-1dbd4c526a3f.png)

Only noticed because I added a little bit of a delay with some score post-processing.