### PR TITLE
Fix slider samples being overwritten by the last node

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -56,6 +57,7 @@ namespace osu.Game.Rulesets.Catch.Objects
                 Volume = s.Volume
             }).ToList();
 
+            int nodeIndex = 0;
             SliderEventDescriptor? lastEvent = null;
 
             foreach (var e in SliderEventGenerator.Generate(StartTime, SpanDuration, Velocity, TickDistance, Path.Distance, this.SpanCount(), LegacyLastTickOffset, cancellationToken))
@@ -105,7 +107,7 @@ namespace osu.Game.Rulesets.Catch.Objects
                     case SliderEventType.Repeat:
                         AddNested(new Fruit
                         {
-                            Samples = Samples,
+                            Samples = this.GetNodeSamples(nodeIndex++),
                             StartTime = e.Time,
                             X = X + Path.PositionAt(e.PathProgress).X,
                         });
@@ -119,7 +121,7 @@ namespace osu.Game.Rulesets.Catch.Objects
         public double Duration
         {
             get => this.SpanCount() * Path.Distance / Velocity;
-            set => throw new System.NotSupportedException($"Adjust via {nameof(RepeatCount)} instead"); // can be implemented if/when needed.
+            set => throw new NotSupportedException($"Adjust via {nameof(RepeatCount)} instead"); // can be implemented if/when needed.
         }
 
         public double EndTime => StartTime + Duration;

--- a/osu.Game.Rulesets.Mania/Resources/Testing/Beatmaps/convert-samples-expected-conversion.json
+++ b/osu.Game.Rulesets.Mania/Resources/Testing/Beatmaps/convert-samples-expected-conversion.json
@@ -10,7 +10,7 @@
         ["soft-hitnormal"],
         ["drum-hitnormal"]
       ],
-      "Samples": ["drum-hitnormal"]
+      "Samples": ["-hitnormal"]
     }, {
       "StartTime": 1875.0,
       "EndTime": 2750.0,
@@ -19,7 +19,7 @@
         ["soft-hitnormal"],
         ["drum-hitnormal"]
       ],
-      "Samples": ["drum-hitnormal"]
+      "Samples": ["-hitnormal"]
     }]
   }, {
     "StartTime": 3750.0,

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -137,6 +137,10 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             Velocity = scoringDistance / timingPoint.BeatLength;
             TickDistance = scoringDistance / difficulty.SliderTickRate * TickDistanceMultiplier;
+
+            // The samples should be attached to the slider tail, however this can only be done after LegacyLastTick is removed otherwise they would play earlier than they're intended to.
+            // For now, the samples are attached to and played by the slider itself at the correct end time.
+            Samples = this.GetNodeSamples(repeatCount + 1);
         }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
@@ -230,14 +234,11 @@ namespace osu.Game.Rulesets.Osu.Objects
                 tick.Samples = sampleList;
 
             foreach (var repeat in NestedHitObjects.OfType<SliderRepeat>())
-                repeat.Samples = getNodeSamples(repeat.RepeatIndex + 1);
+                repeat.Samples = this.GetNodeSamples(repeat.RepeatIndex + 1);
 
             if (HeadCircle != null)
-                HeadCircle.Samples = getNodeSamples(0);
+                HeadCircle.Samples = this.GetNodeSamples(0);
         }
-
-        private IList<HitSampleInfo> getNodeSamples(int nodeIndex) =>
-            nodeIndex < NodeSamples.Count ? NodeSamples[nodeIndex] : Samples;
 
         public override Judgement CreateJudgement() => new OsuIgnoreJudgement();
 

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -184,9 +184,6 @@ namespace osu.Game.Rulesets.Objects.Legacy
                     nodeSamples.Add(convertSoundType(nodeSoundTypes[i], nodeBankInfos[i]));
 
                 result = CreateSlider(pos, combo, comboOffset, convertControlPoints(points, pathType), length, repeatCount, nodeSamples);
-
-                // The samples are played when the slider ends, which is the last node
-                result.Samples = nodeSamples[^1];
             }
             else if (type.HasFlag(LegacyHitObjectType.Spinner))
             {

--- a/osu.Game/Rulesets/Objects/Types/IHasRepeats.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasRepeats.cs
@@ -35,5 +35,15 @@ namespace osu.Game.Rulesets.Objects.Types
         /// </summary>
         /// <param name="obj">The object that has repeats.</param>
         public static int SpanCount(this IHasRepeats obj) => obj.RepeatCount + 1;
+
+        /// <summary>
+        /// Retrieves the samples at a particular node in a <see cref="IHasRepeats"/> object.
+        /// </summary>
+        /// <param name="obj">The <see cref="HitObject"/>.</param>
+        /// <param name="nodeIndex">The node to attempt to retrieve the samples at.</param>
+        /// <returns>The samples at the given node index, or <paramref name="obj"/>'s default samples if the given node doesn't exist.</returns>
+        public static IList<HitSampleInfo> GetNodeSamples<T>(this T obj, int nodeIndex)
+            where T : HitObject, IHasRepeats
+            => nodeIndex < obj.NodeSamples.Count ? obj.NodeSamples[nodeIndex] : obj.Samples;
     }
 }


### PR DESCRIPTION
Mania requires knowledge of the slider's default samples:

https://github.com/ppy/osu/blob/da0308425163b4330073fbdf4ee0250314c5ae48/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs#L368-L369

But they were being replaced during parsing by the last node's samples. The way `Slider`'s doing things is still likely completely incorrect, because it then uses these samples to determine the tick's bank/volume, but the purpose of this PR is not to fix that:
https://github.com/ppy/osu/blob/da0308425163b4330073fbdf4ee0250314c5ae48/osu.Game.Rulesets.Osu/Objects/Slider.cs#L215-L216

I've tested this against (and cross-checked with stable):
https://osu.ppy.sh/beatmapsets/692068#osu/1464590
https://osu.ppy.sh/beatmapsets/177187#osu/426550 (fully keysounded)

Furthermore, I also noticed `JuiceStream` completely disregarding the existence of per-node samples, which led to incorrect playback in maps like the second one above. I've fixed this since it's a very minor change.