### PR TITLE
Move cache and lookup logic to base MemoryCachingComponent class

### DIFF
--- a/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapDifficultyManagerTest.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 
@@ -14,8 +15,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyEqualsWithDifferentModInstances()
         {
-            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
-            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
 
             Assert.That(key1, Is.EqualTo(key2));
         }
@@ -23,8 +24,8 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestKeyEqualsWithDifferentModOrder()
         {
-            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
-            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(1234, 0, new Mod[] { new OsuModHidden(), new OsuModHardRock() });
+            var key1 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHardRock(), new OsuModHidden() });
+            var key2 = new BeatmapDifficultyCache.DifficultyCacheLookup(new BeatmapInfo { ID = 1234 }, new RulesetInfo { ID = 0 }, new Mod[] { new OsuModHidden(), new OsuModHardRock() });
 
             Assert.That(key1, Is.EqualTo(key2));
         }

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -273,7 +273,8 @@ namespace osu.Game.Beatmaps
             public DifficultyCacheLookup([NotNull] BeatmapInfo beatmap, [NotNull] RulesetInfo ruleset, IEnumerable<Mod> mods)
             {
                 Beatmap = beatmap;
-                Ruleset = ruleset;
+                // In the case that the user hasn't given us a ruleset, use the beatmap's default ruleset.
+                Ruleset = ruleset ?? Beatmap.Ruleset;
                 OrderedMods = mods?.OrderBy(m => m.Acronym).ToArray() ?? Array.Empty<Mod>();
             }
 

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -270,7 +270,7 @@ namespace osu.Game.Beatmaps
 
             public readonly Mod[] OrderedMods;
 
-            public DifficultyCacheLookup([NotNull] BeatmapInfo beatmap, [NotNull] RulesetInfo ruleset, IEnumerable<Mod> mods)
+            public DifficultyCacheLookup([NotNull] BeatmapInfo beatmap, [CanBeNull] RulesetInfo ruleset, IEnumerable<Mod> mods)
             {
                 Beatmap = beatmap;
                 // In the case that the user hasn't given us a ruleset, use the beatmap's default ruleset.

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -113,19 +113,6 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Retrieves the difficulty of a <see cref="BeatmapInfo"/>.
-        /// </summary>
-        /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> to get the difficulty of.</param>
-        /// <param name="rulesetInfo">The <see cref="RulesetInfo"/> to get the difficulty with.</param>
-        /// <param name="mods">The <see cref="Mod"/>s to get the difficulty with.</param>
-        /// <returns>The <see cref="StarDifficulty"/>.</returns>
-        public StarDifficulty GetDifficulty([NotNull] BeatmapInfo beatmapInfo, [CanBeNull] RulesetInfo rulesetInfo = null, [CanBeNull] IEnumerable<Mod> mods = null)
-        {
-            // this is safe in this usage because the only asynchronous part is handled by the local scheduler.
-            return GetDifficultyAsync(beatmapInfo, rulesetInfo, mods).Result;
-        }
-
-        /// <summary>
         /// Retrieves the <see cref="DifficultyRating"/> that describes a star rating.
         /// </summary>
         /// <remarks>

--- a/osu.Game/Database/MemoryCachingComponent.cs
+++ b/osu.Game/Database/MemoryCachingComponent.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Database
         /// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
         protected async Task<TValue> GetAsync([NotNull] TLookup lookup, CancellationToken token = default)
         {
-            if (cache.TryGetValue(lookup, out TValue performance))
+            if (CheckExists(lookup, out TValue performance))
                 return performance;
 
             var computed = await ComputeValueAsync(lookup, token);

--- a/osu.Game/Database/MemoryCachingComponent.cs
+++ b/osu.Game/Database/MemoryCachingComponent.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Database
         protected virtual bool CacheNullValues => true;
 
         /// <summary>
-        /// Retrieve the cached value for the given <see cref="TLookup"/>.
+        /// Retrieve the cached value for the given lookup.
         /// </summary>
         /// <param name="lookup">The lookup to retrieve.</param>
         /// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
@@ -36,6 +36,9 @@ namespace osu.Game.Database
 
             return computed;
         }
+
+        protected bool CheckExists([NotNull] TLookup lookup, out TValue value) =>
+            cache.TryGetValue(lookup, out value);
 
         /// <summary>
         /// Called on cache miss to compute the value for the specified lookup.

--- a/osu.Game/Database/MemoryCachingComponent.cs
+++ b/osu.Game/Database/MemoryCachingComponent.cs
@@ -2,6 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 
 namespace osu.Game.Database
@@ -12,6 +15,34 @@ namespace osu.Game.Database
     /// </summary>
     public abstract class MemoryCachingComponent<TLookup, TValue> : Component
     {
-        protected readonly ConcurrentDictionary<TLookup, TValue> Cache = new ConcurrentDictionary<TLookup, TValue>();
+        private readonly ConcurrentDictionary<TLookup, TValue> cache = new ConcurrentDictionary<TLookup, TValue>();
+
+        protected virtual bool CacheNullValues => true;
+
+        /// <summary>
+        /// Retrieve the cached value for the given <see cref="TLookup"/>.
+        /// </summary>
+        /// <param name="lookup">The lookup to retrieve.</param>
+        /// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
+        protected async Task<TValue> GetAsync([NotNull] TLookup lookup, CancellationToken token = default)
+        {
+            if (cache.TryGetValue(lookup, out TValue performance))
+                return performance;
+
+            var computed = await ComputeValueAsync(lookup, token);
+
+            if (computed != null || CacheNullValues)
+                cache[lookup] = computed;
+
+            return computed;
+        }
+
+        /// <summary>
+        /// Called on cache miss to compute the value for the specified lookup.
+        /// </summary>
+        /// <param name="lookup">The lookup to retrieve.</param>
+        /// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
+        /// <returns>The computed value.</returns>
+        protected abstract Task<TValue> ComputeValueAsync(TLookup lookup, CancellationToken token = default);
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -77,6 +77,8 @@ namespace osu.Game.Screens.Ranking.Expanded
             statisticDisplays.AddRange(topStatistics);
             statisticDisplays.AddRange(bottomStatistics);
 
+            var starDifficulty = beatmapDifficultyCache.GetDifficultyAsync(beatmap, score.Ruleset, score.Mods).Result;
+
             InternalChildren = new Drawable[]
             {
                 new FillFlowContainer
@@ -143,7 +145,7 @@ namespace osu.Game.Screens.Ranking.Expanded
                                     Spacing = new Vector2(5, 0),
                                     Children = new Drawable[]
                                     {
-                                        new StarRatingDisplay(beatmapDifficultyCache.GetDifficulty(beatmap, score.Ruleset, score.Mods))
+                                        new StarRatingDisplay(starDifficulty)
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft


### PR DESCRIPTION
Should simplify things in the corresponding two usages.

Wasn't sure if we should add a synchronous lookup pathway right now (`BeatmapDifficultyCache` uses this in a few places, but by keeping it local we can guarantee `GetAsync.Result` safety (unless the underlying cache implementation changes in the future)).

- [x] Depends on https://github.com/ppy/osu/pull/10711