### PR TITLE
Apply rounding when calculating beatmap difficulty rating

### DIFF
--- a/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
@@ -28,5 +28,28 @@ namespace osu.Game.Tests.Beatmaps
 
             Assert.That(key1, Is.EqualTo(key2));
         }
+
+        [TestCase(1.3, DifficultyRating.Easy)]
+        [TestCase(1.993, DifficultyRating.Easy)]
+        [TestCase(1.998, DifficultyRating.Normal)]
+        [TestCase(2.4, DifficultyRating.Normal)]
+        [TestCase(2.693, DifficultyRating.Normal)]
+        [TestCase(2.698, DifficultyRating.Hard)]
+        [TestCase(3.5, DifficultyRating.Hard)]
+        [TestCase(3.993, DifficultyRating.Hard)]
+        [TestCase(3.997, DifficultyRating.Insane)]
+        [TestCase(5.0, DifficultyRating.Insane)]
+        [TestCase(5.292, DifficultyRating.Insane)]
+        [TestCase(5.297, DifficultyRating.Expert)]
+        [TestCase(6.2, DifficultyRating.Expert)]
+        [TestCase(6.493, DifficultyRating.Expert)]
+        [TestCase(6.498, DifficultyRating.ExpertPlus)]
+        [TestCase(8.3, DifficultyRating.ExpertPlus)]
+        public void TestDifficultyRatingMapping(double starRating, DifficultyRating expectedBracket)
+        {
+            var actualBracket = BeatmapDifficultyManager.GetDifficultyRating(starRating);
+
+            Assert.AreEqual(expectedBracket, actualBracket);
+        }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyManager.cs
@@ -14,6 +14,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Lists;
 using osu.Framework.Threading;
+using osu.Framework.Utils;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 
@@ -124,13 +125,22 @@ namespace osu.Game.Beatmaps
         /// <returns>The <see cref="DifficultyRating"/> that best describes <paramref name="starRating"/>.</returns>
         public static DifficultyRating GetDifficultyRating(double starRating)
         {
-            if (starRating < 2.0) return DifficultyRating.Easy;
-            if (starRating < 2.7) return DifficultyRating.Normal;
-            if (starRating < 4.0) return DifficultyRating.Hard;
-            if (starRating < 5.3) return DifficultyRating.Insane;
-            if (starRating < 6.5) return DifficultyRating.Expert;
+            if (Precision.AlmostBigger(starRating, 6.5, 0.005))
+                return DifficultyRating.ExpertPlus;
 
-            return DifficultyRating.ExpertPlus;
+            if (Precision.AlmostBigger(starRating, 5.3, 0.005))
+                return DifficultyRating.Expert;
+
+            if (Precision.AlmostBigger(starRating, 4.0, 0.005))
+                return DifficultyRating.Insane;
+
+            if (Precision.AlmostBigger(starRating, 2.7, 0.005))
+                return DifficultyRating.Hard;
+
+            if (Precision.AlmostBigger(starRating, 2.0, 0.005))
+                return DifficultyRating.Normal;
+
+            return DifficultyRating.Easy;
         }
 
         private CancellationTokenSource trackedUpdateCancellationSource;


### PR DESCRIPTION
Resolves #10457.

# Summary

As noted by @Game4all, `BeatmapDifficultyRating.GetDifficultyRating()` was operating on raw `double` values which caused the colours to look wrong in the UI (and inconsistent with web) after rounding was applied.

Resolve by replacing the hard threshold checks with ones leveraging `Precision.AlmostBigger`. Precision chosen was 0.005, as star rating is displayed with 2 decimal places everywhere as far as I know.

# Remarks

Includes tests because why not at this point.