### PR TITLE
Avoid consuming keystrokes in editor when a modifier key is held down

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -192,6 +192,9 @@ namespace osu.Game.Rulesets.Edit
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            if (e.ControlPressed || e.AltPressed || e.SuperPressed)
+                return false;
+
             if (checkLeftToggleFromKey(e.Key, out var leftIndex))
             {
                 var item = toolboxCollection.Items.ElementAtOrDefault(leftIndex);


### PR DESCRIPTION
Without this it may block `GlobalAction`s.