### PR TITLE
Add missing user activities for Multi screens

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -137,7 +137,7 @@ namespace osu.Desktop
                     return edit.Beatmap.ToString();
 
                 case UserActivity.InLobby lobby:
-                    return lobby.Room.Name.ToString();
+                    return lobby.Room.Name.Value;
             }
 
             return string.Empty;

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -135,6 +135,9 @@ namespace osu.Desktop
 
                 case UserActivity.Editing edit:
                     return edit.Beatmap.ToString();
+
+                case UserActivity.InLobby lobby:
+                    return lobby.Room.Name.ToString();
             }
 
             return string.Empty;

--- a/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestGenericActivity()
         {
-            AddStep("Set activity", () => API.Activity.Value = new UserActivity.InLobby());
+            AddStep("Set activity", () => API.Activity.Value = new UserActivity.InLobby(null));
 
             AddStep("Run command", () => Add(new NowPlayingCommand()));
 
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Visual.Online
         [TestCase(false)]
         public void TestLinkPresence(bool hasOnlineId)
         {
-            AddStep("Set activity", () => API.Activity.Value = new UserActivity.InLobby());
+            AddStep("Set activity", () => API.Activity.Value = new UserActivity.InLobby(null));
 
             AddStep("Set beatmap", () => Beatmap.Value = new DummyWorkingBeatmap(Audio, null)
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -51,6 +51,7 @@ using osu.Game.Screens.Select;
 using osu.Game.Updater;
 using osu.Game.Utils;
 using LogLevel = osu.Framework.Logging.LogLevel;
+using osu.Game.Users;
 
 namespace osu.Game
 {
@@ -961,11 +962,15 @@ namespace osu.Game
             LocalUserPlaying.Value = false;
 
             if (current is IOsuScreen currentOsuScreen)
+            {
                 OverlayActivationMode.UnbindFrom(currentOsuScreen.OverlayActivationMode);
+                API.Activity.UnbindFrom(currentOsuScreen.Activity);
+            }
 
             if (newScreen is IOsuScreen newOsuScreen)
             {
                 OverlayActivationMode.BindTo(newOsuScreen.OverlayActivationMode);
+                ((IBindable<UserActivity>)API.Activity).BindTo(newOsuScreen.Activity);
 
                 MusicController.AllowRateAdjustments = newOsuScreen.AllowRateAdjustments;
 

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -6,6 +6,7 @@ using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
+using osu.Game.Users;
 
 namespace osu.Game.Screens
 {
@@ -42,6 +43,11 @@ namespace osu.Game.Screens
         /// Whether overlays should be able to be opened when this screen is current.
         /// </summary>
         IBindable<OverlayActivation> OverlayActivationMode { get; }
+
+        /// <summary>
+        /// The current <see cref="UserActivity"/> for this screen.
+        /// </summary>
+        IBindable<UserActivity> Activity { get; }
 
         /// <summary>
         /// The amount of parallax to be applied while this screen is displayed.

--- a/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
@@ -14,6 +14,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
 using osu.Game.Screens.Multi.Lounge.Components;
 using osu.Game.Screens.Multi.Match;
+using osu.Game.Users;
 
 namespace osu.Game.Screens.Multi.Lounge
 {
@@ -23,6 +24,8 @@ namespace osu.Game.Screens.Multi.Lounge
         public override string Title => "Lounge";
 
         protected FilterControl Filter;
+
+        protected override UserActivity InitialActivity => new UserActivity.SearchingForLobby();
 
         private readonly Bindable<bool> initialRoomsReceived = new Bindable<bool>();
 

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -21,6 +21,7 @@ using osu.Game.Screens.Multi.Play;
 using osu.Game.Screens.Multi.Ranking;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
+using osu.Game.Users;
 using Footer = osu.Game.Screens.Multi.Match.Components.Footer;
 
 namespace osu.Game.Screens.Multi.Match
@@ -60,6 +61,7 @@ namespace osu.Game.Screens.Multi.Match
         public MatchSubScreen(Room room)
         {
             Title = room.RoomID.Value == null ? "New room" : room.Name.Value;
+            Activity.Value = new UserActivity.InLobby(room);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -24,6 +24,7 @@ using osu.Game.Screens.Multi.Lounge;
 using osu.Game.Screens.Multi.Lounge.Components;
 using osu.Game.Screens.Multi.Match;
 using osu.Game.Screens.Multi.Match.Components;
+using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Screens.Multi
@@ -140,10 +141,10 @@ namespace osu.Game.Screens.Multi
                 }
             };
 
-            screenStack.Push(loungeSubScreen = new LoungeSubScreen());
-
             screenStack.ScreenPushed += screenPushed;
             screenStack.ScreenExited += screenExited;
+
+            screenStack.Push(loungeSubScreen = new LoungeSubScreen());
         }
 
         private readonly IBindable<APIState> apiState = new Bindable<APIState>();
@@ -311,18 +312,18 @@ namespace osu.Game.Screens.Multi
 
         private void screenPushed(IScreen lastScreen, IScreen newScreen)
         {
-            subScreenChanged(newScreen);
+            subScreenChanged(lastScreen, newScreen);
         }
 
         private void screenExited(IScreen lastScreen, IScreen newScreen)
         {
-            subScreenChanged(newScreen);
+            subScreenChanged(lastScreen, newScreen);
 
             if (screenStack.CurrentScreen == null && this.IsCurrentScreen())
                 this.Exit();
         }
 
-        private void subScreenChanged(IScreen newScreen)
+        private void subScreenChanged(IScreen lastScreen, IScreen newScreen)
         {
             switch (newScreen)
             {
@@ -336,6 +337,12 @@ namespace osu.Game.Screens.Multi
                     headerBackground.MoveToX(-MultiplayerSubScreen.X_SHIFT, MultiplayerSubScreen.X_MOVE_DURATION, Easing.OutQuint);
                     break;
             }
+
+            if (lastScreen is IOsuScreen lastOsuScreen)
+                Activity.UnbindFrom(lastOsuScreen.Activity);
+
+            if (newScreen is IOsuScreen newOsuScreen)
+                ((IBindable<UserActivity>)Activity).BindTo(newOsuScreen.Activity);
 
             updatePollingRate(isIdle.Value);
             createButton.FadeTo(newScreen is LoungeSubScreen ? 1 : 0, 200);

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -14,7 +14,6 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.Menu;
 using osu.Game.Overlays;
 using osu.Game.Users;
-using osu.Game.Online.API;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Screens
@@ -63,22 +62,12 @@ namespace osu.Game.Screens
         /// </summary>
         protected virtual UserActivity InitialActivity => null;
 
-        private UserActivity activity;
-
         /// <summary>
         /// The current <see cref="UserActivity"/> for this screen.
         /// </summary>
-        protected UserActivity Activity
-        {
-            get => activity;
-            set
-            {
-                if (value == activity) return;
+        protected readonly Bindable<UserActivity> Activity;
 
-                activity = value;
-                updateActivity();
-            }
-        }
+        IBindable<UserActivity> IOsuScreen.Activity => Activity;
 
         /// <summary>
         /// Whether to disallow changes to game-wise Beatmap/Ruleset bindables for this screen (and all children).
@@ -135,15 +124,13 @@ namespace osu.Game.Screens
         [Resolved(canBeNull: true)]
         private OsuLogo logo { get; set; }
 
-        [Resolved(canBeNull: true)]
-        private IAPIProvider api { get; set; }
-
         protected OsuScreen()
         {
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
             OverlayActivationMode = new Bindable<OverlayActivation>(InitialOverlayActivationMode);
+            Activity = new Bindable<UserActivity>();
         }
 
         [BackgroundDependencyLoader(true)]
@@ -157,8 +144,6 @@ namespace osu.Game.Screens
             if (PlayResumeSound)
                 sampleExit?.Play();
             applyArrivingDefaults(true);
-
-            updateActivity();
 
             base.OnResuming(last);
         }
@@ -176,8 +161,8 @@ namespace osu.Game.Screens
 
             backgroundStack?.Push(localBackground = CreateBackground());
 
-            if (activity == null)
-                Activity = InitialActivity;
+            if (Activity.Value == null)
+                Activity.Value = InitialActivity;
 
             base.OnEntering(last);
         }
@@ -194,12 +179,6 @@ namespace osu.Game.Screens
                 backgroundStack?.Exit();
 
             return false;
-        }
-
-        private void updateActivity()
-        {
-            if (api != null)
-                api.Activity.Value = activity;
         }
 
         /// <summary>

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -56,9 +56,9 @@ namespace osu.Game.Screens
         protected new OsuGameBase Game => base.Game as OsuGameBase;
 
         /// <summary>
-        /// The <see cref="UserActivity"/> to set the user's activity automatically to when this screen is entered
-        /// <para>This <see cref="Activity"/> will be automatically set to <see cref="InitialActivity"/> for this screen on entering unless
-        /// <see cref="Activity"/> is manually set before.</para>
+        /// The <see cref="UserActivity"/> to set the user's activity automatically to when this screen is entered.
+        /// <para>This <see cref="Activity"/> will be automatically set to <see cref="InitialActivity"/> for this screen on entering for the first time
+        /// unless <see cref="Activity"/> is manually set before.</para>
         /// </summary>
         protected virtual UserActivity InitialActivity => null;
 

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -138,8 +138,7 @@ namespace osu.Game.Screens
         {
             sampleExit = audio.Samples.Get(@"UI/screen-back");
 
-            if (Activity.Value == null)
-                Activity.Value = InitialActivity;
+            Activity.Value ??= InitialActivity;
         }
 
         public override void OnResuming(IScreen last)

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens
         /// <summary>
         /// The current <see cref="UserActivity"/> for this screen.
         /// </summary>
-        protected readonly Bindable<UserActivity> Activity;
+        protected readonly Bindable<UserActivity> Activity = new Bindable<UserActivity>();
 
         IBindable<UserActivity> IOsuScreen.Activity => Activity;
 
@@ -130,7 +130,6 @@ namespace osu.Game.Screens
             Origin = Anchor.Centre;
 
             OverlayActivationMode = new Bindable<OverlayActivation>(InitialOverlayActivationMode);
-            Activity = new Bindable<UserActivity>();
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -137,6 +137,9 @@ namespace osu.Game.Screens
         private void load(OsuGame osu, AudioManager audio)
         {
             sampleExit = audio.Samples.Get(@"UI/screen-back");
+
+            if (Activity.Value == null)
+                Activity.Value = InitialActivity;
         }
 
         public override void OnResuming(IScreen last)
@@ -160,9 +163,6 @@ namespace osu.Game.Screens
             applyArrivingDefaults(false);
 
             backgroundStack?.Push(localBackground = CreateBackground());
-
-            if (Activity.Value == null)
-                Activity.Value = InitialActivity;
 
             base.OnEntering(last);
         }

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -3,6 +3,7 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets;
 using osuTK.Graphics;
 
@@ -61,9 +62,21 @@ namespace osu.Game.Users
             public override string Status => @"Spectating a game";
         }
 
+        public class SearchingForLobby : UserActivity
+        {
+            public override string Status => @"Looking for a lobby";
+        }
+
         public class InLobby : UserActivity
         {
             public override string Status => @"In a multiplayer lobby";
+
+            public readonly Room Room;
+
+            public InLobby(Room room)
+            {
+                Room = room;
+            }
         }
     }
 }


### PR DESCRIPTION
# Summary

This adds "missing" user activities for the multi screens which are already live. 

I also took this opportunity to refactor the user activity handling logic in OsuScreen which was making it basically impossible to share the current activity to the screen stack (in the case of screens being subscreens and not actual screens). The logic now uses a bindable flow, very similarly to how it's done for OverlayActivationMode.

I'm hesitant to push the one-liner change to display the room name on the discord integration as it looks weird right now (the status and details are reversed)