### PR TITLE
Fix spinners crashing on unpause

### DIFF
--- a/osu.Game.Tests/NonVisual/GameplayClockTest.cs
+++ b/osu.Game.Tests/NonVisual/GameplayClockTest.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Timing;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class GameplayClockTest
+    {
+        [TestCase(0)]
+        [TestCase(1)]
+        public void TestTrueGameplayRateWithZeroAdjustment(double underlyingClockRate)
+        {
+            var framedClock = new FramedClock(new ManualClock { Rate = underlyingClockRate });
+            var gameplayClock = new TestGameplayClock(framedClock);
+
+            gameplayClock.MutableNonGameplayAdjustments.Add(new BindableDouble());
+
+            Assert.That(gameplayClock.TrueGameplayRate, Is.EqualTo(0));
+        }
+
+        private class TestGameplayClock : GameplayClock
+        {
+            public List<Bindable<double>> MutableNonGameplayAdjustments { get; } = new List<Bindable<double>>();
+
+            public override IEnumerable<Bindable<double>> NonGameplayAdjustments => MutableNonGameplayAdjustments;
+
+            public TestGameplayClock(IFrameBasedClock underlyingClock)
+                : base(underlyingClock)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Play/GameplayClock.cs
+++ b/osu.Game/Screens/Play/GameplayClock.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Timing;
+using osu.Framework.Utils;
 
 namespace osu.Game.Screens.Play
 {
@@ -47,7 +48,12 @@ namespace osu.Game.Screens.Play
                 double baseRate = Rate;
 
                 foreach (var adjustment in NonGameplayAdjustments)
+                {
+                    if (Precision.AlmostEquals(adjustment.Value, 0))
+                        return 0;
+
                     baseRate /= adjustment.Value;
+                }
 
                 return baseRate;
             }


### PR DESCRIPTION
Resolves #10362.

# Summary

As noted in the issue thread, right after unpause there was a possibility for a `NaN` to pop up at `TrueGameplayRate`, if the underlying clock was paused and there was also an adjustment applied (in this case it was the pause frequency adjustment, which transforms from 0 back to 1 on unpause).

Resolve by explicitly checking for near-zero adjustments and returning a `TrueGameplayRate` of 0 if one is found.

# Remarks

Includes a mightily indirect test case. Direct ones are way harder to write due to the specificity of scenario involved but I really didn't want to submit any fix to this without a test.