### PR TITLE
Add textbox entry for speed multiplier and volume

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.904.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.930.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.1001.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Tournament/Components/DateTextBox.cs
+++ b/osu.Game.Tournament/Components/DateTextBox.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Tournament.Components
         {
             base.Bindable = new Bindable<string>();
 
-            ((OsuTextBox)Control).OnCommit = (sender, newText) =>
+            ((OsuTextBox)Control).OnCommit += (sender, newText) =>
             {
                 try
                 {

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -59,12 +59,13 @@ namespace osu.Game.Online.Chat
                     RelativeSizeAxes = Axes.X,
                     Height = textbox_height,
                     PlaceholderText = "type your message",
-                    OnCommit = postMessage,
                     ReleaseFocusOnCommit = false,
                     HoldFocus = true,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                 });
+
+                textbox.OnCommit += postMessage;
             }
 
             Channel.BindValueChanged(channelChanged);

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -146,7 +146,6 @@ namespace osu.Game.Overlays
                                             RelativeSizeAxes = Axes.Both,
                                             Height = 1,
                                             PlaceholderText = "type your message",
-                                            OnCommit = postMessage,
                                             ReleaseFocusOnCommit = false,
                                             HoldFocus = true,
                                         }
@@ -185,6 +184,8 @@ namespace osu.Game.Overlays
                     },
                 },
             };
+
+            textbox.OnCommit += postMessage;
 
             ChannelTabControl.Current.ValueChanged += current => channelManager.CurrentChannel.Value = current.NewValue;
             ChannelTabControl.ChannelSelectorActive.ValueChanged += active => ChannelSelectionOverlay.State.Value = active.NewValue ? Visibility.Visible : Visibility.Hidden;

--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Overlays.Music
                 },
             };
 
-            filter.Search.OnCommit = (sender, newText) =>
+            filter.Search.OnCommit += (sender, newText) =>
             {
                 BeatmapInfo toSelect = list.FirstVisibleSet?.Beatmaps?.FirstOrDefault();
 

--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -236,7 +236,6 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         PlaceholderText = "password",
                         RelativeSizeAxes = Axes.X,
                         TabbableContentContainer = this,
-                        OnCommit = (sender, newText) => performLogin()
                     },
                     new SettingsCheckbox
                     {
@@ -276,6 +275,8 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         }
                     }
                 };
+
+                password.OnCommit += (sender, newText) => performLogin();
             }
 
             public override bool AcceptsFocus => true;

