### PR TITLE
Fixed metadata text not aligning correctly

### DIFF
--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -23,32 +23,6 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public class BeatmapMetadataDisplay : Container
     {
-        private class MetadataLine : Container
-        {
-            public MetadataLine(string left, string right)
-            {
-                AutoSizeAxes = Axes.Both;
-                Children = new Drawable[]
-                {
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.TopRight,
-                        Margin = new MarginPadding { Right = 5 },
-                        Colour = OsuColour.Gray(0.8f),
-                        Text = left,
-                    },
-                    new OsuSpriteText
-                    {
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.TopLeft,
-                        Margin = new MarginPadding { Left = 5 },
-                        Text = string.IsNullOrEmpty(right) ? @"-" : right,
-                    }
-                };
-            }
-        }
-
         private readonly WorkingBeatmap beatmap;
         private readonly Bindable<IReadOnlyList<Mod>> mods;
         private readonly Drawable facade;
@@ -81,6 +55,7 @@ namespace osu.Game.Screens.Play
         private void load()
         {
             var metadata = beatmap.BeatmapInfo?.Metadata ?? new BeatmapMetadata();
+            TextFlowContainer metadataLine;
 
             AutoSizeAxes = Axes.Both;
             Children = new Drawable[]
@@ -145,15 +120,11 @@ namespace osu.Game.Screens.Play
                                 Bottom = 40
                             },
                         },
-                        new MetadataLine("Source", metadata.Source)
+                        metadataLine = new TextFlowContainer
                         {
+                            AutoSizeAxes = Axes.Both,
                             Origin = Anchor.TopCentre,
-                            Anchor = Anchor.TopCentre,
-                        },
-                        new MetadataLine("Mapper", metadata.AuthorString)
-                        {
-                            Origin = Anchor.TopCentre,
-                            Anchor = Anchor.TopCentre,
+                            Anchor = Anchor.TopCentre
                         },
                         new ModDisplay
                         {
@@ -166,6 +137,20 @@ namespace osu.Game.Screens.Play
                     },
                 }
             };
+
+            metadataLine.AddText("Source", t =>
+            {
+                t.Colour = OsuColour.Gray(0.8f);
+                t.Padding = new MarginPadding { Right = 10 };
+            });
+            metadataLine.AddText(string.IsNullOrEmpty(metadata.Source) ? @"-" : metadata.Source);
+
+            metadataLine.AddParagraph("Mapper", t =>
+            {
+                t.Colour = OsuColour.Gray(0.8f);
+                t.Padding = new MarginPadding { Right = 10 };
+            });
+            metadataLine.AddText(string.IsNullOrEmpty(metadata.AuthorString) ? @"-" : metadata.AuthorString);
 
             Loading = true;
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/4506.

Use a single TextFlowContainer to center align the metadata on beatmap load.

Output from maps mentioned in the #4506 :
![blooming](https://user-images.githubusercontent.com/5779211/95004280-031aed00-059e-11eb-9b8d-c3f1dfd1a26a.png)
![Neo-Aspect](https://user-images.githubusercontent.com/5779211/95004281-06ae7400-059e-11eb-992c-85e07ae8bca3.png)
![Jojo](https://user-images.githubusercontent.com/5779211/95004282-08783780-059e-11eb-8408-7c704685e0ba.png)


