### PR TITLE
Change editor timing screen seek behaviour to only occur on clicking table rows

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -178,6 +178,9 @@ namespace osu.Game.Screens.Edit.Timing
             private readonly Box hoveredBackground;
 
             [Resolved]
+            private EditorClock clock { get; set; }
+
+            [Resolved]
             private Bindable<ControlPointGroup> selectedGroup { get; set; }
 
             public RowBackground(ControlPointGroup controlGroup)
@@ -200,7 +203,11 @@ namespace osu.Game.Screens.Edit.Timing
                     },
                 };
 
-                Action = () => selectedGroup.Value = controlGroup;
+                Action = () =>
+                {
+                    selectedGroup.Value = controlGroup;
+                    clock.SeekTo(controlGroup.Time);
+                };
             }
 
             private Color4 colourHover;

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -22,9 +22,6 @@ namespace osu.Game.Screens.Edit.Timing
         [Cached]
         private Bindable<ControlPointGroup> selectedGroup = new Bindable<ControlPointGroup>();
 
-        [Resolved]
-        private EditorClock clock { get; set; }
-
         public TimingScreen()
             : base(EditorScreenMode.Timing)
         {
@@ -47,17 +44,6 @@ namespace osu.Game.Screens.Edit.Timing
                 },
             }
         };
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            selectedGroup.BindValueChanged(selected =>
-            {
-                if (selected.NewValue != null)
-                    clock.SeekTo(selected.NewValue.Time);
-            });
-        }
 
         protected override void OnTimelineLoaded(TimelineArea timelineArea)
         {


### PR DESCRIPTION
Previously it would react to any selection changed event, which could include time changes (which is done by removing then adding the ControlPointGroup).

Closes #10590.