### PR TITLE
Split editor setup screen up into sections

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.Editing
                 using (var zip = ZipArchive.Open(temp))
                     zip.WriteToDirectory(extractedFolder);
 
-                bool success = setup.ChangeAudioTrack(Path.Combine(extractedFolder, "03. Renatus - Soleily 192kbps.mp3"));
+                bool success = setup.ChildrenOfType<ResourcesSection>().First().ChangeAudioTrack(Path.Combine(extractedFolder, "03. Renatus - Soleily 192kbps.mp3"));
 
                 File.Delete(temp);
                 Directory.Delete(extractedFolder, true);

--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    /// <summary>
+    /// A labelled textbox which reveals an inline file chooser when clicked.
+    /// </summary>
+    internal class FileChooserLabelledTextBox : LabelledTextBox
+    {
+        public Container Target;
+
+        private readonly IBindable<FileInfo> currentFile = new Bindable<FileInfo>();
+
+        public FileChooserLabelledTextBox()
+        {
+            currentFile.BindValueChanged(onFileSelected);
+        }
+
+        private void onFileSelected(ValueChangedEvent<FileInfo> file)
+        {
+            if (file.NewValue == null)
+                return;
+
+            Target.Clear();
+            Current.Value = file.NewValue.FullName;
+        }
+
+        protected override OsuTextBox CreateTextBox() =>
+            new FileChooserOsuTextBox
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.X,
+                CornerRadius = CORNER_RADIUS,
+                OnFocused = DisplayFileChooser
+            };
+
+        public void DisplayFileChooser()
+        {
+            Target.Child = new FileSelector(validFileExtensions: ResourcesSection.AudioExtensions)
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 400,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                CurrentFile = { BindTarget = currentFile }
+            };
+        }
+
+        internal class FileChooserOsuTextBox : OsuTextBox
+        {
+            public Action OnFocused;
+
+            protected override void OnFocus(FocusEvent e)
+            {
+                OnFocused?.Invoke();
+                base.OnFocus(e);
+
+                GetContainingInputManager().TriggerFocusContention(this);
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    internal class MetadataSection : SetupSection
+    {
+        private LabelledTextBox artistTextBox;
+        private LabelledTextBox titleTextBox;
+        private LabelledTextBox creatorTextBox;
+        private LabelledTextBox difficultyTextBox;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Flow.Children = new Drawable[]
+            {
+                new OsuSpriteText
+                {
+                    Text = "Beatmap metadata"
+                },
+                artistTextBox = new LabelledTextBox
+                {
+                    Label = "Artist",
+                    Current = { Value = Beatmap.Value.Metadata.Artist },
+                    TabbableContentContainer = this
+                },
+                titleTextBox = new LabelledTextBox
+                {
+                    Label = "Title",
+                    Current = { Value = Beatmap.Value.Metadata.Title },
+                    TabbableContentContainer = this
+                },
+                creatorTextBox = new LabelledTextBox
+                {
+                    Label = "Creator",
+                    Current = { Value = Beatmap.Value.Metadata.AuthorString },
+                    TabbableContentContainer = this
+                },
+                difficultyTextBox = new LabelledTextBox
+                {
+                    Label = "Difficulty Name",
+                    Current = { Value = Beatmap.Value.BeatmapInfo.Version },
+                    TabbableContentContainer = this
+                },
+            };
+
+            foreach (var item in Flow.OfType<LabelledTextBox>())
+                item.OnCommit += onCommit;
+        }
+
+        private void onCommit(TextBox sender, bool newText)
+        {
+            if (!newText) return;
+
+            // for now, update these on commit rather than making BeatmapMetadata bindables.
+            // after switching database engines we can reconsider if switching to bindables is a good direction.
+            Beatmap.Value.Metadata.Artist = artistTextBox.Current.Value;
+            Beatmap.Value.Metadata.Title = titleTextBox.Current.Value;
+            Beatmap.Value.Metadata.AuthorString = creatorTextBox.Current.Value;
+            Beatmap.Value.BeatmapInfo.Version = difficultyTextBox.Current.Value;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.Edit.Setup
         [BackgroundDependencyLoader]
         private void load()
         {
-            Flow.Children = new Drawable[]
+            Children = new Drawable[]
             {
                 new OsuSpriteText
                 {
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Edit.Setup
                 },
             };
 
-            foreach (var item in Flow.OfType<LabelledTextBox>())
+            foreach (var item in Children.OfType<LabelledTextBox>())
                 item.OnCommit += onCommit;
         }
 

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -1,0 +1,211 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables;
+using osu.Game.Database;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    internal class ResourcesSection : SetupSection, ICanAcceptFiles
+    {
+        private LabelledTextBox audioTrackTextBox;
+        private Container backgroundSpriteContainer;
+
+        public IEnumerable<string> HandledExtensions => ImageExtensions.Concat(AudioExtensions);
+
+        public static string[] ImageExtensions { get; } = { ".jpg", ".jpeg", ".png" };
+
+        public static string[] AudioExtensions { get; } = { ".mp3", ".ogg" };
+
+        [Resolved]
+        private OsuGameBase game { get; set; }
+
+        [Resolved]
+        private MusicController music { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private Editor editor { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Container audioTrackFileChooserContainer = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+            };
+
+            Flow.Children = new Drawable[]
+            {
+                backgroundSpriteContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 250,
+                    Masking = true,
+                    CornerRadius = 10,
+                },
+                new OsuSpriteText
+                {
+                    Text = "Resources"
+                },
+                audioTrackTextBox = new FileChooserLabelledTextBox
+                {
+                    Label = "Audio Track",
+                    Current = { Value = Beatmap.Value.Metadata.AudioFile ?? "Click to select a track" },
+                    Target = audioTrackFileChooserContainer,
+                    TabbableContentContainer = this
+                },
+                audioTrackFileChooserContainer,
+            };
+
+            updateBackgroundSprite();
+
+            audioTrackTextBox.Current.BindValueChanged(audioTrackChanged);
+        }
+
+        Task ICanAcceptFiles.Import(params string[] paths)
+        {
+            Schedule(() =>
+            {
+                var firstFile = new FileInfo(paths.First());
+
+                if (ImageExtensions.Contains(firstFile.Extension))
+                {
+                    ChangeBackgroundImage(firstFile.FullName);
+                }
+                else if (AudioExtensions.Contains(firstFile.Extension))
+                {
+                    audioTrackTextBox.Text = firstFile.FullName;
+                }
+            });
+            return Task.CompletedTask;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            game.RegisterImportHandler(this);
+        }
+
+        public bool ChangeBackgroundImage(string path)
+        {
+            var info = new FileInfo(path);
+
+            if (!info.Exists)
+                return false;
+
+            var set = Beatmap.Value.BeatmapSetInfo;
+
+            // remove the previous background for now.
+            // in the future we probably want to check if this is being used elsewhere (other difficulties?)
+            var oldFile = set.Files.FirstOrDefault(f => f.Filename == Beatmap.Value.Metadata.BackgroundFile);
+
+            using (var stream = info.OpenRead())
+            {
+                if (oldFile != null)
+                    beatmaps.ReplaceFile(set, oldFile, stream, info.Name);
+                else
+                    beatmaps.AddFile(set, stream, info.Name);
+            }
+
+            Beatmap.Value.Metadata.BackgroundFile = info.Name;
+            updateBackgroundSprite();
+
+            return true;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            game?.UnregisterImportHandler(this);
+        }
+
+        public bool ChangeAudioTrack(string path)
+        {
+            var info = new FileInfo(path);
+
+            if (!info.Exists)
+                return false;
+
+            var set = Beatmap.Value.BeatmapSetInfo;
+
+            // remove the previous audio track for now.
+            // in the future we probably want to check if this is being used elsewhere (other difficulties?)
+            var oldFile = set.Files.FirstOrDefault(f => f.Filename == Beatmap.Value.Metadata.AudioFile);
+
+            using (var stream = info.OpenRead())
+            {
+                if (oldFile != null)
+                    beatmaps.ReplaceFile(set, oldFile, stream, info.Name);
+                else
+                    beatmaps.AddFile(set, stream, info.Name);
+            }
+
+            Beatmap.Value.Metadata.AudioFile = info.Name;
+
+            music.ReloadCurrentTrack();
+
+            editor?.UpdateClockSource();
+            return true;
+        }
+
+        private void audioTrackChanged(ValueChangedEvent<string> filePath)
+        {
+            if (!ChangeAudioTrack(filePath.NewValue))
+                audioTrackTextBox.Current.Value = filePath.OldValue;
+        }
+
+        private void updateBackgroundSprite()
+        {
+            LoadComponentAsync(new BeatmapBackgroundSprite(Beatmap.Value)
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                FillMode = FillMode.Fill,
+            }, background =>
+            {
+                if (background.Texture != null)
+                    backgroundSpriteContainer.Child = background;
+                else
+                {
+                    backgroundSpriteContainer.Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = Colours.GreySeafoamDarker,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(size: 24))
+                        {
+                            Text = "Drag image here to set beatmap background!",
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            AutoSizeAxes = Axes.X,
+                        }
+                    };
+                }
+
+                background.FadeInFromZero(500);
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Edit.Setup
                 AutoSizeAxes = Axes.Y,
             };
 
-            Flow.Children = new Drawable[]
+            Children = new Drawable[]
             {
                 backgroundSpriteContainer = new Container
                 {

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -1,76 +1,33 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.Drawables;
-using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
-using osuTK;
 
 namespace osu.Game.Screens.Edit.Setup
 {
-    public class SetupScreen : EditorScreen, ICanAcceptFiles
+    public class SetupScreen : EditorScreen
     {
-        public IEnumerable<string> HandledExtensions => ImageExtensions.Concat(AudioExtensions);
-
-        public static string[] ImageExtensions { get; } = { ".jpg", ".jpeg", ".png" };
-
-        public static string[] AudioExtensions { get; } = { ".mp3", ".ogg" };
-
-        private FillFlowContainer flow;
-        private LabelledTextBox artistTextBox;
-        private LabelledTextBox titleTextBox;
-        private LabelledTextBox creatorTextBox;
-        private LabelledTextBox difficultyTextBox;
-        private LabelledTextBox audioTrackTextBox;
-        private Container backgroundSpriteContainer;
-
         [Resolved]
-        private OsuGameBase game { get; set; }
+        private OsuColour colours { get; set; }
 
-        [Resolved]
-        private MusicController music { get; set; }
-
-        [Resolved]
-        private BeatmapManager beatmaps { get; set; }
-
-        [Resolved(canBeNull: true)]
-        private Editor editor { get; set; }
+        [Cached]
+        protected readonly OverlayColourProvider ColourProvider;
 
         public SetupScreen()
             : base(EditorScreenMode.SongSetup)
         {
+            ColourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
         }
-
-        [Resolved]
-        private OsuColour colours { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Container audioTrackFileChooserContainer = new Container
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-            };
-
             Child = new Container
             {
                 RelativeSizeAxes = Axes.Both,
@@ -87,273 +44,33 @@ namespace osu.Game.Screens.Edit.Setup
                             Colour = colours.GreySeafoamDark,
                             RelativeSizeAxes = Axes.Both,
                         },
-                        new OsuScrollContainer
+                        new SectionsContainer<SetupSection>
                         {
+                            FixedHeader = new SetupScreenHeader(),
                             RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding(10),
-                            Child = flow = new FillFlowContainer
+                            Children = new SetupSection[]
                             {
-                                RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y,
-                                Spacing = new Vector2(20),
-                                Direction = FillDirection.Vertical,
-                                Children = new Drawable[]
-                                {
-                                    backgroundSpriteContainer = new Container
-                                    {
-                                        RelativeSizeAxes = Axes.X,
-                                        Height = 250,
-                                        Masking = true,
-                                        CornerRadius = 10,
-                                    },
-                                    new OsuSpriteText
-                                    {
-                                        Text = "Resources"
-                                    },
-                                    audioTrackTextBox = new FileChooserLabelledTextBox
-                                    {
-                                        Label = "Audio Track",
-                                        Current = { Value = Beatmap.Value.Metadata.AudioFile ?? "Click to select a track" },
-                                        Target = audioTrackFileChooserContainer,
-                                        TabbableContentContainer = this
-                                    },
-                                    audioTrackFileChooserContainer,
-                                    new OsuSpriteText
-                                    {
-                                        Text = "Beatmap metadata"
-                                    },
-                                    artistTextBox = new LabelledTextBox
-                                    {
-                                        Label = "Artist",
-                                        Current = { Value = Beatmap.Value.Metadata.Artist },
-                                        TabbableContentContainer = this
-                                    },
-                                    titleTextBox = new LabelledTextBox
-                                    {
-                                        Label = "Title",
-                                        Current = { Value = Beatmap.Value.Metadata.Title },
-                                        TabbableContentContainer = this
-                                    },
-                                    creatorTextBox = new LabelledTextBox
-                                    {
-                                        Label = "Creator",
-                                        Current = { Value = Beatmap.Value.Metadata.AuthorString },
-                                        TabbableContentContainer = this
-                                    },
-                                    difficultyTextBox = new LabelledTextBox
-                                    {
-                                        Label = "Difficulty Name",
-                                        Current = { Value = Beatmap.Value.BeatmapInfo.Version },
-                                        TabbableContentContainer = this
-                                    },
-                                }
-                            },
+                                new ResourcesSection(),
+                                new MetadataSection(),
+                            }
                         },
                     }
                 }
             };
-
-            updateBackgroundSprite();
-
-            audioTrackTextBox.Current.BindValueChanged(audioTrackChanged);
-
-            foreach (var item in flow.OfType<LabelledTextBox>())
-                item.OnCommit += onCommit;
-        }
-
-        Task ICanAcceptFiles.Import(params string[] paths)
-        {
-            Schedule(() =>
-            {
-                var firstFile = new FileInfo(paths.First());
-
-                if (ImageExtensions.Contains(firstFile.Extension))
-                {
-                    ChangeBackgroundImage(firstFile.FullName);
-                }
-                else if (AudioExtensions.Contains(firstFile.Extension))
-                {
-                    audioTrackTextBox.Text = firstFile.FullName;
-                }
-            });
-
-            return Task.CompletedTask;
-        }
-
-        private void updateBackgroundSprite()
-        {
-            LoadComponentAsync(new BeatmapBackgroundSprite(Beatmap.Value)
-            {
-                RelativeSizeAxes = Axes.Both,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                FillMode = FillMode.Fill,
-            }, background =>
-            {
-                if (background.Texture != null)
-                    backgroundSpriteContainer.Child = background;
-                else
-                {
-                    backgroundSpriteContainer.Children = new Drawable[]
-                    {
-                        new Box
-                        {
-                            Colour = colours.GreySeafoamDarker,
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(size: 24))
-                        {
-                            Text = "Drag image here to set beatmap background!",
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            AutoSizeAxes = Axes.X,
-                        }
-                    };
-                }
-
-                background.FadeInFromZero(500);
-            });
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-            game.RegisterImportHandler(this);
-        }
-
-        public bool ChangeBackgroundImage(string path)
-        {
-            var info = new FileInfo(path);
-
-            if (!info.Exists)
-                return false;
-
-            var set = Beatmap.Value.BeatmapSetInfo;
-
-            // remove the previous background for now.
-            // in the future we probably want to check if this is being used elsewhere (other difficulties?)
-            var oldFile = set.Files.FirstOrDefault(f => f.Filename == Beatmap.Value.Metadata.BackgroundFile);
-
-            using (var stream = info.OpenRead())
-            {
-                if (oldFile != null)
-                    beatmaps.ReplaceFile(set, oldFile, stream, info.Name);
-                else
-                    beatmaps.AddFile(set, stream, info.Name);
-            }
-
-            Beatmap.Value.Metadata.BackgroundFile = info.Name;
-            updateBackgroundSprite();
-
-            return true;
-        }
-
-        public bool ChangeAudioTrack(string path)
-        {
-            var info = new FileInfo(path);
-
-            if (!info.Exists)
-                return false;
-
-            var set = Beatmap.Value.BeatmapSetInfo;
-
-            // remove the previous audio track for now.
-            // in the future we probably want to check if this is being used elsewhere (other difficulties?)
-            var oldFile = set.Files.FirstOrDefault(f => f.Filename == Beatmap.Value.Metadata.AudioFile);
-
-            using (var stream = info.OpenRead())
-            {
-                if (oldFile != null)
-                    beatmaps.ReplaceFile(set, oldFile, stream, info.Name);
-                else
-                    beatmaps.AddFile(set, stream, info.Name);
-            }
-
-            Beatmap.Value.Metadata.AudioFile = info.Name;
-
-            music.ReloadCurrentTrack();
-
-            editor?.UpdateClockSource();
-            return true;
-        }
-
-        private void audioTrackChanged(ValueChangedEvent<string> filePath)
-        {
-            if (!ChangeAudioTrack(filePath.NewValue))
-                audioTrackTextBox.Current.Value = filePath.OldValue;
-        }
-
-        private void onCommit(TextBox sender, bool newText)
-        {
-            if (!newText) return;
-
-            // for now, update these on commit rather than making BeatmapMetadata bindables.
-            // after switching database engines we can reconsider if switching to bindables is a good direction.
-            Beatmap.Value.Metadata.Artist = artistTextBox.Current.Value;
-            Beatmap.Value.Metadata.Title = titleTextBox.Current.Value;
-            Beatmap.Value.Metadata.AuthorString = creatorTextBox.Current.Value;
-            Beatmap.Value.BeatmapInfo.Version = difficultyTextBox.Current.Value;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-            game?.UnregisterImportHandler(this);
         }
     }
 
