### PR TITLE
Avoid saving state changes if nothing has changed (via binary comparison)

### DIFF
--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Rulesets.Objects;
 
@@ -89,23 +91,27 @@ namespace osu.Game.Screens.Edit
             if (isRestoring)
                 return;
 
-            if (currentState < savedStates.Count - 1)
-                savedStates.RemoveRange(currentState + 1, savedStates.Count - currentState - 1);
-
-            if (savedStates.Count > MAX_SAVED_STATES)
-                savedStates.RemoveAt(0);
-
             using (var stream = new MemoryStream())
             {
                 using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                     new LegacyBeatmapEncoder(editorBeatmap, editorBeatmap.BeatmapSkin).Encode(sw);
 
-                savedStates.Add(stream.ToArray());
+                var newState = stream.ToArray();
+
+                // if the previous state is binary equal we don't need to push a new one, unless this is the initial state.
+                if (savedStates.Count > 0 && newState.SequenceEqual(savedStates.Last())) return;
+
+                if (currentState < savedStates.Count - 1)
+                    savedStates.RemoveRange(currentState + 1, savedStates.Count - currentState - 1);
+
+                if (savedStates.Count > MAX_SAVED_STATES)
+                    savedStates.RemoveAt(0);
+
+                savedStates.Add(newState);
+
+                currentState = savedStates.Count - 1;
+                updateBindables();
             }
-
-            currentState = savedStates.Count - 1;
-
-            updateBindables();
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Rulesets.Objects;
 


### PR DESCRIPTION
There are occasions we perform a `Begin`/`EndChange` but don't actually make any changes inside the block. This does a binary comparison and avoids polluting the undo change history in such cases. Probably not the most optimal method of doing this but I believe the state component will change in the future to not use the legacy serialization so should-do-for-now.