### PR TITLE
Replace rankHistory in JsonProperty with rank_history for consistency

### DIFF
--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Users
             }
         }
 
-        [JsonProperty(@"rankHistory")]
+        [JsonProperty(@"rank_history")]
         private RankHistoryData rankHistory
         {
             set => statistics.RankHistory = value;


### PR DESCRIPTION
As noted here
https://github.com/ppy/osu-web/blob/4818f49af0a16ee7dd170fc805a5c2074d44b6bd/app/Transformers/UserCompactTransformer.php#L66
the JSON property name used for rank history in lazer is inconsistent in naming convention.
Since this is already supported by web it seems to work fine.

Should I also PR to web to remove the TODO or is there something else that depends on 'rankHistory' existing there? 