### PR TITLE
Debounce calls to UpdateTernaryStates

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -419,11 +419,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
 
             // bring in updates from selection changes
-            EditorBeatmap.HitObjectUpdated += _ => UpdateTernaryStates();
+            EditorBeatmap.HitObjectUpdated += _ => Scheduler.AddOnce(UpdateTernaryStates);
             EditorBeatmap.SelectedHitObjects.CollectionChanged += (sender, args) =>
             {
                 Scheduler.AddOnce(updateVisibility);
-                UpdateTernaryStates();
+                Scheduler.AddOnce(UpdateTernaryStates);
             };
         }
 


### PR DESCRIPTION
Just something I noticed in passing recently which may help with reducing performance overhead of some batch operations.  