### PR TITLE
Add screen hierarchy for spectating another player

### DIFF
--- a/osu.Game.Tests/NonVisual/StreamingFramedReplayInputHandlerTest.cs
+++ b/osu.Game.Tests/NonVisual/StreamingFramedReplayInputHandlerTest.cs
@@ -1,0 +1,296 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Replays;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class StreamingFramedReplayInputHandlerTest
+    {
+        private Replay replay;
+        private TestInputHandler handler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            handler = new TestInputHandler(replay = new Replay
+            {
+                HasReceivedAllFrames = false,
+                Frames = new List<ReplayFrame>
+                {
+                    new TestReplayFrame(0),
+                    new TestReplayFrame(1000),
+                    new TestReplayFrame(2000),
+                    new TestReplayFrame(3000, true),
+                    new TestReplayFrame(4000, true),
+                    new TestReplayFrame(5000, true),
+                    new TestReplayFrame(7000, true),
+                    new TestReplayFrame(8000),
+                }
+            });
+        }
+
+        [Test]
+        public void TestNormalPlayback()
+        {
+            Assert.IsNull(handler.CurrentFrame);
+
+            confirmCurrentFrame(null);
+            confirmNextFrame(0);
+
+            setTime(0, 0);
+            confirmCurrentFrame(0);
+            confirmNextFrame(1);
+
+            // if we hit the first frame perfectly, time should progress to it.
+            setTime(1000, 1000);
+            confirmCurrentFrame(1);
+            confirmNextFrame(2);
+
+            // in between non-important frames should progress based on input.
+            setTime(1200, 1200);
+            confirmCurrentFrame(1);
+
+            setTime(1400, 1400);
+            confirmCurrentFrame(1);
+
+            // progressing beyond the next frame should force time to that frame once.
+            setTime(2200, 2000);
+            confirmCurrentFrame(2);
+
+            // second attempt should progress to input time
+            setTime(2200, 2200);
+            confirmCurrentFrame(2);
+
+            // entering important section
+            setTime(3000, 3000);
+            confirmCurrentFrame(3);
+
+            // cannot progress within
+            setTime(3500, null);
+            confirmCurrentFrame(3);
+
+            setTime(4000, 4000);
+            confirmCurrentFrame(4);
+
+            // still cannot progress
+            setTime(4500, null);
+            confirmCurrentFrame(4);
+
+            setTime(5200, 5000);
+            confirmCurrentFrame(5);
+
+            // important section AllowedImportantTimeSpan allowance
+            setTime(5200, 5200);
+            confirmCurrentFrame(5);
+
+            setTime(7200, 7000);
+            confirmCurrentFrame(6);
+
+            setTime(7200, null);
+            confirmCurrentFrame(6);
+
+            // exited important section
+            setTime(8200, 8000);
+            confirmCurrentFrame(7);
+            confirmNextFrame(null);
+
+            setTime(8200, null);
+            confirmCurrentFrame(7);
+            confirmNextFrame(null);
+
+            setTime(8400, null);
+            confirmCurrentFrame(7);
+            confirmNextFrame(null);
+        }
+
+        [Test]
+        public void TestIntroTime()
+        {
+            setTime(-1000, -1000);
+            confirmCurrentFrame(null);
+            confirmNextFrame(0);
+
+            setTime(-500, -500);
+            confirmCurrentFrame(null);
+            confirmNextFrame(0);
+
+            setTime(0, 0);
+            confirmCurrentFrame(0);
+            confirmNextFrame(1);
+        }
+
+        [Test]
+        public void TestBasicRewind()
+        {
+            setTime(2800, 0);
+            setTime(2800, 1000);
+            setTime(2800, 2000);
+            setTime(2800, 2800);
+            confirmCurrentFrame(2);
+            confirmNextFrame(3);
+
+            // pivot without crossing a frame boundary
+            setTime(2700, 2700);
+            confirmCurrentFrame(2);
+            confirmNextFrame(1);
+
+            // cross current frame boundary; should not yet update frame
+            setTime(1980, 1980);
+            confirmCurrentFrame(2);
+            confirmNextFrame(1);
+
+            setTime(1200, 1200);
+            confirmCurrentFrame(2);
+            confirmNextFrame(1);
+
+            // ensure each frame plays out until start
+            setTime(-500, 1000);
+            confirmCurrentFrame(1);
+            confirmNextFrame(0);
+
+            setTime(-500, 0);
+            confirmCurrentFrame(0);
+            confirmNextFrame(null);
+
+            setTime(-500, -500);
+            confirmCurrentFrame(0);
+            confirmNextFrame(null);
+        }
+
+        [Test]
+        public void TestRewindInsideImportantSection()
+        {
+            fastForwardToPoint(3000);
+
+            setTime(4000, 4000);
+            confirmCurrentFrame(4);
+            confirmNextFrame(5);
+
+            setTime(3500, null);
+            confirmCurrentFrame(4);
+            confirmNextFrame(3);
+
+            setTime(3000, 3000);
+            confirmCurrentFrame(3);
+            confirmNextFrame(2);
+
+            setTime(3500, null);
+            confirmCurrentFrame(3);
+            confirmNextFrame(4);
+
+            setTime(4000, 4000);
+            confirmCurrentFrame(4);
+            confirmNextFrame(5);
+
+            setTime(4500, null);
+            confirmCurrentFrame(4);
+            confirmNextFrame(5);
+
+            setTime(4000, null);
+            confirmCurrentFrame(4);
+            confirmNextFrame(5);
+
+            setTime(3500, null);
+            confirmCurrentFrame(4);
+            confirmNextFrame(3);
+
+            setTime(3000, 3000);
+            confirmCurrentFrame(3);
+            confirmNextFrame(2);
+        }
+
+        [Test]
+        public void TestRewindOutOfImportantSection()
+        {
+            fastForwardToPoint(3500);
+
+            confirmCurrentFrame(3);
+            confirmNextFrame(4);
+
+            setTime(3200, null);
+            // next frame doesn't change even though direction reversed, because of important section.
+            confirmCurrentFrame(3);
+            confirmNextFrame(4);
+
+            setTime(3000, null);
+            confirmCurrentFrame(3);
+            confirmNextFrame(4);
+
+            setTime(2800, 2800);
+            confirmCurrentFrame(3);
+            confirmNextFrame(2);
+        }
+
+        private void fastForwardToPoint(double destination)
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                if (handler.SetFrameFromTime(destination) == null)
+                    return;
+            }
+
+            throw new TimeoutException("Seek was never fulfilled");
+        }
+
+        private void setTime(double set, double? expect)
+        {
+            Assert.AreEqual(expect, handler.SetFrameFromTime(set));
+        }
+
+        private void confirmCurrentFrame(int? frame)
+        {
+            if (frame.HasValue)
+            {
+                Assert.IsNotNull(handler.CurrentFrame);
+                Assert.AreEqual(replay.Frames[frame.Value].Time, handler.CurrentFrame.Time);
+            }
+            else
+            {
+                Assert.IsNull(handler.CurrentFrame);
+            }
+        }
+
+        private void confirmNextFrame(int? frame)
+        {
+            if (frame.HasValue)
+            {
+                Assert.IsNotNull(handler.NextFrame);
+                Assert.AreEqual(replay.Frames[frame.Value].Time, handler.NextFrame.Time);
+            }
+            else
+            {
+                Assert.IsNull(handler.NextFrame);
+            }
+        }
+
+        private class TestReplayFrame : ReplayFrame
+        {
+            public readonly bool IsImportant;
+
+            public TestReplayFrame(double time, bool isImportant = false)
+                : base(time)
+            {
+                IsImportant = isImportant;
+            }
+        }
+
+        private class TestInputHandler : FramedReplayInputHandler<TestReplayFrame>
+        {
+            public TestInputHandler(Replay replay)
+                : base(replay)
+            {
+                FrameAccuratePlayback = true;
+            }
+
+            protected override double AllowedImportantTimeSpan => 1000;
+
+            protected override bool IsImportant(TestReplayFrame frame) => frame.IsImportant;
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestHostStartsPlayingWhileAlreadyWatching()
+        public void TestHostRetriesWhileWatching()
         {
             loadSpectatingScreen();
 
@@ -171,9 +171,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             sendFrames();
             waitForPlayer();
 
-            // should immediately exit and unbind from streaming client
             AddStep("stop spectating", () => (Stack.CurrentScreen as Player)?.Exit());
-            AddUntilStep("spectating stopped", () => spectatorScreen.GetParentScreen() == null);
+            AddUntilStep("spectating stopped", () => spectatorScreen.GetChildScreen() == null);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -82,12 +82,20 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for frame starvation", () => replayHandler.NextFrame == null);
             checkPaused(true);
 
+            double? pausedTime = null;
+
+            AddStep("store time", () => pausedTime = currentFrameStableTime);
+
             sendFrames();
 
-            checkPaused(false);
             AddUntilStep("wait for frame starvation", () => replayHandler.NextFrame == null);
             checkPaused(true);
+
+            AddAssert("time advanced", () => currentFrameStableTime > pausedTime);
         }
+
+        private double currentFrameStableTime
+            => player.ChildrenOfType<FrameStabilityContainer>().First().FrameStableClock.CurrentTime;
 
         [Test]
         public void TestPlayStartsWithNoFrames()
@@ -98,7 +106,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             waitForPlayer();
             checkPaused(true);
 
-            sendFrames();
+            sendFrames(1000); // send enough frames to ensure play won't be paused
 
             checkPaused(false);
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -176,6 +176,23 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestStopWatchingThenHostRetries()
+        {
+            loadSpectatingScreen();
+
+            start();
+            sendFrames();
+            waitForPlayer();
+
+            AddStep("stop spectating", () => (Stack.CurrentScreen as Player)?.Exit());
+            AddUntilStep("spectating stopped", () => spectatorScreen.GetChildScreen() == null);
+
+            // host starts playing a new session
+            start();
+            waitForPlayer();
+        }
+
+        [Test]
         public void TestWatchingBeatmapThatDoesntExistLocally()
         {
             loadSpectatingScreen();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             start();
             waitForPlayer();
-            AddUntilStep("game is paused", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value);
+            checkPaused(true);
 
             sendFrames();
 
@@ -134,8 +134,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             loadSpectatingScreen();
 
             start();
-            sendFrames();
 
+            waitForPlayer();
+            checkPaused(true);
+
+            finish();
+
+            checkPaused(false);
             // TODO: should replay until running out of frames then fail
         }
 
@@ -168,8 +173,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void start(int? beatmapId = null) => AddStep("start play", () => testSpectatorStreamingClient.StartPlay(beatmapId ?? importedBeatmapId));
 
+        private void finish(int? beatmapId = null) => AddStep("end play", () => testSpectatorStreamingClient.EndPlay(beatmapId ?? importedBeatmapId));
+
         private void checkPaused(bool state) =>
-            AddAssert($"game is {(state ? "paused" : "playing")}", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value == state);
+            AddUntilStep($"game is {(state ? "paused" : "playing")}", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value == state);
 
         private void sendFrames(int count = 10)
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -56,6 +56,9 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestBasicSpectatingFlow()
         {
             loadSpectatingScreen();
+
+            AddAssert("screen hasn't changed", () => Stack.CurrentScreen is Spectator);
+
             AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
 
             sendFrames();
@@ -71,6 +74,18 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for frame starvation", () => replayHandler.NextFrame == null);
             AddAssert("game is paused", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value);
+        }
+
+        [Test]
+        public void TestPlayStartsWithNoFrames()
+        {
+            loadSpectatingScreen();
+
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is Player);
+
+            AddUntilStep("game is paused", () => player.ChildrenOfType<DrawableRuleset>().First().IsPaused.Value);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -9,6 +9,8 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Beatmaps.IO;
 using osu.Game.Users;
@@ -38,12 +40,19 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
         }
 
