### PR TITLE
Fix "bounce" when metadata container text is empty in song select

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -300,6 +300,7 @@ namespace osu.Game.Screens.Select
 
             public MetadataSection(string title)
             {
+                Alpha = 0;
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
 


### PR DESCRIPTION
Closes #9335
Supersedes / closes #9338

Previously an empty `source` metadata container would push down the neighboring `tags` metadata container, before immediately initiating a fade out due to having no text. This made the `tags` container appear to "bounce"

The change can be verified with the ["all except source"](https://github.com/ppy/osu/blob/aa1daa0ad50205ea96da37b358e71820c04e41da/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapDetails.cs#L59) visual test. Also see the "all metrics" test for intended behaviour

Before:
![2020-10-31_03-14-51](https://user-images.githubusercontent.com/25311843/97715436-429a1200-1b27-11eb-8ac4-2f8894a0e42d.gif)

After:
![2020-10-31_03-16-07](https://user-images.githubusercontent.com/25311843/97715569-7117ed00-1b27-11eb-8569-fbadb2371788.gif)
