### PR TITLE
Add support for bottom-anchored hit error display

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -22,8 +22,10 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         private BarHitErrorMeter barMeter;
         private BarHitErrorMeter barMeter2;
+        private BarHitErrorMeter barMeter3;
         private ColourHitErrorMeter colourMeter;
         private ColourHitErrorMeter colourMeter2;
+        private ColourHitErrorMeter colourMeter3;
         private HitWindows hitWindows;
 
         public TestSceneHitErrorMeter()
@@ -115,6 +117,13 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Origin = Anchor.CentreLeft,
             });
 
+            Add(barMeter3 = new BarHitErrorMeter(hitWindows, true)
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.CentreLeft,
+                Rotation = 270,
+            });
+
             Add(colourMeter = new ColourHitErrorMeter(hitWindows)
             {
                 Anchor = Anchor.CentreRight,
@@ -126,6 +135,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
+                Margin = new MarginPadding { Left = 50 }
+            });
+
+            Add(colourMeter3 = new ColourHitErrorMeter(hitWindows)
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.CentreLeft,
+                Rotation = 270,
                 Margin = new MarginPadding { Left = 50 }
             });
         }
@@ -140,8 +157,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             barMeter.OnNewJudgement(judgement);
             barMeter2.OnNewJudgement(judgement);
+            barMeter3.OnNewJudgement(judgement);
             colourMeter.OnNewJudgement(judgement);
             colourMeter2.OnNewJudgement(judgement);
+            colourMeter3.OnNewJudgement(judgement);
         }
     }
 }

--- a/osu.Game/Configuration/ScoreMeterType.cs
+++ b/osu.Game/Configuration/ScoreMeterType.cs
@@ -16,7 +16,10 @@ namespace osu.Game.Configuration
         [Description("Hit Error (right)")]
         HitErrorRight,
 
-        [Description("Hit Error (both)")]
+        [Description("Hit Error (bottom)")]
+        HitErrorBottom,
+
+        [Description("Hit Error (left+right)")]
         HitErrorBoth,
 
         [Description("Colour (left)")]
@@ -25,7 +28,10 @@ namespace osu.Game.Configuration
         [Description("Colour (right)")]
         ColourRight,
 
-        [Description("Colour (both)")]
+        [Description("Colour (left+right)")]
         ColourBoth,
+
+        [Description("Colour (bottom)")]
+        ColourBottom,
     }
 }

--- a/osu.Game/Screens/Play/HUD/HitErrorDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorDisplay.cs
@@ -66,54 +66,69 @@ namespace osu.Game.Screens.Play.HUD
             switch (type.NewValue)
             {
                 case ScoreMeterType.HitErrorBoth:
-                    createBar(false);
-                    createBar(true);
+                    createBar(Anchor.CentreLeft);
+                    createBar(Anchor.CentreRight);
                     break;
 
                 case ScoreMeterType.HitErrorLeft:
-                    createBar(false);
+                    createBar(Anchor.CentreLeft);
                     break;
 
                 case ScoreMeterType.HitErrorRight:
-                    createBar(true);
+                    createBar(Anchor.CentreRight);
+                    break;
+
+                case ScoreMeterType.HitErrorBottom:
+                    createBar(Anchor.BottomCentre);
                     break;
 
                 case ScoreMeterType.ColourBoth:
-                    createColour(false);
-                    createColour(true);
+                    createColour(Anchor.CentreLeft);
+                    createColour(Anchor.CentreRight);
                     break;
 
                 case ScoreMeterType.ColourLeft:
-                    createColour(false);
+                    createColour(Anchor.CentreLeft);
                     break;
 
                 case ScoreMeterType.ColourRight:
-                    createColour(true);
+                    createColour(Anchor.CentreRight);
+                    break;
+
+                case ScoreMeterType.ColourBottom:
+                    createColour(Anchor.BottomCentre);
                     break;
             }
         }
 
-        private void createBar(bool rightAligned)
+        private void createBar(Anchor anchor)
         {
+            bool rightAligned = (anchor & Anchor.x2) > 0;
+            bool bottomAligned = (anchor & Anchor.y2) > 0;
+
             var display = new BarHitErrorMeter(hitWindows, rightAligned)
             {
                 Margin = new MarginPadding(margin),
-                Anchor = rightAligned ? Anchor.CentreRight : Anchor.CentreLeft,
-                Origin = rightAligned ? Anchor.CentreRight : Anchor.CentreLeft,
+                Anchor = anchor,
+                Origin = bottomAligned ? Anchor.CentreLeft : anchor,
                 Alpha = 0,
+                Rotation = bottomAligned ? 270 : 0
             };
 
             completeDisplayLoading(display);
         }
 
-        private void createColour(bool rightAligned)
+        private void createColour(Anchor anchor)
         {
+            bool bottomAligned = (anchor & Anchor.y2) > 0;
+
             var display = new ColourHitErrorMeter(hitWindows)
             {
                 Margin = new MarginPadding(margin),
-                Anchor = rightAligned ? Anchor.CentreRight : Anchor.CentreLeft,
-                Origin = rightAligned ? Anchor.CentreRight : Anchor.CentreLeft,
+                Anchor = anchor,
+                Origin = bottomAligned ? Anchor.CentreLeft : anchor,
                 Alpha = 0,
+                Rotation = bottomAligned ? 270 : 0
             };
 
             completeDisplayLoading(display);

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -99,7 +99,9 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                                 Size = new Vector2(10),
                                 Icon = FontAwesome.Solid.ShippingFast,
                                 Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
+                                Origin = Anchor.Centre,
+                                // undo any layout rotation to display the icon the correct orientation
+                                Rotation = -Rotation,
                             },
                             new SpriteIcon
                             {
@@ -107,7 +109,9 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                                 Size = new Vector2(10),
                                 Icon = FontAwesome.Solid.Bicycle,
                                 Anchor = Anchor.BottomCentre,
-                                Origin = Anchor.BottomCentre,
+                                Origin = Anchor.Centre,
+                                // undo any layout rotation to display the icon the correct orientation
+                                Rotation = -Rotation,
                             }
                         }
                     },


### PR DESCRIPTION
Not the most amazing code, but it's a common request and it feels like we should just do it this way until the component is completely rewritten.

![image](https://user-images.githubusercontent.com/191335/96110188-7ae00480-0f1a-11eb-9973-5a6cf33a1de2.png)

Possible thanks to the layout improvements in https://github.com/ppy/osu/pull/10502.

