### PR TITLE
Implement bonus result judgements/statistics

### DIFF
--- a/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
@@ -8,31 +8,13 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchBananaJudgement : CatchJudgement
     {
+        public override HitResult MaxResult => HitResult.LargeBonusHit;
+
         public override bool AffectsCombo => false;
 
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
+        protected override int NumericResultFor(HitResult result) => result == MaxResult ? LARGE_BONUS_RESULT : 0;
 
-                case HitResult.Perfect:
-                    return 1100;
-            }
-        }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.75;
-            }
-        }
+        protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? DEFAULT_MAX_HEALTH_INCREASE * 0.75 : 0;
 
         public override bool ShouldExplodeFor(JudgementResult result) => true;
     }

--- a/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
@@ -9,6 +9,10 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchJudgement : Judgement
     {
+        public const int SMALL_BONUS_RESULT = 10;
+
+        public const int LARGE_BONUS_RESULT = 1100;
+
         public override HitResult MaxResult => HitResult.Perfect;
 
         protected override int NumericResultFor(HitResult result)

--- a/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
@@ -7,30 +7,12 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchTinyDropletJudgement : CatchJudgement
     {
+        public override HitResult MaxResult => HitResult.SmallBonusHit;
+
         public override bool AffectsCombo => false;
 
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
+        protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_BONUS_RESULT : 0;
 
-                case HitResult.Perfect:
-                    return 10;
-            }
-        }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return 0.02;
-            }
-        }
+        protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.02 : 0;
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -13,8 +13,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     {
         protected override HitResult HitResult => HitResult.LargeBonusHit;
 
-        protected override HitResult MissResult => HitResult.LargeBonusMiss;
-
         public DrawableBanana(Banana h)
             : base(h)
         {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -4,12 +4,17 @@
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Scoring;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableBanana : DrawableFruit
     {
+        protected override HitResult HitResult => HitResult.LargeBonusHit;
+
+        protected override HitResult MissResult => HitResult.LargeBonusMiss;
+
         public DrawableBanana(Banana h)
             : base(h)
         {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -63,6 +63,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
     public abstract class DrawableCatchHitObject : DrawableHitObject<CatchHitObject>
     {
+        protected virtual HitResult HitResult => HitResult.Perfect;
+
+        protected virtual HitResult MissResult => HitResult.Miss;
+
         public virtual bool StaysOnPlate => HitObject.CanBePlated;
 
         public float DisplayRadius => DrawSize.X / 2 * Scale.X * HitObject.Scale;
@@ -86,7 +90,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             if (CheckPosition == null) return;
 
             if (timeOffset >= 0 && Result != null)
-                ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? HitResult.Perfect : HitResult.Miss);
+                ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? HitResult : MissResult);
         }
 
         protected override void UpdateStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -65,8 +65,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     {
         protected virtual HitResult HitResult => HitResult.Perfect;
 
-        protected virtual HitResult MissResult => HitResult.Miss;
-
         public virtual bool StaysOnPlate => HitObject.CanBePlated;
 
         public float DisplayRadius => DrawSize.X / 2 * Scale.X * HitObject.Scale;
@@ -90,7 +88,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             if (CheckPosition == null) return;
 
             if (timeOffset >= 0 && Result != null)
-                ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? HitResult : MissResult);
+                ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? HitResult : HitResult.Miss);
         }
 
         protected override void UpdateStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
