### PR TITLE
Add support for deleting objects when Shift is held down

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -107,14 +107,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 case MouseButton.Right:
                     rightClickPosition = e.MouseDownPosition;
-                    return false; // Allow right click to be handled by context menu
+                    break;
 
                 case MouseButton.Left when e.ControlPressed && IsSelected:
                     placementControlPointIndex = addControlPoint(e.MousePosition);
                     return true; // Stop input from being handled and modifying the selection
             }
 
-            return false;
+            return base.OnMouseDown(e);
         }
 
         private int? placementControlPointIndex;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -107,14 +107,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 case MouseButton.Right:
                     rightClickPosition = e.MouseDownPosition;
-                    break;
+                    return false; // Allow right click to be handled by context menu
 
                 case MouseButton.Left when e.ControlPressed && IsSelected:
                     placementControlPointIndex = addControlPoint(e.MousePosition);
                     return true; // Stop input from being handled and modifying the selection
             }
 
-            return base.OnMouseDown(e);
+            return false;
         }
 
         private int? placementControlPointIndex;

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -120,6 +120,11 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         public void Deselect() => State = SelectionState.NotSelected;
 
+        /// <summary>
+        /// Toggles the selection state of this <see cref="OverlaySelectionBlueprint"/>.
+        /// </summary>
+        public void ToggleSelection() => State = IsSelected ? SelectionState.NotSelected : SelectionState.Selected;
+
         public bool IsSelected => State == SelectionState.Selected;
 
         /// <summary>

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -8,13 +8,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Screens.Edit;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -53,20 +50,6 @@ namespace osu.Game.Rulesets.Edit
         {
             base.LoadComplete();
             updateState();
-        }
-
-        [Resolved]
-        private EditorBeatmap editorBeatmap { get; set; }
-
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            if (e.CurrentState.Keyboard.ShiftPressed && e.IsPressed(MouseButton.Right))
-            {
-                editorBeatmap.Remove(HitObject);
-                return true;
-            }
-
-            return base.OnMouseDown(e);
         }
 
         private SelectionState state;

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -8,10 +8,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Screens.Edit;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -50,6 +53,20 @@ namespace osu.Game.Rulesets.Edit
         {
             base.LoadComplete();
             updateState();
+        }
+
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (e.CurrentState.Keyboard.ShiftPressed && e.IsPressed(MouseButton.Right))
+            {
+                editorBeatmap.Remove(HitObject);
+                return true;
+            }
+
+            return base.OnMouseDown(e);
         }
 
         private SelectionState state;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -298,13 +298,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             Debug.Assert(!clickSelectionBegan);
 
