### PR TITLE
Fix some current time button crashes

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -113,7 +113,6 @@ namespace osu.Game.Screens.Edit.Timing
                 };
 
                 controlPoints = group.ControlPoints.GetBoundCopy();
-                controlPoints.CollectionChanged += (_, __) => createChildren();
             }
 
             [Resolved]
@@ -123,6 +122,12 @@ namespace osu.Game.Screens.Edit.Timing
             private void load()
             {
                 createChildren();
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                controlPoints.CollectionChanged += (_, __) => createChildren();
             }
 
             private void createChildren()

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -111,7 +111,8 @@ namespace osu.Game.Screens.Edit.Timing
             foreach (var cp in currentGroupItems)
                 Beatmap.Value.Beatmap.ControlPointInfo.Add(time, cp);
 
-            SelectedGroup.Value = Beatmap.Value.Beatmap.ControlPointInfo.GroupAt(time);
+            // the control point might not necessarily exist yet, if currentGroupItems was empty.
+            SelectedGroup.Value = Beatmap.Value.Beatmap.ControlPointInfo.GroupAt(time, true);
 
             changeHandler?.EndChange();
         }


### PR DESCRIPTION
Resolves #10412.

# Summary

This PR fixes two possible crashes related to the "Use current time" button:

* One was a regression/oversight from #10315 (that's the original case from the issue). `ControlGroupAttributes` subscribed to the `CollectionChanged` event in the constructor, but the event callback accessed the resolved `colours`, which were not available at that point.

  Resolve by moving the subscription to `LoadComplete()`.
* Another case happened when "Use current time" was pressed on a control point group without attributes. In those cases, the loop over control points would not run, therefore the group was being deleted, but not restored later.

  Resolve by creating the group if the `Add()` calls didn't already.

# Remarks

There is a third crash that's yet unresolved - to reproduce it, you have to delete all control point groups from a map. That triggers ppy/osu-framework#3919, as `GroupSection`'s selected group change callback uses the same call pattern of:

https://github.com/ppy/osu/blob/6627e7e459afa71822cd5041ca914d42d737c7cf/osu.Game/Screens/Edit/Timing/GroupSection.cs#L82-L91

Test coverage not included, because case (1) was a plain oversight and case (2) has a comment, and editor doesn't have a lot of test coverage anyway - but I will include a test on request.