### PR TITLE
Standardise scoring across all rulesets

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModPerfect.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModPerfect.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
         public void TestDroplet(bool shouldMiss) => CreateHitObjectTest(new HitObjectTestData(new Droplet { StartTime = 1000 }), shouldMiss);
 
         // We only care about testing misses, hits are tested via JuiceStream
-        [TestCase(false)]
+        [TestCase(true)]
         public void TestTinyDroplet(bool shouldMiss) => CreateHitObjectTest(new HitObjectTestData(new TinyDroplet { StartTime = 1000 }), shouldMiss);
     }
 }

--- a/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchBananaJudgement.cs
@@ -8,31 +8,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchBananaJudgement : CatchJudgement
     {
-        public override bool AffectsCombo => false;
-
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return 1100;
-            }
-        }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.75;
-            }
-        }
+        public override HitResult MaxResult => HitResult.LargeBonus;
 
         public override bool ShouldExplodeFor(JudgementResult result) => true;
     }

--- a/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchDropletJudgement.cs
@@ -7,16 +7,6 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchDropletJudgement : CatchJudgement
     {
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return 30;
-            }
-        }
+        public override HitResult MaxResult => HitResult.LargeTickHit;
     }
 }

--- a/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
@@ -9,19 +9,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchJudgement : Judgement
     {
-        public override HitResult MaxResult => HitResult.Perfect;
-
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return 300;
-            }
-        }
+        public override HitResult MaxResult => HitResult.Great;
 
         /// <summary>
         /// Whether fruit on the platter should explode or drop.

--- a/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchJudgement.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchJudgement : Judgement
     {
-        public override HitResult MaxResult => HitResult.Great;
+        public override HitResult MaxResult => HitResult.Perfect;
 
         /// <summary>
         /// Whether fruit on the platter should explode or drop.

--- a/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchTinyDropletJudgement.cs
@@ -7,30 +7,6 @@ namespace osu.Game.Rulesets.Catch.Judgements
 {
     public class CatchTinyDropletJudgement : CatchJudgement
     {
-        public override bool AffectsCombo => false;
-
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return 10;
-            }
-        }
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return 0.02;
-            }
-        }
+        public override HitResult MaxResult => HitResult.SmallTickHit;
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Catch.UI;
 using osuTK;
 using osuTK.Graphics;
@@ -86,7 +85,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             if (CheckPosition == null) return;
 
             if (timeOffset >= 0 && Result != null)
-                ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? HitResult.Perfect : HitResult.Miss);
+                ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Catch.Scoring
 {
     public class CatchScoreProcessor : ScoreProcessor
     {
-        public override HitWindows CreateHitWindows() => new CatchHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatchComboDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchComboDisplay.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void OnNewResult(DrawableCatchHitObject judgedObject, JudgementResult result)
         {
-            if (!result.Judgement.AffectsCombo || !result.HasResult)
+            if (!result.Type.AffectsCombo() || !result.HasResult)
                 return;
 
             if (result.Type == HitResult.Miss)
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void OnRevertResult(DrawableCatchHitObject judgedObject, JudgementResult result)
         {
-            if (!result.Judgement.AffectsCombo || !result.HasResult)
+            if (!result.Type.AffectsCombo() || !result.HasResult)
                 return;
 
             updateCombo(result.ComboAtJudgement, judgedObject.AccentColour.Value);

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -11,6 +11,7 @@ using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osuTK;
 
@@ -52,7 +53,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void OnNewResult(DrawableCatchHitObject fruit, JudgementResult result)
         {
-            if (result.Judgement is IgnoreJudgement)
+            if (!result.Type.IsScorable())
                 return;
 
             void runAfterLoaded(Action action)

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Miss);
-            assertTickJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickMiss);
             assertTailJudgement(HitResult.Miss);
-            assertNoteJudgement(HitResult.Perfect);
+            assertNoteJudgement(HitResult.IgnoreHit);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Miss);
-            assertTickJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickMiss);
             assertTailJudgement(HitResult.Miss);
         }
 
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Miss);
-            assertTickJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickMiss);
             assertTailJudgement(HitResult.Miss);
         }
 
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Perfect);
-            assertTickJudgement(HitResult.Perfect);
+            assertTickJudgement(HitResult.LargeTickHit);
             assertTailJudgement(HitResult.Miss);
         }
 
@@ -122,7 +122,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Perfect);
-            assertTickJudgement(HitResult.Perfect);
+            assertTickJudgement(HitResult.LargeTickHit);
             assertTailJudgement(HitResult.Perfect);
         }
 
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Perfect);
-            assertTickJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickMiss);
             assertTailJudgement(HitResult.Miss);
         }
 
@@ -161,7 +161,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Perfect);
-            assertTickJudgement(HitResult.Perfect);
+            assertTickJudgement(HitResult.LargeTickHit);
             assertTailJudgement(HitResult.Miss);
         }
 
@@ -181,7 +181,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Perfect);
-            assertTickJudgement(HitResult.Perfect);
+            assertTickJudgement(HitResult.LargeTickHit);
             assertTailJudgement(HitResult.Meh);
         }
 
@@ -199,7 +199,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Miss);
-            assertTickJudgement(HitResult.Perfect);
+            assertTickJudgement(HitResult.LargeTickHit);
             assertTailJudgement(HitResult.Miss);
         }
 
@@ -217,7 +217,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Miss);
-            assertTickJudgement(HitResult.Perfect);
+            assertTickJudgement(HitResult.LargeTickHit);
             assertTailJudgement(HitResult.Meh);
         }
 
@@ -235,7 +235,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             });
 
             assertHeadJudgement(HitResult.Miss);
-            assertTickJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickMiss);
             assertTailJudgement(HitResult.Meh);
         }
 
@@ -280,10 +280,10 @@ namespace osu.Game.Rulesets.Mania.Tests
             }, beatmap);
 
             AddAssert("first hold note missed", () => judgementResults.Where(j => beatmap.HitObjects[0].NestedHitObjects.Contains(j.HitObject))
-                                                                      .All(j => j.Type == HitResult.Miss));
+                                                                      .All(j => !j.Type.IsHit()));
 
             AddAssert("second hold note missed", () => judgementResults.Where(j => beatmap.HitObjects[1].NestedHitObjects.Contains(j.HitObject))
-                                                                       .All(j => j.Type == HitResult.Perfect));
+                                                                       .All(j => j.Type.IsHit()));
         }
 
         private void assertHeadJudgement(HitResult result)