+        private OsuFramedReplayInputHandler replayHandler =>
+            (OsuFramedReplayInputHandler)Stack.ChildrenOfType<OsuInputManager>().First().ReplayInputHandler;
+
         [Test]
         public void TestBasicSpectatingFlow()
         {
             beginSpectating();
             AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
             AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is Player);
+
+            AddAssert("ensure frames arrived", () => replayHandler.HasFrames);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -170,8 +171,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
         }
 
-        private void loadSpectatingScreen() =>
+        private void loadSpectatingScreen()
+        {
             AddStep("load screen", () => LoadScreen(spectatorScreen = new Spectator(testSpectatorStreamingClient.StreamingUser)));
+            AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded);
+        }
 
         internal class TestSpectatorStreamingClient : SpectatorStreamingClient
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             loadSpectatingScreen();
 
-            start(88);
+            start(-1234);
             sendFrames();
 
             AddAssert("screen didn't change", () => Stack.CurrentScreen is Spectator);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Screens.Play;
@@ -15,9 +17,13 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Cached(typeof(SpectatorStreamingClient))]
         private TestSpectatorStreamingClient testSpectatorStreamingClient = new TestSpectatorStreamingClient();
 
+        [Resolved]
+        private OsuGameBase game { get; set; }
+
         [Test]
         public void TestSpectating()
         {
+            AddStep("add streaming client", () => Add(testSpectatorStreamingClient));
             AddStep("load screen", () => LoadScreen(new Spectator(testSpectatorStreamingClient.StreamingUser)));
             AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
             AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
@@ -25,11 +31,18 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         internal class TestSpectatorStreamingClient : SpectatorStreamingClient
         {
+            [Resolved]
+            private BeatmapManager beatmaps { get; set; }
+
             public readonly User StreamingUser = new User { Id = 1234, Username = "Test user" };
 
             public void StartPlay()
             {
-                ((ISpectatorClient)this).UserBeganPlaying((int)StreamingUser.Id, new SpectatorState());
+                ((ISpectatorClient)this).UserBeganPlaying((int)StreamingUser.Id, new SpectatorState
+                {
+                    BeatmapID = beatmaps.GetAllUsableBeatmapSets().First().Beatmaps.First().OnlineBeatmapID,
+                    RulesetID = 0,
+                });
             }
 
             public void SendFrames()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -61,11 +61,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             finish();
         }
 
-        private OsuFramedReplayInputHandler replayHandler =>
-            (OsuFramedReplayInputHandler)Stack.ChildrenOfType<OsuInputManager>().First().ReplayInputHandler;
-
-        private Player player => Stack.CurrentScreen as Player;
-
         [Test]
         public void TestFrameStarvationAndResume()
         {
@@ -93,9 +88,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddAssert("time advanced", () => currentFrameStableTime > pausedTime);
         }
-
-        private double currentFrameStableTime
-            => player.ChildrenOfType<FrameStabilityContainer>().First().FrameStableClock.CurrentTime;
 
         [Test]
         public void TestPlayStartsWithNoFrames()
@@ -202,6 +194,14 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddAssert("screen didn't change", () => Stack.CurrentScreen is Spectator);
         }
+
+        private OsuFramedReplayInputHandler replayHandler =>
+            (OsuFramedReplayInputHandler)Stack.ChildrenOfType<OsuInputManager>().First().ReplayInputHandler;
+
+        private Player player => Stack.CurrentScreen as Player;
+
+        private double currentFrameStableTime
+            => player.ChildrenOfType<FrameStabilityContainer>().First().FrameStableClock.CurrentTime;
 
         private void waitForPlayer() => AddUntilStep("wait for player", () => Stack.CurrentScreen is Player);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private Player player => Stack.CurrentScreen as Player;
 
         [Test]
