### PR TITLE
Increase reliability of editor beatmap change handling

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private void updatePath()
         {
             HitObject.Path.ExpectedDistance.Value = composer?.GetSnappedDistanceFromDistance(HitObject.StartTime, (float)HitObject.Path.CalculatedDistance) ?? (float)HitObject.Path.CalculatedDistance;
-            editorBeatmap?.UpdateHitObject(HitObject);
+            editorBeatmap?.Update(HitObject);
         }
 
         public override MenuItem[] ContextMenuItems => new MenuItem[]

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
                 if (h.IsStrong != state)
                 {
                     h.IsStrong = state;
-                    EditorBeatmap.UpdateHitObject(h);
+                    EditorBeatmap.Update(h);
                 }
             }
 

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
         {
             var hits = SelectedHitObjects.OfType<Hit>();
 
-            ChangeHandler.BeginChange();
+            EditorBeatmap.BeginChange();
 
             foreach (var h in hits)
             {
@@ -65,19 +65,19 @@ namespace osu.Game.Rulesets.Taiko.Edit
                 }
             }
 
-            ChangeHandler.EndChange();
+            EditorBeatmap.EndChange();
         }
 
         public void SetRimState(bool state)
         {
             var hits = SelectedHitObjects.OfType<Hit>();
 
-            ChangeHandler.BeginChange();
+            EditorBeatmap.BeginChange();
 
             foreach (var h in hits)
                 h.Type = state ? HitType.Rim : HitType.Centre;
 
-            ChangeHandler.EndChange();
+            EditorBeatmap.EndChange();
         }
 
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint> selection)

