### PR TITLE
Increase backwards seek magnitude when the track is running

### DIFF
--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Screens.Edit
         /// </summary>
         /// <param name="snapped">Whether to snap to the closest beat after seeking.</param>
         /// <param name="amount">The relative amount (magnitude) which should be seeked.</param>
-        public void SeekBackward(bool snapped = false, double amount = 1) => seek(-1, snapped, amount);
+        public void SeekBackward(bool snapped = false, double amount = 1) => seek(-1, snapped, amount + (IsRunning ? 1.5 : 0));
 
         /// <summary>
         /// Seeks forwards by one beat length.


### PR DESCRIPTION
This matches osu-stable. When the track is running, seeking backwards (against the flow) is harder than seeking forwards. Adding a mutliplier makes it feel much better.

Note that this is additive not multiplicative because for larger seeks the (where `amount` > 1) we don't want to jump an insanely huge amount - just offset the seek slightly to account for playing audio.

To test this, start audio playing in the editor and use arrow keys or scroll wheel to seek backwards and forwards. You should be able to maintain your relative position much better than on `master`.