### PR TITLE
Use default storage when accessing cache data

### DIFF
--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -57,10 +57,8 @@ namespace osu.Game.IO
                 TryChangeToCustomStorage(out Error);
         }
 
-        public Storage GetStorageFromPath(string path)
-        {
-            return IGNORE_DIRECTORIES.Any(x => path.StartsWith(x)) ? defaultStorage : UnderlyingStorage;
-        }
+        public Storage GetStorageFromPath(string path) =>
+            IGNORE_DIRECTORIES.Any(x => path.StartsWith(x)) ? defaultStorage : UnderlyingStorage;
 
         public override string GetFullPath(string path, bool createIfNotExisting = false) =>
             GetStorageFromPath(path).GetFullPath(MutatePath(path), createIfNotExisting);

--- a/osu.Game/IO/WrappedStorage.cs
+++ b/osu.Game/IO/WrappedStorage.cs
@@ -56,7 +56,7 @@ namespace osu.Game.IO
         public override IEnumerable<string> GetDirectories(string path) =>
             ToLocalRelative(UnderlyingStorage.GetDirectories(MutatePath(path)));
 
-        public IEnumerable<string> ToLocalRelative(IEnumerable<string> paths)
+        public virtual IEnumerable<string> ToLocalRelative(IEnumerable<string> paths)
         {
             string localRoot = GetFullPath(string.Empty);
 


### PR DESCRIPTION
Referencing the cache issue mentioned at the end of #10484.

During folder migration, the `cache` folder is ignored in migration. However, subsequent access to the cache uses `UnderlyingStorage` instead of `defaultStorage`. So even though the `cache` files aren't copied over to the migrated location, they will be recreated there, which defeats the purpose of ignoring them during migration.

In addition, the following edge case will cause an exception to be thrown.
1. Use the migration feature
2. Try to import a beatmap without exiting the game first
3. The game will throw an exception because the cache folder was not migrated, and subsequent access to the cache is trying to access the cache under the migrated path instead of the default path:
![image](https://user-images.githubusercontent.com/70926398/95931479-1f790f80-0d7e-11eb-864e-23339d9c5b46.png)
4. Upon restarting the game, the cache folder will be recreated under the migrated path

Stack trace for the exception above:
```
at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
at System.IO.Enumeration.FileSystemEnumerator`1.Init()
at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, Boolean isNormalized, EnumerationOptions options)
at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
at System.IO.Enumeration.FileSystemEnumerableFactory.UserFiles(String directory, String expression, EnumerationOptions options)
at System.IO.Directory.InternalEnumeratePaths(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
at System.IO.Directory.GetFiles(String path, String searchPattern)
at osu.Framework.Platform.NativeStorage.GetFiles(String path, String pattern) in D:\src\vs\osu-framework\osu.Framework\Platform\NativeStorage.cs:line 45
at osu.Game.IO.WrappedStorage.GetFiles(String path, String pattern) in D:\src\vs\osu\osu.Game\IO\WrappedStorage.cs:line 68
at osu.Game.IO.WrappedStorage.GetFiles(String path, String pattern) in D:\src\vs\osu\osu.Game\IO\WrappedStorage.cs:line 68
at osu.Framework.IO.Stores.RawCachingGlyphStore.createCachedPageInfo(Int32 page) in D:\src\vs\osu-framework\osu.Framework\IO\Stores\RawCachingGlyphStore.cs:line 56
at osu.Framework.IO.Stores.RawCachingGlyphStore.LoadCharacter(Character character) in D:\src\vs\osu-framework\osu.Framework\IO\Stores\RawCachingGlyphStore.cs:line 40
at osu.Framework.IO.Stores.GlyphStore.Get(String name) in D:\src\vs\osu-framework\osu.Framework\IO\Stores\GlyphStore.cs:line 128
at osu.Framework.IO.Stores.ResourceStore`1.Get(String name) in D:\src\vs\osu-framework\osu.Framework\IO\Stores\ResourceStore.cs:line 131
at osu.Framework.Graphics.Textures.TextureStore.getTexture(String name, WrapMode wrapModeS, WrapMode wrapModeT) in D:\src\vs\osu-framework\osu.Framework\Graphics\Textures\TextureStore.cs:line 54
at osu.Framework.Graphics.Textures.TextureStore.Get(String name, WrapMode wrapModeS, WrapMode wrapModeT) in D:\src\vs\osu-framework\osu.Framework\Graphics\Textures\TextureStore.cs:line 132
at osu.Framework.IO.Stores.FontStore.Get(String name) in D:\src\vs\osu-framework\osu.Framework\IO\Stores\FontStore.cs:line 117
at osu.Framework.IO.Stores.FontStore.Get(String fontName, Char character) in D:\src\vs\osu-framework\osu.Framework\IO\Stores\FontStore.cs:line 144
at osu.Framework.Graphics.Sprites.SpriteText.load(ShaderManager shaders) in D:\src\vs\osu-framework\osu.Framework\Graphics\Sprites\SpriteText.cs:line 77
```