--- a/osu.Game.Tests/Editing/TransactionalCommitComponentTest.cs
+++ b/osu.Game.Tests/Editing/TransactionalCommitComponentTest.cs
@@ -1,0 +1,100 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Tests.Editing
+{
+    [TestFixture]
+    public class TransactionalCommitComponentTest
+    {
+        private TestHandler handler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            handler = new TestHandler();
+        }
+
+        [Test]
+        public void TestCommitTransaction()
+        {
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(0));
+
+            handler.BeginChange();
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(0));
+            handler.EndChange();
+
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestSaveOutsideOfTransactionTriggersUpdates()
+        {
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(0));
+
+            handler.SaveState();
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(1));
+
+            handler.SaveState();
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestEventsFire()
+        {
+            int transactionBegan = 0;
+            int transactionEnded = 0;
+            int stateSaved = 0;
+
+            handler.TransactionBegan += () => transactionBegan++;
+            handler.TransactionEnded += () => transactionEnded++;
+            handler.SaveStateTriggered += () => stateSaved++;
+
+            handler.BeginChange();
+            Assert.That(transactionBegan, Is.EqualTo(1));
+
+            handler.EndChange();
+            Assert.That(transactionEnded, Is.EqualTo(1));
+
+            Assert.That(stateSaved, Is.EqualTo(0));
+            handler.SaveState();
+            Assert.That(stateSaved, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestSaveDuringTransactionDoesntTriggerUpdate()
+        {
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(0));
+
+            handler.BeginChange();
+
+            handler.SaveState();
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(0));
+
+            handler.EndChange();
+
+            Assert.That(handler.StateUpdateCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestEndWithoutBeginThrows()
+        {
+            handler.BeginChange();
+            handler.EndChange();
+            Assert.That(() => handler.EndChange(), Throws.TypeOf<InvalidOperationException>());
+        }
+
+        private class TestHandler : TransactionalCommitComponent
+        {
+            public int StateUpdateCount { get; private set; }
+
+            protected override void UpdateState()
+            {
+                StateUpdateCount++;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -436,8 +436,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 // Apply the start time at the newly snapped-to position
                 double offset = result.Time.Value - draggedObject.StartTime;
+
                 foreach (HitObject obj in SelectionHandler.SelectedHitObjects)
+                {
                     obj.StartTime += offset;
+                    Beatmap.UpdateHitObject(obj);
+                }
             }
 
             return true;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 // handle positional change etc.
                 foreach (var obj in selectedHitObjects)
-                    Beatmap.UpdateHitObject(obj);
+                    Beatmap.Update(obj);
 
                 changeHandler?.EndChange();
                 isDraggingBlueprint = false;
@@ -440,7 +440,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 foreach (HitObject obj in SelectionHandler.SelectedHitObjects)
                 {
                     obj.StartTime += offset;
-                    Beatmap.UpdateHitObject(obj);
+                    Beatmap.Update(obj);
                 }
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -335,7 +335,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (comboInfo == null || comboInfo.NewCombo == state) continue;
 
                 comboInfo.NewCombo = state;
-                EditorBeatmap?.UpdateHitObject(h);
+                EditorBeatmap?.Update(h);
             }
 
             EditorBeatmap?.EndChange();

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -238,9 +238,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void deleteSelected()
         {
-            ChangeHandler?.BeginChange();
             EditorBeatmap?.RemoveRange(selectedBlueprints.Select(b => b.HitObject));
-            ChangeHandler?.EndChange();
         }
 
         #endregion
@@ -307,7 +305,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="sampleName">The name of the hit sample.</param>
         public void AddHitSample(string sampleName)
         {
-            ChangeHandler?.BeginChange();
+            EditorBeatmap?.BeginChange();
 
             foreach (var h in SelectedHitObjects)
             {
@@ -318,7 +316,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 h.Samples.Add(new HitSampleInfo { Name = sampleName });
             }
 
-            ChangeHandler?.EndChange();
+            EditorBeatmap?.EndChange();
         }
 
         /// <summary>
@@ -328,7 +326,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <exception cref="InvalidOperationException">Throws if any selected object doesn't implement <see cref="IHasComboInformation"/></exception>
         public void SetNewCombo(bool state)
         {
-            ChangeHandler?.BeginChange();
+            EditorBeatmap?.BeginChange();
 
             foreach (var h in SelectedHitObjects)
             {
@@ -340,7 +338,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 EditorBeatmap?.UpdateHitObject(h);
             }
 
-            ChangeHandler?.EndChange();
+            EditorBeatmap?.EndChange();
         }
 
         /// <summary>
@@ -349,12 +347,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="sampleName">The name of the hit sample.</param>
         public void RemoveHitSample(string sampleName)
         {
-            ChangeHandler?.BeginChange();
+            EditorBeatmap?.BeginChange();
 
             foreach (var h in SelectedHitObjects)
                 h.SamplesBindable.RemoveAll(s => s.Name == sampleName);
 
-            ChangeHandler?.EndChange();
+            EditorBeatmap?.EndChange();
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -392,6 +392,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 return;
 
                             repeatHitObject.RepeatCount = proposedCount;
+                            beatmap.UpdateHitObject(hitObject);
                             break;
 
                         case IHasDuration endTimeHitObject:
@@ -401,10 +402,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 return;
 
                             endTimeHitObject.Duration = snappedTime - hitObject.StartTime;
+                            beatmap.UpdateHitObject(hitObject);
                             break;
                     }
-
-                    beatmap.UpdateHitObject(hitObject);
                 }
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -392,7 +392,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 return;
 
                             repeatHitObject.RepeatCount = proposedCount;
-                            beatmap.UpdateHitObject(hitObject);
+                            beatmap.Update(hitObject);
                             break;
 
                         case IHasDuration endTimeHitObject:
@@ -402,7 +402,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 return;
 
                             endTimeHitObject.Duration = snappedTime - hitObject.StartTime;
-                            beatmap.UpdateHitObject(hitObject);
+                            beatmap.Update(hitObject);
                             break;
                     }
                 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -509,14 +509,14 @@ namespace osu.Game.Screens.Edit
             foreach (var h in objects)
                 h.StartTime += timeOffset;
 
