### PR TITLE
Fix ternary button states not updating correctly after a paste operation

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Mania.Edit
             int minColumn = int.MaxValue;
             int maxColumn = int.MinValue;
 
-            foreach (var obj in SelectedHitObjects.OfType<ManiaHitObject>())
+            foreach (var obj in EditorBeatmap.SelectedHitObjects.OfType<ManiaHitObject>())
             {
                 if (obj.Column < minColumn)
                     minColumn = obj.Column;
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 
             columnDelta = Math.Clamp(columnDelta, -minColumn, maniaPlayfield.TotalColumns - 1 - maxColumn);
 
-            foreach (var obj in SelectedHitObjects.OfType<ManiaHitObject>())
+            foreach (var obj in EditorBeatmap.SelectedHitObjects.OfType<ManiaHitObject>())
                 obj.Column += columnDelta;
         }
     }

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             base.OnSelectionChanged();
 
-            bool canOperate = SelectedHitObjects.Count() > 1 || SelectedHitObjects.Any(s => s is Slider);
+            bool canOperate = EditorBeatmap.SelectedHitObjects.Count > 1 || EditorBeatmap.SelectedHitObjects.Any(s => s is Slider);
 
             SelectionBox.CanRotate = canOperate;
             SelectionBox.CanScaleX = canOperate;
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// <param name="points">The points to calculate a quad for.</param>
         private Quad getSurroundingQuad(IEnumerable<Vector2> points)
         {
-            if (!SelectedHitObjects.Any())
+            if (!EditorBeatmap.SelectedHitObjects.Any())
                 return new Quad();
 
             Vector2 minPosition = new Vector2(float.MaxValue, float.MaxValue);
@@ -203,10 +203,10 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// <summary>
         /// All osu! hitobjects which can be moved/rotated/scaled.
         /// </summary>
-        private OsuHitObject[] selectedMovableObjects => SelectedHitObjects
-                                                         .OfType<OsuHitObject>()
-                                                         .Where(h => !(h is Spinner))
-                                                         .ToArray();
+        private OsuHitObject[] selectedMovableObjects => EditorBeatmap.SelectedHitObjects
+                                                                      .OfType<OsuHitObject>()
+                                                                      .Where(h => !(h is Spinner))
+                                                                      .ToArray();
 
         /// <summary>
         /// Rotate a point around an arbitrary origin.

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
         public void SetStrongState(bool state)
         {
-            var hits = SelectedHitObjects.OfType<Hit>();
+            var hits = EditorBeatmap.SelectedHitObjects.OfType<Hit>();
 
             ChangeHandler.BeginChange();
 
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
         public void SetRimState(bool state)
         {
-            var hits = SelectedHitObjects.OfType<Hit>();
+            var hits = EditorBeatmap.SelectedHitObjects.OfType<Hit>();
 
             ChangeHandler.BeginChange();
 
@@ -93,8 +93,8 @@ namespace osu.Game.Rulesets.Taiko.Edit
         {
             base.UpdateTernaryStates();
 
-            selectionRimState.Value = GetStateFromSelection(SelectedHitObjects.OfType<Hit>(), h => h.Type == HitType.Rim);
-            selectionStrongState.Value = GetStateFromSelection(SelectedHitObjects.OfType<TaikoHitObject>(), h => h.IsStrong);
+            selectionRimState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<Hit>(), h => h.Type == HitType.Rim);
+            selectionStrongState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<TaikoHitObject>(), h => h.IsStrong);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -436,7 +436,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 // Apply the start time at the newly snapped-to position
                 double offset = result.Time.Value - draggedObject.StartTime;
-                foreach (HitObject obj in SelectionHandler.SelectedHitObjects)
+                foreach (HitObject obj in Beatmap.SelectedHitObjects)
                     obj.StartTime += offset;
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public int SelectedCount => selectedBlueprints.Count;
 
-        public IEnumerable<HitObject> SelectedHitObjects => EditorBeatmap.SelectedHitObjects;
-
         private Drawable content;
 
         private OsuSpriteText selectionDetailsText;
@@ -309,7 +307,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             ChangeHandler?.BeginChange();
 
-            foreach (var h in SelectedHitObjects)
+            foreach (var h in EditorBeatmap.SelectedHitObjects)
             {
                 // Make sure there isn't already an existing sample
                 if (h.Samples.Any(s => s.Name == sampleName))
@@ -330,7 +328,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             ChangeHandler?.BeginChange();
 
-            foreach (var h in SelectedHitObjects)
+            foreach (var h in EditorBeatmap.SelectedHitObjects)
             {
                 var comboInfo = h as IHasComboInformation;
 
@@ -351,7 +349,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             ChangeHandler?.BeginChange();
 
-            foreach (var h in SelectedHitObjects)
+            foreach (var h in EditorBeatmap.SelectedHitObjects)
                 h.SamplesBindable.RemoveAll(s => s.Name == sampleName);
 
             ChangeHandler?.EndChange();
@@ -425,11 +423,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         protected virtual void UpdateTernaryStates()
         {
-            SelectionNewComboState.Value = GetStateFromSelection(SelectedHitObjects.OfType<IHasComboInformation>(), h => h.NewCombo);
+            SelectionNewComboState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<IHasComboInformation>(), h => h.NewCombo);
 
             foreach (var (sampleName, bindable) in SelectionSampleStates)
             {
-                bindable.Value = GetStateFromSelection(SelectedHitObjects, h => h.Samples.Any(s => s.Name == sampleName));
+                bindable.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects, h => h.Samples.Any(s => s.Name == sampleName));
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected SelectionBox SelectionBox { get; private set; }
 
-        [Resolved(CanBeNull = true)]
+        [Resolved]
         protected EditorBeatmap EditorBeatmap { get; private set; }
 
         [Resolved(CanBeNull = true)]
@@ -243,7 +243,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void deleteSelected()
         {
-            EditorBeatmap?.RemoveRange(selectedBlueprints.Select(b => b.HitObject));
+            EditorBeatmap.RemoveRange(selectedBlueprints.Select(b => b.HitObject));
         }
 
         #endregion
@@ -310,7 +310,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="sampleName">The name of the hit sample.</param>
         public void AddHitSample(string sampleName)
         {
-            EditorBeatmap?.BeginChange();
+            EditorBeatmap.BeginChange();
 
             foreach (var h in EditorBeatmap.SelectedHitObjects)
             {
@@ -321,7 +321,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 h.Samples.Add(new HitSampleInfo { Name = sampleName });
             }
 
-            EditorBeatmap?.EndChange();
+            EditorBeatmap.EndChange();
         }
 
         /// <summary>
@@ -331,7 +331,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <exception cref="InvalidOperationException">Throws if any selected object doesn't implement <see cref="IHasComboInformation"/></exception>
         public void SetNewCombo(bool state)
         {
-            EditorBeatmap?.BeginChange();
+            EditorBeatmap.BeginChange();
 
             foreach (var h in EditorBeatmap.SelectedHitObjects)
             {
@@ -340,10 +340,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (comboInfo == null || comboInfo.NewCombo == state) continue;
 
                 comboInfo.NewCombo = state;
-                EditorBeatmap?.Update(h);
+                EditorBeatmap.Update(h);
             }
 
-            EditorBeatmap?.EndChange();
+            EditorBeatmap.EndChange();
         }
 
         /// <summary>
@@ -352,12 +352,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="sampleName">The name of the hit sample.</param>
         public void RemoveHitSample(string sampleName)
         {
-            EditorBeatmap?.BeginChange();
+            EditorBeatmap.BeginChange();
 
             foreach (var h in EditorBeatmap.SelectedHitObjects)
                 h.SamplesBindable.RemoveAll(s => s.Name == sampleName);
 
-            EditorBeatmap?.EndChange();
+            EditorBeatmap.EndChange();
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public int SelectedCount => selectedBlueprints.Count;
 
-        public IEnumerable<HitObject> SelectedHitObjects => selectedBlueprints.Select(b => b.HitObject);
+        public IEnumerable<HitObject> SelectedHitObjects => EditorBeatmap.SelectedHitObjects;
 
         private Drawable content;
 


### PR DESCRIPTION
Accessing selected objects via blueprints was not realiable (dependent on action flow). Such was the case for the `UpdateTernaryStates()` function, which after a paste operation could not see the new selected objects (`selectedBlueprints` had not yet been populated).