--- a/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/HoldNoteTickJudgement.cs
@@ -7,18 +7,6 @@ namespace osu.Game.Rulesets.Mania.Judgements
 {
     public class HoldNoteTickJudgement : ManiaJudgement
     {
-        protected override int NumericResultFor(HitResult result) => result == MaxResult ? 20 : 0;
-
-        protected override double HealthIncreaseFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Perfect:
-                    return 0.01;
-            }
-        }
+        public override HitResult MaxResult => HitResult.LargeTickHit;
     }
 }

--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -2,34 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Judgements
 {
     public class ManiaJudgement : Judgement
     {
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Meh:
-                    return 50;
-
-                case HitResult.Ok:
-                    return 100;
-
-                case HitResult.Good:
-                    return 200;
-
-                case HitResult.Great:
-                    return 300;
-
-                case HitResult.Perfect:
-                    return 350;
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -239,7 +239,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             if (Tail.AllJudged)
             {
-                ApplyResult(r => r.Type = HitResult.Perfect);
+                ApplyResult(r => r.Type = r.Judgement.MaxResult);
                 endHold();
             }
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {
@@ -73,9 +72,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             var startTime = HoldStartTime?.Invoke();
 
             if (startTime == null || startTime > HitObject.StartTime)
-                ApplyResult(r => r.Type = HitResult.Miss);
+                ApplyResult(r => r.Type = r.Judgement.MinResult);
             else
-                ApplyResult(r => r.Type = HitResult.Perfect);
+                ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public class DrawableHoldNoteTick : DrawableManiaHitObject<HoldNoteTick>
     {
+        public override bool DisplayResult => false;
+
         /// <summary>
         /// References the time at which the user started holding the hold note.
         /// </summary>

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -10,7 +10,5 @@ namespace osu.Game.Rulesets.Mania.Scoring
         protected override double DefaultAccuracyPortion => 0.95;
 
         protected override double DefaultComboPortion => 0.05;
-
-        public override HitWindows CreateHitWindows() => new ManiaHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/ManiaLegacySkinTransformer.cs
@@ -130,6 +130,9 @@ namespace osu.Game.Rulesets.Mania.Skinning
 
         private Drawable getResult(HitResult result)
         {
+            if (!hitresult_mapping.ContainsKey(result))
+                return null;
+
             string filename = this.GetManiaSkinConfig<string>(hitresult_mapping[result])?.Value
                               ?? default_hitresult_skin_filenames[result];
 

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Mania.UI
             if (result.IsHit)
                 hitPolicy.HandleHit(judgedObject);
 
-            if (!result.IsHit || !judgedObject.DisplayResult || !DisplayJudgements.Value)
+            if (!result.IsHit || !DisplayJudgements.Value)
                 return;
 
             HitObjectArea.Explosions.Add(hitExplosionPool.Get(e => e.Apply(result)));

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOutOfOrderHits.cs
@@ -209,9 +209,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.IgnoreHit);
             addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.Miss);
-            addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.Great);
+            addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
         }
 
         /// <summary>
@@ -252,9 +252,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.IgnoreHit);
             addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.Great);
-            addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.Great);
+            addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
         }
 
         /// <summary>
@@ -331,7 +331,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.IgnoreHit);
         }
 
         private void addJudgementAssert(OsuHitObject hitObject, HitResult result)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.RightButton }, Time = time_during_slide_2 },
             });
 
-            AddAssert("Tracking retained", assertGreatJudge);
+            AddAssert("Tracking retained", assertMaxJudge);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.RightButton }, Time = time_during_slide_1 },
             });
 
-            AddAssert("Tracking retained", assertGreatJudge);
+            AddAssert("Tracking retained", assertMaxJudge);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Position = new Vector2(0, 0), Actions = { OsuAction.RightButton }, Time = time_during_slide_1 },
             });
 
-            AddAssert("Tracking retained", assertGreatJudge);
+            AddAssert("Tracking retained", assertMaxJudge);
         }
 
         /// <summary>
@@ -288,7 +288,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Position = new Vector2(slider_path_length, OsuHitObject.OBJECT_RADIUS * 1.199f), Actions = { OsuAction.LeftButton }, Time = time_slider_end },
             });
 
-            AddAssert("Tracking kept", assertGreatJudge);
+            AddAssert("Tracking kept", assertMaxJudge);
         }
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("Tracking dropped", assertMidSliderJudgementFail);
         }
 
-        private bool assertGreatJudge() => judgementResults.Any() && judgementResults.All(t => t.Type.IsHit());
+        private bool assertMaxJudge() => judgementResults.Any() && judgementResults.All(t => t.Type == t.Judgement.MaxResult);
 
         private bool assertHeadMissTailTracked() => judgementResults[^2].Type == HitResult.IgnoreHit && judgementResults.First().Type == HitResult.Miss;
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -312,13 +312,13 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("Tracking dropped", assertMidSliderJudgementFail);
         }
 
-        private bool assertGreatJudge() => judgementResults.Any() && judgementResults.All(t => t.Type == HitResult.Great);
+        private bool assertGreatJudge() => judgementResults.Any() && judgementResults.All(t => t.Type.IsHit());
 
-        private bool assertHeadMissTailTracked() => judgementResults[^2].Type == HitResult.Great && judgementResults.First().Type == HitResult.Miss;
+        private bool assertHeadMissTailTracked() => judgementResults[^2].Type == HitResult.IgnoreHit && judgementResults.First().Type == HitResult.Miss;
 
-        private bool assertMidSliderJudgements() => judgementResults[^2].Type == HitResult.Great;
+        private bool assertMidSliderJudgements() => judgementResults[^2].Type == HitResult.IgnoreHit;
 
