### PR TITLE
Improve behaviour of "check for updates" button

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -29,6 +29,11 @@ namespace osu.Desktop.Updater
 
         private static readonly Logger logger = Logger.GetLogger("updater");
 
+        /// <summary>
+        /// Whether an update has been downloaded but not yet applied.
+        /// </summary>
+        private bool updatePending;
+
         [BackgroundDependencyLoader]
         private void load(NotificationOverlay notification)
         {
@@ -49,9 +54,19 @@ namespace osu.Desktop.Updater
                 updateManager ??= await UpdateManager.GitHubUpdateManager(@"https://github.com/ppy/osu", @"osulazer", null, null, true);
 
                 var info = await updateManager.CheckForUpdate(!useDeltaPatching);
+
                 if (info.ReleasesToApply.Count == 0)
+                {
+                    if (updatePending)
+                    {
+                        // the user may have dismissed the completion notice, so show it again.
+                        notificationOverlay.Post(new UpdateCompleteNotification(this));
+                        return true;
+                    }
+
                     // no updates available. bail and retry later.
                     return false;
+                }
 
                 if (notification == null)
                 {
@@ -72,6 +87,7 @@ namespace osu.Desktop.Updater
                     await updateManager.ApplyReleases(info, p => notification.Progress = p / 100f);
 
                     notification.State = ProgressNotificationState.Completed;
+                    updatePending = true;
                 }
                 catch (Exception e)
                 {
@@ -113,10 +129,27 @@ namespace osu.Desktop.Updater
             updateManager?.Dispose();
         }
 
+        private class UpdateCompleteNotification : ProgressCompletionNotification
+        {
+            [Resolved]
+            private OsuGame game { get; set; }
+
+            public UpdateCompleteNotification(SquirrelUpdateManager updateManager)
+            {
+                Text = @"Update ready to install. Click to restart!";
+
+                Activated = () =>
+                {
+                    updateManager.PrepareUpdateAsync()
+                                 .ContinueWith(_ => updateManager.Schedule(() => game.GracefullyExit()));
+                    return true;
+                };
+            }
+        }
+
         private class UpdateProgressNotification : ProgressNotification
         {
             private readonly SquirrelUpdateManager updateManager;
-            private OsuGame game;
 
             public UpdateProgressNotification(SquirrelUpdateManager updateManager)
             {
@@ -125,23 +158,12 @@ namespace osu.Desktop.Updater
 
             protected override Notification CreateCompletionNotification()
             {
-                return new ProgressCompletionNotification
-                {
-                    Text = @"Update ready to install. Click to restart!",
-                    Activated = () =>
-                    {
-                        updateManager.PrepareUpdateAsync()
-                                     .ContinueWith(_ => updateManager.Schedule(() => game.GracefullyExit()));
-                        return true;
-                    }
-                };
+                return new UpdateCompleteNotification(updateManager);
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours, OsuGame game)
+            private void load(OsuColour colours)
             {
-                this.game = game;
-
                 IconContent.AddRange(new Drawable[]
                 {
                     new Box

--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -37,9 +37,9 @@ namespace osu.Desktop.Updater
             Splat.Locator.CurrentMutable.Register(() => new SquirrelLogger(), typeof(Splat.ILogger));
         }
 
-        protected override async Task PerformUpdateCheck() => await checkForUpdateAsync();
+        protected override async Task<bool> PerformUpdateCheck() => await checkForUpdateAsync();
 
-        private async Task checkForUpdateAsync(bool useDeltaPatching = true, UpdateProgressNotification notification = null)
+        private async Task<bool> checkForUpdateAsync(bool useDeltaPatching = true, UpdateProgressNotification notification = null)
         {
             // should we schedule a retry on completion of this check?
             bool scheduleRecheck = true;
@@ -51,7 +51,7 @@ namespace osu.Desktop.Updater
                 var info = await updateManager.CheckForUpdate(!useDeltaPatching);
                 if (info.ReleasesToApply.Count == 0)
                     // no updates available. bail and retry later.
-                    return;
+                    return false;
 
                 if (notification == null)
                 {
@@ -103,6 +103,8 @@ namespace osu.Desktop.Updater
                     Scheduler.AddDelayed(async () => await checkForUpdateAsync(), 60000 * 30);
                 }
             }
+
+            return true;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
 
         private SettingsButton checkForUpdatesButton;
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private NotificationOverlay notifications { get; set; }
 
         [BackgroundDependencyLoader(true)]
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
                         {
                             if (!t.Result)
                             {
-                                notifications.Post(new SimpleNotification
+                                notifications?.Post(new SimpleNotification
                                 {
                                     Text = $"You are running the latest release ({game.Version})",
                                     Icon = FontAwesome.Solid.CheckCircle,

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 Bindable = config.GetBindable<ReleaseStream>(OsuSetting.ReleaseStream),
             });
 
-            //if (updateManager?.CanCheckForUpdate == true)
+            if (updateManager?.CanCheckForUpdate == true)
             {
                 Add(checkForUpdatesButton = new SettingsButton
                 {

--- a/osu.Game/Updater/SimpleUpdateManager.cs
+++ b/osu.Game/Updater/SimpleUpdateManager.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Updater
             version = game.Version;
         }
 
-        protected override async Task PerformUpdateCheck()
+        protected override async Task<bool> PerformUpdateCheck()
         {
             try
             {
@@ -53,12 +53,17 @@ namespace osu.Game.Updater
                             return true;
                         }
                     });
+
+                    return true;
                 }
             }
             catch
             {
                 // we shouldn't crash on a web failure. or any failure for the matter.
+                return true;
             }
+
+            return false;
         }
 
         private string getBestUrl(GitHubRelease release)

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -61,6 +61,9 @@ namespace osu.Game.Updater
 
         public async Task<bool> CheckForUpdateAsync()
         {
+            if (!CanCheckForUpdate)
+                return false;
+
             Task<bool> waitTask;
 
             lock (updateTaskLock)

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -57,25 +57,28 @@ namespace osu.Game.Updater
 
         private readonly object updateTaskLock = new object();
 
-        private Task updateCheckTask;
+        private Task<bool> updateCheckTask;
 
-        public async Task CheckForUpdateAsync()
+        public async Task<bool> CheckForUpdateAsync()
         {
-            if (!CanCheckForUpdate)
-                return;
-
-            Task waitTask;
+            Task<bool> waitTask;
 
             lock (updateTaskLock)
                 waitTask = (updateCheckTask ??= PerformUpdateCheck());
 
-            await waitTask;
+            bool hasUpdates = await waitTask;
 
             lock (updateTaskLock)
                 updateCheckTask = null;
+
+            return hasUpdates;
         }
 
-        protected virtual Task PerformUpdateCheck() => Task.CompletedTask;
+        /// <summary>
+        /// Performs an asynchronous check for application updates.
+        /// </summary>
+        /// <returns>Whether any update is waiting. May return true if an error occured (there is potentially an update available).</returns>
+        protected virtual Task<bool> PerformUpdateCheck() => Task.FromResult(false);
 
         private class UpdateCompleteNotification : SimpleNotification
         {


### PR DESCRIPTION
- Now lets the user know if they are already on the latest version.
- Squirrel updater will re-post the "click to restart/update" notification, in case the user missed / dismissed it.

I was looking into this because the "check for updates" button didn't seem to work on windows. I get the feeling it was in the above state, so want to get this in and see if it fixes the behaviour in future builds, or if there's something else at play. In local testing I couldn't notice any other fail scenarios.