### PR TITLE
Fix score panel being incorrectly vertically aligned on screen resize

### DIFF
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -273,10 +273,10 @@ namespace osu.Game.Screens.Ranking
                 detachedPanelContainer.Add(expandedPanel);
 
                 // Move into its original location in the local container first, then to the final location.
-                var origLocation = detachedPanelContainer.ToLocalSpace(screenSpacePos);
-                expandedPanel.MoveTo(origLocation)
+                var origLocation = detachedPanelContainer.ToLocalSpace(screenSpacePos).X;
+                expandedPanel.MoveToX(origLocation)
                              .Then()
-                             .MoveTo(new Vector2(StatisticsPanel.SIDE_PADDING, origLocation.Y), 150, Easing.OutQuint);
+                             .MoveToX(StatisticsPanel.SIDE_PADDING, 150, Easing.OutQuint);
 
                 // Hide contracted panels.
                 foreach (var contracted in ScorePanelList.GetScorePanels().Where(p => p.State == PanelState.Contracted))

--- a/osu.Game/Screens/Ranking/ScorePanelList.cs
+++ b/osu.Game/Screens/Ranking/ScorePanelList.cs
@@ -99,6 +99,8 @@ namespace osu.Game.Screens.Ranking
         {
             var panel = new ScorePanel(score)
             {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
                 PostExpandAction = () => PostExpandAction?.Invoke()
             }.With(p =>
             {


### PR DESCRIPTION
On changing the screen aspect ratio while the extended results are visible, then returning to non-extended, the panel will be at an incorrect vertical location.

Fixed by using vertical centre at all times, and only adjusting the X positioning.

Before:

![2020-09-24 12 52 24](https://user-images.githubusercontent.com/191335/94099012-e1ff2180-fe64-11ea-9012-e9a3517858a5.gif)

After:

![2020-09-24 12 53 44](https://user-images.githubusercontent.com/191335/94099100-0d820c00-fe65-11ea-8b4b-1b6bad3d4828.gif)
