### PR TITLE
Make stacked hitcircles more visible when using default skin

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/RingPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/RingPiece.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             Origin = Anchor.Centre;
 
             Masking = true;
-            BorderThickness = 10;
+            BorderThickness = 9; // roughly matches slider borders and makes stacked circles distinctly visible from each other.
             BorderColour = Color4.White;
 
             Child = new Box


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/95161206-81190700-07dd-11eb-9bd7-c150ab448455.png)


After:

![image](https://user-images.githubusercontent.com/191335/95161291-b7ef1d00-07dd-11eb-9638-d735609d6205.png)

Closes #3207.