### PR TITLE
Make FollowPointRenderer use hitobject models

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     }
 
                     hitObjectContainer.Add(drawableObject);
-                    followPointRenderer.AddFollowPoints(drawableObject);
+                    followPointRenderer.AddFollowPoints(objects[i]);
                 }
             });
         }
@@ -180,10 +180,10 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             AddStep("remove hitobject", () =>
             {
-                var drawableObject = getFunc?.Invoke();
+                var drawableObject = getFunc.Invoke();
 
                 hitObjectContainer.Remove(drawableObject);
-                followPointRenderer.RemoveFollowPoints(drawableObject);
+                followPointRenderer.RemoveFollowPoints(drawableObject.HitObject);
             });
         }
 
@@ -215,10 +215,10 @@ namespace osu.Game.Rulesets.Osu.Tests
                     DrawableOsuHitObject expectedStart = getObject(i);
                     DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
 
-                    if (getGroup(i).Start != expectedStart)
+                    if (getGroup(i).Start != expectedStart.HitObject)
                         throw new AssertionException($"Object {i} expected to be the start of group {i}.");
 
-                    if (getGroup(i).End != expectedEnd)
+                    if (getGroup(i).End != expectedEnd?.HitObject)
                         throw new AssertionException($"Object {(expectedEnd == null ? "null" : i.ToString())} expected to be the end of group {i}.");
                 }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -24,19 +24,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         public override bool RemoveCompletedTransforms => false;
 
         /// <summary>
-        /// Adds the <see cref="FollowPoint"/>s around a <see cref="DrawableOsuHitObject"/>.
+        /// Adds the <see cref="FollowPoint"/>s around an <see cref="OsuHitObject"/>.
         /// This includes <see cref="FollowPoint"/>s leading into <paramref name="hitObject"/>, and <see cref="FollowPoint"/>s exiting <paramref name="hitObject"/>.
         /// </summary>
-        /// <param name="hitObject">The <see cref="DrawableOsuHitObject"/> to add <see cref="FollowPoint"/>s for.</param>
-        public void AddFollowPoints(DrawableOsuHitObject hitObject)
+        /// <param name="hitObject">The <see cref="OsuHitObject"/> to add <see cref="FollowPoint"/>s for.</param>
+        public void AddFollowPoints(OsuHitObject hitObject)
             => addConnection(new FollowPointConnection(hitObject).With(g => g.StartTime.BindValueChanged(_ => onStartTimeChanged(g))));
 
         /// <summary>
-        /// Removes the <see cref="FollowPoint"/>s around a <see cref="DrawableOsuHitObject"/>.
+        /// Removes the <see cref="FollowPoint"/>s around an <see cref="OsuHitObject"/>.
         /// This includes <see cref="FollowPoint"/>s leading into <paramref name="hitObject"/>, and <see cref="FollowPoint"/>s exiting <paramref name="hitObject"/>.
         /// </summary>
-        /// <param name="hitObject">The <see cref="DrawableOsuHitObject"/> to remove <see cref="FollowPoint"/>s for.</param>
-        public void RemoveFollowPoints(DrawableOsuHitObject hitObject) => removeGroup(connections.Single(g => g.Start == hitObject));
+        /// <param name="hitObject">The <see cref="OsuHitObject"/> to remove <see cref="FollowPoint"/>s for.</param>
+        public void RemoveFollowPoints(OsuHitObject hitObject) => removeGroup(connections.Single(g => g.Start == hitObject));
 
         /// <summary>
         /// Adds a <see cref="FollowPointConnection"/> to this <see cref="FollowPointRenderer"/>.

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -4,12 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
 using osu.Game.Rulesets.Osu.Scoring;
@@ -17,10 +20,6 @@ using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Skinning;
-using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Game.Rulesets.Osu.Configuration;
-using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.UI
@@ -96,6 +95,8 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public override void Add(DrawableHitObject h)
         {
+            DrawableOsuHitObject osuHitObject = (DrawableOsuHitObject)h;
+
             h.OnNewResult += onNewResult;
             h.OnLoadComplete += d =>
             {
@@ -108,18 +109,19 @@ namespace osu.Game.Rulesets.Osu.UI
 
             base.Add(h);
 
-            DrawableOsuHitObject osuHitObject = (DrawableOsuHitObject)h;
             osuHitObject.CheckHittable = hitPolicy.IsHittable;
 
-            followPoints.AddFollowPoints((OsuHitObject)h.HitObject);
+            followPoints.AddFollowPoints(osuHitObject.HitObject);
         }
 
         public override bool Remove(DrawableHitObject h)
         {
+            DrawableOsuHitObject osuHitObject = (DrawableOsuHitObject)h;
+
             bool result = base.Remove(h);
 
             if (result)
-                followPoints.RemoveFollowPoints((OsuHitObject)h.HitObject);
+                followPoints.RemoveFollowPoints(osuHitObject.HitObject);
 
             return result;
         }

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -20,6 +20,7 @@ using osu.Game.Skinning;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Osu.Configuration;
+using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.UI
@@ -110,7 +111,7 @@ namespace osu.Game.Rulesets.Osu.UI
             DrawableOsuHitObject osuHitObject = (DrawableOsuHitObject)h;
             osuHitObject.CheckHittable = hitPolicy.IsHittable;
 
-            followPoints.AddFollowPoints(osuHitObject);
+            followPoints.AddFollowPoints((OsuHitObject)h.HitObject);
         }
 
         public override bool Remove(DrawableHitObject h)
@@ -118,7 +119,7 @@ namespace osu.Game.Rulesets.Osu.UI
             bool result = base.Remove(h);
 
             if (result)
-                followPoints.RemoveFollowPoints((DrawableOsuHitObject)h);
+                followPoints.RemoveFollowPoints((OsuHitObject)h.HitObject);
 
             return result;
         }


### PR DESCRIPTION
Full set of changes can be found in https://github.com/ppy/osu/compare/master...smoogipoo:hitobject-pooling

When pooling, we'll only have full knowledge of the hitobject models. This is a bit of an MVP implementation that keeps all the logic the same and only changes the type that's referenced. We'll also want to pool followpoints in the future, but that's much harder to implement and will probably require rewriting this class.