### PR TITLE
Fix visual brokenness in taiko tests using DrawableTestHit

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTestHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTestHit.cs
@@ -22,6 +22,12 @@ namespace osu.Game.Rulesets.Taiko.Tests
             HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
         }
 
+        protected override void UpdateInitialTransforms()
+        {
+            // base implementation in DrawableHitObject forces alpha to 1.
+            // suppress locally to allow hiding the visuals wherever necessary.
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
@@ -212,7 +212,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             foreach (var playfield in playfields)
             {
                 var hit = new DrawableTestHit(new Hit(), judgementResult.Type);
-                Add(hit);
+                playfield.Add(hit);
 
                 playfield.OnNewResult(hit, judgementResult);
             }

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
@@ -35,7 +35,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    hit,
+                    // the hit needs to be added to hierarchy in order for nested objects to be created correctly.
+                    // setting zero alpha is supposed to prevent the test from looking broken.
+                    hit.With(h => h.Alpha = 0),
                     new HitExplosion(hit, hit.Type)
                     {
                         Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
             var h = new DrawableTestHit(hit) { X = RNG.NextSingle(hitResult == HitResult.Good ? -0.1f : -0.05f, hitResult == HitResult.Good ? 0.1f : 0.05f) };
 
-            Add(h);
+            drawableRuleset.Playfield.Add(h);
 
             ((TaikoPlayfield)drawableRuleset.Playfield).OnNewResult(h, new JudgementResult(new HitObject(), new TaikoJudgement()) { Type = hitResult });
         }
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
             var h = new DrawableTestHit(hit) { X = RNG.NextSingle(hitResult == HitResult.Good ? -0.1f : -0.05f, hitResult == HitResult.Good ? 0.1f : 0.05f) };
 
-            Add(h);
+            drawableRuleset.Playfield.Add(h);
 
             ((TaikoPlayfield)drawableRuleset.Playfield).OnNewResult(h, new JudgementResult(new HitObject(), new TaikoJudgement()) { Type = hitResult });
             ((TaikoPlayfield)drawableRuleset.Playfield).OnNewResult(new TestStrongNestedHit(h), new JudgementResult(new HitObject(), new TaikoStrongJudgement()) { Type = HitResult.Great });
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         private void addMissJudgement()
         {
             DrawableTestHit h;
-            Add(h = new DrawableTestHit(new Hit(), HitResult.Miss));
+            drawableRuleset.Playfield.Add(h = new DrawableTestHit(new Hit(), HitResult.Miss));
             ((TaikoPlayfield)drawableRuleset.Playfield).OnNewResult(h, new JudgementResult(new HitObject(), new TaikoJudgement()) { Type = HitResult.Miss });
         }
 


### PR DESCRIPTION
# Summary

#10250 has left `TestSceneHits` and `TestSceneDrawableTaikoMascot` looking pretty broken visually, due to changing the inheritance hierarchy from

```
DrawableTaikoHitObject
  DrawableHit
    DrawableTestStrongHit
  DrawableTestHit
```

to the more correct

```
DrawableTaikoHitObject
  DrawableHit
    DrawableTestHit
      DrawableTestStrongHit
```

In tests that interact with taiko drawable hitobjects they need to be added to the visual hierarchy so that nested objects are created properly, which at the state of current `master` leads to stuff like this:

| `TestSceneHits` | `TestSceneDrawableTaikoMascot` |
| :-: | :-: |
| ![2020-09-26-210550_1920x1138_scrot](https://user-images.githubusercontent.com/20418176/94348389-2395f500-003c-11eb-8c5a-e3218b3e8693.png) | ![2020-09-26-210601_1920x1138_scrot](https://user-images.githubusercontent.com/20418176/94348392-2b559980-003c-11eb-8817-2767556357a8.png) |

which looks pretty bad.

In those two tests it is possible to add the object to the playfield rather than the immediate child of the test window, which fixes the brokenness. However, `TestSceneHitExplosion` would also display the object - and there's no playfield in sight there to add to, so instead I opted for a workaround local to `DrawableTestHit` to be able to apply zero alpha.

# Remarks

`TestSceneHitExplosion` was broken like so from the start. I figured I should fix it if I'm already fixing the others, though, especially seeing that I wrote it. It's the worst fix, by far, too (suppressing the base call), but there's not much room to maneuver there...