### PR TITLE
Fix drum rolls only spawning centre flying hits

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneFlyingHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneFlyingHits.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Judgements;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.UI;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    [TestFixture]
+    public class TestSceneFlyingHits : DrawableTaikoRulesetTestScene
+    {
+        [TestCase(HitType.Centre)]
+        [TestCase(HitType.Rim)]
+        public void TestFlyingHits(HitType hitType)
+        {
+            DrawableFlyingHit flyingHit = null;
+
+            AddStep("add flying hit", () =>
+            {
+                addFlyingHit(hitType);
+
+                // flying hits all land in one common scrolling container (and stay there for rewind purposes),
+                // so we need to manually get the latest one.
+                flyingHit = this.ChildrenOfType<DrawableFlyingHit>()
+                                .OrderByDescending(h => h.HitObject.StartTime)
+                                .FirstOrDefault();
+            });
+
+            AddAssert("hit type is correct", () => flyingHit.HitObject.Type == hitType);
+        }
+
+        private void addFlyingHit(HitType hitType)
+        {
+            var tick = new DrumRollTick { HitWindows = HitWindows.Empty, StartTime = DrawableRuleset.Playfield.Time.Current };
+
+            DrawableDrumRollTick h;
+            DrawableRuleset.Playfield.Add(h = new DrawableDrumRollTick(tick) { JudgementType = hitType });
+            ((TaikoPlayfield)DrawableRuleset.Playfield).OnNewResult(h, new JudgementResult(tick, new TaikoDrumRollTickJudgement()) { Type = HitResult.Perfect });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableFlyingHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableFlyingHit.cs
@@ -27,5 +27,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             base.LoadComplete();
             ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
+
+        protected override void LoadSamples()
+        {
+            // block base call - flying hits are not supposed to play samples
+            // the base call could overwrite the type of this hit
+        }
     }
 }


### PR DESCRIPTION
- Resolves a regression from #10217.
- [x] Depends on #10259 (first in chain).
- [x] Depends on #10260 (for the testing infrastructure).

Not sold on the resolution at all, so PRing more for discussion.

# Summary

The bidirectional sample-hit type mapping introduced in the aforementioned PR breaks flying hits, because they get no samples assigned from the tick that created them, therefore always ending up being centres.

Resolve by suppressing the flying hit's base call to `LoadSamples()`, which is a resolution that makes the most semantic sense for me (the flying hit is not supposed to play audio anyway, and suppressing the base call disables the sample -> hit type remapping that caused the type to be changed from `Rim` to `Centre`).

# Remarks

I know this is a bad resolution. I don't see good ones, not at least without majorly reworking how the bidirectional propagation of sample-to-hit-type works right now. The data is flying back and forth in multiple places:

- beatmap decoder is setting both hit type and samples
- `Hit` ctor copies hit type from hit object
- `LoadSamples` writes same value back (which is what failed here)
- any type change affects samples
- any sample change affects type

I'm PRing this mostly as it's an immediate, *relatively* non-invasive fix. A singular source of truth would go a long way here instead of trying to keep this state consistent at all times, but as I'm typing this I'm not yet sure how to make it happen given all of the things that are happening listed above.