--- a/osu.Game/Screens/Edit/Timing/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Timing/DifficultySection.cs
@@ -2,27 +2,23 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Screens.Edit.Timing
 {
     internal class DifficultySection : Section<DifficultyControlPoint>
     {
-        private SettingsSlider<double> multiplier;
+        private SliderWithTextBoxInput<double> multiplierSlider;
 
         [BackgroundDependencyLoader]
         private void load()
         {
             Flow.AddRange(new[]
             {
-                multiplier = new SettingsSlider<double>
+                multiplierSlider = new SliderWithTextBoxInput<double>("Speed Multiplier")
                 {
-                    LabelText = "Speed Multiplier",
-                    Bindable = new DifficultyControlPoint().SpeedMultiplierBindable,
-                    RelativeSizeAxes = Axes.X,
+                    Current = new DifficultyControlPoint().SpeedMultiplierBindable
                 }
             });
         }
@@ -31,7 +27,7 @@ namespace osu.Game.Screens.Edit.Timing
         {
             if (point.NewValue != null)
             {
-                multiplier.Bindable = point.NewValue.SpeedMultiplierBindable;
+                multiplierSlider.Current = point.NewValue.SpeedMultiplierBindable;
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/SampleSection.cs
+++ b/osu.Game/Screens/Edit/Timing/SampleSection.cs
@@ -2,18 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Screens.Edit.Timing
 {
     internal class SampleSection : Section<SampleControlPoint>
     {
         private LabelledTextBox bank;
-        private SettingsSlider<int> volume;
+        private SliderWithTextBoxInput<int> volume;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -24,10 +23,9 @@ namespace osu.Game.Screens.Edit.Timing
                 {
                     Label = "Bank Name",
                 },
-                volume = new SettingsSlider<int>
+                volume = new SliderWithTextBoxInput<int>("Volume")
                 {
-                    Bindable = new SampleControlPoint().SampleVolumeBindable,
-                    LabelText = "Volume",
+                    Current = new SampleControlPoint().SampleVolumeBindable,
                 }
             });
         }
@@ -37,7 +35,7 @@ namespace osu.Game.Screens.Edit.Timing
             if (point.NewValue != null)
             {
                 bank.Current = point.NewValue.SampleBankBindable;
-                volume.Bindable = point.NewValue.SampleVolumeBindable;
+                volume.Current = point.NewValue.SampleVolumeBindable;
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    internal class SliderWithTextBoxInput<T> : CompositeDrawable, IHasCurrentValue<T>
+        where T : struct, IEquatable<T>, IComparable<T>, IConvertible
+    {
+        private readonly SettingsSlider<T> slider;
+
+        public SliderWithTextBoxInput(string labelText)
+        {
+            LabelledTextBox textbox;
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChildren = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        textbox = new LabelledTextBox
+                        {
+                            Label = labelText,
+                        },
+                        slider = new SettingsSlider<T>
+                        {
+                            RelativeSizeAxes = Axes.X,
+                        }
+                    }
+                },
+            };
+
+            textbox.OnCommit += (t, isNew) =>
+            {
+                if (!isNew) return;
+
+                try
+                {
+                    slider.Bindable.Parse(t.Text);
+                }
+                catch
+                {
+                    // will restore the previous text value on failure.
+                    Current.TriggerChange();
+                }
+            };
+
+            Current.BindValueChanged(val =>
+            {
+                textbox.Text = val.NewValue.ToString();
+            }, true);
+        }
+
+        public Bindable<T> Current
+        {
+            get => slider.Bindable;
+            set => slider.Bindable = value;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
@@ -54,9 +54,12 @@ namespace osu.Game.Screens.Edit.Timing
                 }
                 catch
                 {
-                    // will restore the previous text value on failure.
-                    Current.TriggerChange();
+                    // TriggerChange below will restore the previous text value on failure.
                 }
+
+                // This is run regardless of parsing success as the parsed number may not actually trigger a change
+                // due to bindable clamping. Even in such a case we want to update the textbox to a sane visual state.
+                Current.TriggerChange();
             };
 
             Current.BindValueChanged(val =>

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -65,18 +65,19 @@ namespace osu.Game.Screens.Edit.Timing
                 {
                     if (!isNew) return;
 
-                    if (double.TryParse(Current.Value, out double doubleVal))
+                    try
                     {
-                        try
-                        {
+                        if (double.TryParse(Current.Value, out double doubleVal) && doubleVal > 0)
                             beatLengthBindable.Value = beatLengthToBpm(doubleVal);
-                        }
-                        catch
-                        {
-                            // will restore the previous text value on failure.
-                            beatLengthBindable.TriggerChange();
-                        }
                     }
+                    catch
+                    {
+                        // TriggerChange below will restore the previous text value on failure.
+                    }
+
+                    // This is run regardless of parsing success as the parsed number may not actually trigger a change
+                    // due to bindable clamping. Even in such a case we want to update the textbox to a sane visual state.
+                    beatLengthBindable.TriggerChange();
                 };
 
                 beatLengthBindable.BindValueChanged(val =>

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.930.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.1001.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.904.0" />
     <PackageReference Include="Sentry" Version="2.1.6" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.930.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.1001.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.904.0" />
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
@@ -80,7 +80,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.930.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.1001.0" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/10302
- [x] Depends on https://github.com/ppy/osu-framework/pull/3907
- [x] Framework update

I looked at making this share logic with the BPM entry textbox/slider but that one is a bit custom (doing conversion to beatlength).