-            changeHandler.BeginChange();
+            editorBeatmap.BeginChange();
 
             editorBeatmap.SelectedHitObjects.Clear();
 
             editorBeatmap.AddRange(objects);
             editorBeatmap.SelectedHitObjects.AddRange(objects);
 
-            changeHandler.EndChange();
+            editorBeatmap.EndChange();
         }
 
         protected void Undo() => changeHandler.RestoreState(-1);

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -141,6 +141,7 @@ namespace osu.Game.Screens.Edit
                 beatmapProcessor?.PostProcess();
 
                 HitObjectAdded?.Invoke(hitObject);
+                SaveState();
             }
         }
 
@@ -222,6 +223,7 @@ namespace osu.Game.Screens.Edit
                 beatmapProcessor?.PostProcess();
 
                 HitObjectRemoved?.Invoke(hitObject);
+                SaveState();
             }
         }
 

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -131,18 +131,9 @@ namespace osu.Game.Screens.Edit
 
             mutableHitObjects.Insert(index, hitObject);
 
-            if (TransactionActive)
-                batchPendingInserts.Add(hitObject);
-            else
-            {
-                // must be run after any change to hitobject ordering
-                beatmapProcessor?.PreProcess();
-                processHitObject(hitObject);
-                beatmapProcessor?.PostProcess();
-
-                HitObjectAdded?.Invoke(hitObject);
-                SaveState();
-            }
+            BeginChange();
+            batchPendingInserts.Add(hitObject);
+            EndChange();
         }
 
         /// <summary>
@@ -213,18 +204,9 @@ namespace osu.Game.Screens.Edit
             bindable.UnbindAll();
             startTimeBindables.Remove(hitObject);
 
-            if (TransactionActive)
-                batchPendingDeletes.Add(hitObject);
-            else
-            {
-                // must be run after any change to hitobject ordering
-                beatmapProcessor?.PreProcess();
-                processHitObject(hitObject);
-                beatmapProcessor?.PostProcess();
-
-                HitObjectRemoved?.Invoke(hitObject);
-                SaveState();
-            }
+            BeginChange();
+            batchPendingDeletes.Add(hitObject);
+            EndChange();
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -237,13 +237,19 @@ namespace osu.Game.Screens.Edit
 
             beatmapProcessor?.PostProcess();
 
-            foreach (var h in batchPendingDeletes) HitObjectRemoved?.Invoke(h);
-            foreach (var h in batchPendingInserts) HitObjectAdded?.Invoke(h);
-            foreach (var h in batchPendingUpdates) HitObjectUpdated?.Invoke(h);
-
+            // callbacks may modify the lists so let's be safe about it
+            var deletes = batchPendingDeletes.ToArray();
             batchPendingDeletes.Clear();
+
+            var inserts = batchPendingInserts.ToArray();
             batchPendingInserts.Clear();
+
+            var updates = batchPendingUpdates.ToArray();
             batchPendingUpdates.Clear();
+
+            foreach (var h in deletes) HitObjectRemoved?.Invoke(h);
+            foreach (var h in inserts) HitObjectAdded?.Invoke(h);
+            foreach (var h in updates) HitObjectUpdated?.Invoke(h);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -53,21 +53,15 @@ namespace osu.Game.Screens.Edit
         {
             this.editorBeatmap = editorBeatmap;
 
-            editorBeatmap.HitObjectAdded += hitObjectAdded;
-            editorBeatmap.HitObjectRemoved += hitObjectRemoved;
-            editorBeatmap.HitObjectUpdated += hitObjectUpdated;
+            editorBeatmap.TransactionBegan += BeginChange;
+            editorBeatmap.TransactionEnded += EndChange;
+            editorBeatmap.SaveStateTriggered += SaveState;
 
             patcher = new LegacyEditorBeatmapPatcher(editorBeatmap);
 
             // Initial state.
             SaveState();
         }
