### PR TITLE
Fix osu!catch banana animation not playing due to incorrect lifetimes

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
     public abstract class DrawableCatchHitObject : DrawableHitObject<CatchHitObject>
     {
+        protected override double InitialLifetimeOffset => HitObject.TimePreempt;
+
         public virtual bool StaysOnPlate => HitObject.CanBePlated;
 
         public float DisplayRadius => DrawSize.X / 2 * Scale.X * HitObject.Scale;


### PR DESCRIPTION
Closes #10117.

I've tested via tests scenes and gameplay and this doesn't look to break anything but it's best this is visually tested by reviewers to make sure I haven't missed something.