### PR TITLE
Change editor timeline mouse wheel handling to scroll by default (and zoom with alt held)

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
@@ -7,13 +7,14 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Utils;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
 {
@@ -88,6 +89,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             // Scroll in at 0.25
             AddStep("Move mouse to 0.25x", () => InputManager.MoveMouseTo(new Vector2(scrollQuad.TopLeft.X + 0.25f * scrollQuad.Size.X, scrollQuad.Centre.Y)));
+            AddStep("Press alt down", () => InputManager.PressKey(Key.AltLeft));
             AddStep("Scroll by 3", () => InputManager.ScrollBy(new Vector2(0, 3)));
             AddAssert("Box not at 0", () => !Precision.AlmostEquals(boxQuad.TopLeft, scrollQuad.TopLeft));
             AddAssert("Box 1/4 at 1/4", () => Precision.AlmostEquals(boxQuad.TopLeft.X + 0.25f * boxQuad.Size.X, scrollQuad.TopLeft.X + 0.25f * scrollQuad.Size.X));
@@ -96,12 +98,15 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("Scroll by -3", () => InputManager.ScrollBy(new Vector2(0, -3)));
             AddAssert("Box at 0", () => Precision.AlmostEquals(boxQuad.TopLeft, scrollQuad.TopLeft));
             AddAssert("Box 1/4 at 1/4", () => Precision.AlmostEquals(boxQuad.TopLeft.X + 0.25f * boxQuad.Size.X, scrollQuad.TopLeft.X + 0.25f * scrollQuad.Size.X));
+            AddStep("Release alt", () => InputManager.ReleaseKey(Key.AltLeft));
         }
 
         [Test]
         public void TestMouseZoomInTwiceOutTwice()
         {
             reset();
+
+            AddStep("Press alt down", () => InputManager.PressKey(Key.AltLeft));
 
             // Scroll in at 0.25
             AddStep("Move mouse to 0.25x", () => InputManager.MoveMouseTo(new Vector2(scrollQuad.TopLeft.X + 0.25f * scrollQuad.Size.X, scrollQuad.Centre.Y)));
@@ -124,6 +129,8 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("Move mouse to 0.25x", () => InputManager.MoveMouseTo(new Vector2(scrollQuad.TopLeft.X + 0.25f * scrollQuad.Size.X, scrollQuad.Centre.Y)));
             AddStep("Scroll by -1", () => InputManager.ScrollBy(new Vector2(0, -1)));
             AddAssert("Box at 0", () => Precision.AlmostEquals(boxQuad.TopLeft, scrollQuad.TopLeft));
+
+            AddStep("Release alt", () => InputManager.ReleaseKey(Key.AltLeft));
         }
 
         private void reset()

--- a/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneZoomableScrollContainer.cs
@@ -102,6 +102,24 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestMouseZoomInThenScroll()
+        {
+            reset();
+
+            // Scroll in at 0.25
+            AddStep("Move mouse to 0.25x", () => InputManager.MoveMouseTo(new Vector2(scrollQuad.TopLeft.X + 0.25f * scrollQuad.Size.X, scrollQuad.Centre.Y)));
+            AddStep("Press alt down", () => InputManager.PressKey(Key.AltLeft));
+            AddStep("Zoom by 3", () => InputManager.ScrollBy(new Vector2(0, 3)));
+            AddStep("Release alt", () => InputManager.ReleaseKey(Key.AltLeft));
+
+            AddStep("Scroll far left", () => InputManager.ScrollBy(new Vector2(0, 30)));
+            AddUntilStep("Scroll is at start", () => Precision.AlmostEquals(scrollQuad.TopLeft.X, boxQuad.TopLeft.X, 1));
+
+            AddStep("Scroll far right", () => InputManager.ScrollBy(new Vector2(0, -300)));
+            AddUntilStep("Scroll is at end", () => Precision.AlmostEquals(scrollQuad.TopRight.X, boxQuad.TopRight.X, 1));
+        }
+
+        [Test]
         public void TestMouseZoomInTwiceOutTwice()
         {
             reset();

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -113,19 +113,18 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            if (e.IsPrecise)
+            if (e.CurrentState.Keyboard.AltPressed)
             {
-                // can't handle scroll correctly while playing.
-                // the editor will handle this case for us.
-                if (editorClock?.IsRunning == true)
-                    return false;
-
-                // for now, we don't support zoom when using a precision scroll device. this needs gesture support.
-                return base.OnScroll(e);
+                // zoom when holding alt.
+                setZoomTarget(zoomTarget + e.ScrollDelta.Y, zoomedContent.ToLocalSpace(e.ScreenSpaceMousePosition).X);
             }
 
-            setZoomTarget(zoomTarget + e.ScrollDelta.Y, zoomedContent.ToLocalSpace(e.ScreenSpaceMousePosition).X);
-            return true;
+            // can't handle scroll correctly while playing.
+            // the editor will handle this case for us.
+            if (editorClock?.IsRunning == true)
+                return false;
+
+            return base.OnScroll(e);
         }
 
         private void updateZoomedContentWidth() => zoomedContent.Width = DrawWidth * currentZoom;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            if (e.CurrentState.Keyboard.AltPressed)
+            if (e.AltPressed)
             {
                 // zoom when holding alt.
                 setZoomTarget(zoomTarget + e.ScrollDelta.Y, zoomedContent.ToLocalSpace(e.ScreenSpaceMousePosition).X);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/ZoomableScrollContainer.cs
@@ -117,6 +117,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 // zoom when holding alt.
                 setZoomTarget(zoomTarget + e.ScrollDelta.Y, zoomedContent.ToLocalSpace(e.ScreenSpaceMousePosition).X);
+                return true;
             }
 
             // can't handle scroll correctly while playing.


### PR DESCRIPTION
The previous logic would zoom for non-precision devices, and scroll for precision. I've changed this to perform the same operations for both device types (for now).

Gesture support (as mentioned in the comment) is probably far enough away that we don't need to mention it for now.

Closes https://github.com/ppy/osu/issues/10670.