### PR TITLE
Add mod subclass to handle visibility adjusment mods

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHidden.cs
@@ -17,9 +17,11 @@ namespace osu.Game.Rulesets.Catch.Mods
         private const double fade_out_offset_multiplier = 0.6;
         private const double fade_out_duration_multiplier = 0.44;
 
-        protected override void ApplyHiddenState(DrawableHitObject drawable, ArmedState state)
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            if (!(drawable is DrawableCatchHitObject catchDrawable))
+            base.ApplyNormalVisibilityState(hitObject, state);
+
+            if (!(hitObject is DrawableCatchHitObject catchDrawable))
                 return;
 
             if (catchDrawable.NestedHitObjects.Any())

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         private const double fade_in_duration_multiplier = 0.4;
         private const double fade_out_duration_multiplier = 0.3;
 
-        protected override bool IsFirstHideableObject(DrawableHitObject hitObject) => !(hitObject is DrawableSpinner);
+        protected override bool IsFirstAdjustableObject(HitObject hitObject) => !(hitObject is Spinner);
 
         public override void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
         {
@@ -42,9 +42,17 @@ namespace osu.Game.Rulesets.Osu.Mods
         private double lastSliderHeadFadeOutStartTime;
         private double lastSliderHeadFadeOutDuration;
 
-        protected override void ApplyFirstObjectIncreaseVisibilityState(DrawableHitObject drawable, ArmedState state) => applyState(drawable, true);
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+            base.ApplyIncreasedVisibilityState(hitObject, state);
+            applyState(hitObject, true);
+        }
 
-        protected override void ApplyHiddenState(DrawableHitObject drawable, ArmedState state) => applyState(drawable, false);
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+            base.ApplyNormalVisibilityState(hitObject, state);
+            applyState(hitObject, false);
+        }
 
         private void applyState(DrawableHitObject drawable, bool increaseVisibility)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -27,16 +26,18 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
         {
-            static void adjustFadeIn(OsuHitObject h) => h.TimeFadeIn = h.TimePreempt * fade_in_duration_multiplier;
-
-            foreach (var d in drawables.OfType<DrawableOsuHitObject>())
-            {
-                adjustFadeIn(d.HitObject);
-                foreach (var h in d.HitObject.NestedHitObjects.OfType<OsuHitObject>())
-                    adjustFadeIn(h);
-            }
+            foreach (var d in drawables)
+                d.ApplyCustomUpdateState += applyFadeInAdjustment;
 
             base.ApplyToDrawableHitObjects(drawables);
+        }
+
+        private void applyFadeInAdjustment(DrawableHitObject hitObject, ArmedState state)
+        {
+            if (!(hitObject is DrawableOsuHitObject d))
+                return;
+
+            d.HitObject.TimeFadeIn = d.HitObject.TimePreempt * fade_in_duration_multiplier;
         }
 
         private double lastSliderHeadFadeOutStartTime;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -26,11 +26,11 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override Type[] IncompatibleMods => new[] { typeof(OsuModSpinIn), typeof(OsuModTraceable) };
 