-        private bool assertMidSliderJudgementFail() => judgementResults[^2].Type == HitResult.Miss;
+        private bool assertMidSliderJudgementFail() => judgementResults[^2].Type == HitResult.IgnoreMiss;
 
         private ScoreAccessibleReplayPlayer currentPlayer;
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 // multipled by 2 to nullify the score multiplier. (autoplay mod selected)
                 var totalScore = ((ScoreExposedPlayer)Player).ScoreProcessor.TotalScore.Value * 2;
-                return totalScore == (int)(drawableSpinner.RotationTracker.RateAdjustedRotation / 360) * SpinnerTick.SCORE_PER_TICK;
+                return totalScore == (int)(drawableSpinner.RotationTracker.RateAdjustedRotation / 360) * new SpinnerTick().CreateJudgement().MaxNumericResult;
             });
 
             addSeekStep(0);

--- a/osu.Game.Rulesets.Osu/Judgements/OsuIgnoreJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuIgnoreJudgement.cs
@@ -7,10 +7,6 @@ namespace osu.Game.Rulesets.Osu.Judgements
 {
     public class OsuIgnoreJudgement : OsuJudgement
     {
-        public override bool AffectsCombo => false;
-
-        protected override int NumericResultFor(HitResult result) => 0;
-
-        protected override double HealthIncreaseFor(HitResult result) => 0;
+        public override HitResult MaxResult => HitResult.IgnoreHit;
     }
 }

--- a/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuJudgement.cs
@@ -9,23 +9,5 @@ namespace osu.Game.Rulesets.Osu.Judgements
     public class OsuJudgement : Judgement
     {
         public override HitResult MaxResult => HitResult.Great;
-
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.Meh:
-                    return 50;
-
-                case HitResult.Good:
-                    return 100;
-
-                case HitResult.Great:
-                    return 300;
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
-using osu.Game.Rulesets.Scoring;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
@@ -50,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (sliderRepeat.StartTime <= Time.Current)
-                ApplyResult(r => r.Type = drawableSlider.Tracking.Value ? HitResult.Great : HitResult.Miss);
+                ApplyResult(r => r.Type = drawableSlider.Tracking.Value ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Scoring;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
@@ -46,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (!userTriggered && timeOffset >= 0)
-                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : HitResult.Miss);
+                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         private void updatePosition() => Position = HitObject.Position - slider.Position;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -10,7 +10,6 @@ using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Skinning;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -64,7 +63,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (timeOffset >= 0)
-                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : HitResult.Miss);
+                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Scoring;
-
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSpinnerTick : DrawableOsuHitObject
@@ -18,6 +16,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// Apply a judgement result.
         /// </summary>
         /// <param name="hit">Whether this tick was reached.</param>
-        internal void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : HitResult.Miss);
+        internal void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : r.Judgement.MinResult);
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
@@ -5,7 +5,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Rulesets.Judgements;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
@@ -14,6 +13,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
     /// </summary>
     public class SpinnerBonusDisplay : CompositeDrawable
     {
+        private static readonly int score_per_tick = new SpinnerBonusTick().CreateJudgement().MaxNumericResult;
+
         private readonly OsuSpriteText bonusCounter;
 
         public SpinnerBonusDisplay()
@@ -37,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 return;
 
             displayedCount = count;
-            bonusCounter.Text = $"{Judgement.LARGE_BONUS_SCORE * count}";
+            bonusCounter.Text = $"{score_per_tick * count}";
             bonusCounter.FadeOutFromOne(1500);
             bonusCounter.ScaleTo(1.5f).Then().ScaleTo(1f, 1000, Easing.OutQuint);
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerBonusDisplay.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Judgements;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
@@ -36,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 return;
 
             displayedCount = count;
-            bonusCounter.Text = $"{SpinnerBonusTick.SCORE_PER_TICK * count}";
+            bonusCounter.Text = $"{Judgement.LARGE_BONUS_SCORE * count}";
             bonusCounter.FadeOutFromOne(1500);
             bonusCounter.ScaleTo(1.5f).Then().ScaleTo(1f, 1000, Easing.OutQuint);
         }

