### PR TITLE
Fix looping samples not pausing in gameplay

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -45,6 +45,9 @@ namespace osu.Game.Rulesets.UI
             stabilityGameplayClock = new StabilityGameplayClock(framedClock = new FramedClock(manualClock = new ManualClock()));
 
             this.gameplayStartTime = gameplayStartTime;
+
+            // UpdateSubTree() does not necessarily always run, but we want to manually process the clock regardless of that.
+            ProcessCustomClock = false;
         }
 
         private readonly ManualClock manualClock;
@@ -103,6 +106,10 @@ namespace osu.Game.Rulesets.UI
             validState = !GameplayClock.IsPaused.Value;
 
             int loops = 0;
+
+            // gameplay clock does not update its underlying clocks, but we need to run its frames
+            // to propagate the state of the clocks it wraps to whichever component needs to read it
+            stabilityGameplayClock.ProcessFrame();
 
             while (validState && requireMoreUpdateLoops && loops++ < MaxCatchUpFrames)
             {


### PR DESCRIPTION
Resolves #10454.

# Summary

The sample pausing logic added in `ISamplePlaybackDisabler` and `GameplayClock`:

https://github.com/ppy/osu/blob/bd44340423e5517b580cabfaa715fb8cd4fb9058/osu.Game/Screens/Play/GameplayClock.cs#L71-L76

would not run in gameplay due to the `FrameStabilityContainer` never processing it while paused:

https://github.com/ppy/osu/blob/bd44340423e5517b580cabfaa715fb8cd4fb9058/osu.Game/Rulesets/UI/FrameStabilityContainer.cs#L103-L116

Even though the container had `ProcessCustomClock` set, the call to the base `UpdateSubTree()` does not run when paused, leading to the frames never getting processed.

Ensure the `StabilityGameplayClock` is processed regardless of pause state. On its own it performs no timing logic and explicitly does not process its underlying clocks, so it does not affect frame stability in any way (only propagates updates of the sample disable for now).

# Remarks

Was not initially sure of this. A little more convinced this is OK now, but not 100%. Suggestions how to improve welcome - also not sure if the comments are all that legible.

Did not include a test as the issue was incomplete integration and any test would probably be a bit finicky. Will include one on request, though.