### PR TITLE
Add new method handling hit state specifically

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -6,9 +6,8 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
@@ -90,22 +89,17 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
-            var endTime = HitObject.GetEndTime();
-
-            using (BeginAbsoluteSequence(endTime, true))
+            switch (state)
             {
-                switch (state)
-                {
-                    case ArmedState.Miss:
-                        this.FadeOut(250).RotateTo(Rotation * 2, 250, Easing.Out);
-                        break;
+                case ArmedState.Miss:
+                    this.FadeOut(250).RotateTo(Rotation * 2, 250, Easing.Out);
+                    break;
 
-                    case ArmedState.Hit:
-                        this.FadeOut();
-                        break;
-                }
+                case ArmedState.Hit:
+                    this.FadeOut();
+                    break;
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaBeatSnapGrid.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaBeatSnapGrid.cs
@@ -204,10 +204,6 @@ namespace osu.Game.Rulesets.Mania.Edit
             protected override void UpdateInitialTransforms()
             {
                 // don't perform any fading – we are handling that ourselves.
-            }
-
-            protected override void UpdateStateTransforms(ArmedState state)
-            {
                 LifetimeEnd = HitObject.StartTime + visible_range;
             }
         }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
@@ -1,10 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osuTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Rulesets.Objects.Drawables;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
@@ -71,6 +70,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
         }
 
-        protected override void UpdateStateTransforms(ArmedState state) => this.FadeOut(150);
+        protected override void UpdateStartTimeStateTransforms() => this.FadeOut(150);
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -229,12 +229,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             }
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
-        {
-            using (BeginDelayedSequence(HitObject.Duration, true))
-                base.UpdateStateTransforms(state);
-        }
-
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (Tail.AllJudged)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Objects.Drawables;
-
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {
     /// <summary>
@@ -19,8 +17,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         public void UpdateResult() => base.UpdateResult(true);
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateInitialTransforms()
         {
+            base.UpdateInitialTransforms();
+
             // This hitobject should never expire, so this is just a safe maximum.
             LifetimeEnd = LifetimeStart + 30000;
         }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             Anchor = Origin = e.NewValue == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             switch (state)
             {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -164,19 +164,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             ApproachCircle.Expire(true);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
-            base.UpdateStateTransforms(state);
-
             Debug.Assert(HitObject.HitWindows != null);
 
             switch (state)
             {
                 case ArmedState.Idle:
                     this.Delay(HitObject.TimePreempt).FadeOut(500);
-
-                    Expire(true);
-
                     HitArea.HitAction = null;
                     break;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -51,17 +51,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected virtual void Shake(double maximumLength) => shakeContainer.Shake(maximumLength);
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateInitialTransforms()
         {
-            base.UpdateStateTransforms(state);
+            base.UpdateInitialTransforms();
 
-            switch (state)
-            {
-                case ArmedState.Idle:
-                    // Manually set to reduce the number of future alive objects to a bare minimum.
-                    LifetimeStart = HitObject.StartTime - HitObject.TimePreempt;
-                    break;
-            }
+            // Manually set to reduce the number of future alive objects to a bare minimum.
+            LifetimeStart = HitObject.StartTime - HitObject.TimePreempt;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -253,29 +253,31 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 base.PlaySamples();
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateStartTimeStateTransforms()
         {
-            base.UpdateStateTransforms(state);
+            base.UpdateStartTimeStateTransforms();
 
             Ball.FadeIn();
             Ball.ScaleTo(HitObject.Scale);
+        }
 
-            using (BeginDelayedSequence(slider.Duration, true))
+        protected override void UpdateHitStateTransforms(ArmedState state)
+        {
+            base.UpdateHitStateTransforms(state);
+
+            const float fade_out_time = 450;
+
+            // intentionally pile on an extra FadeOut to make it happen much faster.
+            Ball.FadeOut(fade_out_time / 4, Easing.Out);
+
+            switch (state)
             {
-                const float fade_out_time = 450;
-
-                // intentionally pile on an extra FadeOut to make it happen much faster.
-                Ball.FadeOut(fade_out_time / 4, Easing.Out);
-
-                switch (state)
-                {
-                    case ArmedState.Hit:
-                        Ball.ScaleTo(HitObject.Scale * 1.4f, fade_out_time, Easing.Out);
-                        break;
-                }
-
-                this.FadeOut(fade_out_time, Easing.OutQuint);
+                case ArmedState.Hit:
+                    Ball.ScaleTo(HitObject.Scale * 1.4f, fade_out_time, Easing.Out);
+                    break;
             }
+
+            this.FadeOut(fade_out_time, Easing.OutQuint);
         }
 
         public Drawable ProxiedLayer => HeadCircle.ProxiedLayer;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -77,9 +77,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             );
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
-            base.UpdateStateTransforms(state);
+            base.UpdateHitStateTransforms(state);
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -67,9 +67,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             circlePiece.FadeInFromZero(HitObject.TimeFadeIn);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
-            base.UpdateStateTransforms(state);
+            base.UpdateHitStateTransforms(state);
 
             Debug.Assert(HitObject.HitWindows != null);
 
@@ -77,8 +77,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 case ArmedState.Idle:
                     this.Delay(HitObject.TimePreempt).FadeOut(500);
-
-                    Expire(true);
                     break;
 
                 case ArmedState.Miss:

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -72,9 +72,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             this.ScaleTo(0.5f).ScaleTo(1f, ANIM_DURATION * 4, Easing.OutElasticHalf);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
-            base.UpdateStateTransforms(state);
+            base.UpdateHitStateTransforms(state);
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -142,12 +142,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
-            base.UpdateStateTransforms(state);
+            base.UpdateHitStateTransforms(state);
 
-            using (BeginDelayedSequence(Spinner.Duration, true))
-                this.FadeOut(160);
+            this.FadeOut(160);
 
             // skin change does a rewind of transforms, which will stop the spinning sound from playing if it's currently in playback.
             isSpinning?.TriggerChange();

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableBarLine.cs
@@ -58,6 +58,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             });
         }
 