-
-        private void hitObjectAdded(HitObject obj) => SaveState();
-
-        private void hitObjectRemoved(HitObject obj) => SaveState();
-
-        private void hitObjectUpdated(HitObject obj) => SaveState();
 
         protected override void UpdateState()
         {

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Edit
     /// <summary>
     /// Tracks changes to the <see cref="Editor"/>.
     /// </summary>
-    public class EditorChangeHandler : IEditorChangeHandler
+    public class EditorChangeHandler : TransactionalCommitComponent, IEditorChangeHandler
     {
         public readonly Bindable<bool> CanUndo = new Bindable<bool>();
         public readonly Bindable<bool> CanRedo = new Bindable<bool>();
@@ -41,7 +41,6 @@ namespace osu.Game.Screens.Edit
         }
 
         private readonly EditorBeatmap editorBeatmap;
-        private int bulkChangesStarted;
         private bool isRestoring;
 
         public const int MAX_SAVED_STATES = 50;
@@ -70,22 +69,8 @@ namespace osu.Game.Screens.Edit
 
         private void hitObjectUpdated(HitObject obj) => SaveState();
 
-        public void BeginChange() => bulkChangesStarted++;
-
-        public void EndChange()
+        protected override void UpdateState()
         {
-            if (bulkChangesStarted == 0)
-                throw new InvalidOperationException($"Cannot call {nameof(EndChange)} without a previous call to {nameof(BeginChange)}.");
-
-            if (--bulkChangesStarted == 0)
-                SaveState();
-        }
-
-        public void SaveState()
-        {
-            if (bulkChangesStarted > 0)
-                return;
-
             if (isRestoring)
                 return;
 
@@ -120,7 +105,7 @@ namespace osu.Game.Screens.Edit
         /// <param name="direction">The direction to restore in. If less than 0, an older state will be used. If greater than 0, a newer state will be used.</param>
         public void RestoreState(int direction)
         {
-            if (bulkChangesStarted > 0)
+            if (TransactionActive)
                 return;
 
             if (savedStates.Count == 0)

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -68,19 +68,20 @@ namespace osu.Game.Screens.Edit
             toRemove.Sort();
             toAdd.Sort();
 
-            editorBeatmap.ApplyBatchChanges(eb =>
-            {
-                // Apply the changes.
-                for (int i = toRemove.Count - 1; i >= 0; i--)
-                    eb.RemoveAt(toRemove[i]);
+            editorBeatmap.BeginChange();
 
-                if (toAdd.Count > 0)
-                {
-                    IBeatmap newBeatmap = readBeatmap(newState);
-                    foreach (var i in toAdd)
-                        eb.Insert(i, newBeatmap.HitObjects[i]);
-                }
-            });
+            // Apply the changes.
+            for (int i = toRemove.Count - 1; i >= 0; i--)
+                editorBeatmap.RemoveAt(toRemove[i]);
+
+            if (toAdd.Count > 0)
+            {
+                IBeatmap newBeatmap = readBeatmap(newState);
+                foreach (var i in toAdd)
+                    editorBeatmap.Insert(i, newBeatmap.HitObjects[i]);
+            }
+
+            editorBeatmap.EndChange();
         }
 
         private string readString(byte[] state) => Encoding.UTF8.GetString(state);

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.Value.BeatmapInfo.BaseDifficulty.ApproachRate = approachRateSlider.Current.Value;
             Beatmap.Value.BeatmapInfo.BaseDifficulty.OverallDifficulty = overallDifficultySlider.Current.Value;
 
-            editorBeatmap.UpdateBeatmap();
+            editorBeatmap.UpdateAllHitObjects();
         }
     }
 }

