### PR TITLE
Forcefully re-apply DrawableHitObject state transforms on post-load DefaultsApplied

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -186,6 +186,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         private void onDefaultsApplied(HitObject hitObject)
         {
             apply(hitObject);
+            updateState(state.Value, true);
             DefaultsApplied?.Invoke(this);
         }
 


### PR DESCRIPTION
Fixes sliders not correctly adjusting their fade when extending their path length, amongst other similar issues.