### PR TITLE
Fix scroll container's scrollbar not respecting minimum size on first resize

### DIFF
--- a/osu.Game/Graphics/Containers/OsuScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuScrollContainer.cs
@@ -112,6 +112,9 @@ namespace osu.Game.Graphics.Containers
 
                 CornerRadius = 5;
 
+                // needs to be set initially for the ResizeTo to respect minimum size
+                Size = new Vector2(SCROLL_BAR_HEIGHT);
+
                 const float margin = 3;
 
                 Margin = new MarginPadding


### PR DESCRIPTION
Wasn't being set early enough to be correctly considered for initial resize update call. Visible at song select with many beatmaps (fixes after first selection of a different panel after entering).

Closes https://github.com/ppy/osu/issues/10219