### PR TITLE
Add manage collections button to beatmap options

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -13,6 +13,7 @@ using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Options;
 using osu.Game.Tests.Beatmaps.IO;
 using osuTK;
 using osuTK.Input;
@@ -168,6 +169,29 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("Mods overlay still visible", () => songSelect.ModSelectOverlay.State.Value == Visibility.Visible);
         }
 
+        [Test]
+        public void TestBeatmapOptionsInput()
+        {
+            TestSongSelect songSelect = null;
+
+            PushAndConfirm(() => songSelect = new TestSongSelect());
+
+            AddStep("Show options overlay", () => songSelect.BeatmapOptionsOverlay.Show());
+
+            AddStep("Change ruleset to osu!taiko", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.Number2);
+
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.Number2);
+            });
+
+            AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.ID == 1);
+
+            AddAssert("Options overlay still visible", () => songSelect.BeatmapOptionsOverlay.State.Value == Visibility.Visible);
+        }
+
         private void pushEscape() =>
             AddStep("Press escape", () => pressAndRelease(Key.Escape));
 
@@ -193,6 +217,8 @@ namespace osu.Game.Tests.Visual.Navigation
         private class TestSongSelect : PlaySongSelect
         {
             public ModSelectOverlay ModSelectOverlay => ModSelect;
+
+            public BeatmapOptionsOverlay BeatmapOptionsOverlay => BeatmapOptions;
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Screens.Select.Options;
 using osuTK.Graphics;
-using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
@@ -16,10 +15,10 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             var overlay = new BeatmapOptionsOverlay();
 
-            overlay.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, Color4.Purple, null, Key.Number1);
-            overlay.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, Color4.Purple, null, Key.Number2);
-            overlay.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, Color4.Pink, null, Key.Number3);
-            overlay.AddButton(@"Edit", @"beatmap", FontAwesome.Solid.PencilAlt, Color4.Yellow, null, Key.Number4);
+            overlay.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, Color4.Purple, null);
+            overlay.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, Color4.Purple, null);
+            overlay.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, Color4.Pink, null);
+            overlay.AddButton(@"Edit", @"beatmap", FontAwesome.Solid.PencilAlt, Color4.Yellow, null);
 
             Add(overlay);
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             var colours = new OsuColour();
 
+            overlay.AddButton(@"Manage", @"collections", FontAwesome.Solid.Book, colours.Green, null);
             overlay.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
             overlay.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, null);
             overlay.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, null);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
@@ -18,9 +18,9 @@ namespace osu.Game.Tests.Visual.SongSelect
             var colours = new OsuColour();
 
             overlay.AddButton(@"Manage", @"collections", FontAwesome.Solid.Book, colours.Green, null);
+            overlay.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, null);
             overlay.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
             overlay.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, null);
-            overlay.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, null);
             overlay.AddButton(@"Edit", @"beatmap", FontAwesome.Solid.PencilAlt, colours.Yellow, null);
 
             Add(overlay);

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapOptionsOverlay.cs
@@ -3,8 +3,8 @@
 
 using System.ComponentModel;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Screens.Select.Options;
-using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
@@ -15,10 +15,12 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             var overlay = new BeatmapOptionsOverlay();
 
-            overlay.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, Color4.Purple, null);
-            overlay.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, Color4.Purple, null);
-            overlay.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, Color4.Pink, null);
-            overlay.AddButton(@"Edit", @"beatmap", FontAwesome.Solid.PencilAlt, Color4.Yellow, null);
+            var colours = new OsuColour();
+
+            overlay.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
+            overlay.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, null);
+            overlay.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, null);
+            overlay.AddButton(@"Edit", @"beatmap", FontAwesome.Solid.PencilAlt, colours.Yellow, null);
 
             Add(overlay);
 

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
@@ -52,8 +52,6 @@ namespace osu.Game.Screens.Select.Options
             set => secondLine.Text = value;
         }
 
-        public Key? HotKey;
-
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             flash.FadeTo(0.1f, 1000, Easing.OutQuint);
@@ -73,17 +71,6 @@ namespace osu.Game.Screens.Select.Options
             flash.FadeOut(800, Easing.OutExpo);
 
             return base.OnClick(e);
