### PR TITLE
Fix default spinner flashing yellow glow before completion

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -93,6 +93,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             drawableSpinner.RotationTracker.Complete.BindValueChanged(complete => updateComplete(complete.NewValue, 200));
             drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
+
+            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
         }
 
         protected override void Update()
@@ -124,6 +126,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
+            if (!(drawableHitObject is DrawableSpinner))
+                return;
+
             centre.ScaleTo(0);
             mainContainer.ScaleTo(0);
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -72,10 +72,15 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             this.FadeOut();
             drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
+
+            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
         }
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
+            if (!(drawableHitObject is DrawableSpinner))
+                return;
+
             var spinner = (Spinner)drawableSpinner.HitObject;
 
             using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -86,10 +86,15 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             this.FadeOut();
             drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
+
+            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
         }
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
+            if (!(drawableHitObject is DrawableSpinner))
+                return;
+
             var spinner = drawableSpinner.HitObject;
 
             using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -51,12 +51,12 @@ namespace osu.Game.Rulesets.Objects.Drawables
         public override bool PropagateNonPositionalInputSubTree => HandleUserInput;
 
         /// <summary>
-        /// Invoked when a <see cref="JudgementResult"/> has been applied by this <see cref="DrawableHitObject"/> or a nested <see cref="DrawableHitObject"/>.
+        /// Invoked by this or a nested <see cref="DrawableHitObject"/> after a <see cref="JudgementResult"/> has been applied.
         /// </summary>
         public event Action<DrawableHitObject, JudgementResult> OnNewResult;
 
         /// <summary>
-        /// Invoked when a <see cref="JudgementResult"/> is being reverted by this <see cref="DrawableHitObject"/> or a nested <see cref="DrawableHitObject"/>.
+        /// Invoked by this or a nested <see cref="DrawableHitObject"/> prior to a <see cref="JudgementResult"/> being reverted.
         /// </summary>
         public event Action<DrawableHitObject, JudgementResult> OnRevertResult;
 
@@ -236,7 +236,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         #region State / Transform Management
 
         /// <summary>
-        /// Bind to apply a custom state which can override the default implementation.
+        /// Invoked by this or a nested <see cref="DrawableHitObject"/> to apply a custom state that can override the default implementation.
         /// </summary>
         public event Action<DrawableHitObject, ArmedState> ApplyCustomUpdateState;
 


### PR DESCRIPTION
I'm not sure what regressed this, if this is even a regression. There's really two issues here:
1. The state event happens in `DrawableSpinner.LoadComplete`, which happens much earlier than `DefaultSpinnerDisc.LoadComplete` (a child of `DrawableSpinner`).
2. `ApplyCustomUpdateState` is propagated upwards from nested hitobjects, so it'd receive `Hit` and `Idle` events as ticks get hit and as ticks load and trigger their initial `ApplyCustomUpdateState`.

Not sure what the best way to test this is, or if it needs to be tested?