### PR TITLE
Use asynchronous load instead of constructor for osu! DrawableHitObjects

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
@@ -295,7 +295,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         private void assertControlPointPosition(int index, Vector2 position) =>
             AddAssert($"control point {index} at {position}", () => Precision.AlmostEquals(position, getSlider().Path.ControlPoints[index].Position.Value, 1));
 
-        private Slider getSlider() => HitObjectContainer.Count > 0 ? (Slider)((DrawableSlider)HitObjectContainer[0]).HitObject : null;
+        private Slider getSlider() => HitObjectContainer.Count > 0 ? ((DrawableSlider)HitObjectContainer[0]).HitObject : null;
 
         protected override DrawableHitObject CreateHitObject(HitObject hitObject) => new DrawableSlider((Slider)hitObject);
         protected override PlacementBlueprint CreateBlueprint() => new SliderPlacementBlueprint();

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -112,10 +112,10 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new HitSampleInfo { Name = HitSampleInfo.HIT_WHISTLE },
             });
 
-            AddAssert("head samples updated", () => assertSamples(((Slider)slider.HitObject).HeadCircle));
-            AddAssert("tick samples not updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<SliderTick>().All(assertTickSamples));
-            AddAssert("repeat samples updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<SliderRepeat>().All(assertSamples));
-            AddAssert("tail has no samples", () => ((Slider)slider.HitObject).TailCircle.Samples.Count == 0);
+            AddAssert("head samples updated", () => assertSamples(slider.HitObject.HeadCircle));
+            AddAssert("tick samples not updated", () => slider.HitObject.NestedHitObjects.OfType<SliderTick>().All(assertTickSamples));
+            AddAssert("repeat samples updated", () => slider.HitObject.NestedHitObjects.OfType<SliderRepeat>().All(assertSamples));
+            AddAssert("tail has no samples", () => slider.HitObject.TailCircle.Samples.Count == 0);
 
             static bool assertTickSamples(SliderTick tick) => tick.Samples.Single().Name == "slidertick";
 
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 slider = (DrawableSlider)createSlider(repeats: 1);
 
                 for (int i = 0; i < 2; i++)
-                    ((Slider)slider.HitObject).NodeSamples.Add(new List<HitSampleInfo> { new HitSampleInfo { Name = HitSampleInfo.HIT_FINISH } });
+                    slider.HitObject.NodeSamples.Add(new List<HitSampleInfo> { new HitSampleInfo { Name = HitSampleInfo.HIT_FINISH } });
 
                 Add(slider);
             });
@@ -147,10 +147,10 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new HitSampleInfo { Name = HitSampleInfo.HIT_WHISTLE },
             });
 
