### PR TITLE
Fix MultiMod throwing exceptions when creating copies

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
@@ -95,6 +95,24 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("copy has original value", () => Precision.AlmostEquals(1.5, copy.SpeedChange.Value));
         }
 
+        [Test]
+        public void TestMultiModSettingsUnboundWhenCopied()
+        {
+            MultiMod original = null;
+            MultiMod copy = null;
+
+            AddStep("create mods", () =>
+            {
+                original = new MultiMod(new OsuModDoubleTime());
+                copy = (MultiMod)original.CreateCopy();
+            });
+
+            AddStep("change property", () => ((OsuModDoubleTime)original.Mods[0]).SpeedChange.Value = 2);
+
+            AddAssert("original has new value", () => Precision.AlmostEquals(2.0, ((OsuModDoubleTime)original.Mods[0]).SpeedChange.Value));
+            AddAssert("copy has original value", () => Precision.AlmostEquals(1.5, ((OsuModDoubleTime)copy.Mods[0]).SpeedChange.Value));
+        }
+
         private void createModSelect()
         {
             AddStep("create mod select", () =>

--- a/osu.Game/Rulesets/Mods/MultiMod.cs
+++ b/osu.Game/Rulesets/Mods/MultiMod.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public class MultiMod : Mod
+    public sealed class MultiMod : Mod
     {
         public override string Name => string.Empty;
         public override string Acronym => string.Empty;
@@ -19,6 +19,8 @@ namespace osu.Game.Rulesets.Mods
         {
             Mods = mods;
         }
+
+        public override Mod CreateCopy() => new MultiMod(Mods.Select(m => m.CreateCopy()).ToArray());
 
         public override Type[] IncompatibleMods => Mods.SelectMany(m => m.IncompatibleMods).ToArray();
     }


### PR DESCRIPTION
Also, `MultiMod` should never be derived.