-        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            base.ApplyNormalVisibilityState(hitObject, state);
-            applyCustomState(hitObject, state);
         }
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state) => applyCustomState(hitObject, state);
 
         private void applyCustomState(DrawableHitObject drawable, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -2,11 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -17,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     /// <summary>
     /// Adjusts the size of hit objects during their fade in animation.
     /// </summary>
-    public abstract class OsuModObjectScaleTween : Mod, IReadFromConfig, IApplicableToDrawableHitObjects
+    public abstract class OsuModObjectScaleTween : ModWithVisibilityAdjustment
     {
         public override ModType Type => ModType.Fun;
 
@@ -27,33 +24,19 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         protected virtual float EndScale => 1;
 
-        private Bindable<bool> increaseFirstObjectVisibility = new Bindable<bool>();
-
         public override Type[] IncompatibleMods => new[] { typeof(OsuModSpinIn), typeof(OsuModTraceable) };
 
-        public void ReadFromConfig(OsuConfigManager config)
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            increaseFirstObjectVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility);
+            base.ApplyNormalVisibilityState(hitObject, state);
+            applyCustomState(hitObject, state);
         }
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        private void applyCustomState(DrawableHitObject drawable, ArmedState state)
         {
-            foreach (var drawable in drawables.Skip(increaseFirstObjectVisibility.Value ? 1 : 0))
-            {
-                switch (drawable)
-                {
-                    case DrawableSpinner _:
-                        continue;
+            if (drawable is DrawableSpinner)
+                return;
 
-                    default:
-                        drawable.ApplyCustomUpdateState += ApplyCustomState;
-                        break;
-                }
-            }
-        }
-
-        protected virtual void ApplyCustomState(DrawableHitObject drawable, ArmedState state)
-        {
             var h = (OsuHitObject)drawable.HitObject;
 
             // apply grow effect

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -27,11 +27,11 @@ namespace osu.Game.Rulesets.Osu.Mods
         private const int rotate_offset = 360;
         private const float rotate_starting_width = 2;
 
-        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            base.ApplyNormalVisibilityState(hitObject, state);
-            applyZoomState(hitObject, state);
         }
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state) => applyZoomState(hitObject, state);
 
         private void applyZoomState(DrawableHitObject drawable, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpinIn.cs
@@ -2,12 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
@@ -16,7 +12,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModSpinIn : Mod, IApplicableToDrawableHitObjects, IReadFromConfig
+    public class OsuModSpinIn : ModWithVisibilityAdjustment
     {
         public override string Name => "Spin In";
         public override string Acronym => "SI";
@@ -31,31 +27,17 @@ namespace osu.Game.Rulesets.Osu.Mods
         private const int rotate_offset = 360;
         private const float rotate_starting_width = 2;
 
-        private Bindable<bool> increaseFirstObjectVisibility = new Bindable<bool>();
-
-        public void ReadFromConfig(OsuConfigManager config)
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            increaseFirstObjectVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility);
-        }
-
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
-        {
-            foreach (var drawable in drawables.Skip(increaseFirstObjectVisibility.Value ? 1 : 0))
-            {
-                switch (drawable)
-                {
-                    case DrawableSpinner _:
-                        continue;
-
-                    default:
-                        drawable.ApplyCustomUpdateState += applyZoomState;
-                        break;
-                }
-            }
+            base.ApplyNormalVisibilityState(hitObject, state);
+            applyZoomState(hitObject, state);
         }
 
         private void applyZoomState(DrawableHitObject drawable, ArmedState state)
         {
+            if (drawable is DrawableSpinner)
+                return;
+
             var h = (OsuHitObject)drawable.HitObject;
 
             switch (drawable)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -2,12 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
-using osu.Framework.Bindables;
-using System.Collections.Generic;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -15,7 +11,7 @@ using osu.Game.Rulesets.Osu.Objects.Drawables.Pieces;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModTraceable : Mod, IReadFromConfig, IApplicableToDrawableHitObjects
+    internal class OsuModTraceable : ModWithVisibilityAdjustment
     {
         public override string Name => "Traceable";
         public override string Acronym => "TC";
@@ -24,20 +20,14 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 1;
 
         public override Type[] IncompatibleMods => new[] { typeof(OsuModHidden), typeof(OsuModSpinIn), typeof(OsuModObjectScaleTween) };
-        private Bindable<bool> increaseFirstObjectVisibility = new Bindable<bool>();
 
-        public void ReadFromConfig(OsuConfigManager config)
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            increaseFirstObjectVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility);
+            base.ApplyNormalVisibilityState(hitObject, state);
+            applyTraceableState(hitObject, state);
         }
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
-        {
-            foreach (var drawable in drawables.Skip(increaseFirstObjectVisibility.Value ? 1 : 0))
-                drawable.ApplyCustomUpdateState += ApplyTraceableState;
-        }
-
-        protected void ApplyTraceableState(DrawableHitObject drawable, ArmedState state)
+        private void applyTraceableState(DrawableHitObject drawable, ArmedState state)
         {
             if (!(drawable is DrawableOsuHitObject))
                 return;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTraceable.cs
@@ -21,11 +21,11 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override Type[] IncompatibleMods => new[] { typeof(OsuModHidden), typeof(OsuModSpinIn), typeof(OsuModObjectScaleTween) };
 
-        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            base.ApplyNormalVisibilityState(hitObject, state);
-            applyTraceableState(hitObject, state);
         }
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state) => applyTraceableState(hitObject, state);
 
         private void applyTraceableState(DrawableHitObject drawable, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
@@ -13,7 +12,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModTransform : Mod, IApplicableToDrawableHitObjects
+    internal class OsuModTransform : ModWithVisibilityAdjustment
     {
         public override string Name => "Transform";
         public override string Acronym => "TR";
@@ -25,11 +24,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private float theta;
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
-        {
-            foreach (var drawable in drawables)
-                drawable.ApplyCustomUpdateState += applyTransform;
-        }
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state) => applyTransform(hitObject, state);
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state) => applyTransform(hitObject, state);
 
         private void applyTransform(DrawableHitObject drawable, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
@@ -13,7 +12,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    internal class OsuModWiggle : Mod, IApplicableToDrawableHitObjects
+    internal class OsuModWiggle : ModWithVisibilityAdjustment
     {
         public override string Name => "Wiggle";
         public override string Acronym => "WG";
@@ -26,11 +25,9 @@ namespace osu.Game.Rulesets.Osu.Mods
         private const int wiggle_duration = 90; // (ms) Higher = fewer wiggles
         private const int wiggle_strength = 10; // Higher = stronger wiggles
 
-        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
-        {
-            foreach (var drawable in drawables)
-                drawable.ApplyCustomUpdateState += drawableOnApplyCustomUpdateState;
-        }
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state) => drawableOnApplyCustomUpdateState(hitObject, state);
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state) => drawableOnApplyCustomUpdateState(hitObject, state);
 
         private void drawableOnApplyCustomUpdateState(DrawableHitObject drawable, ArmedState state)
         {

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -49,7 +49,6 @@ namespace osu.Game.Rulesets.Mods
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            base.ApplyIncreasedVisibilityState(hitObject, state);
 #pragma warning disable 618
             ApplyFirstObjectIncreaseVisibilityState(hitObject, state);
 #pragma warning restore 618
@@ -57,7 +56,6 @@ namespace osu.Game.Rulesets.Mods
 
         protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
-            base.ApplyNormalVisibilityState(hitObject, state);
 #pragma warning disable 618
             ApplyHiddenState(hitObject, state);
 #pragma warning restore 618

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Mods
         /// Can be used to skip spinners, for instance.
         /// </summary>
         /// <param name="hitObject">The hitobject to check.</param>
-        [Obsolete("Use IsFirstAdjustableObject() instead.")]
+        [Obsolete("Use IsFirstAdjustableObject() instead.")] // Can be removed 20210506
         protected virtual bool IsFirstHideableObject(DrawableHitObject hitObject) => true;
 
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
         /// <param name="state">The state of the hit object.</param>
-        [Obsolete("Use ApplyIncreasedVisibilityState() instead.")]
+        [Obsolete("Use ApplyIncreasedVisibilityState() instead.")] // Can be removed 20210506
         protected virtual void ApplyFirstObjectIncreaseVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
         }
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
         /// <param name="state">The state of the hit object.</param>
