### PR TITLE
Simplify input buttons/keys in tests

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
@@ -280,8 +280,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         private void addClickStep(MouseButton button)
         {
-            AddStep($"press {button}", () => InputManager.PressButton(button));
-            AddStep($"release {button}", () => InputManager.ReleaseButton(button));
+            AddStep($"click {button}", () => InputManager.Click(button));
         }
 
         private void assertPlaced(bool expected) => AddAssert($"slider {(expected ? "placed" : "not placed")}", () => (getSlider() != null) == expected);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAutoplay.cs
@@ -41,11 +41,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("store time", () => time = Player.GameplayClockContainer.GameplayClock.CurrentTime);
 
             // test seek via keyboard
-            AddStep("seek with right arrow key", () => press(Key.Right));
+            AddStep("seek with right arrow key", () => InputManager.Key(Key.Right));
             AddAssert("time seeked forward", () => Player.GameplayClockContainer.GameplayClock.CurrentTime > time + 2000);
 
             AddStep("store time", () => time = Player.GameplayClockContainer.GameplayClock.CurrentTime);
-            AddStep("seek with left arrow key", () => press(Key.Left));
+            AddStep("seek with left arrow key", () => InputManager.Key(Key.Left));
             AddAssert("time seeked backward", () => Player.GameplayClockContainer.GameplayClock.CurrentTime < time);
 
             seekToBreak(0);
@@ -66,12 +66,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for seek to complete", () => Player.HUDOverlay.Progress.ReferenceClock.CurrentTime >= destBreak().StartTime);
 
             BreakPeriod destBreak() => Beatmap.Value.Beatmap.Breaks.ElementAt(breakIndex);
-        }
-
-        private void press(Key key)
-        {
-            InputManager.PressKey(key);
-            InputManager.ReleaseKey(key);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             showOverlay();
 
-            AddStep("Up arrow", () => press(Key.Up));
+            AddStep("Up arrow", () => InputManager.Key(Key.Up));
             AddAssert("Last button selected", () => pauseOverlay.Buttons.Last().Selected.Value);
         }
 
@@ -98,7 +98,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             showOverlay();
 
-            AddStep("Down arrow", () => press(Key.Down));
+            AddStep("Down arrow", () => InputManager.Key(Key.Down));
             AddAssert("First button selected", () => getButton(0).Selected.Value);
         }
 
@@ -110,11 +110,11 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("Show overlay", () => failOverlay.Show());
 
-            AddStep("Up arrow", () => press(Key.Up));
+            AddStep("Up arrow", () => InputManager.Key(Key.Up));
             AddAssert("Last button selected", () => failOverlay.Buttons.Last().Selected.Value);
-            AddStep("Up arrow", () => press(Key.Up));
+            AddStep("Up arrow", () => InputManager.Key(Key.Up));
             AddAssert("First button selected", () => failOverlay.Buttons.First().Selected.Value);
-            AddStep("Up arrow", () => press(Key.Up));
+            AddStep("Up arrow", () => InputManager.Key(Key.Up));
             AddAssert("Last button selected", () => failOverlay.Buttons.Last().Selected.Value);
         }
 
@@ -126,11 +126,11 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("Show overlay", () => failOverlay.Show());
 
-            AddStep("Down arrow", () => press(Key.Down));
+            AddStep("Down arrow", () => InputManager.Key(Key.Down));
             AddAssert("First button selected", () => failOverlay.Buttons.First().Selected.Value);
-            AddStep("Down arrow", () => press(Key.Down));
+            AddStep("Down arrow", () => InputManager.Key(Key.Down));
             AddAssert("Last button selected", () => failOverlay.Buttons.Last().Selected.Value);
-            AddStep("Down arrow", () => press(Key.Down));
+            AddStep("Down arrow", () => InputManager.Key(Key.Down));
             AddAssert("First button selected", () => failOverlay.Buttons.First().Selected.Value);
         }
 
@@ -177,7 +177,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             showOverlay();
 
-            AddStep("Down arrow", () => press(Key.Down));
+            AddStep("Down arrow", () => InputManager.Key(Key.Down));
             AddStep("Hover second button", () => InputManager.MoveMouseTo(getButton(1)));
             AddAssert("First button not selected", () => !getButton(0).Selected.Value);
             AddAssert("Second button selected", () => getButton(1).Selected.Value);
