### PR TITLE
Reduce children levels in RingPiece

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/Components/SpinnerPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/Components/SpinnerPiece.cs
@@ -34,11 +34,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners.Components
                     Alpha = 0.5f,
                     Child = new Box { RelativeSizeAxes = Axes.Both }
                 },
-                ring = new RingPiece
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
-                }
+                ring = new RingPiece()
             };
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/RingPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/RingPiece.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Shapes;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
-    public class RingPiece : Container
+    public class RingPiece : CircularContainer
     {
         public RingPiece()
         {
@@ -18,21 +18,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            InternalChild = new CircularContainer
+            Masking = true;
+            BorderThickness = 10;
+            BorderColour = Color4.White;
+
+            Child = new Box
             {
-                Masking = true,
-                BorderThickness = 10,
-                BorderColour = Color4.White,
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
-                {
-                    new Box
-                    {
-                        AlwaysPresent = true,
-                        Alpha = 0,
-                        RelativeSizeAxes = Axes.Both
-                    }
-                }
+                AlwaysPresent = true,
+                Alpha = 0,
+                RelativeSizeAxes = Axes.Both
             };
         }
     }


### PR DESCRIPTION
This is used in a lot of places and actually adds a noticeable overhead in construction and input handling (when having a huge selection in the editor). Haven't profiled this but see it as a code quality improvement anyways.