--- a/osu.Game.Rulesets.Osu/Objects/SliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderRepeat.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class SliderRepeatJudgement : OsuJudgement
         {
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? 30 : 0;
+            public override HitResult MaxResult => HitResult.LargeTickHit;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -29,9 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class SliderTailJudgement : OsuJudgement
         {
-            protected override int NumericResultFor(HitResult result) => 0;
-
-            public override bool AffectsCombo => false;
+            public override HitResult MaxResult => HitResult.IgnoreHit;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTick.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class SliderTickJudgement : OsuJudgement
         {
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? 10 : 0;
+            public override HitResult MaxResult => HitResult.LargeTickHit;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
@@ -9,8 +9,6 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SpinnerBonusTick : SpinnerTick
     {
-        public new const int SCORE_PER_TICK = 50;
-
         public SpinnerBonusTick()
         {
             Samples.Add(new HitSampleInfo { Name = "spinnerbonus" });
@@ -20,9 +18,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerBonusTickJudgement : OsuSpinnerTickJudgement
         {
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SCORE_PER_TICK : 0;
-
-            protected override double HealthIncreaseFor(HitResult result) => base.HealthIncreaseFor(result) * 2;
+            public override HitResult MaxResult => HitResult.LargeBonus;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerTick.cs
@@ -9,19 +9,13 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SpinnerTick : OsuHitObject
     {
-        public const int SCORE_PER_TICK = 10;
-
         public override Judgement CreateJudgement() => new OsuSpinnerTickJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
 
         public class OsuSpinnerTickJudgement : OsuJudgement
         {
-            public override bool AffectsCombo => false;
-
-            protected override int NumericResultFor(HitResult result) => result == MaxResult ? SCORE_PER_TICK : 0;
-
-            protected override double HealthIncreaseFor(HitResult result) => result == MaxResult ? 0.6 * base.HealthIncreaseFor(result) : 0;
+            public override HitResult MaxResult => HitResult.SmallBonus;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -25,7 +25,5 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     return new OsuJudgementResult(hitObject, judgement);
             }
         }
-
-        public override HitWindows CreateHitWindows() => new OsuHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             createDrawableRuleset();
 
             assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Idle);
-            assertStateAfterResult(new JudgementResult(new StrongHitObject(), new TaikoStrongJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Idle);
+            assertStateAfterResult(new JudgementResult(new StrongHitObject(), new TaikoStrongJudgement()) { Type = HitResult.IgnoreMiss }, TaikoMascotAnimationState.Idle);
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             createDrawableRuleset();
 
             assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Good }, TaikoMascotAnimationState.Kiai);
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoStrongJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Kiai);
+            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoStrongJudgement()) { Type = HitResult.IgnoreMiss }, TaikoMascotAnimationState.Kiai);
             assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Fail);
         }
 

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
@@ -7,19 +7,7 @@ namespace osu.Game.Rulesets.Taiko.Judgements
 {
     public class TaikoDrumRollTickJudgement : TaikoJudgement
     {
-        public override bool AffectsCombo => false;
-
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.Great:
-                    return 200;
-
-                default:
-                    return 0;
-            }
-        }
+        public override HitResult MaxResult => HitResult.SmallTickHit;
 
         protected override double HealthIncreaseFor(HitResult result)
         {

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoJudgement.cs
@@ -10,21 +10,6 @@ namespace osu.Game.Rulesets.Taiko.Judgements
     {
         public override HitResult MaxResult => HitResult.Great;
 
-        protected override int NumericResultFor(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.Good:
-                    return 100;
-
-                case HitResult.Great:
-                    return 300;
-
-                default:
-                    return 0;
-            }
-        }
-
         protected override double HealthIncreaseFor(HitResult result)
         {
             switch (result)

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoStrongJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoStrongJudgement.cs
@@ -7,9 +7,9 @@ namespace osu.Game.Rulesets.Taiko.Judgements
 {
     public class TaikoStrongJudgement : TaikoJudgement
     {
+        public override HitResult MaxResult => HitResult.SmallBonus;
+
         // MainObject already changes the HP
         protected override double HealthIncreaseFor(HitResult result) => 0;
-
-        public override bool AffectsCombo => false;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             if (countHit >= HitObject.RequiredGoodHits)
             {
-                ApplyResult(r => r.Type = countHit >= HitObject.RequiredGreatHits ? HitResult.Great : HitResult.Good);
+                ApplyResult(r => r.Type = countHit >= HitObject.RequiredGreatHits ? HitResult.Great : HitResult.Ok);
             }
             else
                 ApplyResult(r => r.Type = HitResult.Miss);
@@ -174,7 +174,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 if (!MainObject.Judged)
                     return;
 
-                ApplyResult(r => r.Type = MainObject.IsHit ? HitResult.Great : HitResult.Miss);
+                ApplyResult(r => r.Type = MainObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
 
             public override bool OnPressed(TaikoAction action) => false;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             if (countHit >= HitObject.RequiredGoodHits)
             {
-                ApplyResult(r => r.Type = countHit >= HitObject.RequiredGreatHits ? HitResult.Great : HitResult.Ok);
+                ApplyResult(r => r.Type = countHit >= HitObject.RequiredGreatHits ? HitResult.Great : HitResult.Good);
             }
             else
                 ApplyResult(r => r.Type = HitResult.Miss);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
@@ -34,14 +33,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (!userTriggered)
             {
                 if (timeOffset > HitObject.HitWindow)
-                    ApplyResult(r => r.Type = HitResult.Miss);
+                    ApplyResult(r => r.Type = r.Judgement.MinResult);
                 return;
             }
 
             if (Math.Abs(timeOffset) > HitObject.HitWindow)
                 return;
 
-            ApplyResult(r => r.Type = HitResult.Great);
+            ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
 
         protected override void UpdateStateTransforms(ArmedState state)
@@ -74,7 +73,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 if (!MainObject.Judged)
                     return;
 
-                ApplyResult(r => r.Type = MainObject.IsHit ? HitResult.Great : HitResult.Miss);
+                ApplyResult(r => r.Type = MainObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
 
             public override bool OnPressed(TaikoAction action) => false;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -257,19 +257,19 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                 if (!MainObject.Result.IsHit)
                 {
-                    ApplyResult(r => r.Type = HitResult.Miss);
+                    ApplyResult(r => r.Type = r.Judgement.MinResult);
                     return;
                 }
 
                 if (!userTriggered)
                 {
                     if (timeOffset - MainObject.Result.TimeOffset > second_hit_window)
-                        ApplyResult(r => r.Type = HitResult.Miss);
+                        ApplyResult(r => r.Type = r.Judgement.MinResult);
                     return;
                 }
 
                 if (Math.Abs(timeOffset - MainObject.Result.TimeOffset) <= second_hit_window)
-                    ApplyResult(r => r.Type = MainObject.Result.Type);
+                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
             }
 
             public override bool OnPressed(TaikoAction action)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     }
                 }
 
-                nextTick?.TriggerResult(HitResult.Great);
+                nextTick?.TriggerResult(true);
 
                 var numHits = ticks.Count(r => r.IsHit);
 
@@ -208,10 +208,10 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                         continue;
                     }
 
-                    tick.TriggerResult(HitResult.Miss);
+                    tick.TriggerResult(false);
                 }
 
-                var hitResult = numHits > HitObject.RequiredHits / 2 ? HitResult.Good : HitResult.Miss;
+                var hitResult = numHits > HitObject.RequiredHits / 2 ? HitResult.Ok : HitResult.Miss;
 
                 ApplyResult(r => r.Type = hitResult);
             }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     tick.TriggerResult(false);
                 }
 
-                var hitResult = numHits > HitObject.RequiredHits / 2 ? HitResult.Ok : HitResult.Miss;
+                var hitResult = numHits > HitObject.RequiredHits / 2 ? HitResult.Good : HitResult.Miss;
 
                 ApplyResult(r => r.Type = hitResult);
             }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
@@ -19,10 +18,10 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override void UpdateInitialTransforms() => this.FadeOut();
 
