### PR TITLE
Add the most basic implementation of LabelledSliderBar feasible

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public class TestSceneLabelledSliderBar : OsuTestScene
+    {
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestSliderBar(bool hasDescription) => createSliderBar(hasDescription);
+
+        private void createSliderBar(bool hasDescription = false)
+        {
+            AddStep("create component", () =>
+            {
+                LabelledSliderBar<double> component;
+
+                Child = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 500,
+                    AutoSizeAxes = Axes.Y,
+                    Child = component = new LabelledSliderBar<double>
+                    {
+                        Current = new BindableDouble(5)
+                        {
+                            MinValue = 0,
+                            MaxValue = 10,
+                            Precision = 1,
+                        }
+                    }
+                };
+
+                component.Label = "a sample component";
+                component.Description = hasDescription ? "this text describes the component" : string.Empty;
+            });
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledSliderBar.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public class LabelledSliderBar<TNumber> : LabelledComponent<SettingsSlider<TNumber>, TNumber>
+        where TNumber : struct, IEquatable<TNumber>, IComparable<TNumber>, IConvertible
+    {
+        public LabelledSliderBar()
+            : base(true)
+        {
+        }
+
+        protected override SettingsSlider<TNumber> CreateComponent() => new SettingsSlider<TNumber>
+        {
+            TransferValueOnCommit = true,
+            RelativeSizeAxes = Axes.X,
+        };
+    }
+}


### PR DESCRIPTION
- [x] Depends on #10387

I revisited https://github.com/ppy/osu/pull/3084 and merged it up-to-date. Some pieces may be usable, but a lot isn't. This is the most basic implementation possible so I can continue moving forward without worrying too much about it.

There's a lot of work to be done to bring `SettingsX` in line with `LabelledX` going forwards.