### PR TITLE
Remove stored hitobject references from osu! components

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private PlaySliderBody sliderBody => Body.Drawable as PlaySliderBody;
 
+        public readonly IBindable<int> PathVersion = new Bindable<int>();
+
         private Container<DrawableSliderHead> headContainer;
         private Container<DrawableSliderTail> tailContainer;
         private Container<DrawableSliderTick> tickContainer;
@@ -51,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 tailContainer = new Container<DrawableSliderTail> { RelativeSizeAxes = Axes.Both },
                 tickContainer = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
                 repeatContainer = new Container<DrawableSliderRepeat> { RelativeSizeAxes = Axes.Both },
-                Ball = new SliderBall(HitObject, this)
+                Ball = new SliderBall(this)
                 {
                     GetInitialHitAction = () => HeadCircle.HitAction,
                     BypassAutoSizeAxes = Axes.Both,
@@ -60,6 +62,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 },
                 headContainer = new Container<DrawableSliderHead> { RelativeSizeAxes = Axes.Both },
             };
+
+            PathVersion.BindTo(HitObject.Path.Version);
 
             PositionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition, true);
             StackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition, true);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     Children = new Drawable[]
                     {
                         new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SpinnerBody), _ => new DefaultSpinnerDisc()),
-                        RotationTracker = new SpinnerRotationTracker(HitObject)
+                        RotationTracker = new SpinnerRotationTracker(this)
                     }
                 },
                 SpmCounter = new SpinnerSpmCounter

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                     Origin = Anchor.Centre,
                     Texture = textures.Get(@"Gameplay/osu/disc"),
                 },
-                new TrianglesPiece((int)drawableHitObject.HitObject.StartTime)
+                new TrianglesPiece(drawableHitObject.GetHashCode())
                 {
                     RelativeSizeAxes = Axes.Both,
                     Blending = BlendingParameters.Additive,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
     {
         private DrawableSpinner drawableSpinner;
 
-        private Spinner spinner;
-
         private const float initial_scale = 1.3f;
         private const float idle_alpha = 0.2f;
         private const float tracking_alpha = 0.4f;
@@ -52,7 +50,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         private void load(OsuColour colours, DrawableHitObject drawableHitObject)
         {
             drawableSpinner = (DrawableSpinner)drawableHitObject;
-            spinner = drawableSpinner.HitObject;
 
             normalColour = colours.BlueDark;
             completeColour = colours.YellowLight;
@@ -130,18 +127,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             if (!(drawableHitObject is DrawableSpinner))
                 return;
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            using (BeginAbsoluteSequence(drawableSpinner.HitObject.StartTime - drawableSpinner.HitObject.TimePreempt, true))
             {
                 this.ScaleTo(initial_scale);
                 this.RotateTo(0);
 
-                using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
+                using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt / 2, true))
                 {
                     // constant ambient rotation to give the spinner "spinning" character.
-                    this.RotateTo((float)(25 * spinner.Duration / 2000), spinner.TimePreempt + spinner.Duration);
+                    this.RotateTo((float)(25 * drawableSpinner.HitObject.Duration / 2000), drawableSpinner.HitObject.TimePreempt + drawableSpinner.HitObject.Duration);
                 }
 
-                using (BeginDelayedSequence(spinner.TimePreempt + spinner.Duration + drawableHitObject.Result.TimeOffset, true))
+                using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt + drawableSpinner.HitObject.Duration + drawableHitObject.Result.TimeOffset, true))
                 {
                     switch (state)
                     {
@@ -157,26 +154,26 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 }
             }
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            using (BeginAbsoluteSequence(drawableSpinner.HitObject.StartTime - drawableSpinner.HitObject.TimePreempt, true))
             {
                 centre.ScaleTo(0);
                 mainContainer.ScaleTo(0);
 
-                using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
+                using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt / 2, true))
                 {
-                    centre.ScaleTo(0.3f, spinner.TimePreempt / 4, Easing.OutQuint);
-                    mainContainer.ScaleTo(0.2f, spinner.TimePreempt / 4, Easing.OutQuint);
+                    centre.ScaleTo(0.3f, drawableSpinner.HitObject.TimePreempt / 4, Easing.OutQuint);
+                    mainContainer.ScaleTo(0.2f, drawableSpinner.HitObject.TimePreempt / 4, Easing.OutQuint);
 
-                    using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
+                    using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt / 2, true))
                     {
-                        centre.ScaleTo(0.5f, spinner.TimePreempt / 2, Easing.OutQuint);
-                        mainContainer.ScaleTo(1, spinner.TimePreempt / 2, Easing.OutQuint);
+                        centre.ScaleTo(0.5f, drawableSpinner.HitObject.TimePreempt / 2, Easing.OutQuint);
+                        mainContainer.ScaleTo(1, drawableSpinner.HitObject.TimePreempt / 2, Easing.OutQuint);
                     }
                 }
             }
 
             // transforms we have from completing the spinner will be rolled back, so reapply immediately.
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            using (BeginAbsoluteSequence(drawableSpinner.HitObject.StartTime - drawableSpinner.HitObject.TimePreempt, true))
                 updateComplete(state == ArmedState.Hit, 0);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/DefaultSpinnerDisc.cs
