### PR TITLE
Add support for legacy miss & strong hit explosions

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTestStrongHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTestStrongHit.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class DrawableTestStrongHit : DrawableHit
+    {
+        private readonly HitResult type;
+        private readonly bool hitBoth;
+
+        public DrawableTestStrongHit(double startTime, HitResult type = HitResult.Great, bool hitBoth = true)
+            : base(new Hit
+            {
+                IsStrong = true,
+                StartTime = startTime,
+            })
+        {
+            // in order to create nested strong hit
+            HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            this.type = type;
+            this.hitBoth = hitBoth;
+        }
+
+        protected override void LoadAsyncComplete()
+        {
+            base.LoadAsyncComplete();
+
+            Result.Type = type;
+
+            var nestedStrongHit = (DrawableStrongNestedHit)NestedHitObjects.Single();
+            nestedStrongHit.Result.Type = hitBoth ? type : HitResult.Miss;
+        }
+
+        public override bool OnPressed(TaikoAction action) => false;
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Scoring;
@@ -15,24 +14,29 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
     [TestFixture]
     public class TestSceneHitExplosion : TaikoSkinnableTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
+        [Test]
+        public void TestNormalHit()
         {
-            AddStep("Great", () => SetContents(() => getContentFor(HitResult.Great)));
-            AddStep("Good", () => SetContents(() => getContentFor(HitResult.Good)));
-            AddStep("Miss", () => SetContents(() => getContentFor(HitResult.Miss)));
+            AddStep("Great", () => SetContents(() => getContentFor(createHit(HitResult.Great))));
+            AddStep("Good", () => SetContents(() => getContentFor(createHit(HitResult.Good))));
+            AddStep("Miss", () => SetContents(() => getContentFor(createHit(HitResult.Miss))));
         }
 
-        private Drawable getContentFor(HitResult type)
+        [Test]
+        public void TestStrongHit([Values(false, true)] bool hitBoth)
         {
-            DrawableTaikoHitObject hit;
+            AddStep("Great", () => SetContents(() => getContentFor(createStrongHit(HitResult.Great, hitBoth))));
+            AddStep("Good", () => SetContents(() => getContentFor(createStrongHit(HitResult.Good, hitBoth))));
+        }
 
+        private Drawable getContentFor(DrawableTaikoHitObject hit)
+        {
             return new Container
             {
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    hit = createHit(type),
+                    hit,
                     new HitExplosion(hit)
                     {
                         Anchor = Anchor.Centre,
@@ -43,5 +47,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         }
 
         private DrawableTaikoHitObject createHit(HitResult type) => new DrawableTestHit(new Hit { StartTime = Time.Current }, type);
+
+        private DrawableTaikoHitObject createStrongHit(HitResult type, bool hitBoth)
+            => new DrawableTestStrongHit(Time.Current, type, hitBoth);
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -174,7 +174,9 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         private void addMissJudgement()
         {
-            ((TaikoPlayfield)drawableRuleset.Playfield).OnNewResult(new DrawableTestHit(new Hit()), new JudgementResult(new HitObject(), new TaikoJudgement()) { Type = HitResult.Miss });
+            DrawableTestHit h;
+            Add(h = new DrawableTestHit(new Hit(), HitResult.Miss));
+            ((TaikoPlayfield)drawableRuleset.Playfield).OnNewResult(h, new JudgementResult(new HitObject(), new TaikoJudgement()) { Type = HitResult.Miss });
         }
 
         private void addBarLine(bool major, double delay = scroll_time)

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -75,7 +75,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                     return null;
 
                 case TaikoSkinComponents.TaikoExplosionGood:
+                case TaikoSkinComponents.TaikoExplosionGoodStrong:
                 case TaikoSkinComponents.TaikoExplosionGreat:
+                case TaikoSkinComponents.TaikoExplosionGreatStrong:
                 case TaikoSkinComponents.TaikoExplosionMiss:
 
                     var sprite = this.GetAnimation(getHitName(taikoComponent.Component), true, false);
@@ -107,8 +109,14 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                 case TaikoSkinComponents.TaikoExplosionGood:
                     return "taiko-hit100";
 
+                case TaikoSkinComponents.TaikoExplosionGoodStrong:
+                    return "taiko-hit100k";
+
                 case TaikoSkinComponents.TaikoExplosionGreat:
                     return "taiko-hit300";
+
+                case TaikoSkinComponents.TaikoExplosionGreatStrong:
+                    return "taiko-hit300k";
             }
 
             throw new ArgumentOutOfRangeException(nameof(component), "Invalid result type");

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -17,7 +17,9 @@ namespace osu.Game.Rulesets.Taiko
         BarLine,
         TaikoExplosionMiss,
         TaikoExplosionGood,
+        TaikoExplosionGoodStrong,
         TaikoExplosionGreat,
+        TaikoExplosionGreatStrong,
         Scroller,
         Mascot,
     }

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -205,9 +205,6 @@ namespace osu.Game.Rulesets.Taiko.UI
                         X = result.IsHit ? judgedObject.Position.X : 0,
                     });
 