-        }
-
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (!e.Repeat && e.Key == HotKey)
-            {
-                Click();
-                return true;
-            }
-
-            return false;
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
@@ -12,7 +12,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
-using osuTK.Input;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Screens.Select.Options

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
@@ -27,33 +27,6 @@ namespace osu.Game.Screens.Select.Options
 
         public override bool BlockScreenWideMouse => false;
 
-        protected override void PopIn()
-        {
-            base.PopIn();
-
-            this.FadeIn(transition_duration, Easing.OutQuint);
-
-            if (buttonsContainer.Position.X == 1 || Alpha == 0)
-                buttonsContainer.MoveToX(x_position - x_movement);
-
-            holder.ScaleTo(new Vector2(1, 1), transition_duration / 2, Easing.OutQuint);
-
-            buttonsContainer.MoveToX(x_position, transition_duration, Easing.OutQuint);
-            buttonsContainer.TransformSpacingTo(Vector2.Zero, transition_duration, Easing.OutQuint);
-        }
-
-        protected override void PopOut()
-        {
-            base.PopOut();
-
-            holder.ScaleTo(new Vector2(1, 0), transition_duration / 2, Easing.InSine);
-
-            buttonsContainer.MoveToX(x_position + x_movement, transition_duration, Easing.InSine);
-            buttonsContainer.TransformSpacingTo(new Vector2(200f, 0f), transition_duration, Easing.InSine);
-
-            this.FadeOut(transition_duration, Easing.InQuint);
-        }
-
         public BeatmapOptionsOverlay()
         {
             AutoSizeAxes = Axes.Y;
@@ -106,6 +79,33 @@ namespace osu.Game.Screens.Select.Options
             };
 
             buttonsContainer.Add(button);
+        }
+
+        protected override void PopIn()
+        {
+            base.PopIn();
+
+            this.FadeIn(transition_duration, Easing.OutQuint);
+
+            if (buttonsContainer.Position.X == 1 || Alpha == 0)
+                buttonsContainer.MoveToX(x_position - x_movement);
+
+            holder.ScaleTo(new Vector2(1, 1), transition_duration / 2, Easing.OutQuint);
+
+            buttonsContainer.MoveToX(x_position, transition_duration, Easing.OutQuint);
+            buttonsContainer.TransformSpacingTo(Vector2.Zero, transition_duration, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            base.PopOut();
+
+            holder.ScaleTo(new Vector2(1, 0), transition_duration / 2, Easing.InSine);
+
+            buttonsContainer.MoveToX(x_position + x_movement, transition_duration, Easing.InSine);
+            buttonsContainer.TransformSpacingTo(new Vector2(200f, 0f), transition_duration, Easing.InSine);
+
+            this.FadeOut(transition_duration, Easing.InQuint);
         }
     }
 }

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
@@ -11,6 +11,8 @@ using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
 using osu.Game.Graphics.Containers;
