### PR TITLE
Fix ki* textures having an incorrect vertical position

### DIFF
--- a/osu.Game/Skinning/LegacyHealthDisplay.cs
+++ b/osu.Game/Skinning/LegacyHealthDisplay.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Skinning
                 Math.Clamp(Clock.ElapsedFrameTime, 0, 200),
                 fill.Width, (float)Current.Value * maxFillWidth, 0, 200, Easing.OutQuint);
 
-            marker.Position = fill.Position + new Vector2(fill.DrawWidth, 0);
+            marker.Position = fill.Position + new Vector2(fill.DrawWidth, isNewStyle ? fill.DrawHeight / 2 : 0);
         }
 
         public void Flash(JudgementResult result) => marker.Flash(result);

--- a/osu.Game/Skinning/LegacyHealthDisplay.cs
+++ b/osu.Game/Skinning/LegacyHealthDisplay.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Skinning
                 Math.Clamp(Clock.ElapsedFrameTime, 0, 200),
                 fill.Width, (float)Current.Value * maxFillWidth, 0, 200, Easing.OutQuint);
 
-            marker.Position = fill.Position + new Vector2(fill.DrawWidth, fill.DrawHeight / 2);
+            marker.Position = fill.Position + new Vector2(fill.DrawWidth, 0);
         }
 
         public void Flash(JudgementResult result) => marker.Flash(result);


### PR DESCRIPTION
This "broke" my skin in lazer whereas it looked fine in stable.
Should now match stable in positioning.

Here is a very basic example skin that shows the issue: [skin.zip](https://github.com/ppy/osu/files/5508234/testnew.zip)
Previously, the `scorebar-ki.png` would display below the visible part of the `scorebar-colour.png` texture.
With this change, this behavior is reversed and matches stable.