### PR TITLE
Reduce complexity of AllHitObjects enumerator when nested playfields are not present

### DIFF
--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -37,7 +37,21 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// All the <see cref="DrawableHitObject"/>s contained in this <see cref="Playfield"/> and all <see cref="NestedPlayfields"/>.
         /// </summary>
-        public IEnumerable<DrawableHitObject> AllHitObjects => HitObjectContainer?.Objects.Concat(NestedPlayfields.SelectMany(p => p.AllHitObjects)) ?? Enumerable.Empty<DrawableHitObject>();
+        public IEnumerable<DrawableHitObject> AllHitObjects
+        {
+            get
+            {
+                if (HitObjectContainer == null)
+                    return Enumerable.Empty<DrawableHitObject>();
+
+                var enumerable = HitObjectContainer.Objects;
+
+                if (nestedPlayfields.IsValueCreated)
+                    enumerable = enumerable.Concat(NestedPlayfields.SelectMany(p => p.AllHitObjects));
+
+                return enumerable;
+            }
+        }
 
         /// <summary>
         /// All <see cref="Playfield"/>s nested inside this <see cref="Playfield"/>.


### PR DESCRIPTION
This enumerable should not exist. Probably should be replaced with a BindableList or something else that doesn't require this nested linq. The expensive part doesn't stop at this change, but there is casting and ordering occurring in the underlying call to `HitObjectContainer.Objects`.

Helps with non-mania editor compose screens a bit, but again, we really need to do some work to banish this from existence. Every use of it is bad (including removal / addition of new objects and other non-editor cases).

Before:

![image](https://user-images.githubusercontent.com/191335/93864825-68e6b980-fd00-11ea-9867-5a9385cbf10d.png)

After:

![image](https://user-images.githubusercontent.com/191335/93864851-7308b800-fd00-11ea-880c-f41c6534b2eb.png)