-        protected override void UpdateStateTransforms(ArmedState state) => this.FadeOut(150);
+        protected override void UpdateHitStateTransforms(ArmedState state) => this.FadeOut(150);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -135,13 +135,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 ApplyResult(r => r.Type = r.Judgement.MinResult);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             switch (state)
             {
                 case ArmedState.Hit:
                 case ArmedState.Miss:
-                    this.Delay(HitObject.Duration).FadeOut(100);
+                    this.FadeOut(100);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             ApplyResult(r => r.Type = r.Judgement.MaxResult);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             switch (state)
             {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             pressHandledThisFrame = false;
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             Debug.Assert(HitObject.HitWindows != null);
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -215,15 +215,15 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             }
         }
 
-        protected override void UpdateInitialTransforms()
+        protected override void UpdateStartTimeStateTransforms()
         {
-            base.UpdateInitialTransforms();
+            base.UpdateStartTimeStateTransforms();
 
-            using (BeginAbsoluteSequence(HitObject.StartTime - ring_appear_offset, true))
+            using (BeginDelayedSequence(-ring_appear_offset, true))
                 targetRing.ScaleTo(target_ring_scale, 400, Easing.OutQuint);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             const double transition_duration = 300;
 
@@ -235,12 +235,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                 case ArmedState.Miss:
                 case ArmedState.Hit:
-                    using (BeginDelayedSequence(HitObject.Duration, true))
-                    {
-                        this.FadeOut(transition_duration, Easing.Out);
-                        bodyContainer.ScaleTo(1.4f, transition_duration);
-                    }
-
+                    this.FadeOut(transition_duration, Easing.Out);
+                    bodyContainer.ScaleTo(1.4f, transition_duration);
                     break;
             }
         }

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -37,6 +37,12 @@ namespace osu.Game.Rulesets.Judgements
         public double TimeOffset { get; internal set; }
 
         /// <summary>
+        /// The absolute time at which this <see cref="JudgementResult"/> occurred.
+        /// Equal to the (end) time of the <see cref="HitObject"/> + <see cref="TimeOffset"/>.
+        /// </summary>
+        public double TimeAbsolute => HitObject.GetEndTime() + TimeOffset;
+
+        /// <summary>
         /// The combo prior to this <see cref="JudgementResult"/> occurring.
         /// </summary>
         public int ComboAtJudgement { get; internal set; }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -265,11 +265,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             using (BeginAbsoluteSequence(StateUpdateTime, true))
                 UpdateStartTimeStateTransforms();
 
-            if (newState != ArmedState.Idle)
-            {
-                using (BeginAbsoluteSequence(HitStateUpdateTime, true))
-                    UpdateHitStateTransforms(newState);
-            }
+            using (BeginAbsoluteSequence(HitStateUpdateTime, true))
+                UpdateHitStateTransforms(newState);
 
             state.Value = newState;
 
@@ -319,7 +316,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         /// <summary>
         /// Apply transforms based on the current <see cref="ArmedState"/>. This call is offset by <see cref="HitStateUpdateTime"/> (HitObject.EndTime + Result.Offset), equivalent to when the user hit the object.
