### PR TITLE
 Only regenerate autoplay on editor state change

### DIFF
--- a/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
@@ -40,17 +40,21 @@ namespace osu.Game.Rulesets.Edit
             Playfield.DisplayJudgements.Value = false;
         }
 
+        [Resolved]
+        private IEditorChangeHandler changeHandler { get; set; }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
             beatmap.HitObjectAdded += addHitObject;
-            beatmap.HitObjectUpdated += updateReplay;
             beatmap.HitObjectRemoved += removeHitObject;
+
+            // for now only regenerate replay on a finalised state change, not HitObjectUpdated.
+            changeHandler.OnStateChange += updateReplay;
         }
 
-        private void updateReplay(HitObject obj = null) =>
-            drawableRuleset.RegenerateAutoplay();
+        private void updateReplay() => drawableRuleset.RegenerateAutoplay();
 
         private void addHitObject(HitObject hitObject)
         {
@@ -69,7 +73,7 @@ namespace osu.Game.Rulesets.Edit
             drawableRuleset.Playfield.Remove(drawableObject);
             drawableRuleset.Playfield.PostProcess();
 
-            drawableRuleset.RegenerateAutoplay();
+            updateReplay();
         }
 
         public override bool PropagatePositionalInputSubTree => false;

--- a/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Edit
             Playfield.DisplayJudgements.Value = false;
         }
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
         private IEditorChangeHandler changeHandler { get; set; }
 
         protected override void LoadComplete()
@@ -50,8 +50,15 @@ namespace osu.Game.Rulesets.Edit
             beatmap.HitObjectAdded += addHitObject;
             beatmap.HitObjectRemoved += removeHitObject;
 
-            // for now only regenerate replay on a finalised state change, not HitObjectUpdated.
-            changeHandler.OnStateChange += updateReplay;
+            if (changeHandler != null)
+            {
+                // for now only regenerate replay on a finalised state change, not HitObjectUpdated.
+                changeHandler.OnStateChange += updateReplay;
+            }
+            else
+            {
+                beatmap.HitObjectUpdated += _ => updateReplay();
+            }
         }
 
         private void updateReplay() => drawableRuleset.RegenerateAutoplay();

--- a/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs
@@ -69,8 +69,6 @@ namespace osu.Game.Rulesets.Edit
 
             drawableRuleset.Playfield.Add(drawableObject);
             drawableRuleset.Playfield.PostProcess();
-
-            updateReplay();
         }
 
         private void removeHitObject(HitObject hitObject)
@@ -79,8 +77,6 @@ namespace osu.Game.Rulesets.Edit
 
             drawableRuleset.Playfield.Remove(drawableObject);
             drawableRuleset.Playfield.PostProcess();
-
-            updateReplay();
         }
 
         public override bool PropagatePositionalInputSubTree => false;

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Screens.Edit
         public readonly Bindable<bool> CanUndo = new Bindable<bool>();
         public readonly Bindable<bool> CanRedo = new Bindable<bool>();
 
+        public event Action OnStateChange;
+
         private readonly LegacyEditorBeatmapPatcher patcher;
         private readonly List<byte[]> savedStates = new List<byte[]>();
 
@@ -109,6 +111,8 @@ namespace osu.Game.Screens.Edit
                 savedStates.Add(newState);
 
                 currentState = savedStates.Count - 1;
+
+                OnStateChange?.Invoke();
                 updateBindables();
             }
         }
@@ -136,6 +140,7 @@ namespace osu.Game.Screens.Edit
 
             isRestoring = false;
 
+            OnStateChange?.Invoke();
             updateBindables();
         }
 

--- a/osu.Game/Screens/Edit/IEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/IEditorChangeHandler.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Fired whenever a state change occurs.
         /// </summary>
-        public event Action OnStateChange;
+        event Action OnStateChange;
 
         /// <summary>
         /// Begins a bulk state change event. <see cref="EndChange"/> should be invoked soon after.

--- a/osu.Game/Screens/Edit/IEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/IEditorChangeHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Screens.Edit
@@ -10,6 +11,11 @@ namespace osu.Game.Screens.Edit
     /// </summary>
     public interface IEditorChangeHandler
     {
+        /// <summary>
+        /// Fired whenever a state change occurs.
+        /// </summary>
+        public event Action OnStateChange;
+
         /// <summary>
         /// Begins a bulk state change event. <see cref="EndChange"/> should be invoked soon after.
         /// </summary>


### PR DESCRIPTION
Alleviates performance concerns without having much of a visual effect (unless you're playing the beatmap while dragging a selection, which is very unlikely).

We can potentially change this in the future if/when we have partial regeneration support.