### PR TITLE
Trigger a hitobject update after blueprint drag ends

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -201,6 +201,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (isDraggingBlueprint)
             {
+                // handle positional change etc.
+                foreach (var obj in selectedHitObjects)
+                    Beatmap.UpdateHitObject(obj);
+
                 changeHandler?.EndChange();
                 isDraggingBlueprint = false;
             }


### PR DESCRIPTION
Was missing, causing no undo history (or general hitobject update) to occur after moving an object in space but not time.