### PR TITLE
Hide sliderend & repeat circles in traceable mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -39,10 +39,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected void ApplyTraceableState(DrawableHitObject drawable, ArmedState state)
         {
-            if (!(drawable is DrawableOsuHitObject drawableOsu))
+            if (!(drawable is DrawableOsuHitObject))
                 return;
-
-            var h = drawableOsu.HitObject;
 
             //todo: expose and hide spinner background somehow
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using System.Collections.Generic;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -49,9 +50,16 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 case DrawableHitCircle circle:
                     // we only want to see the approach circle
-                    using (circle.BeginAbsoluteSequence(h.StartTime - h.TimePreempt, true))
-                        circle.CirclePiece.Hide();
+                    applyCirclePieceState(circle, circle.CirclePiece);
+                    break;
 
+                case DrawableSliderTail sliderTail:
+                    applyCirclePieceState(sliderTail);
+                    break;
+
+                case DrawableSliderRepeat sliderRepeat:
+                    // show only the repeat arrow
+                    applyCirclePieceState(sliderRepeat, sliderRepeat.CirclePiece);
                     break;
 
                 case DrawableSlider slider:
@@ -59,6 +67,13 @@ namespace osu.Game.Rulesets.Osu.Mods
                     applySliderState(slider);
                     break;
             }
+        }
+
+        private void applyCirclePieceState(DrawableOsuHitObject hitObject, IDrawable hitCircle = null)
+        {
+            var h = hitObject.HitObject;
+            using (hitObject.BeginAbsoluteSequence(h.StartTime - h.TimePreempt, true))
+                (hitCircle ?? hitObject).Hide();
         }
 
         private void applySliderState(DrawableSlider slider)


### PR DESCRIPTION
Resolves #10479.

Not much to write about. Existing resolution for hit circles extended to sliderends & repeats.

Testing is sort of dicey as we don't have mod tests with custom skins yet. Can be tested on classic skin, though. [Video preview of change.](https://drive.google.com/file/d/1Cu6YBZmoxgddcG8jB16-rpqj0hiEOV6G/view?usp=sharing)