### PR TITLE
Fix potential null reference when loading background

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
@@ -149,17 +149,13 @@ namespace osu.Game.Tests.Visual.Background
             => AddStep($"set seasonal mode to {mode}", () => config.Set(OsuSetting.SeasonalBackgroundMode, mode));
 
         private void createLoader()
-        {
-            AddStep("create loader", () =>
+            => AddStep("create loader", () =>
             {
                 if (backgroundLoader != null)
                     Remove(backgroundLoader);
 
-                LoadComponentAsync(backgroundLoader = new SeasonalBackgroundLoader(), Add);
+                Add(backgroundLoader = new SeasonalBackgroundLoader());
             });
-
-            AddUntilStep("wait for loaded", () => backgroundLoader.IsLoaded);
-        }
 
         private void loadNextBackground()
         {

--- a/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
+++ b/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
@@ -15,7 +15,6 @@ using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Graphics.Backgrounds
 {
-    [LongRunningLoad]
     public class SeasonalBackgroundLoader : Component
     {
         /// <summary>

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Screens.Backgrounds
             mode = config.GetBindable<BackgroundSource>(OsuSetting.MenuBackgroundSource);
             introSequence = config.GetBindable<IntroSequence>(OsuSetting.IntroSequence);
 
+            AddInternal(seasonalBackgroundLoader);
+
             user.ValueChanged += _ => Next();
             skin.ValueChanged += _ => Next();
             mode.ValueChanged += _ => Next();
@@ -53,7 +55,6 @@ namespace osu.Game.Screens.Backgrounds
 
             currentDisplay = RNG.Next(0, background_count);
 
-            LoadComponentAsync(seasonalBackgroundLoader);
             Next();
         }
 


### PR DESCRIPTION
As seen in
https://discordapp.com/channels/188630481301012481/188630652340404224/772094427342569493.
Caused due to async load of the loader, which means it may not be ready
before Next() is called.