### PR TITLE
Add autoplay support to editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
@@ -39,7 +39,11 @@ namespace osu.Game.Rulesets.Osu.Edit
             // adjust the visuals of certain object types to make them stay on screen for longer than usual.
             switch (hitObject)
             {
-                case DrawableSlider slider:
+                default:
+                    // there are quite a few drawable hit types we don't want to extent (spinners, ticks etc.)
+                    return;
+
+                case DrawableSlider _:
                     // no specifics to sliders but let them fade slower below.
                     break;
 
@@ -48,10 +52,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                           .FadeOutFromOne(editor_hit_object_fade_out_extension)
                           .Expire();
                     break;
-
-                default:
-                    // there are quite a few drawable hit types we don't want to extent (spinners, ticks etc.)
-                    return;
             }
 
             // Get the existing fade out transform

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// Hit objects are intentionally made to fade out at a constant slower rate than in gameplay.
         /// This allows a mapper to gain better historical context and use recent hitobjects as reference / snap points.
         /// </summary>
-        private const double editor_hit_object_fade_out_extension = 500;
+        private const double editor_hit_object_fade_out_extension = 700;
 
         public DrawableOsuEditRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
@@ -32,20 +33,37 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void updateState(DrawableHitObject hitObject, ArmedState state)
         {
-            switch (state)
+            if (state == ArmedState.Idle)
+                return;
+
+            // adjust the visuals of certain object types to make them stay on screen for longer than usual.
+            switch (hitObject)
             {
-                case ArmedState.Miss:
-                    // Get the existing fade out transform
-                    var existing = hitObject.Transforms.LastOrDefault(t => t.TargetMember == nameof(Alpha));
-                    if (existing == null)
-                        return;
-
-                    hitObject.RemoveTransform(existing);
-
-                    using (hitObject.BeginAbsoluteSequence(existing.StartTime))
-                        hitObject.FadeOut(editor_hit_object_fade_out_extension).Expire();
+                case DrawableSlider slider:
+                    // no specifics to sliders but let them fade slower below.
                     break;
+
+                case DrawableHitCircle circle: // also handles slider heads
+                    circle.ApproachCircle
+                          .FadeOutFromOne(editor_hit_object_fade_out_extension)
+                          .Expire();
+                    break;
+
+                default:
+                    // there are quite a few drawable hit types we don't want to extent (spinners, ticks etc.)
+                    return;
             }
+
+            // Get the existing fade out transform
+            var existing = hitObject.Transforms.LastOrDefault(t => t.TargetMember == nameof(Alpha));
+
+            if (existing == null)
+                return;
+
+            hitObject.RemoveTransform(existing);
+
+            using (hitObject.BeginAbsoluteSequence(existing.StartTime))
+                hitObject.FadeOut(editor_hit_object_fade_out_extension).Expire();
         }
 
         protected override Playfield CreatePlayfield() => new OsuPlayfieldNoCursor();

--- a/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
@@ -45,8 +45,12 @@ namespace osu.Game.Rulesets.Edit
             base.LoadComplete();
 
             beatmap.HitObjectAdded += addHitObject;
+            beatmap.HitObjectUpdated += updateReplay;
             beatmap.HitObjectRemoved += removeHitObject;
         }
+
+        private void updateReplay(HitObject obj = null) =>
+            drawableRuleset.RegenerateAutoplay();
 
         private void addHitObject(HitObject hitObject)
         {
@@ -54,6 +58,8 @@ namespace osu.Game.Rulesets.Edit
 
             drawableRuleset.Playfield.Add(drawableObject);
             drawableRuleset.Playfield.PostProcess();
+
+            updateReplay();
         }
 
         private void removeHitObject(HitObject hitObject)
@@ -62,6 +68,8 @@ namespace osu.Game.Rulesets.Edit
 
             drawableRuleset.Playfield.Remove(drawableObject);
             drawableRuleset.Playfield.PostProcess();
+
+            drawableRuleset.RegenerateAutoplay();
         }
 
         public override bool PropagatePositionalInputSubTree => false;

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Edit
 
             try
             {
-                drawableRulesetWrapper = new DrawableEditRulesetWrapper<TObject>(CreateDrawableRuleset(Ruleset, EditorBeatmap.PlayableBeatmap))
+                drawableRulesetWrapper = new DrawableEditRulesetWrapper<TObject>(CreateDrawableRuleset(Ruleset, EditorBeatmap.PlayableBeatmap, new[] { Ruleset.GetAutoplayMod() }))
                 {
                     Clock = EditorClock,
                     ProcessCustomClock = false

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -151,8 +151,11 @@ namespace osu.Game.Rulesets.UI
 
         public virtual PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new PlayfieldAdjustmentContainer();
 
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, CancellationToken? cancellationToken)
+        private void load(CancellationToken? cancellationToken)
         {
             InternalChildren = new Drawable[]
             {
@@ -178,9 +181,16 @@ namespace osu.Game.Rulesets.UI
                         .WithChild(ResumeOverlay)));
             }
 
-            applyRulesetMods(Mods, config);
+            RegenerateAutoplay();
 
             loadObjects(cancellationToken);
+        }
+
+        public void RegenerateAutoplay()
+        {
+            // for now this is applying mods which aren't just autoplay.
+            // we'll need to reconsider this flow in the future.
+            applyRulesetMods(Mods, config);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -212,6 +212,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (blueprint != null)
             {
+                // doing this post-creations as adding the default hit sample should be the case regardless of the ruleset.
+                blueprint.HitObject.Samples.Add(new HitSampleInfo { Name = HitSampleInfo.HIT_NORMAL });
+
                 placementBlueprintContainer.Child = currentPlacement = blueprint;
 
                 // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame


### PR DESCRIPTION
- Fixes hitsounds not playing
- Fixes hitobjects not looking like they are getting hit
- [x] Depends on https://github.com/ppy/osu/pull/10274
- [x] Depends on https://github.com/ppy/osu/pull/10275

Known issues which will be fixed in future PRs:
- Rewinding to the exact location of a hitobject then playing forwards will cause it to not explode (likely an issue with replay handling).
- Seeking forward may cause some objects in the past to not be an a hit state. Not a huge deal and fixes itself after rewinding before the objects. Pretty obvious why this happens (frame stability disabled).

This adjusts fade out extension logic to act more like stable (leaving the approach circle behind). Probably not the final look we want, but it's what people are used to and works better with autoplay causing the hits to explode (approach circle is quite a stable drawable to work with in contrast).

hitcircles:
![2020-09-28 16 29 08](https://user-images.githubusercontent.com/191335/94403022-c6b74d80-01a7-11eb-9bdb-9b0ed5b4f805.gif)

sliders:
![2020-09-28 16 29 39](https://user-images.githubusercontent.com/191335/94403081-dafb4a80-01a7-11eb-911c-296752345e58.gif)