@@ -127,18 +127,20 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             if (!(drawableHitObject is DrawableSpinner))
                 return;
 
-            using (BeginAbsoluteSequence(drawableSpinner.HitObject.StartTime - drawableSpinner.HitObject.TimePreempt, true))
+            Spinner spinner = drawableSpinner.HitObject;
+
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
             {
                 this.ScaleTo(initial_scale);
                 this.RotateTo(0);
 
-                using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt / 2, true))
+                using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
                 {
                     // constant ambient rotation to give the spinner "spinning" character.
-                    this.RotateTo((float)(25 * drawableSpinner.HitObject.Duration / 2000), drawableSpinner.HitObject.TimePreempt + drawableSpinner.HitObject.Duration);
+                    this.RotateTo((float)(25 * spinner.Duration / 2000), spinner.TimePreempt + spinner.Duration);
                 }
 
-                using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt + drawableSpinner.HitObject.Duration + drawableHitObject.Result.TimeOffset, true))
+                using (BeginDelayedSequence(spinner.TimePreempt + spinner.Duration + drawableHitObject.Result.TimeOffset, true))
                 {
                     switch (state)
                     {
@@ -154,26 +156,26 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 }
             }
 
-            using (BeginAbsoluteSequence(drawableSpinner.HitObject.StartTime - drawableSpinner.HitObject.TimePreempt, true))
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
             {
                 centre.ScaleTo(0);
                 mainContainer.ScaleTo(0);
 
-                using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt / 2, true))
+                using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
                 {
-                    centre.ScaleTo(0.3f, drawableSpinner.HitObject.TimePreempt / 4, Easing.OutQuint);
-                    mainContainer.ScaleTo(0.2f, drawableSpinner.HitObject.TimePreempt / 4, Easing.OutQuint);
+                    centre.ScaleTo(0.3f, spinner.TimePreempt / 4, Easing.OutQuint);
+                    mainContainer.ScaleTo(0.2f, spinner.TimePreempt / 4, Easing.OutQuint);
 
-                    using (BeginDelayedSequence(drawableSpinner.HitObject.TimePreempt / 2, true))
+                    using (BeginDelayedSequence(spinner.TimePreempt / 2, true))
                     {
-                        centre.ScaleTo(0.5f, drawableSpinner.HitObject.TimePreempt / 2, Easing.OutQuint);
-                        mainContainer.ScaleTo(1, drawableSpinner.HitObject.TimePreempt / 2, Easing.OutQuint);
+                        centre.ScaleTo(0.5f, spinner.TimePreempt / 2, Easing.OutQuint);
+                        mainContainer.ScaleTo(1, spinner.TimePreempt / 2, Easing.OutQuint);
                     }
                 }
             }
 
             // transforms we have from completing the spinner will be rolled back, so reapply immediately.
-            using (BeginAbsoluteSequence(drawableSpinner.HitObject.StartTime - drawableSpinner.HitObject.TimePreempt, true))
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
                 updateComplete(state == ArmedState.Hit, 0);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/MainCirclePiece.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject drawableObject)
         {
-            OsuHitObject osuObject = (OsuHitObject)drawableObject.HitObject;
+            var drawableOsuObject = (DrawableOsuHitObject)drawableObject;
 
             state.BindTo(drawableObject.State);
             state.BindValueChanged(updateState, true);
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 circle.Colour = colour.NewValue;
             }, true);
 
