### PR TITLE
Add additional bonus HitResult types

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -92,10 +92,8 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 new TableColumn("max combo", Anchor.CentreLeft, new Dimension(GridSizeMode.Distributed, minSize: 70, maxSize: 120))
             };
 
-            foreach (var statistic in score.SortedStatistics.Take(score.SortedStatistics.Count() - 1))
-                columns.Add(new TableColumn(statistic.Key.GetDescription(), Anchor.CentreLeft, new Dimension(GridSizeMode.Distributed, minSize: 35, maxSize: 60)));
-
-            columns.Add(new TableColumn(score.SortedStatistics.LastOrDefault().Key.GetDescription(), Anchor.CentreLeft, new Dimension(GridSizeMode.Distributed, minSize: 45, maxSize: 95)));
+            foreach (var (key, _, _) in score.GetStatisticsForDisplay())
+                columns.Add(new TableColumn(key.GetDescription(), Anchor.CentreLeft, new Dimension(GridSizeMode.Distributed, minSize: 35, maxSize: 60)));
 
             if (showPerformancePoints)
                 columns.Add(new TableColumn("pp", Anchor.CentreLeft, new Dimension(GridSizeMode.Absolute, 30)));
@@ -148,13 +146,13 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 }
             };
 
-            foreach (var kvp in score.SortedStatistics)
+            foreach (var (_, value, maxCount) in score.GetStatisticsForDisplay())
             {
                 content.Add(new OsuSpriteText
                 {
-                    Text = $"{kvp.Value}",
+                    Text = maxCount == null ? $"{value}" : $"{value}/{maxCount}",
                     Font = OsuFont.GetFont(size: text_size),
-                    Colour = kvp.Value == 0 ? Color4.Gray : Color4.White
+                    Colour = value == 0 ? Color4.Gray : Color4.White
                 });
             }
 

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 ppColumn.Alpha = value.Beatmap?.Status == BeatmapSetOnlineStatus.Ranked ? 1 : 0;
                 ppColumn.Text = $@"{value.PP:N0}";
 
-                statisticsColumns.ChildrenEnumerable = value.SortedStatistics.Select(kvp => createStatisticsColumn(kvp.Key, kvp.Value));
+                statisticsColumns.ChildrenEnumerable = value.GetStatisticsForDisplay().Select(s => createStatisticsColumn(s.result, s.count, s.maxCount));
                 modsColumn.Mods = value.Mods;
 
                 if (scoreManager != null)
@@ -125,9 +125,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             }
         }
 
-        private TextColumn createStatisticsColumn(HitResult hitResult, int count) => new TextColumn(hitResult.GetDescription(), smallFont, bottom_columns_min_width)
+        private TextColumn createStatisticsColumn(HitResult hitResult, int count, int? maxCount) => new TextColumn(hitResult.GetDescription(), smallFont, bottom_columns_min_width)
         {
-            Text = count.ToString()
+            Text = maxCount == null ? $"{count}" : $"{count}/{maxCount}"
         };
 
         private class InfoColumn : CompositeDrawable

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -87,15 +87,21 @@ namespace osu.Game.Rulesets.Scoring
         SmallBonus = 254,
 
         /// <summary>
-        /// Indicate a large bonus.
+        /// Indicates a large bonus.
         /// </summary>
         [Description("L Bonus")]
         [Order(8)]
         LargeBonus = 320,
 
+        /// <summary>
+        /// Indicates a miss that should be ignored for scoring purposes.
+        /// </summary>
         [Order(13)]
         IgnoreMiss = 384,
 
+        /// <summary>
+        /// Indicates a hit that should be ignored for scoring purposes.
+        /// </summary>
         [Order(12)]
         IgnoreHit,
     }

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         [Description(@"")]
         [Order(14)]
-        None = 0,
+        None,
 
         /// <summary>
         /// Indicates that the object has been judged as a miss.
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </remarks>
         [Description(@"Miss")]
         [Order(5)]
