### PR TITLE
Fix HitObject samples getting stuck in a playing state on seeking far into the future

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -110,6 +110,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
+        public override void StopAllSamples()
+        {
+            base.StopAllSamples();
+            slidingSample?.Stop();
+        }
+
         private void updateSlidingSample(ValueChangedEvent<bool> tracking)
         {
             if (tracking.NewValue)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -124,6 +124,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
+        public override void StopAllSamples()
+        {
+            base.StopAllSamples();
+            spinningSample?.Stop();
+        }
+
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
             base.AddNestedHitObject(hitObject);

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSamplePlayback.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Testing;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneEditorSamplePlayback : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        [Test]
+        public void TestSlidingSampleStopsOnSeek()
+        {
+            DrawableSlider slider = null;
+            DrawableSample[] samples = null;
+
+            AddStep("get first slider", () =>
+            {
+                slider = Editor.ChildrenOfType<DrawableSlider>().OrderBy(s => s.HitObject.StartTime).First();
+                samples = slider.ChildrenOfType<DrawableSample>().ToArray();
+            });
+
+            AddStep("start playback", () => EditorClock.Start());
+
+            AddUntilStep("wait for slider sliding then seek", () =>
+            {
+                if (!slider.Tracking.Value)
+                    return false;
+
+                if (!samples.Any(s => s.Playing))
+                    return false;
+
+                EditorClock.Seek(20000);
+                return true;
+            });
+
+            AddAssert("slider samples are not playing", () => samples.Length == 5 && samples.All(s => s.Played && !s.Playing));
+        }
+    }
+}

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -387,6 +387,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
         }
 
+        /// <summary>
+        /// Stops playback of all samples. Automatically called when <see cref="DrawableHitObject{TObject}"/>'s lifetime has been exceeded.
+        /// </summary>
+        public virtual void StopAllSamples() => Samples?.Stop();
+
         protected override void Update()
         {
             base.Update();
@@ -454,6 +459,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             foreach (var nested in NestedHitObjects)
                 nested.OnKilled();
+
+            StopAllSamples();
 
             UpdateResult(false);
         }

--- a/osu.Game/Skinning/PausableSkinnableSound.cs
+++ b/osu.Game/Skinning/PausableSkinnableSound.cs
@@ -41,8 +41,14 @@ namespace osu.Game.Skinning
                         // it's not easy to know if a sample has finished playing (to end).
                         // to keep things simple only resume playing looping samples.
                         else if (Looping)
+                        {
                             // schedule so we don't start playing a sample which is no longer alive.
-                            Schedule(base.Play);
+                            Schedule(() =>
+                            {
+                                if (RequestedPlaying)
+                                    base.Play();
+                            });
+                        }
                     }
                 });
             }

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -73,7 +73,8 @@ namespace osu.Game.Skinning
                         // it's not easy to know if a sample has finished playing (to end).
                         // to keep things simple only resume playing looping samples.
                         else if (Looping)
-                            play();
+                            // schedule so we don't start playing a sample which is no longer alive.
+                            Schedule(play);
                     }
                 });
             }


### PR DESCRIPTION
This is generally avoided due to `FrameStability` in gameplay, but as the editor removes the guarantee that we are running in a frame stable context this is required.

Note that this does not fix a similar issue faced by storyboard samples, which will need event passing from their nested `LifetimeManagementContainer`.

- [x] Depends on https://github.com/ppy/osu/pull/10285 for merge ease.