-            indexInCurrentCombo.BindTo(osuObject.IndexInCurrentComboBindable);
+            indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
             indexInCurrentCombo.BindValueChanged(index => number.Text = (index.NewValue + 1).ToString(), true);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/PlaySliderBody.cs
@@ -17,23 +17,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         private IBindable<int> pathVersion;
         private IBindable<Color4> accentColour;
 
-        [Resolved]
-        private DrawableHitObject drawableObject { get; set; }
-
         [Resolved(CanBeNull = true)]
         private OsuRulesetConfigManager config { get; set; }
 
-        private Slider slider;
-
         [BackgroundDependencyLoader]
-        private void load(ISkinSource skin)
+        private void load(ISkinSource skin, DrawableHitObject drawableObject)
         {
-            slider = (Slider)drawableObject.HitObject;
+            var drawableSlider = (DrawableSlider)drawableObject;
 
-            scaleBindable = slider.ScaleBindable.GetBoundCopy();
+            scaleBindable = drawableSlider.ScaleBindable.GetBoundCopy();
             scaleBindable.BindValueChanged(scale => PathRadius = OsuHitObject.OBJECT_RADIUS * scale.NewValue, true);
 
-            pathVersion = slider.Path.Version.GetBoundCopy();
+            pathVersion = drawableSlider.PathVersion.GetBoundCopy();
             pathVersion.BindValueChanged(_ => Refresh());
 
             accentColour = drawableObject.AccentColour.GetBoundCopy();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -30,15 +30,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             set => ball.Colour = value;
         }
 
-        private readonly Slider slider;
         private readonly Drawable followCircle;
         private readonly DrawableSlider drawableSlider;
         private readonly Drawable ball;
 
