### PR TITLE
Fix editor seek transform seeking too much

### DIFF
--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -266,8 +266,15 @@ namespace osu.Game.Screens.Edit
         {
             public override string TargetMember => nameof(currentTime);
 
-            protected override void Apply(EditorClock clock, double time) =>
-                clock.currentTime = Interpolation.ValueAt(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            protected override void Apply(EditorClock clock, double time) => clock.currentTime = valueAt(time);
+
+            private double valueAt(double time)
+            {
+                if (time < StartTime) return StartValue;
+                if (time >= EndTime) return EndValue;
+
+                return Interpolation.ValueAt(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            }
 
             protected override void ReadIntoStartValue(EditorClock clock) => StartValue = clock.currentTime;
         }


### PR DESCRIPTION
If the game lags, `time` can be much greater than `EndTime`, which would cause a seek very far into the future.

I haven't written a test for this since the same logic is done elsewhere, and this was only done this way as a measure for reducing implementation overhead at the time of writing.
Most noticeable with my hitobject pooling changes (https://github.com/smoogipoo/osu/tree/hitobject-pooling).