### PR TITLE
Rework legacy taiko strong explosions to not require frame-perfect hits to show

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         private DrawableHit hit;
         private DrawableStrongNestedHit nestedStrongHit;
+        private bool switchedToStrongSprite;
 
         /// <summary>
         /// Creates a new legacy hit explosion.
@@ -84,16 +85,17 @@ namespace osu.Game.Rulesets.Taiko.Skinning
         {
             base.Update();
 
-            if (shouldSwitchToStrongSprite() && strongSprite != null)
+            if (shouldSwitchToStrongSprite() && !switchedToStrongSprite)
             {
                 sprite.FadeOut(50, Easing.OutQuint);
                 strongSprite.FadeIn(50, Easing.OutQuint);
+                switchedToStrongSprite = true;
             }
         }
 
         private bool shouldSwitchToStrongSprite()
         {
-            if (hit == null || nestedStrongHit == null)
+            if (hit == null || nestedStrongHit == null || strongSprite == null)
                 return false;
 
             return nestedStrongHit.IsHit;

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
             if (hit == null || nestedStrongHit == null)
                 return false;
 
-            return hit.Result.Type == nestedStrongHit.Result.Type;
+            return nestedStrongHit.IsHit;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
@@ -15,7 +15,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning
         private readonly Drawable sprite;
         private readonly Drawable strongSprite;
 
-        private DrawableHit hit;
         private DrawableStrongNestedHit nestedStrongHit;
         private bool switchedToStrongSprite;
 
@@ -58,11 +57,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                 }));
             }
 
-            if (judgedObject is DrawableHit h)
-            {
-                hit = h;
+            if (judgedObject is DrawableHit hit)
                 nestedStrongHit = hit.NestedHitObjects.SingleOrDefault() as DrawableStrongNestedHit;
-            }
         }
 
         protected override void LoadComplete()