-        public void TriggerResult(HitResult type)
+        public void TriggerResult(bool hit)
         {
             HitObject.StartTime = Time.Current;
-            ApplyResult(r => r.Type = type);
+            ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -10,7 +10,5 @@ namespace osu.Game.Rulesets.Taiko.Scoring
         protected override double DefaultAccuracyPortion => 0.75;
 
         protected override double DefaultComboPortion => 0.25;
-
-        public override HitWindows CreateHitWindows() => new TaikoHitWindows();
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/LegacyTaikoScroller.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                 var r = result.NewValue;
 
                 // always ignore hitobjects that don't affect combo (drumroll ticks etc.)
-                if (r?.Judgement.AffectsCombo == false)
+                if (r?.Type.AffectsCombo() == false)
                     return;
 
                 passing = r == null || r.Type > HitResult.Miss;

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoMascot.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Screens.Play;
 
@@ -77,7 +78,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                 lastObjectHit = true;
             }
 
-            if (!result.Judgement.AffectsCombo)
+            if (!result.Type.AffectsCombo())
                 return;
 
             lastObjectHit = result.IsHit;
@@ -115,7 +116,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         }
 
         private bool triggerComboClear(JudgementResult judgementResult)
-            => (judgementResult.ComboAtJudgement + 1) % 50 == 0 && judgementResult.Judgement.AffectsCombo && judgementResult.IsHit;
+            => (judgementResult.ComboAtJudgement + 1) % 50 == 0 && judgementResult.Type.AffectsCombo() && judgementResult.IsHit;
 
         private bool triggerSwellClear(JudgementResult judgementResult)
             => judgementResult.Judgement is TaikoSwellJudgement && judgementResult.IsHit;

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Tests.Gameplay
 
             beatmap.HitObjects.Add(new JudgeableHitObject { StartTime = 0 });
             for (double time = 0; time < 5000; time += 100)
-                beatmap.HitObjects.Add(new JudgeableHitObject(false) { StartTime = time });
+                beatmap.HitObjects.Add(new JudgeableHitObject(HitResult.LargeBonus) { StartTime = time });
             beatmap.HitObjects.Add(new JudgeableHitObject { StartTime = 5000 });
 
             createProcessor(beatmap);
@@ -215,23 +215,23 @@ namespace osu.Game.Tests.Gameplay
 
         private class JudgeableHitObject : HitObject
         {
-            private readonly bool affectsCombo;
+            private readonly HitResult maxResult;
 
-            public JudgeableHitObject(bool affectsCombo = true)
+            public JudgeableHitObject(HitResult maxResult = HitResult.Perfect)
             {
-                this.affectsCombo = affectsCombo;
+                this.maxResult = maxResult;
             }
 
-            public override Judgement CreateJudgement() => new TestJudgement(affectsCombo);
+            public override Judgement CreateJudgement() => new TestJudgement(maxResult);
             protected override HitWindows CreateHitWindows() => new HitWindows();
 
             private class TestJudgement : Judgement
             {
-                public override bool AffectsCombo { get; }
+                public override HitResult MaxResult { get; }
 
-                public TestJudgement(bool affectsCombo)
+                public TestJudgement(HitResult maxResult)
                 {
-                    AffectsCombo = affectsCombo;
+                    MaxResult = maxResult;
                 }
             }
         }

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -263,7 +263,7 @@ namespace osu.Game.Tests.Gameplay
             public double Duration { get; set; } = 5000;
 
             public JudgeableLongHitObject()
-                : base(false)
+                : base(HitResult.LargeBonus)
             {
             }
 

--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -17,13 +17,13 @@ namespace osu.Game.Tests.Gameplay
         [Test]
         public void TestNoScoreIncreaseFromMiss()
         {
-            var beatmap = new Beatmap<TestHitObject> { HitObjects = { new TestHitObject() } };
+            var beatmap = new Beatmap<HitObject> { HitObjects = { new HitObject() } };
 
             var scoreProcessor = new ScoreProcessor();
             scoreProcessor.ApplyBeatmap(beatmap);
 
             // Apply a miss judgement
-            scoreProcessor.ApplyResult(new JudgementResult(new TestHitObject(), new TestJudgement()) { Type = HitResult.Miss });
+            scoreProcessor.ApplyResult(new JudgementResult(new HitObject(), new TestJudgement()) { Type = HitResult.Miss });
 
             Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(0.0));
         }
@@ -31,37 +31,25 @@ namespace osu.Game.Tests.Gameplay
         [Test]
         public void TestOnlyBonusScore()
         {
-            var beatmap = new Beatmap<TestBonusHitObject> { HitObjects = { new TestBonusHitObject() } };
+            var beatmap = new Beatmap<HitObject> { HitObjects = { new HitObject() } };
 
             var scoreProcessor = new ScoreProcessor();
             scoreProcessor.ApplyBeatmap(beatmap);
 
             // Apply a judgement
-            scoreProcessor.ApplyResult(new JudgementResult(new TestBonusHitObject(), new TestBonusJudgement()) { Type = HitResult.Perfect });
+            scoreProcessor.ApplyResult(new JudgementResult(new HitObject(), new TestJudgement(HitResult.LargeBonus)) { Type = HitResult.LargeBonus });
 
-            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(100));
-        }
-
-        private class TestHitObject : HitObject
-        {
-            public override Judgement CreateJudgement() => new TestJudgement();
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(Judgement.LARGE_BONUS_SCORE));
         }
 
         private class TestJudgement : Judgement
         {
-            protected override int NumericResultFor(HitResult result) => 100;
-        }
+            public override HitResult MaxResult { get; }
 
-        private class TestBonusHitObject : HitObject
-        {
-            public override Judgement CreateJudgement() => new TestBonusJudgement();
-        }
-
-        private class TestBonusJudgement : Judgement
-        {
-            public override bool AffectsCombo => false;
-
-            protected override int NumericResultFor(HitResult result) => 100;
+            public TestJudgement(HitResult maxResult = HitResult.Perfect)
+            {
+                MaxResult = maxResult;
+            }
         }
     }
 }

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -35,10 +35,10 @@ namespace osu.Game.Tests.Rulesets.Scoring
         }
 
         [TestCase(ScoringMode.Standardised, HitResult.Meh, 750_000)]