-            AddAssert("head samples not updated", () => assertSamples(((Slider)slider.HitObject).HeadCircle));
-            AddAssert("tick samples not updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<SliderTick>().All(assertTickSamples));
-            AddAssert("repeat samples not updated", () => ((Slider)slider.HitObject).NestedHitObjects.OfType<SliderRepeat>().All(assertSamples));
-            AddAssert("tail has no samples", () => ((Slider)slider.HitObject).TailCircle.Samples.Count == 0);
+            AddAssert("head samples not updated", () => assertSamples(slider.HitObject.HeadCircle));
+            AddAssert("tick samples not updated", () => slider.HitObject.NestedHitObjects.OfType<SliderTick>().All(assertTickSamples));
+            AddAssert("repeat samples not updated", () => slider.HitObject.NestedHitObjects.OfType<SliderRepeat>().All(assertSamples));
+            AddAssert("tail has no samples", () => slider.HitObject.TailCircle.Samples.Count == 0);
 
             static bool assertTickSamples(SliderTick tick) => tick.Samples.Single().Name == "slidertick";
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         protected override void OnSelected()
         {
-            AddInternal(ControlPointVisualiser = new PathControlPointVisualiser((Slider)slider.HitObject, true)
+            AddInternal(ControlPointVisualiser = new PathControlPointVisualiser(slider.HitObject, true)
             {
                 RemoveControlPointsRequested = removeControlPoints
             });

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
@@ -21,28 +20,25 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableHitCircle : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
-        public ApproachCircle ApproachCircle { get; }
-
-        private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
-        private readonly IBindable<int> stackHeightBindable = new Bindable<int>();
-        private readonly IBindable<float> scaleBindable = new BindableFloat();
-
         public OsuAction? HitAction => HitArea.HitAction;
-
-        public readonly HitReceptor HitArea;
-        public readonly SkinnableDrawable CirclePiece;
-        private readonly Container scaleContainer;
-
         protected virtual OsuSkinComponents CirclePieceComponent => OsuSkinComponents.HitCircle;
 
+        public ApproachCircle ApproachCircle { get; private set; }
+        public HitReceptor HitArea { get; private set; }
+        public SkinnableDrawable CirclePiece { get; private set; }
+
+        private Container scaleContainer;
         private InputManager inputManager;
 
         public DrawableHitCircle(HitCircle h)
             : base(h)
         {
-            Origin = Anchor.Centre;
+        }
 
-            Position = HitObject.StackedPosition;
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Origin = Anchor.Centre;
 
             InternalChildren = new Drawable[]
             {
@@ -75,19 +71,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             };
 
             Size = HitArea.DrawSize;
-        }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            positionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
-            stackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
-            scaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
-
-            positionBindable.BindTo(HitObject.PositionBindable);
-            stackHeightBindable.BindTo(HitObject.StackHeightBindable);
-            scaleBindable.BindTo(HitObject.ScaleBindable);
-
+            PositionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition, true);
+            StackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition, true);
+            ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
             AccentColour.BindValueChanged(accent => ApproachCircle.Colour = accent.NewValue, true);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -2,18 +2,24 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Osu.UI;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableOsuHitObject : DrawableHitObject<OsuHitObject>
     {
-        private readonly ShakeContainer shakeContainer;
+        public readonly IBindable<Vector2> PositionBindable = new Bindable<Vector2>();
+        public readonly IBindable<int> StackHeightBindable = new Bindable<int>();
+        public readonly IBindable<float> ScaleBindable = new BindableFloat();
+        public readonly IBindable<int> IndexInCurrentComboBindable = new Bindable<int>();
 
         // Must be set to update IsHovered as it's used in relax mdo to detect osu hit objects.
         public override bool HandlePositionalInput => true;
@@ -26,16 +32,28 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// </summary>
         public Func<DrawableHitObject, double, bool> CheckHittable;
 
+        private ShakeContainer shakeContainer;
+
         protected DrawableOsuHitObject(OsuHitObject hitObject)
             : base(hitObject)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Alpha = 0;
+
             base.AddInternal(shakeContainer = new ShakeContainer
             {
                 ShakeDuration = 30,
                 RelativeSizeAxes = Axes.Both
             });
 
-            Alpha = 0;
+            IndexInCurrentComboBindable.BindTo(HitObject.IndexInCurrentComboBindable);
+            PositionBindable.BindTo(HitObject.PositionBindable);
+            StackHeightBindable.BindTo(HitObject.StackHeightBindable);
+            ScaleBindable.BindTo(HitObject.ScaleBindable);
         }
 
         // Forward all internal management to shakeContainer.

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -20,62 +20,50 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSlider : DrawableOsuHitObject, IDrawableHitObjectWithProxiedApproach
     {
+        public new Slider HitObject => (Slider)base.HitObject;
+
         public DrawableSliderHead HeadCircle => headContainer.Child;
         public DrawableSliderTail TailCircle => tailContainer.Child;
 
-        public readonly SliderBall Ball;
-        public readonly SkinnableDrawable Body;
+        public SliderBall Ball { get; private set; }
+        public SkinnableDrawable Body { get; private set; }
 
         public override bool DisplayResult => false;
 
         private PlaySliderBody sliderBody => Body.Drawable as PlaySliderBody;
 
-        private readonly Container<DrawableSliderHead> headContainer;
-        private readonly Container<DrawableSliderTail> tailContainer;
-        private readonly Container<DrawableSliderTick> tickContainer;
-        private readonly Container<DrawableSliderRepeat> repeatContainer;
-
-        private readonly Slider slider;
-
-        private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
-        private readonly IBindable<int> stackHeightBindable = new Bindable<int>();
-        private readonly IBindable<float> scaleBindable = new BindableFloat();
+        private Container<DrawableSliderHead> headContainer;
+        private Container<DrawableSliderTail> tailContainer;
+        private Container<DrawableSliderTick> tickContainer;
+        private Container<DrawableSliderRepeat> repeatContainer;
 
         public DrawableSlider(Slider s)
             : base(s)
         {
-            slider = s;
+        }
 
-            Position = s.StackedPosition;
-
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             InternalChildren = new Drawable[]
             {
                 Body = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderBody), _ => new DefaultSliderBody(), confineMode: ConfineMode.NoScaling),
                 tailContainer = new Container<DrawableSliderTail> { RelativeSizeAxes = Axes.Both },
                 tickContainer = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
                 repeatContainer = new Container<DrawableSliderRepeat> { RelativeSizeAxes = Axes.Both },