-        public void TestBasicSpectatingFlow()
+        public void TestFrameStarvationAndResume()
         {
             loadSpectatingScreen();
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Screens.Play;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public class TestSceneSpectator : ScreenTestScene
+    {
+        private readonly User user = new User { Id = 1234, Username = "Test user" };
+
+        [Test]
+        public void TestSpectating()
+        {
+            AddStep("load screen", () => LoadScreen(new Spectator(user)));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -134,8 +134,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             start();
             sendFrames();
 
+            waitForPlayer();
+
+            Player lastPlayer = null;
+            AddStep("store first player", () => lastPlayer = player);
+
             start();
             sendFrames();
+
+            waitForPlayer();
+            AddAssert("player is different", () => lastPlayer != player);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -57,6 +57,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Remove(testSpectatorStreamingClient);
                 Add(testSpectatorStreamingClient);
             });
+
+            finish();
         }
 
         private OsuFramedReplayInputHandler replayHandler =>
@@ -212,6 +214,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                     BeatmapID = beatmapId,
                     RulesetID = 0,
                 });
+
+                sentState = false;
             }
 
             private bool sentState;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -2,6 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Online.Spectator;
+using osu.Game.Replays.Legacy;
 using osu.Game.Screens.Play;
 using osu.Game.Users;
 
@@ -9,12 +12,34 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public class TestSceneSpectator : ScreenTestScene
     {
-        private readonly User user = new User { Id = 1234, Username = "Test user" };
+        [Cached(typeof(SpectatorStreamingClient))]
+        private TestSpectatorStreamingClient testSpectatorStreamingClient = new TestSpectatorStreamingClient();
 
         [Test]
         public void TestSpectating()
         {
-            AddStep("load screen", () => LoadScreen(new Spectator(user)));
+            AddStep("load screen", () => LoadScreen(new Spectator(testSpectatorStreamingClient.StreamingUser)));
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+            AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+        }
+
+        internal class TestSpectatorStreamingClient : SpectatorStreamingClient
+        {
+            public readonly User StreamingUser = new User { Id = 1234, Username = "Test user" };
+
+            public void StartPlay()
+            {
+                ((ISpectatorClient)this).UserBeganPlaying((int)StreamingUser.Id, new SpectatorState());
+            }
+
+            public void SendFrames()
+            {
+                ((ISpectatorClient)this).UserSentFrames((int)StreamingUser.Id, new FrameDataBundle(new[]
+                {
+                    // todo: populate more frames
+                    new LegacyReplayFrame(0, 0, 0, ReplayButtonState.Left1)
+                }));
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Resolved]
         private OsuGameBase game { get; set; }
 
-        private int nextFrame = 0;
+        private int nextFrame;
 
         public override void SetUpSteps()
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -4,10 +4,13 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Screens.Play;
+using osu.Game.Tests.Beatmaps.IO;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -17,14 +20,28 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Cached(typeof(SpectatorStreamingClient))]
         private TestSpectatorStreamingClient testSpectatorStreamingClient = new TestSpectatorStreamingClient();
 
+        private Spectator spectatorScreen;
+
         [Resolved]
         private OsuGameBase game { get; set; }
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadOszIntoOsu(game, virtualTrack: true).Wait());
+
+            AddStep("add streaming client", () =>
+            {
+                Remove(testSpectatorStreamingClient);
+                Add(testSpectatorStreamingClient);
+            });
+        }
 
         [Test]
         public void TestBasicSpectatingFlow()
         {
-            AddStep("add streaming client", () => Add(testSpectatorStreamingClient));
-            AddStep("load screen", () => LoadScreen(new Spectator(testSpectatorStreamingClient.StreamingUser)));
+            beginSpectating();
             AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
             AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
         }
@@ -32,26 +49,67 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestSpectatingDuringGameplay()
         {
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+            AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+
             // should seek immediately to available frames
+            beginSpectating();
         }
 
         [Test]
         public void TestHostStartsPlayingWhileAlreadyWatching()
         {
+            beginSpectating();
+
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+            AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+            AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
             // should restart either immediately or after running out of frames
         }
 
         [Test]
         public void TestHostFails()
         {
+            beginSpectating();
+
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+            AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+            // todo: send fail state
+
             // should replay until running out of frames then fail
         }
 
         [Test]
         public void TestStopWatchingDuringPlay()
         {
+            beginSpectating();
+
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+            AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+
+            AddUntilStep("wait for player", () => Stack.CurrentScreen is Player);
+
             // should immediately exit and unbind from streaming client
+            AddStep("stop spectating", () => (Stack.CurrentScreen as Player)?.Exit());
+
+            AddUntilStep("spectating stopped", () => spectatorScreen.GetParentScreen() == null);
         }
+
+        [Test]
+        public void TestWatchingBeatmapThatDoesntExistLocally()
+        {
+            beginSpectating();
+
+            AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
+            AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+
+            // player should never arrive.
+        }
+
+        private void beginSpectating() =>
+            AddStep("load screen", () => LoadScreen(spectatorScreen = new Spectator(testSpectatorStreamingClient.StreamingUser)));
 
         internal class TestSpectatorStreamingClient : SpectatorStreamingClient
         {
@@ -64,7 +122,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 ((ISpectatorClient)this).UserBeganPlaying((int)StreamingUser.Id, new SpectatorState
                 {
-                    BeatmapID = beatmaps.GetAllUsableBeatmapSets().First().Beatmaps.First().OnlineBeatmapID,
+                    BeatmapID = beatmaps.GetAllUsableBeatmapSets().First().Beatmaps.First(b => b.RulesetID == 0).OnlineBeatmapID,
+                    RulesetID = 0,
+                });
+            }
+
+            public void EndPlay()
+            {
+                ((ISpectatorClient)this).UserFinishedPlaying((int)StreamingUser.Id, new SpectatorState
+                {
+                    BeatmapID = beatmaps.GetAllUsableBeatmapSets().First().Beatmaps.First(b => b.RulesetID == 0).OnlineBeatmapID,
                     RulesetID = 0,
                 });
             }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -93,9 +93,15 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestSpectatingDuringGameplay()
         {
             start();
-            sendFrames();
-            // should seek immediately to available frames
+
             loadSpectatingScreen();
+
+            AddStep("advance frame count", () => nextFrame = 300);
+            sendFrames();
+
+            waitForPlayer();
+
+            AddUntilStep("playing from correct point in time", () => player.ChildrenOfType<DrawableRuleset>().First().FrameStableClock.CurrentTime > 30000);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -21,12 +21,36 @@ namespace osu.Game.Tests.Visual.Gameplay
         private OsuGameBase game { get; set; }
 
         [Test]
-        public void TestSpectating()
+        public void TestBasicSpectatingFlow()
         {
             AddStep("add streaming client", () => Add(testSpectatorStreamingClient));
             AddStep("load screen", () => LoadScreen(new Spectator(testSpectatorStreamingClient.StreamingUser)));
             AddStep("start play", () => testSpectatorStreamingClient.StartPlay());
             AddStep("send frames", () => testSpectatorStreamingClient.SendFrames());
+        }
+
+        [Test]
+        public void TestSpectatingDuringGameplay()
+        {
+            // should seek immediately to available frames
+        }
+
+        [Test]
+        public void TestHostStartsPlayingWhileAlreadyWatching()
+        {
+            // should restart either immediately or after running out of frames
+        }
+
+        [Test]
+        public void TestHostFails()
+        {
+            // should replay until running out of frames then fail
+        }
+
+        [Test]
+        public void TestStopWatchingDuringPlay()
+        {
+            // should immediately exit and unbind from streaming client
         }
 
         internal class TestSpectatorStreamingClient : SpectatorStreamingClient

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Online.Spectator
         public event Action<int, SpectatorState> OnUserBeganPlaying;
 
         /// <summary>
-        /// Called whenever a user starts a play session.
+        /// Called whenever a user finishes a play session.
         /// </summary>
         public event Action<int, SpectatorState> OnUserFinishedPlaying;
 

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -64,6 +64,16 @@ namespace osu.Game.Online.Spectator
         /// </summary>
         public event Action<int, FrameDataBundle> OnNewFrames;
 
+        /// <summary>
+        /// Called whenever a user starts a play session.
+        /// </summary>
+        public event Action<int, SpectatorState> OnUserBeganPlaying;
+
+        /// <summary>
+        /// Called whenever a user starts a play session.
+        /// </summary>
+        public event Action<int, SpectatorState> OnUserFinishedPlaying;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -154,18 +164,24 @@ namespace osu.Game.Online.Spectator
             if (!playingUsers.Contains(userId))
                 playingUsers.Add(userId);
 
+            OnUserBeganPlaying?.Invoke(userId, state);
+
             return Task.CompletedTask;
         }
 
         Task ISpectatorClient.UserFinishedPlaying(int userId, SpectatorState state)
         {
             playingUsers.Remove(userId);
+
+            OnUserFinishedPlaying?.Invoke(userId, state);
+
             return Task.CompletedTask;
         }
 
         Task ISpectatorClient.UserSentFrames(int userId, FrameDataBundle data)
         {
             OnNewFrames?.Invoke(userId, data);
+
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -227,7 +227,7 @@ namespace osu.Game.Online.Spectator
             connection.SendAsync(nameof(ISpectatorServer.EndPlaySession), currentState);
         }
 
