### PR TITLE
Fix autoplay generators failing on empty hitobjects lists

### DIFF
--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -31,6 +31,9 @@ namespace osu.Game.Rulesets.Catch.Replays
 
         public override Replay Generate()
         {
+            if (Beatmap.HitObjects.Count == 0)
+                return Replay;
+
             // todo: add support for HT DT
             const double dash_speed = Catcher.BASE_SPEED;
             const double movement_speed = dash_speed / 2;

--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Rulesets.Mania.Replays
 
         public override Replay Generate()
         {
+            if (Beatmap.HitObjects.Count == 0)
+                return Replay;
+
             var pointGroups = generateActionPoints().GroupBy(a => a.Time).OrderBy(g => g.First().Time);
 
             var actions = new List<ManiaAction>();

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -72,6 +72,9 @@ namespace osu.Game.Rulesets.Osu.Replays
 
         public override Replay Generate()
         {
+            if (Beatmap.HitObjects.Count == 0)
+                return Replay;
+
             buttonIndex = 0;
 
             AddFrameToReplay(new OsuReplayFrame(-100000, new Vector2(256, 500)));

--- a/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
+++ b/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
@@ -30,6 +30,9 @@ namespace osu.Game.Rulesets.Taiko.Replays
 
         public override Replay Generate()
         {
+            if (Beatmap.HitObjects.Count == 0)
+                return Replay;
+
             bool hitButton = true;
 
             Frames.Add(new TaikoReplayFrame(-100000));


### PR DESCRIPTION
Not sure if there's a better way we can do this (ie. protect before generating) but honestly feels like an exception should not be thrown in these cases anyway.