-            // Deselections are only allowed for control + left clicks
-            bool allowDeselection = e.ControlPressed && e.Button == MouseButton.Left;
-
-            // Todo: This is probably incorrectly disallowing multiple selections on stacked objects
-            if (!allowDeselection && SelectionHandler.SelectedBlueprints.Any(s => s.IsHovered))
-                return;
-
             foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
             {
                 if (blueprint.IsHovered)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -225,9 +225,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="state">The input state at the point of selection.</param>
         internal void HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
         {
-            if (state.Keyboard.ShiftPressed && state.Mouse.IsPressed(MouseButton.Right))
-                EditorBeatmap.Remove(blueprint.HitObject);
-            else if (state.Keyboard.ControlPressed)
+            if (state.Keyboard.ControlPressed)
                 blueprint.ToggleSelection();
             else
                 ensureSelected(blueprint);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -24,6 +24,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -224,7 +225,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="state">The input state at the point of selection.</param>
         internal void HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
         {
-            if (state.Keyboard.ControlPressed)
+            if (state.Keyboard.ShiftPressed && state.Mouse.IsPressed(MouseButton.Right))
+                EditorBeatmap.Remove(blueprint.HitObject);
+            else if (state.Keyboard.ControlPressed && state.Mouse.IsPressed(MouseButton.Left))
                 blueprint.ToggleSelection();
             else
                 ensureSelected(blueprint);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -24,7 +24,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -226,11 +226,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="state">The input state at the point of selection.</param>
         internal void HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
         {
-            shiftClickDeleteCheck(blueprint, state);
-            multiSelectionHandler(blueprint, state);
+            if (!shiftClickDeleteCheck(blueprint, state))
+                handleMultiSelection(blueprint, state);
         }
 
-        private void multiSelectionHandler(SelectionBlueprint blueprint, InputState state)
+        private void handleMultiSelection(SelectionBlueprint blueprint, InputState state)
         {
             if (state.Keyboard.ControlPressed)
             {
@@ -249,13 +249,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private void shiftClickDeleteCheck(SelectionBlueprint blueprint, InputState state)
+        private bool shiftClickDeleteCheck(SelectionBlueprint blueprint, InputState state)
         {
             if (state.Keyboard.ShiftPressed && state.Mouse.IsPressed(MouseButton.Right))
             {
                 EditorBeatmap.Remove(blueprint.HitObject);
-                return;
+                return true;
             }
+            return false;
         }
 
         private void deleteSelected()

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -14,7 +14,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Game.Audio;
 using osu.Game.Graphics;
@@ -226,37 +225,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="state">The input state at the point of selection.</param>
         internal void HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
         {
-            if (!shiftClickDeleteCheck(blueprint, state))
-                handleMultiSelection(blueprint, state);
-        }
-
-        private void handleMultiSelection(SelectionBlueprint blueprint, InputState state)
-        {
-            if (state.Keyboard.ControlPressed)
-            {
-                if (blueprint.IsSelected)
-                    blueprint.Deselect();
-                else
-                    blueprint.Select();
-            }
-            else
-            {
-                if (blueprint.IsSelected)
-                    return;
-
-                DeselectAll?.Invoke();
-                blueprint.Select();
-            }
-        }
-
-        private bool shiftClickDeleteCheck(SelectionBlueprint blueprint, InputState state)
-        {
             if (state.Keyboard.ShiftPressed && state.Mouse.IsPressed(MouseButton.Right))
-            {
                 EditorBeatmap.Remove(blueprint.HitObject);
-                return true;
-            }
-            return false;
+            else if (state.Keyboard.ControlPressed)
+                blueprint.ToggleSelection();
+            else
+                ensureSelected(blueprint);
+        }
+
+        private void ensureSelected(SelectionBlueprint blueprint)
+        {
+            if (blueprint.IsSelected)
+                return;
+
+            DeselectAll?.Invoke();
+            blueprint.Select();
         }
 
         private void deleteSelected()

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -25,6 +25,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
@@ -33,7 +34,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// </summary>
     public class SelectionHandler : CompositeDrawable, IKeyBindingHandler<PlatformAction>, IHasContextMenu
     {
-        private bool shiftPressed;
 
         public IEnumerable<SelectionBlueprint> SelectedBlueprints => selectedBlueprints;
         private readonly List<SelectionBlueprint> selectedBlueprints;
@@ -167,17 +167,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether any <see cref="DrawableHitObject"/>s could be reversed.</returns>
         public virtual bool HandleReverse() => false;
 
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            shiftPressed = e.ShiftPressed;
-            return false;
-        }
-
-        protected override void OnKeyUp(KeyUpEvent e)
-        {
-            shiftPressed = e.ShiftPressed;
-        }
-
         public bool OnPressed(PlatformAction action)
         {
             switch (action.ActionMethod)
@@ -238,6 +227,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="state">The input state at the point of selection.</param>
         internal void HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
         {
+            shiftClickDeleteCheck(blueprint, state);
+            multiSelectionHandler(blueprint, state);
+
+        }
+
+        private void multiSelectionHandler(SelectionBlueprint blueprint, InputState state)
+        {
             if (state.Keyboard.ControlPressed)
             {
                 if (blueprint.IsSelected)
@@ -252,6 +248,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                 DeselectAll?.Invoke();
                 blueprint.Select();
+            }
+        }
+
+        private void shiftClickDeleteCheck(SelectionBlueprint blueprint, InputState state)
+        {
+            if (state.Keyboard.ShiftPressed && state.Mouse.IsPressed(MouseButton.Right))
+            {
+                EditorBeatmap.Remove(blueprint.HitObject);
+                return;
             }
         }
 
@@ -469,12 +474,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             get
             {
-                if (shiftPressed)
-                {
-                    deleteSelected();
-                    return null;
-                }
-
                 if (!selectedBlueprints.Any(b => b.IsHovered))
                     return Array.Empty<MenuItem>();
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Game.Audio;
 using osu.Game.Graphics;
@@ -32,6 +33,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// </summary>
     public class SelectionHandler : CompositeDrawable, IKeyBindingHandler<PlatformAction>, IHasContextMenu
     {
+        private bool shiftPressed;
+
         public IEnumerable<SelectionBlueprint> SelectedBlueprints => selectedBlueprints;
         private readonly List<SelectionBlueprint> selectedBlueprints;
 
@@ -163,6 +166,17 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <returns>Whether any <see cref="DrawableHitObject"/>s could be reversed.</returns>
         public virtual bool HandleReverse() => false;
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            shiftPressed = e.ShiftPressed;
+            return false;
+        }
+
+        protected override void OnKeyUp(KeyUpEvent e)
+        {
+            shiftPressed = e.ShiftPressed;
+        }
 
         public bool OnPressed(PlatformAction action)
         {
@@ -455,6 +469,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             get
             {
+                if (shiftPressed)
+                {
+                    deleteSelected();
+                    return null;
+                }
+
                 if (!selectedBlueprints.Any(b => b.IsHovered))
                     return Array.Empty<MenuItem>();
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -34,7 +34,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// </summary>
     public class SelectionHandler : CompositeDrawable, IKeyBindingHandler<PlatformAction>, IHasContextMenu
     {
-
         public IEnumerable<SelectionBlueprint> SelectedBlueprints => selectedBlueprints;
         private readonly List<SelectionBlueprint> selectedBlueprints;
 
@@ -229,7 +228,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             shiftClickDeleteCheck(blueprint, state);
             multiSelectionHandler(blueprint, state);
-
         }
 
         private void multiSelectionHandler(SelectionBlueprint blueprint, InputState state)


### PR DESCRIPTION
This fixes #10485

When a circle is right clicked in the editor while shift is pressed, the circle is deleted. I added a function to SelectionHandler.cs to solve this.