-        Miss = 64,
+        Miss,
 
         [Description(@"Meh")]
         [Order(4)]
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates small tick miss.
         /// </summary>
         [Order(11)]
-        SmallTickMiss = 128,
+        SmallTickMiss,
 
         /// <summary>
         /// Indicates a small tick hit.
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates a large tick miss.
         /// </summary>
         [Order(10)]
-        LargeTickMiss = 192,
+        LargeTickMiss,
 
         /// <summary>
         /// Indicates a large tick hit.
@@ -84,20 +84,20 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         [Description("S Bonus")]
         [Order(9)]
-        SmallBonus = 254,
+        SmallBonus,
 
         /// <summary>
         /// Indicates a large bonus.
         /// </summary>
         [Description("L Bonus")]
         [Order(8)]
-        LargeBonus = 320,
+        LargeBonus,
 
         /// <summary>
         /// Indicates a miss that should be ignored for scoring purposes.
         /// </summary>
         [Order(13)]
-        IgnoreMiss = 384,
+        IgnoreMiss,
 
         /// <summary>
         /// Indicates a hit that should be ignored for scoring purposes.

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Scoring
     public static class HitResultExtensions
     {
         /// <summary>
-        /// Whether a <see cref="HitResult"/> affects the combo.
+        /// Whether a <see cref="HitResult"/> increases/decreases the combo, and affects the combo portion of the score.
         /// </summary>
         public static bool AffectsCombo(this HitResult result)
         {
@@ -122,12 +122,14 @@ namespace osu.Game.Rulesets.Scoring
         }
 
         /// <summary>
-        /// Whether a <see cref="HitResult"/> should be counted as combo score.
+        /// Whether a <see cref="HitResult"/> affects the accuracy portion of the score.
         /// </summary>
-        /// <remarks>
-        /// This is not the reciprocal of <see cref="AffectsCombo"/>, as <see cref="HitResult.SmallTickHit"/> and <see cref="HitResult.SmallTickMiss"/> do not affect combo
-        /// but are still considered as part of the accuracy (not bonus) portion of the score.
-        /// </remarks>
+        public static bool AffectsAccuracy(this HitResult result)
+            => IsScorable(result) && !IsBonus(result);
+
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> should be counted as bonus score.
+        /// </summary>
         public static bool IsBonus(this HitResult result)
         {
             switch (result)

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         [Description(@"")]
         [Order(14)]
-        None,
+        None = 0,
 
         /// <summary>
         /// Indicates that the object has been judged as a miss.
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </remarks>
         [Description(@"Miss")]
         [Order(5)]
-        Miss,
+        Miss = 64,
 
         [Description(@"Meh")]
         [Order(4)]
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates small tick miss.
         /// </summary>
         [Order(11)]
-        SmallTickMiss,
+        SmallTickMiss = 128,
 
         /// <summary>
         /// Indicates a small tick hit.
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates a large tick miss.
         /// </summary>
         [Order(10)]
-        LargeTickMiss,
+        LargeTickMiss = 192,
 
         /// <summary>
         /// Indicates a large tick hit.
@@ -84,17 +84,17 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         [Description("S Bonus")]
         [Order(9)]
-        SmallBonus,
+        SmallBonus = 254,
 
         /// <summary>
         /// Indicate a large bonus.
         /// </summary>
         [Description("L Bonus")]
         [Order(8)]
-        LargeBonus,
+        LargeBonus = 320,
 
         [Order(13)]
-        IgnoreMiss,
+        IgnoreMiss = 384,
 
         [Order(12)]
         IgnoreHit,

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -13,11 +13,8 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates that the object has not been judged yet.
         /// </summary>
         [Description(@"")]
-        [Order(13)]
+        [Order(14)]
         None,
-
-        [Order(12)]
-        Ignore,
 
         /// <summary>
         /// Indicates that the object has been judged as a miss.
@@ -95,6 +92,12 @@ namespace osu.Game.Rulesets.Scoring
         [Description("L Bonus")]
         [Order(8)]
         LargeBonus,
+
+        [Order(13)]
+        IgnoreMiss,
+
+        [Order(12)]
+        IgnoreHit,
     }
 
     public static class HitResultExtensions
@@ -151,7 +154,7 @@ namespace osu.Game.Rulesets.Scoring
             switch (result)
             {
                 case HitResult.None:
-                case HitResult.Ignore:
+                case HitResult.IgnoreMiss:
                 case HitResult.Miss:
                 case HitResult.SmallTickMiss:
                 case HitResult.LargeTickMiss:
@@ -165,6 +168,6 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Whether a <see cref="HitResult"/> is scorable.
         /// </summary>
-        public static bool IsScorable(this HitResult result) => result > HitResult.Ignore;
+        public static bool IsScorable(this HitResult result) => result >= HitResult.Miss && result < HitResult.IgnoreMiss;
     }
 }

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -2,16 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Scoring
 {
+    [HasOrderedElements]
     public enum HitResult
     {
         /// <summary>
         /// Indicates that the object has not been judged yet.
         /// </summary>
         [Description(@"")]
+        [Order(13)]
         None,
+
+        [Order(12)]
+        Ignore,
 
         /// <summary>
         /// Indicates that the object has been judged as a miss.
@@ -21,47 +27,142 @@ namespace osu.Game.Rulesets.Scoring
         /// "too far in the future). It should also define when a forced miss should be triggered (as a result of no user input in time).
         /// </remarks>
         [Description(@"Miss")]
+        [Order(5)]
         Miss,
 
         [Description(@"Meh")]
+        [Order(4)]
         Meh,
 
         /// <summary>
         /// Optional judgement.
         /// </summary>
         [Description(@"OK")]
+        [Order(3)]
         Ok,
 
         [Description(@"Good")]
+        [Order(2)]
         Good,
 
         [Description(@"Great")]
+        [Order(1)]
         Great,
 
         /// <summary>
         /// Optional judgement.
         /// </summary>
         [Description(@"Perfect")]
+        [Order(0)]
         Perfect,
 
         /// <summary>
         /// Indicates small tick miss.
         /// </summary>
+        [Order(11)]
         SmallTickMiss,
 
         /// <summary>
         /// Indicates a small tick hit.
         /// </summary>
+        [Description(@"S Tick")]
+        [Order(7)]
         SmallTickHit,
 
         /// <summary>
         /// Indicates a large tick miss.
         /// </summary>
+        [Order(10)]
         LargeTickMiss,
 
         /// <summary>
         /// Indicates a large tick hit.
         /// </summary>
-        LargeTickHit
+        [Description(@"L Tick")]
+        [Order(6)]
+        LargeTickHit,
+
+        /// <summary>
+        /// Indicates a small bonus.
+        /// </summary>
+        [Description("S Bonus")]
+        [Order(9)]
+        SmallBonus,
+
+        /// <summary>
+        /// Indicate a large bonus.
+        /// </summary>
+        [Description("L Bonus")]
+        [Order(8)]
+        LargeBonus,
+    }
+
+    public static class HitResultExtensions
+    {
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> affects the combo.
+        /// </summary>
+        public static bool AffectsCombo(this HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Miss:
+                case HitResult.Meh:
+                case HitResult.Ok:
+                case HitResult.Good:
+                case HitResult.Great:
+                case HitResult.Perfect:
+                case HitResult.LargeTickHit:
+                case HitResult.LargeTickMiss:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> should be counted as combo score.
+        /// </summary>
+        /// <remarks>
+        /// This is not the reciprocal of <see cref="AffectsCombo"/>, as <see cref="HitResult.SmallTickHit"/> and <see cref="HitResult.SmallTickMiss"/> do not affect combo
+        /// but are still considered as part of the accuracy (not bonus) portion of the score.
+        /// </remarks>
+        public static bool IsBonus(this HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.SmallBonus:
+                case HitResult.LargeBonus:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> represents a successful hit.
+        /// </summary>
+        public static bool IsHit(this HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.None:
+                case HitResult.Ignore:
+                case HitResult.Miss:
+                case HitResult.SmallTickMiss:
+                case HitResult.LargeTickMiss:
+                    return false;
+
+                default:
+                    return true;
+            }
+        }
+
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> is scorable.
+        /// </summary>
+        public static bool IsScorable(this HitResult result) => result > HitResult.Ignore;
     }
 }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Rulesets;
@@ -147,8 +148,6 @@ namespace osu.Game.Scoring
         [JsonProperty("statistics")]
         public Dictionary<HitResult, int> Statistics = new Dictionary<HitResult, int>();
 
-        public IOrderedEnumerable<KeyValuePair<HitResult, int>> SortedStatistics => Statistics.OrderByDescending(pair => pair.Key);
-
         [JsonIgnore]
         [Column("Statistics")]
         public string StatisticsJson
@@ -185,6 +184,48 @@ namespace osu.Game.Scoring
         [NotMapped]
         [JsonProperty("position")]
         public int? Position { get; set; }
+
+        public IEnumerable<(HitResult result, int count, int? maxCount)> GetStatisticsForDisplay()
+        {
+            foreach (var key in OrderAttributeUtils.GetValuesInOrder<HitResult>())
+            {
+                if (key.IsBonus())
+                    continue;
+
+                int value = Statistics.GetOrDefault(key);
+
+                switch (key)
+                {
+                    case HitResult.SmallTickHit:
+                    {
+                        int total = value + Statistics.GetOrDefault(HitResult.SmallTickMiss);
+                        if (total > 0)
+                            yield return (key, value, total);
+
+                        break;
+                    }
+
+                    case HitResult.LargeTickHit:
+                    {
+                        int total = value + Statistics.GetOrDefault(HitResult.LargeTickMiss);
+                        if (total > 0)
+                            yield return (key, value, total);
+
+                        break;
+                    }
+
+                    case HitResult.SmallTickMiss:
+                    case HitResult.LargeTickMiss:
+                        break;
+
+                    default:
+                        if (value > 0 || key == HitResult.Miss)
+                            yield return (key, value, null);
+
+                        break;
+                }
+            }
+        }
 
         [Serializable]
         protected class DeserializedMod : IMod

--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelMiddleContent.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Leaderboards;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
@@ -116,7 +117,7 @@ namespace osu.Game.Screens.Ranking.Contracted
                                             AutoSizeAxes = Axes.Y,
                                             Direction = FillDirection.Vertical,
                                             Spacing = new Vector2(0, 5),
-                                            ChildrenEnumerable = score.SortedStatistics.Select(s => createStatistic(s.Key.GetDescription(), s.Value.ToString()))
+                                            ChildrenEnumerable = score.GetStatisticsForDisplay().Select(s => createStatistic(s.result, s.count, s.maxCount))
                                         },
                                         new FillFlowContainer
                                         {
@@ -197,6 +198,9 @@ namespace osu.Game.Screens.Ranking.Contracted
                 }
             };
         }
