### PR TITLE
Rename cache classes in line with their function (and share a base implementation)

### DIFF
--- a/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyEqualsWithDifferentModInstances()
         {
-            var key1 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
-            var key2 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
 
             Assert.That(key1, Is.EqualTo(key2));
         }
@@ -23,8 +23,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyEqualsWithDifferentModOrder()
         {
-            var key1 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
-            var key2 = new BeatmapDifficultyManager.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHidden(), new OsuModHardRock() });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHidden(), new OsuModHardRock() });
 
             Assert.That(key1, Is.EqualTo(key2));
         }
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Beatmaps
         [TestCase(8.3, DifficultyRating.ExpertPlus)]
         public void TestDifficultyRatingMapping(double starRating, DifficultyRating expectedBracket)
         {
-            var actualBracket = BeatmapDifficultyManager.GetDifficultyRating(starRating);
+            var actualBracket = BeatmapDifficultyCache.GetDifficultyRating(starRating);
 
             Assert.AreEqual(expectedBracket, actualBracket);
         }

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics;
 using osu.Framework.Lists;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
@@ -23,10 +23,14 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Beatmaps
 {
-    public class BeatmapDifficultyManager : CompositeDrawable
+    /// <summary>
+    /// A component which performs and acts as a central cache for difficulty calculations of beatmap/ruleset/mod combinations.
+    /// Currently not persisted between game sessions.
+    /// </summary>
+    public class BeatmapDifficultyCache : Component
     {
         // Too many simultaneous updates can lead to stutters. One thread seems to work fine for song select display purposes.
-        private readonly ThreadedTaskScheduler updateScheduler = new ThreadedTaskScheduler(1, nameof(BeatmapDifficultyManager));
+        private readonly ThreadedTaskScheduler updateScheduler = new ThreadedTaskScheduler(1, nameof(BeatmapDifficultyCache));
 
         // A permanent cache to prevent re-computations.
         private readonly ConcurrentDictionary<DifficultyCacheLookup, StarDifficulty> difficultyCache = new ConcurrentDictionary<DifficultyCacheLookup, StarDifficulty>();
@@ -387,6 +391,6 @@ namespace osu.Game.Beatmaps
             Attributes = null;
         }
 
-        public DifficultyRating DifficultyRating => BeatmapDifficultyManager.GetDifficultyRating(Stars);
+        public DifficultyRating DifficultyRating => BeatmapDifficultyCache.GetDifficultyRating(Stars);
     }
 }

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -16,7 +16,6 @@ using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Database;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 
@@ -343,50 +342,5 @@ namespace osu.Game.Beatmaps
                 CancellationToken = cancellationToken;
             }
         }
-    }
-
-    public readonly struct StarDifficulty
-    {
-        /// <summary>
-        /// The star difficulty rating for the given beatmap.
-        /// </summary>
-        public readonly double Stars;
-
-        /// <summary>
-        /// The maximum combo achievable on the given beatmap.
-        /// </summary>
-        public readonly int MaxCombo;
-
-        /// <summary>
-        /// The difficulty attributes computed for the given beatmap.
-        /// Might not be available if the star difficulty is associated with a beatmap that's not locally available.
-        /// </summary>
-        [CanBeNull]
-        public readonly DifficultyAttributes Attributes;
-
-        /// <summary>
-        /// Creates a <see cref="StarDifficulty"/> structure based on <see cref="DifficultyAttributes"/> computed
-        /// by a <see cref="DifficultyCalculator"/>.
-        /// </summary>
-        public StarDifficulty([NotNull] DifficultyAttributes attributes)
-        {
-            Stars = attributes.StarRating;
-            MaxCombo = attributes.MaxCombo;
-            Attributes = attributes;
-            // Todo: Add more members (BeatmapInfo.DifficultyRating? Attributes? Etc...)
-        }
-
-        /// <summary>
-        /// Creates a <see cref="StarDifficulty"/> structure with a pre-populated star difficulty and max combo
-        /// in scenarios where computing <see cref="DifficultyAttributes"/> is not feasible (i.e. when working with online sources).
-        /// </summary>
-        public StarDifficulty(double starDifficulty, int maxCombo)
-        {
-            Stars = starDifficulty;
-            MaxCombo = maxCombo;
-            Attributes = null;
-        }
-
-        public DifficultyRating DifficultyRating => BeatmapDifficultyCache.GetDifficultyRating(Stars);
     }
 }

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Beatmaps
         public List<ScoreInfo> Scores { get; set; }
 
         [JsonIgnore]
