### PR TITLE
Fix mod select overlay absorbing input from toolbar ruleset selector

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -6,9 +6,11 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
+using osu.Game.Overlays.Toolbar;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
 using osu.Game.Tests.Beatmaps.IO;
@@ -141,6 +143,29 @@ namespace osu.Game.Tests.Visual.Navigation
 
             AddUntilStep("Track was completed", () => trackCompleted);
             AddUntilStep("Track was restarted", () => Game.MusicController.IsPlaying);
+        }
+
+        [Test]
+        public void TestModSelectInput()
+        {
+            TestSongSelect songSelect = null;
+
+            PushAndConfirm(() => songSelect = new TestSongSelect());
+
+            AddStep("Show mods overlay", () => songSelect.ModSelectOverlay.Show());
+
+            AddStep("Change ruleset to osu!taiko", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.Number2);
+
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.Number2);
+            });
+
+            AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.ID == 1);
+
+            AddAssert("Mods overlay still visible", () => songSelect.ModSelectOverlay.State.Value == Visibility.Visible);
         }
 
         private void pushEscape() =>

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -390,6 +390,9 @@ namespace osu.Game.Overlays.Mods
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            // don't absorb control as ToolbarRulesetSelector uses control + number to navigate
+            if (e.ControlPressed) return false;
+
             switch (e.Key)
             {
                 case Key.Number1:


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/8001.

This is because `ModSelectOverlay` is a `WaveOverlayContainer` and will prioritize input because it'll get focus when visible. I did a local fix in `ModSelectOverlay` for now, since I don't know the regressions this'll cause if put in `OsuFocusedOverlayContainer`.

In https://github.com/ppy/osu/issues/10123, I'm changing `BeatmapOptionsOverlay` to *handle* input of all the buttons to avoid hardcoded key params but the same exact issue happens. Once I PR that, it would have the same fix as done here.