### PR TITLE
Fix ISourcedFromTouch events being blocked by LoadingLayer

### DIFF
--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Graphics.UserInterface
                     return false;
 
                 // blocking touch events causes the ISourcedFromTouch versions to not be fired, potentially impeding behaviour of drawables *above* the loading layer that may utilise these.
-                // note that this will not work well if touch handling elements are beneath the this loading layer (something to consider for the future).
+                // note that this will not work well if touch handling elements are beneath this loading layer (something to consider for the future).
                 case TouchEvent _:
                     return false;
             }

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -44,6 +44,11 @@ namespace osu.Game.Graphics.UserInterface
                 // blocking scroll can cause weird behaviour when this layer is used within a ScrollContainer.
                 case ScrollEvent _:
                     return false;
+
+                // blocking touch events causes the ISourcedFromTouch versions to not be fired, potentially impeding behaviour of drawables *above* the loading layer that may utilise these.
+                // note that this will not work well if touch handling elements are beneath the this loading layer (something to consider for the future).
+                case TouchEvent _:
+                    return false;
             }
 
             return true;


### PR DESCRIPTION
Noticed this on iOS (log out -> details at song select behind settings overlay). Blocking until I can test on hardware (seems to be correct in simulator, but fps is so low I want to make certain).

Open to suggestions for a better method of providing this behaviour.

