### PR TITLE
Fix osu!catch showing two combo counters for legacy skins

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/CatchLegacySkinTransformer.cs
@@ -13,6 +13,11 @@ namespace osu.Game.Rulesets.Catch.Skinning
 {
     public class CatchLegacySkinTransformer : LegacySkinTransformer
     {
+        /// <summary>
+        /// For simplicity, let's use legacy combo font texture existence as a way to identify legacy skins from default.
+        /// </summary>
+        private bool providesComboCounter => this.HasFont(GetConfig<LegacySetting, string>(LegacySetting.ComboPrefix)?.Value ?? "score");
+
         public CatchLegacySkinTransformer(ISkinSource source)
             : base(source)
         {
@@ -20,6 +25,16 @@ namespace osu.Game.Rulesets.Catch.Skinning
 
         public override Drawable GetDrawableComponent(ISkinComponent component)
         {
+            if (component is HUDSkinComponent hudComponent)
+            {
+                switch (hudComponent.Component)
+                {
+                    case HUDSkinComponents.ComboCounter:
+                        // catch may provide its own combo counter; hide the default.
+                        return providesComboCounter ? Drawable.Empty() : null;
+                }
+            }
+
             if (!(component is CatchSkinComponent catchSkinComponent))
                 return null;
 
@@ -55,10 +70,8 @@ namespace osu.Game.Rulesets.Catch.Skinning
                            this.GetAnimation("fruit-ryuuta", true, true, true);
 
                 case CatchSkinComponents.CatchComboCounter:
-                    var comboFont = GetConfig<LegacySetting, string>(LegacySetting.ComboPrefix)?.Value ?? "score";
 
-                    // For simplicity, let's use legacy combo font texture existence as a way to identify legacy skins from default.
-                    if (this.HasFont(comboFont))
+                    if (providesComboCounter)
                         return new LegacyCatchComboCounter(Source);
 
                     break;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -221,8 +221,12 @@ namespace osu.Game.Screens.Play
                 createGameplayComponents(Beatmap.Value, playableBeatmap)
             });
 
+            // also give the HUD a ruleset container to allow rulesets to potentially override HUD elements (used to disable combo counters etc.)
+            // we may want to limit this in the future to disallow rulesets from outright replacing elements the user expects to be there.
+            var hudRulesetContainer = new SkinProvidingContainer(ruleset.CreateLegacySkinProvider(beatmapSkinProvider, playableBeatmap));
+
             // add the overlay components as a separate step as they proxy some elements from the above underlay/gameplay components.
-            GameplayClockContainer.Add(createOverlayComponents(Beatmap.Value));
+            GameplayClockContainer.Add(hudRulesetContainer.WithChild(createOverlayComponents(Beatmap.Value)));
 
             if (!DrawableRuleset.AllowGameplayOverlays)
             {


### PR DESCRIPTION
Addresses part of #10526