### PR TITLE
Fix potential endless taiko beatmap conversion

### DIFF
--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets.Taiko.Objects;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
@@ -86,6 +87,9 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     if (shouldConvertSliderToHits(obj, beatmap, distanceData, out var taikoDuration, out var tickSpacing))
                     {
                         List<IList<HitSampleInfo>> allSamples = obj is IHasPathWithRepeats curveData ? curveData.NodeSamples : new List<IList<HitSampleInfo>>(new[] { samples });
+
+                        if (Precision.AlmostEquals(0, tickSpacing))
+                            yield break;
 
                         int i = 0;
 


### PR DESCRIPTION
Visible on https://osu.ppy.sh/beatmapsets/321566#osu/1270556

This eventually also needs a cancellation token too, but it should suffice for now - I don't believe `tickSpacing` can get small and pass this check without the duration also being small since they're both relative to beat length.