-        public void WatchUser(int userId)
+        public virtual void WatchUser(int userId)
         {
             if (watchingUsers.Contains(userId))
                 return;

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -8,6 +8,12 @@ namespace osu.Game.Replays
 {
     public class Replay
     {
+        /// <summary>
+        /// Whether all frames for this replay have been received.
+        /// If false, gameplay would be paused to wait for further data, for instance.
+        /// </summary>
+        public bool HasReceivedAllFrames = true;
+
         public List<ReplayFrame> Frames = new List<ReplayFrame>();
     }
 }

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Replays
                     return null;
 
                 if (!currentFrameIndex.HasValue)
-                    return (TFrame)Frames[0];
+                    return currentDirection > 0 ? (TFrame)Frames[0] : null;
 
                 int nextFrame = clampedNextFrameIndex;
 
@@ -109,30 +109,54 @@ namespace osu.Game.Rulesets.Replays
 
             Debug.Assert(currentDirection != 0);
 
-            TFrame next = NextFrame;
-
-            // check if the next frame is valid for the current playback direction.
-            // validity is if the next frame is equal or "earlier" than the current point in time (so we can change to it)
-            int compare = time.CompareTo(next?.Time);
-
-            if (next != null && (compare == 0 || compare == currentDirection))
+            if (!HasFrames)
             {
-                currentFrameIndex = clampedNextFrameIndex;
-                return CurrentTime = CurrentFrame.Time;
+                // in the case all frames are received, allow time to progress regardless.
+                if (replay.HasReceivedAllFrames)
+                    return CurrentTime = time;
+
+                return null;
             }
 
-            // at this point, the frame can't be advanced (in the replay).
-            // even so, we may be able to move the clock forward due to being at the end of the replay or
-            // moving towards the next valid frame.
+            TFrame next = NextFrame;
+
+            // if we have a next frame, check if it is before or at the current time in playback, and advance time to it if so.
+            if (next != null)
+            {
+                int compare = time.CompareTo(next.Time);
+
+                if (compare == 0 || compare == currentDirection)
+                {
+                    currentFrameIndex = clampedNextFrameIndex;
+                    return CurrentTime = CurrentFrame.Time;
+                }
+            }
+
+            // at this point, the frame index can't be advanced.
+            // even so, we may be able to propose the clock progresses forward due to being at an extent of the replay,
+            // or moving towards the next valid frame (ie. interpolating in a non-important section).
 
             // the exception is if currently in an important section, which is respected above all.
             if (inImportantSection)
+            {
+                Debug.Assert(next != null || !replay.HasReceivedAllFrames);
                 return null;
+            }
 
-            // in the case we have no next frames and haven't received the full replay, block.
-            if (next == null && !replay.HasReceivedAllFrames) return null;
+            // if a next frame does exist, allow interpolation.
+            if (next != null)
+                return CurrentTime = time;
 
-            return CurrentTime = time;
+            // if all frames have been received, allow playing beyond extents.
+            if (replay.HasReceivedAllFrames)
+                return CurrentTime = time;
+
+            // if not all frames are received but we are before the first frame, allow playing.
+            if (time < Frames[0].Time)
+                return CurrentTime = time;
+
+            // in the case we have no next frames and haven't received enough frame data, block.
+            return null;
         }
 
         private void updateDirection(double time)

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -162,6 +162,12 @@ namespace osu.Game.Rulesets.Replays
                     // if we didn't change frames, we need to ensure we are allowed to run frames in between, else return null.
                 }
             }
+            else
+            {
+                // if we never received frames and are expecting to, block.
+                if (!replay.HasReceivedAllFrames)
+                    return null;
+            }
 
             return CurrentTime = time;
         }

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
@@ -112,15 +113,9 @@ namespace osu.Game.Rulesets.Replays
         /// <returns>The usable time value. If null, we should not advance time as we do not have enough data.</returns>
         public override double? SetFrameFromTime(double time)
         {
-            if (!CurrentTime.HasValue)
-            {
-                currentDirection = 1;
-            }
-            else
-            {
-                currentDirection = time.CompareTo(CurrentTime);
-                if (currentDirection == 0) currentDirection = 1;
-            }
+            updateDirection(time);
+
+            Debug.Assert(currentDirection != 0);
 
             if (HasFrames)
             {
@@ -170,6 +165,19 @@ namespace osu.Game.Rulesets.Replays
             }
 
             return CurrentTime = time;
+        }
+
+        private void updateDirection(double time)
+        {
+            if (!CurrentTime.HasValue)
+            {
+                currentDirection = 1;
+            }
+            else
+            {
+                currentDirection = time.CompareTo(CurrentTime);
+                if (currentDirection == 0) currentDirection = 1;
+            }
         }
     }
 }

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Replays
         /// </summary>
         public bool FrameAccuratePlayback = false;
 
