### PR TITLE
Fix legacy patcher crash on no objects present

### DIFF
--- a/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
+++ b/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
@@ -38,6 +38,12 @@ namespace osu.Game.Tests.Editing
         }
 
         [Test]
+        public void TestPatchNoObjectChanges()
+        {
+            runTest(new OsuBeatmap());
+        }
+
+        [Test]
         public void TestAddHitObject()
         {
             var patch = new OsuBeatmap

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -235,10 +235,10 @@ namespace osu.Game.Beatmaps.Formats
 
         private void handleHitObjects(TextWriter writer)
         {
+            writer.WriteLine("[HitObjects]");
+
             if (beatmap.HitObjects.Count == 0)
                 return;
-
-            writer.WriteLine("[HitObjects]");
 
             foreach (var h in beatmap.HitObjects)
                 handleHitObject(writer, h);

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using DiffPlex;
@@ -34,6 +35,9 @@ namespace osu.Game.Screens.Edit
             // Find the index of [HitObject] sections. Lines changed prior to this index are ignored.
             int oldHitObjectsIndex = Array.IndexOf(result.PiecesOld, "[HitObjects]");
             int newHitObjectsIndex = Array.IndexOf(result.PiecesNew, "[HitObjects]");
+
+            Debug.Assert(oldHitObjectsIndex >= 0);
+            Debug.Assert(newHitObjectsIndex >= 0);
 
             var toRemove = new List<int>();
             var toAdd = new List<int>();


### PR DESCRIPTION
Fixed this by changing the way we write files, as I believe this is more expected behaviour. Note that the test doesn't actually cover the behaviour as it is quite hard to test with the existing test setup (which is guaranteeing pre and post-patch content is the same, but the failure relies on non-hitobject content changing, which isn't covered by the patcher right now).

- Closes #10728 
- Is alternative to and closes #10729