### PR TITLE
Fix mania crashing due to spectator client handling frames with unconverted beatmap

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -12,11 +13,13 @@ using osu.Framework.Input.Events;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Testing;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual.UserInterface;
 using osuTK;
 using osuTK.Graphics;
@@ -32,6 +35,9 @@ namespace osu.Game.Tests.Visual.Gameplay
         private Replay replay;
 
         private TestReplayRecorder recorder;
+
+        [Cached]
+        private GameplayBeatmap gameplayBeatmap = new GameplayBeatmap(new Beatmap());
 
         [SetUp]
         public void SetUp() => Schedule(() =>

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecording.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecording.cs
@@ -2,17 +2,20 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.StateChanges;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual.UserInterface;
 using osuTK;
 using osuTK.Graphics;
@@ -24,6 +27,9 @@ namespace osu.Game.Tests.Visual.Gameplay
         private readonly TestRulesetInputManager playbackManager;
 
         private readonly TestRulesetInputManager recordingManager;
+
+        [Cached]
+        private GameplayBeatmap gameplayBeatmap = new GameplayBeatmap(new Beatmap());
 
         public TestSceneReplayRecording()
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
@@ -27,6 +27,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual.UserInterface;
 using osuTK;
 using osuTK.Graphics;
@@ -57,6 +58,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Resolved]
         private SpectatorStreamingClient streamingClient { get; set; }
+
+        [Cached]
+        private GameplayBeatmap gameplayBeatmap = new GameplayBeatmap(new Beatmap());
 
         [SetUp]
         public void SetUp() => Schedule(() =>

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -19,6 +20,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Online.Spectator
 {
@@ -44,8 +46,8 @@ namespace osu.Game.Online.Spectator
         [Resolved]
         private IAPIProvider api { get; set; }
 
-        [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; }
+        [CanBeNull]
+        private IBeatmap currentBeatmap;
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; }
@@ -167,7 +169,7 @@ namespace osu.Game.Online.Spectator
             return Task.CompletedTask;
         }
 
-        public void BeginPlaying()
+        public void BeginPlaying(GameplayBeatmap beatmap)
         {
             if (isPlaying)
                 throw new InvalidOperationException($"Cannot invoke {nameof(BeginPlaying)} when already playing");
@@ -175,10 +177,11 @@ namespace osu.Game.Online.Spectator
             isPlaying = true;
 
             // transfer state at point of beginning play
-            currentState.BeatmapID = beatmap.Value.BeatmapInfo.OnlineBeatmapID;
+            currentState.BeatmapID = beatmap.BeatmapInfo.OnlineBeatmapID;
             currentState.RulesetID = ruleset.Value.ID;
             currentState.Mods = mods.Value.Select(m => new APIMod(m));
 
+            currentBeatmap = beatmap.PlayableBeatmap;
             beginPlaying();
         }
 
@@ -201,6 +204,7 @@ namespace osu.Game.Online.Spectator
         public void EndPlaying()
         {
             isPlaying = false;
+            currentBeatmap = null;
 
             if (!isConnected) return;
 
@@ -247,7 +251,7 @@ namespace osu.Game.Online.Spectator
         public void HandleFrame(ReplayFrame frame)
         {
             if (frame is IConvertibleReplayFrame convertible)
-                pendingFrames.Enqueue(convertible.ToLegacy(beatmap.Value.Beatmap));
+                pendingFrames.Enqueue(convertible.ToLegacy(currentBeatmap));
 
             if (pendingFrames.Count > max_pending_frames)
                 purgePendingFrames();

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -50,10 +50,10 @@ namespace osu.Game.Online.Spectator
         private IBeatmap currentBeatmap;
 
         [Resolved]
-        private IBindable<RulesetInfo> ruleset { get; set; }
+        private IBindable<RulesetInfo> currentRuleset { get; set; }
 
         [Resolved]
-        private IBindable<IReadOnlyList<Mod>> mods { get; set; }
+        private IBindable<IReadOnlyList<Mod>> currentMods { get; set; }
 
         private readonly SpectatorState currentState = new SpectatorState();
 
@@ -178,8 +178,8 @@ namespace osu.Game.Online.Spectator
 
             // transfer state at point of beginning play
             currentState.BeatmapID = beatmap.BeatmapInfo.OnlineBeatmapID;
-            currentState.RulesetID = ruleset.Value.ID;
-            currentState.Mods = mods.Value.Select(m => new APIMod(m));
+            currentState.RulesetID = currentRuleset.Value.ID;
+            currentState.Mods = currentMods.Value.Select(m => new APIMod(m));
 
             currentBeatmap = beatmap.PlayableBeatmap;
             beginPlaying();

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -5,15 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Screens.Play;
 using osuTK;
 
 namespace osu.Game.Rulesets.UI
@@ -33,7 +32,7 @@ namespace osu.Game.Rulesets.UI
         private SpectatorStreamingClient spectatorStreaming { get; set; }
 
         [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; }
+        private GameplayBeatmap gameplayBeatmap { get; set; }
 
         protected ReplayRecorder(Replay target)
         {
@@ -50,7 +49,7 @@ namespace osu.Game.Rulesets.UI
 
             inputManager = GetContainingInputManager();
 
-            spectatorStreaming?.BeginPlaying();
+            spectatorStreaming?.BeginPlaying(gameplayBeatmap);
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Not confident about this at all, but I wanted to get this out for discussion at least.

# Summary

On current `master`, trying to start a mania map crashes with a

```
[runtime] 2020-10-26 23:41:00 [error]: System.InvalidCastException: Unable to cast object of type 'osu.Game.Beatmaps.Beatmap' to type 'osu.Game.Rulesets.Mania.Beatmaps.ManiaBeatmap'.
[runtime] 2020-10-26 23:41:00 [error]: at osu.Game.Rulesets.Mania.Replays.ManiaReplayFrame.ToLegacy(IBeatmap beatmap) in /home/dachb/Dokumenty/opensource/osu/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs:line 57
[runtime] 2020-10-26 23:41:00 [error]: at osu.Game.Online.Spectator.SpectatorStreamingClient.HandleFrame(ReplayFrame frame) in /home/dachb/Dokumenty/opensource/osu/osu.Game/Online/Spectator/SpectatorStreamingClient.cs:line 250
[runtime] 2020-10-26 23:41:00 [error]: at osu.Game.Rulesets.UI.ReplayRecorder`1.recordFrame(Boolean important) in /home/dachb/Dokumenty/opensource/osu/osu.Game/Rulesets/UI/ReplayRecorder.cs:line 96
```

This is due to `ManiaReplayFrame` being hard-coupled to the converted beatmap:

https://github.com/ppy/osu/blob/19e58dc4fc244bbadb992942f07a35dbed00142d/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs#L28-L30

while the spectator client was using a plain one taken from `WorkingBeatmap`:

https://github.com/ppy/osu/blob/19e58dc4fc244bbadb992942f07a35dbed00142d/osu.Game/Online/Spectator/SpectatorStreamingClient.cs#L47-L48

Resolve by shoving the converted beatmap into the spectator client through `ReplayRecorder`, to avoid converting/applying mods twice. Unfortunately it's infeasible to use DI given the current structure without at least adding a game-level bindable - which is mostly why I'm bothering to PR this as I'm not sure I see any alternative.

# Remarks

A few test scenes need a cached `GameplayBeatmap` after this change, as evidenced by the diff.