### PR TITLE
Avoid unnecessary object updates from SelectionHandlers

### DIFF
--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -57,7 +57,13 @@ namespace osu.Game.Rulesets.Taiko.Edit
             ChangeHandler.BeginChange();
 
             foreach (var h in hits)
-                h.IsStrong = state;
+            {
+                if (h.IsStrong != state)
+                {
+                    h.IsStrong = state;
+                    EditorBeatmap.UpdateHitObject(h);
+                }
+            }
 
             ChangeHandler.EndChange();
         }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -288,8 +288,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 var comboInfo = h as IHasComboInformation;
 
-                if (comboInfo == null)
-                    continue;
+                if (comboInfo == null || comboInfo.NewCombo == state) continue;
 
                 comboInfo.NewCombo = state;
                 EditorBeatmap?.UpdateHitObject(h);


### PR DESCRIPTION
Regressions from recent sample/type button ternary logic. Basically we want to avoid calling `UpdateHitObject` when nothing has changed, and a few new cases of this were introduced.