### PR TITLE
Change shift-tab to cycle between available HUD visibility modes

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestExternalHideDoesntAffectConfig()
         {
-            HUDVisibilityMode originalConfigValue = HUDVisibilityMode.HideDuringBreaks;
+            HUDVisibilityMode originalConfigValue = HUDVisibilityMode.HideDuringGameplay;
 
             createNew();
 

--- a/osu.Game/Configuration/HUDVisibilityMode.cs
+++ b/osu.Game/Configuration/HUDVisibilityMode.cs
@@ -12,9 +12,6 @@ namespace osu.Game.Configuration
         [Description("Hide during gameplay")]
         HideDuringGameplay,
 
-        [Description("Hide during breaks")]
-        HideDuringBreaks,
-
         Always
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -170,6 +170,7 @@ namespace osu.Game.Configuration
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
         {
             new TrackedSetting<bool>(OsuSetting.MouseDisableButtons, v => new SettingDescription(!v, "gameplay mouse buttons", v ? "disabled" : "enabled")),
+            new TrackedSetting<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode, m => new SettingDescription(m, "HUD Visibility", m.GetDescription())),
             new TrackedSetting<ScalingMode>(OsuSetting.Scaling, m => new SettingDescription(m, "scaling", m.GetDescription())),
         };
     }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -277,9 +277,25 @@ namespace osu.Game.Screens.Play
                 switch (e.Key)
                 {
                     case Key.Tab:
-                        configVisibilityMode.Value = configVisibilityMode.Value != HUDVisibilityMode.Never
-                            ? HUDVisibilityMode.Never
-                            : HUDVisibilityMode.HideDuringGameplay;
+                        switch (configVisibilityMode.Value)
+                        {
+                            case HUDVisibilityMode.Never:
+                                configVisibilityMode.Value = HUDVisibilityMode.HideDuringGameplay;
+                                break;
+
+                            case HUDVisibilityMode.HideDuringGameplay:
+                                configVisibilityMode.Value = HUDVisibilityMode.HideDuringBreaks;
+                                break;
+
+                            case HUDVisibilityMode.HideDuringBreaks:
+                                configVisibilityMode.Value = HUDVisibilityMode.Always;
+                                break;
+
+                            case HUDVisibilityMode.Always:
+                                configVisibilityMode.Value = HUDVisibilityMode.Never;
+                                break;
+                        }
+
                         return true;
                 }
             }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -223,11 +223,6 @@ namespace osu.Game.Screens.Play
                     ShowHud.Value = false;
                     break;
 
-                case HUDVisibilityMode.HideDuringBreaks:
-                    // always show during replay as we want the seek bar to be visible.
-                    ShowHud.Value = replayLoaded.Value || !IsBreakTime.Value;
-                    break;
-
                 case HUDVisibilityMode.HideDuringGameplay:
                     // always show during replay as we want the seek bar to be visible.
                     ShowHud.Value = replayLoaded.Value || IsBreakTime.Value;
@@ -284,10 +279,6 @@ namespace osu.Game.Screens.Play
                                 break;
 
                             case HUDVisibilityMode.HideDuringGameplay:
-                                configVisibilityMode.Value = HUDVisibilityMode.HideDuringBreaks;
-                                break;
-
-                            case HUDVisibilityMode.HideDuringBreaks:
                                 configVisibilityMode.Value = HUDVisibilityMode.Always;
                                 break;
 


### PR DESCRIPTION
I ended up just making the key cycle. It feels good enough and keeps all options available and at a configuration level.

![2020-10-30 13 12 17](https://user-images.githubusercontent.com/191335/97659143-8eaa6f80-1ab1-11eb-81f4-c4b874ca8a9d.gif)

Closes https://github.com/ppy/osu/issues/10570