### PR TITLE
Fix incorrect timing distribution display due to lack of rounding

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -24,6 +24,12 @@ namespace osu.Game.Tests.Visual.Ranking
         }
 
         [Test]
+        public void TestAroundCentre()
+        {
+            createTest(Enumerable.Range(-100, 100).Select(i => new HitEvent(i / 50f, HitResult.Perfect, new HitCircle(), new HitCircle(), null)).ToList());
+        }
+
+        [Test]
         public void TestZeroTimeOffset()
         {
             createTest(Enumerable.Range(0, 100).Select(_ => new HitEvent(0, HitResult.Perfect, new HitCircle(), new HitCircle(), null)).ToList());

--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Visual.Ranking
         [Test]
         public void TestAroundCentre()
         {
-            createTest(Enumerable.Range(-100, 100).Select(i => new HitEvent(i / 50f, HitResult.Perfect, new HitCircle(), new HitCircle(), null)).ToList());
+            createTest(Enumerable.Range(-150, 300).Select(i => new HitEvent(i / 50f, HitResult.Perfect, new HitCircle(), new HitCircle(), null)).ToList());
         }
 
         [Test]

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             foreach (var e in hitEvents)
             {
-                int binOffset = (int)Math.Round(e.TimeOffset / binSize);
+                int binOffset = (int)Math.Round(e.TimeOffset / binSize, MidpointRounding.AwayFromZero);
                 bins[timing_distribution_centre_bin_index + binOffset]++;
             }
 

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             foreach (var e in hitEvents)
             {
-                int binOffset = (int)(e.TimeOffset / binSize);
+                int binOffset = (int)Math.Round(e.TimeOffset / binSize);
                 bins[timing_distribution_centre_bin_index + binOffset]++;
             }
 


### PR DESCRIPTION
Closes #10426.

Before:

![image](https://user-images.githubusercontent.com/191335/95507830-fc9cd300-09ec-11eb-8763-63068fb94f50.png)


After:

![image](https://user-images.githubusercontent.com/191335/95507813-f575c500-09ec-11eb-99c8-57e7c7400d9c.png)