-        [TestCase(ScoringMode.Standardised, HitResult.Good, 800_000)]
+        [TestCase(ScoringMode.Standardised, HitResult.Good, 900_000)]
         [TestCase(ScoringMode.Standardised, HitResult.Great, 1_000_000)]
         [TestCase(ScoringMode.Classic, HitResult.Meh, 50)]
-        [TestCase(ScoringMode.Classic, HitResult.Good, 100)]
+        [TestCase(ScoringMode.Classic, HitResult.Good, 200)]
         [TestCase(ScoringMode.Classic, HitResult.Great, 300)]
         public void TestSingleOsuHit(ScoringMode scoringMode, HitResult hitResult, int expectedScore)
         {

--- a/osu.Game/Rulesets/Judgements/IgnoreJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/IgnoreJudgement.cs
@@ -7,10 +7,6 @@ namespace osu.Game.Rulesets.Judgements
 {
     public class IgnoreJudgement : Judgement
     {
-        public override bool AffectsCombo => false;
-
-        protected override int NumericResultFor(HitResult result) => 0;
-
-        protected override double HealthIncreaseFor(HitResult result) => 0;
+        public override HitResult MaxResult => HitResult.IgnoreHit;
     }
 }

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -15,12 +15,12 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// The score awarded for a small bonus.
         /// </summary>
-        public const double SMALL_BONUS_SCORE = 10;
+        public const int SMALL_BONUS_SCORE = 10;
 
         /// <summary>
         /// The score awarded for a large bonus.
         /// </summary>
-        public const double LARGE_BONUS_SCORE = 50;
+        public const int LARGE_BONUS_SCORE = 50;
 
         /// <summary>
         /// The default health increase for a maximum judgement, as a proportion of total health.
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// The numeric score representation for the maximum achievable result.
         /// </summary>
-        public double MaxNumericResult => ToNumericResult(MaxResult);
+        public int MaxNumericResult => ToNumericResult(MaxResult);
 
         /// <summary>
         /// The health increase for the maximum achievable result.
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Judgements
         /// </summary>
         /// <param name="result">The <see cref="JudgementResult"/> to find the numeric score representation for.</param>
         /// <returns>The numeric score representation of <paramref name="result"/>.</returns>
-        public double NumericResultFor(JudgementResult result) => ToNumericResult(result.Type);
+        public int NumericResultFor(JudgementResult result) => ToNumericResult(result.Type);
 
         /// <summary>
         /// Retrieves the numeric health increase of a <see cref="HitResult"/>.
@@ -155,7 +155,7 @@ namespace osu.Game.Rulesets.Judgements
 
         public override string ToString() => $"MaxResult:{MaxResult} MaxScore:{MaxNumericResult}";
 
-        public static double ToNumericResult(HitResult result)
+        public static int ToNumericResult(HitResult result)
         {
             switch (result)
             {
@@ -163,25 +163,25 @@ namespace osu.Game.Rulesets.Judgements
                     return 0;
 
                 case HitResult.SmallTickHit:
-                    return 1 / 30d;
+                    return 10;
 
                 case HitResult.LargeTickHit:
-                    return 1 / 10d;
+                    return 30;
 
                 case HitResult.Meh:
-                    return 1 / 6d;
+                    return 50;
 
                 case HitResult.Ok:
-                    return 1 / 3d;
+                    return 100;
 
                 case HitResult.Good:
-                    return 2 / 3d;
+                    return 200;
 
                 case HitResult.Great:
-                    return 1d;
+                    return 300;
 
                 case HitResult.Perfect:
-                    return 7 / 6d;
+                    return 350;
 
                 case HitResult.SmallBonus:
                     return SMALL_BONUS_SCORE;

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -82,12 +82,12 @@ namespace osu.Game.Rulesets.Judgements
         public double MaxHealthIncrease => HealthIncreaseFor(MaxResult);
 
         /// <summary>
-        /// Retrieves the numeric score representation of a <see cref="JudgementResult"/>.
+        /// Retrieves the numeric score representation of a <see cref="HitResult"/>.
         /// </summary>
-        /// <param name="result">The <see cref="JudgementResult"/> to find the numeric score representation for.</param>
+        /// <param name="result">The <see cref="HitResult"/> to find the numeric score representation for.</param>
         /// <returns>The numeric score representation of <paramref name="result"/>.</returns>
-        [Obsolete("Has no effect. Use ToNumericResult(HitResult) (standardised across all rulesets).")] // Can be removed 20210328
-        protected virtual int NumericResultFor(HitResult result) => result == HitResult.Miss ? 0 : 1;
+        [Obsolete("Has no effect. Use ToNumericResult(HitResult) (standardised across all rulesets).")] // Can be made non-virtual 20210328
+        protected virtual int NumericResultFor(HitResult result) => ToNumericResult(result);
 
         /// <summary>
         /// Retrieves the numeric score representation of a <see cref="JudgementResult"/>.

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
@@ -12,10 +13,32 @@ namespace osu.Game.Rulesets.Judgements
     public class Judgement
     {
         /// <summary>
+        /// The score awarded for a small bonus.
+        /// </summary>
+        public const double SMALL_BONUS_SCORE = 10;
+
+        /// <summary>
+        /// The score awarded for a large bonus.
+        /// </summary>
+        public const double LARGE_BONUS_SCORE = 50;
+
+        /// <summary>
         /// The default health increase for a maximum judgement, as a proportion of total health.
         /// By default, each maximum judgement restores 5% of total health.
         /// </summary>
         protected const double DEFAULT_MAX_HEALTH_INCREASE = 0.05;
+
+        /// <summary>
+        /// Whether this <see cref="Judgement"/> should affect the current combo.
+        /// </summary>
+        [Obsolete("Has no effect. Use HitResult members instead (e.g. use small-tick or bonus to not affect combo).")] // Can be removed 20210328
+        public virtual bool AffectsCombo => true;
+
+        /// <summary>
+        /// Whether this <see cref="Judgement"/> should be counted as base (combo) or bonus score.
+        /// </summary>
+        [Obsolete("Has no effect. Use HitResult members instead (e.g. use small-tick or bonus to not affect combo).")] // Can be removed 20210328
+        public virtual bool IsBonus => !AffectsCombo;
 
         /// <summary>
         /// The maximum <see cref="HitResult"/> that can be achieved.
@@ -23,19 +46,35 @@ namespace osu.Game.Rulesets.Judgements
         public virtual HitResult MaxResult => HitResult.Perfect;
 
         /// <summary>
-        /// Whether this <see cref="Judgement"/> should affect the current combo.
+        /// The minimum <see cref="HitResult"/> that can be achieved - the inverse of <see cref="MaxResult"/>.
         /// </summary>
-        public virtual bool AffectsCombo => true;
+        public HitResult MinResult
+        {
+            get
+            {
+                switch (MaxResult)
+                {
+                    case HitResult.SmallBonus:
+                    case HitResult.LargeBonus:
+                    case HitResult.IgnoreHit:
+                        return HitResult.IgnoreMiss;
 
-        /// <summary>
-        /// Whether this <see cref="Judgement"/> should be counted as base (combo) or bonus score.
-        /// </summary>
-        public virtual bool IsBonus => !AffectsCombo;
+                    case HitResult.SmallTickHit:
+                        return HitResult.SmallTickMiss;
+
+                    case HitResult.LargeTickHit:
+                        return HitResult.LargeTickMiss;
+
+                    default:
+                        return HitResult.Miss;
+                }
+            }
+        }
 
         /// <summary>
         /// The numeric score representation for the maximum achievable result.
         /// </summary>
-        public int MaxNumericResult => NumericResultFor(MaxResult);
+        public double MaxNumericResult => ToNumericResult(MaxResult);
 
         /// <summary>
         /// The health increase for the maximum achievable result.
@@ -43,18 +82,19 @@ namespace osu.Game.Rulesets.Judgements
         public double MaxHealthIncrease => HealthIncreaseFor(MaxResult);
 
         /// <summary>
-        /// Retrieves the numeric score representation of a <see cref="HitResult"/>.
+        /// Retrieves the numeric score representation of a <see cref="JudgementResult"/>.
         /// </summary>
-        /// <param name="result">The <see cref="HitResult"/> to find the numeric score representation for.</param>
+        /// <param name="result">The <see cref="JudgementResult"/> to find the numeric score representation for.</param>
         /// <returns>The numeric score representation of <paramref name="result"/>.</returns>
-        protected virtual int NumericResultFor(HitResult result) => result > HitResult.Miss ? 1 : 0;
+        [Obsolete("Has no effect. Use ToNumericResult(HitResult) (standardised across all rulesets).")] // Can be removed 20210328
+        protected virtual int NumericResultFor(HitResult result) => result == HitResult.Miss ? 0 : 1;
 
         /// <summary>
         /// Retrieves the numeric score representation of a <see cref="JudgementResult"/>.
         /// </summary>
         /// <param name="result">The <see cref="JudgementResult"/> to find the numeric score representation for.</param>
         /// <returns>The numeric score representation of <paramref name="result"/>.</returns>
-        public int NumericResultFor(JudgementResult result) => NumericResultFor(result.Type);
+        public double NumericResultFor(JudgementResult result) => ToNumericResult(result.Type);
 
         /// <summary>
         /// Retrieves the numeric health increase of a <see cref="HitResult"/>.
@@ -65,6 +105,21 @@ namespace osu.Game.Rulesets.Judgements
         {
             switch (result)
             {
+                default:
+                    return 0;
+
+                case HitResult.SmallTickHit:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.05;
+
+                case HitResult.SmallTickMiss:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;
+
+                case HitResult.LargeTickHit:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+
+                case HitResult.LargeTickMiss:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+
                 case HitResult.Miss:
                     return -DEFAULT_MAX_HEALTH_INCREASE;
 
@@ -83,8 +138,11 @@ namespace osu.Game.Rulesets.Judgements
                 case HitResult.Perfect:
                     return DEFAULT_MAX_HEALTH_INCREASE * 1.05;
 
-                default:
-                    return 0;
+                case HitResult.SmallBonus:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+
+                case HitResult.LargeBonus:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.2;
             }
         }
 
@@ -95,6 +153,42 @@ namespace osu.Game.Rulesets.Judgements
         /// <returns>The numeric health increase of <paramref name="result"/>.</returns>
         public double HealthIncreaseFor(JudgementResult result) => HealthIncreaseFor(result.Type);
 
-        public override string ToString() => $"AffectsCombo:{AffectsCombo} MaxResult:{MaxResult} MaxScore:{MaxNumericResult}";
+        public override string ToString() => $"MaxResult:{MaxResult} MaxScore:{MaxNumericResult}";
+
+        public static double ToNumericResult(HitResult result)
+        {
+            switch (result)
+            {
+                default:
+                    return 0;
+
+                case HitResult.SmallTickHit:
+                    return 1 / 30d;
+
+                case HitResult.LargeTickHit:
+                    return 1 / 10d;
+
+                case HitResult.Meh:
+                    return 1 / 6d;
+
+                case HitResult.Ok:
+                    return 1 / 3d;
+
+                case HitResult.Good:
+                    return 2 / 3d;
+
+                case HitResult.Great:
+                    return 1d;
+
+                case HitResult.Perfect:
+                    return 7 / 6d;
+
+                case HitResult.SmallBonus:
+                    return SMALL_BONUS_SCORE;
+
+                case HitResult.LargeBonus:
+                    return LARGE_BONUS_SCORE;
+            }
+        }
     }
 }

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// Whether a successful hit occurred.
         /// </summary>
-        public bool IsHit => Type > HitResult.Miss;
+        public bool IsHit => Type.IsHit();
 
         /// <summary>
         /// Creates a new <see cref="JudgementResult"/>.

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -16,8 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Description => "SS or quit.";
 
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
-            => !(result.Judgement is IgnoreJudgement)
-               && result.Judgement.AffectsCombo
+            => result.Type.AffectsAccuracy()
                && result.Type != result.Judgement.MaxResult;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Rulesets.Mods
             healthProcessor.FailConditions += FailCondition;
         }
 
-        protected virtual bool FailCondition(HealthProcessor healthProcessor, JudgementResult result) => !result.IsHit && result.Judgement.AffectsCombo;
+        protected virtual bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
+            => result.Type.AffectsCombo()
+               && !result.IsHit;
     }
 }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -475,6 +475,21 @@ namespace osu.Game.Rulesets.Objects.Drawables
             if (!Result.HasResult)
                 throw new InvalidOperationException($"{GetType().ReadableName()} applied a {nameof(JudgementResult)} but did not update {nameof(JudgementResult.Type)}.");
 
