### PR TITLE
Fix maps with only bonus score having NaN scores

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -28,6 +28,20 @@ namespace osu.Game.Tests.Gameplay
             Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(0.0));
         }
 
+        [Test]
+        public void TestOnlyBonusScore()
+        {
+            var beatmap = new Beatmap<TestBonusHitObject> { HitObjects = { new TestBonusHitObject() } };
+
+            var scoreProcessor = new ScoreProcessor();
+            scoreProcessor.ApplyBeatmap(beatmap);
+
+            // Apply a judgement
+            scoreProcessor.ApplyResult(new JudgementResult(new TestBonusHitObject(), new TestBonusJudgement()) { Type = HitResult.Perfect });
+
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(100));
+        }
+
         private class TestHitObject : HitObject
         {
             public override Judgement CreateJudgement() => new TestJudgement();
@@ -35,6 +49,18 @@ namespace osu.Game.Tests.Gameplay
 
         private class TestJudgement : Judgement
         {
+            protected override int NumericResultFor(HitResult result) => 100;
+        }
+
+        private class TestBonusHitObject : HitObject
+        {
+            public override Judgement CreateJudgement() => new TestBonusJudgement();
+        }
+
+        private class TestBonusJudgement : Judgement
+        {
+            public override bool AffectsCombo => false;
+
             protected override int NumericResultFor(HitResult result) => 100;
         }
     }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -202,7 +202,13 @@ namespace osu.Game.Rulesets.Scoring
             TotalScore.Value = getScore(Mode.Value);
         }
 
-        private double getScore(ScoringMode mode) => GetScore(mode, maxHighestCombo, baseScore / maxBaseScore, (double)HighestCombo.Value / maxHighestCombo, bonusScore);
+        private double getScore(ScoringMode mode)
+        {
+            return GetScore(mode, maxHighestCombo,
+                maxBaseScore > 0 ? baseScore / maxBaseScore : 0,
+                maxHighestCombo > 0 ? (double)HighestCombo.Value / maxHighestCombo : 0,
+                bonusScore);
+        }
 
         /// <summary>
         /// Computes the total score.


### PR DESCRIPTION
This isn't a regression, just an edge case that's never been tested before.

Example: https://osu.ppy.sh/beatmapsets/23210#fruits/80895