### PR TITLE
Silence EF warning due to ordinal being unsupported

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -96,12 +96,13 @@ namespace osu.Game.Rulesets
                 context.SaveChanges();
 
                 // add any other modes
+                var existingRulesets = context.RulesetInfo.ToList();
+
                 foreach (var r in instances.Where(r => !(r is ILegacyRuleset)))
                 {
                     // todo: StartsWith can be changed to Equals on 2020-11-08
                     // This is to give users enough time to have their database use new abbreviated info).
-                    // ReSharper disable once StringStartsWithIsCultureSpecific (silences EF warning of ordinal being unsupported)
-                    if (context.RulesetInfo.FirstOrDefault(ri => ri.InstantiationInfo.StartsWith(r.RulesetInfo.InstantiationInfo)) == null)
+                    if (existingRulesets.FirstOrDefault(ri => ri.InstantiationInfo.StartsWith(r.RulesetInfo.InstantiationInfo, StringComparison.Ordinal)) == null)
                         context.RulesetInfo.Add(r.RulesetInfo);
                 }
 

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -100,7 +100,8 @@ namespace osu.Game.Rulesets
                 {
                     // todo: StartsWith can be changed to Equals on 2020-11-08
                     // This is to give users enough time to have their database use new abbreviated info).
-                    if (context.RulesetInfo.FirstOrDefault(ri => ri.InstantiationInfo.StartsWith(r.RulesetInfo.InstantiationInfo, StringComparison.Ordinal)) == null)
+                    // ReSharper disable once StringStartsWithIsCultureSpecific (silences EF warning of ordinal being unsupported)
+                    if (context.RulesetInfo.FirstOrDefault(ri => ri.InstantiationInfo.StartsWith(r.RulesetInfo.InstantiationInfo)) == null)
                         context.RulesetInfo.Add(r.RulesetInfo);
                 }
 


### PR DESCRIPTION
Warning that would trigger every startup. Can probably be removed/reconsidered with Realm.