### PR TITLE
Fix hard crash on deleting a collection with no collection selected

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -189,7 +189,15 @@ namespace osu.Game.Screens.Select
                 }
             };
 
-            collectionDropdown.Current.ValueChanged += _ => updateCriteria();
+            collectionDropdown.Current.ValueChanged += val =>
+            {
+                if (val.NewValue == null)
+                    // may be null briefly while menu is repopulated.
+                    return;
+
+                updateCriteria();
+            };
+
             searchTextBox.Current.ValueChanged += _ => updateCriteria();
 
             updateCriteria();


### PR DESCRIPTION
- Enter song select
- Add collection
- Delete collection from manage dialog without selecting an active collection in the dropdown menu

Not sure when this regressed as it did initially work. I started to fix it by implementing `CollectionChanged` properly rather than doing a full clear of the list, but not sure if it's worth the immediate effort. Maybe a task for another day?