### PR TITLE
Fix hard crash on saving empty beatmap twice in a row

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -307,8 +307,17 @@ namespace osu.Game.Screens.Edit
             // apply any set-level metadata changes.
             beatmapManager.Update(playableBeatmap.BeatmapInfo.BeatmapSet);
 
-            // save the loaded beatmap's data stream.
-            beatmapManager.Save(playableBeatmap.BeatmapInfo, editorBeatmap, editorBeatmap.BeatmapSkin);
+            try
+            {
+                // save the loaded beatmap's data stream.
+                beatmapManager.Save(playableBeatmap.BeatmapInfo, editorBeatmap, editorBeatmap.BeatmapSkin);
+            }
+            catch
+            {
+                // this is a temporary measure to avoid hard crashes on saving identical beatmaps.
+                // should be replaced in the future once we aren't relying on the isNewBeatmap flag.
+                beatmapManager.Delete(playableBeatmap.BeatmapInfo.BeatmapSet);
+            }
 
             updateLastSavedHash();
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10734. This obviously isn't the perfect solution (will still show database errors) but at least it avoids the hard crash experienced otherwise.

Handling this in a better way isn't to simple right now.