### PR TITLE
Lock the orientation on Android and iOS devices to landscape

### DIFF
--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -9,7 +9,7 @@ using osu.Framework.Android;
 
 namespace osu.Android
 {
-    [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullSensor, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
+    [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.Landscape, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
     public class OsuGameActivity : AndroidGameActivity
     {
         protected override Framework.Game CreateGame() => new OsuGameAndroid();

--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -39,8 +39,6 @@
 	<string>We don&apos;t really use the microphone.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>


### PR DESCRIPTION
# Issue
The portrait orientation of osu! in the menu is stretched and overlaps itself.

- The menu is cut off on either side
- Auto rotations are very annoying

# Photos
https://photos.app.goo.gl/G5d3h8G6uGDTqZ6g7

# Solution
Restrict the orientation of the Android and iOS builds from `FullSensor` (aka all four orientations regardless of rotation lock) to `Landscape`.