### PR TITLE
Adjust hp increases

### DIFF
--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -124,19 +124,19 @@ namespace osu.Game.Rulesets.Judgements
                     return -DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.Meh:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.Ok:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.01;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.3;
 
                 case HitResult.Good:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
 
                 case HitResult.Great:
-                    return DEFAULT_MAX_HEALTH_INCREASE;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.8;
 
                 case HitResult.Perfect:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 1.05;
+                    return DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.SmallBonus:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.1;


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/10288

I'm still able to complete maps with HP10 maintaining 97% accuracy with no sweat. At the same time I'm unable to mash osu!mania in situations that I also can't in stable but can on lazer master.

Old: https://docs.google.com/spreadsheets/d/1GQDqv7X1nIhcoF2b_b1K-IG-Grvl2RZz5V2AkhBabjE/edit#gid=1016810544

This PR: https://docs.google.com/spreadsheets/d/1WYOfjB-xjn0DZI99d2-Pxpo5CYxPyW15yzYDz9gc8Ug/edit#gid=1016810544

The listed percentage values are relative to the max increase, which is 5% of the HP bar itself. So -50% implies HP decreases by 2.5%.