### PR TITLE
Confine available area for HUD components to exclude the song progress area

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -63,6 +63,8 @@ namespace osu.Game.Screens.Play
 
         private readonly Container topScoreContainer;
 
+        private FillFlowContainer bottomRightElements;
+
         private IEnumerable<Drawable> hideTargets => new Drawable[] { visibilityContainer, KeyCounter };
 
         public HUDOverlay(ScoreProcessor scoreProcessor, HealthProcessor healthProcessor, DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods)
@@ -119,16 +121,16 @@ namespace osu.Game.Screens.Play
                         },
                         RowDimensions = new[]
                         {
-                            new Dimension(GridSizeMode.Distributed),
+                            new Dimension(),
                             new Dimension(GridSizeMode.AutoSize)
                         }
                     },
                 },
-                new FillFlowContainer
+                bottomRightElements = new FillFlowContainer
                 {
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,
-                    Position = -new Vector2(5, TwoLayerButton.SIZE_RETRACTED.Y),
+                    X = -5,
                     AutoSizeAxes = Axes.Both,
                     LayoutDuration = fade_duration / 2,
                     LayoutEasing = fade_easing,
@@ -207,6 +209,12 @@ namespace osu.Game.Screens.Play
             }, true);
 
             replayLoaded.BindValueChanged(replayLoadedValueChanged, true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            bottomRightElements.Y = -Progress.Height;
         }
 
         private void replayLoadedValueChanged(ValueChangedEvent<bool> e)

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -80,26 +80,49 @@ namespace osu.Game.Screens.Play
                 visibilityContainer = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    Child = new GridContainer
                     {
-                        HealthDisplay = CreateHealthDisplay(),
-                        topScoreContainer = new Container
+                        RelativeSizeAxes = Axes.Both,
+                        Content = new[]
                         {
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            AutoSizeAxes = Axes.Both,
-                            Children = new Drawable[]
+                            new Drawable[]
                             {
-                                AccuracyCounter = CreateAccuracyCounter(),
-                                ScoreCounter = CreateScoreCounter(),
-                                ComboCounter = CreateComboCounter(),
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Children = new Drawable[]
+                                    {
+                                        HealthDisplay = CreateHealthDisplay(),
+                                        topScoreContainer = new Container
+                                        {
+                                            Anchor = Anchor.TopCentre,
+                                            Origin = Anchor.TopCentre,
+                                            AutoSizeAxes = Axes.Both,
+                                            Children = new Drawable[]
+                                            {
+                                                AccuracyCounter = CreateAccuracyCounter(),
+                                                ScoreCounter = CreateScoreCounter(),
+                                                ComboCounter = CreateComboCounter(),
+                                            },
+                                        },
+                                        ComboCounter = CreateComboCounter(),
+                                        ModDisplay = CreateModsContainer(),
+                                        HitErrorDisplay = CreateHitErrorDisplayOverlay(),
+                                        PlayerSettingsOverlay = CreatePlayerSettingsOverlay(),
+                                    }
+                                },
                             },
+                            new Drawable[]
+                            {
+                                Progress = CreateProgress(),
+                            }
                         },
-                        Progress = CreateProgress(),
-                        ModDisplay = CreateModsContainer(),
-                        HitErrorDisplay = CreateHitErrorDisplayOverlay(),
-                        PlayerSettingsOverlay = CreatePlayerSettingsOverlay(),
-                    }
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.Distributed),
+                            new Dimension(GridSizeMode.AutoSize)
+                        }
+                    },
                 },
                 new FillFlowContainer
                 {

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Play
 
         private readonly Container topScoreContainer;
 
-        private FillFlowContainer bottomRightElements;
+        private readonly FillFlowContainer bottomRightElements;
 
         private IEnumerable<Drawable> hideTargets => new Drawable[] { visibilityContainer, KeyCounter };
 

--- a/osu.Game/Screens/Play/SongProgress.cs
+++ b/osu.Game/Screens/Play/SongProgress.cs
@@ -70,7 +70,6 @@ namespace osu.Game.Screens.Play
         public SongProgress()
         {
             Masking = true;
-            Height = bottom_bar_height + graph_height + handle_size.Y + info_height;
 
             Children = new Drawable[]
             {
@@ -148,6 +147,8 @@ namespace osu.Game.Screens.Play
 
             bar.CurrentTime = gameplayTime;
             graph.Progress = (int)(graph.ColumnCount * progress);
+
+            Height = bottom_bar_height + graph_height + handle_size.Y + info_height - graph.Y;
         }
 
         private void updateBarVisibility()


### PR DESCRIPTION
This change bring the available area for main HUD components to exclude the song progress region. Generally improves the relative behaviour of components as can be seen:

![2020-10-14 18 51 29](https://user-images.githubusercontent.com/191335/95973333-76e6b080-0e4e-11eb-948e-7c326281ddca.gif)


This is a prerequisite for legacy skinning of HUD components (ie. allowing the combo counter to exist at the bottom-left corner).

For simplicity I'm just using every-update height propagation. `SongProgress` could support `AutoSize` with some work but I don't think it's worth it at this point in time.