### PR TITLE
Ensure track is looping in song select immediately

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -517,6 +517,8 @@ namespace osu.Game.Screens.Select
             FilterControl.Activate();
 
             ModSelect.SelectedMods.BindTo(selectedMods);
+
+            music.TrackChanged += ensureTrackLooping;
         }
 
         private const double logo_transition = 250;
@@ -568,6 +570,7 @@ namespace osu.Game.Screens.Select
             BeatmapDetails.Refresh();
 
             music.CurrentTrack.Looping = true;
+            music.TrackChanged += ensureTrackLooping;
             music.ResetTrackAdjustments();
 
             if (Beatmap != null && !Beatmap.Value.BeatmapSetInfo.DeletePending)
@@ -593,6 +596,7 @@ namespace osu.Game.Screens.Select
             BeatmapOptions.Hide();
 
             music.CurrentTrack.Looping = false;
+            music.TrackChanged -= ensureTrackLooping;
 
             this.ScaleTo(1.1f, 250, Easing.InSine);
 
@@ -614,9 +618,13 @@ namespace osu.Game.Screens.Select
             FilterControl.Deactivate();
 
             music.CurrentTrack.Looping = false;
+            music.TrackChanged -= ensureTrackLooping;
 
             return false;
         }
+
+        private void ensureTrackLooping(WorkingBeatmap beatmap, TrackChangeDirection changeDirection)
+            => music.CurrentTrack.Looping = true;
 
         public override bool OnBackButton()
         {
@@ -653,8 +661,6 @@ namespace osu.Game.Screens.Select
             beatmapInfoWedge.Beatmap = beatmap;
 
             BeatmapDetails.Beatmap = beatmap;
-
-            music.CurrentTrack.Looping = true;
         }
 
         private readonly WeakReference<ITrack> lastTrack = new WeakReference<ITrack>(null);

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -642,6 +642,7 @@ namespace osu.Game.Screens.Select
             base.Dispose(isDisposing);
 
             decoupledRuleset.UnbindAll();
+            music.TrackChanged -= ensureTrackLooping;
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #10127.

# Summary

I'm PRing this mostly for feedback. As I mentioned in the issue thread, tests exposed that it was possible for tracks to complete and switch away on their own in song select instead of looping, therefore causing a potential race between asserts checking the track and the track switching away in song select tests that caused the intermittent failure.

The reason it was possible for the track to switch away is that because the looping flag was being set in the following call tree:

```
performUpdateSelected+run()
    updateComponentFromBeatmap()
```

which doesn't necessarily execute right away - it can be delayed up to 200ms if a map was previously selected:

https://github.com/ppy/osu/blob/5740fc2bd099b2141f2d5c9be7282611f769012c/osu.Game/Screens/Select/SongSelect.cs#L454-L457

The resolution aims to resolve this by subscribing to `MusicController.TrackChanged` to immediately set the loop flag on every track change handled by the music controller.

This can be tested by running `TestScenePlaySongSelect.TestPresentNewBeatmapNewRuleset` *in the visual test browser* (*not* headless with nunit runner, as in that variant asserts can pretty often win the race). In visual tests the test should fail almost every time and look wrong on `master`, and work with this branch.

# Remarks

[As discussed on discord](https://discord.com/channels/188630481301012481/188630652340404224/754297416039006269), the alternatives were:

* moving the `Looping = true` set somewhere where it would be executed immediately in the beatmap change callback, but it would have to be scheduled to be 100% safe, because the music controller *also* changes track in a beatmap change callback, so without the schedule we'd be relying on callback execution order for the fix to work,
* adding some sort of global field in `MusicController` that would have all loaded tracks loop - sucks because now there are two sources for one setting.

This resolution has some risk in it because events, so there's a potential for missed unsubscribes, but compared to the alternatives above I think it's way better. I've tested it a little bit and it seems to behave ok and pass tests, but this is the sort of change where I wouldn't necessarily trust that that's enough to catch all possible kinks.