-        public DifficultyRating DifficultyRating => BeatmapDifficultyManager.GetDifficultyRating(StarDifficulty);
+        public DifficultyRating DifficultyRating => BeatmapDifficultyCache.GetDifficultyRating(StarDifficulty);
 
         public string[] SearchableTerms => new[]
         {

--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Beatmaps.Drawables
             private CancellationTokenSource difficultyCancellation;
 
             [Resolved]
-            private BeatmapDifficultyManager difficultyManager { get; set; }
+            private BeatmapDifficultyCache difficultyCache { get; set; }
 
             public DifficultyRetriever(BeatmapInfo beatmap, RulesetInfo ruleset, IReadOnlyList<Mod> mods)
             {
@@ -158,8 +158,8 @@ namespace osu.Game.Beatmaps.Drawables
             {
                 difficultyCancellation = new CancellationTokenSource();
                 localStarDifficulty = ruleset != null
-                    ? difficultyManager.GetBindableDifficulty(beatmap, ruleset, mods, difficultyCancellation.Token)
-                    : difficultyManager.GetBindableDifficulty(beatmap, difficultyCancellation.Token);
+                    ? difficultyCache.GetBindableDifficulty(beatmap, ruleset, mods, difficultyCancellation.Token)
+                    : difficultyCache.GetBindableDifficulty(beatmap, difficultyCancellation.Token);
                 localStarDifficulty.BindValueChanged(difficulty => StarDifficulty.Value = difficulty.NewValue);
             }
 

--- a/osu.Game/Beatmaps/StarDifficulty.cs
+++ b/osu.Game/Beatmaps/StarDifficulty.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Game.Rulesets.Difficulty;
+
+namespace osu.Game.Beatmaps
+{
+    public readonly struct StarDifficulty
+    {
+        /// <summary>
+        /// The star difficulty rating for the given beatmap.
+        /// </summary>
+        public readonly double Stars;
+
+        /// <summary>
+        /// The maximum combo achievable on the given beatmap.
+        /// </summary>
+        public readonly int MaxCombo;
+
+        /// <summary>
+        /// The difficulty attributes computed for the given beatmap.
+        /// Might not be available if the star difficulty is associated with a beatmap that's not locally available.
+        /// </summary>
+        [CanBeNull]
+        public readonly DifficultyAttributes Attributes;
+
+        /// <summary>
+        /// Creates a <see cref="StarDifficulty"/> structure based on <see cref="DifficultyAttributes"/> computed
+        /// by a <see cref="DifficultyCalculator"/>.
+        /// </summary>
+        public StarDifficulty([NotNull] DifficultyAttributes attributes)
+        {
+            Stars = attributes.StarRating;
+            MaxCombo = attributes.MaxCombo;
+            Attributes = attributes;
+            // Todo: Add more members (BeatmapInfo.DifficultyRating? Attributes? Etc...)
+        }
+
+        /// <summary>
+        /// Creates a <see cref="StarDifficulty"/> structure with a pre-populated star difficulty and max combo
+        /// in scenarios where computing <see cref="DifficultyAttributes"/> is not feasible (i.e. when working with online sources).
+        /// </summary>
+        public StarDifficulty(double starDifficulty, int maxCombo)
+        {
+            Stars = starDifficulty;
+            MaxCombo = maxCombo;
+            Attributes = null;
+        }
+
+        public DifficultyRating DifficultyRating => BeatmapDifficultyCache.GetDifficultyRating(Stars);
+    }
+}

--- a/osu.Game/Database/MemoryCachingComponent.cs
+++ b/osu.Game/Database/MemoryCachingComponent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Concurrent;
+using osu.Framework.Graphics;
+
+namespace osu.Game.Database
+{
+    /// <summary>
+    /// A component which performs lookups (or calculations) and caches the results.
+    /// Currently not persisted between game sessions.
+    /// </summary>
+    public abstract class MemoryCachingComponent<TLookup, TValue> : Component
+    {
+        protected readonly ConcurrentDictionary<TLookup, TValue> Cache = new ConcurrentDictionary<TLookup, TValue>();
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -229,7 +229,7 @@ namespace osu.Game
             dependencies.Cache(DifficultyCache = new BeatmapDifficultyCache());
             AddInternal(DifficultyCache);
 
-            var scorePerformanceManager = new ScorePerformanceManager();
+            var scorePerformanceManager = new ScorePerformanceCache();
             dependencies.Cache(scorePerformanceManager);
             AddInternal(scorePerformanceManager);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -59,7 +59,7 @@ namespace osu.Game
 
         protected ScoreManager ScoreManager;
 
-        protected BeatmapDifficultyManager DifficultyManager;
+        protected BeatmapDifficultyCache DifficultyCache;
 
         protected SkinManager SkinManager;
 
@@ -202,7 +202,7 @@ namespace osu.Game
             dependencies.Cache(FileStore = new FileStore(contextFactory, Storage));
 
             // ordering is important here to ensure foreign keys rules are not broken in ModelStore.Cleanup()
-            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, API, contextFactory, Host, () => DifficultyManager, LocalConfig));
+            dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, API, contextFactory, Host, () => DifficultyCache, LocalConfig));
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, contextFactory, RulesetStore, API, Audio, Host, defaultBeatmap, true));
 
             // this should likely be moved to ArchiveModelManager when another case appers where it is necessary
