### PR TITLE
Fix potential nullref in FilterControl during asynchronous load

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -66,23 +66,8 @@ namespace osu.Game.Screens.Select
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(OsuColour colours, IBindable<RulesetInfo> parentRuleset, OsuConfigManager config)
         {
-            config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConverted);
-            showConverted.ValueChanged += _ => updateCriteria();
-
-            config.BindWith(OsuSetting.DisplayStarsMinimum, minimumStars);
-            minimumStars.ValueChanged += _ => updateCriteria();
-
-            config.BindWith(OsuSetting.DisplayStarsMaximum, maximumStars);
-            maximumStars.ValueChanged += _ => updateCriteria();
-
-            ruleset.BindTo(parentRuleset);
-            ruleset.BindValueChanged(_ => updateCriteria());
-
             sortMode = config.GetBindable<SortMode>(OsuSetting.SongSelectSortingMode);
             groupMode = config.GetBindable<GroupMode>(OsuSetting.SongSelectGroupingMode);
-
-            groupMode.BindValueChanged(_ => updateCriteria());
-            sortMode.BindValueChanged(_ => updateCriteria());
 
             Children = new Drawable[]
             {
@@ -181,6 +166,21 @@ namespace osu.Game.Screens.Select
                     }
                 }
             };
+
+            config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConverted);
+            showConverted.ValueChanged += _ => updateCriteria();
+
+            config.BindWith(OsuSetting.DisplayStarsMinimum, minimumStars);
+            minimumStars.ValueChanged += _ => updateCriteria();
+
+            config.BindWith(OsuSetting.DisplayStarsMaximum, maximumStars);
+            maximumStars.ValueChanged += _ => updateCriteria();
+
+            ruleset.BindTo(parentRuleset);
+            ruleset.BindValueChanged(_ => updateCriteria());
+
+            groupMode.BindValueChanged(_ => updateCriteria());
+            sortMode.BindValueChanged(_ => updateCriteria());
 
             collectionDropdown.Current.ValueChanged += val =>
             {


### PR DESCRIPTION
Yes, these bindables should probably be bound in `LoadComplete`, but I'm looking to fix test failures *without* regressing behaviour. And I think there may be a reason they are done here, related to song select's async load nature, so I'm not touching for now.

Fixes:

```
osu.Game.Tests.Visual.Navigation.TestSettingsMigration.TestDisplayStarsMigration

TearDown : System.NullReferenceException : Object reference not set to an instance of an object. --TearDown at osu.Game.Screens.Select.FilterControl.CreateCriteria() in /Users/dean/Projects/osu/osu.Game/Screens/Select/FilterControl.cs:line 41 at osu.Game.Screens.Select.FilterControl.updateCriteria() in /Users/dean/Projects/osu/osu.Game/Screens/Select/FilterControl.cs:line 219 at osu.Game.Screens.Select.FilterControl.

<load>b<strong>10<em>2(ValueChangedEvent`1 </em>) in /Users/dean/Projects/osu/osu.Game/Screens/Select/FilterControl.cs:line 76
   at osu.Framework.Bindables.Bindable<code>1.TriggerValueChange(T previousValue, Bindable</code>1 source, Boolean propagateToBindings, Boolean bypassChecks)
   at osu.Framework.Bindables.Bindable<code>1.TriggerValueChange(T previousValue, Bindable</code>1 source, Boolean propagateToBindings, Boolean bypassChecks)
   at osu.Framework.Bindables.Bindable<code>1.set_Value(T value)
   at osu.Framework.Bindables.BindableNumber</code>1.SetValue(T value)
   at osu.Framework.Configuration.ConfigManager`1.Set<a href="TLookup lookup, TValue value">TValue</a>
   at osu.Game.Tests.Visual.Navigation.TestSettingsMigration.<testdisplaystarsmigration>b</testdisplaystarsmigration></strong>1_1() in /Users/dean/Projects/osu/osu.Game.Tests/Visual/Navigation/TestSettingsMigration.cs:line 28
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.&lt;.ctor&gt;b__1_0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action<code>1 onError, Func</code>2 stopCondition)
--- End of stack trace from previous location where exception was thrown ---
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 349
   at osu.Framework.Testing.TestScene.RunTests()</load>
```