### PR TITLE
Fix drag handles not showing on now playing playlist items

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestScenePlaylistOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestScenePlaylistOverlay.cs
@@ -2,32 +2,35 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Music;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    public class TestScenePlaylistOverlay : OsuTestScene
+    public class TestScenePlaylistOverlay : OsuManualInputManagerTestScene
     {
         private readonly BindableList<BeatmapSetInfo> beatmapSets = new BindableList<BeatmapSetInfo>();
+
+        private PlaylistOverlay playlistOverlay;
 
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            PlaylistOverlay overlay;
-
             Child = new Container
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(300, 500),
-                Child = overlay = new PlaylistOverlay
+                Child = playlistOverlay = new PlaylistOverlay
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -53,7 +56,45 @@ namespace osu.Game.Tests.Visual.UserInterface
                 });
             }
 
-            overlay.BeatmapSets.BindTo(beatmapSets);
+            playlistOverlay.BeatmapSets.BindTo(beatmapSets);
         });
+
+        [Test]
+        public void TestRearrangeItems()
+        {
+            AddUntilStep("wait for animations to complete", () => !playlistOverlay.Transforms.Any());
+
+            AddStep("hold 1st item handle", () =>
+            {
+                var handle = this.ChildrenOfType<PlaylistItem.PlaylistItemHandle>().First();
+                InputManager.MoveMouseTo(handle.ScreenSpaceDrawQuad.Centre);
+                InputManager.PressButton(MouseButton.Left);
+            });
+
+            AddStep("drag to 5th", () =>
+            {
+                var item = this.ChildrenOfType<PlaylistItem>().ElementAt(4);
+                InputManager.MoveMouseTo(item.ScreenSpaceDrawQuad.Centre);
+            });
+
+            AddAssert("song 1 is 5th", () => beatmapSets[4].Metadata.Title == "Some Song 1");
+
+            AddStep("release handle", () => InputManager.ReleaseButton(MouseButton.Left));
+        }
+
+        [Test]
+        public void TestFiltering()
+        {
+            AddStep("set filter to \"10\"", () =>
+            {
+                var filterControl = playlistOverlay.ChildrenOfType<FilterControl>().Single();
+                filterControl.Search.Current.Value = "10";
+            });
+
+            AddAssert("results filtered correctly",
+                () => playlistOverlay.ChildrenOfType<PlaylistItem>()
+                                     .Where(item => item.MatchingFilter)
+                                     .All(item => item.FilterTerms.Any(term => term.Contains("10"))));
+        }
     }
 }

--- a/osu.Game/Graphics/Containers/OsuRearrangeableListItem.cs
+++ b/osu.Game/Graphics/Containers/OsuRearrangeableListItem.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Graphics.Containers
         /// <summary>
         /// Whether the drag handle should be shown.
         /// </summary>
-        protected readonly Bindable<bool> ShowDragHandle = new Bindable<bool>();
+        protected readonly Bindable<bool> ShowDragHandle = new Bindable<bool>(true);
 
         private Container handleContainer;
         private PlaylistItemHandle handle;

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -39,6 +39,8 @@ namespace osu.Game.Overlays.Music
             Padding = new MarginPadding { Left = 5 };
 
             FilterTerms = item.Metadata.SearchableTerms;
+
+            ShowDragHandle.Value = true;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Music/PlaylistItem.cs
+++ b/osu.Game/Overlays/Music/PlaylistItem.cs
@@ -39,8 +39,6 @@ namespace osu.Game.Overlays.Music
             Padding = new MarginPadding { Left = 5 };
 
             FilterTerms = item.Metadata.SearchableTerms;
-
-            ShowDragHandle.Value = true;
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/commit/1260e30cde06611ca403a972a54403879c338223.

Not sure if it should be true by default in `OsuRearrangeableListItem`.