-        public SliderBall(Slider slider, DrawableSlider drawableSlider = null)
+        public SliderBall(DrawableSlider drawableSlider)
         {
             this.drawableSlider = drawableSlider;
-            this.slider = slider;
 
             Origin = Anchor.Centre;
 
@@ -133,7 +131,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             if (headCircleHitAction == null)
                 timeToAcceptAnyKeyAfter = null;
 
-            var actions = drawableSlider?.OsuActionInputManager?.PressedActions;
+            var actions = drawableSlider.OsuActionInputManager?.PressedActions;
 
             // if the head circle was hit with a specific key, tracking should only occur while that key is pressed.
             if (headCircleHitAction != null && timeToAcceptAnyKeyAfter == null)
@@ -147,7 +145,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Tracking =
                 // in valid time range
-                Time.Current >= slider.StartTime && Time.Current < slider.EndTime &&
+                Time.Current >= drawableSlider.HitObject.StartTime && Time.Current < drawableSlider.HitObject.EndTime &&
                 // in valid position range
                 lastScreenSpaceMousePosition.HasValue && followCircle.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
                 // valid action
@@ -172,9 +170,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         public void UpdateProgress(double completionProgress)
         {
-            var newPos = slider.CurvePositionAt(completionProgress);
+            var newPos = drawableSlider.HitObject.CurvePositionAt(completionProgress);
 
-            var diff = lastPosition.HasValue ? lastPosition.Value - newPos : newPos - slider.CurvePositionAt(completionProgress + 0.01f);
+            var diff = lastPosition.HasValue ? lastPosition.Value - newPos : newPos - drawableSlider.HitObject.CurvePositionAt(completionProgress + 0.01f);
             if (diff == Vector2.Zero)
                 return;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SnakingSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SnakingSliderBody.cs
@@ -51,27 +51,30 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         /// </summary>
         private Vector2 snakedPathOffset;
 
-        private Slider slider;
+        private DrawableSlider drawableSlider;
 
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject drawableObject)
         {
-            slider = (Slider)drawableObject.HitObject;
+            drawableSlider = (DrawableSlider)drawableObject;
 
             Refresh();
         }
 
         public void UpdateProgress(double completionProgress)
         {
-            var span = slider.SpanAt(completionProgress);
-            var spanProgress = slider.ProgressAt(completionProgress);
+            if (drawableSlider == null)
+                return;
+
+            var span = drawableSlider.HitObject.SpanAt(completionProgress);
+            var spanProgress = drawableSlider.HitObject.ProgressAt(completionProgress);
 
             double start = 0;
-            double end = SnakingIn.Value ? Math.Clamp((Time.Current - (slider.StartTime - slider.TimePreempt)) / (slider.TimePreempt / 3), 0, 1) : 1;
+            double end = SnakingIn.Value ? Math.Clamp((Time.Current - (drawableSlider.HitObject.StartTime - drawableSlider.HitObject.TimePreempt)) / (drawableSlider.HitObject.TimePreempt / 3), 0, 1) : 1;
 
-            if (span >= slider.SpanCount() - 1)
+            if (span >= drawableSlider.HitObject.SpanCount() - 1)
             {
-                if (Math.Min(span, slider.SpanCount() - 1) % 2 == 1)
+                if (Math.Min(span, drawableSlider.HitObject.SpanCount() - 1) % 2 == 1)
                 {
                     start = 0;
                     end = SnakingOut.Value ? spanProgress : 1;
@@ -87,8 +90,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
         public void Refresh()
         {
+            if (drawableSlider == null)
+                return;
+
             // Generate the entire curve
-            slider.Path.GetPathToProgress(CurrentCurve, 0, 1);
+            drawableSlider.HitObject.Path.GetPathToProgress(CurrentCurve, 0, 1);
             SetVertices(CurrentCurve);
 
             // Force the body to be the final path size to avoid excessive autosize computations
@@ -132,7 +138,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             SnakedStart = p0;
             SnakedEnd = p1;
 
-            slider.Path.GetPathToProgress(CurrentCurve, p0, p1);
+            drawableSlider.HitObject.Path.GetPathToProgress(CurrentCurve, p0, p1);
 
             SetVertices(CurrentCurve);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SnakingSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SnakingSliderBody.cs
@@ -66,15 +66,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             if (drawableSlider == null)
                 return;
 
-            var span = drawableSlider.HitObject.SpanAt(completionProgress);
-            var spanProgress = drawableSlider.HitObject.ProgressAt(completionProgress);
+            Slider slider = drawableSlider.HitObject;
+
+            var span = slider.SpanAt(completionProgress);
+            var spanProgress = slider.ProgressAt(completionProgress);
 
             double start = 0;
-            double end = SnakingIn.Value ? Math.Clamp((Time.Current - (drawableSlider.HitObject.StartTime - drawableSlider.HitObject.TimePreempt)) / (drawableSlider.HitObject.TimePreempt / 3), 0, 1) : 1;
+            double end = SnakingIn.Value ? Math.Clamp((Time.Current - (slider.StartTime - slider.TimePreempt)) / (slider.TimePreempt / 3), 0, 1) : 1;
 
-            if (span >= drawableSlider.HitObject.SpanCount() - 1)
+            if (span >= slider.SpanCount() - 1)
             {
-                if (Math.Min(span, drawableSlider.HitObject.SpanCount() - 1) % 2 == 1)
+                if (Math.Min(span, slider.SpanCount() - 1) % 2 == 1)
                 {
                     start = 0;
                     end = SnakingOut.Value ? spanProgress : 1;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SpinnerRotationTracker.cs
@@ -15,13 +15,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class SpinnerRotationTracker : CircularContainer
     {
-        private readonly Spinner spinner;
-
         public override bool IsPresent => true; // handle input when hidden
 
-        public SpinnerRotationTracker(Spinner s)
+        private readonly DrawableSpinner drawableSpinner;
+
+        public SpinnerRotationTracker(DrawableSpinner drawableSpinner)
         {
-            spinner = s;
+            this.drawableSpinner = drawableSpinner;
 
             RelativeSizeAxes = Axes.Both;
         }
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         /// <summary>
         /// Whether currently in the correct time range to allow spinning.
         /// </summary>
-        private bool isSpinnableTime => spinner.StartTime <= Time.Current && spinner.EndTime > Time.Current;
+        private bool isSpinnableTime => drawableSpinner.HitObject.StartTime <= Time.Current && drawableSpinner.HitObject.EndTime > Time.Current;
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
@@ -11,6 +11,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -47,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject drawableObject)
         {
-            OsuHitObject osuObject = (OsuHitObject)drawableObject.HitObject;
+            var drawableOsuObject = (DrawableOsuHitObject)drawableObject;
 
             bool allowFallback = false;
 
@@ -111,7 +112,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             state.BindTo(drawableObject.State);
             accentColour.BindTo(drawableObject.AccentColour);
-            indexInCurrentCombo.BindTo(osuObject.IndexInCurrentComboBindable);
+            indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
 
             Texture getTextureWithFallback(string name)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -75,23 +75,21 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
-            if (!(drawableHitObject is DrawableSpinner))
+            if (!(drawableHitObject is DrawableSpinner spinner))
                 return;
 
-            var spinner = drawableSpinner.HitObject;
-
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimePreempt, true))
                 this.FadeOut();
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
-                this.FadeInFromZero(spinner.TimeFadeIn / 2);
+            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimeFadeIn / 2, true))
+                this.FadeInFromZero(spinner.HitObject.TimeFadeIn / 2);
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimePreempt, true))
             {
                 fixedMiddle.FadeColour(Color4.White);
 
-                using (BeginDelayedSequence(spinner.TimePreempt, true))
-                    fixedMiddle.FadeColour(Color4.Red, spinner.Duration);
+                using (BeginDelayedSequence(spinner.HitObject.TimePreempt, true))
+                    fixedMiddle.FadeColour(Color4.Red, spinner.HitObject.Duration);
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK;
@@ -75,21 +76,23 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
-            if (!(drawableHitObject is DrawableSpinner spinner))
+            if (!(drawableHitObject is DrawableSpinner d))
                 return;
 
-            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimePreempt, true))
+            Spinner spinner = d.HitObject;
+
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
                 this.FadeOut();
 
-            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimeFadeIn / 2, true))
-                this.FadeInFromZero(spinner.HitObject.TimeFadeIn / 2);
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
+                this.FadeInFromZero(spinner.TimeFadeIn / 2);
 