+
+        private Drawable createStatistic(HitResult result, int count, int? maxCount)
+            => createStatistic(result.GetDescription(), maxCount == null ? $"{count}" : $"{count}/{maxCount}");
 
         private Drawable createStatistic(string key, string value) => new Container
         {

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -65,8 +65,9 @@ namespace osu.Game.Screens.Ranking.Expanded
             };
 
             var bottomStatistics = new List<StatisticDisplay>();
-            foreach (var stat in score.SortedStatistics)
-                bottomStatistics.Add(new HitResultStatistic(stat.Key, stat.Value));
+
+            foreach (var (key, value, maxCount) in score.GetStatisticsForDisplay())
+                bottomStatistics.Add(new HitResultStatistic(key, value, maxCount));
 
             statisticDisplays.AddRange(topStatistics);
             statisticDisplays.AddRange(bottomStatistics);

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -16,6 +17,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
     public class CounterStatistic : StatisticDisplay
     {
         private readonly int count;
+        private readonly int? maxCount;
 
         private RollingCounter<int> counter;
 
@@ -24,10 +26,12 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         /// </summary>
         /// <param name="header">The name of the statistic.</param>
         /// <param name="count">The value to display.</param>
-        public CounterStatistic(string header, int count)
+        /// <param name="maxCount">The maximum value of <paramref name="count"/>. Not displayed if null.</param>
+        public CounterStatistic(string header, int count, int? maxCount = null)
             : base(header)
         {
             this.count = count;
+            this.maxCount = maxCount;
         }
 
         public override void Appear()
@@ -36,7 +40,33 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
             counter.Current.Value = count;
         }
 