-        [Obsolete("Use ApplyNormalVisibilityState() instead.")]
+        [Obsolete("Use ApplyNormalVisibilityState() instead.")] // Can be removed 20210506
         protected virtual void ApplyHiddenState(DrawableHitObject hitObject, ArmedState state)
         {
         }

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -1,19 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Configuration;
+using System;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
-using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModHidden : Mod, IReadFromConfig, IApplicableToDrawableHitObjects, IApplicableToScoreProcessor
+    public abstract class ModHidden : ModWithVisibilityAdjustment, IApplicableToScoreProcessor
     {
         public override string Name => "Hidden";
         public override string Acronym => "HD";
@@ -21,36 +18,13 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override bool Ranked => true;
 
-        protected Bindable<bool> IncreaseFirstObjectVisibility = new Bindable<bool>();
-
         /// <summary>
         /// Check whether the provided hitobject should be considered the "first" hideable object.
         /// Can be used to skip spinners, for instance.
         /// </summary>
         /// <param name="hitObject">The hitobject to check.</param>
+        [Obsolete("Use IsFirstAdjustableObject() instead.")]
         protected virtual bool IsFirstHideableObject(DrawableHitObject hitObject) => true;
-
-        public void ReadFromConfig(OsuConfigManager config)
-        {
-            IncreaseFirstObjectVisibility = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility);
-        }
-
-        public virtual void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
-        {
-            if (IncreaseFirstObjectVisibility.Value)
-            {
-                drawables = drawables.SkipWhile(h => !IsFirstHideableObject(h));
-
-                var firstObject = drawables.FirstOrDefault();
-                if (firstObject != null)
-                    firstObject.ApplyCustomUpdateState += ApplyFirstObjectIncreaseVisibilityState;
-
-                drawables = drawables.Skip(1);
-            }
-
-            foreach (var dho in drawables)
-                dho.ApplyCustomUpdateState += ApplyHiddenState;
-        }
 
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {
@@ -73,11 +47,28 @@ namespace osu.Game.Rulesets.Mods
             }
         }
 
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+            base.ApplyIncreasedVisibilityState(hitObject, state);
+#pragma warning disable 618
+            ApplyFirstObjectIncreaseVisibilityState(hitObject, state);
+#pragma warning restore 618
+        }
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+            base.ApplyNormalVisibilityState(hitObject, state);
+#pragma warning disable 618
+            ApplyHiddenState(hitObject, state);
+#pragma warning restore 618
+        }
+
         /// <summary>
         /// Apply a special visibility state to the first object in a beatmap, if the user chooses to turn on the "increase first object visibility" setting.
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
         /// <param name="state">The state of the hit object.</param>
