### PR TITLE
Fix UserListPanel background position

### DIFF
--- a/osu.Game/Users/UserListPanel.cs
+++ b/osu.Game/Users/UserListPanel.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Users
         private void load()
         {
             Background.Width = 0.5f;
+            Background.Origin = Anchor.CentreRight;
+            Background.Anchor = Anchor.CentreRight;
             Background.Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(1), Color4.White.Opacity(0.3f));
         }
 


### PR DESCRIPTION
| Web  | 2020.9.25.0 | this PR |
| ------------- | ------------- | ------------- |
| ![Screenshot 2020-10-01 015932](https://user-images.githubusercontent.com/6506864/94728636-bad7b100-038a-11eb-83fb-2186dd3b5866.png) | ![Screenshot 2020-10-01 015637](https://user-images.githubusercontent.com/6506864/94728694-ccb95400-038a-11eb-87a0-db00a057f81d.png) | ![Screenshot 2020-10-01 015839](https://user-images.githubusercontent.com/6506864/94728704-d3e06200-038a-11eb-8071-6a1f0d6f5d1b.png) |

A simple workaround to fix this visual awkwardness. No tests were added as this is a visual change and its already visible on some test scenes (FriendDisplay, UserPanel)

