### PR TITLE
Adjust accuracy display to match stable

### DIFF
--- a/osu.Game/Skinning/LegacyAccuracyCounter.cs
+++ b/osu.Game/Skinning/LegacyAccuracyCounter.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Skinning
             Anchor = Anchor.TopRight;
             Origin = Anchor.TopRight;
 
-            Scale = new Vector2(0.75f);
+            Scale = new Vector2(0.6f);
             Margin = new MarginPadding(10);
 
             this.skin = skin;

--- a/osu.Game/Skinning/LegacyScoreCounter.cs
+++ b/osu.Game/Skinning/LegacyScoreCounter.cs
@@ -5,6 +5,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osuTK;
 
 namespace osu.Game.Skinning
 {
@@ -28,6 +29,7 @@ namespace osu.Game.Skinning
             // base class uses int for display, but externally we bind to ScoreProcesssor as a double for now.
             Current.BindValueChanged(v => base.Current.Value = (int)v.NewValue);
 
+            Scale = new Vector2(0.96f);
             Margin = new MarginPadding(10);
         }
 


### PR DESCRIPTION
~Note that in stable score is supposed to be 0.96f, but I'm not adding that because I don't think it's noticeable.~ Updated score too. Someone will complain otherwise.

![image](https://user-images.githubusercontent.com/191335/96242357-58afba80-0fde-11eb-98b2-afcdeb9d40cc.png)
