### PR TITLE
Fix tests specifying steps in their constructors

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHoldNote.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneHoldNote.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -13,7 +14,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
 {
     public class TestSceneHoldNote : ManiaHitObjectTestScene
     {
-        public TestSceneHoldNote()
+        [Test]
+        public void TestHoldNote()
         {
             AddToggleStep("toggle hitting", v =>
             {

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneNotes.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneNotes.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -31,22 +32,30 @@ namespace osu.Game.Rulesets.Mania.Tests
         [Test]
         public void TestVariousNotes()
         {
-            Child = new FillFlowContainer
+            DrawableNote note1 = null;
+            DrawableNote note2 = null;
+            DrawableHoldNote holdNote1 = null;
+            DrawableHoldNote holdNote2 = null;
+
+            AddStep("create notes", () =>
             {
-                Clock = new FramedClock(new ManualClock()),
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                AutoSizeAxes = Axes.Both,
-                Direction = FillDirection.Horizontal,
-                Spacing = new Vector2(20),
-                Children = new[]
+                Child = new FillFlowContainer
                 {
-                    createNoteDisplay(ScrollingDirection.Down, 1, out var note1),
-                    createNoteDisplay(ScrollingDirection.Up, 2, out var note2),
-                    createHoldNoteDisplay(ScrollingDirection.Down, 1, out var holdNote1),
-                    createHoldNoteDisplay(ScrollingDirection.Up, 2, out var holdNote2),
-                }
-            };
+                    Clock = new FramedClock(new ManualClock()),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(20),
+                    Children = new[]
+                    {
+                        createNoteDisplay(ScrollingDirection.Down, 1, out note1),
+                        createNoteDisplay(ScrollingDirection.Up, 2, out note2),
+                        createHoldNoteDisplay(ScrollingDirection.Down, 1, out holdNote1),
+                        createHoldNoteDisplay(ScrollingDirection.Up, 2, out holdNote2),
+                    }
+                };
+            });
 
             AddAssert("note 1 facing downwards", () => verifyAnchors(note1, Anchor.y2));
             AddAssert("note 2 facing upwards", () => verifyAnchors(note2, Anchor.y0));

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneNotes.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneNotes.cs
@@ -9,7 +9,6 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneNotes.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneNotes.cs
@@ -28,8 +28,8 @@ namespace osu.Game.Rulesets.Mania.Tests
     [TestFixture]
     public class TestSceneNotes : OsuTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
+        [Test]
+        public void TestVariousNotes()
         {
             Child = new FillFlowContainer
             {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -20,7 +20,8 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         private int depthIndex;
 
-        public TestSceneHitCircle()
+        [Test]
+        public void TestVariousHitCircles()
         {
             AddStep("Miss Big Single", () => SetContents(() => testSingle(2)));
             AddStep("Miss Medium Single", () => SetContents(() => testSingle(5)));

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -27,7 +27,8 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         private int depthIndex;
 
-        public TestSceneSlider()
+        [Test]
+        public void TestVariousSliders()
         {
             AddStep("Big Single", () => SetContents(() => testSimpleBig()));
             AddStep("Medium Single", () => SetContents(() => testSimpleMedium()));

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -3,7 +3,6 @@
 
 using System;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -30,8 +29,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         private readonly Random rng = new Random(1337);
 
-        [BackgroundDependencyLoader]
-        private void load()
+        [Test]
+        public void TestVariousHits()
         {
             AddStep("Hit", () => addHitJudgement(false));
             AddStep("Strong hit", () => addStrongHitJudgement(false));


### PR DESCRIPTION
Not sure if this is all of them, but should be an improvement.. all the other similar (hitobject) test already used a "Various" test method or run steps in BDL/LoadComplete; just left those for now.