### PR TITLE
Don't force playback of (non-looping) DrawableHitObject samples after skin change

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -273,7 +273,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             // apply any custom state overrides
             ApplyCustomUpdateState?.Invoke(this, newState);
 
-            if (newState == ArmedState.Hit)
+            if (!force && newState == ArmedState.Hit)
                 PlaySamples();
         }
 


### PR DESCRIPTION
"Fixes" #5798 (as in the particular scenario I touch on will no longer occur). Does not fix the fact that `SkinnableSound`'s `Play`/`Stop` are unsafe in a context where the skin could be changed.

This "resume playback" logic is already covered by `SkinnableSound` itself, so while I don't think it sounds good, it still plays the sample on skin change (at an incorrect point in time...). I'd argue the resuming should only apply to looped sounds, or (even better) we should let the old samples finish playing. But that may be a nightmare in terms of managing the lifetime of the previous skin.