### PR TITLE
Add change handler callbacks from timing screen / components

### DIFF
--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -79,9 +79,6 @@ namespace osu.Game.Screens.Edit
                 SaveState();
         }
 
-        /// <summary>
-        /// Saves the current <see cref="Editor"/> state.
-        /// </summary>
         public void SaveState()
         {
             if (bulkChangesStarted > 0)

--- a/osu.Game/Screens/Edit/IEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/IEditorChangeHandler.cs
@@ -29,5 +29,11 @@ namespace osu.Game.Screens.Edit
         /// This should be invoked as soon as possible after <see cref="BeginChange"/> to cause a state change.
         /// </remarks>
         void EndChange();
+
+        /// <summary>
+        /// Immediately saves the current <see cref="Editor"/> state.
+        /// Note that this will be a no-op if there is a change in progress via <see cref="BeginChange"/>.
+        /// </summary>
+        void SaveState();
     }
 }

--- a/osu.Game/Screens/Edit/Timing/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Timing/DifficultySection.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Screens.Edit.Timing
             if (point.NewValue != null)
             {
                 multiplierSlider.Current = point.NewValue.SpeedMultiplierBindable;
+                multiplierSlider.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/EffectSection.cs
+++ b/osu.Game/Screens/Edit/Timing/EffectSection.cs
@@ -28,7 +28,10 @@ namespace osu.Game.Screens.Edit.Timing
             if (point.NewValue != null)
             {
                 kiai.Current = point.NewValue.KiaiModeBindable;
+                kiai.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
+
                 omitBarLine.Current = point.NewValue.OmitFirstBarLineBindable;
+                omitBarLine.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/SampleSection.cs
+++ b/osu.Game/Screens/Edit/Timing/SampleSection.cs
@@ -35,7 +35,10 @@ namespace osu.Game.Screens.Edit.Timing
             if (point.NewValue != null)
             {
                 bank.Current = point.NewValue.SampleBankBindable;
+                bank.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
+
                 volume.Current = point.NewValue.SampleVolumeBindable;
+                volume.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
             }
         }
 

--- a/osu.Game/Screens/Edit/Timing/Section.cs
+++ b/osu.Game/Screens/Edit/Timing/Section.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         protected Bindable<ControlPointGroup> SelectedGroup { get; private set; }
 
+        [Resolved(canBeNull: true)]
+        protected IEditorChangeHandler ChangeHandler { get; private set; }
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {

--- a/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Screens.Edit.Timing
                         },
                         slider = new SettingsSlider<T>
                         {
+                            TransferValueOnCommit = true,
                             RelativeSizeAxes = Axes.X,
                         }
                     }

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -87,6 +87,9 @@ namespace osu.Game.Screens.Edit.Timing
             [Resolved]
             private Bindable<ControlPointGroup> selectedGroup { get; set; }
 
+            [Resolved(canBeNull: true)]
+            private IEditorChangeHandler changeHandler { get; set; }
+
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
@@ -146,6 +149,7 @@ namespace osu.Game.Screens.Edit.Timing
                 controlGroups.BindCollectionChanged((sender, args) =>
                 {
                     table.ControlGroups = controlGroups;
+                    changeHandler.SaveState();
                 }, true);
             }
 

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -37,8 +37,13 @@ namespace osu.Game.Screens.Edit.Timing
             if (point.NewValue != null)
             {
                 bpmSlider.Bindable = point.NewValue.BeatLengthBindable;
+                bpmSlider.Bindable.BindValueChanged(_ => ChangeHandler?.SaveState());
+
                 bpmTextEntry.Bindable = point.NewValue.BeatLengthBindable;
+                // no need to hook change handler here as it's the same bindable as above
+
                 timeSignature.Bindable = point.NewValue.TimeSignatureBindable;
+                timeSignature.Bindable.BindValueChanged(_ => ChangeHandler?.SaveState());
             }
         }
 
@@ -117,6 +122,8 @@ namespace osu.Game.Screens.Edit.Timing
                 bpmBindable.BindValueChanged(bpm => beatLengthBindable.Value = beatLengthToBpm(bpm.NewValue));
 
                 base.Bindable = bpmBindable;
+
+                TransferValueOnCommit = true;
             }
 
             public override Bindable<double> Bindable


### PR DESCRIPTION
Addresses part of #10314. As @smoogipoo discovered, `EditorChangeHandler`'s patching doesn't support control points, so actually undoing/redoing will have no effect until that is fixed.

Also, textboxes will save too many states until framework issue https://github.com/ppy/osu-framework/issues/3912 is addressed. I had a local fix for this prepared, but it's probably not worth it.

I've confirmed via breakpoints that this change behaves as expected.

- [x] Loosely depends on https://github.com/ppy/osu/pull/10325