@@ -2,11 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableTinyDroplet : DrawableDroplet
     {
+        protected override HitResult HitResult => HitResult.SmallBonusHit;
+
+        protected override HitResult MissResult => HitResult.SmallBonusMiss;
+
         public DrawableTinyDroplet(TinyDroplet h)
             : base(h)
         {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
@@ -10,8 +10,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     {
         protected override HitResult HitResult => HitResult.SmallBonusHit;
 
-        protected override HitResult MissResult => HitResult.SmallBonusMiss;
-
         public DrawableTinyDroplet(TinyDroplet h)
             : base(h)
         {

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Scoring
@@ -8,5 +9,19 @@ namespace osu.Game.Rulesets.Catch.Scoring
     public class CatchScoreProcessor : ScoreProcessor
     {
         public override HitWindows CreateHitWindows() => new CatchHitWindows();
+
+        protected override int GetNumericBonusResult(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.SmallBonusHit:
+                    return CatchJudgement.SMALL_BONUS_RESULT;
+
+                case HitResult.LargeBonusHit:
+                    return CatchJudgement.LARGE_BONUS_RESULT;
+            }
+
+            return 0;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -15,6 +15,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Replays;
@@ -146,7 +147,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 // multipled by 2 to nullify the score multiplier. (autoplay mod selected)
                 var totalScore = ((ScoreExposedPlayer)Player).ScoreProcessor.TotalScore.Value * 2;
-                return totalScore == (int)(drawableSpinner.RotationTracker.RateAdjustedRotation / 360) * SpinnerTick.SCORE_PER_TICK;
+                return totalScore == (int)(drawableSpinner.RotationTracker.RateAdjustedRotation / 360) * OsuJudgement.SMALL_TICK_RESULT;
             });
 
             addSeekStep(0);

--- a/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
@@ -8,6 +8,9 @@ namespace osu.Game.Rulesets.Osu.Judgements
 {
     public class OsuJudgement : Judgement
     {
+        public const int SMALL_TICK_RESULT = 10;
+        public const int SMALL_BONUS_RESULT = 50;
+
         public override HitResult MaxResult => HitResult.Great;
 
         protected override int NumericResultFor(HitResult result)

--- a/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
@@ -9,7 +9,8 @@ namespace osu.Game.Rulesets.Osu.Judgements
     public class OsuJudgement : Judgement
     {
         public const int SMALL_TICK_RESULT = 10;
-        public const int SMALL_BONUS_RESULT = 50;
+        public const int SMALL_BONUS_RESULT = 10;
+        public const int LARGE_BONUS_RESULT = 50;
 
         public override HitResult MaxResult => HitResult.Great;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (timeOffset >= 0)
-                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : HitResult.Miss);
+                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : HitResult.SmallTickMiss);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Scoring;
-
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSpinnerBonusTick : DrawableSpinnerTick
@@ -11,7 +9,5 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             : base(spinnerTick)
         {
         }
-
-        internal override void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
         }
 
-        internal override void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
+        internal override void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.LargeBonusMiss);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Scoring;
+
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSpinnerBonusTick : DrawableSpinnerTick
@@ -9,5 +11,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             : base(spinnerTick)
         {
         }
+
+        internal override void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerBonusTick.cs
@@ -12,6 +12,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
         }
 
-        internal override void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.LargeBonusMiss);
+        internal override void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -18,6 +18,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// Apply a judgement result.
         /// </summary>
         /// <param name="hit">Whether this tick was reached.</param>
-        internal void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
+        internal virtual void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.SmallBonusMiss);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -18,6 +18,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// Apply a judgement result.
         /// </summary>
         /// <param name="hit">Whether this tick was reached.</param>
-        internal virtual void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
+        internal void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -18,6 +18,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// Apply a judgement result.
         /// </summary>
         /// <param name="hit">Whether this tick was reached.</param>
-        internal virtual void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.SmallBonusMiss);
+        internal virtual void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 return;
 
             displayedCount = count;
-            bonusCounter.Text = $"{OsuJudgement.SMALL_TICK_RESULT * count}";
+            bonusCounter.Text = $"{OsuJudgement.LARGE_BONUS_RESULT * count}";
             bonusCounter.FadeOutFromOne(1500);
             bonusCounter.ScaleTo(1.5f).Then().ScaleTo(1f, 1000, Easing.OutQuint);
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Osu.Judgements;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
@@ -36,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 return;
 
             displayedCount = count;