@@ -95,7 +91,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
         private bool shouldSwitchToStrongSprite()
         {
-            if (hit == null || nestedStrongHit == null || strongSprite == null)
+            if (nestedStrongHit == null || strongSprite == null)
                 return false;
 
             return nestedStrongHit.IsHit;

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -8,14 +9,36 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 {
     public class LegacyHitExplosion : CompositeDrawable
     {
-        public LegacyHitExplosion(Drawable sprite)
-        {
-            InternalChild = sprite;
+        private readonly Drawable sprite;
+        private readonly Drawable strongSprite;
 
+        /// <summary>
+        /// Creates a new legacy hit explosion.
+        /// </summary>
+        /// <remarks>
+        /// Contrary to stable's, this implementation doesn't require a frame-perfect hit
+        /// for the strong sprite to be displayed.
+        /// </remarks>
+        /// <param name="sprite">The normal legacy explosion sprite.</param>
+        /// <param name="strongSprite">The strong legacy explosion sprite.</param>
+        public LegacyHitExplosion(Drawable sprite, Drawable strongSprite = null)
+        {
+            this.sprite = sprite;
+            this.strongSprite = strongSprite;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
             AutoSizeAxes = Axes.Both;
+
+            AddInternal(sprite);
+
+            if (strongSprite != null)
+                AddInternal(strongSprite.With(s => s.Alpha = 0));
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyHitExplosion.cs
@@ -41,10 +41,21 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
             AutoSizeAxes = Axes.Both;
 
-            AddInternal(sprite);
+            AddInternal(sprite.With(s =>
+            {
+                s.Anchor = Anchor.Centre;
+                s.Origin = Anchor.Centre;
+            }));
 
             if (strongSprite != null)
-                AddInternal(strongSprite.With(s => s.Alpha = 0));
+            {
+                AddInternal(strongSprite.With(s =>
+                {
+                    s.Alpha = 0;
+                    s.Anchor = Anchor.Centre;
+                    s.Origin = Anchor.Centre;
+                }));
+            }
 
             if (judgedObject is DrawableHit h)
             {

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -74,15 +74,23 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
                     return null;
 
-                case TaikoSkinComponents.TaikoExplosionGood:
-                case TaikoSkinComponents.TaikoExplosionGoodStrong:
-                case TaikoSkinComponents.TaikoExplosionGreat:
-                case TaikoSkinComponents.TaikoExplosionGreatStrong:
                 case TaikoSkinComponents.TaikoExplosionMiss:
 
-                    var sprite = this.GetAnimation(getHitName(taikoComponent.Component), true, false);
-                    if (sprite != null)
-                        return new LegacyHitExplosion(sprite);
+                    var missSprite = this.GetAnimation(getHitName(taikoComponent.Component), true, false);
+                    if (missSprite != null)
+                        return new LegacyHitExplosion(missSprite);
+
+                    return null;
+
+                case TaikoSkinComponents.TaikoExplosionGood:
+                case TaikoSkinComponents.TaikoExplosionGreat:
+
+                    var hitName = getHitName(taikoComponent.Component);
+                    var hitSprite = this.GetAnimation(hitName, true, false);
+                    var strongHitSprite = this.GetAnimation($"{hitName}k", true, false);
+
+                    if (hitSprite != null)
+                        return new LegacyHitExplosion(hitSprite, strongHitSprite);
 
                     return null;
 
@@ -109,17 +117,11 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                 case TaikoSkinComponents.TaikoExplosionGood:
                     return "taiko-hit100";
 
-                case TaikoSkinComponents.TaikoExplosionGoodStrong:
-                    return "taiko-hit100k";
-
                 case TaikoSkinComponents.TaikoExplosionGreat:
                     return "taiko-hit300";
-
-                case TaikoSkinComponents.TaikoExplosionGreatStrong:
-                    return "taiko-hit300k";
             }
 
-            throw new ArgumentOutOfRangeException(nameof(component), "Invalid result type");
+            throw new ArgumentOutOfRangeException(nameof(component), $"Invalid component type: {component}");
         }
 
         public override SampleChannel GetSample(ISampleInfo sampleInfo) => Source.GetSample(new LegacyTaikoSampleInfo(sampleInfo));

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -17,9 +17,7 @@ namespace osu.Game.Rulesets.Taiko
         BarLine,
         TaikoExplosionMiss,
         TaikoExplosionGood,
-        TaikoExplosionGoodStrong,
         TaikoExplosionGreat,
-        TaikoExplosionGreatStrong,
         Scroller,
         Mascot,
     }

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -10,7 +9,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
-using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.UI
@@ -50,10 +48,10 @@ namespace osu.Game.Rulesets.Taiko.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            Child = skinnable = new SkinnableDrawable(new TaikoSkinComponent(getComponentName(JudgedObject)), _ => new DefaultHitExplosion(JudgedObject, result));
+            Child = skinnable = new SkinnableDrawable(new TaikoSkinComponent(getComponentName(result)), _ => new DefaultHitExplosion(JudgedObject, result));
         }
 
-        private TaikoSkinComponents getComponentName(DrawableHitObject judgedObject)
+        private static TaikoSkinComponents getComponentName(HitResult result)
         {
             switch (result)
             {
@@ -61,28 +59,13 @@ namespace osu.Game.Rulesets.Taiko.UI
                     return TaikoSkinComponents.TaikoExplosionMiss;
 
                 case HitResult.Good:
-                    return useStrongExplosion(judgedObject)
-                        ? TaikoSkinComponents.TaikoExplosionGoodStrong
-                        : TaikoSkinComponents.TaikoExplosionGood;
+                    return TaikoSkinComponents.TaikoExplosionGood;
 
                 case HitResult.Great:
-                    return useStrongExplosion(judgedObject)
-                        ? TaikoSkinComponents.TaikoExplosionGreatStrong
-                        : TaikoSkinComponents.TaikoExplosionGreat;
+                    return TaikoSkinComponents.TaikoExplosionGreat;
             }
 
-            throw new ArgumentOutOfRangeException(nameof(judgedObject), "Invalid result type");
-        }
-
-        private bool useStrongExplosion(DrawableHitObject judgedObject)
-        {
-            if (!(judgedObject.HitObject is Hit))
-                return false;
-
-            if (!(judgedObject.NestedHitObjects.SingleOrDefault() is DrawableStrongNestedHit nestedHit))
-                return false;
-
-            return judgedObject.Result.Type == nestedHit.Result.Type;
+            throw new ArgumentOutOfRangeException(nameof(result), $"Invalid result type: {result}");
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -215,16 +215,12 @@ namespace osu.Game.Rulesets.Taiko.UI
         private void addDrumRollHit(DrawableDrumRollTick drawableTick) =>
             drumRollHitContainer.Add(new DrawableFlyingHit(drawableTick));
 
-        /// <remarks>
-        /// As legacy skins have different explosions for singular and double strong hits,
-        /// explosion addition is scheduled to ensure that both hits are processed if they occur on the same frame.
-        /// </remarks>
-        private void addExplosion(DrawableHitObject drawableObject, HitResult result, HitType type) => Schedule(() =>
+        private void addExplosion(DrawableHitObject drawableObject, HitResult result, HitType type)
         {
             hitExplosionContainer.Add(new HitExplosion(drawableObject, result));
             if (drawableObject.HitObject.Kiai)
                 kiaiExplosionContainer.Add(new KiaiHitExplosion(drawableObject, type));
-        });
+        }
 
         private class ProxyContainer : LifetimeManagementContainer
         {


### PR DESCRIPTION
Additionally resolves #10252 (which is a regression from the original 300k explosion PR at #10196).

# Summary

This PR is a proposal for a departure from stable's behaviour, in that the `taiko-hit{100,300}k` will be permitted to show if a strong hit is registered over its entire timing window, instead of requiring it to be a frame-perfect hit as is the case in stable (and as the current implementation in lazer has it).

This is done by keeping both sprites in the legacy explosion and fading from one to the other once the strong hit is registered. This has the added benefit of no longer requiring the schedule in `TaikoPlayfield` to work correctly, which resolves the default skin explosion regression mentioned in the issue linked. The cost is some overhead in `Update()`, but it doesn't even make top 5 in 

# Remarks

The crossfade between sprites might be slightly overkill and shouldn't be all that noticeable as in the absolute worst case the whole `LegacyHitExplosion` fades in through 120ms, while with the current numbers the sprite swap can take at absolute worst 80ms (30ms second hit window from `DrawableHit` + 50ms specified in the class). I didn't want to have no transition outright, though, as that's jank.

The old behaviour could be restored with the current structure by doing a schedule or something, but seeing that there are requests from users to change the behaviour I'm thinking we might as well do it here where it's at least somewhat feasible to achieve.