### PR TITLE
Fix bar lines ("down beat" as people call it) showing up too often in timeline

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -112,13 +112,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         if (beat == 0 && i == 0)
                             nextMinTick = float.MinValue;
 
-                        var indexInBeat = beat % beatDivisor.Value;
+                        var indexInBar = beat % ((int)point.TimeSignature * beatDivisor.Value);
 
                         var divisor = BindableBeatDivisor.GetDivisorForBeatIndex(beat, beatDivisor.Value);
                         var colour = BindableBeatDivisor.GetColourFor(divisor, colours);
 
                         // even though "bar lines" take up the full vertical space, we render them in two pieces because it allows for less anchor/origin churn.
-                        var height = indexInBeat == 0 ? 0.5f : 0.1f - (float)divisor / highestDivisor * 0.08f;
+                        var height = indexInBar == 0 ? 0.5f : 0.1f - (float)divisor / highestDivisor * 0.08f;
 
                         var topPoint = getNextUsablePoint();
                         topPoint.X = xPos;


### PR DESCRIPTION
Matches stable (and expectations).

Before:

![image](https://user-images.githubusercontent.com/191335/95568001-a8323b80-0a5e-11eb-9fcf-2a668a201c5c.png)

After:

![image](https://user-images.githubusercontent.com/191335/95567892-833dc880-0a5e-11eb-95c1-d291a28ff4bd.png)