-        /// This method is only called on <see cref="ArmedState.Hit"/> or <see cref="ArmedState.Miss"/>. If <see cref="Drawable.LifetimeEnd"/> was not set during this call, <see cref="Drawable.Expire"/> will be invoked.
+        /// If <see cref="Drawable.LifetimeEnd"/> was not set during this call, <see cref="Drawable.Expire"/> will be invoked.
         /// Previous states are automatically cleared.
         /// </summary>
         /// <param name="state">The new armed state.</param>

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -257,8 +257,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
             using (BeginAbsoluteSequence(transformTime, true))
                 UpdateInitialTransforms();
 
-            using (BeginAbsoluteSequence(StateUpdateTime, true))
+#pragma warning disable 618
+            using (BeginAbsoluteSequence(StateUpdateTime + (Result?.TimeOffset ?? 0), true))
                 UpdateStateTransforms(newState);
+#pragma warning restore 618
+
+            using (BeginAbsoluteSequence(StateUpdateTime, true))
+                UpdateStartTimeStateTransforms();
 
             if (newState != ArmedState.Idle)
             {
@@ -298,13 +303,23 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// In the case of a non-idle <see cref="ArmedState"/>, and if <see cref="Drawable.LifetimeEnd"/> was not set during this call, <see cref="Drawable.Expire"/> will be invoked.
         /// </summary>
         /// <param name="state">The new armed state.</param>
+        [Obsolete("Use UpdateStartTimeStateTransforms and UpdateHitStateTransforms instead")] // Can be removed 20210504
         protected virtual void UpdateStateTransforms(ArmedState state)
         {
         }
 
         /// <summary>
+        /// Apply passive transforms at the <see cref="HitObject"/>'s StartTime.
+        /// This is called each time <see cref="State"/> changes.
+        /// Previous states are automatically cleared.
+        /// </summary>
+        protected virtual void UpdateStartTimeStateTransforms()
+        {
+        }
+
+        /// <summary>
         /// Apply transforms based on the current <see cref="ArmedState"/>. This call is offset by <see cref="HitStateUpdateTime"/> (HitObject.EndTime + Result.Offset), equivalent to when the user hit the object.
-        /// This method is only called on <see cref="ArmedState.Hit"/> or <see cref="ArmedState.Miss"/>.
+        /// This method is only called on <see cref="ArmedState.Hit"/> or <see cref="ArmedState.Miss"/>. If <see cref="Drawable.LifetimeEnd"/> was not set during this call, <see cref="Drawable.Expire"/> will be invoked.
         /// Previous states are automatically cleared.
         /// </summary>
         /// <param name="state">The new armed state.</param>

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -257,13 +257,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
             using (BeginAbsoluteSequence(transformTime, true))
                 UpdateInitialTransforms();
 
+            using (BeginAbsoluteSequence(StateUpdateTime, true))
+                UpdateStartTimeStateTransforms();
+
 #pragma warning disable 618
             using (BeginAbsoluteSequence(StateUpdateTime + (Result?.TimeOffset ?? 0), true))
                 UpdateStateTransforms(newState);
 #pragma warning restore 618
-
-            using (BeginAbsoluteSequence(StateUpdateTime, true))
-                UpdateStartTimeStateTransforms();
 
             using (BeginAbsoluteSequence(HitStateUpdateTime, true))
                 UpdateHitStateTransforms(newState);


### PR DESCRIPTION
Not sure whether the `StartTime` method should have `State` in its name, please advise.

# Breaking Changes

## DrawableHitObject.UpdateStateTransforms is now obsoleted.

Until now UpdateStateTransforms was applying results offsets to StartTime. This didn't cover the case of a HitObject with duration, where the call would be made with `StartTime + hitOffset` rather than `EndTime + hitOffset`.

To resolve this, a two new methods have been added to improve clarity on what each UpdateState call should be used for.

`UpdateStartTimeStateTransforms`: `hitObject.StartTime`, regardless of `ArmedState`
`UpdateHitStateTransforms`: `hitObject.EndTime` + `result.TimeOffset`, potentially dependent on `ArmedState`.

### To migrate

- For all `DrawableHitObjects`, move any non-state dependent transforms to `UpdateStartTimeStateTransforms`
- For objects with no duration, rename any remaining `UpdateStateTransforms` to `UpdateHitStateTransforms`.
- For objects with duration, remove any manually applied `BeginDelayedSequence(hitObject.Duration)` and use `UpdateHitStateTransforms()` instead of `UpdateStateTransforms()`