--- a/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
+++ b/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
@@ -2,14 +2,30 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics;
 
 namespace osu.Game.Screens.Edit
 {
     /// <summary>
     /// A component that tracks a batch change, only applying after all active changes are completed.
     /// </summary>
-    public abstract class TransactionalCommitComponent
+    public abstract class TransactionalCommitComponent : Component
     {
+        /// <summary>
+        /// Fires whenever a transaction begins. Will not fire on nested transactions.
+        /// </summary>
+        public event Action TransactionBegan;
+
+        /// <summary>
+        /// Fires when the last transaction completes.
+        /// </summary>
+        public event Action TransactionEnded;
+
+        /// <summary>
+        /// Fires when <see cref="SaveState"/> is called and results in a non-transactional state save.
+        /// </summary>
+        public event Action SaveStateTriggered;
+
         public bool TransactionActive => bulkChangesStarted > 0;
 
         private int bulkChangesStarted;
@@ -17,7 +33,11 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Signal the beginning of a change.
         /// </summary>
-        public void BeginChange() => bulkChangesStarted++;
+        public void BeginChange()
+        {
+            if (bulkChangesStarted++ == 0)
+                TransactionBegan?.Invoke();
+        }
 
         /// <summary>
         /// Signal the end of a change.
@@ -29,14 +49,22 @@ namespace osu.Game.Screens.Edit
                 throw new InvalidOperationException($"Cannot call {nameof(EndChange)} without a previous call to {nameof(BeginChange)}.");
 
             if (--bulkChangesStarted == 0)
+            {
                 UpdateState();
+                TransactionEnded?.Invoke();
+            }
         }
 
+        /// <summary>
+        /// Force an update of the state with no attached transaction.
+        /// This is a no-op if a transaction is already active. Should generally be used as a safety measure to ensure granular changes are not left outside a transaction.
+        /// </summary>
         public void SaveState()
         {
             if (bulkChangesStarted > 0)
                 return;
 
+            SaveStateTriggered?.Invoke();
             UpdateState();
         }
 

--- a/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
+++ b/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Screens.Edit
+{
+    /// <summary>
+    /// A component that tracks a batch change, only applying after all active changes are completed.
+    /// </summary>
+    public abstract class TransactionalCommitComponent
+    {
+        public bool TransactionActive => bulkChangesStarted > 0;
+
+        private int bulkChangesStarted;
+
+        /// <summary>
+        /// Signal the beginning of a change.
+        /// </summary>
+        public void BeginChange() => bulkChangesStarted++;
+
+        /// <summary>
+        /// Signal the end of a change.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Throws if <see cref="BeginChange"/> was not first called.</exception>
+        public void EndChange()
+        {
+            if (bulkChangesStarted == 0)
+                throw new InvalidOperationException($"Cannot call {nameof(EndChange)} without a previous call to {nameof(BeginChange)}.");
+
+            if (--bulkChangesStarted == 0)
+                UpdateState();
+        }
+
+        public void SaveState()
+        {
+            if (bulkChangesStarted > 0)
+                return;
+
+            UpdateState();
+        }
+
+        protected abstract void UpdateState();
+    }
+}


### PR DESCRIPTION
This makes a few important changes:

- `EditorBeatmap` employs the same transactional logic as `ChangeHandler`. I have chosen this over the recently added `ApplyBatchChanges(Action action)` as it works better in cases where we are DIing the beatmap and don't always expect it to be present. Annoying to code around if you have to null check then run the delegate locally to ensure correct behaviour.
- `ChangeHandler` binds to `EditorBeatmap`'s transactional events, ensuring 100% coverage. This means that calling only `EditorBeatmap.SaveState` is enough to save an undo state too.
- `EditorBeatmap.BeginChange`/`EndChange` is preferred when operating on the beatmap directly and in one batch (ie. without game loop running while in a transaction). `ChangeHandler` is still used in many places, and has a slightly different meaning – it will not stop the flow of `HitObject` updates for instance. The remaining usages are in areas like `DragStart`/`DragEnd`, where we want to track a change but it's a long-running operation.
- Calling `EditorBeatmap.Update` is still debounced as previously, even when not in a transaction. I tried removing this and making the debounce local (ie. in `SliderSelectionBlueprint`) but ran into order-of-execution issues. I think this is fine though.

Closes #10215.