### PR TITLE
Add support for spinner "spin" text in legacy skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -27,8 +27,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
         private Sprite spinningMiddle;
         private Sprite fixedMiddle;
 
-        private const float final_scale = 0.625f;
-
         private readonly Color4 glowColour = new Color4(3, 151, 255, 255);
 
         private Container scaleContainer;
@@ -38,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             AddInternal(scaleContainer = new Container
             {
-                Scale = new Vector2(final_scale),
+                Scale = new Vector2(SPRITE_SCALE),
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
@@ -127,7 +125,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             glow.Alpha = DrawableSpinner.Progress;
 
-            scaleContainer.Scale = new Vector2(final_scale * (0.8f + (float)Interpolation.ApplyEasing(Easing.Out, DrawableSpinner.Progress) * 0.2f));
+            scaleContainer.Scale = new Vector2(SPRITE_SCALE * (0.8f + (float)Interpolation.ApplyEasing(Easing.Out, DrawableSpinner.Progress) * 0.2f));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             Scale = new Vector2(final_scale);
 
-            InternalChildren = new Drawable[]
+            AddRangeInternal(new Drawable[]
             {
                 glow = new Sprite
                 {
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     Origin = Anchor.Centre,
                     Texture = source.GetTexture("spinner-middle2")
                 }
-            };
+            });
         }
 
         protected override void UpdateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -19,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
     /// Legacy skinned spinner with two main spinning layers, one fixed overlay and one final spinning overlay.
     /// No background layer.
     /// </summary>
-    public class LegacyNewStyleSpinner : CompositeDrawable
+    public class LegacyNewStyleSpinner : LegacySpinner
     {
         private Sprite glow;
         private Sprite discBottom;
@@ -27,17 +26,13 @@ namespace osu.Game.Rulesets.Osu.Skinning
         private Sprite spinningMiddle;
         private Sprite fixedMiddle;
 
-        private DrawableSpinner drawableSpinner;
-
         private const float final_scale = 0.625f;
 
         private readonly Color4 glowColour = new Color4(3, 151, 255, 255);
 
         [BackgroundDependencyLoader]
-        private void load(ISkinSource source, DrawableHitObject drawableObject)
+        private void load(ISkinSource source)
         {
-            drawableSpinner = (DrawableSpinner)drawableObject;
-
             Scale = new Vector2(final_scale);
 
             InternalChildren = new Drawable[]
@@ -77,16 +72,10 @@ namespace osu.Game.Rulesets.Osu.Skinning
             };
         }
 
-        protected override void LoadComplete()
+        protected override void UpdateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
-            base.LoadComplete();
+            base.UpdateStateTransforms(drawableHitObject, state);
 
-            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
-            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
-        }
-
-        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
-        {
             switch (drawableHitObject)
             {
                 case DrawableSpinner d:
@@ -125,20 +114,12 @@ namespace osu.Game.Rulesets.Osu.Skinning
         protected override void Update()
         {
             base.Update();
-            spinningMiddle.Rotation = discTop.Rotation = drawableSpinner.RotationTracker.Rotation;
+            spinningMiddle.Rotation = discTop.Rotation = DrawableSpinner.RotationTracker.Rotation;
             discBottom.Rotation = discTop.Rotation / 3;
 
-            glow.Alpha = drawableSpinner.Progress;
+            glow.Alpha = DrawableSpinner.Progress;
 
-            Scale = new Vector2(final_scale * (0.8f + (float)Interpolation.ApplyEasing(Easing.Out, drawableSpinner.Progress) * 0.2f));
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (drawableSpinner != null)
-                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+            Scale = new Vector2(final_scale * (0.8f + (float)Interpolation.ApplyEasing(Easing.Out, DrawableSpinner.Progress) * 0.2f));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyNewStyleSpinner.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -30,44 +31,51 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private readonly Color4 glowColour = new Color4(3, 151, 255, 255);
 
+        private Container scaleContainer;
+
         [BackgroundDependencyLoader]
         private void load(ISkinSource source)
         {
-            Scale = new Vector2(final_scale);
-
-            AddRangeInternal(new Drawable[]
+            AddInternal(scaleContainer = new Container
             {
-                glow = new Sprite
+                Scale = new Vector2(final_scale),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Texture = source.GetTexture("spinner-glow"),
-                    Blending = BlendingParameters.Additive,
-                    Colour = glowColour,
-                },
-                discBottom = new Sprite
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Texture = source.GetTexture("spinner-bottom")
-                },
-                discTop = new Sprite
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Texture = source.GetTexture("spinner-top")
-                },
-                fixedMiddle = new Sprite
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Texture = source.GetTexture("spinner-middle")
-                },
-                spinningMiddle = new Sprite
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Texture = source.GetTexture("spinner-middle2")
+                    glow = new Sprite
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Texture = source.GetTexture("spinner-glow"),
+                        Blending = BlendingParameters.Additive,
+                        Colour = glowColour,
+                    },
+                    discBottom = new Sprite
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Texture = source.GetTexture("spinner-bottom")
+                    },
+                    discTop = new Sprite
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Texture = source.GetTexture("spinner-top")
+                    },
+                    fixedMiddle = new Sprite
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Texture = source.GetTexture("spinner-middle")
+                    },
+                    spinningMiddle = new Sprite
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Texture = source.GetTexture("spinner-middle2")
+                    }
                 }
             });
         }