-                Ball = new SliderBall(s, this)
+                Ball = new SliderBall(HitObject, this)
                 {
                     GetInitialHitAction = () => HeadCircle.HitAction,
                     BypassAutoSizeAxes = Axes.Both,
-                    Scale = new Vector2(s.Scale),
                     AlwaysPresent = true,
                     Alpha = 0
                 },
                 headContainer = new Container<DrawableSliderHead> { RelativeSizeAxes = Axes.Both },
             };
-        }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            positionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
-            stackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
-            scaleBindable.BindValueChanged(scale => Ball.Scale = new Vector2(scale.NewValue));
-
-            positionBindable.BindTo(HitObject.PositionBindable);
-            stackHeightBindable.BindTo(HitObject.StackHeightBindable);
-            scaleBindable.BindTo(HitObject.ScaleBindable);
+            PositionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition, true);
+            StackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition, true);
+            ScaleBindable.BindValueChanged(scale => Ball.Scale = new Vector2(scale.NewValue), true);
 
             AccentColour.BindValueChanged(colour =>
             {
@@ -162,20 +150,20 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             switch (hitObject)
             {
                 case SliderTailCircle tail:
-                    return new DrawableSliderTail(slider, tail);
+                    return new DrawableSliderTail(tail);
 
                 case SliderHeadCircle head:
-                    return new DrawableSliderHead(slider, head)
+                    return new DrawableSliderHead(HitObject, head)
                     {
                         OnShake = Shake,
                         CheckHittable = (d, t) => CheckHittable?.Invoke(d, t) ?? true
                     };
 
                 case SliderTick tick:
-                    return new DrawableSliderTick(tick) { Position = tick.Position - slider.Position };
+                    return new DrawableSliderTick(tick) { Position = tick.Position - HitObject.Position };
 
                 case SliderRepeat repeat:
-                    return new DrawableSliderRepeat(repeat, this) { Position = repeat.Position - slider.Position };
+                    return new DrawableSliderRepeat(repeat, this) { Position = repeat.Position - HitObject.Position };
             }
 
             return base.CreateNestedHitObject(hitObject);
@@ -200,14 +188,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 // keep the sliding sample playing at the current tracking position
                 slidingSample.Balance.Value = CalculateSamplePlaybackBalance(Ball.X / OsuPlayfield.BASE_SIZE.X);
 
-            double completionProgress = Math.Clamp((Time.Current - slider.StartTime) / slider.Duration, 0, 1);
+            double completionProgress = Math.Clamp((Time.Current - HitObject.StartTime) / HitObject.Duration, 0, 1);
 
             Ball.UpdateProgress(completionProgress);
             sliderBody?.UpdateProgress(completionProgress);
 
             foreach (DrawableHitObject hitObject in NestedHitObjects)
             {
-                if (hitObject is ITrackSnaking s) s.UpdateSnakingPosition(slider.Path.PositionAt(sliderBody?.SnakedStart ?? 0), slider.Path.PositionAt(sliderBody?.SnakedEnd ?? 0));
+                if (hitObject is ITrackSnaking s) s.UpdateSnakingPosition(HitObject.Path.PositionAt(sliderBody?.SnakedStart ?? 0), HitObject.Path.PositionAt(sliderBody?.SnakedEnd ?? 0));
                 if (hitObject is IRequireTracking t) t.Tracking = Ball.Tracking;
             }
 
@@ -239,7 +227,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
-            if (userTriggered || Time.Current < slider.EndTime)
+            if (userTriggered || Time.Current < HitObject.EndTime)
                 return;
 
             ApplyResult(r => r.Type = r.Judgement.MaxResult);
@@ -260,7 +248,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Ball.FadeIn();
             Ball.ScaleTo(HitObject.Scale);
 
-            using (BeginDelayedSequence(slider.Duration, true))
+            using (BeginDelayedSequence(HitObject.Duration, true))
             {
                 const float fade_out_time = 450;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -5,13 +5,11 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Types;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSliderHead : DrawableHitCircle
     {
-        private readonly IBindable<Vector2> positionBindable = new Bindable<Vector2>();
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 
         protected override OsuSkinComponents CirclePieceComponent => OsuSkinComponents.SliderHeadHitCircle;
@@ -27,10 +25,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            positionBindable.BindTo(HitObject.PositionBindable);
             pathVersion.BindTo(slider.Path.Version);
 
-            positionBindable.BindValueChanged(_ => updatePosition());
+            PositionBindable.BindValueChanged(_ => updatePosition());
             pathVersion.BindValueChanged(_ => updatePosition(), true);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
@@ -22,9 +21,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private double animDuration;
 
-        private readonly Drawable scaleContainer;
-
-        public readonly Drawable CirclePiece;
+        public Drawable CirclePiece { get; private set; }
+        private Drawable scaleContainer;
+        private ReverseArrowPiece arrow;
 
         public override bool DisplayResult => false;
 
@@ -33,10 +32,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             this.sliderRepeat = sliderRepeat;
             this.drawableSlider = drawableSlider;
+        }
 
-            Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
-
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             Origin = Anchor.Centre;
+            Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 
             InternalChild = scaleContainer = new Container
             {
@@ -50,15 +52,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     arrow = new ReverseArrowPiece(),
                 }
             };
-        }
 
-        private readonly IBindable<float> scaleBindable = new BindableFloat();
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            scaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
-            scaleBindable.BindTo(HitObject.ScaleBindable);
+            ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -99,8 +94,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         private bool hasRotation;
-
-        private readonly ReverseArrowPiece arrow;
 
         public void UpdateSnakingPosition(Vector2 start, Vector2 end)
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -23,18 +22,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public bool Tracking { get; set; }
 
-        private readonly IBindable<float> scaleBindable = new BindableFloat();
+        private SkinnableDrawable circlePiece;
+        private Container scaleContainer;
 
-        private readonly SkinnableDrawable circlePiece;
-
-        private readonly Container scaleContainer;
-
-        public DrawableSliderTail(Slider slider, SliderTailCircle tailCircle)
+        public DrawableSliderTail(SliderTailCircle tailCircle)
             : base(tailCircle)
         {
             this.tailCircle = tailCircle;
-            Origin = Anchor.Centre;
+        }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Origin = Anchor.Centre;
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 
             InternalChildren = new Drawable[]
@@ -51,13 +51,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     }
                 },
             };