-        protected bool HasFrames => Frames.Count > 0;
+        public bool HasFrames => Frames.Count > 0;
 
         private bool inImportantSection
         {

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -96,6 +96,7 @@ namespace osu.Game.Rulesets.UI
         public override bool UpdateSubTree()
         {
             requireMoreUpdateLoops = true;
+
             validState = !frameStableClock.IsPaused.Value;
 
             int loops = 0;
@@ -191,7 +192,7 @@ namespace osu.Game.Rulesets.UI
             finally
             {
                 if (newProposedTime != manualClock.CurrentTime)
-                    direction = newProposedTime > manualClock.CurrentTime ? 1 : -1;
+                    direction = newProposedTime >= manualClock.CurrentTime ? 1 : -1;
 
                 manualClock.CurrentTime = newProposedTime;
                 manualClock.Rate = Math.Abs(parentGameplayClock.Rate) * direction;

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.UI
 
         public override bool UpdateSubTree()
         {
-            double proposedTime = manualClock.CurrentTime;
+            double aimTime = manualClock.CurrentTime;
 
             if (frameStableClock.WaitingOnFrames.Value)
             {
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.UI
                 if (parentGameplayClock == null)
                     setClock(); // LoadComplete may not be run yet, but we still want the clock.
 
-                proposedTime = parentGameplayClock.CurrentTime;
+                aimTime = parentGameplayClock.CurrentTime;
             }
             else
             {
@@ -113,7 +113,9 @@ namespace osu.Game.Rulesets.UI
 
             while (loops-- > 0)
             {
-                updateClock(ref proposedTime);
+                // update clock is always trying to approach the aim time.
+                // it should be provided as the original value each loop.
+                updateClock(aimTime);
 
                 if (state == PlaybackState.NotValid)
                     break;
@@ -125,7 +127,7 @@ namespace osu.Game.Rulesets.UI
             return true;
         }
 
-        private void updateClock(ref double proposedTime)
+        private void updateClock(double proposedTime)
         {
             // each update start with considering things in valid state.
             state = PlaybackState.Valid;

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -144,21 +144,21 @@ namespace osu.Game.Rulesets.UI
                     state = PlaybackState.NotValid;
             }
 
-            if (proposedTime != manualClock.CurrentTime)
+            if (state == PlaybackState.Valid)
                 direction = proposedTime >= manualClock.CurrentTime ? 1 : -1;
+
+            double timeBehind = Math.Abs(proposedTime - parentGameplayClock.CurrentTime);
+
+            frameStableClock.IsCatchingUp.Value = timeBehind > 200;
+            frameStableClock.WaitingOnFrames.Value = state == PlaybackState.NotValid;
 
             manualClock.CurrentTime = proposedTime;
             manualClock.Rate = Math.Abs(parentGameplayClock.Rate) * direction;
             manualClock.IsRunning = parentGameplayClock.IsRunning;
 
-            double timeBehind = Math.Abs(manualClock.CurrentTime - parentGameplayClock.CurrentTime);
-
             // determine whether catch-up is required.
             if (state == PlaybackState.Valid && timeBehind > 0)
                 state = PlaybackState.RequiresCatchUp;
-
-            frameStableClock.IsCatchingUp.Value = timeBehind > 200;
-            frameStableClock.WaitingOnFrames.Value = state == PlaybackState.NotValid;
 
             // The manual clock time has changed in the above code. The framed clock now needs to be updated
             // to ensure that the its time is valid for our children before input is processed

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -85,15 +85,10 @@ namespace osu.Game.Rulesets.UI
 
         public override bool UpdateSubTree()
         {
-            if (parentGameplayClock == null)
-                setClock(); // LoadComplete may not be run yet, but we still want the clock.
-
-            double aimTime = parentGameplayClock.CurrentTime;
-
             if (frameStableClock.WaitingOnFrames.Value)
             {
                 // waiting on frames is a special case where we want to avoid doing any update propagation, unless new frame data has arrived.
-                state = ReplayInputHandler.SetFrameFromTime(aimTime) != null ? PlaybackState.Valid : PlaybackState.NotValid;
+                state = PlaybackState.Valid;
             }
             else if (!frameStableClock.IsPaused.Value)
             {
@@ -103,10 +98,8 @@ namespace osu.Game.Rulesets.UI
             {
                 // time should not advance while paused, nor should anything run.
                 state = PlaybackState.NotValid;
-            }
-
-            if (state == PlaybackState.NotValid)
                 return true;
+            }
 
             int loops = MaxCatchUpFrames;
 
@@ -114,7 +107,7 @@ namespace osu.Game.Rulesets.UI
             {
                 // update clock is always trying to approach the aim time.
                 // it should be provided as the original value each loop.
-                updateClock(aimTime);
+                updateClock();
 
                 if (state == PlaybackState.NotValid)
                     break;
@@ -126,8 +119,13 @@ namespace osu.Game.Rulesets.UI
             return true;
         }
 
-        private void updateClock(double proposedTime)
+        private void updateClock()
         {
+            if (parentGameplayClock == null)
+                setClock(); // LoadComplete may not be run yet, but we still want the clock.
+
+            double proposedTime = parentGameplayClock.CurrentTime;
+
             // each update start with considering things in valid state.
             state = PlaybackState.Valid;
 

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -96,7 +96,10 @@ namespace osu.Game.Rulesets.UI
 
             int loops = MaxCatchUpFrames;
 
-            while (state != PlaybackState.NotValid && loops-- > 0)
+            if (state == PlaybackState.NotValid)
+                return true;
+
+            while (loops-- > 0)
             {
                 updateClock();
 

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.UI
 
             int loops = MaxCatchUpFrames;
 
-            while (loops-- > 0)
+            do
             {
                 // update clock is always trying to approach the aim time.
                 // it should be provided as the original value each loop.
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.UI
 
                 base.UpdateSubTree();
                 UpdateSubTreeMasking(this, ScreenSpaceDrawQuad.AABBFloat);
-            }
+            } while (state == PlaybackState.RequiresCatchUp && loops-- > 0);
 
             return true;
         }

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -85,23 +85,31 @@ namespace osu.Game.Rulesets.UI
 
         public override bool UpdateSubTree()
         {
-            state = frameStableClock.IsPaused.Value ? PlaybackState.NotValid : PlaybackState.Valid;
+            double proposedTime = manualClock.CurrentTime;
 
             if (frameStableClock.WaitingOnFrames.Value)
             {
-                // for now, force one update loop to check if frames have arrived
-                // this may have to change in the future where we want stable user pausing during replay playback.
+                // when waiting on frames, the update loop still needs to be run (at least once) to check for newly arrived frames.
+                // time should not be sourced from the parent clock in this case.
                 state = PlaybackState.Valid;
+            }
+            else if (!frameStableClock.IsPaused.Value)
+            {
+                state = PlaybackState.Valid;
+                proposedTime = parentGameplayClock.CurrentTime;
+            }
+            else
+            {
+                // time should not advance while paused, not should anything run.
+                state = PlaybackState.NotValid;
+                return true;
             }
 
             int loops = MaxCatchUpFrames;
 
-            if (state == PlaybackState.NotValid)
-                return true;
-
             while (loops-- > 0)
             {
-                updateClock();
+                updateClock(ref proposedTime);
 
                 if (state == PlaybackState.NotValid)
                     break;
@@ -113,16 +121,13 @@ namespace osu.Game.Rulesets.UI
             return true;
         }
 
-        private void updateClock()
+        private void updateClock(ref double proposedTime)
         {
             if (parentGameplayClock == null)
                 setClock(); // LoadComplete may not be run yet, but we still want the clock.
 
             // each update start with considering things in valid state.
             state = PlaybackState.Valid;
-
-            // our goal is to catch up to the time provided by the parent clock.
-            var proposedTime = parentGameplayClock.CurrentTime;
 
             if (FrameStablePlayback)
                 // if we require frame stability, the proposed time will be adjusted to move at most one known

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -96,6 +96,10 @@ namespace osu.Game.Rulesets.UI
             else if (!frameStableClock.IsPaused.Value)
             {
                 state = PlaybackState.Valid;
+
+                if (parentGameplayClock == null)
+                    setClock(); // LoadComplete may not be run yet, but we still want the clock.
+
                 proposedTime = parentGameplayClock.CurrentTime;
             }
             else
@@ -123,9 +127,6 @@ namespace osu.Game.Rulesets.UI
 
         private void updateClock(ref double proposedTime)
         {
-            if (parentGameplayClock == null)
-                setClock(); // LoadComplete may not be run yet, but we still want the clock.
-
             // each update start with considering things in valid state.
             state = PlaybackState.Valid;
 

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -101,6 +101,13 @@ namespace osu.Game.Rulesets.UI
 
             int loops = 0;
 
+            if (frameStableClock.WaitingOnFrames.Value)
+            {
+                // for now, force one update loop to check if frames have arrived
+                // this may have to change in the future where we want stable user pausing during replay playback.
+                validState = true;
+            }
+
             while (validState && requireMoreUpdateLoops && loops++ < MaxCatchUpFrames)
             {
                 updateClock();
@@ -203,6 +210,7 @@ namespace osu.Game.Rulesets.UI
                 requireMoreUpdateLoops |= timeBehind != 0;
 
                 frameStableClock.IsCatchingUp.Value = timeBehind > 200;
+                frameStableClock.WaitingOnFrames.Value = !validState;
 
                 // The manual clock time has changed in the above code. The framed clock now needs to be updated
                 // to ensure that the its time is valid for our children before input is processed
@@ -231,6 +239,8 @@ namespace osu.Game.Rulesets.UI
 
             public readonly Bindable<bool> IsCatchingUp = new Bindable<bool>();
 
+            public readonly Bindable<bool> WaitingOnFrames = new Bindable<bool>();
+
             public override IEnumerable<Bindable<double>> NonGameplayAdjustments => ParentGameplayClock?.NonGameplayAdjustments ?? Enumerable.Empty<Bindable<double>>();
 
             public FrameStabilityClock(FramedClock underlyingClock)
@@ -239,6 +249,8 @@ namespace osu.Game.Rulesets.UI
             }
 
             IBindable<bool> IFrameStableClock.IsCatchingUp => IsCatchingUp;
+
+            IBindable<bool> IFrameStableClock.WaitingOnFrames => WaitingOnFrames;
         }
     }
 }

--- a/osu.Game/Rulesets/UI/IFrameStableClock.cs
+++ b/osu.Game/Rulesets/UI/IFrameStableClock.cs
@@ -10,6 +10,9 @@ namespace osu.Game.Rulesets.UI
     {
         IBindable<bool> IsCatchingUp { get; }
 
+        /// <summary>
+        /// Whether the frame stable clock is waiting on new frames to arrive to be able to progress time.
+        /// </summary>
         IBindable<bool> WaitingOnFrames { get; }
     }
 }

--- a/osu.Game/Rulesets/UI/IFrameStableClock.cs
+++ b/osu.Game/Rulesets/UI/IFrameStableClock.cs
@@ -9,5 +9,7 @@ namespace osu.Game.Rulesets.UI
     public interface IFrameStableClock : IFrameBasedClock
     {
         IBindable<bool> IsCatchingUp { get; }
+
+        IBindable<bool> WaitingOnFrames { get; }
     }
 }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -63,6 +63,14 @@ namespace osu.Game.Screens.Play
 
         private readonly FramedOffsetClock platformOffsetClock;
 
+        /// <summary>
+        /// Creates a new <see cref="GameplayClockContainer"/>.
+        /// </summary>
+        /// <param name="beatmap">The beatmap being played.</param>
+        /// <param name="gameplayStartTime">The suggested time to start gameplay at.</param>
+        /// <param name="startAtGameplayStart">
+        /// Whether <paramref name="gameplayStartTime"/> should be used regardless of when storyboard events and hitobjects are supposed to start.
+        /// </param>
         public GameplayClockContainer(WorkingBeatmap beatmap, double gameplayStartTime, bool startAtGameplayStart = false)
         {
             this.beatmap = beatmap;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -238,6 +238,14 @@ namespace osu.Game.Screens.Play
                 skipOverlay.Hide();
             }
 
+            DrawableRuleset.FrameStableClock.WaitingOnFrames.BindValueChanged(waiting =>
+            {
+                if (waiting.NewValue)
+                    GameplayClockContainer.Stop();
+                else
+                    GameplayClockContainer.Start();
+            });
+
             DrawableRuleset.IsPaused.BindValueChanged(paused =>
             {
                 updateGameplayState();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Screens.Play
             if (!ScoreProcessor.Mode.Disabled)
                 config.BindWith(OsuSetting.ScoreDisplayMode, ScoreProcessor.Mode);
 
-            InternalChild = GameplayClockContainer = new GameplayClockContainer(Beatmap.Value, DrawableRuleset.GameplayStartTime);
+            InternalChild = GameplayClockContainer = CreateGameplayClockContainer(Beatmap.Value, DrawableRuleset.GameplayStartTime);
 
             AddInternal(gameplayBeatmap = new GameplayBeatmap(playableBeatmap));
             AddInternal(screenSuspension = new ScreenSuspensionHandler(GameplayClockContainer));
@@ -287,6 +287,8 @@ namespace osu.Game.Screens.Play
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
             IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
         }
+
+        protected virtual GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new GameplayClockContainer(beatmap, gameplayStart);
 
         private Drawable createUnderlayComponents() =>
             DimmableStoryboard = new DimmableStoryboard(Beatmap.Value.Storyboard) { RelativeSizeAxes = Axes.Both };

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Play
         public ReplayPlayer(Score score, bool allowPause = true, bool showResults = true)
             : base(allowPause, showResults)
         {
-            this.Score = score;
+            Score = score;
         }
 
         protected override void PrepareReplay()

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Screens.Play
 {
     public class ReplayPlayer : Player
     {
-        private readonly Score score;
+        protected readonly Score Score;
 
         // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
         protected override bool CheckModsAllowFailure() => false;
@@ -16,12 +16,12 @@ namespace osu.Game.Screens.Play
         public ReplayPlayer(Score score, bool allowPause = true, bool showResults = true)
             : base(allowPause, showResults)
         {
-            this.score = score;
+            this.Score = score;
         }
 
         protected override void PrepareReplay()
         {
-            DrawableRuleset?.SetReplayScore(score);
+            DrawableRuleset?.SetReplayScore(Score);
         }
 
         protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, false);
@@ -31,9 +31,9 @@ namespace osu.Game.Screens.Play
             var baseScore = base.CreateScore();
 
             // Since the replay score doesn't contain statistics, we'll pass them through here.
-            score.ScoreInfo.HitEvents = baseScore.HitEvents;
+            Score.ScoreInfo.HitEvents = baseScore.HitEvents;
 
-            return score.ScoreInfo;
+            return Score.ScoreInfo;
         }
     }
 }

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Screens.Play
             ruleset.Value = resolvedRuleset.RulesetInfo;
             beatmap.Value = beatmaps.GetWorkingBeatmap(resolvedBeatmap);
 
-            this.Push(new ReplayPlayerLoader(new Score
+            this.Push(new SpectatorPlayerLoader(new Score
             {
                 ScoreInfo = scoreInfo,
                 Replay = replay,

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Screens.Play
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
             spectatorStreaming.OnUserBeganPlaying += userBeganPlaying;
             spectatorStreaming.OnUserFinishedPlaying += userFinishedPlaying;
             spectatorStreaming.OnNewFrames += userSentFrames;

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -236,7 +236,7 @@ namespace osu.Game.Screens.Play
                 spectatorStreaming.StopWatchingUser((int)targetUser.Id);
             }
 
-            managerUpdated.UnbindAll();
+            managerUpdated?.UnbindAll();
         }
     }
 }

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -160,8 +160,6 @@ namespace osu.Game.Screens.Play
             if (userId != targetUser.Id)
                 return;
 
-            replay ??= new Replay { HasReceivedAllFrames = false };
-
             this.state = state;
 
             Schedule(attemptStart);
@@ -196,6 +194,8 @@ namespace osu.Game.Screens.Play
                 showBeatmapPanel(state.BeatmapID.Value);
                 return;
             }
+
+            replay ??= new Replay { HasReceivedAllFrames = false };
 
             var scoreInfo = new ScoreInfo
             {

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Users;
+
+namespace osu.Game.Screens.Play
+{
+    public class Spectator : OsuScreen
+    {
+        private readonly User targetUser;
+
+        public Spectator([NotNull] User targetUser)
+        {
+            this.targetUser = targetUser ?? throw new ArgumentNullException(nameof(targetUser));
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new OsuSpriteText
+                {
+                    Text = $"Watching {targetUser}",
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -63,6 +63,11 @@ namespace osu.Game.Screens.Play
 
         private IBindable<WeakReference<BeatmapSetInfo>> managerUpdated;
 
+        /// <summary>
+        /// Becomes true if a new state is waiting to be loaded (while this screen was not active).
+        /// </summary>
+        private bool newStatePending;
+
         public Spectator([NotNull] User targetUser)
         {
             this.targetUser = targetUser ?? throw new ArgumentNullException(nameof(targetUser));
@@ -162,7 +167,21 @@ namespace osu.Game.Screens.Play
 
             this.state = state;
 
-            Schedule(attemptStart);
+            if (this.IsCurrentScreen())
+                Schedule(attemptStart);
+            else
+                newStatePending = true;
+        }
+
+        public override void OnResuming(IScreen last)
+        {
+            base.OnResuming(last);
+
+            if (newStatePending)
+            {
+                attemptStart();
+                newStatePending = false;
+            }
         }
 
         private void userFinishedPlaying(int userId, SpectatorState state)

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -2,10 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Spectator;
+using osu.Game.Replays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Replays.Types;
+using osu.Game.Scoring;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Play
@@ -13,6 +25,26 @@ namespace osu.Game.Screens.Play
     public class Spectator : OsuScreen
     {
         private readonly User targetUser;
+
+        [Resolved]
+        private Bindable<WorkingBeatmap> beatmap { get; set; }
+
+        [Resolved]
+        private Bindable<RulesetInfo> ruleset { get; set; }
+
+        [Resolved]
+        private Bindable<IReadOnlyList<Mod>> mods { get; set; }
+
+        [Resolved]
+        private SpectatorStreamingClient spectatorStreaming { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        private Replay replay;
 
         public Spectator([NotNull] User targetUser)
         {
@@ -31,6 +63,87 @@ namespace osu.Game.Screens.Play
                     Origin = Anchor.Centre,
                 },
             };
+
+            spectatorStreaming.OnUserBeganPlaying += userBeganPlaying;
+            spectatorStreaming.OnUserFinishedPlaying += userFinishedPlaying;
+            spectatorStreaming.OnNewFrames += userSentFrames;
+
+            spectatorStreaming.WatchUser((int)targetUser.Id);
+        }
+
+        private void userSentFrames(int userId, FrameDataBundle data)
+        {
+            if (userId != targetUser.Id)
+                return;
+
+            var rulesetInstance = ruleset.Value.CreateInstance();
+
+            foreach (var frame in data.Frames)
+            {
+                IConvertibleReplayFrame convertibleFrame = rulesetInstance.CreateConvertibleReplayFrame();
+                convertibleFrame.FromLegacy(frame, beatmap.Value.Beatmap, null);
+
+                var convertedFrame = (ReplayFrame)convertibleFrame;
+                convertedFrame.Time = frame.Time;
+
+                replay.Frames.Add(convertedFrame);
+            }
+        }
+
+        private void userBeganPlaying(int userId, SpectatorState state)
+        {
+            if (userId != targetUser.Id)
+                return;
+
+            replay ??= new Replay();
+
+            var resolvedRuleset = rulesets.AvailableRulesets.FirstOrDefault(r => r.ID == state.RulesetID)?.CreateInstance();
+
+            // ruleset not available
+            if (resolvedRuleset == null)
+                return;
+
+            var resolvedBeatmap = beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == state.BeatmapID);
+
+            if (resolvedBeatmap == null)
+                return;
+
+            var scoreInfo = new ScoreInfo
+            {
+                Beatmap = resolvedBeatmap,
+                Mods = state.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
+                Ruleset = resolvedRuleset.RulesetInfo,
+            };
+
+            this.MakeCurrent();
+
+            ruleset.Value = resolvedRuleset.RulesetInfo;
+            beatmap.Value = beatmaps.GetWorkingBeatmap(resolvedBeatmap);
+
+            this.Push(new ReplayPlayerLoader(new Score
+            {
+                ScoreInfo = scoreInfo,
+                Replay = replay,
+            }));
+        }
+
+        private void userFinishedPlaying(int userId, SpectatorState state)
+        {
+            // todo: handle this in some way?
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (spectatorStreaming != null)
+            {
+                spectatorStreaming.OnUserBeganPlaying -= userBeganPlaying;
+                spectatorStreaming.OnUserFinishedPlaying -= userFinishedPlaying;
+                spectatorStreaming.OnNewFrames -= userSentFrames;
+
+                spectatorStreaming.StopWatchingUser((int)targetUser.Id);
+            }
         }
     }
 }

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -63,7 +63,11 @@ namespace osu.Game.Screens.Play
                     Origin = Anchor.Centre,
                 },
             };
+        }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
             spectatorStreaming.OnUserBeganPlaying += userBeganPlaying;
             spectatorStreaming.OnUserFinishedPlaying += userFinishedPlaying;
             spectatorStreaming.OnNewFrames += userSentFrames;
@@ -74,6 +78,11 @@ namespace osu.Game.Screens.Play
         private void userSentFrames(int userId, FrameDataBundle data)
         {
             if (userId != targetUser.Id)
+                return;
+
+            // this should never happen as the server sends the user's state on watching,
+            // but is here as a safety measure.
+            if (replay == null)
                 return;
 
             var rulesetInstance = ruleset.Value.CreateInstance();

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -167,6 +167,16 @@ namespace osu.Game.Screens.Play
             attemptStart();
         }
 
+        private void userFinishedPlaying(int userId, SpectatorState state)
+        {
+            if (userId != targetUser.Id)
+                return;
+
+            if (replay == null) return;
+
+            replay.HasReceivedAllFrames = true;
+        }
+
         private void attemptStart()
         {
             var resolvedRuleset = rulesets.AvailableRulesets.FirstOrDefault(r => r.ID == state.RulesetID)?.CreateInstance();
@@ -214,13 +224,6 @@ namespace osu.Game.Screens.Play
             });
 
             api.Queue(req);
-        }
-
-        private void userFinishedPlaying(int userId, SpectatorState state)
-        {
-            if (replay == null) return;
-
-            replay.HasReceivedAllFrames = true;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Screens.Play
 
             this.state = state;
 
-            attemptStart();
+            Schedule(attemptStart);
         }
 
         private void userFinishedPlaying(int userId, SpectatorState state)
