### PR TITLE
Improve TimelineTickDisplay performance

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineTickDisplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineTickDisplay.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Edit.Compose.Components;
-using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Editing
@@ -13,7 +12,7 @@ namespace osu.Game.Tests.Visual.Editing
     [TestFixture]
     public class TestSceneTimelineTickDisplay : TimelineTestScene
     {
-        public override Drawable CreateTestComponent() => new TimelineTickDisplay();
+        public override Drawable CreateTestComponent() => Empty(); // tick display is implicitly inside the timeline.
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osuTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
 {
@@ -13,15 +13,20 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
     public class PointVisualisation : Box
     {
         public PointVisualisation(double startTime)
+            : this()
+        {
+            X = (float)startTime;
+        }
+
+        public PointVisualisation()
         {
             Origin = Anchor.TopCentre;
 
+            RelativePositionAxes = Axes.X;
             RelativeSizeAxes = Axes.Y;
+
             Width = 1;
             EdgeSmoothness = new Vector2(1, 0);
-
-            RelativePositionAxes = Axes.X;
-            X = (float)startTime;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
     /// </summary>
     public class PointVisualisation : Box
     {
+        public const float WIDTH = 1;
+
         public PointVisualisation(double startTime)
             : this()
         {
@@ -25,8 +27,8 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
             RelativePositionAxes = Axes.X;
             RelativeSizeAxes = Axes.Y;
 
-            Width = 1;
-            EdgeSmoothness = new Vector2(1, 0);
+            Width = WIDTH;
+            EdgeSmoothness = new Vector2(WIDTH, 0);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -66,8 +66,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             if (timeline != null)
             {
                 var newRange = (
-                    ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopLeft).X / DrawWidth * Content.RelativeChildSize.X,
-                    ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopRight).X / DrawWidth * Content.RelativeChildSize.X);
+                    (ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopLeft).X - PointVisualisation.WIDTH * 2) / DrawWidth * Content.RelativeChildSize.X,
+                    (ToLocalSpace(timeline.ScreenSpaceDrawQuad.TopRight).X + PointVisualisation.WIDTH * 2) / DrawWidth * Content.RelativeChildSize.X);
 
                 if (visibleRange != newRange)
                 {


### PR DESCRIPTION
Before: ~20ms (1/8 tick divisor on solace of oblivion)
After: ~0.3ms

I started by using a `DrawablePool` but it makes more sense to locally optimise this one. May turn out that we want to abstract this into `TimelinePart` for other usages (the display bounds part at least) but want to get this into the next lazer release if possible, as it's causing 90% of the editor performance issues.