### PR TITLE
Pause playback in present tests to avoid track inadvertently changing at menu

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -74,6 +74,13 @@ namespace osu.Game.Tests.Visual.Navigation
 
         private void returnToMenu()
         {
+            // if we don't pause, there's a chance the track may change at the main menu out of our control (due to reaching the end of the track).
+            AddStep("pause audio", () =>
+            {
+                if (Game.MusicController.IsPlaying)
+                    Game.MusicController.TogglePause();
+            });
+
             AddStep("return to menu", () => Game.ScreenStack.CurrentScreen.Exit());
             AddUntilStep("wait for menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
         }

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
@@ -110,6 +110,13 @@ namespace osu.Game.Tests.Visual.Navigation
 
         private void returnToMenu()
         {
+            // if we don't pause, there's a chance the track may change at the main menu out of our control (due to reaching the end of the track).
+            AddStep("pause audio", () =>
+            {
+                if (Game.MusicController.IsPlaying)
+                    Game.MusicController.TogglePause();
+            });
+
             AddStep("return to menu", () => Game.ScreenStack.CurrentScreen.Exit());
             AddUntilStep("wait for menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
         }


### PR DESCRIPTION
Similar to https://github.com/ppy/osu/issues/10127, but in these tests we return to the main menu, where looping is removed.

This seems like the best way to handle this for now..