### PR TITLE
Allow rebinding of mods/random/options in song selector

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -92,8 +92,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F2, GlobalAction.FooterRandom),
             new KeyBinding(InputKey.F3, GlobalAction.FooterOptions),
         };
-
-
+        
         protected override IEnumerable<Drawable> KeyBindingInputQueue =>
             handler == null ? base.KeyBindingInputQueue : base.KeyBindingInputQueue.Prepend(handler);
     }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -205,7 +205,5 @@ namespace osu.Game.Input.Bindings
 
         [Description("Timing Mode")]
         EditorTimingMode,
-
     }
-
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -50,7 +50,6 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.KeypadEnter, GlobalAction.Select),
         };
 
-        
         public IEnumerable<KeyBinding> EditorKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.F1 }, GlobalAction.EditorComposeMode),
@@ -98,8 +97,6 @@ namespace osu.Game.Input.Bindings
         protected override IEnumerable<Drawable> KeyBindingInputQueue =>
             handler == null ? base.KeyBindingInputQueue : base.KeyBindingInputQueue.Prepend(handler);
     }
-
-
 
     public enum GlobalAction
     {
@@ -209,6 +206,6 @@ namespace osu.Game.Input.Bindings
         [Description("Timing Mode")]
         EditorTimingMode,
 
-        
     }
+
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -50,13 +50,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.KeypadEnter, GlobalAction.Select),
         };
 
-        public IEnumerable<KeyBinding> SongSelectorBindings => new[]
-        {
-            new KeyBinding(InputKey.F1, GlobalAction.FooterMods),
-            new KeyBinding(InputKey.F2, GlobalAction.FooterRandom),
-            new KeyBinding(InputKey.F3, GlobalAction.FooterOptions),
-        };
-
+        
         public IEnumerable<KeyBinding> EditorKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.F1 }, GlobalAction.EditorComposeMode),
@@ -93,9 +87,19 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F3, GlobalAction.MusicPlay)
         };
 
+        public IEnumerable<KeyBinding> SongSelectorBindings => new[]
+        {
+            new KeyBinding(InputKey.F1, GlobalAction.FooterMods),
+            new KeyBinding(InputKey.F2, GlobalAction.FooterRandom),
+            new KeyBinding(InputKey.F3, GlobalAction.FooterOptions),
+        };
+
+
         protected override IEnumerable<Drawable> KeyBindingInputQueue =>
             handler == null ? base.KeyBindingInputQueue : base.KeyBindingInputQueue.Prepend(handler);
     }
+
+
 
     public enum GlobalAction
     {

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Input.Bindings
                 handler = game;
         }
 
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => GlobalKeyBindings.Concat(InGameKeyBindings).Concat(AudioControlKeyBindings).Concat(EditorKeyBindings);
+        public override IEnumerable<KeyBinding> DefaultKeyBindings => GlobalKeyBindings.Concat(InGameKeyBindings).Concat(SongSelectorBindings).Concat(AudioControlKeyBindings).Concat(EditorKeyBindings);
 
         public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {
@@ -48,6 +48,13 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Space, GlobalAction.Select),
             new KeyBinding(InputKey.Enter, GlobalAction.Select),
             new KeyBinding(InputKey.KeypadEnter, GlobalAction.Select),
+        };
+
+        public IEnumerable<KeyBinding> SongSelectorBindings => new[]
+        {
+            new KeyBinding(InputKey.F1, GlobalAction.FooterMods),
+            new KeyBinding(InputKey.F2, GlobalAction.FooterRandom),
+            new KeyBinding(InputKey.F3, GlobalAction.FooterOptions),
         };
 
         public IEnumerable<KeyBinding> EditorKeyBindings => new[]
@@ -119,6 +126,16 @@ namespace osu.Game.Input.Bindings
         [Description("Toggle mute")]
         ToggleMute,
 
+        //Song selector bindings
+        [Description("Choose a random song")]
+        FooterRandom,
+
+        [Description("Change beatmap options")]
+        FooterOptions,
+
+        [Description("Select mods")]
+        FooterMods,
+
         // In-Game Keybindings
         [Description("Skip cutscene")]
         SkipCutscene,
@@ -187,5 +204,7 @@ namespace osu.Game.Input.Bindings
 
         [Description("Timing Mode")]
         EditorTimingMode,
+
+        
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F2, GlobalAction.FooterRandom),
             new KeyBinding(InputKey.F3, GlobalAction.FooterOptions),
         };
-        
+
         protected override IEnumerable<Drawable> KeyBindingInputQueue =>
             handler == null ? base.KeyBindingInputQueue : base.KeyBindingInputQueue.Prepend(handler);
     }

--- a/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/KeyBinding/GlobalKeyBindingsSection.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Overlays.KeyBinding
         public GlobalKeyBindingsSection(GlobalActionContainer manager)
         {
             Add(new DefaultBindingsSubsection(manager));
+            Add(new SongSelectorBindingsSubsection(manager));
             Add(new AudioControlKeyBindingsSubsection(manager));
             Add(new InGameKeyBindingsSubsection(manager));
             Add(new EditorKeyBindingsSubsection(manager));
@@ -33,6 +34,17 @@ namespace osu.Game.Overlays.KeyBinding
                 : base(null)
             {
                 Defaults = manager.GlobalKeyBindings;
+            }
+        }
+
+        private class SongSelectorBindingsSubsection : KeyBindingsSubsection
+        {
+            protected override string Header => "Song Selector";
+
+            public SongSelectorBindingsSubsection(GlobalActionContainer manager)
+                : base(null)
+            {
+                Defaults = manager.SongSelectorBindings;
             }
         }
 

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -15,7 +15,6 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
 using osu.Framework.Input.Bindings;
 
