### PR TITLE
Expose BreakTracker.IsBreakTime in Player

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Whether the gameplay is currently in a break.
         /// </summary>
-        public readonly BindableBool IsBreakTime = new BindableBool();
+        public readonly IBindable<bool> IsBreakTime = new BindableBool();
 
         private BreakTracker breakTracker;
 
@@ -261,8 +261,8 @@ namespace osu.Game.Screens.Play
             foreach (var mod in Mods.Value.OfType<IApplicableToHealthProcessor>())
                 mod.ApplyToHealthProcessor(HealthProcessor);
 
+            IsBreakTime.BindTo(breakTracker.IsBreakTime);
             breakTracker.IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
-            IsBreakTime.BindTo((BindableBool)breakTracker.IsBreakTime);
         }
 
         private Drawable createUnderlayComponents() =>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -231,7 +231,6 @@ namespace osu.Game.Screens.Play
 
             DrawableRuleset.IsPaused.BindValueChanged(_ => updateGameplayState());
             DrawableRuleset.HasReplayLoaded.BindValueChanged(_ => updateGameplayState());
-            breakTracker.IsBreakTime.BindValueChanged(_ => updateGameplayState());
 
             DrawableRuleset.HasReplayLoaded.BindValueChanged(_ => updatePauseOnFocusLostState(), true);
 
@@ -262,7 +261,7 @@ namespace osu.Game.Screens.Play
                 mod.ApplyToHealthProcessor(HealthProcessor);
 
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
-            breakTracker.IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
+            IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
         }
 
         private Drawable createUnderlayComponents() =>
@@ -360,6 +359,7 @@ namespace osu.Game.Screens.Play
 
         private void onBreakTimeChanged(ValueChangedEvent<bool> isBreakTime)
         {
+            updateGameplayState();
             updatePauseOnFocusLostState();
             HUDOverlay.KeyCounter.IsCounting = !isBreakTime.NewValue;
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -89,6 +89,8 @@ namespace osu.Game.Screens.Play
 
         public BreakOverlay BreakOverlay;
 
+        public IBindable<bool> IsBreakTime => breakTracker?.IsBreakTime;
+
         private BreakTracker breakTracker;
 
         private SkipOverlay skipOverlay;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -89,7 +89,10 @@ namespace osu.Game.Screens.Play
 
         public BreakOverlay BreakOverlay;
 
-        public IBindable<bool> IsBreakTime => breakTracker?.IsBreakTime;
+        /// <summary>
+        /// Whether the gameplay is currently in a break.
+        /// </summary>
+        public readonly BindableBool IsBreakTime = new BindableBool();
 
         private BreakTracker breakTracker;
 
@@ -259,6 +262,7 @@ namespace osu.Game.Screens.Play
                 mod.ApplyToHealthProcessor(HealthProcessor);
 
             breakTracker.IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
+            IsBreakTime.BindTo((BindableBool)breakTracker.IsBreakTime);
         }
 
         private Drawable createUnderlayComponents() =>


### PR DESCRIPTION
Required by https://github.com/ppy/osu/pull/9606. This allows others such as mods to subscribe to the break state of the player.