### PR TITLE
Fix compose mode not showing distance snap grid when entering with a selection

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -54,6 +54,9 @@ namespace osu.Game.Rulesets.Osu.Edit
             EditorBeatmap.SelectedHitObjects.CollectionChanged += (_, __) => updateDistanceSnapGrid();
             EditorBeatmap.PlacementObject.ValueChanged += _ => updateDistanceSnapGrid();
             distanceSnapToggle.ValueChanged += _ => updateDistanceSnapGrid();
+
+            // we may be entering the screen with a selection already active
+            updateDistanceSnapGrid();
         }
 
         protected override ComposeBlueprintContainer CreateBlueprintContainer(IEnumerable<DrawableHitObject> hitObjects)


### PR DESCRIPTION
Repro:

- Select hitobjects in osu! editor (so the distance snap grid is visible)
- Enter timing mode
- Return to select mode

Notice grid is now missing until selection is updated.