### PR TITLE
Fix editor clock not always remaining stopped when dragging timeline

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -165,6 +165,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             if (!track.IsLoaded || track.Length == 0)
                 return;
 
+            // covers the case where the user starts playback after a drag is in progress.
+            // we want to ensure the clock is always stopped during drags to avoid weird audio playback.
+            if (handlingDragInput)
+                editorClock.Stop();
+
             ScrollTo((float)(editorClock.CurrentTime / track.Length) * Content.DrawWidth, false);
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10461.

Not sure there's a better way to handle this. Optimally, the track would not be allowed to start during a drag, but this is hard to enforce from the timeline itself.

Also, while fixing this I managed to reproduce two other bugs (sample pause not succeeding / clock reporting paused while audio still playing) but these are not related to the fix here.