### PR TITLE
Standardise time display formats across the editor

### DIFF
--- a/osu.Game/Extensions/EditorDisplayExtensions.cs
+++ b/osu.Game/Extensions/EditorDisplayExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Extensions
+{
+    public static class EditorDisplayExtensions
+    {
+        /// <summary>
+        /// Get an editor formatted string (mm:ss:mss)
+        /// </summary>
+        /// <param name="milliseconds">A time value in milliseconds.</param>
+        /// <returns>An editor formatted display string.</returns>
+        public static string ToEditorFormattedString(this double milliseconds) =>
+            ToEditorFormattedString(TimeSpan.FromMilliseconds(milliseconds));
+
+        /// <summary>
+        /// Get an editor formatted string (mm:ss:mss)
+        /// </summary>
+        /// <param name="timeSpan">A time value.</param>
+        /// <returns>An editor formatted display string.</returns>
+        public static string ToEditorFormattedString(this TimeSpan timeSpan) =>
+            $"{(timeSpan < TimeSpan.Zero ? "-" : string.Empty)}{timeSpan:mm\\:ss\\:fff}";
+    }
+}

--- a/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
+++ b/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
@@ -3,8 +3,8 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
-using System;
 using osu.Framework.Allocation;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 
 namespace osu.Game.Screens.Edit.Components
@@ -35,9 +35,7 @@ namespace osu.Game.Screens.Edit.Components
         protected override void Update()
         {
             base.Update();
-
-            var timespan = TimeSpan.FromMilliseconds(editorClock.CurrentTime);
-            trackTimer.Text = $"{(timespan < TimeSpan.Zero ? "-" : string.Empty)}{timespan:mm\\:ss\\:fff}";
+            trackTimer.Text = editorClock.CurrentTime.ToEditorFormattedString();
         }
     }
 }

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -89,7 +90,7 @@ namespace osu.Game.Screens.Edit.Timing
             },
             new OsuSpriteText
             {
-                Text = $"{group.Time:n0}ms",
+                Text = group.Time.ToEditorFormattedString(),
                 Font = OsuFont.GetFont(size: text_size, weight: FontWeight.Bold)
             },
             new ControlGroupAttributes(group),


### PR DESCRIPTION
Generally want to keep time displays always using this format.

![image](https://user-images.githubusercontent.com/191335/94641045-297d2600-031b-11eb-9821-34ac557edbfd.png)
