### PR TITLE
Fix fail animation breaking on post-fail judgements

### DIFF
--- a/osu.Game/Screens/Play/FailAnimation.cs
+++ b/osu.Game/Screens/Play/FailAnimation.cs
@@ -89,6 +89,8 @@ namespace osu.Game.Screens.Play
 
         private void applyToPlayfield(Playfield playfield)
         {
+            double failTime = playfield.Time.Current;
+
             foreach (var nested in playfield.NestedPlayfields)
                 applyToPlayfield(nested);
 
@@ -97,10 +99,26 @@ namespace osu.Game.Screens.Play
                 if (appliedObjects.Contains(obj))
                     continue;
 
-                obj.RotateTo(RNG.NextSingle(-90, 90), duration);
-                obj.ScaleTo(obj.Scale * 0.5f, duration);
-                obj.MoveToOffset(new Vector2(0, 400), duration);
+                float rotation = RNG.NextSingle(-90, 90);
+                Vector2 originalPosition = obj.Position;
+                Vector2 originalScale = obj.Scale;
+
+                dropOffScreen(obj, failTime, rotation, originalScale, originalPosition);
+
+                // need to reapply the fail drop after judgement state changes
+                obj.ApplyCustomUpdateState += (o, _) => dropOffScreen(obj, failTime, rotation, originalScale, originalPosition);
+
                 appliedObjects.Add(obj);
+            }
+        }
+
+        private void dropOffScreen(DrawableHitObject obj, double failTime, float randomRotation, Vector2 originalScale, Vector2 originalPosition)
+        {
+            using (obj.BeginAbsoluteSequence(failTime))
+            {
+                obj.RotateTo(randomRotation, duration);
+                obj.ScaleTo(originalScale * 0.5f, duration);
+                obj.MoveTo(originalPosition + new Vector2(0, 400), duration);
             }
         }
 


### PR DESCRIPTION
Before:

![2020-09-22 15 10 40](https://user-images.githubusercontent.com/191335/93848944-e6510080-fce5-11ea-9c3d-7329d615bf5d.gif)

After:

![2020-09-22 15 09 21](https://user-images.githubusercontent.com/191335/93849004-02ed3880-fce6-11ea-976d-ef64bc061361.gif)

Also fixes similar issues on the other three rulesets (tested each to look more correct than before). Can be tested using `TestSceneFailAnimation`.
