### PR TITLE
Use int instead of long for user_id fields for now

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             public void EndPlay(int beatmapId)
             {
-                ((ISpectatorClient)this).UserFinishedPlaying((int)StreamingUser.Id, new SpectatorState
+                ((ISpectatorClient)this).UserFinishedPlaying(StreamingUser.Id, new SpectatorState
                 {
                     BeatmapID = beatmapId,
                     RulesetID = 0,
@@ -273,7 +273,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 }
 
                 var bundle = new FrameDataBundle(frames);
-                ((ISpectatorClient)this).UserSentFrames((int)StreamingUser.Id, bundle);
+                ((ISpectatorClient)this).UserSentFrames(StreamingUser.Id, bundle);
 
                 if (!sentState)
                     sendState(beatmapId);
@@ -293,7 +293,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             private void sendState(int beatmapId)
             {
                 sentState = true;
-                ((ISpectatorClient)this).UserBeganPlaying((int)StreamingUser.Id, new SpectatorState
+                ((ISpectatorClient)this).UserBeganPlaying(StreamingUser.Id, new SpectatorState
                 {
                     BeatmapID = beatmapId,
                     RulesetID = 0,

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -277,7 +277,7 @@ namespace osu.Game.Tournament.Screens.Editors
                         userId.Value = user.Id.ToString();
                         userId.BindValueChanged(idString =>
                         {
-                            long.TryParse(idString.NewValue, out var parsed);
+                            int.TryParse(idString.NewValue, out var parsed);
 
                             user.Id = parsed;
 

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Online.API.Requests.Responses
         private int[] ratings { get; set; }
 
         [JsonProperty(@"user_id")]
-        private long creatorId
+        private int creatorId
         {
             set => Author.Id = value;
         }

--- a/osu.Game/Online/API/Requests/Responses/APIChangelogUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIChangelogUser.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public string OsuUsername { get; set; }
 
         [JsonProperty("user_id")]
-        public long? UserId { get; set; }
+        public int? UserId { get; set; }
 
         [JsonProperty("user_url")]
         public string UserUrl { get; set; }

--- a/osu.Game/Online/Chat/Channel.cs
+++ b/osu.Game/Online/Chat/Channel.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Online.Chat
         public readonly ObservableCollection<User> Users = new ObservableCollection<User>();
 
         [JsonProperty(@"users")]
-        private long[] userIds
+        private int[] userIds
         {
             set
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -278,7 +278,7 @@ namespace osu.Game
                     break;
 
                 case LinkAction.OpenUserProfile:
-                    if (long.TryParse(link.Argument, out long userId))
+                    if (int.TryParse(link.Argument, out int userId))
                         ShowUser(userId);
                     break;
 
@@ -321,7 +321,7 @@ namespace osu.Game
         /// Show a user's profile as an overlay.
         /// </summary>
         /// <param name="userId">The user to display.</param>
-        public void ShowUser(long userId) => waitForReady(() => userProfile, _ => userProfile.ShowUser(userId));
+        public void ShowUser(int userId) => waitForReady(() => userProfile, _ => userProfile.ShowUser(userId));
 
         /// <summary>
         /// Show a beatmap's set as an overlay, displaying the given beatmap.

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.Dashboard
                             var request = new GetUserRequest(u);
                             request.Success += user => Schedule(() =>
                             {
-                                if (playingUsers.Contains((int)user.Id))
+                                if (playingUsers.Contains(user.Id))
                                     userFlow.Add(createUserPanel(user));
                             });
                             api.Queue(request);

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays
         {
         }
 
-        public void ShowUser(long userId) => ShowUser(new User { Id = userId });
+        public void ShowUser(int userId) => ShowUser(new User { Id = userId });
 
         public void ShowUser(User user, bool fetchOnline = true)
         {

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Scoring
 
         [JsonIgnore]
         [Column("UserID")]
-        public long? UserID
+        public int? UserID
         {
             get => User?.Id ?? 1;
             set

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Screens.Play
             spectatorStreaming.OnUserFinishedPlaying += userFinishedPlaying;
             spectatorStreaming.OnNewFrames += userSentFrames;
 
-            spectatorStreaming.WatchUser((int)targetUser.Id);
+            spectatorStreaming.WatchUser(targetUser.Id);
 
             managerUpdated = beatmaps.ItemUpdated.GetBoundCopy();
             managerUpdated.BindValueChanged(beatmapUpdated);
@@ -353,7 +353,7 @@ namespace osu.Game.Screens.Play
                 spectatorStreaming.OnUserFinishedPlaying -= userFinishedPlaying;
                 spectatorStreaming.OnNewFrames -= userSentFrames;
 
-                spectatorStreaming.StopWatchingUser((int)targetUser.Id);
+                spectatorStreaming.StopWatchingUser(targetUser.Id);
             }
 
             managerUpdated?.UnbindAll();

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Users
     public class User : IEquatable<User>
     {
         [JsonProperty(@"id")]
-        public long Id = 1;
+        public int Id = 1;
 
         [JsonProperty(@"join_date")]
         public DateTimeOffset JoinDate;


### PR DESCRIPTION
I don't believe we will ever overflow this. Avoids casts from `int` to `long` in multiple places.