### PR TITLE
Remember leaderboard mods filter selection in song select

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Configuration
             Set(OsuSetting.Skin, 0, -1, int.MaxValue);
 
             Set(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
+            Set(OsuSetting.BeatmapDetailModsFilter, false);
 
             Set(OsuSetting.ShowConvertedBeatmaps, true);
             Set(OsuSetting.DisplayStarsMinimum, 0.0, 0, 10, 0.1);
@@ -200,6 +201,7 @@ namespace osu.Game.Configuration
         CursorRotation,
         MenuParallax,
         BeatmapDetailTab,
+        BeatmapDetailModsFilter,
         Username,
         ReleaseStream,
         SavePassword,

--- a/osu.Game/Screens/Select/BeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailArea.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.Select
 
         protected Bindable<BeatmapDetailAreaTabItem> CurrentTab => tabControl.Current;
 
+        protected Bindable<bool> CurrentModsFilter => tabControl.CurrentModsFilter;
+
         private readonly Container content;
         protected override Container<Drawable> Content => content;
 

--- a/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
+++ b/osu.Game/Screens/Select/BeatmapDetailAreaTabControl.cs
@@ -26,6 +26,12 @@ namespace osu.Game.Screens.Select
             set => tabs.Current = value;
         }
 
+        public Bindable<bool> CurrentModsFilter
+        {
+            get => modsCheckbox.Current;
+            set => modsCheckbox.Current = value;
+        }
+
         public Action<BeatmapDetailAreaTabItem, bool> OnFilter; // passed the selected tab and if mods is checked
 
         public IReadOnlyList<BeatmapDetailAreaTabItem> TabItems

--- a/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Screens.Select
 
         private Bindable<TabType> selectedTab;
 
+        private Bindable<bool> selectedModsFilter;
+
         public PlayBeatmapDetailArea()
         {
             Add(Leaderboard = new BeatmapLeaderboard { RelativeSizeAxes = Axes.Both });
@@ -38,8 +40,13 @@ namespace osu.Game.Screens.Select
         private void load(OsuConfigManager config)
         {
             selectedTab = config.GetBindable<TabType>(OsuSetting.BeatmapDetailTab);
+            selectedModsFilter = config.GetBindable<bool>(OsuSetting.BeatmapDetailModsFilter);
+
             selectedTab.BindValueChanged(tab => CurrentTab.Value = getTabItemFromTabType(tab.NewValue), true);
             CurrentTab.BindValueChanged(tab => selectedTab.Value = getTabTypeFromTabItem(tab.NewValue));
+
+            selectedModsFilter.BindValueChanged(checkbox => CurrentModsFilter.Value = checkbox.NewValue, true);
+            CurrentModsFilter.BindValueChanged(checkbox => selectedModsFilter.Value = checkbox.NewValue);
         }
 
         public override void Refresh()


### PR DESCRIPTION
In stable, users can set the leaderboard to `Global Ranking (Selected Mods)` and it'll remember every session. Since the mods filter is decoupled from leaderboard tabs in lazer, we need to remember both selections.