### PR TITLE
Add a basic file selector with extension filtering support

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 
@@ -9,10 +9,16 @@ namespace osu.Game.Tests.Visual.Settings
 {
     public class TestSceneFileSelector : OsuTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
+        [Test]
+        public void TestAllFiles()
         {
-            Add(new FileSelector { RelativeSizeAxes = Axes.Both });
+            AddStep("create", () => Child = new FileSelector { RelativeSizeAxes = Axes.Both });
+        }
+
+        [Test]
+        public void TestJpgFilesOnly()
+        {
+            AddStep("create", () => Child = new FileSelector(validFileExtensions: new[] { ".jpg" }) { RelativeSizeAxes = Axes.Both });
         }
     }
 }

--- a/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
@@ -7,12 +7,12 @@ using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Tests.Visual.Settings
 {
-    public class TestSceneDirectorySelector : OsuTestScene
+    public class TestSceneFileSelector : OsuTestScene
     {
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(new DirectorySelector { RelativeSizeAxes = Axes.Both });
+            Add(new FileSelector { RelativeSizeAxes = Axes.Both });
         }
     }
 }

--- a/osu.Game.Tournament/Screens/StablePathSelectScreen.cs
+++ b/osu.Game.Tournament/Screens/StablePathSelectScreen.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Tournament.Screens
 
         protected virtual void ChangePath()
         {
-            var target = directorySelector.CurrentDirectory.Value.FullName;
+            var target = directorySelector.CurrentPath.Value.FullName;
             var fileBasedIpc = ipc as FileBasedIPC;
             Logger.Log($"Changing Stable CE location to {target}");
 

--- a/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
@@ -62,7 +62,33 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             protected override string FallbackName => file.Name;
 
-            protected override IconUsage? Icon => FontAwesome.Regular.FileAudio;
+            protected override IconUsage? Icon
+            {
+                get
+                {
+                    switch (file.Extension)
+                    {
+                        case ".ogg":
+                        case ".mp3":
+                        case ".wav":
+                            return FontAwesome.Regular.FileAudio;
+
+                        case ".jpg":
+                        case ".jpeg":
+                        case ".png":
+                            return FontAwesome.Regular.FileImage;
+
+                        case ".mp4":
+                        case ".avi":
+                        case ".mov":
+                        case ".flv":
+                            return FontAwesome.Regular.FileVideo;
+
+                        default:
+                            return FontAwesome.Regular.File;
+                    }
+                }
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FileSelector.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public class FileSelector : DirectorySelector
+    {
+        private readonly string[] validFileExtensions;
+
+        [Cached]
+        public readonly Bindable<FileInfo> CurrentFile = new Bindable<FileInfo>();
+
+        public FileSelector(string initialPath = null, string[] validFileExtensions = null)
+            : base(initialPath)
+        {
+            this.validFileExtensions = validFileExtensions ?? Array.Empty<string>();
+        }
+
+        protected override IEnumerable<DisplayPiece> GetEntriesForPath(DirectoryInfo path)
+        {
+            foreach (var dir in base.GetEntriesForPath(path))
+                yield return dir;
+
+            IEnumerable<FileInfo> files = path.GetFiles();
+
+            if (validFileExtensions.Length > 0)
+                files = files.Where(f => validFileExtensions.Contains(f.Extension));
+
+            foreach (var file in files.OrderBy(d => d.Name))
+            {
+                if ((file.Attributes & FileAttributes.Hidden) == 0)
+                    yield return new FilePiece(file);
+            }
+        }
+
+        protected class FilePiece : DisplayPiece
+        {
+            private readonly FileInfo file;
+
+            [Resolved]
+            private Bindable<FileInfo> currentFile { get; set; }
+
+            public FilePiece(FileInfo file)
+            {
+                this.file = file;
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                currentFile.Value = file;
+                return true;
+            }
+
+            protected override string FallbackName => file.Name;
+
+            protected override IconUsage? Icon => FontAwesome.Regular.FileAudio;
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
         private void start()
         {
-            var target = directorySelector.CurrentDirectory.Value;
+            var target = directorySelector.CurrentPath.Value;
 
             try
             {


### PR DESCRIPTION
Extends directory selector for simplicity. Will be used for beatmap audio file selection and more in the future.