### PR TITLE
Show current hit circle placement in timeline

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -21,6 +21,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
             InternalChild = circlePiece = new HitCirclePiece();
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            BeginPlacement();
+        }
+
         protected override void Update()
         {
             base.Update();


### PR DESCRIPTION
Resolves #10459.

Not sure it's even worth writing a description for this one. The diff speaks for itself.

(It did take me about 30 minutes bumbling through figuring out that this was the proper way to do this, though. Which is not a discredit to the editor's structure, mind you.)