### PR TITLE
Add ability to save a failed score and replay to local leaderboards

### DIFF
--- a/osu.Game/Scoring/ScoreRank.cs
+++ b/osu.Game/Scoring/ScoreRank.cs
@@ -7,6 +7,9 @@ namespace osu.Game.Scoring
 {
     public enum ScoreRank
     {
+        [Description(@"F")]
+        F,
+
         [Description(@"D")]
         D,
 

--- a/osu.Game/Screens/Play/FailOverlay.cs
+++ b/osu.Game/Screens/Play/FailOverlay.cs
@@ -1,9 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Graphics;
-using osuTK.Graphics;
+using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play
 {
@@ -12,11 +19,48 @@ namespace osu.Game.Screens.Play
         public override string Header => "failed";
         public override string Description => "you're dead, try again?";
 
+        public Action OnSave;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
             AddButton("Retry", colours.YellowDark, () => OnRetry?.Invoke());
             AddButton("Quit", new Color4(170, 27, 39, 255), () => OnQuit?.Invoke());
+
+            Add(new Container
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                RelativeSizeAxes = Axes.X,
+                Height = TwoLayerButton.SIZE_EXTENDED.Y,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4Extensions.FromHex("#333")
+                    },
+                    new FillFlowContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        AutoSizeAxes = Axes.X,
+                        RelativeSizeAxes = Axes.Y,
+                        Spacing = new Vector2(5),
+                        Padding = new MarginPadding(10),
+                        Direction = FillDirection.Horizontal,
+                        Children = new Drawable[]
+                        {
+                            new SaveScoreButton()
+                            {
+                                OnSave = OnSave,
+                                RelativeSizeAxes = Axes.Y,
+                                Width = 300
+                            },
+                        }
+                    }
+                }
+            });
         }
     }
 }

--- a/osu.Game/Screens/Play/SaveScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveScoreButton.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Graphics.UserInterface;

--- a/osu.Game/Screens/Play/SaveScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveScoreButton.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online;
+
+namespace osu.Game.Screens.Play
+{
+    public class SaveScoreButton : DownloadButton
+    {
+
+        public Action OnSave;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            State.BindValueChanged(updateTooltip, true);
+            Action = saveScore;
+        }
+
+        private void saveScore()
+        {
+            if (State.Value != DownloadState.LocallyAvailable)
+                OnSave?.Invoke();
+
+            State.Value = DownloadState.LocallyAvailable;
+        }
+
+        private void updateTooltip(ValueChangedEvent<DownloadState> state)
+        {
+            switch (state.NewValue)
+            {
+                case DownloadState.LocallyAvailable:
+                    TooltipText = @"Score saved";
+                    break;
+
+                default:
+                    TooltipText = @"Save score";
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Play/SaveScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveScoreButton.cs
@@ -8,7 +8,6 @@ namespace osu.Game.Screens.Play
 {
     public class SaveScoreButton : DownloadButton
     {
-
         public Action OnSave;
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Related to #8721

Adds the ability to save your score to local leaderboards if you failed the map. Since the whole score is saved, you can also watch the replay through the scores info page.

This also means the addition of a new ScoreRank (ScoreRank.F). This could cause major problems to existing architecture but my knowledge of the code base is limited.