### PR TITLE
Try to match stable's judgement animations

### DIFF
--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -71,8 +71,12 @@ namespace osu.Game.Rulesets.Judgements
 
         protected virtual void ApplyHitAnimations()
         {
-            JudgementBody.ScaleTo(0.9f);
-            JudgementBody.ScaleTo(1, 500, Easing.OutElastic);
+            if (bodyDrawable.Drawable is LegacySkinExtensions.SkinnableTextureAnimation) { }
+            else
+            {
+                JudgementBody.ScaleTo(0.9f);
+                JudgementBody.ScaleTo(1, 500, Easing.OutElastic);
+            }
 
             this.Delay(FadeOutDelay).FadeOut(400);
         }


### PR DESCRIPTION
Closes #10195

In this PR, ``DrawableJudgment`` is made to check if its drawable is animatable legacy skin component and if so it won't get any scale effects applied. This should match what stable does, where scale effects only apply to skins with no animations.