### PR TITLE
Fix import tests not waiting long enough before performing migration

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -28,7 +28,7 @@ using FileInfo = System.IO.FileInfo;
 namespace osu.Game.Tests.Beatmaps.IO
 {
     [TestFixture]
-    public class ImportBeatmapTest
+    public class ImportBeatmapTest : ImportTest
     {
         [Test]
         public async Task TestImportWhenClosed()
@@ -38,7 +38,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    await LoadOszIntoOsu(loadOsu(host));
+                    await LoadOszIntoOsu(LoadOsuIntoHost(host));
                 }
                 finally
                 {
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var imported = await LoadOszIntoOsu(osu);
 
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var imported = await LoadOszIntoOsu(osu);
                     var importedSecondTime = await LoadOszIntoOsu(osu);
@@ -102,7 +102,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
 
@@ -160,7 +160,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
 
@@ -211,7 +211,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
 
@@ -263,7 +263,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var imported = await LoadOszIntoOsu(osu);
 
@@ -314,7 +314,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                             Interlocked.Increment(ref loggedExceptionCount);
                     };
 
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
                     // ReSharper disable once AccessToModifiedClosure
@@ -382,7 +382,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var imported = await LoadOszIntoOsu(osu);
 
@@ -410,7 +410,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var imported = await LoadOszIntoOsu(osu);
 
@@ -444,7 +444,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var metadata = new BeatmapMetadata
                     {
@@ -504,7 +504,7 @@ namespace osu.Game.Tests.Beatmaps.IO
                     Assert.IsTrue(host.IsPrimaryInstance);
                     Assert.IsFalse(client.IsPrimaryInstance);
 
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
 
@@ -530,7 +530,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
                     var temp = TestResources.GetTestBeatmapForImport();
                     using (File.OpenRead(temp))
                         await osu.Dependencies.Get<BeatmapManager>().Import(temp);
@@ -552,7 +552,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
 
@@ -594,7 +594,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
 
@@ -639,7 +639,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     var temp = TestResources.GetTestBeatmapForImport();
 
@@ -693,7 +693,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
                     var temp = TestResources.GetTestBeatmapForImport();
@@ -723,7 +723,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
                     var temp = TestResources.GetTestBeatmapForImport();
@@ -765,7 +765,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
                     var working = manager.CreateNew(new OsuRuleset().RulesetInfo, User.SYSTEM_USER);
@@ -792,7 +792,7 @@ namespace osu.Game.Tests.Beatmaps.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
                     var manager = osu.Dependencies.Get<BeatmapManager>();
 
                     var working = manager.CreateNew(new OsuRuleset().RulesetInfo, User.SYSTEM_USER);
@@ -861,14 +861,6 @@ namespace osu.Game.Tests.Beatmaps.IO
         private void checkSingleReferencedFileCount(OsuGameBase osu, int expected)
         {
             Assert.AreEqual(expected, osu.Dependencies.Get<FileStore>().QueryFiles(f => f.ReferenceCount == 1).Count());
-        }
-
-        private OsuGameBase loadOsu(GameHost host)
-        {
-            var osu = new OsuGameBase();
-            Task.Run(() => host.Run(osu));
-            waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
-            return osu;
         }
 
         private static void ensureLoaded(OsuGameBase osu, int timeout = 60000)

--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -4,18 +4,15 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Platform;
-using osu.Game.Collections;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Collections.IO
 {
     [TestFixture]
-    public class ImportCollectionsTest
+    public class ImportCollectionsTest : ImportTest
     {
         [Test]
         public async Task TestImportEmptyDatabase()
@@ -24,7 +21,7 @@ namespace osu.Game.Tests.Collections.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     await osu.CollectionManager.Import(new MemoryStream());
 
@@ -44,7 +41,7 @@ namespace osu.Game.Tests.Collections.IO
             {
                 try
                 {
-                    var osu = loadOsu(host);
+                    var osu = LoadOsuIntoHost(host);
 
                     await osu.CollectionManager.Import(TestResources.OpenResource("Collections/collections.db"));
 
@@ -70,7 +67,7 @@ namespace osu.Game.Tests.Collections.IO
             {
                 try
                 {
-                    var osu = loadOsu(host, true);
+                    var osu = LoadOsuIntoHost(host, true);
 
                     await osu.CollectionManager.Import(TestResources.OpenResource("Collections/collections.db"));
 
@@ -101,7 +98,7 @@ namespace osu.Game.Tests.Collections.IO
                 {
                     AppDomain.CurrentDomain.UnhandledException += setException;
 
-                    var osu = loadOsu(host, true);
+                    var osu = LoadOsuIntoHost(host, true);
 
                     using (var ms = new MemoryStream())
                     {
@@ -135,7 +132,7 @@ namespace osu.Game.Tests.Collections.IO
             {
                 try
                 {
-                    var osu = loadOsu(host, true);
+                    var osu = LoadOsuIntoHost(host, true);
 
                     await osu.CollectionManager.Import(TestResources.OpenResource("Collections/collections.db"));
 
@@ -156,7 +153,7 @@ namespace osu.Game.Tests.Collections.IO
             {
                 try
                 {
-                    var osu = loadOsu(host, true);
+                    var osu = LoadOsuIntoHost(host, true);
 
                     Assert.That(osu.CollectionManager.Collections.Count, Is.EqualTo(2));
 
@@ -170,51 +167,6 @@ namespace osu.Game.Tests.Collections.IO
                 {
                     host.Exit();
                 }
-            }
-        }
-
-        private TestOsuGameBase loadOsu(GameHost host, bool withBeatmap = false)
-        {
-            var osu = new TestOsuGameBase(withBeatmap);
-
-#pragma warning disable 4014
-            Task.Run(() => host.Run(osu));
-#pragma warning restore 4014
-
-            waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
-
-            return osu;
-        }
-
-        private void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 60000)
-        {
-            Task task = Task.Run(() =>
-            {
-                while (!result()) Thread.Sleep(200);
-            });
-
-            Assert.IsTrue(task.Wait(timeout), failureMessage);
-        }
-
-        private class TestOsuGameBase : OsuGameBase
-        {
-            public CollectionManager CollectionManager { get; private set; }
-
-            private readonly bool withBeatmap;
-
-            public TestOsuGameBase(bool withBeatmap)
-            {
-                this.withBeatmap = withBeatmap;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                // Beatmap must be imported before the collection manager is loaded.
-                if (withBeatmap)
-                    BeatmapManager.Import(TestResources.GetTestBeatmapForImport()).Wait();
-
-                AddInternal(CollectionManager = new CollectionManager(Storage));
             }
         }
     }

--- a/osu.Game.Tests/ImportTest.cs
+++ b/osu.Game.Tests/ImportTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Platform;
+using osu.Game.Collections;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests
+{
+    public abstract class ImportTest
+    {
+        protected virtual TestOsuGameBase LoadOsuIntoHost(GameHost host, bool withBeatmap = false)
+        {
+            var osu = new TestOsuGameBase(withBeatmap);
+            Task.Run(() => host.Run(osu));
+
+            waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
+
+            bool ready = false;
+            // wait for two update frames to be executed. this ensures that all components have had a change to run LoadComplete and hopefully avoid
+            // database access (GlobalActionContainer is one to do this).
+            host.UpdateThread.Scheduler.Add(() => host.UpdateThread.Scheduler.Add(() => ready = true));
+
+            waitForOrAssert(() => ready, @"osu! failed to start in a reasonable amount of time");
+
+            return osu;
+        }
+
+        private void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 60000)
+        {
+            Task task = Task.Run(() =>
+            {
+                while (!result()) Thread.Sleep(200);
+            });
+
+            Assert.IsTrue(task.Wait(timeout), failureMessage);
+        }
+
+        public class TestOsuGameBase : OsuGameBase
+        {
+            public CollectionManager CollectionManager { get; private set; }
+
+            private readonly bool withBeatmap;
+
+            public TestOsuGameBase(bool withBeatmap)
+            {
+                this.withBeatmap = withBeatmap;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                // Beatmap must be imported before the collection manager is loaded.
+                if (withBeatmap)
+                    BeatmapManager.Import(TestResources.GetTestBeatmapForImport()).Wait();
+
+                AddInternal(CollectionManager = new CollectionManager(Storage));
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
+++ b/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -22,7 +23,7 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void TestDefaultDirectory()
         {
-            using (HeadlessGameHost host = new CustomTestHeadlessGameHost(nameof(TestDefaultDirectory)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 try
                 {
@@ -45,7 +46,7 @@ namespace osu.Game.Tests.NonVisual
         {
             string customPath = prepareCustomPath();
 
-            using (var host = new CustomTestHeadlessGameHost(nameof(TestCustomDirectory)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 using (var storageConfig = new StorageConfigManager(host.InitialStorage))
                     storageConfig.Set(StorageConfig.FullPath, customPath);
@@ -71,7 +72,7 @@ namespace osu.Game.Tests.NonVisual
         {
             string customPath = prepareCustomPath();
 
-            using (var host = new CustomTestHeadlessGameHost(nameof(TestSubDirectoryLookup)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 using (var storageConfig = new StorageConfigManager(host.InitialStorage))
                     storageConfig.Set(StorageConfig.FullPath, customPath);
@@ -104,7 +105,7 @@ namespace osu.Game.Tests.NonVisual
         {
             string customPath = prepareCustomPath();
 
-            using (HeadlessGameHost host = new CustomTestHeadlessGameHost(nameof(TestMigration)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 try
                 {
@@ -165,7 +166,7 @@ namespace osu.Game.Tests.NonVisual
             string customPath = prepareCustomPath();
             string customPath2 = prepareCustomPath("-2");
 
-            using (HeadlessGameHost host = new CustomTestHeadlessGameHost(nameof(TestMigrationBetweenTwoTargets)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 try
                 {
@@ -194,7 +195,7 @@ namespace osu.Game.Tests.NonVisual
         {
             string customPath = prepareCustomPath();
 
-            using (HeadlessGameHost host = new CustomTestHeadlessGameHost(nameof(TestMigrationToSameTargetFails)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 try
                 {
@@ -215,7 +216,7 @@ namespace osu.Game.Tests.NonVisual
         {
             string customPath = prepareCustomPath();
 
-            using (HeadlessGameHost host = new CustomTestHeadlessGameHost(nameof(TestMigrationToNestedTargetFails)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 try
                 {
@@ -244,7 +245,7 @@ namespace osu.Game.Tests.NonVisual
         {
             string customPath = prepareCustomPath();
 
-            using (HeadlessGameHost host = new CustomTestHeadlessGameHost(nameof(TestMigrationToSeeminglyNestedTarget)))
+            using (var host = new CustomTestHeadlessGameHost())
             {
                 try
                 {
@@ -315,14 +316,14 @@ namespace osu.Game.Tests.NonVisual
             return path;
         }
 
-        public class CustomTestHeadlessGameHost : HeadlessGameHost
+        public class CustomTestHeadlessGameHost : CleanRunHeadlessGameHost
         {
             public Storage InitialStorage { get; }
 
-            public CustomTestHeadlessGameHost(string name)
-                : base(name)
+            public CustomTestHeadlessGameHost([CallerMemberName] string callingMethodName = @"")
+                : base(callingMethodName: callingMethodName)
             {
-                string defaultStorageLocation = getDefaultLocationFor(name);
+                string defaultStorageLocation = getDefaultLocationFor(callingMethodName);
 
                 InitialStorage = new DesktopStorage(defaultStorageLocation, this);
                 InitialStorage.DeleteDirectory(string.Empty);

--- a/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
+++ b/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
@@ -272,7 +272,15 @@ namespace osu.Game.Tests.NonVisual
         {
             var osu = new OsuGameBase();
             Task.Run(() => host.Run(osu));
+
             waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
+
+            bool ready = false;
+            // wait for two update frames to be executed. this ensures that all components have had a change to run LoadComplete and hopefully avoid
+            // database access (GlobalActionContainer is one to do this).
+            host.UpdateThread.Scheduler.Add(() => host.UpdateThread.Scheduler.Add(() => ready = true));
+
+            waitForOrAssert(() => ready, @"osu! failed to start in a reasonable amount of time");
 
             return osu;
         }


### PR DESCRIPTION
Resolves https://ci.appveyor.com/project/peppy/osu/builds/35249434.

Also removes local `nameof()` specifications and uses the clean run game host.