### PR TITLE
Clean up FrameStabilityContainer state handling logic

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -236,14 +236,13 @@ namespace osu.Game.Rulesets.UI
             NotValid,
 
             /// <summary>
-            /// Whether we are running up-to-date with our parent clock.
-            /// If not, we will need to keep processing children until we catch up.
+            /// Playback is running behind real-time. Catch-up will be attempted by processing more than once per
+            /// game loop (limited to a sane maximum to avoid frame drops).
             /// </summary>
             RequiresCatchUp,
 
             /// <summary>
-            /// Whether we are in a valid state (ie. should we keep processing children frames).
-            /// This should be set to false when the replay is, for instance, waiting for future frames to arrive.
+            /// In a valid state, progressing one child hierarchy loop per game loop.
             /// </summary>
             Valid
         }

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -120,7 +120,12 @@ namespace osu.Game.Rulesets.UI
                 applyFrameStability(ref proposedTime);
 
             if (hasReplayAttached)
-                state = updateReplay(ref proposedTime);
+            {
+                bool valid = updateReplay(ref proposedTime);
+
+                if (!valid)
+                    state = PlaybackState.NotValid;
+            }
 
             if (proposedTime != manualClock.CurrentTime)
                 direction = proposedTime > manualClock.CurrentTime ? 1 : -1;
@@ -132,8 +137,8 @@ namespace osu.Game.Rulesets.UI
             double timeBehind = Math.Abs(manualClock.CurrentTime - parentGameplayClock.CurrentTime);
 
             // determine whether catch-up is required.
-            if (state != PlaybackState.NotValid)
-                state = timeBehind > 0 ? PlaybackState.RequiresCatchUp : PlaybackState.Valid;
+            if (state == PlaybackState.Valid && timeBehind > 0)
+                state = PlaybackState.RequiresCatchUp;
 
             frameStableClock.IsCatchingUp.Value = timeBehind > 200;
 
@@ -146,7 +151,8 @@ namespace osu.Game.Rulesets.UI
         /// Attempt to advance replay playback for a given time.
         /// </summary>
         /// <param name="proposedTime">The time which is to be displayed.</param>
-        private PlaybackState updateReplay(ref double proposedTime)
+        /// <returns>Whether playback is still valid.</returns>
+        private bool updateReplay(ref double proposedTime)
         {
             double? newTime;
 
@@ -172,10 +178,10 @@ namespace osu.Game.Rulesets.UI
             }
 
             if (newTime == null)
-                return PlaybackState.NotValid;
+                return false;
 
             proposedTime = newTime.Value;
-            return PlaybackState.Valid;
+            return true;
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -114,37 +114,32 @@ namespace osu.Game.Rulesets.UI
             // our goal is to catch up to the time provided by the parent clock.
             var proposedTime = parentGameplayClock.CurrentTime;
 
-            try
-            {
-                if (FrameStablePlayback)
-                    // if we require frame stability, the proposed time will be adjusted to move at most one known
-                    // frame interval in the current direction.
-                    applyFrameStability(ref proposedTime);
+            if (FrameStablePlayback)
+                // if we require frame stability, the proposed time will be adjusted to move at most one known
+                // frame interval in the current direction.
+                applyFrameStability(ref proposedTime);
 
-                if (hasReplayAttached)
-                    state = updateReplay(ref proposedTime);
-            }
-            finally
-            {
-                if (proposedTime != manualClock.CurrentTime)
-                    direction = proposedTime > manualClock.CurrentTime ? 1 : -1;
+            if (hasReplayAttached)
+                state = updateReplay(ref proposedTime);
 
-                manualClock.CurrentTime = proposedTime;
-                manualClock.Rate = Math.Abs(parentGameplayClock.Rate) * direction;
-                manualClock.IsRunning = parentGameplayClock.IsRunning;
+            if (proposedTime != manualClock.CurrentTime)
+                direction = proposedTime >= manualClock.CurrentTime ? 1 : -1;
 
-                double timeBehind = Math.Abs(manualClock.CurrentTime - parentGameplayClock.CurrentTime);
+            manualClock.CurrentTime = proposedTime;
+            manualClock.Rate = Math.Abs(parentGameplayClock.Rate) * direction;
+            manualClock.IsRunning = parentGameplayClock.IsRunning;
 
-                // determine whether catch-up is required.
-                if (state != PlaybackState.NotValid)
-                    state = timeBehind > 0 ? PlaybackState.RequiresCatchUp : PlaybackState.Valid;
+            double timeBehind = Math.Abs(manualClock.CurrentTime - parentGameplayClock.CurrentTime);
 
-                frameStableClock.IsCatchingUp.Value = timeBehind > 200;
+            // determine whether catch-up is required.
+            if (state != PlaybackState.NotValid)
+                state = timeBehind > 0 ? PlaybackState.RequiresCatchUp : PlaybackState.Valid;
 
-                // The manual clock time has changed in the above code. The framed clock now needs to be updated
-                // to ensure that the its time is valid for our children before input is processed
-                framedClock.ProcessFrame();
-            }
+            frameStableClock.IsCatchingUp.Value = timeBehind > 200;
+
+            // The manual clock time has changed in the above code. The framed clock now needs to be updated
+            // to ensure that the its time is valid for our children before input is processed
+            framedClock.ProcessFrame();
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.UI
                 state = updateReplay(ref proposedTime);
 
             if (proposedTime != manualClock.CurrentTime)
-                direction = proposedTime >= manualClock.CurrentTime ? 1 : -1;
+                direction = proposedTime > manualClock.CurrentTime ? 1 : -1;
 
             manualClock.CurrentTime = proposedTime;
             manualClock.Rate = Math.Abs(parentGameplayClock.Rate) * direction;


### PR DESCRIPTION
Figured this could be improved while working through the spectator logic.

This should not change any logic, just restructure to be easier to follow.