### PR TITLE
Ensure stable sorting order in beatmap conversion tests

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapConversionTest.cs
@@ -83,11 +83,17 @@ namespace osu.Game.Rulesets.Mania.Tests
             RandomZ = snapshot.RandomZ;
         }
 
+        public override void PostProcess()
+        {
+            base.PostProcess();
+            Objects.Sort();
+        }
+
         public bool Equals(ManiaConvertMapping other) => other != null && RandomW == other.RandomW && RandomX == other.RandomX && RandomY == other.RandomY && RandomZ == other.RandomZ;
         public override bool Equals(ConvertMapping<ConvertValue> other) => base.Equals(other) && Equals(other as ManiaConvertMapping);
     }
 
-    public struct ConvertValue : IEquatable<ConvertValue>
+    public struct ConvertValue : IEquatable<ConvertValue>, IComparable<ConvertValue>
     {
         /// <summary>
         /// A sane value to account for osu!stable using ints everwhere.
@@ -102,5 +108,15 @@ namespace osu.Game.Rulesets.Mania.Tests
             => Precision.AlmostEquals(StartTime, other.StartTime, conversion_lenience)
                && Precision.AlmostEquals(EndTime, other.EndTime, conversion_lenience)
                && Column == other.Column;
+
+        public int CompareTo(ConvertValue other)
+        {
+            var result = StartTime.CompareTo(other.StartTime);
+
+            if (result != 0)
+                return result;
+
+            return Column.CompareTo(other.Column);
+        }
     }
 }

--- a/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
@@ -34,6 +34,12 @@ namespace osu.Game.Tests.Beatmaps
             var ourResult = convert(name, mods.Select(m => (Mod)Activator.CreateInstance(m)).ToArray());
             var expectedResult = read(name);
 
+            foreach (var m in ourResult.Mappings)
+                m.PostProcess();
+
+            foreach (var m in expectedResult.Mappings)
+                m.PostProcess();
+
             Assert.Multiple(() =>
             {
                 int mappingCounter = 0;
@@ -237,6 +243,13 @@ namespace osu.Game.Tests.Beatmaps
         private List<TConvertValue> setObjects
         {
             set => Objects = value;
+        }
+
+        /// <summary>
+        /// Invoked after this <see cref="ConvertMapping{TConvertValue}"/> is populated to post-process the contained data.
+        /// </summary>
+        public virtual void PostProcess()
+        {
         }
 
         public virtual bool Equals(ConvertMapping<TConvertValue> other) => StartTime == other?.StartTime;


### PR DESCRIPTION
Since mania has multiple hitobjects at the same time, there needs to be some way to ensure that the order of the hitobjects contained by `ConvertMapping` is stable.

The ordering that seems most adequate is by-StartTime then by-Column.