-            bonusCounter.Text = $"{SpinnerBonusTick.SCORE_PER_TICK * count}";
+            bonusCounter.Text = $"{OsuJudgement.SMALL_TICK_RESULT * count}";
             bonusCounter.FadeOutFromOne(1500);
             bonusCounter.ScaleTo(1.5f).Then().ScaleTo(1f, 1000, Easing.OutQuint);
         }

--- a/osu.Game.Rulesets.Osu/Objects/SliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTick.cs
@@ -36,7 +36,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class SliderTickJudgement : OsuJudgement
         {
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? 10 : 0;
+            public override HitResult MaxResult => HitResult.SmallTickHit;
+
+            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_TICK_RESULT : 0;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
@@ -9,8 +9,6 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SpinnerBonusTick : SpinnerTick
     {
-        public new const int SCORE_PER_TICK = 50;
-
         public SpinnerBonusTick()
         {
             Samples.Add(new HitSampleInfo { Name = "spinnerbonus" });
@@ -20,7 +18,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerBonusTickJudgement : OsuSpinnerTickJudgement
         {
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SCORE_PER_TICK : 0;
+            public override HitResult MaxResult => HitResult.SmallBonus;
+
+            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_BONUS_RESULT : 0;
 
             protected override double HealthIncreaseFor(HitResult result) => base.HealthIncreaseFor(result) * 2;
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
@@ -18,9 +18,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerBonusTickJudgement : OsuSpinnerTickJudgement
         {
-            public override HitResult MaxResult => HitResult.SmallBonus;
+            public override HitResult MaxResult => HitResult.LargeBonusHit;
 
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_BONUS_RESULT : 0;
+            protected override int NumericResultFor(HitResult result) => result == MaxResult ? LARGE_BONUS_RESULT : 0;
 
             protected override double HealthIncreaseFor(HitResult result) => base.HealthIncreaseFor(result) * 2;
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
@@ -9,17 +9,17 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SpinnerTick : OsuHitObject
     {
-        public const int SCORE_PER_TICK = 10;
-
         public override Judgement CreateJudgement() => new OsuSpinnerTickJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
 
         public class OsuSpinnerTickJudgement : OsuJudgement
         {
+            public override HitResult MaxResult => HitResult.SmallTickHit;
+
             public override bool AffectsCombo => false;
 
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SCORE_PER_TICK : 0;
+            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_TICK_RESULT : 0;
 
             protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.6 * base.HealthIncreaseFor(result) : 0;
         }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
@@ -15,11 +15,11 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerTickJudgement : OsuJudgement
         {
-            public override HitResult MaxResult => HitResult.SmallTickHit;
+            public override HitResult MaxResult => HitResult.SmallBonusHit;
 
             public override bool AffectsCombo => false;
 
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_TICK_RESULT : 0;
+            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_BONUS_RESULT : 0;
 
             protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.6 * base.HealthIncreaseFor(result) : 0;
         }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -27,5 +27,19 @@ namespace osu.Game.Rulesets.Osu.Scoring
         }
 
         public override HitWindows CreateHitWindows() => new OsuHitWindows();
+
+        protected override int GetNumericBonusResult(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.SmallBonusHit:
+                    return OsuJudgement.SMALL_BONUS_RESULT;
+
+                case HitResult.LargeBonusHit:
+                    return OsuJudgement.LARGE_BONUS_RESULT;
+            }
+
+            return 0;
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
@@ -7,30 +7,12 @@ namespace osu.Game.Rulesets.Taiko.Judgements
 {
     public class TaikoDrumRollTickJudgement : TaikoJudgement
     {
+        public override HitResult MaxResult => HitResult.SmallBonusHit;
+
         public override bool AffectsCombo => false;
 
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.Great:
-                    return 200;
+        protected override int NumericResultFor(HitResult result) => result == MaxResult ? SMALL_BONUS_RESULT : 0;
 
-                default:
-                    return 0;
-            }
-        }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.Great:
-                    return 0.15;
-
-                default:
-                    return 0;
-            }
-        }
+        protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.15 : 0;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoJudgement.cs
@@ -8,6 +8,9 @@ namespace osu.Game.Rulesets.Taiko.Judgements
 {
     public class TaikoJudgement : Judgement
     {
+        public const int SMALL_BONUS_RESULT = 200;
+        public const int LARGE_BONUS_RESULT = 300;
+
         public override HitResult MaxResult => HitResult.Great;
 
         protected override int NumericResultFor(HitResult result)

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoStrongJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoStrongJudgement.cs
@@ -7,9 +7,13 @@ namespace osu.Game.Rulesets.Taiko.Judgements
 {
     public class TaikoStrongJudgement : TaikoJudgement
     {
+        public override HitResult MaxResult => HitResult.LargeBonusHit;
+
         // MainObject already changes the HP
         protected override double HealthIncreaseFor(HitResult result) => 0;
 
         public override bool AffectsCombo => false;
+
+        protected override int NumericResultFor(HitResult result) => result == MaxResult ? LARGE_BONUS_RESULT : 0;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Judgements;
 
 namespace osu.Game.Rulesets.Taiko.Scoring
 {
@@ -12,5 +13,19 @@ namespace osu.Game.Rulesets.Taiko.Scoring
         protected override double DefaultComboPortion => 0.25;
 
         public override HitWindows CreateHitWindows() => new TaikoHitWindows();
+
+        protected override int GetNumericBonusResult(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.SmallBonusHit:
+                    return TaikoJudgement.SMALL_BONUS_RESULT;
+
+                case HitResult.LargeBonusHit:
+                    return TaikoJudgement.LARGE_BONUS_RESULT;
+            }
+
+            return 0;
+        }
     }
 }

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// Whether a successful hit occurred.
         /// </summary>
-        public bool IsHit => Type > HitResult.Miss;
+        public bool IsHit => Type > HitResult.Miss && Type != HitResult.SmallTickMiss && Type != HitResult.LargeTickMiss;
 
         /// <summary>
         /// Creates a new <see cref="JudgementResult"/>.

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -62,6 +62,26 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Indicates a large tick hit.
         /// </summary>
-        LargeTickHit
+        LargeTickHit,
+
+        /// <summary>
+        /// Indicates a small bonus hit.
+        /// </summary>
+        SmallBonusHit,
+
+        /// <summary>
+        /// Indicates a small bonus miss.
+        /// </summary>
+        SmallBonusMiss,
+
+        /// <summary>
+        /// Indicates a large bonus hit.
+        /// </summary>
+        LargeBonusHit,
+
+        /// <summary>
+        /// Indicates a large bonus hit.
+        /// </summary>
+        LargeBonusMiss,
     }
 }

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -70,18 +70,8 @@ namespace osu.Game.Rulesets.Scoring
         SmallBonusHit,
 
         /// <summary>
-        /// Indicates a small bonus miss.
-        /// </summary>
-        SmallBonusMiss,
-
-        /// <summary>
         /// Indicates a large bonus hit.
         /// </summary>
         LargeBonusHit,
-
-        /// <summary>
-        /// Indicates a large bonus hit.
-        /// </summary>
-        LargeBonusMiss,
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -204,10 +204,15 @@ namespace osu.Game.Rulesets.Scoring
 
         private double getScore(ScoringMode mode)
         {
+            double calculatedBonusScore = 0;
+
+            calculatedBonusScore += GetStatistic(HitResult.SmallBonusHit) * GetNumericBonusResult(HitResult.SmallBonusHit);
+            calculatedBonusScore += GetStatistic(HitResult.LargeBonusHit) * GetNumericBonusResult(HitResult.LargeBonusHit);
+
             return GetScore(mode, maxHighestCombo,
                 maxBaseScore > 0 ? baseScore / maxBaseScore : 0,
                 maxHighestCombo > 0 ? (double)HighestCombo.Value / maxHighestCombo : 0,
-                bonusScore);
+                calculatedBonusScore);
         }
 
         /// <summary>
@@ -321,6 +326,20 @@ namespace osu.Game.Rulesets.Scoring
         /// Create a <see cref="HitWindows"/> for this processor.
         /// </summary>
         public virtual HitWindows CreateHitWindows() => new HitWindows();
+
+        protected virtual int GetNumericBonusResult(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.SmallBonusHit:
+                    return 10;
+
+                case HitResult.LargeBonusHit:
+                    return 50;
+            }
+
+            return 0;
+        }
     }
 
     public enum ScoringMode

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -123,6 +123,8 @@ namespace osu.Game.Rulesets.Scoring
                     case HitResult.None:
                         break;
 