-    internal class FileChooserLabelledTextBox : LabelledTextBox
+    internal class SetupScreenHeader : OverlayHeader
     {
-        public Container Target;
+        protected override OverlayTitle CreateTitle() => new SetupScreenTitle();
 
-        private readonly IBindable<FileInfo> currentFile = new Bindable<FileInfo>();
-
-        public FileChooserLabelledTextBox()
+        private class SetupScreenTitle : OverlayTitle
         {
-            currentFile.BindValueChanged(onFileSelected);
-        }
-
-        private void onFileSelected(ValueChangedEvent<FileInfo> file)
-        {
-            if (file.NewValue == null)
-                return;
-
-            Target.Clear();
-            Current.Value = file.NewValue.FullName;
-        }
-
-        protected override OsuTextBox CreateTextBox() =>
-            new FileChooserOsuTextBox
+            public SetupScreenTitle()
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.X,
-                CornerRadius = CORNER_RADIUS,
-                OnFocused = DisplayFileChooser
-            };
-
-        public void DisplayFileChooser()
-        {
-            Target.Child = new FileSelector(validFileExtensions: SetupScreen.AudioExtensions)
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 400,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                CurrentFile = { BindTarget = currentFile }
-            };
-        }
-
-        internal class FileChooserOsuTextBox : OsuTextBox
-        {
-            public Action OnFocused;
-
-            protected override void OnFocus(FocusEvent e)
-            {
-                OnFocused?.Invoke();
-                base.OnFocus(e);
-
-                GetContainingInputManager().TriggerFocusContention(this);
+                Title = "beatmap setup";
+                Description = "change general settings of your beatmap";
+                IconTexture = "Icons/Hexacons/social";
             }
         }
     }