+using osu.Framework.Input.Events;
+using System.Linq;
 
 namespace osu.Game.Screens.Select.Options
 {
@@ -60,9 +62,8 @@ namespace osu.Game.Screens.Select.Options
         /// <param name="secondLine">Text in the second line.</param>
         /// <param name="colour">Colour of the button.</param>
         /// <param name="icon">Icon of the button.</param>
-        /// <param name="hotkey">Hotkey of the button.</param>
         /// <param name="action">Binding the button does.</param>
-        public void AddButton(string firstLine, string secondLine, IconUsage icon, Color4 colour, Action action, Key? hotkey = null)
+        public void AddButton(string firstLine, string secondLine, IconUsage icon, Color4 colour, Action action)
         {
             var button = new BeatmapOptionsButton
             {
@@ -75,7 +76,6 @@ namespace osu.Game.Screens.Select.Options
                     Hide();
                     action?.Invoke();
                 },
-                HotKey = hotkey
             };
 
             buttonsContainer.Add(button);
@@ -106,6 +106,25 @@ namespace osu.Game.Screens.Select.Options
             buttonsContainer.TransformSpacingTo(new Vector2(200f, 0f), transition_duration, Easing.InSine);
 
             this.FadeOut(transition_duration, Easing.InQuint);
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (!e.Repeat && e.Key >= Key.Number1 && e.Key <= Key.Number9)
+            {
+                int requested = e.Key - Key.Number1;
+
+                // go reverse as buttonsContainer is a ReverseChildIDFillFlowContainer
+                BeatmapOptionsButton found = buttonsContainer.Children.ElementAtOrDefault((buttonsContainer.Children.Count - 1) - requested);
+
+                if (found != null)
+                {
+                    found.Click();
+                    return true;
+                }
+            }
+
+            return base.OnKeyDown(e);
         }
     }
 }

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
@@ -110,6 +110,9 @@ namespace osu.Game.Screens.Select.Options
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            // don't absorb control as ToolbarRulesetSelector uses control + number to navigate
+            if (e.ControlPressed) return false;
+
             if (!e.Repeat && e.Key >= Key.Number1 && e.Key <= Key.Number9)
             {
                 int requested = e.Key - Key.Number1;

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Select
             {
                 ValidForResume = false;
                 Edit();
-            }, Key.Number4);
+            });
 
             ((PlayBeatmapDetailArea)BeatmapDetails).Leaderboard.ScoreSelected += PresentScore;
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -103,11 +103,8 @@ namespace osu.Game.Screens.Select
         [Resolved]
         private MusicController music { get; set; }
 
-        [Resolved(CanBeNull = true)]
-        private ManageCollectionsDialog manageCollectionsDialog { get; set; }
-
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores, CollectionManager collections)
+        private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores, CollectionManager collections, ManageCollectionsDialog manageCollectionsDialog)
         {
             // initial value transfer is required for FilterControl (it uses our re-cached bindables in its async load for the initial filter).
             transferRulesetValue();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -275,9 +275,9 @@ namespace osu.Game.Screens.Select
                 Footer.AddButton(new FooterButtonRandom { Action = triggerRandom });
                 Footer.AddButton(new FooterButtonOptions(), BeatmapOptions);
 
-                BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null, Key.Number1);
-                BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, () => clearScores(Beatmap.Value.BeatmapInfo), Key.Number2);
-                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo), Key.Number3);
+                BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
+                BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, () => clearScores(Beatmap.Value.BeatmapInfo));
+                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo));
             }
 
             dialogOverlay = dialog;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -279,9 +279,9 @@ namespace osu.Game.Screens.Select
                 Footer.AddButton(new FooterButtonOptions(), BeatmapOptions);
 
                 BeatmapOptions.AddButton(@"Manage", @"collections", FontAwesome.Solid.Book, colours.Green, () => manageCollectionsDialog?.Show());
+                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo));
                 BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
                 BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, () => clearScores(Beatmap.Value.BeatmapInfo));
-                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo));
             }
 
             dialogOverlay = dialog;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -103,6 +103,9 @@ namespace osu.Game.Screens.Select
         [Resolved]
         private MusicController music { get; set; }
 
+        [Resolved(CanBeNull = true)]
+        private ManageCollectionsDialog manageCollectionsDialog { get; set; }
+
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores, CollectionManager collections)
         {
@@ -275,6 +278,7 @@ namespace osu.Game.Screens.Select
                 Footer.AddButton(new FooterButtonRandom { Action = triggerRandom });
                 Footer.AddButton(new FooterButtonOptions(), BeatmapOptions);
 
+                BeatmapOptions.AddButton(@"Manage", @"collections", FontAwesome.Solid.Book, colours.Green, () => manageCollectionsDialog?.Show());
                 BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
                 BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, () => clearScores(Beatmap.Value.BeatmapInfo));
                 BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo));


### PR DESCRIPTION
Kinda resolves https://github.com/ppy/osu/issues/10123. I matched stable behavior, but the manage collections dialog/overlay doesn't support adding yet though.

Most changes are the input regression test as I made `BeatmapOptionsOverlay` handle input of the buttons now.

Copied the navigation code from `ToolbarRulesetSelector` with minor tweaks.
https://github.com/ppy/osu/blob/16d32f5246f0daf1cfaa967e909418cd336e4f8b/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs#L94-L109