### PR TITLE
Fix HitWindows getting serialized alongside HitObjects

### DIFF
--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -77,6 +77,7 @@ namespace osu.Game.Rulesets.Objects
         /// <summary>
         /// The hit windows for this <see cref="HitObject"/>.
         /// </summary>
+        [JsonIgnore]
         public HitWindows HitWindows { get; set; }
 
         private readonly List<HitObject> nestedHitObjects = new List<HitObject>();


### PR DESCRIPTION
These were being serialized as the base type. On deserialization, due to the HitWindow of objects being non-null, they would not get correctly initialised by the `CreateHitWindows()` virtual method:

https://github.com/ppy/osu/blob/c803be2dd260ce5d1963a53c08d9f48bbc9c8d35/osu.Game/Rulesets/Objects/HitObject.cs#L132-L138

The correct type would only assigned if non-null.

- Closes #10403