### PR TITLE
Fix tick miss judgments not breaking combo

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -31,37 +31,49 @@ namespace osu.Game.Tests.Gameplay
         [Test]
         public void TestOnlyBonusScore()
         {
-            var beatmap = new Beatmap<TestBonusHitObject> { HitObjects = { new TestBonusHitObject() } };
+            var beatmap = new Beatmap<TestHitObject> { HitObjects = { new TestHitObject(false) } };
 
             var scoreProcessor = new ScoreProcessor();
             scoreProcessor.ApplyBeatmap(beatmap);
 
             // Apply a judgement
-            scoreProcessor.ApplyResult(new JudgementResult(new TestBonusHitObject(), new TestBonusJudgement()) { Type = HitResult.Perfect });
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], beatmap.HitObjects[0].CreateJudgement()) { Type = HitResult.Perfect });
 
             Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(100));
         }
 
         private class TestHitObject : HitObject
         {
-            public override Judgement CreateJudgement() => new TestJudgement();
+            private readonly bool affectsCombo;
+            private readonly int numericResult;
+            private readonly HitResult maxResult;
+
+            public TestHitObject(bool affectsCombo = true, int numericResult = 100, HitResult maxResult = HitResult.Perfect)
+            {
+                this.affectsCombo = affectsCombo;
+                this.numericResult = numericResult;
+                this.maxResult = maxResult;
+            }
+
+            public override Judgement CreateJudgement() => new TestJudgement(affectsCombo, numericResult, maxResult);
         }
 
         private class TestJudgement : Judgement
         {
-            protected override int NumericResultFor(HitResult result) => 100;
-        }
+            private readonly int numericResult;
 
-        private class TestBonusHitObject : HitObject
-        {
-            public override Judgement CreateJudgement() => new TestBonusJudgement();
-        }
+            public TestJudgement(bool affectsCombo = true, int numericResult = 100, HitResult maxResult = HitResult.Perfect)
+            {
+                AffectsCombo = affectsCombo;
+                this.numericResult = numericResult;
+                MaxResult = maxResult;
+            }
 
-        private class TestBonusJudgement : Judgement
-        {
-            public override bool AffectsCombo => false;
+            protected override int NumericResultFor(HitResult result) => numericResult;
 
-            protected override int NumericResultFor(HitResult result) => 100;
+            public override bool AffectsCombo { get; }
+
+            public override HitResult MaxResult { get; }
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -14,6 +14,16 @@ namespace osu.Game.Rulesets.Scoring
         None,
 
         /// <summary>
+        /// Indicates small tick miss.
+        /// </summary>
+        SmallTickMiss,
+
+        /// <summary>
+        /// Indicates a large tick miss.
+        /// </summary>
+        LargeTickMiss,
+
+        /// <summary>
         /// Indicates that the object has been judged as a miss.
         /// </summary>
         /// <remarks>
@@ -45,19 +55,9 @@ namespace osu.Game.Rulesets.Scoring
         Perfect,
 
         /// <summary>
-        /// Indicates small tick miss.
-        /// </summary>
-        SmallTickMiss,
-
-        /// <summary>
         /// Indicates a small tick hit.
         /// </summary>
         SmallTickHit,
-
-        /// <summary>
-        /// Indicates a large tick miss.
-        /// </summary>
-        LargeTickMiss,
 
         /// <summary>
         /// Indicates a large tick hit.

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -118,22 +118,13 @@ namespace osu.Game.Rulesets.Scoring
 
             if (result.Judgement.AffectsCombo)
             {
-                switch (result.Type)
-                {
-                    case HitResult.None:
-                        break;
-
-                    case HitResult.Miss:
-                        Combo.Value = 0;
-                        break;
-
-                    default:
-                        Combo.Value++;
-                        break;
-                }
+                if (result.Type > HitResult.Miss)
+                    Combo.Value++;
+                else if (result.Type > HitResult.None)
+                    Combo.Value = 0;
             }
 
-            double scoreIncrease = result.Type == HitResult.Miss ? 0 : result.Judgement.NumericResultFor(result);
+            double scoreIncrease = result.IsHit ? result.Judgement.NumericResultFor(result) : 0;
 
             if (result.Judgement.IsBonus)
             {
@@ -171,7 +162,7 @@ namespace osu.Game.Rulesets.Scoring
             if (result.FailedAtJudgement)
                 return;
 
-            double scoreIncrease = result.Type == HitResult.Miss ? 0 : result.Judgement.NumericResultFor(result);
+            double scoreIncrease = result.IsHit ? result.Judgement.NumericResultFor(result) : 0;
 
             if (result.Judgement.IsBonus)
             {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -110,6 +110,8 @@ namespace osu.Game.Rulesets.Scoring
 
         protected sealed override void ApplyResultInternal(JudgementResult result)
         {
+            Debug.Assert(result.Type > HitResult.None);
+
             result.ComboAtJudgement = Combo.Value;
             result.HighestComboAtJudgement = HighestCombo.Value;
 
@@ -120,7 +122,7 @@ namespace osu.Game.Rulesets.Scoring
             {
                 if (result.Type > HitResult.Miss)
                     Combo.Value++;
-                else if (result.Type > HitResult.None)
+                else
                     Combo.Value = 0;
             }
 
@@ -156,6 +158,8 @@ namespace osu.Game.Rulesets.Scoring
 
         protected sealed override void RevertResultInternal(JudgementResult result)
         {
+            Debug.Assert(result.Type > HitResult.None);
+
             Combo.Value = result.ComboAtJudgement;
             HighestCombo.Value = result.HighestComboAtJudgement;
 


### PR DESCRIPTION
This doesn't affect any of our rulesets, since we don't use these judgements yet. There are more issues with `IsHit`, but I'll tackle those in a separate PR...

Also fixes the miss judgements potentially awarding score, which was fixed for `HitResult.Miss` previously.