### PR TITLE
Fix key counter actions displaying out of order

### DIFF
--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -136,7 +136,11 @@ namespace osu.Game.Rulesets.UI
             KeyBindingContainer.Add(receptor);
 
             keyCounter.SetReceptor(receptor);
-            keyCounter.AddRange(KeyBindingContainer.DefaultKeyBindings.Select(b => b.GetAction<T>()).Distinct().Select(b => new KeyCounterAction<T>(b)));
+            keyCounter.AddRange(KeyBindingContainer.DefaultKeyBindings
+                                                   .Select(b => b.GetAction<T>())
+                                                   .Distinct()
+                                                   .OrderBy(action => action)
+                                                   .Select(action => new KeyCounterAction<T>(action)));
         }
 
         public class ActionReceptor : KeyCounterDisplay.Receptor, IKeyBindingHandler<T>


### PR DESCRIPTION
Resolves #10545.

# Summary

In taiko, the key counter actions appeared out of order, because `RulesetInputManager` (which is responsible for attaching the ruleset to the key counter) used the order of `Ruleset.GetDefaultKeyBindings`:

https://github.com/ppy/osu/blob/daa0a05d9e95ffd0a9994e5da027cbd502a84793/osu.Game.Rulesets.Taiko/TaikoRuleset.cs#L48-L56

To resolve, add an explicit sort by the action enum value.

# Remarks

Ideally I'd fix this by overriding `Compare(Drawable, Drawable)` in the `KeyCounterDisplay` itself, but the code for that would be super finicky, because `KeyCounterDisplay` is not generic while `KeyCounterAction` is, and there are more implementations of `KeyCounter` so such code would be really unpleasant to read (need to match instantiated generics...) and probably not worth the effort.

I also tried specifying `Depth` but that doesn't work either, as the key counters are in a fill flow, and `FlowingChildren` [ignores depth](https://github.com/ppy/osu-framework/blob/950220701e7e3c5f7783cc2d382c3cef308b759b/osu.Framework/Graphics/Containers/FlowContainer.cs#L152-L155)...

No tests because this is unlikely to break and they would be finicky and long. Will add on request.