### PR TITLE
Fix a potential null reference when loading carousel difficulties

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Screens.Select.Carousel
                 LoadComponentAsync(beatmapContainer, loaded =>
                 {
                     // make sure the pooled target hasn't changed.
-                    if (carouselBeatmapSet != Item)
+                    if (beatmapContainer != loaded)
                         return;
 
                     Content.Child = loaded;


### PR DESCRIPTION
As reported on discord:

```csharp
System.NullReferenceException: Object reference not set to an instance of an object.
   at osu.Game.Screens.Select.Carousel.DrawableCarouselBeatmapSet.<>c__DisplayClass29_0.<updateBeatmapDifficulties>g__updateBeatmapYPositions|2() in /home/dachb/Dokumenty/opensource/osu/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs:line 155
   at osu.Game.Screens.Select.Carousel.DrawableCarouselBeatmapSet.<>c__DisplayClass29_0.<updateBeatmapDifficulties>b__1(Container`1 loaded) in /home/dachb/Dokumenty/opensource/osu/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs:line 147
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c__DisplayClass15_0`1.<LoadComponentAsync>b__0(IEnumerable`1 l)
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c__DisplayClass17_2`1.<LoadComponentsAsync>b__4()
```

We were checking the item hasn't changed, but this doesn't necessarily cover all scenarios (ie. if a change happened twice and the original item returned, but the container may be in a different state). Replacing with a direct comparison on the loaded drawable avoids the above and other potential issues.