+                    case HitResult.SmallTickMiss:
+                    case HitResult.LargeTickMiss:
                     case HitResult.Miss:
                         Combo.Value = 0;
                         break;
@@ -133,7 +135,7 @@ namespace osu.Game.Rulesets.Scoring
                 }
             }
 
-            double scoreIncrease = result.Type == HitResult.Miss ? 0 : result.Judgement.NumericResultFor(result);
+            double scoreIncrease = result.IsHit ? result.Judgement.NumericResultFor(result) : 0;
 
             if (result.Judgement.IsBonus)
             {
@@ -174,7 +176,7 @@ namespace osu.Game.Rulesets.Scoring
             if (result.FailedAtJudgement)
                 return;
 
-            double scoreIncrease = result.Type == HitResult.Miss ? 0 : result.Judgement.NumericResultFor(result);
+            double scoreIncrease = result.IsHit ? result.Judgement.NumericResultFor(result) : 0;
 
             if (result.Judgement.IsBonus)
             {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -138,7 +138,10 @@ namespace osu.Game.Rulesets.Scoring
             if (result.Judgement.IsBonus)
             {
                 if (result.IsHit)
+                {
                     bonusScore += scoreIncrease;
+                    scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) + 1;
+                }
             }
             else
             {
@@ -176,7 +179,10 @@ namespace osu.Game.Rulesets.Scoring
             if (result.Judgement.IsBonus)
             {
                 if (result.IsHit)
+                {
                     bonusScore -= scoreIncrease;
+                    scoreResultCounts[result.Type] = scoreResultCounts.GetOrDefault(result.Type) - 1;
+                }
             }
             else
             {

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -170,18 +170,15 @@ namespace osu.Game.Scoring
 
             private void updateScore(int beatmapMaxCombo)
             {
-                if (beatmapMaxCombo == 0)
-                {
-                    Value = 0;
-                    return;
-                }
-
                 var ruleset = score.Ruleset.CreateInstance();
-                var scoreProcessor = ruleset.CreateScoreProcessor();
 
+                var scoreProcessor = ruleset.CreateScoreProcessor();
                 scoreProcessor.Mods.Value = score.Mods;
 
-                Value = (long)Math.Round(scoreProcessor.GetScore(ScoringMode.Value, beatmapMaxCombo, score.Accuracy, (double)score.MaxCombo / beatmapMaxCombo, 0));
+                Value = (long)Math.Round(scoreProcessor.GetScore(ScoringMode.Value, beatmapMaxCombo,
+                    beatmapMaxCombo > 0 ? score.Accuracy : 0,
+                    beatmapMaxCombo > 0 ? (double)score.MaxCombo / beatmapMaxCombo : 0,
+                    score.Statistics));
             }
         }
 


### PR DESCRIPTION
PRing for comments, not merge, because I don't like the way this is going and want to start up a conversation while brainstorming how this flow should work.

- [x] `IsHit` doesn't consider `SmallTickMiss` or `LargeTickMiss`.
- [x] `ScoreProcessor.ApplyResult`/`RevertResult` don't consider combo breaks on `SmallTickMiss` or `LargeTickMiss`.
- [ ] Performance calculator support.
- [ ] Need to fix the hacky auto statistic writing of `ScoreProcessor`.
- [ ] I don't like the `ScoreProcessor.GetNumericBonusResult()` method, but I don't know how to improve this yet.

It feels like bonuses, and potentially ticks, should be kept separate to the main hit results somehow. It's all getting to be too much of a mess.