### PR TITLE
Fix legacy score & combo counter text overflowing outside padding

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableScoreCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableScoreCounter.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
@@ -42,6 +43,12 @@ namespace osu.Game.Tests.Visual.Gameplay
                 foreach (var s in scoreCounters)
                     s.Current.Value += 300;
             });
+        }
+
+        [Test]
+        public void TestVeryLargeScore()
+        {
+            AddStep("set large score", () => scoreCounters.ForEach(counter => counter.Current.Value = 1_00_000_000));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableScoreCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableScoreCounter.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestVeryLargeScore()
         {
-            AddStep("set large score", () => scoreCounters.ForEach(counter => counter.Current.Value = 1_00_000_000));
+            AddStep("set large score", () => scoreCounters.ForEach(counter => counter.Current.Value = 1_000_000_000));
         }
     }
 }

--- a/osu.Game/Skinning/LegacyAccuracyCounter.cs
+++ b/osu.Game/Skinning/LegacyAccuracyCounter.cs
@@ -29,7 +29,9 @@ namespace osu.Game.Skinning
         [Resolved(canBeNull: true)]
         private HUDOverlay hud { get; set; }
 
-        protected sealed override OsuSpriteText CreateSpriteText() => (OsuSpriteText)skin?.GetDrawableComponent(new HUDSkinComponent(HUDSkinComponents.ScoreText));
+        protected sealed override OsuSpriteText CreateSpriteText()
+            => (OsuSpriteText)skin?.GetDrawableComponent(new HUDSkinComponent(HUDSkinComponents.ScoreText))
+                                  ?.With(s => s.Anchor = s.Origin = Anchor.TopRight);
 
         protected override void Update()
         {

--- a/osu.Game/Skinning/LegacyScoreCounter.cs
+++ b/osu.Game/Skinning/LegacyScoreCounter.cs
@@ -33,6 +33,6 @@ namespace osu.Game.Skinning
             Margin = new MarginPadding(10);
         }
 
-        protected sealed override OsuSpriteText CreateSpriteText() => (OsuSpriteText)skin.GetDrawableComponent(new HUDSkinComponent(HUDSkinComponents.ScoreText));
+        protected sealed override OsuSpriteText CreateSpriteText() => ((OsuSpriteText)skin.GetDrawableComponent(new HUDSkinComponent(HUDSkinComponents.ScoreText))).With(s => s.Anchor = s.Origin = Anchor.TopRight);
     }
 }

--- a/osu.Game/Skinning/LegacyScoreCounter.cs
+++ b/osu.Game/Skinning/LegacyScoreCounter.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Skinning
             Margin = new MarginPadding(10);
         }
 
-        protected sealed override OsuSpriteText CreateSpriteText() => ((OsuSpriteText)skin.GetDrawableComponent(new HUDSkinComponent(HUDSkinComponents.ScoreText))).With(s => s.Anchor = s.Origin = Anchor.TopRight);
+        protected sealed override OsuSpriteText CreateSpriteText()
+            => (OsuSpriteText)skin.GetDrawableComponent(new HUDSkinComponent(HUDSkinComponents.ScoreText))
+                                  .With(s => s.Anchor = s.Origin = Anchor.TopRight);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/10536. `LegacyScoreCounter` has `Anchor.TopRight` on `Origin` and `Anchor`. However it's child still has `Anchor.TopLeft` on both properties causing it to jitter violently and its text overflowing outside padding during gameplay.