+            // Some (especially older) rulesets use scorable judgements instead of the newer ignorehit/ignoremiss judgements.
+            if (Result.Judgement.MaxResult == HitResult.IgnoreHit)
+            {
+                if (Result.Type == HitResult.Miss)
+                    Result.Type = HitResult.IgnoreMiss;
+                else if (Result.Type >= HitResult.Meh && Result.Type <= HitResult.Perfect)
+                    Result.Type = HitResult.IgnoreHit;
+            }
+
+            if (!Result.Type.IsValidHitResult(Result.Judgement.MinResult, Result.Judgement.MaxResult))
+            {
+                throw new InvalidOperationException(
+                    $"{GetType().ReadableName()} applied an invalid hit result (was: {Result.Type}, expected: [{Result.Judgement.MinResult} ... {Result.Judgement.MaxResult}]).");
+            }
+
             // Ensure that the judgement is given a valid time offset, because this may not get set by the caller
             var endTime = HitObject.GetEndTime();
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Logging;
 using osu.Framework.Threading;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Judgements;
@@ -476,12 +477,21 @@ namespace osu.Game.Rulesets.Objects.Drawables
                 throw new InvalidOperationException($"{GetType().ReadableName()} applied a {nameof(JudgementResult)} but did not update {nameof(JudgementResult.Type)}.");
 
             // Some (especially older) rulesets use scorable judgements instead of the newer ignorehit/ignoremiss judgements.
