### PR TITLE
Fix selection box action tooltips still being visible after object deletion

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -210,10 +210,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
 
             if (DragBox.State == Visibility.Visible)
-            {
                 DragBox.Hide();
-                SelectionHandler.UpdateVisibility();
-            }
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)
@@ -352,11 +349,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Selects all <see cref="SelectionBlueprint"/>s.
         /// </summary>
-        private void selectAll()
-        {
-            SelectionBlueprints.ToList().ForEach(m => m.Select());
-            SelectionHandler.UpdateVisibility();
-        }
+        private void selectAll() => SelectionBlueprints.ToList().ForEach(m => m.Select());
 
         /// <summary>
         /// Deselects all selected <see cref="SelectionBlueprint"/>s.

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -201,8 +201,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // there are potentially multiple SelectionHandlers active, but we only want to add hitobjects to the selected list once.
             if (!EditorBeatmap.SelectedHitObjects.Contains(blueprint.HitObject))
                 EditorBeatmap.SelectedHitObjects.Add(blueprint.HitObject);
-
-            UpdateVisibility();
         }
 
         /// <summary>
@@ -214,8 +212,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             selectedBlueprints.Remove(blueprint);
 
             EditorBeatmap.SelectedHitObjects.Remove(blueprint.HitObject);
-
-            UpdateVisibility();
         }
 
         /// <summary>
@@ -254,7 +250,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Updates whether this <see cref="SelectionHandler"/> is visible.
         /// </summary>
-        internal void UpdateVisibility()
+        private void updateVisibility()
         {
             int count = selectedBlueprints.Count;
 
@@ -421,7 +417,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // bring in updates from selection changes
             EditorBeatmap.HitObjectUpdated += _ => UpdateTernaryStates();
-            EditorBeatmap.SelectedHitObjects.CollectionChanged += (sender, args) => UpdateTernaryStates();
+            EditorBeatmap.SelectedHitObjects.CollectionChanged += (sender, args) =>
+            {
+                updateVisibility();
+                UpdateTernaryStates();
+            };
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -257,16 +257,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
             selectionDetailsText.Text = count > 0 ? count.ToString() : string.Empty;
 
             if (count > 0)
-            {
                 Show();
-                OnSelectionChanged();
-            }
             else
                 Hide();
+
+            OnSelectionChanged();
         }
 
         /// <summary>
-        /// Triggered whenever more than one object is selected, on each change.
+        /// Triggered whenever the set of selected objects changes.
         /// Should update the selection box's state to match supported operations.
         /// </summary>
         protected virtual void OnSelectionChanged()

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -256,11 +256,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             selectionDetailsText.Text = count > 0 ? count.ToString() : string.Empty;
 
-            if (count > 0)
-                Show();
-            else
-                Hide();
-
+            this.FadeTo(count > 0 ? 1 : 0);
             OnSelectionChanged();
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -414,7 +414,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             EditorBeatmap.HitObjectUpdated += _ => UpdateTernaryStates();
             EditorBeatmap.SelectedHitObjects.CollectionChanged += (sender, args) =>
             {
-                updateVisibility();
+                Scheduler.AddOnce(updateVisibility);
                 UpdateTernaryStates();
             };
         }


### PR DESCRIPTION
# Summary

No linked issue, spotted this on my own. Reproduction steps on `master`:

* Select object(s) on an osu! map so that the selection box actions are visible
* Delete object(s)
* Hover mouse over where the selection box action buttons were
* The tooltips will show even though the selection box is hidden

There were actually a few factors for this that seem like oversights, related to when `OsuSelectionHandler.OnSelectionChanged()` was being called:

https://github.com/ppy/osu/blob/ea007af57260f0a0121c57c2d2d4aaad7bb46730/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs#L20-L30

* `UpdateVisibility()` was being called manually at a few places, which was brittle, as forgetting to call it (or mutating selection from anywhere else other than this class) could mean that the state of the buttons would not be consistent with the selection box's invariants. This was changed to bind directly to any change in the collection to avoid both issues.
* Secondarily, `OnSelectionChanged()` was only being called when there was any selected object, which meant that the buttons would stay behind if the current object was deselected, as the method would not be fired in this case. This is fixed by making `OnSelectionChanged()` run also on deselection.

Note that the current logic for setting `Alpha` on the selection handler wasn't having the desired effect due to it being always present.

# Remarks

Performance-wise maybe this isn't the best choice ever in cases like `selectAll()`, but those need to be improved in the end anyway (all objects should probably be added to the list in bulk to prevent N callbacks from firing), but I think this is definitely way better than having to remember to call the method to have the selection box behave as desired.