### PR TITLE
Add opacity adjustment for waveform editor

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -132,6 +132,8 @@ namespace osu.Game.Configuration
 
             Set(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin);
             Set(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Sometimes);
+
+            Set(OsuSetting.EditorWaveformOpacity, 1f);
         }
 
         public OsuConfigManager(Storage storage)
@@ -241,6 +243,7 @@ namespace osu.Game.Configuration
         HitLighting,
         MenuBackgroundSource,
         GameplayDisableWinKey,
-        SeasonalBackgroundMode
+        SeasonalBackgroundMode,
+        EditorWaveformOpacity,
     }
 }

--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
@@ -163,30 +163,27 @@ namespace osu.Game.Screens.Edit.Components.Menus
 
             protected override Framework.Graphics.UserInterface.Menu CreateSubMenu() => new SubMenu();
 
-            protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableSubMenuItem(item);
-
-            private class DrawableSubMenuItem : DrawableOsuMenuItem
+            protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item)
             {
-                public DrawableSubMenuItem(MenuItem item)
+                switch (item)
+                {
+                    case EditorMenuItemSpacer spacer:
+                        return new DrawableSpacer(spacer);
+                }
+
+                return base.CreateDrawableMenuItem(item);
+            }
+
+            private class DrawableSpacer : DrawableOsuMenuItem
+            {
+                public DrawableSpacer(MenuItem item)
                     : base(item)
                 {
                 }
 
-                protected override bool OnHover(HoverEvent e)
-                {
-                    if (Item is EditorMenuItemSpacer)
-                        return true;
+                protected override bool OnHover(HoverEvent e) => true;
 
-                    return base.OnHover(e);
-                }
-
-                protected override bool OnClick(ClickEvent e)
-                {
-                    if (Item is EditorMenuItemSpacer)
-                        return true;
-
-                    return base.OnClick(e);
-                }
+                protected override bool OnClick(ClickEvent e) => true;
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osuTK;
@@ -67,8 +68,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private TimelineControlPointDisplay controlPoints;
 
+        private Bindable<float> waveformOpacity;
+
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours)
+        private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours, OsuConfigManager config)
         {
             AddRange(new Drawable[]
             {
@@ -95,7 +98,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             // We don't want the centre marker to scroll
             AddInternal(new CentreMarker { Depth = float.MaxValue });
 
-            WaveformVisible.ValueChanged += visible => waveform.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
+            waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
+            waveformOpacity.BindValueChanged(_ => updateWaveformOpacity(), true);
+
+            WaveformVisible.ValueChanged += _ => updateWaveformOpacity();
             ControlPointsVisible.ValueChanged += visible => controlPoints.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
             TicksVisible.ValueChanged += visible => ticks.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint);
 
@@ -114,6 +120,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 }
             }, true);
         }
+
+        private void updateWaveformOpacity() =>
+            waveform.FadeTo(WaveformVisible.Value ? waveformOpacity.Value : 0, 200, Easing.OutQuint);
 
         private float getZoomLevelForVisibleMilliseconds(double milliseconds) => Math.Max(1, (float)(track.Length / milliseconds));
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -20,6 +20,7 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
@@ -103,7 +104,7 @@ namespace osu.Game.Screens.Edit
         private MusicController music { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, GameHost host)
+        private void load(OsuColour colours, GameHost host, OsuConfigManager config)
         {
             beatDivisor.Value = Beatmap.Value.BeatmapInfo.BeatDivisor;
             beatDivisor.BindValueChanged(divisor => Beatmap.Value.BeatmapInfo.BeatDivisor = divisor.NewValue);
@@ -207,6 +208,13 @@ namespace osu.Game.Screens.Edit
                                         cutMenuItem = new EditorMenuItem("Cut", MenuItemType.Standard, Cut),
                                         copyMenuItem = new EditorMenuItem("Copy", MenuItemType.Standard, Copy),
                                         pasteMenuItem = new EditorMenuItem("Paste", MenuItemType.Standard, Paste),
+                                    }
+                                },
+                                new MenuItem("View")
+                                {
+                                    Items = new[]
+                                    {
+                                        new WaveformOpacityMenu(config)
                                     }
                                 }
                             }

--- a/osu.Game/Screens/Edit/WaveformOpacityMenu.cs
+++ b/osu.Game/Screens/Edit/WaveformOpacityMenu.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Edit
+{
+    internal class WaveformOpacityMenu : MenuItem
+    {
+        private readonly Bindable<float> waveformOpacity;
+
+        private readonly Dictionary<float, ToggleMenuItem> menuItemLookup = new Dictionary<float, ToggleMenuItem>();
+
+        public WaveformOpacityMenu(OsuConfigManager config)
+            : base("Waveform opacity")
+        {
+            Items = new[]
+            {
+                createMenuItem(0.25f),
+                createMenuItem(0.5f),
+                createMenuItem(0.75f),
+                createMenuItem(1f),
+            };
+
+            waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
+            waveformOpacity.BindValueChanged(opacity =>
+            {
+                foreach (var kvp in menuItemLookup)
+                    kvp.Value.State.Value = kvp.Key == opacity.NewValue;
+            }, true);
+        }
+
+        private ToggleMenuItem createMenuItem(float opacity)
+        {
+            var item = new ToggleMenuItem($"{opacity * 100}%", MenuItemType.Standard, _ => updateOpacity(opacity));
+            menuItemLookup[opacity] = item;
+            return item;
+        }
+
+        private void updateOpacity(float opacity) => waveformOpacity.Value = opacity;
+    }
+}


### PR DESCRIPTION
![2020-11-03 16 08 55](https://user-images.githubusercontent.com/191335/97957616-eff27b80-1dee-11eb-8697-e5855854f5d2.gif)

Good chance to start adding editor configuration persistence and fix up some issues with the menu display.

Closes #10666.