### PR TITLE
Re-enable and fix gameplay sample playback test

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySamplePlayback.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Audio;
@@ -17,7 +18,6 @@ namespace osu.Game.Tests.Visual.Gameplay
     public class TestSceneGameplaySamplePlayback : PlayerTestScene
     {
         [Test]
-        [Ignore("temporarily disabled pending investigation")]
         public void TestAllSamplesStopDuringSeek()
         {
             DrawableSlider slider = null;
@@ -47,13 +47,19 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             // because we are in frame stable context, it's quite likely that not all samples are "played" at this point.
             // the important thing is that at least one started, and that sample has since stopped.
-            AddAssert("no samples are playing", () => Player.ChildrenOfType<PausableSkinnableSound>().All(s => !s.IsPlaying));
+            AddAssert("all looping samples stopped immediately", () => allStopped(allLoopingSounds));
+            AddUntilStep("all samples stopped eventually", () => allStopped(allSounds));
 
             AddAssert("sample playback still disabled", () => gameplayClock.SamplePlaybackDisabled.Value);
 
             AddUntilStep("seek finished, sample playback enabled", () => !gameplayClock.SamplePlaybackDisabled.Value);
             AddUntilStep("any sample is playing", () => Player.ChildrenOfType<PausableSkinnableSound>().Any(s => s.IsPlaying));
         }
+
+        private IEnumerable<PausableSkinnableSound> allSounds => Player.ChildrenOfType<PausableSkinnableSound>();
+        private IEnumerable<PausableSkinnableSound> allLoopingSounds => allSounds.Where(sound => sound.Looping);
+
+        private bool allStopped(IEnumerable<PausableSkinnableSound> sounds) => sounds.All(sound => !sound.IsPlaying);
 
         protected override bool Autoplay => true;
 


### PR DESCRIPTION
# Summary

The test added in #10371 and then temporarily disabled again in #10374 had an issue that surfaced almost immediately and without fail for me - namely that it expected all samples to stop immediately. In my tests, I found that there was a single slider circle hit sample that wasn't getting muted, as non-looping samples get a chance to play out:

https://github.com/ppy/osu/blob/12c84df2085d706cb22de22616167115bc60c5f9/osu.Game/Skinning/PausableSkinnableSound.cs#L35-L40

I confirmed it by placing some log statements, yielding this (numbers are hash codes of each sample, aiming to approximate identity):

```
[runtime] 2020-10-05 19:04:03 [verbose]: sample 50348007 has not been requested to play, skipping trying to stop it
[runtime] 2020-10-05 19:04:03 [verbose]: requesting stop of sample 51460466
[runtime] 2020-10-05 19:04:03 [verbose]: sample 61111257 is not looping, leaving it alone
[runtime] 2020-10-05 19:04:03 [verbose]: sample 55927184 has not been requested to play, skipping trying to stop it
[runtime] 2020-10-05 19:04:03 [verbose]: sample 33770477 has not been requested to play, skipping trying to stop it
[runtime] 2020-10-05 19:04:03 [verbose]: sample 48461545 has not been requested to play, skipping trying to stop it

(...)

1014600: step 6 Assert: sample playback disabled
[runtime] 2020-10-05 19:04:03 [debug]: Pressed (LeftButton) handled by DrawableHitCircle+HitReceptor.
[runtime] 2020-10-05 19:04:03 [verbose]: sample 61111257 is not stopping
```

To resolve, first check that all the looping samples (like sample 51460466 above) have stopped immediately, then check that all samples end eventually.

# Remarks

Tested both locally by running the test 1000 times on repeat for ~2 hours and on my fork's appveyor over four runs ([first](https://ci.appveyor.com/project/bdach/osu/builds/35580994), [second](https://ci.appveyor.com/project/bdach/osu/builds/35581526), [third](https://ci.appveyor.com/project/bdach/osu/builds/35582274), [fourth](https://ci.appveyor.com/project/bdach/osu/builds/35582825)).