### PR TITLE
Lock screen rotation while in gameplay on android

### DIFF
--- a/osu.Android/GameplayScreenRotationLocker.cs
+++ b/osu.Android/GameplayScreenRotationLocker.cs
@@ -17,7 +17,7 @@ namespace osu.Android
         private void load(OsuGame game)
         {
             localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
-            localUserPlaying.BindValueChanged(userPlaying => updateLock(userPlaying));
+            localUserPlaying.ValueChanged += updateLock;
         }
 
         private void updateLock(ValueChangedEvent<bool> userPlaying)

--- a/osu.Android/GameplayScreenRotationLocker.cs
+++ b/osu.Android/GameplayScreenRotationLocker.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Android.Content.PM;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game;
+
+namespace osu.Android
+{
+    public class GameplayScreenRotationLocker : Component
+    {
+        private Bindable<bool> localUserPlaying;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGame game)
+        {
+            localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
+            localUserPlaying.BindValueChanged(_ => updateLock());
+        }
+
+        private void updateLock()
+        {
+            OsuGameActivity.Activity.RunOnUiThread(() =>
+            {
+                OsuGameActivity.Activity.RequestedOrientation = localUserPlaying.Value ? ScreenOrientation.Locked : ScreenOrientation.FullUser;
+            });
+        }
+    }
+}

--- a/osu.Android/GameplayScreenRotationLocker.cs
+++ b/osu.Android/GameplayScreenRotationLocker.cs
@@ -20,7 +20,7 @@ namespace osu.Android
         private void load(OsuGame game)
         {
             localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
-            localUserPlaying.ValueChanged += updateLock;
+            localUserPlaying.BindValueChanged(updateLock, true);
         }
 
         private void updateLock(ValueChangedEvent<bool> userPlaying)

--- a/osu.Android/GameplayScreenRotationLocker.cs
+++ b/osu.Android/GameplayScreenRotationLocker.cs
@@ -17,14 +17,14 @@ namespace osu.Android
         private void load(OsuGame game)
         {
             localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
-            localUserPlaying.BindValueChanged(_ => updateLock());
+            localUserPlaying.BindValueChanged(userPlaying => updateLock(userPlaying));
         }
 
-        private void updateLock()
+        private void updateLock(ValueChangedEvent<bool> userPlaying)
         {
             OsuGameActivity.Activity.RunOnUiThread(() =>
             {
-                OsuGameActivity.Activity.RequestedOrientation = localUserPlaying.Value ? ScreenOrientation.Locked : ScreenOrientation.FullUser;
+                OsuGameActivity.Activity.RequestedOrientation = userPlaying.NewValue ? ScreenOrientation.Locked : ScreenOrientation.FullUser;
             });
         }
     }

--- a/osu.Android/GameplayScreenRotationLocker.cs
+++ b/osu.Android/GameplayScreenRotationLocker.cs
@@ -13,6 +13,9 @@ namespace osu.Android
     {
         private Bindable<bool> localUserPlaying;
 
+        [Resolved]
+        private OsuGameActivity gameActivity { get; set; }
+
         [BackgroundDependencyLoader]
         private void load(OsuGame game)
         {
@@ -22,9 +25,9 @@ namespace osu.Android
 
         private void updateLock(ValueChangedEvent<bool> userPlaying)
         {
-            OsuGameActivity.Activity.RunOnUiThread(() =>
+            gameActivity.RunOnUiThread(() =>
             {
-                OsuGameActivity.Activity.RequestedOrientation = userPlaying.NewValue ? ScreenOrientation.Locked : ScreenOrientation.FullUser;
+                gameActivity.RequestedOrientation = userPlaying.NewValue ? ScreenOrientation.Locked : ScreenOrientation.FullUser;
             });
         }
     }

--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -12,7 +12,7 @@ namespace osu.Android
     [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
     public class OsuGameActivity : AndroidGameActivity
     {
-        internal static Activity Activity;
+        internal static Activity Activity { get; private set; }
 
         protected override Framework.Game CreateGame() => new OsuGameAndroid();
 

--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -12,10 +12,14 @@ namespace osu.Android
     [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
     public class OsuGameActivity : AndroidGameActivity
     {
+        internal static Activity Activity;
+
         protected override Framework.Game CreateGame() => new OsuGameAndroid();
 
         protected override void OnCreate(Bundle savedInstanceState)
         {
+            Activity = this;
+
             // The default current directory on android is '/'.
             // On some devices '/' maps to the app data directory. On others it maps to the root of the internal storage.
             // In order to have a consistent current directory on all devices the full path of the app data directory is set as the current directory.

--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -12,14 +12,10 @@ namespace osu.Android
     [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
     public class OsuGameActivity : AndroidGameActivity
     {
-        internal static Activity Activity { get; private set; }
-
-        protected override Framework.Game CreateGame() => new OsuGameAndroid();
+        protected override Framework.Game CreateGame() => new OsuGameAndroid(this);
 
         protected override void OnCreate(Bundle savedInstanceState)
         {
-            Activity = this;
-
             // The default current directory on android is '/'.
             // On some devices '/' maps to the app data directory. On others it maps to the root of the internal storage.
             // In order to have a consistent current directory on all devices the full path of the app data directory is set as the current directory.

--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -55,6 +55,12 @@ namespace osu.Android
             }
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            LoadComponentAsync(new GameplayScreenRotationLocker(), Add);
+        }
+
         protected override UpdateManager CreateUpdateManager() => new SimpleUpdateManager();
     }
 }

--- a/osu.Android/OsuGameAndroid.cs
+++ b/osu.Android/OsuGameAndroid.cs
@@ -4,6 +4,7 @@
 using System;
 using Android.App;
 using Android.OS;
+using osu.Framework.Allocation;
 using osu.Game;
 using osu.Game.Updater;
 
@@ -11,6 +12,15 @@ namespace osu.Android
 {
     public class OsuGameAndroid : OsuGame
     {
+        [Cached]
+        private readonly OsuGameActivity gameActivity;
+
+        public OsuGameAndroid(OsuGameActivity activity)
+            : base(null)
+        {
+            gameActivity = activity;
+        }
+
         public override Version AssemblyVersion
         {
             get

--- a/osu.Android/osu.Android.csproj
+++ b/osu.Android/osu.Android.csproj
@@ -21,6 +21,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GameplayScreenRotationLocker.cs" />
     <Compile Include="OsuGameActivity.cs" />
     <Compile Include="OsuGameAndroid.cs" />
   </ItemGroup>


### PR DESCRIPTION
 # Summary

This adds a `GameplayScreenRotationLocker` component which locks screen rotation on android devices while in gameplay.

Unfortunately, android (same for Xamarin) doesn't expose a nice, non-hackish way to get the current activity from anywhere (which is required to lock the screen rotation) so I had to resort to storing the game activity inside a static field upon startup.

# Testing

No automated testing for this altough from the testing I've done on 3 devices I own, this seems to work fine.