### PR TITLE
Make beatmap wedge difficulty indicators update dynamically

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
@@ -18,13 +18,13 @@ namespace osu.Game.Tests.Visual.Ranking
                 Origin = Anchor.Centre,
                 Children = new Drawable[]
                 {
-                    new StarRatingDisplay(new BeatmapInfo { StarDifficulty = 1.23 }),
-                    new StarRatingDisplay(new BeatmapInfo { StarDifficulty = 2.34 }),
-                    new StarRatingDisplay(new BeatmapInfo { StarDifficulty = 3.45 }),
-                    new StarRatingDisplay(new BeatmapInfo { StarDifficulty = 4.56 }),
-                    new StarRatingDisplay(new BeatmapInfo { StarDifficulty = 5.67 }),
-                    new StarRatingDisplay(new BeatmapInfo { StarDifficulty = 6.78 }),
-                    new StarRatingDisplay(new BeatmapInfo { StarDifficulty = 10.11 }),
+                    new StarRatingDisplay(new StarDifficulty(1.23, 0)),
+                    new StarRatingDisplay(new StarDifficulty(2.34, 0)),
+                    new StarRatingDisplay(new StarDifficulty(3.45, 0)),
+                    new StarRatingDisplay(new StarDifficulty(4.56, 0)),
+                    new StarRatingDisplay(new StarDifficulty(5.67, 0)),
+                    new StarRatingDisplay(new StarDifficulty(6.78, 0)),
+                    new StarRatingDisplay(new StarDifficulty(10.11, 0)),
                 }
             };
         }

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -51,7 +52,7 @@ namespace osu.Game.Screens.Ranking.Expanded
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(BeatmapDifficultyManager beatmapDifficultyManager)
         {
             var beatmap = score.Beatmap;
             var metadata = beatmap.BeatmapSet?.Metadata ?? beatmap.Metadata;
@@ -138,7 +139,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                     Spacing = new Vector2(5, 0),
                                     Children = new Drawable[]
                                     {
-                                        new StarRatingDisplay(beatmap)
+                                        new StarRatingDisplay(beatmapDifficultyManager.GetDifficulty(beatmap, score.Ruleset, score.Mods))
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft

--- a/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
@@ -22,18 +22,7 @@ namespace osu.Game.Screens.Ranking.Expanded
     /// </summary>
     public class StarRatingDisplay : CompositeDrawable
     {
-        private readonly BeatmapInfo beatmap;
-
-        private StarDifficulty? difficulty;
-
-        /// <summary>
-        /// Creates a new <see cref="StarRatingDisplay"/>.
-        /// </summary>
-        /// <param name="beatmap">The <see cref="BeatmapInfo"/> to display the star difficulty of.</param>
-        public StarRatingDisplay(BeatmapInfo beatmap)
-        {
-            this.beatmap = beatmap;
-        }
+        private readonly StarDifficulty difficulty;
 
         /// <summary>
         /// Creates a new <see cref="StarRatingDisplay"/> using an already computed <see cref="StarDifficulty"/>.
@@ -49,17 +38,14 @@ namespace osu.Game.Screens.Ranking.Expanded
         {
             AutoSizeAxes = Axes.Both;
 
-            if (!difficulty.HasValue)
-                difficulty = difficultyManager.GetDifficulty(beatmap);
-
-            var starRatingParts = difficulty.Value.Stars.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
+            var starRatingParts = difficulty.Stars.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
             string wholePart = starRatingParts[0];
             string fractionPart = starRatingParts[1];
             string separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
-            ColourInfo backgroundColour = difficulty.Value.DifficultyRating == DifficultyRating.ExpertPlus
+            ColourInfo backgroundColour = difficulty.DifficultyRating == DifficultyRating.ExpertPlus
                 ? ColourInfo.GradientVertical(Color4Extensions.FromHex("#C1C1C1"), Color4Extensions.FromHex("#595959"))
-                : (ColourInfo)colours.ForDifficultyRating(difficulty.Value.DifficultyRating);
+                : (ColourInfo)colours.ForDifficultyRating(difficulty.DifficultyRating);
 
             InternalChildren = new Drawable[]
             {

--- a/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Screens.Ranking.Expanded
     {
         private readonly BeatmapInfo beatmap;
 
+        private StarDifficulty? difficulty;
+
         /// <summary>
         /// Creates a new <see cref="StarRatingDisplay"/>.
         /// </summary>
@@ -31,20 +33,33 @@ namespace osu.Game.Screens.Ranking.Expanded
         public StarRatingDisplay(BeatmapInfo beatmap)
         {
             this.beatmap = beatmap;
-            AutoSizeAxes = Axes.Both;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="StarRatingDisplay"/> using an already computed <see cref="StarDifficulty"/>.
+        /// </summary>
+        /// <param name="starDifficulty">The already computed <see cref="StarDifficulty"/> to display the star difficulty of.</param>
+        public StarRatingDisplay(StarDifficulty starDifficulty)
+        {
+            difficulty = starDifficulty;
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, BeatmapDifficultyManager difficultyManager)
         {
-            var starRatingParts = beatmap.StarDifficulty.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
+            AutoSizeAxes = Axes.Both;
+
+            if (!difficulty.HasValue)
+                difficulty = difficultyManager.GetDifficulty(beatmap);
+
+            var starRatingParts = difficulty.Value.Stars.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
             string wholePart = starRatingParts[0];
             string fractionPart = starRatingParts[1];
             string separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
-            ColourInfo backgroundColour = beatmap.DifficultyRating == DifficultyRating.ExpertPlus
+            ColourInfo backgroundColour = difficulty.Value.DifficultyRating == DifficultyRating.ExpertPlus
                 ? ColourInfo.GradientVertical(Color4Extensions.FromHex("#C1C1C1"), Color4Extensions.FromHex("#595959"))
-                : (ColourInfo)colours.ForDifficultyRating(beatmap.DifficultyRating);
+                : (ColourInfo)colours.ForDifficultyRating(difficulty.Value.DifficultyRating);
 
             InternalChildren = new Drawable[]
             {

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -238,7 +238,7 @@ namespace osu.Game.Screens.Select
                         Shear = wedged_container_shear,
                         Children = new[]
                         {
-                            createStarRatingDisplay(beatmapInfo).With(display =>
+                            createStarRatingDisplay(starDifficulty).With(display =>
                             {
                                 display.Anchor = Anchor.TopRight;
                                 display.Origin = Anchor.TopRight;
@@ -305,8 +305,8 @@ namespace osu.Game.Screens.Select
                     StatusPill.Hide();
             }
 
-            private static Drawable createStarRatingDisplay(BeatmapInfo beatmapInfo) => beatmapInfo.StarDifficulty > 0
-                ? new StarRatingDisplay(beatmapInfo)
+            private static Drawable createStarRatingDisplay(StarDifficulty difficulty) => difficulty.Stars > 0
+                ? new StarRatingDisplay(difficulty)
                 {
                     Margin = new MarginPadding { Bottom = 5 }
                 }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Screens.Select
 
         private readonly IBindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
 
+        [Resolved]
+        private BeatmapDifficultyManager difficultyManager { get; set; }
+
+        private IBindable<StarDifficulty> beatmapDifficulty;
+
         protected BufferedWedgeInfo Info;
 
         public BeatmapInfoWedge()
@@ -88,6 +93,11 @@ namespace osu.Game.Screens.Select
                 if (beatmap == value) return;
 
                 beatmap = value;
+
+                beatmapDifficulty?.UnbindAll();
+                beatmapDifficulty = difficultyManager.GetBindableDifficulty(beatmap.BeatmapInfo);
+                beatmapDifficulty.BindValueChanged(_ => updateDisplay());
+
                 updateDisplay();
             }
         }
@@ -113,7 +123,7 @@ namespace osu.Game.Screens.Select
                 return;
             }
 
-            LoadComponentAsync(loadingInfo = new BufferedWedgeInfo(beatmap, ruleset.Value)
+            LoadComponentAsync(loadingInfo = new BufferedWedgeInfo(beatmap, ruleset.Value, beatmapDifficulty.Value)
             {
                 Shear = -Shear,
                 Depth = Info?.Depth + 1 ?? 0
@@ -141,12 +151,14 @@ namespace osu.Game.Screens.Select
 
             private readonly WorkingBeatmap beatmap;
             private readonly RulesetInfo ruleset;
+            private readonly StarDifficulty starDifficulty;
 
-            public BufferedWedgeInfo(WorkingBeatmap beatmap, RulesetInfo userRuleset)
+            public BufferedWedgeInfo(WorkingBeatmap beatmap, RulesetInfo userRuleset, StarDifficulty difficulty)
                 : base(pixelSnapping: true)
             {
                 this.beatmap = beatmap;
                 ruleset = userRuleset ?? beatmap.BeatmapInfo.Ruleset;
+                starDifficulty = difficulty;
             }
 
             [BackgroundDependencyLoader]
@@ -190,7 +202,7 @@ namespace osu.Game.Screens.Select
                             },
                         },
                     },
-                    new DifficultyColourBar(beatmapInfo)
+                    new DifficultyColourBar(starDifficulty)
                     {
                         RelativeSizeAxes = Axes.Y,
                         Width = 20,
@@ -447,11 +459,11 @@ namespace osu.Game.Screens.Select
 
             private class DifficultyColourBar : Container
             {
-                private readonly BeatmapInfo beatmap;
+                private readonly StarDifficulty difficulty;
 
-                public DifficultyColourBar(BeatmapInfo beatmap)
+                public DifficultyColourBar(StarDifficulty difficulty)
                 {
-                    this.beatmap = beatmap;
+                    this.difficulty = difficulty;
                 }
 
                 [BackgroundDependencyLoader]
@@ -459,7 +471,7 @@ namespace osu.Game.Screens.Select
                 {
                     const float full_opacity_ratio = 0.7f;
 
-                    var difficultyColour = colours.ForDifficultyRating(beatmap.DifficultyRating);
+                    var difficultyColour = colours.ForDifficultyRating(difficulty.DifficultyRating);
 
                     Children = new Drawable[]
                     {


### PR DESCRIPTION
# Summary

This makes the beatmap wedge difficulty indicators on song select update dynamically according to the currently selected mods.

Note that this is calling `updateDisplay()` when the star rating changes instead of calling `ForceRedraw()` for aesthethic reasons:

 `updateDisplay()` adds a slight visual transition making the change more pleasant visually whereas the change of color / star rating on difficulty indicators when just calling `ForceRedraw()` looks very crude. 

## Visual Demo
https://streamable.com/j2k5ye