### PR TITLE
Allow one hitobject in taiko conversion edge case

### DIFF
--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -89,9 +89,6 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     {
                         List<IList<HitSampleInfo>> allSamples = obj is IHasPathWithRepeats curveData ? curveData.NodeSamples : new List<IList<HitSampleInfo>>(new[] { samples });
 
-                        if (Precision.AlmostEquals(0, tickSpacing))
-                            yield break;
-
                         int i = 0;
 
                         for (double j = obj.StartTime; j <= obj.StartTime + taikoDuration + tickSpacing / 8; j += tickSpacing)
@@ -109,6 +106,9 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                             };
 
                             i = (i + 1) % allSamples.Count;
+
+                            if (Precision.AlmostEquals(0, tickSpacing))
+                                break;
                         }
                     }
                     else


### PR DESCRIPTION
Probably doesn't need recalc. Even on the edgecase map (https://osu.ppy.sh/beatmapsets/321566#osu/1270556) this only changes SR by at most 0.1.