### PR TITLE
Ensure BeatmapProcessor.PostProcess is run before firing HitObjectUpdated events

### DIFF
--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -207,14 +207,15 @@ namespace osu.Game.Screens.Edit
                 beatmapProcessor?.PreProcess();
 
                 foreach (var hitObject in pendingUpdates)
-                {
                     processHitObject(hitObject);
-                    HitObjectUpdated?.Invoke(hitObject);
-                }
-
-                pendingUpdates.Clear();
 
                 beatmapProcessor?.PostProcess();
+
+                // explicitly needs to be fired after PostProcess
+                foreach (var hitObject in pendingUpdates)
+                    HitObjectUpdated?.Invoke(hitObject);
+
+                pendingUpdates.Clear();
             }
         }
 


### PR DESCRIPTION
Closes #10181.