### PR TITLE
Fix spinner not using cancellation token

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Judgements;
@@ -48,14 +49,16 @@ namespace osu.Game.Rulesets.Osu.Objects
             MaximumBonusSpins = (int)((maximum_rotations_per_second - minimumRotationsPerSecond) * secondsDuration);
         }
 
-        protected override void CreateNestedHitObjects()
+        protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
-            base.CreateNestedHitObjects();
+            base.CreateNestedHitObjects(cancellationToken);
 
             int totalSpins = MaximumBonusSpins + SpinsRequired;
 
             for (int i = 0; i < totalSpins; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 double startTime = StartTime + (float)(i + 1) / totalSpins * Duration;
 
                 AddNested(i < SpinsRequired

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Rulesets.Objects
 #pragma warning restore 618
         }
 
+        [Obsolete("Use the cancellation-supporting override")] // Can be removed 20210318
         protected virtual void CreateNestedHitObjects()
         {
         }


### PR DESCRIPTION
Unfortunately the non-cancellable method didn't have an obsoletion notice.