### PR TITLE
Fix editor not using beatmap combo colours initially on load

### DIFF
--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Screens.Edit
                     }
                 },
             };
+
             LoadComponentAsync(CreateMainContent(), content =>
             {
                 spinner.State.Value = Visibility.Hidden;

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Audio;
@@ -13,25 +14,62 @@ namespace osu.Game.Skinning
     /// </summary>
     public class BeatmapSkinProvidingContainer : SkinProvidingContainer
     {
-        private readonly Bindable<bool> beatmapSkins = new Bindable<bool>();
-        private readonly Bindable<bool> beatmapHitsounds = new Bindable<bool>();
+        private Bindable<bool> beatmapSkins;
+        private Bindable<bool> beatmapHitsounds;
 
-        protected override bool AllowConfigurationLookup => beatmapSkins.Value;
-        protected override bool AllowDrawableLookup(ISkinComponent component) => beatmapSkins.Value;
-        protected override bool AllowTextureLookup(string componentName) => beatmapSkins.Value;
-        protected override bool AllowSampleLookup(ISampleInfo componentName) => beatmapHitsounds.Value;
+        protected override bool AllowConfigurationLookup
+        {
+            get
+            {
+                if (beatmapSkins == null)
+                    throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
+
+                return beatmapSkins.Value;
+            }
+        }
+
+        protected override bool AllowDrawableLookup(ISkinComponent component)
+        {
+            if (beatmapSkins == null)
+                throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
+
+            return beatmapSkins.Value;
+        }
+
+        protected override bool AllowTextureLookup(string componentName)
+        {
+            if (beatmapSkins == null)
+                throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
+
+            return beatmapSkins.Value;
+        }
+
+        protected override bool AllowSampleLookup(ISampleInfo componentName)
+        {
+            if (beatmapSkins == null)
+                throw new InvalidOperationException($"{nameof(BeatmapSkinProvidingContainer)} needs to be loaded before being consumed.");
+
+            return beatmapHitsounds.Value;
+        }
 
         public BeatmapSkinProvidingContainer(ISkin skin)
             : base(skin)
         {
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
-            config.BindWith(OsuSetting.BeatmapSkins, beatmapSkins);
-            config.BindWith(OsuSetting.BeatmapHitsounds, beatmapHitsounds);
+            var config = parent.Get<OsuConfigManager>();
 
+            beatmapSkins = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
+            beatmapHitsounds = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
+
+            return base.CreateChildDependencies(parent);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             beatmapSkins.BindValueChanged(_ => TriggerSourceChanged());
             beatmapHitsounds.BindValueChanged(_ => TriggerSourceChanged());
         }


### PR DESCRIPTION
This seems to be a regression from when pieces of the compose screen was converted to `LoadComponentAsync`. The BDL `load()` of `BeatmapSkinProvidingContainer` was not being run in time for the correct bindable state to be reflected in `AllowConfigurationLookup`.

Have guarded against misuse and moved the bindable connections to `CreateChildDependencies`. Done this way rather than forcing a trigger change because this is a performance hot path where we don't want to unnecessarily trigger skin `SourceChanged` in the load process.