-                    if (!result.IsHit)
-                        break;
-
                     var type = (judgedObject.HitObject as Hit)?.Type ?? HitType.Centre;
 
                     addExplosion(judgedObject, type);

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -218,12 +218,16 @@ namespace osu.Game.Rulesets.Taiko.UI
         private void addDrumRollHit(DrawableDrumRollTick drawableTick) =>
             drumRollHitContainer.Add(new DrawableFlyingHit(drawableTick));
 
-        private void addExplosion(DrawableHitObject drawableObject, HitType type)
+        /// <remarks>
+        /// As legacy skins have different explosions for singular and double strong hits,
+        /// explosion addition is scheduled to ensure that both hits are processed if they occur on the same frame.
+        /// </remarks>
+        private void addExplosion(DrawableHitObject drawableObject, HitType type) => Schedule(() =>
         {
             hitExplosionContainer.Add(new HitExplosion(drawableObject));
             if (drawableObject.HitObject.Kiai)
                 kiaiExplosionContainer.Add(new KiaiHitExplosion(drawableObject, type));
-        }
+        });
 
         private class ProxyContainer : LifetimeManagementContainer
         {


### PR DESCRIPTION
- Resolves #8891.
- Resolves #9860.

# Summary

This PR brings back support for displaying miss explosions and strong hit explosions in taiko.

Miss explosions were already theoretically supported, but not actually created and added to the playfield due to a check in `addExplosion()` excluding them from being created.

As for strong hit explosions, as I outlined in the issue thread I'm pretty sure stable only shows them if both hits are frame-perfect (as in they occur on the exact same frame), and this implementation follows the same logic for now.

Here are some videos showing the effects of this change:

| | | |
| :- | :-: | :-: |
| current `master` | [test scene](https://drive.google.com/file/d/1k0YvsZPmBYe6PC-y38Hp1CYTa0Ta229T/view?usp=sharing) | [in-game autoplay](https://drive.google.com/file/d/1WPGqH6hYs1StPt2QFUgOYytw0IncEiSN/view?usp=sharing) |
| this PR | [test scene](https://drive.google.com/file/d/1T8tcDhjaD-y9Ylptvn7wkTWoBmfQkcG3/view?usp=sharing) | [in-game autoplay](https://drive.google.com/file/d/1rwqEqHurWuaWp76KO39-LN-81TcoFItu/view?usp=sharing) |

# Remarks

Not sure about replicating the stable behaviour of strong explosions. It's easy to implement but borderline useless for anything but autoplay. I'll change to something different on request.

Easily the worst part of this diff is the schedule in `addExplosion()`. As the inline comment attempts to explain, it is done to handle both hits potentially firing in the same frame. To explain better, assume that a `LeftCentre` and a `RightCentre` are hit on the same frame. This is how the input is processed:

1. `LeftCentre` press is dispatched to `DrawableHit.DrawableStrongNestedHit`. As the main object is not yet judged, the handler early-returns and does nothing.
2. The main `DrawableHit` is next in the input queue; the hit is processed normally as if it was a single. This is where the explosion would get created and added to the hierarchy without the schedule.
3. `RightCentre` press is dispatched to `DrawableHit.DrawableStrongNestedHit`. The main object is judged, so the double hit result is applied only at this point.
4. `RightCentre` press is then dispatched to the main `DrawableHit`, which early-returns as it's already processed an action in this frame.

The purpose of the schedule is to delay the explosion creation, so that point 3. can execute before the pertinent values of the nested object are read to determine what component should be displayed. I felt this was the simplest way of resolving this, but I'd definitely be happy to see it go - that might require some changes to that action handling logic, however, and definitely warrant a separate PR.

I'm not even entirely sure how that would have to be handled - some kind of framework API to allow `KeyBindingHandler`s to receive events with higher priority, or adding that override locally game-side as part of the input queue construction?