+        [Obsolete("Use ApplyIncreasedVisibilityState() instead.")]
         protected virtual void ApplyFirstObjectIncreaseVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
         }
@@ -87,6 +78,7 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
         /// <param name="state">The state of the hit object.</param>
+        [Obsolete("Use ApplyNormalVisibilityState() instead.")]
         protected virtual void ApplyHiddenState(DrawableHitObject hitObject, ArmedState state)
         {
         }

--- a/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
+++ b/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
@@ -34,18 +34,18 @@ namespace osu.Game.Rulesets.Mods
         protected virtual bool IsFirstAdjustableObject(HitObject hitObject) => true;
 
         /// <summary>
-        /// Apply a special increased-visibility state to the first adjustable object..
+        /// Apply a special increased-visibility state to the first adjustable object.
         /// Only applicable if the user chooses to turn on the "increase first object visibility" setting.
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
-        /// <param name="state">The state of the hit object.</param>
+        /// <param name="state">The state of the hitobject.</param>
         protected abstract void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state);
 
         /// <summary>
         /// Apply a normal visibility state adjustment to an object.
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
-        /// <param name="state">The state of the hit object.</param>
+        /// <param name="state">The state of the hitobject.</param>
         protected abstract void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state);
 
         public virtual void ReadFromConfig(OsuConfigManager config)

