### PR TITLE
Fix HP drain edgecase potentially causing insta-fails

### DIFF
--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Scoring
 
         private double computeDrainRate()
         {
-            if (healthIncreases.Count == 0)
+            if (healthIncreases.Count <= 1)
                 return 0;
 
             int adjustment = 1;


### PR DESCRIPTION
One way this can come up is if you have a single short (no ticks) slider, as the only hitobject in a beatmap.

`DrainingHealthProcessor` needs at least two hp-providing judgements to figure out the drain between them, otherwise it basically goes to infinite drain and fails you right after the first judgement.