-        }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            scaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
-            scaleBindable.BindTo(HitObject.ScaleBindable);
+            ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
@@ -23,10 +22,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public override bool DisplayResult => false;
 
-        private readonly SkinnableDrawable scaleContainer;
+        private SkinnableDrawable scaleContainer;
 
         public DrawableSliderTick(SliderTick sliderTick)
             : base(sliderTick)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
         {
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
             Origin = Anchor.Centre;
@@ -49,15 +53,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             };
-        }
 
-        private readonly IBindable<float> scaleBindable = new BindableFloat();
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            scaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
-            scaleBindable.BindTo(HitObject.ScaleBindable);
+            ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue), true);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         private void load(OsuColour colours, DrawableHitObject drawableHitObject)
         {
             drawableSpinner = (DrawableSpinner)drawableHitObject;
-            spinner = (Spinner)drawableSpinner.HitObject;
+            spinner = drawableSpinner.HitObject;
 
             normalColour = colours.BlueDark;
             completeColour = colours.YellowLight;

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK;
@@ -79,7 +78,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
             if (!(drawableHitObject is DrawableSpinner))
                 return;
 
-            var spinner = (Spinner)drawableSpinner.HitObject;
+            var spinner = drawableSpinner.HitObject;
 
             using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
                 this.FadeOut();

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -125,13 +125,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
             Result = CreateResult(judgement);
             if (Result == null)
                 throw new InvalidOperationException($"{GetType().ReadableName()} must provide a {nameof(JudgementResult)} through {nameof(CreateResult)}.");
-
-            LoadSamples();
         }
 
         protected override void LoadAsyncComplete()
         {
             base.LoadAsyncComplete();
+
+            LoadSamples();
 
             HitObject.DefaultsApplied += onDefaultsApplied;
 


### PR DESCRIPTION
Full set of changes can be found in https://github.com/ppy/osu/compare/master...smoogipoo:hitobject-pooling

The purpose of this PR is to move as much as possible out of the constructor for osu! DHOs. Pooling requires 0 implementation to remain in the ctor. There's a few places this can't be done, such as `DrawableSliderTail`, which will eventually receive an `ApplyParent(DrawableHitObject)` method to facilitate the remaining removals.

Also note that where bindables are used (stack height, position, scale), the `true` parameter can be removed after the pooling implementation but have to remain here for now.

Final questionable change is `LoadSamples` being moved from `DHO.load()` to `DHO.LoadAsyncComplete()`, which is required because `DrawableOsuHitObject` overrides `AddInternal` to forward it to another container. I don't see this as a huge change since it's still in the async process and only very slightly delayed. Consider it a temporary change as it'll be moved into the `Apply(HitObject)` method, which will still be called from `LoadAsyncComplete()`.

Will unblock after I've submitted a few more PRs.