@@ -195,7 +195,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddStep("Hover second button", () => InputManager.MoveMouseTo(getButton(1)));
-            AddStep("Up arrow", () => press(Key.Up));
+            AddStep("Up arrow", () => InputManager.Key(Key.Up));
             AddAssert("Second button not selected", () => !getButton(1).Selected.Value);
             AddAssert("First button selected", () => getButton(0).Selected.Value);
         }
@@ -210,7 +210,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("Hover second button", () => InputManager.MoveMouseTo(getButton(1)));
             AddStep("Unhover second button", () => InputManager.MoveMouseTo(Vector2.Zero));
-            AddStep("Down arrow", () => press(Key.Down));
+            AddStep("Down arrow", () => InputManager.Key(Key.Down));
             AddAssert("First button selected", () => getButton(0).Selected.Value); // Initial state condition
         }
 
@@ -246,8 +246,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("Select second button", () =>
             {
-                press(Key.Down);
-                press(Key.Down);
+                InputManager.Key(Key.Down);
+                InputManager.Key(Key.Down);
             });
 
             bool triggered = false;
@@ -256,7 +256,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 lastAction = pauseOverlay.OnRetry;
                 pauseOverlay.OnRetry = () => triggered = true;
-                press(Key.Enter);
+                InputManager.Key(Key.Enter);
             });
 
             AddAssert("Action was triggered", () =>
@@ -289,12 +289,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void hideOverlay() => AddStep("Hide overlay", () => pauseOverlay.Hide());
 
         private DialogButton getButton(int index) => pauseOverlay.Buttons.Skip(index).First();
-
-        private void press(Key key)
-        {
-            InputManager.PressKey(key);
-            InputManager.ReleaseKey(key);
-        }
 
         private void press(GlobalAction action)
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneKeyBindings.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneKeyBindings.cs
@@ -32,11 +32,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestDefaultsWhenNotDatabased()
         {
-            AddStep("fire key", () =>
-            {
-                InputManager.PressKey(Key.A);
-                InputManager.ReleaseKey(Key.A);
-            });
+            AddStep("fire key", () => InputManager.Key(Key.A));
 
             AddAssert("received key", () => receiver.ReceivedAction);
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
@@ -40,11 +40,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             void addPressKeyStep()
             {
-                AddStep($"Press {testKey} key", () =>
-                {
-                    InputManager.PressKey(testKey);
-                    InputManager.ReleaseKey(testKey);
-                });
+                AddStep($"Press {testKey} key", () => InputManager.Key(testKey));
             }
 
             addPressKeyStep();

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -59,11 +59,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             confirmClockRunning(false);
             confirmPauseOverlayShown(false);
 
-            AddStep("click to resume", () =>
-            {
-                InputManager.PressButton(MouseButton.Left);
-                InputManager.ReleaseButton(MouseButton.Left);
-            });
+            AddStep("click to resume", () => InputManager.Click(MouseButton.Left));
 
             confirmClockRunning(true);
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
@@ -158,8 +158,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("much move with press", () => moveFunction = Scheduler.AddDelayed(() =>
             {
                 InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(-1, 0));
-                InputManager.PressButton(MouseButton.Left);
-                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
             }, 10, true));
             AddWaitStep("move", 10);
             AddStep("stop move", () => moveFunction.Cancel());

--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -65,10 +65,8 @@ namespace osu.Game.Tests.Visual.Menus
                 AddStep($"switch to ruleset {i} via shortcut", () =>
                 {
                     InputManager.PressKey(Key.ControlLeft);
-                    InputManager.PressKey(numberKey);
-
+                    InputManager.Key(numberKey);
                     InputManager.ReleaseKey(Key.ControlLeft);
-                    InputManager.ReleaseKey(numberKey);
                 });
 
                 AddUntilStep("ruleset switched", () => rulesetSelector.Current.Value.Equals(expected));

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
@@ -71,11 +71,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void press(Key down)
         {
-            AddStep($"press {down}", () =>
-            {
-                InputManager.PressKey(down);
-                InputManager.ReleaseKey(down);
-            });
+            AddStep($"press {down}", () => InputManager.Key(down));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.Navigation
             if (withUserPause)
                 AddStep("pause", () => Game.Dependencies.Get<MusicController>().Stop(true));
 
-            AddStep("press enter", () => pressAndRelease(Key.Enter));
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
 
             AddUntilStep("wait for player", () => (player = Game.ScreenStack.CurrentScreen as Player) != null);
             AddUntilStep("wait for fail", () => player.HasFailed);
@@ -122,11 +122,11 @@ namespace osu.Game.Tests.Visual.Navigation
         public void TestOpenOptionsAndExitWithEscape()
         {
             AddUntilStep("Wait for options to load", () => Game.Settings.IsLoaded);
-            AddStep("Enter menu", () => pressAndRelease(Key.Enter));
+            AddStep("Enter menu", () => InputManager.Key(Key.Enter));
             AddStep("Move mouse to options overlay", () => InputManager.MoveMouseTo(optionsButtonPosition));
             AddStep("Click options overlay", () => InputManager.Click(MouseButton.Left));
             AddAssert("Options overlay was opened", () => Game.Settings.State.Value == Visibility.Visible);
-            AddStep("Hide options overlay using escape", () => pressAndRelease(Key.Escape));
+            AddStep("Hide options overlay using escape", () => InputManager.Key(Key.Escape));
             AddAssert("Options overlay was closed", () => Game.Settings.State.Value == Visibility.Hidden);
         }
 
@@ -158,10 +158,8 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("Change ruleset to osu!taiko", () =>
             {
                 InputManager.PressKey(Key.ControlLeft);
-                InputManager.PressKey(Key.Number2);
-
+                InputManager.Key(Key.Number2);
                 InputManager.ReleaseKey(Key.ControlLeft);
-                InputManager.ReleaseKey(Key.Number2);
             });
 
             AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.ID == 1);
@@ -181,10 +179,8 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("Change ruleset to osu!taiko", () =>
             {
                 InputManager.PressKey(Key.ControlLeft);
-                InputManager.PressKey(Key.Number2);
-
+                InputManager.Key(Key.Number2);
                 InputManager.ReleaseKey(Key.ControlLeft);
-                InputManager.ReleaseKey(Key.Number2);
             });
 
             AddAssert("Ruleset changed to osu!taiko", () => Game.Toolbar.ChildrenOfType<ToolbarRulesetSelector>().Single().Current.Value.ID == 1);
@@ -193,7 +189,7 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         private void pushEscape() =>
-            AddStep("Press escape", () => pressAndRelease(Key.Escape));
+            AddStep("Press escape", () => InputManager.Key(Key.Escape));
 
         private void exitViaEscapeAndConfirm()
         {
@@ -206,12 +202,6 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("Move mouse to backButton", () => InputManager.MoveMouseTo(backButtonPosition));
             AddStep("Click back button", () => InputManager.Click(MouseButton.Left));
             ConfirmAtMainMenu();
-        }
-
-        private void pressAndRelease(Key key)
-        {
-            InputManager.PressKey(key);
-            InputManager.ReleaseKey(key);
         }
 
         private class TestSongSelect : PlaySongSelect

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -103,11 +103,7 @@ namespace osu.Game.Tests.Visual.Online
         public void TestChannelShortcutKeys()
         {
             AddStep("Join channels", () => channels.ForEach(channel => channelManager.JoinChannel(channel)));
-            AddStep("Close channel selector", () =>
-            {
-                InputManager.PressKey(Key.Escape);
-                InputManager.ReleaseKey(Key.Escape);
-            });
+            AddStep("Close channel selector", () => InputManager.Key(Key.Escape));
             AddUntilStep("Wait for close", () => chatOverlay.SelectionOverlayState == Visibility.Hidden);
 
             for (int zeroBasedIndex = 0; zeroBasedIndex < 10; ++zeroBasedIndex)
@@ -216,9 +212,8 @@ namespace osu.Game.Tests.Visual.Online
         {
             var channelKey = Key.Number0 + number;
             InputManager.PressKey(Key.AltLeft);
-            InputManager.PressKey(channelKey);
+            InputManager.Key(channelKey);
             InputManager.ReleaseKey(Key.AltLeft);
-            InputManager.ReleaseKey(channelKey);
         }
 
         private void clickDrawable(Drawable d)

--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -51,8 +51,7 @@ namespace osu.Game.Tests.Visual.Settings
 
                 clickDelegate = Scheduler.AddDelayed(() =>
                 {
-                    InputManager.PressButton(MouseButton.Left);
-                    InputManager.ReleaseButton(MouseButton.Left);
+                    InputManager.Click(MouseButton.Left);
 
                     if (++buttonClicks == 2)
                     {

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -98,10 +98,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("select next and enter", () =>
             {
-                InputManager.PressKey(Key.Down);
-                InputManager.ReleaseKey(Key.Down);
-                InputManager.PressKey(Key.Enter);
-                InputManager.ReleaseKey(Key.Enter);
+                InputManager.Key(Key.Down);
+                InputManager.Key(Key.Enter);
             });
 
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
@@ -123,10 +121,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("select next and enter", () =>
             {
-                InputManager.PressKey(Key.Enter);
-                InputManager.ReleaseKey(Key.Enter);
-                InputManager.PressKey(Key.Down);
-                InputManager.ReleaseKey(Key.Down);
+                InputManager.Key(Key.Enter);
+                InputManager.Key(Key.Down);
             });
 
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
@@ -151,11 +147,9 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.MoveMouseTo(songSelect.Carousel.ChildrenOfType<DrawableCarouselBeatmap>()
                                                    .First(b => ((CarouselBeatmap)b.Item).Beatmap != songSelect.Carousel.SelectedBeatmap));
 
-                InputManager.PressButton(MouseButton.Left);
-                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
 
-                InputManager.PressKey(Key.Enter);
-                InputManager.ReleaseKey(Key.Enter);
+                InputManager.Key(Key.Enter);
             });
 
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
@@ -182,8 +176,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 InputManager.PressButton(MouseButton.Left);
 
-                InputManager.PressKey(Key.Enter);
-                InputManager.ReleaseKey(Key.Enter);
+                InputManager.Key(Key.Enter);
 
                 InputManager.ReleaseButton(MouseButton.Left);
             });
@@ -567,10 +560,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("press ctrl+enter", () =>
             {
                 InputManager.PressKey(Key.ControlLeft);
-                InputManager.PressKey(Key.Enter);
-
+                InputManager.Key(Key.Enter);
                 InputManager.ReleaseKey(Key.ControlLeft);
-                InputManager.ReleaseKey(Key.Enter);
             });
 
             AddUntilStep("wait for player", () => Stack.CurrentScreen is PlayerLoader);
@@ -617,8 +608,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 InputManager.MoveMouseTo(difficultyIcon);
 
-                InputManager.PressButton(MouseButton.Left);
-                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
             });
 
             AddAssert("Selected beatmap correct", () => getCurrentBeatmapIndex() == getDifficultyIconIndex(set, difficultyIcon));