@@ -119,7 +127,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             glow.Alpha = DrawableSpinner.Progress;
 
-            Scale = new Vector2(final_scale * (0.8f + (float)Interpolation.ApplyEasing(Easing.Out, DrawableSpinner.Progress) * 0.2f));
+            scaleContainer.Scale = new Vector2(final_scale * (0.8f + (float)Interpolation.ApplyEasing(Easing.Out, DrawableSpinner.Progress) * 0.2f));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             spinnerBlink = source.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.SpinnerNoBlink)?.Value != true;
 
-            InternalChild = new Container
+            AddInternal(new Container
             {
                 // the old-style spinner relied heavily on absolute screen-space coordinate values.
                 // wrap everything in a container simulating absolute coords to preserve alignment
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                         }
                     }
                 }
-            };
+            });
         }
 
         protected override void UpdateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -26,8 +26,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private bool spinnerBlink;
 
-        private const float sprite_scale = 1 / 1.6f;
-        private const float final_metre_height = 692 * sprite_scale;
+        private const float final_metre_height = 692 * SPRITE_SCALE;
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource source)
@@ -50,14 +49,14 @@ namespace osu.Game.Rulesets.Osu.Skinning
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Texture = source.GetTexture("spinner-background"),
-                        Scale = new Vector2(sprite_scale)
+                        Scale = new Vector2(SPRITE_SCALE)
                     },
                     disc = new Sprite
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Texture = source.GetTexture("spinner-circle"),
-                        Scale = new Vector2(sprite_scale)
+                        Scale = new Vector2(SPRITE_SCALE)
                     },
                     metre = new Container
                     {
@@ -73,7 +72,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                             Texture = source.GetTexture("spinner-metre"),
                             Anchor = Anchor.TopLeft,
                             Origin = Anchor.TopLeft,
-                            Scale = new Vector2(0.625f)
+                            Scale = new Vector2(SPRITE_SCALE)
                         }
                     }
                 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyOldStyleSpinner.cs
@@ -18,9 +18,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
     /// <summary>
     /// Legacy skinned spinner with one main spinning layer and a background layer.
     /// </summary>
-    public class LegacyOldStyleSpinner : CompositeDrawable
+    public class LegacyOldStyleSpinner : LegacySpinner
     {
-        private DrawableSpinner drawableSpinner;
         private Sprite disc;
         private Sprite metreSprite;
         private Container metre;
@@ -31,13 +30,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
         private const float final_metre_height = 692 * sprite_scale;
 
         [BackgroundDependencyLoader]
-        private void load(ISkinSource source, DrawableHitObject drawableObject)
+        private void load(ISkinSource source)
         {
             spinnerBlink = source.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.SpinnerNoBlink)?.Value != true;
-
-            drawableSpinner = (DrawableSpinner)drawableObject;
-
-            RelativeSizeAxes = Axes.Both;
 
             InternalChild = new Container
             {
@@ -85,16 +80,10 @@ namespace osu.Game.Rulesets.Osu.Skinning
             };
         }
 
