### PR TITLE
Fix timeline zoom during drag-select causing unexpected behaviour

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
@@ -139,6 +138,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private class TimelineDragBox : DragBox
         {
             private Vector2 lastMouseDown;
+
             private float? lastZoom;
             private float localMouseDown;
 
@@ -166,13 +166,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     lastZoom = null;
                 }
 
-                //Zooming the timeline shifts the coordinate system this compensates for this shift
-                float zoomCorrection = lastZoom.HasValue ? (parent.timeline.Zoom / lastZoom.Value) : 1;
+                //Zooming the timeline shifts the coordinate system. zoomCorrection compensates for that
+                float zoomCorrection = lastZoom.HasValue ? (parent.timeline.CurrentZoom / lastZoom.Value) : 1;
                 localMouseDown *= zoomCorrection;
-                lastZoom = parent.timeline.Zoom;
+                lastZoom = parent.timeline.CurrentZoom;
 
                 float selection1 = localMouseDown;
-                float selection2 = e.MousePosition.X;
+                float selection2 = e.MousePosition.X * zoomCorrection;
 
                 Box.X = Math.Min(selection1, selection2);
                 Box.Width = Math.Abs(selection1 - selection2);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// </summary>
         public float CurrentZoom => currentZoom;
 
-
         [Resolved(canBeNull: true)]
         private IFrameBasedClock editorClock { get; set; }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -29,8 +29,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private readonly Container zoomedContent;
         protected override Container<Drawable> Content => zoomedContent;
-
         private float currentZoom = 1;
+
+        /// <summary>
+        /// The current zoom level of <see cref="ZoomableScrollContainer" />.
+        /// It may differ from <see cref="Zoom" /> during transitions.
+        /// </summary>
+        public float CurrentZoom => currentZoom;
+
 
         [Resolved(canBeNull: true)]
         private IFrameBasedClock editorClock { get; set; }


### PR DESCRIPTION
Fixes #10594 

Drag-selecting while zooming in the timeline would cause unexpected results. The starting point of the selection would shift and the end point behave erratically. I believe this is caused by the scaling of the zoomed content scaling the local coordinates with it. 

```csharp
private void updateZoomedContentWidth() => zoomedContent.Width = DrawWidth * currentZoom;
```

Fixed by exposing ``currentZoom`` value of ``ZoomableScrollContainer`` and compensating for zoom changes in the ``handleDrag()`` method.

I attempted to use ``ToSpaceOfOtherDrawable`` to convert coordinates to and from various related components [as suggested](https://github.com/ppy/osu/issues/10594#issuecomment-716766355). However none of my attempts yielded the expected results. I can not say for sure that a better solution does not exist, but I was unable to find one.

<details>


Before:

![before](https://user-images.githubusercontent.com/22643729/97328924-cda0b100-1876-11eb-9e2c-100fad6110f6.gif)

After:

![after](https://user-images.githubusercontent.com/22643729/97328976-d8f3dc80-1876-11eb-9f59-9ac8d2f33ef1.gif)

</details>



