### PR TITLE
Fix control points not being removed from ControlPointInfo lists when group is removed

### DIFF
--- a/osu.Game.Tests/NonVisual/ControlPointInfoTest.cs
+++ b/osu.Game.Tests/NonVisual/ControlPointInfoTest.cs
@@ -140,6 +140,22 @@ namespace osu.Game.Tests.NonVisual
         }
 
         [Test]
+        public void TestRemoveGroupAlsoRemovedControlPoints()
+        {
+            var cpi = new ControlPointInfo();
+
+            var group = cpi.GroupAt(1000, true);
+
+            group.Add(new SampleControlPoint());
+
+            Assert.That(cpi.SamplePoints.Count, Is.EqualTo(1));
+
+            cpi.RemoveGroup(group);
+
+            Assert.That(cpi.SamplePoints.Count, Is.EqualTo(0));
+        }
+
+        [Test]
         public void TestAddControlPointToGroup()
         {
             var cpi = new ControlPointInfo();

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -158,6 +158,9 @@ namespace osu.Game.Beatmaps.ControlPoints
 
         public void RemoveGroup(ControlPointGroup group)
         {
+            foreach (var item in group.ControlPoints.ToArray())
+                group.Remove(item);
+
             group.ItemAdded -= groupItemAdded;
             group.ItemRemoved -= groupItemRemoved;
 


### PR DESCRIPTION
`ControlPointInfo` manually manages lists for each kind of `ControlPoint`, but these weren't tidied up when removing a group, leaving left-over control points.