### PR TITLE
Allow rotation lock on Android to function properly

### DIFF
--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -9,7 +9,7 @@ using osu.Framework.Android;
 
 namespace osu.Android
 {
-    [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullSensor, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
+    [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
     public class OsuGameActivity : AndroidGameActivity
     {
         protected override Framework.Game CreateGame() => new OsuGameAndroid();


### PR DESCRIPTION
According to Google's documentation, `fullSensor` will ignore rotation locking preferences, while `fullUser` will obey them.

See this issue for more details:
https://github.com/ppy/osu/pull/10347