### PR TITLE
Add more descriptive description and download button when statistics not available

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -220,7 +220,7 @@ namespace osu.Game.Tests.Visual.Ranking
 
             AddStep("load results", () => Child = new TestResultsContainer(screen = createResultsScreen()));
 
-            AddAssert("download button is disabled", () => !screen.ChildrenOfType<DownloadButton>().Single().Enabled.Value);
+            AddAssert("download button is disabled", () => !screen.ChildrenOfType<DownloadButton>().Last().Enabled.Value);
 
             AddStep("click contracted panel", () =>
             {
@@ -229,7 +229,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("download button is enabled", () => screen.ChildrenOfType<DownloadButton>().Single().Enabled.Value);
+            AddAssert("download button is enabled", () => screen.ChildrenOfType<DownloadButton>().Last().Enabled.Value);
         }
 
         private class TestResultsContainer : Container

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -75,7 +75,21 @@ namespace osu.Game.Screens.Ranking.Statistics
                 return;
 
             if (newScore.HitEvents == null || newScore.HitEvents.Count == 0)
-                content.Add(new MessagePlaceholder("Score has no statistics :("));
+                content.Add(new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new MessagePlaceholder("Extended statistics are only available after watching a replay!"),
+                        new ReplayDownloadButton(newScore)
+                        {
+                            Scale = new Vector2(1.5f),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                    }
+                });
             else
             {
                 spinner.Show();

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 return;
 
             if (newScore.HitEvents == null || newScore.HitEvents.Count == 0)
+            {
                 content.Add(new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -90,6 +91,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                         },
                     }
                 });
+            }
             else
             {
                 spinner.Show();


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/94097454-7bc4cf80-fe61-11ea-97ab-3186f89fa847.png)


After:

![2020-09-24 12 29 55](https://user-images.githubusercontent.com/191335/94097629-d3633b00-fe61-11ea-8c8b-ac9807ba7db5.gif)

