### PR TITLE
Never disable pause button on now playing overlay

### DIFF
--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -308,7 +308,6 @@ namespace osu.Game.Overlays
             if (disabled)
                 playlist.Hide();
 
-            playButton.Enabled.Value = !disabled;
             prevButton.Enabled.Value = !disabled;
             nextButton.Enabled.Value = !disabled;
             playlistButton.Enabled.Value = !disabled;


### PR DESCRIPTION
I don't think leaving this enabled is a huge issue. Player already correct maintains paused state even when this is pressed. Also, this was never hard-enforced as key bindings could still triggered pause toggle on master.

Allows toggling pause in screens like results and multiplayer, which is a common user request.

- Closes https://github.com/ppy/osu/issues/10708