### PR TITLE
Fix potential instability of overlay activation tests

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneOverlayActivation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneOverlayActivation.cs
@@ -12,6 +12,14 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         protected new OverlayTestPlayer Player => base.Player as OverlayTestPlayer;
 
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddUntilStep("gameplay has started",
+                () => Player.GameplayClockContainer.GameplayClock.CurrentTime > Player.DrawableRuleset.GameplayStartTime);
+        }
+
         [Test]
         public void TestGameplayOverlayActivation()
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneOverlayActivation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneOverlayActivation.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestGameplayOverlayActivationPaused()
         {
-            AddUntilStep("activation mode is disabled", () => Player.OverlayActivationMode == OverlayActivation.Disabled);
+            AddAssert("activation mode is disabled", () => Player.OverlayActivationMode == OverlayActivation.Disabled);
             AddStep("pause gameplay", () => Player.Pause());
             AddUntilStep("activation mode is user triggered", () => Player.OverlayActivationMode == OverlayActivation.UserTriggered);
         }


### PR DESCRIPTION
As seen [here](https://ci.appveyor.com/project/peppy/osu/builds/35426132/tests).

# Summary

There is a possibility for overlay activation tests to hit a race condition. Under the debugger I noticed this callback was being entered twice:

https://github.com/ppy/osu/blob/db249f6868bc7207dca0d103c4ed5a9659cd4892/osu.Game/Screens/Play/Player.cs#L354-L362

and setting `UserTriggered` the first time and `Disabled` the second. This, in turn, was caused by `IsBreakTime` becoming true. The beatmap used in the test has a `GameplayStartTime` of 170 rather than 0, and time before that is considered a break:

https://github.com/ppy/osu/blob/59dd523d27f957acb940231ecbb989222568ba69/osu.Game/Screens/Play/BreakTracker.cs#L51-L53

Resolve by explicitly waiting for gameplay to start before proceeding with the initial assertions.

# Remarks

This is somewhat theoretical, as stressing the test 1000 times locally didn't yield this failure for me, but the double entry to `updateOverlayActivationMode` is pretty consistent to replicate on `master`.

I've also additionally changed an until step to an assert step in 8d9945d for consistency. Three tests in the scene used `AddAssert` to check the initial activation mode, and one seemingly randomly used `AddUntilStep`, probably due to hitting this race.