-        protected override Drawable CreateContent() => counter = new Counter();
+        protected override Drawable CreateContent()
+        {
+            var container = new FillFlowContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal,
+                Child = counter = new Counter
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre
+                }
+            };
+
+            if (maxCount != null)
+            {
+                container.Add(new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Font = OsuFont.Torus.With(size: 12, fixedWidth: true),
+                    Spacing = new Vector2(-2, 0),
+                    Text = $"/{maxCount}"
+                });
+            }
+
+            return container;
+        }
 
         private class Counter : RollingCounter<int>
         {

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/HitResultStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/HitResultStatistic.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
     {
         private readonly HitResult result;
 
-        public HitResultStatistic(HitResult result, int count)
-            : base(result.GetDescription(), count)
+        public HitResultStatistic(HitResult result, int count, int? maxCount = null)
+            : base(result.GetDescription(), count, maxCount)
         {
             this.result = result;
         }

--- a/osu.Game/Tests/TestScoreInfo.cs
+++ b/osu.Game/Tests/TestScoreInfo.cs
@@ -37,6 +37,12 @@ namespace osu.Game.Tests
             Statistics[HitResult.Meh] = 50;
             Statistics[HitResult.Good] = 100;
             Statistics[HitResult.Great] = 300;
+            Statistics[HitResult.SmallTickHit] = 50;
+            Statistics[HitResult.SmallTickMiss] = 25;
+            Statistics[HitResult.LargeTickHit] = 100;
+            Statistics[HitResult.LargeTickMiss] = 50;
+            Statistics[HitResult.SmallBonus] = 10;
+            Statistics[HitResult.SmallBonus] = 50;
 
             Position = 1;
         }


### PR DESCRIPTION
This is a non-breaking change:
1. Adds `SmallBonus` and `LargeBonus` to `HitResult`.
    * There have been no changes to hitobjects yet, this is tbd in a separate PR.
2. Adds ordering to the enum.
3. Changes displays game-wide to use the new results + ordering.
    * Trims out a few unnecessary (for now) results - bonus judgements, tick misses.
    * Provides a bit more context as to how to display the value. For ticks the display should be x/y and for bonus it should probably just be the raw score value (not done yet).
4. It defines the relationships between all `HitResult` types in terms of whether they are bonus, affect combo, represent hits, or are scorable. These are mostly unused for now, except for the new code in this PR, where it currently has no effect.
    * Going forward, we'll be removing the `AffectsCombo` and `IsBonus` properties of `Judgement`. This is tbd in a separate PR.
    * I've tabulated the decisions for what does what here: https://docs.google.com/spreadsheets/d/1WYOfjB-xjn0DZI99d2-Pxpo5CYxPyW15yzYDz9gc8Ug/edit#gid=0

I've taken a very simple approach to `ScoreTable` (the beatmap overlay one) which is to find all hitresults across all scores displayed. Eventually we'll need a ruleset-level method to find all the applicable results for a ruleset, but this should suffice for now.
As I mentioned in Discord, maybe the way to do this is to expose all retrievable hitobjects for a ruleset and enumerate over them - undecided but that's why I haven't done it here.

(Drafting while further PRs are published, don't review yet in-case I need to move things around more)