### PR TITLE
Add the ability to delete slider control points using shift+right click

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -18,7 +18,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
-using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
@@ -115,9 +114,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         public void OnReleased(PlatformAction action)
         {
         }
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
-            Pieces.Any(p => p.ReceivePositionalInputAt(screenSpacePos));
 
         private void selectPiece(PathControlPointPiece piece, MouseButtonEvent e)
         {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -18,6 +18,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
@@ -105,7 +106,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             switch (action.ActionMethod)
             {
                 case PlatformActionMethod.Delete:
-                    return deleteSelected();
+                    return DeleteSelected();
             }
 
             return false;
@@ -114,6 +115,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         public void OnReleased(PlatformAction action)
         {
         }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            Pieces.Any(p => p.ReceivePositionalInputAt(screenSpacePos));
 
         private void selectPiece(PathControlPointPiece piece, MouseButtonEvent e)
         {
@@ -126,7 +130,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             }
         }
 
-        private bool deleteSelected()
+        public bool DeleteSelected()
         {
             List<PathControlPoint> toRemove = Pieces.Where(p => p.IsSelected.Value).Select(p => p.ControlPoint).ToList();
 
@@ -169,7 +173,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
                 return new MenuItem[]
                 {
-                    new OsuMenuItem($"Delete {"control point".ToQuantity(count, count > 1 ? ShowQuantityAs.Numeric : ShowQuantityAs.None)}", MenuItemType.Destructive, () => deleteSelected()),
+                    new OsuMenuItem($"Delete {"control point".ToQuantity(count, count > 1 ? ShowQuantityAs.Numeric : ShowQuantityAs.None)}", MenuItemType.Destructive, () => DeleteSelected()),
                     new OsuMenuItem("Curve type")
                     {
                         Items = items

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using Humanizer;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -18,6 +19,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit;
 using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
@@ -126,6 +128,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             }
         }
 
+        [Resolved(CanBeNull = true)]
+        private IEditorChangeHandler changeHandler { get; set; }
+
         public bool DeleteSelected()
         {
             List<PathControlPoint> toRemove = Pieces.Where(p => p.IsSelected.Value).Select(p => p.ControlPoint).ToList();
@@ -134,7 +139,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (toRemove.Count == 0)
                 return false;
 
+            changeHandler?.BeginChange();
             RemoveControlPointsRequested?.Invoke(toRemove);
+            changeHandler?.EndChange();
 
             // Since pieces are re-used, they will not point to the deleted control points while remaining selected
             foreach (var piece in Pieces)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -70,6 +71,18 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             pathVersion.BindValueChanged(_ => updatePath());
 
             BodyPiece.UpdateFrom(HitObject);
+        }
+
+        public override bool HandleQuickDeletion()
+        {
+            var hoveredControlPoint = ControlPointVisualiser.Pieces.FirstOrDefault(p => p.IsHovered);
+
+            if (hoveredControlPoint == null)
+                return false;
+
+            hoveredControlPoint.IsSelected.Value = true;
+            ControlPointVisualiser.DeleteSelected();
+            return true;
         }
 
         protected override void Update()
@@ -216,7 +229,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         public override Vector2 ScreenSpaceSelectionPoint => BodyPiece.ToScreenSpace(BodyPiece.PathStartLocation);
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => BodyPiece.ReceivePositionalInputAt(screenSpacePos);
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            BodyPiece.ReceivePositionalInputAt(screenSpacePos) || ControlPointVisualiser?.ReceivePositionalInputAt(screenSpacePos) == true;
 
         protected virtual SliderCircleSelectionBlueprint CreateCircleSelectionBlueprint(DrawableSlider slider, SliderPosition position) => new SliderCircleSelectionBlueprint(slider, position);
     }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -235,7 +235,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         public override Vector2 ScreenSpaceSelectionPoint => BodyPiece.ToScreenSpace(BodyPiece.PathStartLocation);
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
-            BodyPiece.ReceivePositionalInputAt(screenSpacePos) || ControlPointVisualiser?.ReceivePositionalInputAt(screenSpacePos) == true;
+            BodyPiece.ReceivePositionalInputAt(screenSpacePos) || ControlPointVisualiser?.Pieces.Any(p => p.ReceivePositionalInputAt(screenSpacePos)) == true;
 
         protected virtual SliderCircleSelectionBlueprint CreateCircleSelectionBlueprint(DrawableSlider slider, SliderPosition position) => new SliderCircleSelectionBlueprint(slider, position);
     }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -122,9 +122,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                     rightClickPosition = e.MouseDownPosition;
                     return false; // Allow right click to be handled by context menu
 
