### PR TITLE
Fix extending spinners in editor causing them to disappear temporarily

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -93,7 +92,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             base.LoadComplete();
 
             drawableSpinner.RotationTracker.Complete.BindValueChanged(complete => updateComplete(complete.NewValue, 200));
-            drawableSpinner.State.BindValueChanged(updateStateTransforms, true);
+            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
         }
 
         protected override void Update()
@@ -123,7 +122,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             mainContainer.Rotation = drawableSpinner.RotationTracker.Rotation;
         }
 
-        private void updateStateTransforms(ValueChangedEvent<ArmedState> state)
+        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
             centre.ScaleTo(0);
             mainContainer.ScaleTo(0);
@@ -144,11 +143,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             }
 
             // transforms we have from completing the spinner will be rolled back, so reapply immediately.
-            updateComplete(state.NewValue == ArmedState.Hit, 0);
+            updateComplete(state == ArmedState.Hit, 0);
 
             using (BeginDelayedSequence(spinner.Duration, true))
             {
-                switch (state.NewValue)
+                switch (state)
                 {
                     case ArmedState.Hit:
                         this.ScaleTo(Scale * 1.2f, 320, Easing.Out);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -188,7 +188,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+
+            if (drawableSpinner != null)
+                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -184,5 +184,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 return true;
             }
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -72,10 +71,10 @@ namespace osu.Game.Rulesets.Osu.Skinning
             base.LoadComplete();
 
             this.FadeOut();
-            drawableSpinner.State.BindValueChanged(updateStateTransforms, true);
+            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
         }
 
-        private void updateStateTransforms(ValueChangedEvent<ArmedState> state)
+        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
             var spinner = (Spinner)drawableSpinner.HitObject;
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -98,7 +98,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+
+            if (drawableSpinner != null)
+                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -94,5 +94,11 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             Scale = new Vector2(final_scale * (0.8f + (float)Interpolation.ApplyEasing(Easing.Out, drawableSpinner.Progress) * 0.2f));
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -130,7 +130,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+
+            if (drawableSpinner != null)
+                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -86,10 +85,10 @@ namespace osu.Game.Rulesets.Osu.Skinning
             base.LoadComplete();
 
             this.FadeOut();
-            drawableSpinner.State.BindValueChanged(updateStateTransforms, true);
+            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
         }
 
-        private void updateStateTransforms(ValueChangedEvent<ArmedState> state)
+        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
             var spinner = drawableSpinner.HitObject;
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -126,5 +126,11 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             return (float)barCount / total_bars * final_metre_height;
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+        }
     }
 }


### PR DESCRIPTION
The editor triggers `ApplyDefaults` which causes `updateState` to be run on the `DrawableHitObject` itself, but this is a case where a child component binds to that value and don't receive the change because no `ValueChanged` is triggered.

Closes https://github.com/ppy/osu/issues/10279