### PR TITLE
Remove AccentColour binding from judgement lighting

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -2,22 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osuTK;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Skinning;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableOsuJudgement : DrawableJudgement
     {
-        protected SkinnableSprite Lighting;
-
-        private Bindable<Color4> lightingColour;
+        protected SkinnableLighting Lighting { get; private set; }
 
         [Resolved]
         private OsuConfigManager config { get; set; }
@@ -34,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(Lighting = new SkinnableSprite("lighting")
+            AddInternal(Lighting = new SkinnableLighting
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -59,19 +54,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.PrepareForUse();
 
-            lightingColour?.UnbindAll();
-
             Lighting.ResetAnimation();
-
-            if (JudgedObject != null)
-            {
-                lightingColour = JudgedObject.AccentColour.GetBoundCopy();
-                lightingColour.BindValueChanged(colour => Lighting.Colour = Result.IsHit ? colour.NewValue : Color4.Transparent, true);
-            }
-            else
-            {
-                Lighting.Colour = Color4.White;
-            }
+            Lighting.SetColourFrom(JudgedObject, Result);
         }
 
         private double fadeOutDelay;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/SkinnableLighting.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/SkinnableLighting.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Objects.Drawables
+{
+    public class SkinnableLighting : SkinnableSprite
+    {
+        private DrawableHitObject targetObject;
+        private JudgementResult targetResult;
+
+        public SkinnableLighting()
+            : base("lighting")
+        {
+        }
+
+        protected override void SkinChanged(ISkinSource skin, bool allowFallback)
+        {
+            base.SkinChanged(skin, allowFallback);
+            updateColour();
+        }
+
+        /// <summary>
+        /// Updates the lighting colour from a given hitobject and result.
+        /// </summary>
+        /// <param name="targetObject">The <see cref="DrawableHitObject"/> that's been judged.</param>
+        /// <param name="targetResult">The <see cref="JudgementResult"/> that <paramref name="targetObject"/> was judged with.</param>
+        public void SetColourFrom(DrawableHitObject targetObject, JudgementResult targetResult)
+        {
+            this.targetObject = targetObject;
+            this.targetResult = targetResult;
+
+            updateColour();
+        }
+
+        private void updateColour()
+        {
+            if (targetObject == null || targetResult == null)
+                Colour = Color4.White;
+            else
+                Colour = targetResult.IsHit ? targetObject.AccentColour.Value : Color4.Transparent;
+        }
+    }
+}


### PR DESCRIPTION
Full set of changes can be found in https://github.com/ppy/osu/compare/master...smoogipoo:hitobject-pooling

The transform duration of lighting differs from that of the DHOs, so if a DHO is reused then `AccentColour` will be changed to a new colour while the lighting is fading out.