### PR TITLE
Fix anchoring for TeamHeader in TeamDisplay

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                                         AutoSizeAxes = Axes.Both,
                                         Direction = FillDirection.Horizontal,
                                         Spacing = new Vector2(5),
+                                        Origin = anchor,
+                                        Anchor = anchor,
                                         Children = new Drawable[]
                                         {
                                             new DrawableTeamHeader(colour)


### PR DESCRIPTION
The FillFlowContainer that contains TeamScore and the TeamHeader had no anchor and origin, as a result the Blue Team's header moved to the left whenever warmup was toggled to be on (showScore = false). By adding the anchors it now stays put on the right (and left respectively). 

Before: 
![dotnet_2020-09-13_21-05-49](https://user-images.githubusercontent.com/803255/93026261-0bb67e00-f605-11ea-9dd1-2d6a6ff58a76.png)

After: 
![dotnet_2020-09-13_21-04-57](https://user-images.githubusercontent.com/803255/93026265-140eb900-f605-11ea-98d2-b1c312abf7db.png)
