### PR TITLE
Fix osu!catch replay conversion applying left movements to wrong frame

### DIFF
--- a/osu.Game.Rulesets.Catch/Replays/CatchReplayFrame.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchReplayFrame.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                 if (Position > lastCatchFrame.Position)
                     lastCatchFrame.Actions.Add(CatchAction.MoveRight);
                 else if (Position < lastCatchFrame.Position)
-                    Actions.Add(CatchAction.MoveLeft);
+                    lastCatchFrame.Actions.Add(CatchAction.MoveLeft);
             }
         }
 


### PR DESCRIPTION
Huge oversight in the legacy conversion logic. At least it means that actual stored replays are in the correct state.

Closes #9917.