### PR TITLE
Fix bindings not correctly being cleaned up in OsuHitObjectComposer

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -46,13 +46,20 @@ namespace osu.Game.Rulesets.Osu.Edit
             distanceSnapToggle
         };
 
+        private BindableList<HitObject> selectedHitObjects;
+
+        private Bindable<HitObject> placementObject;
+
         [BackgroundDependencyLoader]
         private void load()
         {
             LayerBelowRuleset.Add(distanceSnapGridContainer = new Container { RelativeSizeAxes = Axes.Both });
 
-            EditorBeatmap.SelectedHitObjects.CollectionChanged += (_, __) => updateDistanceSnapGrid();
-            EditorBeatmap.PlacementObject.ValueChanged += _ => updateDistanceSnapGrid();
+            selectedHitObjects = EditorBeatmap.SelectedHitObjects.GetBoundCopy();
+            selectedHitObjects.CollectionChanged += (_, __) => updateDistanceSnapGrid();
+
+            placementObject = EditorBeatmap.PlacementObject.GetBoundCopy();
+            placementObject.ValueChanged += _ => updateDistanceSnapGrid();
             distanceSnapToggle.ValueChanged += _ => updateDistanceSnapGrid();
         }
 


### PR DESCRIPTION
`OsuHitObjectComposer` was binding directly to bindables. Not safe since it gets reconstructed multiple times when switching editor screens.

Closes #10142