@@ -175,6 +175,7 @@ namespace osu.Game.Screens.Play
             if (replay == null) return;
 
             replay.HasReceivedAllFrames = true;
+            replay = null;
         }
 
         private void attemptStart()
@@ -188,8 +189,6 @@ namespace osu.Game.Screens.Play
             if (state.BeatmapID == null)
                 return;
 
-            this.MakeCurrent();
-
             var resolvedBeatmap = beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == state.BeatmapID);
 
             if (resolvedBeatmap == null)
@@ -201,6 +200,7 @@ namespace osu.Game.Screens.Play
             var scoreInfo = new ScoreInfo
             {
                 Beatmap = resolvedBeatmap,
+                User = targetUser,
                 Mods = state.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
                 Ruleset = resolvedRuleset.RulesetInfo,
             };

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Screens.Play
         [Resolved]
         private Bindable<RulesetInfo> ruleset { get; set; }
 
+        private Ruleset rulesetInstance;
+
         [Resolved]
         private Bindable<IReadOnlyList<Mod>> mods { get; set; }
 
@@ -141,12 +143,10 @@ namespace osu.Game.Screens.Play
             if (replay == null)
                 return;
 
-            var rulesetInstance = ruleset.Value.CreateInstance();
-
             foreach (var frame in data.Frames)
             {
                 IConvertibleReplayFrame convertibleFrame = rulesetInstance.CreateConvertibleReplayFrame();
-                convertibleFrame.FromLegacy(frame, beatmap.Value.Beatmap, null);
+                convertibleFrame.FromLegacy(frame, beatmap.Value.Beatmap);
 
                 var convertedFrame = (ReplayFrame)convertibleFrame;
                 convertedFrame.Time = frame.Time;
@@ -206,6 +206,8 @@ namespace osu.Game.Screens.Play
             };
 
             ruleset.Value = resolvedRuleset.RulesetInfo;
