### PR TITLE
Fix spinners not transforming correctly

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         private Spinner spinner;
 
+        private const float initial_scale = 1.3f;
         private const float idle_alpha = 0.2f;
         private const float tracking_alpha = 0.4f;
 
@@ -41,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             // we are slightly bigger than our parent, to clip the top and bottom of the circle
             // this should probably be revisited when scaled spinners are a thing.
-            Scale = new Vector2(1.3f);
+            Scale = new Vector2(initial_scale);
 
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -117,8 +118,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 fill.Alpha = (float)Interpolation.Damp(fill.Alpha, drawableSpinner.RotationTracker.Tracking ? tracking_alpha : idle_alpha, 0.98f, (float)Math.Abs(Clock.ElapsedFrameTime));
             }
 
-            const float initial_scale = 0.2f;
-            float targetScale = initial_scale + (1 - initial_scale) * drawableSpinner.Progress;
+            const float initial_fill_scale = 0.2f;
+            float targetScale = initial_fill_scale + (1 - initial_fill_scale) * drawableSpinner.Progress;
 
             fill.Scale = new Vector2((float)Interpolation.Lerp(fill.Scale.X, targetScale, Math.Clamp(Math.Abs(Time.Elapsed) / 100, 0, 1)));
             mainContainer.Rotation = drawableSpinner.RotationTracker.Rotation;
@@ -129,41 +130,54 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             if (!(drawableHitObject is DrawableSpinner))
                 return;
 
-            centre.ScaleTo(0);
-            mainContainer.ScaleTo(0);
-
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt / 2, true))
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
             {
-                // constant ambient rotation to give the spinner "spinning" character.
-                this.RotateTo((float)(25 * spinner.Duration / 2000), spinner.TimePreempt + spinner.Duration);
-
-                centre.ScaleTo(0.3f, spinner.TimePreempt / 4, Easing.OutQuint);
-                mainContainer.ScaleTo(0.2f, spinner.TimePreempt / 4, Easing.OutQuint);
+                this.ScaleTo(initial_scale);
+                this.RotateTo(0);
 
                 using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
                 {
-                    centre.ScaleTo(0.5f, spinner.TimePreempt / 2, Easing.OutQuint);
-                    mainContainer.ScaleTo(1, spinner.TimePreempt / 2, Easing.OutQuint);
+                    // constant ambient rotation to give the spinner "spinning" character.
+                    this.RotateTo((float)(25 * spinner.Duration / 2000), spinner.TimePreempt + spinner.Duration);
+                }
+
+                using (BeginDelayedSequence(spinner.TimePreempt + spinner.Duration + drawableHitObject.Result.TimeOffset, true))
+                {
+                    switch (state)
+                    {
+                        case ArmedState.Hit:
+                            this.ScaleTo(initial_scale * 1.2f, 320, Easing.Out);
+                            this.RotateTo(mainContainer.Rotation + 180, 320);
+                            break;
+
+                        case ArmedState.Miss:
+                            this.ScaleTo(initial_scale * 0.8f, 320, Easing.In);
+                            break;
+                    }
+                }
+            }
+
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            {
+                centre.ScaleTo(0);
+                mainContainer.ScaleTo(0);
+
+                using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
+                {
+                    centre.ScaleTo(0.3f, spinner.TimePreempt / 4, Easing.OutQuint);
+                    mainContainer.ScaleTo(0.2f, spinner.TimePreempt / 4, Easing.OutQuint);
+
+                    using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
+                    {
+                        centre.ScaleTo(0.5f, spinner.TimePreempt / 2, Easing.OutQuint);
+                        mainContainer.ScaleTo(1, spinner.TimePreempt / 2, Easing.OutQuint);
+                    }
                 }
             }
 
             // transforms we have from completing the spinner will be rolled back, so reapply immediately.
-            updateComplete(state == ArmedState.Hit, 0);
-
-            using (BeginDelayedSequence(spinner.Duration, true))
-            {
-                switch (state)
-                {
-                    case ArmedState.Hit:
-                        this.ScaleTo(Scale * 1.2f, 320, Easing.Out);
-                        this.RotateTo(mainContainer.Rotation + 180, 320);
-                        break;
-
-                    case ArmedState.Miss:
-                        this.ScaleTo(Scale * 0.8f, 320, Easing.In);
-                        break;
-                }
-            }
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+                updateComplete(state == ArmedState.Hit, 0);
         }
 
         private void updateComplete(bool complete, double duration)

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -70,9 +70,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             base.LoadComplete();
 
-            this.FadeOut();
             drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
-
             updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
         }
 
@@ -83,12 +81,19 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             var spinner = (Spinner)drawableSpinner.HitObject;
 
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+                this.FadeOut();
+
             using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
                 this.FadeInFromZero(spinner.TimeFadeIn / 2);
 
-            fixedMiddle.FadeColour(Color4.White);
-            using (BeginAbsoluteSequence(spinner.StartTime, true))
-                fixedMiddle.FadeColour(Color4.Red, spinner.Duration);
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            {
+                fixedMiddle.FadeColour(Color4.White);
+
+                using (BeginDelayedSequence(spinner.TimePreempt, true))
+                    fixedMiddle.FadeColour(Color4.Red, spinner.Duration);
+            }
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -88,9 +88,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             base.LoadComplete();
 
-            this.FadeOut();
             drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
-
             updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
         }
 
@@ -100,6 +98,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 return;
 
             var spinner = drawableSpinner.HitObject;
+
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+                this.FadeOut();
 
             using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
                 this.FadeInFromZero(spinner.TimeFadeIn / 2);


### PR DESCRIPTION
- Fades not inside absolute sequences.
- Missing initial scale/rotation resets in the default disc.

Part of this I could replicate before https://github.com/ppy/osu/pull/10280 - for example, upon rewind the glow would be white during the pre-empt. I also have no reason to believe the fade issue couldn't occur before, but haven't tested it that far.