### PR TITLE
Add the ability to search for local beatmaps via online IDs

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -197,5 +197,22 @@ namespace osu.Game.Tests.NonVisual.Filtering
             carouselItem.Filter(criteria);
             Assert.AreEqual(filtered, carouselItem.Filtered.Value);
         }
+
+        [TestCase("202010", true)]
+        [TestCase("20201010", false)]
+        [TestCase("153", true)]
+        [TestCase("1535", false)]
+        public void TestCriteriaMatchingBeatmapIDs(string query, bool filtered)
+        {
+            var beatmap = getExampleBeatmap();
+            beatmap.OnlineBeatmapID = 20201010;
+            beatmap.BeatmapSet = new BeatmapSetInfo { OnlineBeatmapSetID = 1535 };
+
+            var criteria = new FilterCriteria { SearchText = query };
+            var carouselItem = new CarouselBeatmap(beatmap);
+            carouselItem.Filter(criteria);
+
+            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
     }
 }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -58,6 +58,14 @@ namespace osu.Game.Screens.Select.Carousel
 
                 foreach (var criteriaTerm in criteria.SearchTerms)
                     match &= terms.Any(term => term.IndexOf(criteriaTerm, StringComparison.InvariantCultureIgnoreCase) >= 0);
+
+                // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
+                // this should be done after text matching so we can prioritise matching numbers in metadata.
+                if (!match && criteria.SearchNumber.HasValue)
+                {
+                    match = (Beatmap.OnlineBeatmapID == criteria.SearchNumber.Value) ||
+                            (Beatmap.BeatmapSet?.OnlineBeatmapSetID == criteria.SearchNumber.Value);
+                }
             }
 
             if (match)

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -43,6 +43,11 @@ namespace osu.Game.Screens.Select
 
         private string searchText;
 
+        /// <summary>
+        /// <see cref="SearchText"/> as a number (if it can be parsed as one).
+        /// </summary>
+        public int? SearchNumber { get; private set; }
+
         public string SearchText
         {
             get => searchText;
@@ -50,6 +55,11 @@ namespace osu.Game.Screens.Select
             {
                 searchText = value;
                 SearchTerms = searchText.Split(new[] { ',', ' ', '!' }, StringSplitOptions.RemoveEmptyEntries).ToArray();
+
+                SearchNumber = null;
+
+                if (SearchTerms.Length == 1 && int.TryParse(SearchTerms[0], out int parsed))
+                    SearchNumber = parsed;
             }
         }
 


### PR DESCRIPTION
Closes #10470.

Only allows searching when the search text is a single word and also a number