### PR TITLE
Move control points display to base timeline class (and add toggles)

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -70,20 +71,27 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             AddRange(new Drawable[]
             {
-                waveform = new WaveformGraph
+                new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colours.Blue.Opacity(0.2f),
-                    LowColour = colours.BlueLighter,
-                    MidColour = colours.BlueDark,
-                    HighColour = colours.BlueDarker,
-                    Depth = float.MaxValue
+                    Depth = float.MaxValue,
+                    Children = new Drawable[]
+                    {
+                        waveform = new WaveformGraph
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colours.Blue.Opacity(0.2f),
+                            LowColour = colours.BlueLighter,
+                            MidColour = colours.BlueDark,
+                            HighColour = colours.BlueDarker,
+                        },
+                        controlPoints = new ControlPointPart
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        },
+                        ticks = new TimelineTickDisplay(),
+                    }
                 },
-                controlPoints = new ControlPointPart
-                {
-                    RelativeSizeAxes = Axes.Both
-                },
-                ticks = new TimelineTickDisplay(),
             });
 
             // We don't want the centre marker to scroll

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         public readonly Bindable<bool> ControlPointsVisible = new Bindable<bool>();
 
+        public readonly Bindable<bool> TicksVisible = new Bindable<bool>();
+
         public readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
 
         [Resolved]
@@ -61,6 +63,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private WaveformGraph waveform;
         private ControlPointPart controlPoints;
+        private TimelineTickDisplay ticks;
 
         [BackgroundDependencyLoader]
         private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours)
@@ -80,7 +83,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     RelativeSizeAxes = Axes.Both
                 },
-                new TimelineTickDisplay(),
+                ticks = new TimelineTickDisplay(),
             });
 
             // We don't want the centre marker to scroll
@@ -88,6 +91,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             WaveformVisible.ValueChanged += visible => waveform.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
             ControlPointsVisible.ValueChanged += visible => controlPoints.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
+            TicksVisible.ValueChanged += visible => ticks.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
 
             Beatmap.BindTo(beatmap);
             Beatmap.BindValueChanged(b =>

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
@@ -21,6 +22,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     public class Timeline : ZoomableScrollContainer, IPositionSnapProvider
     {
         public readonly Bindable<bool> WaveformVisible = new Bindable<bool>();
+
+        public readonly Bindable<bool> ControlPointsVisible = new Bindable<bool>();
+
         public readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
 
         [Resolved]
@@ -56,24 +60,34 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         }
 
         private WaveformGraph waveform;
+        private ControlPointPart controlPoints;
 
         [BackgroundDependencyLoader]
         private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours)
         {
-            Add(waveform = new WaveformGraph
+            AddRange(new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Colour = colours.Blue.Opacity(0.2f),
-                LowColour = colours.BlueLighter,
-                MidColour = colours.BlueDark,
-                HighColour = colours.BlueDarker,
-                Depth = float.MaxValue
+                waveform = new WaveformGraph
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Blue.Opacity(0.2f),
+                    LowColour = colours.BlueLighter,
+                    MidColour = colours.BlueDark,
+                    HighColour = colours.BlueDarker,
+                    Depth = float.MaxValue
+                },
+                controlPoints = new ControlPointPart
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                new TimelineTickDisplay(),
             });
 
             // We don't want the centre marker to scroll
             AddInternal(new CentreMarker { Depth = float.MaxValue });
 
             WaveformVisible.ValueChanged += visible => waveform.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
+            ControlPointsVisible.ValueChanged += visible => controlPoints.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
 
             Beatmap.BindTo(beatmap);
             Beatmap.BindValueChanged(b =>

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             OsuCheckbox waveformCheckbox;
             OsuCheckbox controlPointsCheckbox;
+            OsuCheckbox ticksCheckbox;
 
             InternalChildren = new Drawable[]
             {
@@ -71,6 +72,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                             controlPointsCheckbox = new OsuCheckbox
                                             {
                                                 LabelText = "Control Points",
+                                                Current = { Value = true },
+                                            },
+                                            ticksCheckbox = new OsuCheckbox
+                                            {
+                                                LabelText = "Ticks",
                                                 Current = { Value = true },
                                             }
                                         }
@@ -131,6 +137,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             Timeline.WaveformVisible.BindTo(waveformCheckbox.Current);
             Timeline.ControlPointsVisible.BindTo(controlPointsCheckbox.Current);
+            Timeline.TicksVisible.BindTo(ticksCheckbox.Current);
         }
 
         private void changeZoom(float change) => Timeline.Zoom += change;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             CornerRadius = 5;
 
             OsuCheckbox waveformCheckbox;
+            OsuCheckbox controlPointsCheckbox;
 
             InternalChildren = new Drawable[]
             {
@@ -57,12 +58,21 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                         Origin = Anchor.CentreLeft,
                                         AutoSizeAxes = Axes.Y,
                                         Width = 160,
-                                        Padding = new MarginPadding { Horizontal = 15 },
+                                        Padding = new MarginPadding { Horizontal = 10 },
                                         Direction = FillDirection.Vertical,
                                         Spacing = new Vector2(0, 4),
                                         Children = new[]
                                         {
-                                            waveformCheckbox = new OsuCheckbox { LabelText = "Waveform" }
+                                            waveformCheckbox = new OsuCheckbox
+                                            {
+                                                LabelText = "Waveform",
+                                                Current = { Value = true },
+                                            },
+                                            controlPointsCheckbox = new OsuCheckbox
+                                            {
+                                                LabelText = "Control Points",
+                                                Current = { Value = true },
+                                            }
                                         }
                                     }
                                 }
@@ -119,9 +129,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 }
             };
 
-            waveformCheckbox.Current.Value = true;
-
             Timeline.WaveformVisible.BindTo(waveformCheckbox.Current);
+            Timeline.ControlPointsVisible.BindTo(controlPointsCheckbox.Current);
         }
 
         private void changeZoom(float change) => Timeline.Zoom += change;

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -112,7 +112,6 @@ namespace osu.Game.Screens.Edit
                     RelativeSizeAxes = Axes.Both,
                     Children = new[]
                     {
-                        new TimelineTickDisplay(),
                         CreateTimelineContent(),
                     }
                 }, t =>

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -12,7 +12,6 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 
@@ -30,11 +29,6 @@ namespace osu.Game.Screens.Edit.Timing
             : base(EditorScreenMode.Timing)
         {
         }
-
-        protected override Drawable CreateTimelineContent() => new ControlPointPart
-        {
-            RelativeSizeAxes = Axes.Both,
-        };
 
         protected override Drawable CreateMainContent() => new GridContainer
         {


### PR DESCRIPTION
Centralising more elements to the base `TimelineArea` / `Timeline` classes as they should be visible on all editor screens. Getting things ready for more advanced display implementations of control points on the main timeline.

![2020-10-01 18 17 09](https://user-images.githubusercontent.com/191335/94791277-595b2500-0412-11eb-945b-fccbeb44164f.gif)
