### PR TITLE
Avoid destroying editor screens when changing between modes

### DIFF
--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -13,6 +13,11 @@ namespace osu.Game.Screens.Edit.Compose
     {
         private HitObjectComposer composer;
 
+        public ComposeScreen()
+            : base(EditorScreenMode.Compose)
+        {
+        }
+
         protected override Drawable CreateMainContent()
         {
             var ruleset = Beatmap.Value.BeatmapInfo.Ruleset?.CreateInstance();

--- a/osu.Game/Screens/Edit/Design/DesignScreen.cs
+++ b/osu.Game/Screens/Edit/Design/DesignScreen.cs
@@ -6,6 +6,7 @@ namespace osu.Game.Screens.Edit.Design
     public class DesignScreen : EditorScreen
     {
         public DesignScreen()
+            : base(EditorScreenMode.Design)
         {
             Child = new ScreenWhiteBox.UnderConstructionMessage("Design mode");
         }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -518,7 +518,7 @@ namespace osu.Game.Screens.Edit
                 .ScaleTo(0.98f, 200, Easing.OutQuint)
                 .FadeOut(200, Easing.OutQuint);
 
-            if ((currentScreen = screenContainer.FirstOrDefault(s => s.Type == e.NewValue)) != null)
+            if ((currentScreen = screenContainer.SingleOrDefault(s => s.Type == e.NewValue)) != null)
             {
                 screenContainer.ChangeChildDepth(currentScreen, lastScreen?.Depth + 1 ?? 0);
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Edit
         private string lastSavedHash;
 
         private Box bottomBackground;
-        private Container screenContainer;
+        private Container<EditorScreen> screenContainer;
 
         private EditorScreen currentScreen;
 
@@ -163,7 +163,7 @@ namespace osu.Game.Screens.Edit
                         Name = "Screen container",
                         RelativeSizeAxes = Axes.Both,
                         Padding = new MarginPadding { Top = 40, Bottom = 60 },
-                        Child = screenContainer = new Container
+                        Child = screenContainer = new Container<EditorScreen>
                         {
                             RelativeSizeAxes = Axes.Both,
                             Masking = true
@@ -512,7 +512,21 @@ namespace osu.Game.Screens.Edit
 
         private void onModeChanged(ValueChangedEvent<EditorScreenMode> e)
         {
-            currentScreen?.Exit();
+            var lastScreen = currentScreen;
+
+            lastScreen?
+                .ScaleTo(0.98f, 200, Easing.OutQuint)
+                .FadeOut(200, Easing.OutQuint);
+
+            if ((currentScreen = screenContainer.FirstOrDefault(s => s.Type == e.NewValue)) != null)
+            {
+                screenContainer.ChangeChildDepth(currentScreen, lastScreen?.Depth + 1 ?? 0);
+
+                currentScreen
+                    .ScaleTo(1, 200, Easing.OutQuint)
+                    .FadeIn(200, Easing.OutQuint);
+                return;
+            }
 
             switch (e.NewValue)
             {

--- a/osu.Game/Screens/Edit/EditorScreen.cs
+++ b/osu.Game/Screens/Edit/EditorScreen.cs
@@ -23,8 +23,12 @@ namespace osu.Game.Screens.Edit
         protected override Container<Drawable> Content => content;
         private readonly Container content;
 
-        protected EditorScreen()
+        public readonly EditorScreenMode Type;
+
+        protected EditorScreen(EditorScreenMode type)
         {
+            Type = type;
+
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Screens.Edit
 
         private Container timelineContainer;
 
+        protected EditorScreenWithTimeline(EditorScreenMode type)
+            : base(type)
+        {
+        }
+
         [BackgroundDependencyLoader(true)]
         private void load([CanBeNull] BindableBeatDivisor beatDivisor)
         {

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -24,6 +24,11 @@ namespace osu.Game.Screens.Edit.Setup
         private LabelledTextBox creatorTextBox;
         private LabelledTextBox difficultyTextBox;
 
+        public SetupScreen()
+            : base(EditorScreenMode.SongSetup)
+        {
+        }
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -24,6 +24,11 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private EditorClock clock { get; set; }
 
+        public TimingScreen()
+            : base(EditorScreenMode.Timing)
+        {
+        }
+
         protected override Drawable CreateMainContent() => new GridContainer
         {
             RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
I think we want it this way for as long as we can. Probably going to have to take care with cross-screen events and bindables firing unnecessarily (may need an enter/exit mode). Also really this should be using ScreenCarousel but...........................

- Fixes distance snap (and other state) being lost on changing screens
- Improves performance when switching between screens by infinite (after first load)

Consider the transition a best-effort-temporary-thing.