+            rulesetInstance = resolvedRuleset;
+
             beatmap.Value = beatmaps.GetWorkingBeatmap(resolvedBeatmap);
 
             this.Push(new SpectatorPlayerLoader(new Score

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -8,10 +8,15 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
 using osu.Game.Online.Spectator;
+using osu.Game.Overlays.BeatmapListing.Panels;
 using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -19,6 +24,7 @@ using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Scoring;
 using osu.Game.Users;
+using osuTK;
 
 namespace osu.Game.Screens.Play
 {
@@ -36,6 +42,9 @@ namespace osu.Game.Screens.Play
         private Bindable<IReadOnlyList<Mod>> mods { get; set; }
 
         [Resolved]
+        private IAPIProvider api { get; set; }
+
+        [Resolved]
         private SpectatorStreamingClient spectatorStreaming { get; set; }
 
         [Resolved]
@@ -45,6 +54,12 @@ namespace osu.Game.Screens.Play
         private RulesetStore rulesets { get; set; }
 
         private Replay replay;
+
+        private Container beatmapPanelContainer;
+
+        private SpectatorState state;
+
+        private IBindable<WeakReference<BeatmapSetInfo>> managerUpdated;
 
         public Spectator([NotNull] User targetUser)
         {
@@ -56,11 +71,42 @@ namespace osu.Game.Screens.Play
         {
             InternalChildren = new Drawable[]
             {
-                new OsuSpriteText
+                new FillFlowContainer
                 {
-                    Text = $"Watching {targetUser}",
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Spacing = new Vector2(15),
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = "Currently spectating",
+                            Font = OsuFont.Default.With(size: 30),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        new UserGridPanel(targetUser)
+                        {
+                            Width = 290,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        new OsuSpriteText
+                        {
+                            Text = "playing",
+                            Font = OsuFont.Default.With(size: 30),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        beatmapPanelContainer = new Container
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                    }
                 },
             };
         }
@@ -74,6 +120,15 @@ namespace osu.Game.Screens.Play
             spectatorStreaming.OnNewFrames += userSentFrames;
 
             spectatorStreaming.WatchUser((int)targetUser.Id);
+
+            managerUpdated = beatmaps.ItemUpdated.GetBoundCopy();
+            managerUpdated.BindValueChanged(beatmapUpdated);
+        }
+
+        private void beatmapUpdated(ValueChangedEvent<WeakReference<BeatmapSetInfo>> beatmap)
+        {
+            if (beatmap.NewValue.TryGetTarget(out var beatmapSet) && beatmapSet.Beatmaps.Any(b => b.OnlineBeatmapID == state.BeatmapID))
+                attemptStart();
         }
 
         private void userSentFrames(int userId, FrameDataBundle data)
@@ -107,16 +162,31 @@ namespace osu.Game.Screens.Play
 
             replay ??= new Replay { HasReceivedAllFrames = false };
 
+            this.state = state;
+
+            attemptStart();
+        }
+
+        private void attemptStart()
+        {
             var resolvedRuleset = rulesets.AvailableRulesets.FirstOrDefault(r => r.ID == state.RulesetID)?.CreateInstance();
 
             // ruleset not available
             if (resolvedRuleset == null)
                 return;
 
+            if (state.BeatmapID == null)
+                return;
+
+            this.MakeCurrent();
+
             var resolvedBeatmap = beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == state.BeatmapID);
 
             if (resolvedBeatmap == null)
+            {
+                showBeatmapPanel(state.BeatmapID.Value);
                 return;
+            }
 
             var scoreInfo = new ScoreInfo
             {
@@ -124,8 +194,6 @@ namespace osu.Game.Screens.Play
                 Mods = state.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
                 Ruleset = resolvedRuleset.RulesetInfo,
             };
-
-            this.MakeCurrent();
 
             ruleset.Value = resolvedRuleset.RulesetInfo;
             beatmap.Value = beatmaps.GetWorkingBeatmap(resolvedBeatmap);
@@ -135,6 +203,17 @@ namespace osu.Game.Screens.Play
                 ScoreInfo = scoreInfo,
                 Replay = replay,
             }));