-            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimePreempt, true))
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
             {
                 fixedMiddle.FadeColour(Color4.White);
 
-                using (BeginDelayedSequence(spinner.HitObject.TimePreempt, true))
-                    fixedMiddle.FadeColour(Color4.Red, spinner.HitObject.Duration);
+                using (BeginDelayedSequence(spinner.TimePreempt, true))
+                    fixedMiddle.FadeColour(Color4.Red, spinner.Duration);
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK;
@@ -94,14 +95,16 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
-            if (!(drawableHitObject is DrawableSpinner spinner))
+            if (!(drawableHitObject is DrawableSpinner d))
                 return;
 
-            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimePreempt, true))
+            Spinner spinner = d.HitObject;
+
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
                 this.FadeOut();
 
-            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimeFadeIn / 2, true))
-                this.FadeInFromZero(spinner.HitObject.TimeFadeIn / 2);
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
+                this.FadeInFromZero(spinner.TimeFadeIn / 2);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -94,16 +94,14 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
-            if (!(drawableHitObject is DrawableSpinner))
+            if (!(drawableHitObject is DrawableSpinner spinner))
                 return;
 
-            var spinner = drawableSpinner.HitObject;
-
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt, true))
+            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimePreempt, true))
                 this.FadeOut();
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2, true))
-                this.FadeInFromZero(spinner.TimeFadeIn / 2);
+            using (BeginAbsoluteSequence(spinner.HitObject.StartTime - spinner.HitObject.TimeFadeIn / 2, true))
+                this.FadeInFromZero(spinner.HitObject.TimeFadeIn / 2);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySliderBall.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK.Graphics;
 
@@ -26,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         }
 
         [BackgroundDependencyLoader]
-        private void load(ISkinSource skin, DrawableHitObject drawableObject)
+        private void load(ISkinSource skin)
         {
             var ballColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBall)?.Value ?? Color4.White;
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/10689

Full set of changes can be found in https://github.com/ppy/osu/compare/master...smoogipoo:hitobject-pooling

DHOs will be reused with different hitobject models, so the model shouldn't be stored in any drawable components.