### PR TITLE
Fix incorrect zero padding for classic scoring mode

### DIFF
--- a/osu.Game/Graphics/UserInterface/RollingCounter.cs
+++ b/osu.Game/Graphics/UserInterface/RollingCounter.cs
@@ -56,8 +56,7 @@ namespace osu.Game.Graphics.UserInterface
                     return;
 
                 displayedCount = value;
-                if (displayedCountSpriteText != null)
-                    displayedCountSpriteText.Text = FormatCount(value);
+                UpdateDisplay();
             }
         }
 
@@ -73,8 +72,15 @@ namespace osu.Game.Graphics.UserInterface
         private void load()
         {
             displayedCountSpriteText = CreateSpriteText();
-            displayedCountSpriteText.Text = FormatCount(DisplayedCount);
+
+            UpdateDisplay();
             Child = displayedCountSpriteText;
+        }
+
+        protected void UpdateDisplay()
+        {
+            if (displayedCountSpriteText != null)
+                displayedCountSpriteText.Text = FormatCount(DisplayedCount);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterface/ScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/ScoreCounter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Play.HUD;
@@ -17,20 +18,19 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         public bool UseCommaSeparator { get; }
 
-        /// <summary>
-        /// How many leading zeroes the counter has.
-        /// </summary>
-        public uint LeadingZeroes { get; }
+        public Bindable<int> RequiredDisplayDigits { get; } = new Bindable<int>();
 
         /// <summary>
         /// Displays score.
         /// </summary>
         /// <param name="leading">How many leading zeroes the counter will have.</param>
         /// <param name="useCommaSeparator">Whether comma separators should be displayed.</param>
-        protected ScoreCounter(uint leading = 0, bool useCommaSeparator = false)
+        protected ScoreCounter(int leading = 0, bool useCommaSeparator = false)
         {
             UseCommaSeparator = useCommaSeparator;
-            LeadingZeroes = leading;
+
+            RequiredDisplayDigits.Value = leading;
+            RequiredDisplayDigits.BindValueChanged(_ => UpdateDisplay());
         }
 
         protected override double GetProportionalDuration(double currentValue, double newValue)
@@ -40,7 +40,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override string FormatCount(double count)
         {
-            string format = new string('0', (int)LeadingZeroes);
+            string format = new string('0', RequiredDisplayDigits.Value);
 
             if (UseCommaSeparator)
             {

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -76,7 +76,8 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 new SettingsEnumDropdown<ScoringMode>
                 {
                     LabelText = "Score display mode",
-                    Current = config.GetBindable<ScoringMode>(OsuSetting.ScoreDisplayMode)
+                    Current = config.GetBindable<ScoringMode>(OsuSetting.ScoreDisplayMode),
+                    Keywords = new[] { "scoring" }
                 }
             };
 

--- a/osu.Game/Screens/Play/HUD/IScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/IScoreCounter.cs
@@ -15,5 +15,11 @@ namespace osu.Game.Screens.Play.HUD
         /// The current score to be displayed.
         /// </summary>
         Bindable<double> Current { get; }
+
+        /// <summary>
+        /// The number of digits required to display most sane scores.
+        /// This may be exceeded in very rare cases, but is useful to pad or space the display to avoid it jumping around.
+        /// </summary>
+        Bindable<int> RequiredDisplayDigits { get; }
     }
 }

--- a/osu.Game/Screens/Play/HUD/SkinnableScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/SkinnableScoreCounter.cs
@@ -1,7 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play.HUD
@@ -10,10 +14,36 @@ namespace osu.Game.Screens.Play.HUD
     {
         public Bindable<double> Current { get; } = new Bindable<double>();
 
+        private Bindable<ScoringMode> scoreDisplayMode;
+
+        public Bindable<int> RequiredDisplayDigits { get; } = new Bindable<int>();
+
         public SkinnableScoreCounter()
             : base(new HUDSkinComponent(HUDSkinComponents.ScoreCounter), _ => new DefaultScoreCounter())
         {
             CentreComponent = false;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            scoreDisplayMode = config.GetBindable<ScoringMode>(OsuSetting.ScoreDisplayMode);
+            scoreDisplayMode.BindValueChanged(scoreMode =>
+            {
+                switch (scoreMode.NewValue)
+                {
+                    case ScoringMode.Standardised:
+                        RequiredDisplayDigits.Value = 6;
+                        break;
+
+                    case ScoringMode.Classic:
+                        RequiredDisplayDigits.Value = 8;
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(scoreMode));
+                }
+            }, true);
         }
 
         private IScoreCounter skinnedCounter;
@@ -23,7 +53,9 @@ namespace osu.Game.Screens.Play.HUD
             base.SkinChanged(skin, allowFallback);
 
             skinnedCounter = Drawable as IScoreCounter;
+
             skinnedCounter?.Current.BindTo(Current);
+            skinnedCounter?.RequiredDisplayDigits.BindTo(RequiredDisplayDigits);
         }
     }
 }


### PR DESCRIPTION
Fix score displays using non-matching zero padding depending on user score display mode.

- Also adds "scoring" as keyword to more easily find score display mode setting.
- Closes #10535