### PR TITLE
Fix editor crash on exit when forcing exit twice in a row

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -444,12 +444,21 @@ namespace osu.Game.Screens.Edit
                 if (dialogOverlay == null || dialogOverlay.CurrentDialog is PromptForSaveDialog)
                 {
                     confirmExit();
-                    return true;
+                    return false;
                 }
 
                 if (isNewBeatmap || HasUnsavedChanges)
                 {
-                    dialogOverlay?.Push(new PromptForSaveDialog(confirmExit, confirmExitWithSave));
+                    dialogOverlay?.Push(new PromptForSaveDialog(() =>
+                    {
+                        confirmExit();
+                        this.Exit();
+                    }, () =>
+                    {
+                        confirmExitWithSave();
+                        this.Exit();
+                    }));
+
                     return true;
                 }
             }
@@ -464,7 +473,6 @@ namespace osu.Game.Screens.Edit
         {
             exitConfirmed = true;
             Save();
-            this.Exit();
         }
 
         private void confirmExit()
@@ -483,7 +491,6 @@ namespace osu.Game.Screens.Edit
             }
 
             exitConfirmed = true;
-            this.Exit();
         }
 
         private readonly Bindable<string> clipboard = new Bindable<string>();


### PR DESCRIPTION
Basically the editor was calling `this.Exit()` from inside `OnExiting`, which manages to trigger a double `MakeCurrent` call on screen stack. Will be looking at a framework side reproduction / fix for this (to throw a better error message) but it does also need to be fixed locally.

Closes #10418.