### PR TITLE
Fix extended statistics not being vertically centered

### DIFF
--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -91,7 +91,10 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     var rows = new FillFlowContainer
                     {
-                        RelativeSizeAxes = Axes.Both,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
                         Direction = FillDirection.Vertical,
                         Spacing = new Vector2(30, 15),
                         Alpha = 0


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/94097663-e544de00-fe61-11ea-85e8-df019ce59d3b.png)

After:

![image](https://user-images.githubusercontent.com/191335/94097746-0e656e80-fe62-11ea-89c8-65610ed04aa9.png)
