### PR TITLE
Fix crash upon exiting the editor without saving from new beatmap

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointPart.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
         {
             base.LoadBeatmap(beatmap);
 
+            controlPointGroups.UnbindAll();
             controlPointGroups.BindTo(beatmap.Beatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((sender, args) =>
             {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineControlPointDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineControlPointDisplay.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.LoadBeatmap(beatmap);
 
+            controlPointGroups.UnbindAll();
             controlPointGroups.BindTo(beatmap.Beatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((sender, args) =>
             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -499,6 +499,9 @@ namespace osu.Game.Screens.Edit
                 // confirming exit without save means we should delete the new beatmap completely.
                 beatmapManager.Delete(playableBeatmap.BeatmapInfo.BeatmapSet);
 
+                // eagerly clear contents before restoring default beatmap to prevent value change callbacks from firing.
+                ClearInternal();
+
                 // in theory this shouldn't be required but due to EF core not sharing instance states 100%
                 // MusicController is unaware of the changed DeletePending state.
                 Beatmap.SetDefault();


### PR DESCRIPTION
Resolves #10731.

# Summary

The root cause of the stack overflow was a mutual recursion in `BindableList.AddRange` propagation across five list instances. When the editor was being exited, restoring default beatmap in `confirmExit()` would trigger `LoadBeatmap()` in both `ControlPointPart` and `TimelineControlPointDisplay`. Both of these calls did not ensure to unbind before binding to the new beatmap, therefore making it possible they were bound to two control point group lists simultaneously (one of the map being edited, and one of the default beatmap), closing the propagation loop:

```
[runtime] 2020-11-07 18:56:31 [verbose]: caller is 3716977      <- TimelineControlPointDisplay (compose or timing screen)
[runtime] 2020-11-07 18:56:31 [verbose]: caller is 56827235     <- Beatmap.ControlPointInfo.Groups (old)
[runtime] 2020-11-07 18:56:31 [verbose]: caller is 56973701     <- ControlPointPart
[runtime] 2020-11-07 18:56:31 [verbose]: caller is 22238824     <- Beatmap.ControlPointInfo.Groups (new)
[runtime] 2020-11-07 18:56:31 [verbose]: caller is 55034158     <- TimelineControlPointDisplay (timing or compose screen)
[runtime] 2020-11-07 18:56:31 [verbose]: caller is 56827235
```

To resolve, eagerly clear contents of the editor screen in the exit confirmation process, to ensure `UnbindAllBindables()` runs synchronously and that control flow never reaches `LoadBeatmap()` on screen exit.

# Remarks

I also added unbinds in both `LoadBeatmap()` calls, but they don't serve to solve the issue - they're mostly for future-proofing. I would have used that as the primary solution, but for some reason doing so incurs a heavy stutter on exit, and those callbacks shouldn't be running on editor exit anyway as there's not much reason to do so.

As an aside there's also the question of whether this should be considered a programming error, or whether the framework should be ensuring that the binding propagation flow is acyclic. The latter is definitely non-trivial, however, and will presumably incur a heavy performance penalty due to having to walk trees of weak references, so I'd say we should avoid that like the plague for as long as we can.