### PR TITLE
Remove rolling delay on default combo counter

### DIFF
--- a/osu.Game/Screens/Play/HUD/DefaultComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultComboCounter.cs
@@ -15,8 +15,6 @@ namespace osu.Game.Screens.Play.HUD
     {
         private readonly Vector2 offset = new Vector2(20, 5);
 
-        protected override double RollingDuration => 750;
-
         [Resolved(canBeNull: true)]
         private HUDOverlay hud { get; set; }
 


### PR DESCRIPTION
It's not doing any rolling, so this just visually delays the combo increment for no reason.

Closes #10544