### PR TITLE
Fix difficulty retrieval for online-sourced beatmaps

### DIFF
--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -202,7 +202,9 @@ namespace osu.Game.Beatmaps
         /// <param name="cancellationToken">A token that may be used to cancel this update.</param>
         private void updateBindable([NotNull] BindableStarDifficulty bindable, [CanBeNull] RulesetInfo rulesetInfo, [CanBeNull] IEnumerable<Mod> mods, CancellationToken cancellationToken = default)
         {
-            GetAsync(new DifficultyCacheLookup(bindable.Beatmap, rulesetInfo, mods), cancellationToken)
+            // GetDifficultyAsync will fall back to existing data from BeatmapInfo if not locally available
+            // (contrary to GetAsync)
+            GetDifficultyAsync(bindable.Beatmap, rulesetInfo, mods, cancellationToken)
                 .ContinueWith(t =>
                 {
                     // We're on a threadpool thread, but we should exit back to the update thread so consumers can safely handle value-changed events.


### PR DESCRIPTION
Resolves #10725.

This *actually* broke in https://github.com/ppy/osu/pull/10712, and I was misled into thinking this was always broken due to the very subtle distinction between `GetAsync()` and `GetDifficultyAsync()`. I have no good idea how to rename those methods better to make the distinction less subtle, however (much less so seeing that the latter is public), so there's an inline comment in there instead.