+        }
+
+        private void showBeatmapPanel(int beatmapId)
+        {
+            var req = new GetBeatmapSetRequest(beatmapId, BeatmapSetLookupType.BeatmapId);
+            req.Success += res => Schedule(() =>
+            {
+                beatmapPanelContainer.Child = new GridBeatmapPanel(res.ToBeatmapSet(rulesets));
+            });
+
+            api.Queue(req);
         }
 
         private void userFinishedPlaying(int userId, SpectatorState state)
@@ -156,6 +235,8 @@ namespace osu.Game.Screens.Play
 
                 spectatorStreaming.StopWatchingUser((int)targetUser.Id);
             }
+
+            managerUpdated.UnbindAll();
         }
     }
 }

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Play
             if (userId != targetUser.Id)
                 return;
 
-            replay ??= new Replay();
+            replay ??= new Replay { HasReceivedAllFrames = false };
 
             var resolvedRuleset = rulesets.AvailableRulesets.FirstOrDefault(r => r.ID == state.RulesetID)?.CreateInstance();
 
@@ -138,7 +138,9 @@ namespace osu.Game.Screens.Play
 
         private void userFinishedPlaying(int userId, SpectatorState state)
         {
-            // todo: handle this in some way?
+            if (replay == null) return;
+
+            replay.HasReceivedAllFrames = true;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Scoring;
+
+namespace osu.Game.Screens.Play
+{
+    public class SpectatorPlayer : ReplayPlayer
+    {
+        public SpectatorPlayer(Score score)
+            : base(score)
+        {
+        }
+
+        protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart)
+        {
+            // if we already have frames, start gameplay at the point in time they exist, should they be too far into the beatmap.
+            double? firstFrameTime = Score.Replay.Frames.FirstOrDefault()?.Time;
+
+            if (firstFrameTime == null || firstFrameTime <= gameplayStart + 5000)
+                return base.CreateGameplayClockContainer(beatmap, gameplayStart);
+
+            return new GameplayClockContainer(beatmap, firstFrameTime.Value, true);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -26,12 +26,6 @@ namespace osu.Game.Screens.Play
             spectatorStreaming.OnUserBeganPlaying += userBeganPlaying;
         }
 
-        private void userBeganPlaying(int userId, SpectatorState state)
-        {
-            if (userId == Score.ScoreInfo.UserID)
-                Schedule(this.Exit);
-        }
-
         protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart)
         {
             // if we already have frames, start gameplay at the point in time they exist, should they be too far into the beatmap.
@@ -41,6 +35,26 @@ namespace osu.Game.Screens.Play
                 return base.CreateGameplayClockContainer(beatmap, gameplayStart);
 
             return new GameplayClockContainer(beatmap, firstFrameTime.Value, true);
+        }
+
+        public override bool OnExiting(IScreen next)
+        {
+            spectatorStreaming.OnUserBeganPlaying -= userBeganPlaying;
+            return base.OnExiting(next);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (spectatorStreaming != null)
+                spectatorStreaming.OnUserBeganPlaying -= userBeganPlaying;
+        }
+
+        private void userBeganPlaying(int userId, SpectatorState state)
+        {
+            if (userId == Score.ScoreInfo.UserID)
+                Schedule(this.Exit);
         }
     }
 }

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -2,16 +2,34 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Screens;
 using osu.Game.Beatmaps;
+using osu.Game.Online.Spectator;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Play
 {
     public class SpectatorPlayer : ReplayPlayer
     {
+        [Resolved]
+        private SpectatorStreamingClient spectatorStreaming { get; set; }
+
         public SpectatorPlayer(Score score)
             : base(score)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            spectatorStreaming.OnUserBeganPlaying += userBeganPlaying;
+        }
+
+        private void userBeganPlaying(int userId, SpectatorState state)
+        {
+            if (userId == Score.ScoreInfo.UserID)
+                Schedule(this.Exit);
         }
 
         protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart)

--- a/osu.Game/Screens/Play/SpectatorPlayerLoader.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayerLoader.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Screens;
+using osu.Game.Scoring;
+
+namespace osu.Game.Screens.Play
+{
+    public class SpectatorPlayerLoader : PlayerLoader
+    {
+        public readonly ScoreInfo Score;
+
+        public SpectatorPlayerLoader(Score score)
+            : base(() => new SpectatorPlayer(score))
+        {
+            if (score.Replay == null)
+                throw new ArgumentException($"{nameof(score)} must have a non-null {nameof(score.Replay)}.", nameof(score));
+
+            Score = score.ScoreInfo;
+        }
+
+        public override void OnEntering(IScreen last)
+        {
+            // these will be reverted thanks to PlayerLoader's lease.
+            Mods.Value = Score.Mods;
+            Ruleset.Value = Score.Ruleset;
+
+            base.OnEntering(last);
+        }
+    }
+}


### PR DESCRIPTION
Just going to PR this to get something out there (and so I can monitor the size of the diff)

Note that there's no way to reach this from the client itself, and I've been developing it completely via visual tests. Individual commits can be split out if deemed required. A few underlying changes were required to make this work:

- `FrameStabilityContainer` needed logic changes to handle cases where replay data was not completely received. Fixing handling where there's zero frames, or where we've reached the end of streaming data.
- Player needs to act on `FrameStabilityContainer` running out of frames, and pause gameplay. Right now this is done via a simple method, which will likely need to be adjusted once there's the ability for a user to pause replay playback.

Note that some of the tests are incomplete (pending further implementation in the `Spectator` screen component). All the basic flows and behaviours seem to be correct though.