### PR TITLE
Ensure LoadOszIntoOsu returns actual imported map

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/ImportBeatmapTest.cs
@@ -821,15 +821,13 @@ namespace osu.Game.Tests.Beatmaps.IO
 
             var manager = osu.Dependencies.Get<BeatmapManager>();
 
-            await manager.Import(temp);
-
-            var imported = manager.GetAllUsableBeatmapSets();
+            var importedSet = await manager.Import(temp);
 
             ensureLoaded(osu);
 
             waitForOrAssert(() => !File.Exists(temp), "Temporary file still exists after standard import", 5000);
 
-            return imported.LastOrDefault();
+            return manager.GetAllUsableBeatmapSets().Find(beatmapSet => beatmapSet.ID == importedSet.ID);
         }
 
         private void deleteBeatmapSet(BeatmapSetInfo imported, OsuGameBase osu)


### PR DESCRIPTION
Companion piece to #10605. Split as to not inflate/muddle that diff even further.

# Summary

I had tests added in #10605 fail in test browser. The scenario was as follows:

1. I ran those tests the first time a few days ago - they imported `Soleily - Renatus (...).osu` to my local database
2. Today I created a test taiko beatmap with no online ID to test an unrelated crash
3. Afterwards I tried to run tests from #10605 - they failed, as `LoadOszIntoOsu` returned map from point (2) instead of (1) (as it was the last map imported, and `Import()` does not reimport/bump ID if it determines it doesn't need to).

Resolve by ensuring the map returned is actually the one imported. Done by requerying instead of just returning what `Import()` did for two reasons:

* better checking actual DB state,
* I wasn't sure whether the includes would be there, so I decided I'd just keep the previous usage pattern but make the fetch more resilient.