+            // Can be removed 20210328
             if (Result.Judgement.MaxResult == HitResult.IgnoreHit)
             {
+                HitResult originalType = Result.Type;
+
                 if (Result.Type == HitResult.Miss)
                     Result.Type = HitResult.IgnoreMiss;
                 else if (Result.Type >= HitResult.Meh && Result.Type <= HitResult.Perfect)
                     Result.Type = HitResult.IgnoreHit;
+
+                if (Result.Type != originalType)
+                {
+                    Logger.Log($"{GetType().ReadableName()} applied an invalid hit result ({originalType}) when {nameof(HitResult.IgnoreMiss)} or {nameof(HitResult.IgnoreHit)} is expected.\n"
+                               + $"This has been automatically adjusted to {Result.Type}, and support will be removed from 2020-03-28 onwards.", level: LogLevel.Important);
+                }
             }
 
             if (!Result.Type.IsValidHitResult(Result.Judgement.MinResult, Result.Judgement.MaxResult))

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Scoring
         {
             base.ApplyResultInternal(result);
 
-            if (!result.Judgement.IsBonus)
+            if (!result.Type.IsBonus())
                 healthIncreases.Add((result.HitObject.GetEndTime() + result.TimeOffset, GetHealthIncreaseFor(result)));
         }
 

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Scoring
@@ -175,5 +176,24 @@ namespace osu.Game.Rulesets.Scoring
         /// Whether a <see cref="HitResult"/> is scorable.
         /// </summary>
         public static bool IsScorable(this HitResult result) => result >= HitResult.Miss && result < HitResult.IgnoreMiss;
+
+        /// <summary>
+        /// Whether a <see cref="HitResult"/> is valid within a given <see cref="HitResult"/> range.
+        /// </summary>
+        /// <param name="result">The <see cref="HitResult"/> to check.</param>
+        /// <param name="minResult">The minimum <see cref="HitResult"/>.</param>
+        /// <param name="maxResult">The maximum <see cref="HitResult"/>.</param>
+        /// <returns>Whether <see cref="HitResult"/> falls between <paramref name="minResult"/> and <paramref name="maxResult"/>.</returns>
+        public static bool IsValidHitResult(this HitResult result, HitResult minResult, HitResult maxResult)
+        {
+            if (result == HitResult.None)
+                return false;
+
+            if (result == minResult || result == maxResult)
+                return true;
+
+            Debug.Assert(minResult <= maxResult);
+            return result > minResult && result < maxResult;
+        }
     }
 }

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -181,7 +181,7 @@ namespace osu.Game.Scoring
 
                 scoreProcessor.Mods.Value = score.Mods;
 
-                Value = (long)Math.Round(scoreProcessor.GetScore(ScoringMode.Value, beatmapMaxCombo, score.Accuracy, (double)score.MaxCombo / beatmapMaxCombo, 0));
+                Value = (long)Math.Round(scoreProcessor.GetScore(ScoringMode.Value, beatmapMaxCombo, score.Accuracy, (double)score.MaxCombo / beatmapMaxCombo, score.Statistics));
             }
         }
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/10251

Bit of a chunky one, sorry. I'm splitting things out as much as I can, but I can't really make this one smaller.

In an effort to (r)esolve https://github.com/ppy/osu/issues/10144, we need to be able to compute score with more knowledge about how much numeric score each result provides. To do this, we need to:
1. Add bonus results.
2. Make all hit results of the same type give the same score.
3. Make all hit results of the same type affect the same portion of the score.

(2) requires making all scoring relative, except for bonus score.
(3) requires resolving the mess that is `AffectsCombo` and `IsBonus`, which have caused us problems in the past.

I've tabled up all the hit results and their properties here: https://docs.google.com/spreadsheets/d/1WYOfjB-xjn0DZI99d2-Pxpo5CYxPyW15yzYDz9gc8Ug/edit#gid=0

I've tested this with the community rulesets `sentakki`, `tau`, `Rush!`, `Swing` and `Yoso`. All play fine, so this is not a ruleset-api-breaking change.

One important difference of note is that this changes scoring for osu/taiko/catch, which now award 200 for GOODs instead of 100. I plan to address this in a separate PR. If I've changed awarded results from `Good` to `Ok` at any point in this PR, please point it out since that is an unintentional change.

(Drafting while further PRs are published)