-        protected override void LoadComplete()
+        protected override void UpdateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
-            base.LoadComplete();
+            base.UpdateStateTransforms(drawableHitObject, state);
 
-            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
-            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
-        }
-
-        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
-        {
             if (!(drawableHitObject is DrawableSpinner d))
                 return;
 
@@ -110,11 +99,11 @@ namespace osu.Game.Rulesets.Osu.Skinning
         protected override void Update()
         {
             base.Update();
-            disc.Rotation = drawableSpinner.RotationTracker.Rotation;
+            disc.Rotation = DrawableSpinner.RotationTracker.Rotation;
 
             // careful: need to call this exactly once for all calculations in a frame
             // as the function has a random factor in it
-            var metreHeight = getMetreHeight(drawableSpinner.Progress);
+            var metreHeight = getMetreHeight(DrawableSpinner.Progress);
 
             // hack to make the metre blink up from below than down from above.
             // move down the container to be able to apply masking for the metre,
@@ -139,14 +128,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 barCount++;
 
             return (float)barCount / total_bars * final_metre_height;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (drawableSpinner != null)
-                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySpinner.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     Depth = float.MinValue,
                     Texture = source.GetTexture("spinner-spin"),
                     Scale = new Vector2(SPRITE_SCALE),
-                    Y = 120 // todo: make match roughly?
+                    Y = 120 - 45 // offset temporarily to avoid overlapping default spin counter
                 },
             });
         }

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySpinner.cs
@@ -9,11 +9,14 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Skinning
 {
     public abstract class LegacySpinner : CompositeDrawable
     {
+        protected const float SPRITE_SCALE = 0.625f;
+
         protected DrawableSpinner DrawableSpinner { get; private set; }
 
         private Sprite spin;
@@ -33,6 +36,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     Origin = Anchor.Centre,
                     Depth = float.MinValue,
                     Texture = source.GetTexture("spinner-spin"),
+                    Scale = new Vector2(SPRITE_SCALE),
                     Y = 120 // todo: make match roughly?
                 },
             });

--- a/osu.Game.Rulesets.Osu/Skinning/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacySpinner.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Osu.Skinning
+{
+    public abstract class LegacySpinner : CompositeDrawable
+    {
+        protected DrawableSpinner DrawableSpinner { get; private set; }
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableHitObject)
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            DrawableSpinner = (DrawableSpinner)drawableHitObject;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            DrawableSpinner.ApplyCustomUpdateState += UpdateStateTransforms;
+            UpdateStateTransforms(DrawableSpinner, DrawableSpinner.State.Value);
+        }
+
+        protected virtual void UpdateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
+        {
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (DrawableSpinner != null)
+                DrawableSpinner.ApplyCustomUpdateState -= UpdateStateTransforms;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -546,7 +546,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
             // Ensure that the judgement is given a valid time offset, because this may not get set by the caller
             var endTime = HitObject.GetEndTime();
 
-            Result.TimeOffset = Math.Min(HitObject.HitWindows.WindowFor(HitResult.Miss), Time.Current - endTime);
+            Result.TimeOffset = Time.Current - endTime;
+
+            double missWindow = HitObject.HitWindows.WindowFor(HitResult.Miss);
+            if (missWindow > 0)
+                Result.TimeOffset = Math.Min(Result.TimeOffset, missWindow);
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);


### PR DESCRIPTION
- [x] Depends on #10697 for ease of merging.

To make this work, I've adjusted judgement logic to provide correct `TimeOffset` when hitwindows are empty. Let me know if this should be split out into its own PR (exists as a distinct commit for now).

Note that I've added a temporary offset to allow this to coexist with the SPM counter (which is not implemented in legacy skins yet):

With spins:

![2020-11-05 19 09 02](https://user-images.githubusercontent.com/191335/98227326-857e3e80-1f9a-11eb-8bd6-c7b523729e20.gif)

Without spins:

![2020-11-05 19 10 25](https://user-images.githubusercontent.com/191335/98227382-9b8bff00-1f9a-11eb-938f-58f6cb6dc8c5.gif)

This is a screenshot showing the alignment without the offset:

![image](https://user-images.githubusercontent.com/191335/98226885-f96c1700-1f99-11eb-9ef5-a0c5ae5baec4.png)
