### PR TITLE
Bring back health increase/decrease values closer to previous ones

### DIFF
--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -2,10 +2,40 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Judgements
 {
     public class ManiaJudgement : Judgement
     {
+        protected override double HealthIncreaseFor(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.LargeTickHit:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+
+                case HitResult.LargeTickMiss:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+
+                case HitResult.Meh:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
+
+                case HitResult.Ok:
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.3;
+
+                case HitResult.Good:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+
+                case HitResult.Great:
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.8;
+
+                case HitResult.Perfect:
+                    return DEFAULT_MAX_HEALTH_INCREASE;
+
+                default:
+                    return base.HealthIncreaseFor(result);
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -314,11 +314,11 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private bool assertMaxJudge() => judgementResults.Any() && judgementResults.All(t => t.Type == t.Judgement.MaxResult);
 
-        private bool assertHeadMissTailTracked() => judgementResults[^2].Type == HitResult.IgnoreHit && judgementResults.First().Type == HitResult.Miss;
+        private bool assertHeadMissTailTracked() => judgementResults[^2].Type == HitResult.SmallTickHit && judgementResults.First().Type == HitResult.Miss;
 
-        private bool assertMidSliderJudgements() => judgementResults[^2].Type == HitResult.IgnoreHit;
+        private bool assertMidSliderJudgements() => judgementResults[^2].Type == HitResult.SmallTickHit;
 
-        private bool assertMidSliderJudgementFail() => judgementResults[^2].Type == HitResult.IgnoreMiss;
+        private bool assertMidSliderJudgementFail() => judgementResults[^2].Type == HitResult.SmallTickMiss;
 
         private ScoreAccessibleReplayPlayer currentPlayer;
 

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class SliderTailJudgement : OsuJudgement
         {
-            public override HitResult MaxResult => HitResult.IgnoreHit;
+            public override HitResult MaxResult => HitResult.SmallTickHit;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/Judgements/TaikoDrumRollTickJudgement.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Judgements
         {
             switch (result)
             {
-                case HitResult.Great:
+                case HitResult.SmallTickHit:
                     return 0.15;
 
                 default:

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -124,19 +124,19 @@ namespace osu.Game.Rulesets.Judgements
                     return -DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.Meh:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;
 
                 case HitResult.Ok:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.3;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.Good:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.75;
 
                 case HitResult.Great:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.8;
+                    return DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.Perfect:
-                    return DEFAULT_MAX_HEALTH_INCREASE;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 1.05;
 
                 case HitResult.SmallBonus:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.1;

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -109,16 +109,16 @@ namespace osu.Game.Rulesets.Judgements
                     return 0;
 
                 case HitResult.SmallTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.05;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.SmallTickMiss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.05;
+                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.LargeTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+                    return DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.LargeTickMiss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+                    return -DEFAULT_MAX_HEALTH_INCREASE;
 
                 case HitResult.Miss:
                     return -DEFAULT_MAX_HEALTH_INCREASE;
@@ -139,10 +139,10 @@ namespace osu.Game.Rulesets.Judgements
                     return DEFAULT_MAX_HEALTH_INCREASE * 1.05;
 
                 case HitResult.SmallBonus:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
+                    return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.LargeBonus:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.2;
+                    return DEFAULT_MAX_HEALTH_INCREASE;
             }
         }
 


### PR DESCRIPTION
Aims to resolve #10337 "in hotfix mode", so to speak. Not tested very thoroughly in actual gameplay, so buyer beware.

# Summary

There are several issues at play here, so I lumped them into one PR to reduce noise. Taking it from the top:

* In osu!:
  - Slider ends gave no health. To make them give health, they've been changed to be small ticks (can't be large ticks, as that re-introduces sliderend combo break)
  - The only hit result that gave health was GREAT. Both OK and MEH took away health. The old values are restored here.
  - Health increases for spinner ticks have also been decreased significantly; this brings them back up again.
* In taiko:
  - taiko rolls its own HP system, so it was largely unaffected by the changes, there was however one missed reference to `Great` that should have been `SmallTickHit` (see 682b5fb).
* In catch:
  - Droplet health has been brought closer to previous values.
* In mania:
  - The new anti-mashing HP changes from #10291, as well as the new HP increases for ticks have been moved locally to `ManiaJudgement`.

Here's a [spreadsheet](https://docs.google.com/spreadsheets/d/1fM6jCZg3CmZFdqHQeS7d4PKhgqpMLa7plxmeEPfTaTk/edit#gid=0) that aims to provide a comparison of what changed where.

# Remarks

OK and GOOD are slightly different than they were before. Because now 100s are OKs and not GOODs, and GOODs gave 50%, now OKs give 50% and GOODs give the linearly-interpolated 75%. I don't think it should realistically matter for any of our scenarios, as the only ruleset that uses GOODs (mania) has a local override.