### PR TITLE
Fix large construction/disposal overhead on beatmaps with hitobjects at same point in time

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -46,7 +46,20 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         private void addConnection(FollowPointConnection connection)
         {
             // Groups are sorted by their start time when added such that the index can be used to post-process other surrounding connections
-            int index = connections.AddInPlace(connection, Comparer<FollowPointConnection>.Create((g1, g2) => g1.StartTime.Value.CompareTo(g2.StartTime.Value)));
+            int index = connections.AddInPlace(connection, Comparer<FollowPointConnection>.Create((g1, g2) =>
+            {
+                int comp = g1.StartTime.Value.CompareTo(g2.StartTime.Value);
+
+                if (comp != 0)
+                    return comp;
+
+                // we always want to insert the new item after equal ones.
+                // this is important for beatmaps with multiple hitobjects at the same point in time.
+                // if we use standard comparison insert order, there will be a churn of connections getting re-updated to
+                // the next object at the point-in-time, adding a construction/disposal overhead (see FollowPointConnection.End implementation's ClearInternal).
+                // this is easily visible on https://osu.ppy.sh/beatmapsets/150945#osu/372245
+                return -1;
+            }));
 
             if (index < connections.Count - 1)
             {


### PR DESCRIPTION
Basically fixes centipede spending ~5 minutes in async disposal. Inline comment should explain. The underlying disposal overhead is from unbinding from `SourceChanged` hundreds of thousands of times (usually avoided due to disposal order, see [SkinProvidingContainer's Dispose implementation](https://github.com/ppy/osu/blob/7efaa374476a271f25df7c9363f3db9c29cc4fec/osu.Game/Skinning/SkinProvidingContainer.cs#L98-L99)

Before:

![image](https://user-images.githubusercontent.com/191335/93976492-064ef580-fdb4-11ea-9756-9d58feabc1c5.png)

(yes it literally outweighs everything else so much they disappear. also it keeps going beyond my profile session and ends up at around 360,000ms...)

After:

![image](https://user-images.githubusercontent.com/191335/93976218-a0fb0480-fdb3-11ea-9bfc-e3dca8a1714f.png)