--- a/osu.Game/Screens/Edit/Setup/SetupSection.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupSection.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -14,7 +13,7 @@ namespace osu.Game.Screens.Edit.Setup
 {
     internal class SetupSection : Container
     {
-        protected FillFlowContainer Flow;
+        private readonly FillFlowContainer flow;
 
         [Resolved]
         protected OsuColour Colours { get; private set; }
@@ -22,7 +21,7 @@ namespace osu.Game.Screens.Edit.Setup
         [Resolved]
         protected IBindable<WorkingBeatmap> Beatmap { get; private set; }
 
-        public override void Add(Drawable drawable) => throw new InvalidOperationException("Use Flow.Add instead");
+        protected override Container<Drawable> Content => flow;
 
         public SetupSection()
         {
@@ -31,7 +30,7 @@ namespace osu.Game.Screens.Edit.Setup
 
             Padding = new MarginPadding(10);
 
-            InternalChild = Flow = new FillFlowContainer
+            InternalChild = flow = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Edit/Setup/SetupSection.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupSection.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Setup
+{
+    internal class SetupSection : Container
+    {
+        protected FillFlowContainer Flow;
+
+        [Resolved]
+        protected OsuColour Colours { get; private set; }
+
+        [Resolved]
+        protected IBindable<WorkingBeatmap> Beatmap { get; private set; }
+
+        public override void Add(Drawable drawable) => throw new InvalidOperationException("Use Flow.Add instead");
+
+        public SetupSection()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            Padding = new MarginPadding(10);
+
+            InternalChild = Flow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(20),
+                Direction = FillDirection.Vertical,
+            };
+        }
+    }
+}


### PR DESCRIPTION
- [x] Depends on #10388 to avoid very bad merge conflicts.

Unlike the [design](https://user-images.githubusercontent.com/1329837/42362632-3042c92e-812f-11e8-8ee8-85ad31f83745.png) implies, I believe we want all the beatmap settings to be in a single scroll view like the user profile content.

I started to look at sharing implementation with `UserProfileOverlay` to get the tab control displaying but this requires some abstraction work (it's currently very local to that class). Definitely worth putting in the effort to abstract this as it is used in multiple other places on osu-web already.