-
 namespace osu.Game.Screens.Select
 {
     public class FooterButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>
@@ -170,7 +169,6 @@ namespace osu.Game.Screens.Select
             return base.OnClick(e);
         }
 
-
         public bool OnPressed(GlobalAction action)
         {
 
@@ -184,8 +182,6 @@ namespace osu.Game.Screens.Select
             return false;
         }
 
-        public void OnReleased(GlobalAction action)
-        {
-        }
+        public void OnReleased(GlobalAction action ) {}
     }
 }

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -160,7 +160,6 @@ namespace osu.Game.Screens.Select
             box.FadeOut(Footer.TRANSITION_LENGTH, Easing.OutQuint);
             base.OnMouseUp(e);
         }
-
         protected override bool OnClick(ClickEvent e)
         {
             box.ClearTransforms();
@@ -180,7 +179,6 @@ namespace osu.Game.Screens.Select
 
             return false;
         }
-
         public void OnReleased(GlobalAction action){}
     }
 }

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -171,7 +171,6 @@ namespace osu.Game.Screens.Select
 
         public bool OnPressed(GlobalAction action)
         {
-
             if (action == Hotkey)
             {
                 box.FadeOut(Footer.TRANSITION_LENGTH, Easing.OutQuint);

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -12,10 +12,13 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.Containers;
+using osu.Game.Input.Bindings;
+using osu.Framework.Input.Bindings;
+
 
 namespace osu.Game.Screens.Select
 {
-    public class FooterButton : OsuClickableContainer
+    public class FooterButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>
     {
         public const float SHEAR_WIDTH = 7.5f;
 
@@ -117,7 +120,7 @@ namespace osu.Game.Screens.Select
 
         public Action Hovered;
         public Action HoverLost;
-        public Key? Hotkey;
+        public GlobalAction Hotkey;
 
         protected override void UpdateAfterChildren()
         {
@@ -167,15 +170,22 @@ namespace osu.Game.Screens.Select
             return base.OnClick(e);
         }
 
-        protected override bool OnKeyDown(KeyDownEvent e)
+
+        public bool OnPressed(GlobalAction action)
         {
-            if (!e.Repeat && e.Key == Hotkey)
+
+            if (action == Hotkey)
             {
+                box.FadeOut(Footer.TRANSITION_LENGTH, Easing.OutQuint);
                 Click();
                 return true;
             }
 
-            return base.OnKeyDown(e);
+            return false;
+        }
+
+        public void OnReleased(GlobalAction action)
+        {
         }
     }
 }

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -167,7 +167,6 @@ namespace osu.Game.Screens.Select
             box.FadeOut(Footer.TRANSITION_LENGTH * 3, Easing.OutQuint);
             return base.OnClick(e);
         }
-
         public bool OnPressed(GlobalAction action)
         {
             if (action == Hotkey)
@@ -179,6 +178,9 @@ namespace osu.Game.Screens.Select
 
             return false;
         }
-        public void OnReleased(GlobalAction action){}
+        public void OnReleased(GlobalAction action)
+        {
+            return;
+        }
     }
 }

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -181,6 +181,6 @@ namespace osu.Game.Screens.Select
             return false;
         }
 
-        public void OnReleased(GlobalAction action ) {}
+        public void OnReleased(GlobalAction action){}
     }
 }

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -17,7 +17,6 @@ using osuTK.Graphics;
 using osuTK.Input;
 using osu.Game.Input.Bindings;
 
-
 namespace osu.Game.Screens.Select
 {
     public class FooterButtonMods : FooterButton, IHasCurrentValue<IReadOnlyList<Mod>>

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -15,6 +15,8 @@ using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
+using osu.Game.Input.Bindings;
+
 
 namespace osu.Game.Screens.Select
 {
@@ -57,7 +59,7 @@ namespace osu.Game.Screens.Select
             lowMultiplierColour = colours.Red;
             highMultiplierColour = colours.Green;
             Text = @"mods";
-            Hotkey = Key.F1;
+            Hotkey = GlobalAction.FooterMods;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Select/FooterButtonOptions.cs
+++ b/osu.Game/Screens/Select/FooterButtonOptions.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Graphics;
 using osuTK.Input;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Select
 {
@@ -16,7 +17,7 @@ namespace osu.Game.Screens.Select
             SelectedColour = colours.Blue;
             DeselectedColour = SelectedColour.Opacity(0.5f);
             Text = @"options";
-            Hotkey = Key.F3;
+            Hotkey = GlobalAction.FooterOptions;
         }
     }
 }

--- a/osu.Game/Screens/Select/FooterButtonRandom.cs
+++ b/osu.Game/Screens/Select/FooterButtonRandom.cs
@@ -9,6 +9,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK.Input;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Select
 {
@@ -37,7 +38,7 @@ namespace osu.Game.Screens.Select
             SelectedColour = colours.Green;
             DeselectedColour = SelectedColour.Opacity(0.5f);
             Text = @"random";
-            Hotkey = Key.F2;
+            Hotkey = GlobalAction.FooterRandom;
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)


### PR DESCRIPTION
Resolves #9176.

Allows the user to rebind mods/random/options buttons in the footer of the song selector.

New version of #10307 because it did not follow contributing guidelines. In addition, I moved the enums for SongSelectorBindings so that it does not interfere with existing user keybinds.