### PR TITLE
Add the ability to move a control point around in time

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointSettings.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointSettings.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         private IReadOnlyList<Drawable> createSections() => new Drawable[]
         {
+            new GroupSection(),
             new TimingSection(),
             new DifficultySection(),
             new SampleSection(),

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -1,0 +1,96 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    internal class GroupSection : CompositeDrawable
+    {
+        private LabelledTextBox textBox;
+
+        [Resolved]
+        protected Bindable<ControlPointGroup> SelectedGroup { get; private set; }
+
+        [Resolved]
+        protected IBindable<WorkingBeatmap> Beatmap { get; private set; }
+
+        [Resolved]
+        private EditorClock clock { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            Padding = new MarginPadding(10);
+
+            InternalChildren = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(10),
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        textBox = new LabelledTextBox
+                        {
+                            Label = "Time"
+                        },
+                        new TriangleButton
+                        {
+                            Text = "Use current time",
+                            RelativeSizeAxes = Axes.X,
+                            Action = () => changeSelectedGroupTime(clock.CurrentTime)
+                        }
+                    }
+                },
+            };
+
+            textBox.OnCommit += (sender, isNew) =>
+            {
+                if (double.TryParse(sender.Text, out var newTime))
+                {
+                    changeSelectedGroupTime(newTime);
+                }
+            };
+
+            SelectedGroup.BindValueChanged(group =>
+            {
+                if (group.NewValue == null)
+                {
+                    textBox.Text = string.Empty;
+                    textBox.Current.Disabled = true;
+                    return;
+                }
+
+                textBox.Current.Disabled = false;
+                textBox.Text = $"{group.NewValue.Time:n0}";
+            }, true);
+        }
+
+        private void changeSelectedGroupTime(in double time)
+        {
+            var currentGroupItems = SelectedGroup.Value.ControlPoints.ToArray();
+
+            Beatmap.Value.Beatmap.ControlPointInfo.RemoveGroup(SelectedGroup.Value);
+
+            foreach (var cp in currentGroupItems)
+                Beatmap.Value.Beatmap.ControlPointInfo.Add(time, cp);
+
+            SelectedGroup.Value = Beatmap.Value.Beatmap.ControlPointInfo.GroupAt(time);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -93,6 +93,9 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void changeSelectedGroupTime(in double time)
         {
+            if (time == SelectedGroup.Value.Time)
+                return;
+
             changeHandler?.BeginChange();
 
             var currentGroupItems = SelectedGroup.Value.ControlPoints.ToArray();

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -61,9 +61,16 @@ namespace osu.Game.Screens.Edit.Timing
 
             textBox.OnCommit += (sender, isNew) =>
             {
+                if (!isNew)
+                    return;
+
                 if (double.TryParse(sender.Text, out var newTime))
                 {
                     changeSelectedGroupTime(newTime);
+                }
+                else
+                {
+                    SelectedGroup.TriggerChange();
                 }
             };
 

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private EditorClock clock { get; set; }
 
+        [Resolved(canBeNull: true)]
+        private IEditorChangeHandler changeHandler { get; set; }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -90,6 +93,8 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void changeSelectedGroupTime(in double time)
         {
+            changeHandler?.BeginChange();
+
             var currentGroupItems = SelectedGroup.Value.ControlPoints.ToArray();
 
             Beatmap.Value.Beatmap.ControlPointInfo.RemoveGroup(SelectedGroup.Value);
@@ -98,6 +103,8 @@ namespace osu.Game.Screens.Edit.Timing
                 Beatmap.Value.Beatmap.ControlPointInfo.Add(time, cp);
 
             SelectedGroup.Value = Beatmap.Value.Beatmap.ControlPointInfo.GroupAt(time);
+
+            changeHandler?.EndChange();
         }
     }
 }


### PR DESCRIPTION
For now, this does a reconstruction of the group, as there is no way to modify the time (I believe this was the intentional direction to keep things simple, and should be fine for the time being).

- [x] Depends on #10324 

![2020-10-02 15 33 00](https://user-images.githubusercontent.com/191335/94894642-bb746280-04c4-11eb-87c1-8c2ef8849aa2.gif)
