### PR TITLE
Fix timing screen tests and add simple view of control points to timeline

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Timing;
@@ -19,7 +20,7 @@ namespace osu.Game.Tests.Visual.Editing
 
         public TestSceneTimingScreen()
         {
-            editorBeatmap = new EditorBeatmap(new OsuBeatmap());
+            editorBeatmap = new EditorBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Tests.Visual.Editing
         [Cached(typeof(IBeatSnapProvider))]
         private readonly EditorBeatmap editorBeatmap;
 
+        protected override bool ScrollUsingMouseWheel => false;
+
         public TestSceneTimingScreen()
         {
             editorBeatmap = new EditorBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Timing;
 
@@ -27,7 +26,15 @@ namespace osu.Game.Tests.Visual.Editing
         private void load()
         {
             Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+            Beatmap.Disabled = true;
+
             Child = new TimingScreen();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            Beatmap.Disabled = false;
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -14,9 +14,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public class TimelineArea : Container
     {
-        private readonly Timeline timeline = new Timeline { RelativeSizeAxes = Axes.Both };
+        public readonly Timeline Timeline = new Timeline { RelativeSizeAxes = Axes.Both };
 
-        protected override Container<Drawable> Content => timeline;
+        protected override Container<Drawable> Content => Timeline;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -107,7 +107,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                     }
                                 }
                             },
-                            timeline
+                            Timeline
                         },
                     },
                     ColumnDimensions = new[]
@@ -121,9 +121,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             waveformCheckbox.Current.Value = true;
 
-            timeline.WaveformVisible.BindTo(waveformCheckbox.Current);
+            Timeline.WaveformVisible.BindTo(waveformCheckbox.Current);
         }
 
-        private void changeZoom(float change) => timeline.Zoom += change;
+        private void changeZoom(float change) => Timeline.Zoom += change;
     }
 }

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -115,8 +115,16 @@ namespace osu.Game.Screens.Edit
                         new TimelineTickDisplay(),
                         CreateTimelineContent(),
                     }
-                }, timelineContainer.Add);
+                }, t =>
+                {
+                    timelineContainer.Add(t);
+                    OnTimelineLoaded(t);
+                });
             });
+        }
+
+        protected virtual void OnTimelineLoaded(TimelineArea timelineArea)
+        {
         }
 
         protected abstract Drawable CreateMainContent();

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 
@@ -29,6 +30,11 @@ namespace osu.Game.Screens.Edit.Timing
             : base(EditorScreenMode.Timing)
         {
         }
+
+        protected override Drawable CreateTimelineContent() => new ControlPointPart
+        {
+            RelativeSizeAxes = Axes.Both,
+        };
 
         protected override Drawable CreateMainContent() => new GridContainer
         {

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Timing
@@ -56,6 +57,12 @@ namespace osu.Game.Screens.Edit.Timing
                 if (selected.NewValue != null)
                     clock.SeekTo(selected.NewValue.Time);
             });
+        }
+
+        protected override void OnTimelineLoaded(TimelineArea timelineArea)
+        {
+            base.OnTimelineLoaded(timelineArea);
+            timelineArea.Timeline.Zoom = timelineArea.Timeline.MinZoom;
         }
 
         public class ControlPointList : CompositeDrawable

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.Edit.Timing
             private OsuButton deleteButton;
             private ControlPointTable table;
 
-            private BindableList<ControlPointGroup> controlGroups;
+            private IBindableList<ControlPointGroup> controlGroups;
 
             [Resolved]
             private EditorClock clock { get; set; }
@@ -141,8 +141,7 @@ namespace osu.Game.Screens.Edit.Timing
 
                 selectedGroup.BindValueChanged(selected => { deleteButton.Enabled.Value = selected.NewValue != null; }, true);
 
-                // todo: remove cast after https://github.com/ppy/osu-framework/pull/3906 is merged
-                controlGroups = (BindableList<ControlPointGroup>)Beatmap.Value.Beatmap.ControlPointInfo.Groups.GetBoundCopy();
+                controlGroups = Beatmap.Value.Beatmap.ControlPointInfo.Groups.GetBoundCopy();
 
                 controlGroups.BindCollectionChanged((sender, args) =>
                 {

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Edit.Timing
             private OsuButton deleteButton;
             private ControlPointTable table;
 
-            private IBindableList<ControlPointGroup> controlGroups;
+            private BindableList<ControlPointGroup> controlGroups;
 
             [Resolved]
             private EditorClock clock { get; set; }
@@ -128,12 +128,14 @@ namespace osu.Game.Screens.Edit.Timing
 
                 selectedGroup.BindValueChanged(selected => { deleteButton.Enabled.Value = selected.NewValue != null; }, true);
 
-                controlGroups = Beatmap.Value.Beatmap.ControlPointInfo.Groups.GetBoundCopy();
-                controlGroups.CollectionChanged += (sender, args) => createContent();
-                createContent();
-            }
+                // todo: remove cast after https://github.com/ppy/osu-framework/pull/3906 is merged
+                controlGroups = (BindableList<ControlPointGroup>)Beatmap.Value.Beatmap.ControlPointInfo.Groups.GetBoundCopy();
 
-            private void createContent() => table.ControlGroups = controlGroups;
+                controlGroups.BindCollectionChanged((sender, args) =>
+                {
+                    table.ControlGroups = controlGroups;
+                }, true);
+            }
 
             private void delete()
             {

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -103,12 +103,17 @@ namespace osu.Game.Screens.Edit.Timing
             private const double sane_maximum = 240;
 
             private readonly BindableNumber<double> beatLengthBindable = new TimingControlPoint().BeatLengthBindable;
-            private readonly BindableDouble bpmBindable = new BindableDouble();
+
+            private readonly BindableDouble bpmBindable = new BindableDouble(60000 / TimingControlPoint.DEFAULT_BEAT_LENGTH)
+            {
+                MinValue = sane_minimum,
+                MaxValue = sane_maximum,
+            };
 
             public BPMSlider()
             {
                 beatLengthBindable.BindValueChanged(beatLength => updateCurrent(beatLengthToBpm(beatLength.NewValue)), true);
-                bpmBindable.BindValueChanged(bpm => bpmBindable.Default = beatLengthBindable.Value = beatLengthToBpm(bpm.NewValue));
+                bpmBindable.BindValueChanged(bpm => beatLengthBindable.Value = beatLengthToBpm(bpm.NewValue));
 
                 base.Bindable = bpmBindable;
             }

--- a/osu.Game/Tests/Visual/EditorClockTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorClockTestScene.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Tests.Visual
         protected readonly BindableBeatDivisor BeatDivisor = new BindableBeatDivisor();
         protected new readonly EditorClock Clock;
 
+        protected virtual bool ScrollUsingMouseWheel => true;
+
         protected EditorClockTestScene()
         {
             Clock = new EditorClock(new ControlPointInfo(), 5000, BeatDivisor) { IsCoupled = false };
@@ -57,6 +59,9 @@ namespace osu.Game.Tests.Visual
 
         protected override bool OnScroll(ScrollEvent e)
         {
+            if (!ScrollUsingMouseWheel)
+                return false;
+
             if (e.ScrollDelta.Y > 0)
                 Clock.SeekBackward(true);
             else


### PR DESCRIPTION
Fixes up test scene issues, adds a very simple display of control points to the timeline and adjusts the zoom accordingly. More complex stuff will come as follow-up PRs.