-                case MouseButton.Left when e.ControlPressed && IsSelected:
-                    placementControlPointIndex = addControlPoint(e.MousePosition);
-                    return true; // Stop input from being handled and modifying the selection
+                case MouseButton.Left:
+                    if (e.ControlPressed && IsSelected)
+                    {
+                        placementControlPointIndex = addControlPoint(e.MousePosition);
+                        return true; // Stop input from being handled and modifying the selection
+                    }
+
+                    break;
             }
 
             return false;

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -143,5 +143,11 @@ namespace osu.Game.Rulesets.Edit
         public virtual Quad SelectionQuad => ScreenSpaceDrawQuad;
 
         public virtual Vector2 GetInstantDelta(Vector2 screenSpacePosition) => Parent.ToLocalSpace(screenSpacePosition) - Position;
+
+        /// <summary>
+        /// Handle to perform a partial deletion when the user requests a quick delete (Shift+Right Click).
+        /// </summary>
+        /// <returns>True if the deletion operation was handled by this blueprint. Returning false will delete the full blueprint.</returns>
+        public virtual bool HandleQuickDeletion() => false;
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -116,7 +116,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            beginClickSelection(e);
+            if (beginClickSelection(e)) return true;
+
             prepareSelectionMovement();
 
             return e.Button == MouseButton.Left;
@@ -291,19 +292,23 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Attempts to select any hovered blueprints.
         /// </summary>
         /// <param name="e">The input event that triggered this selection.</param>
-        private void beginClickSelection(MouseButtonEvent e)
+        private bool beginClickSelection(MouseButtonEvent e)
         {
             Debug.Assert(!clickSelectionBegan);
+
+            bool rightClickHandled = false;
 
             foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
             {
                 if (blueprint.IsHovered)
                 {
-                    SelectionHandler.HandleSelectionRequested(blueprint, e.CurrentState);
+                    rightClickHandled |= SelectionHandler.HandleSelectionRequested(blueprint, e.CurrentState);
                     clickSelectionBegan = true;
                     break;
                 }
             }
+
+            return rightClickHandled;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (beginClickSelection(e)) return true;
+            if (!beginClickSelection(e)) return true;
 
             prepareSelectionMovement();
 
@@ -292,23 +292,24 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Attempts to select any hovered blueprints.
         /// </summary>
         /// <param name="e">The input event that triggered this selection.</param>
+        /// <returns>Whether a selection was performed.</returns>
         private bool beginClickSelection(MouseButtonEvent e)
         {
             Debug.Assert(!clickSelectionBegan);
 
-            bool rightClickHandled = false;
+            bool selectedPerformed = true;
 
             foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
             {
                 if (blueprint.IsHovered)
                 {
-                    rightClickHandled |= SelectionHandler.HandleSelectionRequested(blueprint, e.CurrentState);
+                    selectedPerformed &= SelectionHandler.HandleSelectionRequested(blueprint, e.CurrentState);
                     clickSelectionBegan = true;
                     break;
                 }
             }
 
-            return rightClickHandled;
+            return selectedPerformed;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -219,13 +219,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <param name="blueprint">The blueprint.</param>
         /// <param name="state">The input state at the point of selection.</param>
-        /// <returns>Whether right click was handled.</returns>
+        /// <returns>Whether a selection was performed.</returns>
         internal bool HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
         {
             if (state.Keyboard.ShiftPressed && state.Mouse.IsPressed(MouseButton.Right))
             {
                 handleQuickDeletion(blueprint);
-                return true;
+                return false;
             }
 
             if (state.Keyboard.ControlPressed && state.Mouse.IsPressed(MouseButton.Left))
@@ -233,7 +233,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             else
                 ensureSelected(blueprint);
 
-            return false;
+            return true;
         }
 
         private void handleQuickDeletion(SelectionBlueprint blueprint)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -219,18 +219,28 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <param name="blueprint">The blueprint.</param>
         /// <param name="state">The input state at the point of selection.</param>
-        internal void HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
+        /// <returns>Whether right click was handled.</returns>
+        internal bool HandleSelectionRequested(SelectionBlueprint blueprint, InputState state)
         {
             if (state.Keyboard.ShiftPressed && state.Mouse.IsPressed(MouseButton.Right))
+            {
                 handleQuickDeletion(blueprint);
-            else if (state.Keyboard.ControlPressed && state.Mouse.IsPressed(MouseButton.Left))
+                return true;
+            }
+
+            if (state.Keyboard.ControlPressed && state.Mouse.IsPressed(MouseButton.Left))
                 blueprint.ToggleSelection();
             else
                 ensureSelected(blueprint);
+
+            return false;
         }
 
         private void handleQuickDeletion(SelectionBlueprint blueprint)
         {
+            if (blueprint.HandleQuickDeletion())
+                return;
+
             if (!blueprint.IsSelected)
                 EditorBeatmap.Remove(blueprint.HitObject);
             else


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10672.

In two minds about how this should be implemented but went in this direction initially. The other way would be to add local handling of Shift-Right Click inside PathControlPointPiece (which is already doing mouse handling itself) but I convinced myself that handling this weird combination in one place is better.