### PR TITLE
Fix hovered tab items not showing hover state when deselected

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -123,8 +123,8 @@ namespace osu.Game.Graphics.UserInterface
 
             protected void FadeUnhovered()
             {
-                Bar.FadeOut(transition_length, Easing.OutQuint);
-                Text.FadeColour(AccentColour, transition_length, Easing.OutQuint);
+                Bar.FadeTo(IsHovered ? 1 : 0, transition_length, Easing.OutQuint);
+                Text.FadeColour(IsHovered ? Color4.White : AccentColour, transition_length, Easing.OutQuint);
             }
 
             protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/ChannelTabItem.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Overlays.Chat.Tabs
 
             TweenEdgeEffectTo(deactivateEdgeEffect, TRANSITION_LENGTH);
 
-            box.FadeColour(BackgroundInactive, TRANSITION_LENGTH, Easing.OutQuint);
+            box.FadeColour(IsHovered ? backgroundHover : BackgroundInactive, TRANSITION_LENGTH, Easing.OutQuint);
             highlightBox.FadeOut(TRANSITION_LENGTH, Easing.OutQuint);
 
             Text.Font = Text.Font.With(weight: FontWeight.Medium);


### PR DESCRIPTION
Before:
![OPOyn8gmzc](https://user-images.githubusercontent.com/35318437/93547440-e8981100-f919-11ea-9dec-68a114032f96.gif)
![rS78Q53XUh](https://user-images.githubusercontent.com/35318437/93564137-1000d500-f93e-11ea-831f-c374f0d39182.gif)

After:
![LMvXrNGLRv](https://user-images.githubusercontent.com/35318437/93547448-eb930180-f919-11ea-9693-a3fe3ed2db25.gif)
![Ygvh43yzbz](https://user-images.githubusercontent.com/35318437/93564060-ed6ebc00-f93d-11ea-8568-9a94ca714d18.gif)
