### PR TITLE
Fix taiko drum not correct handling sample / group point changes

### DIFF
--- a/osu.Game.Rulesets.Taiko/Audio/DrumSampleContainer.cs
+++ b/osu.Game.Rulesets.Taiko/Audio/DrumSampleContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Audio
         private readonly ControlPointInfo controlPoints;
         private readonly Dictionary<double, DrumSample> mappings = new Dictionary<double, DrumSample>();
 
-        private IBindableList<ControlPointGroup> groups;
+        private IBindableList<SampleControlPoint> samplePoints;
 
         public DrumSampleContainer(ControlPointInfo controlPoints)
         {
@@ -31,8 +32,8 @@ namespace osu.Game.Rulesets.Taiko.Audio
         [BackgroundDependencyLoader]
         private void load()
         {
-            groups = controlPoints.Groups.GetBoundCopy();
-            groups.BindCollectionChanged((_, __) => recreateMappings(), true);
+            samplePoints = controlPoints.SamplePoints.GetBoundCopy();
+            samplePoints.BindCollectionChanged((_, __) => recreateMappings(), true);
         }
 
         private void recreateMappings()
@@ -40,14 +41,16 @@ namespace osu.Game.Rulesets.Taiko.Audio
             mappings.Clear();
             ClearInternal();
 
-            IReadOnlyList<SampleControlPoint> samplePoints = controlPoints.SamplePoints.Count == 0 ? new[] { controlPoints.SamplePointAt(double.MinValue) } : controlPoints.SamplePoints;
+            SampleControlPoint[] points = samplePoints.Count == 0
+                ? new[] { controlPoints.SamplePointAt(double.MinValue) }
+                : samplePoints.ToArray();
 
-            for (int i = 0; i < samplePoints.Count; i++)
+            for (int i = 0; i < points.Length; i++)
             {
-                var samplePoint = samplePoints[i];
+                var samplePoint = points[i];
 
                 var lifetimeStart = i > 0 ? samplePoint.Time : double.MinValue;
-                var lifetimeEnd = i + 1 < samplePoints.Count ? samplePoints[i + 1].Time : double.MaxValue;
+                var lifetimeEnd = i + 1 < points.Length ? points[i + 1].Time : double.MaxValue;
 
                 AddInternal(mappings[samplePoint.Time] = new DrumSample(samplePoint)
                 {

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -41,9 +41,9 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// All sound points.
         /// </summary>
         [JsonProperty]
-        public IReadOnlyList<SampleControlPoint> SamplePoints => samplePoints;
+        public IBindableList<SampleControlPoint> SamplePoints => samplePoints;
 
-        private readonly SortedList<SampleControlPoint> samplePoints = new SortedList<SampleControlPoint>(Comparer<SampleControlPoint>.Default);
+        private readonly BindableList<SampleControlPoint> samplePoints = new BindableList<SampleControlPoint>();
 
         /// <summary>
         /// All effect points.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10642

Ended up making `SamplePoints` a bindable list to avoid having to

- Handle group additions
- Handle (potential) `SampleControlPoint` addditions in *every* group

Works fine for `SampleControlPoint`s because the comparer is not important.