--- a/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
+++ b/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
@@ -10,6 +10,10 @@ using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Mods
 {
+    /// <summary>
+    /// A <see cref="Mod"/> which applies visibility adjustments to <see cref="DrawableHitObject"/>s
+    /// with an optional increased visibility adjustment depending on the user's "increase first object visibility" setting.
+    /// </summary>
     public abstract class ModWithVisibilityAdjustment : Mod, IReadFromConfig, IApplicableToBeatmap, IApplicableToDrawableHitObjects
     {
         /// <summary>

--- a/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
+++ b/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
@@ -39,18 +39,14 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
         /// <param name="state">The state of the hit object.</param>
-        protected virtual void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
-        {
-        }
+        protected abstract void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state);
 
         /// <summary>
         /// Apply a normal visibility state adjustment to an object.
         /// </summary>
         /// <param name="hitObject">The hit object to apply the state change to.</param>
         /// <param name="state">The state of the hit object.</param>
-        protected virtual void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
-        {
-        }
+        protected abstract void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state);
 
         public virtual void ReadFromConfig(OsuConfigManager config)
         {

--- a/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
+++ b/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModWithVisibilityAdjustment : Mod, IReadFromConfig, IApplicableToBeatmap, IApplicableToDrawableHitObjects
+    {
+        /// <summary>
+        /// The first adjustable object.
+        /// </summary>
+        protected HitObject FirstObject { get; private set; }
+
+        /// <summary>
+        /// Whether the visibility of <see cref="FirstObject"/> should be increased.
+        /// </summary>
+        protected readonly Bindable<bool> IncreaseFirstObjectVisibility = new Bindable<bool>();
+
+        /// <summary>
+        /// Check whether the provided hitobject should be considered the "first" adjustable object.
+        /// Can be used to skip spinners, for instance.
+        /// </summary>
+        /// <param name="hitObject">The hitobject to check.</param>
+        protected virtual bool IsFirstAdjustableObject(HitObject hitObject) => true;
+
+        /// <summary>
+        /// Apply a special increased-visibility state to the first adjustable object..
+        /// Only applicable if the user chooses to turn on the "increase first object visibility" setting.
+        /// </summary>
+        /// <param name="hitObject">The hit object to apply the state change to.</param>
+        /// <param name="state">The state of the hit object.</param>
+        protected virtual void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+        }
+
+        /// <summary>
+        /// Apply a normal visibility state adjustment to an object.
+        /// </summary>
+        /// <param name="hitObject">The hit object to apply the state change to.</param>
+        /// <param name="state">The state of the hit object.</param>
+        protected virtual void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
+        {
+        }
+
+        public virtual void ReadFromConfig(OsuConfigManager config)
+        {
+            config.BindWith(OsuSetting.IncreaseFirstObjectVisibility, IncreaseFirstObjectVisibility);
+        }
+
+        public virtual void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            FirstObject = getFirstAdjustableObjectRecursive(beatmap.HitObjects);
+
+            HitObject getFirstAdjustableObjectRecursive(IReadOnlyList<HitObject> hitObjects)
+            {
+                foreach (var h in hitObjects)
+                {
+                    if (IsFirstAdjustableObject(h))
+                        return h;
+
+                    var nestedResult = getFirstAdjustableObjectRecursive(h.NestedHitObjects);
+                    if (nestedResult != null)
+                        return nestedResult;
+                }
+
+                return null;
+            }
+        }
+
+        public virtual void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        {
+            foreach (var dho in drawables)
+            {
+                dho.ApplyCustomUpdateState += (o, state) =>
+                {
+                    // Increased visibility is applied to the entire first object, including all of its nested hitobjects.
+                    if (IncreaseFirstObjectVisibility.Value && isObjectEqualToOrNestedIn(o.HitObject, FirstObject))
+                        ApplyIncreasedVisibilityState(o, state);
+                    else
+                        ApplyNormalVisibilityState(o, state);
+                };
+            }
+        }
+
+        /// <summary>
+        /// Checks whether a given object is nested within a target.
+        /// </summary>
+        /// <param name="toCheck">The <see cref="HitObject"/> to check.</param>
+        /// <param name="target">The <see cref="HitObject"/> which may be equal to or contain <paramref name="toCheck"/> as a nested object.</param>
+        /// <returns>Whether <paramref name="toCheck"/> is equal to or nested within <paramref name="target"/>.</returns>
+        private bool isObjectEqualToOrNestedIn(HitObject toCheck, HitObject target)
+        {
+            if (target == null)
+                return false;
+
+            if (toCheck == target)
+                return true;
+
+            foreach (var h in target.NestedHitObjects)
+            {
+                if (isObjectEqualToOrNestedIn(toCheck, h))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Full set of changes can be found in https://github.com/ppy/osu/compare/master...smoogipoo:hitobject-pooling

With hitobject pooling, `ApplyToDrawableHitObjects` is not guaranteed to occur in order, nor is it guaranteed to be given the full set of DHOs. These changes aim to use the `HitObject` models to determine the first adjustable object, and since this is quite a difficult implementation it's been abstracted it into a `ModWithVisibilityAdjustment` class.

There's a slight breaking change in that `IsFirstHideableObject(DrawableHitObject hitObject)` has become unused, but I think this is acceptable given that only the [Swing](https://github.com/EVAST9919/lazer-swing) ruleset uses it and the mod still works fine otherwise.