@@ -226,8 +226,8 @@ namespace osu.Game
                     ScoreManager.Undelete(getBeatmapScores(item), true);
             });
 
-            dependencies.Cache(DifficultyManager = new BeatmapDifficultyManager());
-            AddInternal(DifficultyManager);
+            dependencies.Cache(DifficultyCache = new BeatmapDifficultyCache());
+            AddInternal(DifficultyCache);
 
             var scorePerformanceManager = new ScorePerformanceManager();
             dependencies.Cache(scorePerformanceManager);

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -37,13 +37,13 @@ namespace osu.Game.Scoring
         private readonly Func<BeatmapManager> beatmaps;
 
         [CanBeNull]
-        private readonly Func<BeatmapDifficultyManager> difficulties;
+        private readonly Func<BeatmapDifficultyCache> difficulties;
 
         [CanBeNull]
         private readonly OsuConfigManager configManager;
 
         public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, IAPIProvider api, IDatabaseContextFactory contextFactory, IIpcHost importHost = null,
-                            Func<BeatmapDifficultyManager> difficulties = null, OsuConfigManager configManager = null)
+                            Func<BeatmapDifficultyCache> difficulties = null, OsuConfigManager configManager = null)
             : base(storage, contextFactory, api, new ScoreStore(contextFactory, storage), importHost)
         {
             this.rulesets = rulesets;
@@ -121,14 +121,14 @@ namespace osu.Game.Scoring
             public readonly Bindable<ScoringMode> ScoringMode = new Bindable<ScoringMode>();
 
             private readonly ScoreInfo score;
-            private readonly Func<BeatmapDifficultyManager> difficulties;
+            private readonly Func<BeatmapDifficultyCache> difficulties;
 
             /// <summary>
             /// Creates a new <see cref="TotalScoreBindable"/>.
             /// </summary>
             /// <param name="score">The <see cref="ScoreInfo"/> to provide the total score of.</param>
-            /// <param name="difficulties">A function to retrieve the <see cref="BeatmapDifficultyManager"/>.</param>
-            public TotalScoreBindable(ScoreInfo score, Func<BeatmapDifficultyManager> difficulties)
+            /// <param name="difficulties">A function to retrieve the <see cref="BeatmapDifficultyCache"/>.</param>
+            public TotalScoreBindable(ScoreInfo score, Func<BeatmapDifficultyCache> difficulties)
             {
                 this.score = score;
                 this.difficulties = difficulties;

--- a/osu.Game/Scoring/ScorePerformanceCache.cs
+++ b/osu.Game/Scoring/ScorePerformanceCache.cs
@@ -13,9 +13,10 @@ using osu.Game.Beatmaps;
 namespace osu.Game.Scoring
 {
     /// <summary>
-    /// A global component which calculates and caches results of performance calculations for locally databased scores.
+    /// A component which performs and acts as a central cache for performance calculations of locally databased scores.
+    /// Currently not persisted between game sessions.
     /// </summary>
-    public class ScorePerformanceManager : Component
+    public class ScorePerformanceCache : Component
     {
         // this cache will grow indefinitely per session and should be considered temporary.
         // this whole component should likely be replaced with database persistence.

--- a/osu.Game/Scoring/ScorePerformanceCache.cs
+++ b/osu.Game/Scoring/ScorePerformanceCache.cs
@@ -2,13 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 
 namespace osu.Game.Scoring
 {
@@ -16,12 +15,8 @@ namespace osu.Game.Scoring
     /// A component which performs and acts as a central cache for performance calculations of locally databased scores.
     /// Currently not persisted between game sessions.
     /// </summary>
-    public class ScorePerformanceCache : Component
+    public class ScorePerformanceCache : MemoryCachingComponent<ScorePerformanceCache.PerformanceCacheLookup, double>
     {
-        // this cache will grow indefinitely per session and should be considered temporary.
-        // this whole component should likely be replaced with database persistence.
-        private readonly ConcurrentDictionary<PerformanceCacheLookup, double> performanceCache = new ConcurrentDictionary<PerformanceCacheLookup, double>();
-
         [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; }
 
@@ -34,7 +29,7 @@ namespace osu.Game.Scoring
         {
             var lookupKey = new PerformanceCacheLookup(score);
 
-            if (performanceCache.TryGetValue(lookupKey, out double performance))
+            if (Cache.TryGetValue(lookupKey, out double performance))
                 return Task.FromResult((double?)performance);
 
             return computePerformanceAsync(score, lookupKey, token);
@@ -54,7 +49,7 @@ namespace osu.Game.Scoring
             var total = calculator?.Calculate();
 
             if (total.HasValue)
-                performanceCache[lookupKey] = total.Value;
+                Cache[lookupKey] = total.Value;
 
             return total;
         }

--- a/osu.Game/Scoring/ScorePerformanceManager.cs
+++ b/osu.Game/Scoring/ScorePerformanceManager.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Scoring
         private readonly ConcurrentDictionary<PerformanceCacheLookup, double> performanceCache = new ConcurrentDictionary<PerformanceCacheLookup, double>();
 
         [Resolved]
-        private BeatmapDifficultyManager difficultyManager { get; set; }
+        private BeatmapDifficultyCache difficultyCache { get; set; }
 
         /// <summary>
         /// Calculates performance for the given <see cref="ScoreInfo"/>.
@@ -41,7 +41,7 @@ namespace osu.Game.Scoring
 
         private async Task<double?> computePerformanceAsync(ScoreInfo score, PerformanceCacheLookup lookupKey, CancellationToken token = default)
         {
-            var attributes = await difficultyManager.GetDifficultyAsync(score.Beatmap, score.Ruleset, score.Mods, token);
+            var attributes = await difficultyCache.GetDifficultyAsync(score.Beatmap, score.Ruleset, score.Mods, token);
 
             // Performance calculation requires the beatmap and ruleset to be locally available. If not, return a default value.
             if (attributes.Attributes == null)

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.Ranking.Expanded
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapDifficultyManager beatmapDifficultyManager)
+        private void load(BeatmapDifficultyCache beatmapDifficultyCache)
         {
             var beatmap = score.Beatmap;
             var metadata = beatmap.BeatmapSet?.Metadata ?? beatmap.Metadata;
@@ -143,7 +143,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                     Spacing = new Vector2(5, 0),
                                     Children = new Drawable[]
                                     {
-                                        new StarRatingDisplay(beatmapDifficultyManager.GetDifficulty(beatmap, score.Ruleset, score.Mods))
+                                        new StarRatingDisplay(beatmapDifficultyCache.GetDifficulty(beatmap, score.Ruleset, score.Mods))
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft

--- a/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Ranking.Expanded
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, BeatmapDifficultyManager difficultyManager)
+        private void load(OsuColour colours, BeatmapDifficultyCache difficultyCache)
         {
             AutoSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
             else
             {
                 performanceCache.CalculatePerformanceAsync(score, cancellationTokenSource.Token)
-                                  .ContinueWith(t => Schedule(() => setPerformanceValue(t.Result)), cancellationTokenSource.Token);
+                                .ContinueWith(t => Schedule(() => setPerformanceValue(t.Result)), cancellationTokenSource.Token);
             }
         }
 

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         }
 
         [BackgroundDependencyLoader]
-        private void load(ScorePerformanceManager performanceManager)
+        private void load(ScorePerformanceCache performanceCache)
         {
             if (score.PP.HasValue)
             {
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
             }
             else
             {
-                performanceManager.CalculatePerformanceAsync(score, cancellationTokenSource.Token)
+                performanceCache.CalculatePerformanceAsync(score, cancellationTokenSource.Token)
                                   .ContinueWith(t => Schedule(() => setPerformanceValue(t.Result)), cancellationTokenSource.Token);
             }
         }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Select
         private readonly IBindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
 
         [Resolved]
-        private BeatmapDifficultyManager difficultyManager { get; set; }
+        private BeatmapDifficultyCache difficultyCache { get; set; }
 
         private IBindable<StarDifficulty> beatmapDifficulty;
 
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Select
                 cancellationSource = new CancellationTokenSource();
 
                 beatmapDifficulty?.UnbindAll();
-                beatmapDifficulty = difficultyManager.GetBindableDifficulty(beatmap.BeatmapInfo, cancellationSource.Token);
+                beatmapDifficulty = difficultyCache.GetBindableDifficulty(beatmap.BeatmapInfo, cancellationSource.Token);
                 beatmapDifficulty.BindValueChanged(_ => updateDisplay());
 
                 updateDisplay();

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Select.Carousel
         private BeatmapSetOverlay beatmapOverlay { get; set; }
 
         [Resolved]
-        private BeatmapDifficultyManager difficultyManager { get; set; }
+        private BeatmapDifficultyCache difficultyCache { get; set; }
 
         [Resolved(CanBeNull = true)]
         private CollectionManager collectionManager { get; set; }
@@ -216,7 +216,7 @@ namespace osu.Game.Screens.Select.Carousel
             if (Item.State.Value != CarouselItemState.Collapsed)
             {
                 // We've potentially cancelled the computation above so a new bindable is required.
-                starDifficultyBindable = difficultyManager.GetBindableDifficulty(beatmap, (starDifficultyCancellationSource = new CancellationTokenSource()).Token);
+                starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmap, (starDifficultyCancellationSource = new CancellationTokenSource()).Token);
                 starDifficultyBindable.BindValueChanged(d => starCounter.Current = (float)d.NewValue.Stars, true);
             }
 

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.Select.Details
         private IBindable<RulesetInfo> ruleset { get; set; }
 
         [Resolved]
-        private BeatmapDifficultyManager difficultyManager { get; set; }
+        private BeatmapDifficultyCache difficultyCache { get; set; }
 
         protected readonly StatisticRow FirstValue, HpDrain, Accuracy, ApproachRate;
         private readonly StatisticRow starDifficulty;
@@ -161,8 +161,8 @@ namespace osu.Game.Screens.Select.Details
 
             starDifficultyCancellationSource = new CancellationTokenSource();
 
-            normalStarDifficulty = difficultyManager.GetBindableDifficulty(Beatmap, ruleset.Value, null, starDifficultyCancellationSource.Token);
-            moddedStarDifficulty = difficultyManager.GetBindableDifficulty(Beatmap, ruleset.Value, mods.Value, starDifficultyCancellationSource.Token);
+            normalStarDifficulty = difficultyCache.GetBindableDifficulty(Beatmap, ruleset.Value, null, starDifficultyCancellationSource.Token);
+            moddedStarDifficulty = difficultyCache.GetBindableDifficulty(Beatmap, ruleset.Value, mods.Value, starDifficultyCancellationSource.Token);
 
             normalStarDifficulty.BindValueChanged(_ => updateDisplay());
             moddedStarDifficulty.BindValueChanged(_ => updateDisplay(), true);


### PR DESCRIPTION
Having them exist as "Manager" classes when we exclusively use that term for database backed components has thrown me off multiple times. We can reconsider their naming when they do actually persist somewhere.

This also adds a base class just to get things started. Will likely move more functionality over to the base class as I go.