### PR TITLE
Add "reverse pattern" support to editor selection handler

### DIFF
--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Rulesets.Objects
                             c.Changed += invalidate;
                         break;
 
+                    case NotifyCollectionChangedAction.Reset:
                     case NotifyCollectionChangedAction.Remove:
                         foreach (var c in args.OldItems.Cast<PathControlPoint>())
                             c.Changed -= invalidate;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -17,9 +17,27 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public Action<float> OnRotation;
         public Action<Vector2, Anchor> OnScale;
         public Action<Direction> OnFlip;
+        public Action OnReverse;
 
         public Action OperationStarted;
         public Action OperationEnded;
+
+        private bool canReverse;
+
+        /// <summary>
+        /// Whether pattern reversing support should be enabled.
+        /// </summary>
+        public bool CanReverse
+        {
+            get => canReverse;
+            set
+            {
+                if (canReverse == value) return;
+
+                canReverse = value;
+                recreate();
+            }
+        }
 
         private bool canRotate;
 
@@ -125,6 +143,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (CanScaleX && CanScaleY) addFullScaleComponents();
             if (CanScaleY) addYScaleComponents();
             if (CanRotate) addRotationComponents();
+            if (CanReverse) addButton(FontAwesome.Solid.Backward, "Reverse pattern", () => OnReverse?.Invoke());
         }
 
         private void addRotationComponents()

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Handles the selected <see cref="DrawableHitObject"/>s being rotated.
         /// </summary>
         /// <param name="angle">The delta angle to apply to the selection.</param>
-        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be moved.</returns>
+        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be rotated.</returns>
         public virtual bool HandleRotation(float angle) => false;
 
         /// <summary>
@@ -149,14 +149,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <param name="scale">The delta scale to apply, in playfield local coordinates.</param>
         /// <param name="anchor">The point of reference where the scale is originating from.</param>
-        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be moved.</returns>
+        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be scaled.</returns>
         public virtual bool HandleScale(Vector2 scale, Anchor anchor) => false;
 
         /// <summary>
-        /// Handled the selected <see cref="DrawableHitObject"/>s being flipped.
+        /// Handles the selected <see cref="DrawableHitObject"/>s being flipped.
         /// </summary>
         /// <param name="direction">The direction to flip</param>
-        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be moved.</returns>
+        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be flipped.</returns>
         public virtual bool HandleFlip(Direction direction) => false;
 
         public bool OnPressed(PlatformAction action)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -103,6 +103,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 OnRotation = angle => HandleRotation(angle),
                 OnScale = (amount, anchor) => HandleScale(amount, anchor),
                 OnFlip = direction => HandleFlip(direction),
+                OnReverse = () => HandleReverse(),
             };
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -159,6 +159,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether any <see cref="DrawableHitObject"/>s could be flipped.</returns>
         public virtual bool HandleFlip(Direction direction) => false;
 
+        /// <summary>
+        /// Handles the selected <see cref="DrawableHitObject"/>s being reversed pattern-wise.
+        /// </summary>
+        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be reversed.</returns>
+        public virtual bool HandleReverse() => false;
+
         public bool OnPressed(PlatformAction action)
         {
             switch (action.ActionMethod)


### PR DESCRIPTION
Note that paths are not perfectly reversed if they have excess length at the end. Have to check but I think stable does this too.

![2020-10-09 06 35 18](https://user-images.githubusercontent.com/191335/95516237-e9dccb00-09f9-11eb-859a-aa214d1f1019.gif)

![2020-10-09 06 38 34](https://user-images.githubusercontent.com/191335/95516367-18f33c80-09fa-11eb-9c18-603547c90540.gif)
