### PR TITLE
Fix mania scrollspeed slider precision

### DIFF
--- a/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mania.Configuration
         {
             base.InitialiseDefaults();
 
-            Set(ManiaRulesetSetting.ScrollTime, 1500.0, DrawableManiaRuleset.MIN_TIME_RANGE, DrawableManiaRuleset.MAX_TIME_RANGE, 1);
+            Set(ManiaRulesetSetting.ScrollTime, 1500.0, DrawableManiaRuleset.MIN_TIME_RANGE, DrawableManiaRuleset.MAX_TIME_RANGE, 5);
             Set(ManiaRulesetSetting.ScrollDirection, ManiaScrollingDirection.Down);
         }
 

--- a/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
@@ -34,7 +34,8 @@ namespace osu.Game.Rulesets.Mania
                 new SettingsSlider<double, TimeSlider>
                 {
                     LabelText = "Scroll speed",
-                    Bindable = config.GetBindable<double>(ManiaRulesetSetting.ScrollTime)
+                    Bindable = config.GetBindable<double>(ManiaRulesetSetting.ScrollTime),
+                    KeyboardStep = 5
                 },
             };
         }


### PR DESCRIPTION
This should partly fix #9689 by adding a decently accurate keyboard step to the mania scroll speed slider, thereby making it possible to accurately change its value.

The major underlying issue imo is that the range of the slider is just way too large, but that should probably be addressed elsewhere.