### PR TITLE
Fix MultiMod difficulty calculator combinations not generating correctly

### DIFF
--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Tests.NonVisual
         }
 
         [Test]
-        public void TestMultiMod1()
+        public void TestMultiModFlattening()
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModB(), new ModC())).CreateDifficultyAdjustmentModCombinations();
 
@@ -113,7 +113,7 @@ namespace osu.Game.Tests.NonVisual
         }
 
         [Test]
-        public void TestMultiMod2()
+        public void TestIncompatibleThroughMultiMod()
         {
             var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModB(), new ModIncompatibleWithA())).CreateDifficultyAdjustmentModCombinations();
 

--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -126,6 +126,20 @@ namespace osu.Game.Tests.NonVisual
             Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModIncompatibleWithA);
         }
 
+        [Test]
+        public void TestIncompatibleWithSameInstanceViaMultiMod()
+        {
+            var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModA(), new ModB())).CreateDifficultyAdjustmentModCombinations();
+
+            Assert.AreEqual(3, combinations.Length);
+            Assert.IsTrue(combinations[0] is ModNoMod);
+            Assert.IsTrue(combinations[1] is ModA);
+            Assert.IsTrue(combinations[2] is MultiMod);
+
+            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModA);
+            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModB);
+        }
+
         private class ModA : Mod
         {
             public override string Name => nameof(ModA);

--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -94,6 +94,38 @@ namespace osu.Game.Tests.NonVisual
             Assert.IsTrue(combinations[2] is ModIncompatibleWithAofA);
         }
 
+        [Test]
+        public void TestMultiMod1()
+        {
+            var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModB(), new ModC())).CreateDifficultyAdjustmentModCombinations();
+
+            Assert.AreEqual(4, combinations.Length);
+            Assert.IsTrue(combinations[0] is ModNoMod);
+            Assert.IsTrue(combinations[1] is ModA);
+            Assert.IsTrue(combinations[2] is MultiMod);
+            Assert.IsTrue(combinations[3] is MultiMod);
+
+            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModA);
+            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModB);
+            Assert.IsTrue(((MultiMod)combinations[2]).Mods[2] is ModC);
+            Assert.IsTrue(((MultiMod)combinations[3]).Mods[0] is ModB);
+            Assert.IsTrue(((MultiMod)combinations[3]).Mods[1] is ModC);
+        }
+
+        [Test]
+        public void TestMultiMod2()
+        {
+            var combinations = new TestLegacyDifficultyCalculator(new ModA(), new MultiMod(new ModB(), new ModIncompatibleWithA())).CreateDifficultyAdjustmentModCombinations();
+
+            Assert.AreEqual(3, combinations.Length);
+            Assert.IsTrue(combinations[0] is ModNoMod);
+            Assert.IsTrue(combinations[1] is ModA);
+            Assert.IsTrue(combinations[2] is MultiMod);
+
+            Assert.IsTrue(((MultiMod)combinations[2]).Mods[0] is ModB);
+            Assert.IsTrue(((MultiMod)combinations[2]).Mods[1] is ModIncompatibleWithA);
+        }
+
         private class ModA : Mod
         {
             public override string Name => nameof(ModA);
@@ -110,6 +142,13 @@ namespace osu.Game.Tests.NonVisual
             public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModIncompatibleWithAAndB) };
+        }
+
+        private class ModC : Mod
+        {
+            public override string Name => nameof(ModC);
+            public override string Acronym => nameof(ModC);
+            public override double ScoreMultiplier => 1;
         }
 
         private class ModIncompatibleWithA : Mod

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
@@ -12,7 +11,6 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
-using Sentry;
 
 namespace osu.Game.Rulesets.Difficulty
 {


### PR DESCRIPTION
Two fixes here:
1. Incompatibility should be checked both ways, since mods aren't set to be incompatible with `MultiMod`.
2. `MultiMod` should be flattened into the adjustment set.