@@ -647,8 +637,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 InputManager.MoveMouseTo(filteredIcon);
 
-                InputManager.PressButton(MouseButton.Left);
-                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
             });
 
             AddAssert("Selected beatmap correct", () => songSelect.Carousel.SelectedBeatmap == filteredBeatmap);
@@ -691,8 +680,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 InputManager.MoveMouseTo(difficultyIcon);
 
-                InputManager.PressButton(MouseButton.Left);
-                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
             });
 
             AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.ID == 3);
@@ -738,8 +726,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 InputManager.MoveMouseTo(groupIcon);
 
-                InputManager.PressButton(MouseButton.Left);
-                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
             });
 
             AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.ID == 3);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneCommentEditor.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneCommentEditor.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
             AddStep("enter text", () => commentEditor.Current.Value = "text");
 
-            AddStep("press Enter", () => press(Key.Enter));
+            AddStep("press Enter", () => InputManager.Key(Key.Enter));
 
             AddAssert("text committed", () => commentEditor.CommittedText == "text");
             AddAssert("button is loading", () => commentEditor.IsLoading);
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddStep("press Enter", () => press(Key.Enter));
+            AddStep("press Enter", () => InputManager.Key(Key.Enter));
 
             AddAssert("no text committed", () => commentEditor.CommittedText == null);
             AddAssert("button is not loading", () => !commentEditor.IsLoading);
@@ -99,12 +99,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             AddAssert("cancel action fired", () => cancellableCommentEditor.Cancelled);
-        }
-
-        private void press(Key key)
-        {
-            InputManager.PressKey(key);
-            InputManager.ReleaseKey(key);
         }
 
         private class TestCommentEditor : CommentEditor


### PR DESCRIPTION
Uses the included `Click` and `Key` from `InputManager`.

For diffs with a modifer and normal key pressed, it is normal to release a normal key before a modifier, thus it is:
- `PressKey` modifier
- `Key` (press and release) normal key
- `ReleaseKey` modifier