### PR TITLE
Avoid editor confirm-save dialog looping infinitely when using keyboard shortcut to exit

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -369,7 +369,7 @@ namespace osu.Game.Screens.Edit
 
         public override bool OnExiting(IScreen next)
         {
-            if (!exitConfirmed && dialogOverlay != null && HasUnsavedChanges)
+            if (!exitConfirmed && dialogOverlay != null && HasUnsavedChanges && !(dialogOverlay.CurrentDialog is PromptForSaveDialog))
             {
                 dialogOverlay?.Push(new PromptForSaveDialog(confirmExit, confirmExitWithSave));
                 return true;


### PR DESCRIPTION
Will now exit without saving if the keyboard shortcut is activated twice in a row, as expected.

Closes #10136.