### PR TITLE
Try to match stable's cursor trail density

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/LegacyCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyCursorTrail.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         protected override bool InterpolateMovements => !disjointTrail;
 
-        protected override float IntervalMultiplier => Math.Max(cursorSize.Value, 1);
+        protected override float IntervalMultiplier => 1 / Math.Max(cursorSize.Value, 1);
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyCursorTrail.cs
@@ -1,9 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Skinning;
 
@@ -15,6 +18,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private bool disjointTrail;
         private double lastTrailTime;
+        private IBindable<float> cursorSize;
 
         public LegacyCursorTrail()
         {
@@ -22,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         }
 
         [BackgroundDependencyLoader]
-        private void load(ISkinSource skin)
+        private void load(ISkinSource skin, OsuConfigManager config)
         {
             Texture = skin.GetTexture("cursortrail");
             disjointTrail = skin.GetTexture("cursormiddle") == null;
@@ -32,11 +36,15 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 // stable "magic ratio". see OsuPlayfieldAdjustmentContainer for full explanation.
                 Texture.ScaleAdjust *= 1.6f;
             }
+
+            cursorSize = config.GetBindable<float>(OsuSetting.GameplayCursorSize).GetBoundCopy();
         }
 
         protected override double FadeDuration => disjointTrail ? 150 : 500;
 
         protected override bool InterpolateMovements => !disjointTrail;
+
+        protected override float IntervalMultiplier => Math.Max(cursorSize.Value, 1);
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
@@ -15,6 +16,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Layout;
 using osu.Framework.Timing;
+using osu.Game.Configuration;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Graphics.ES30;
@@ -28,6 +30,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         private readonly TrailPart[] parts = new TrailPart[max_sprites];
         private int currentIndex;
         private IShader shader;
+        private Bindable<float> cursorSize;
         private double timeOffset;
         private float time;
 
@@ -48,9 +51,10 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         }
 
         [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders)
+        private void load(ShaderManager shaders, OsuConfigManager config)
         {
             shader = shaders.Load(@"CursorTrail", FragmentShaderDescriptor.TEXTURE);
+            cursorSize = config.GetBindable<float>(OsuSetting.GameplayCursorSize);
         }
 
         protected override void LoadComplete()
@@ -147,7 +151,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                     float distance = diff.Length;
                     Vector2 direction = diff / distance;
 
-                    float interval = partSize.X / 2.5f;
+                    float interval = partSize.X / 2.5f / cursorSize.Value;
 
                     for (float d = interval; d < distance; d += interval)
                     {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
@@ -16,7 +15,6 @@ using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Layout;
 using osu.Framework.Timing;
-using osu.Game.Configuration;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Graphics.ES30;
@@ -30,7 +28,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         private readonly TrailPart[] parts = new TrailPart[max_sprites];
         private int currentIndex;
         private IShader shader;
-        private Bindable<float> cursorSize;
         private double timeOffset;
         private float time;
 
@@ -51,10 +48,9 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         }
 
         [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders, OsuConfigManager config)
+        private void load(ShaderManager shaders)
         {
             shader = shaders.Load(@"CursorTrail", FragmentShaderDescriptor.TEXTURE);
-            cursorSize = config.GetBindable<float>(OsuSetting.GameplayCursorSize).GetBoundCopy();
         }
 
         protected override void LoadComplete()
@@ -123,6 +119,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         /// </summary>
         protected virtual bool InterpolateMovements => true;
 
+        protected virtual float IntervalMultiplier => 1.0f;
+
         private Vector2? lastPosition;
         private readonly InputResampler resampler = new InputResampler();
 
@@ -151,7 +149,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                     float distance = diff.Length;
                     Vector2 direction = diff / distance;
 
-                    float interval = partSize.X / 2.5f / Math.Max(cursorSize.Value, 1);
+                    float interval = partSize.X / 2.5f / IntervalMultiplier;
 
                     for (float d = interval; d < distance; d += interval)
                     {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                     float distance = diff.Length;
                     Vector2 direction = diff / distance;
 
-                    float interval = partSize.X / 2.5f / cursorSize.Value;
+                    float interval = partSize.X / 2.5f / Math.Max(cursorSize.Value, 1);
 
                     for (float d = interval; d < distance; d += interval)
                     {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         private void load(ShaderManager shaders, OsuConfigManager config)
         {
             shader = shaders.Load(@"CursorTrail", FragmentShaderDescriptor.TEXTURE);
-            cursorSize = config.GetBindable<float>(OsuSetting.GameplayCursorSize);
+            cursorSize = config.GetBindable<float>(OsuSetting.GameplayCursorSize).GetBoundCopy();
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                     float distance = diff.Length;
                     Vector2 direction = diff / distance;
 
-                    float interval = partSize.X / 2.5f / IntervalMultiplier;
+                    float interval = partSize.X / 2.5f * IntervalMultiplier;
 
                     for (float d = interval; d < distance; d += interval)
                     {


### PR DESCRIPTION
This addresses the issue in #6115 but does not close it (as this PR doesn't add the ability to adjust the density, it just makes it more in match with stable)

Quoting my comment from that issue:
> I think the issue here is that on stable, density of the trail polygons stays the same no matter what cursor size you use. So if you move your 1.0x cursor size cursor when your trail is a 8x8 file it will get a new polygon every 4px for an overlap of 4px, but if you move your 2.0x cursor size cursor keeping the same trail file dimensions, you will still get a new polygon every 4px but now you overlap 12px.

~~If something like this could be considered I can record comparison videos. Going to open the PR as a draft because this.~~

Comparison video here: https://youtu.be/iHeu8hPEYAY
This PR is top-left, current release is top-right, stable is bottom. 

Rendered another video with chroma key: https://youtu.be/CR88gzm0I7A
stable is left, this PR is middle, current release is right (and unkeyed, it looks bad with video compressions, but it also looks bad in-game, that's why I want this change)