### PR TITLE
Fix music being paused after retrying & exiting timeshift map

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
 
             if (withUserPause)
-                AddStep("pause", () => Game.Dependencies.Get<MusicController>().Stop());
+                AddStep("pause", () => Game.Dependencies.Get<MusicController>().Stop(true));
 
             AddStep("press enter", () => pressAndRelease(Key.Enter));
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -187,7 +187,7 @@ namespace osu.Game.Overlays
         /// Specifying <c>true</c> will ensure that other methods like <see cref="EnsurePlayingSomething"/>
         /// will not resume music playback until the next explicit call to <see cref="Play"/>.
         /// </param>
-        public void Stop(bool requestedByUser = true)
+        public void Stop(bool requestedByUser = false)
         {
             IsUserPaused |= requestedByUser;
             if (CurrentTrack.IsRunning)
@@ -201,7 +201,7 @@ namespace osu.Game.Overlays
         public bool TogglePause()
         {
             if (CurrentTrack.IsRunning)
-                Stop();
+                Stop(true);
             else
                 Play();
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -182,9 +182,14 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Stop playing the current track and pause at the current position.
         /// </summary>
-        public void Stop()
+        /// <param name="requestedByUser">
+        /// Whether the request to stop was issued by the user rather than internally.
+        /// Specifying <c>true</c> will ensure that other methods like <see cref="EnsurePlayingSomething"/>
+        /// will not resume music playback until the next explicit call to <see cref="Play"/>.
+        /// </param>
+        public void Stop(bool requestedByUser = true)
         {
-            IsUserPaused = true;
+            IsUserPaused |= requestedByUser;
             if (CurrentTrack.IsRunning)
                 CurrentTrack.Stop();
         }

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -166,10 +166,17 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Start playing the current track (if not already playing).
         /// </summary>
+        /// <param name="restart">Whether to restart the track from the beginning.</param>
+        /// <param name="requestedByUser">
+        /// Whether the request to play was issued by the user rather than internally.
+        /// Specifying <c>true</c> will ensure that other methods like <see cref="EnsurePlayingSomething"/>
+        /// will resume music playback going forward.
+        /// </param>
         /// <returns>Whether the operation was successful.</returns>
-        public bool Play(bool restart = false)
+        public bool Play(bool restart = false, bool requestedByUser = false)
         {
-            IsUserPaused = false;
+            if (requestedByUser)
+                IsUserPaused = false;
 
             if (restart)
                 CurrentTrack.Restart();
@@ -203,7 +210,7 @@ namespace osu.Game.Overlays
             if (CurrentTrack.IsRunning)
                 Stop(true);
             else
-                Play();
+                Play(requestedByUser: true);
 
             return true;
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -472,7 +472,7 @@ namespace osu.Game.Screens.Play
         {
             // at the point of restarting the track should either already be paused or the volume should be zero.
             // stopping here is to ensure music doesn't become audible after exiting back to PlayerLoader.
-            musicController.Stop(false);
+            musicController.Stop();
 
             sampleRestart?.Play();
             RestartRequested?.Invoke();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -472,7 +472,7 @@ namespace osu.Game.Screens.Play
         {
             // at the point of restarting the track should either already be paused or the volume should be zero.
             // stopping here is to ensure music doesn't become audible after exiting back to PlayerLoader.
-            musicController.Stop();
+            musicController.Stop(false);
 
             sampleRestart?.Play();
             RestartRequested?.Invoke();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -579,7 +579,8 @@ namespace osu.Game.Screens.Select
                 updateComponentFromBeatmap(Beatmap.Value);
 
                 // restart playback on returning to song select, regardless.
-                music.Play();
+                // not sure this should be a permanent thing (we may want to leave a user pause paused even on returning)
+                music.Play(requestedByUser: true);
             }
 
             this.FadeIn(250);

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Tests.Visual
             rulesetDependencies?.Dispose();
 
             if (MusicController?.TrackLoaded == true)
-                MusicController.CurrentTrack.Stop();
+                MusicController.Stop(false);
 
             if (contextFactory?.IsValueCreated == true)
                 contextFactory.Value.ResetDatabase();

--- a/osu.Game/Tests/Visual/OsuTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuTestScene.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Tests.Visual
             rulesetDependencies?.Dispose();
 
             if (MusicController?.TrackLoaded == true)
-                MusicController.Stop(false);
+                MusicController.Stop();
 
             if (contextFactory?.IsValueCreated == true)
                 contextFactory.Value.ResetDatabase();


### PR DESCRIPTION
Closes #10632.

# Summary

Regression of sorts from #10406. On restart, `Player` used `MusicController.Stop()` to stop the current track to avoid having it play while the retry/`PlayerLoader` sequence ran, but `MusicController.Stop()` had an implicit meaning of being a user-requested pause, which means that other methods like the beatmap changed callback or `EnsurePlayingSomething()` would not resume playback due to respecting what was seemingly the user's choice to pause playback.

Resolve [as proposed on discord](https://discord.com/channels/188630481301012481/188630652340404224/772107193309986836) by adding a parameter that allows to clarify intent.

# Remarks

Not sure on the param being default, or its default value - current variant is mostly backwards compatibility mode, but unsure if backwards compatibility is to be preserved.

I also replaced one direct `MusicController.CurrentTrack.Stop()` call in tests to use this new method.