### PR TITLE
Force beatmap listing overlay's textbox back on screen when a key is pressed

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -33,6 +33,11 @@ namespace osu.Game.Overlays.BeatmapListing
         public Action SearchStarted;
 
         /// <summary>
+        /// Any time the search text box receives key events (even while masked).
+        /// </summary>
+        public Action TypingStarted;
+
+        /// <summary>
         /// True when pagination has reached the end of available results.
         /// </summary>
         private bool noMoreResults;
@@ -82,7 +87,10 @@ namespace osu.Game.Overlays.BeatmapListing
                             Radius = 3,
                             Offset = new Vector2(0f, 1f),
                         },
-                        Child = searchControl = new BeatmapListingSearchControl(),
+                        Child = searchControl = new BeatmapListingSearchControl
+                        {
+                            TypingStarted = () => TypingStarted?.Invoke()
+                        }
                     },
                     new Container
                     {

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osuTK;
 using osu.Framework.Bindables;
+using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
@@ -19,6 +21,11 @@ namespace osu.Game.Overlays.BeatmapListing
 {
     public class BeatmapListingSearchControl : CompositeDrawable
     {
+        /// <summary>
+        /// Any time the text box receives key events (even while masked).
+        /// </summary>
+        public Action TypingStarted;
+
         public Bindable<string> Query => textBox.Current;
 
         public Bindable<RulesetInfo> Ruleset => modeFilter.Current;
@@ -102,6 +109,7 @@ namespace osu.Game.Overlays.BeatmapListing
                             textBox = new BeatmapSearchTextBox
                             {
                                 RelativeSizeAxes = Axes.X,
+                                TypingStarted = () => TypingStarted?.Invoke(),
                             },
                             new ReverseChildIDFillFlowContainer<Drawable>
                             {
@@ -138,11 +146,22 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private class BeatmapSearchTextBox : SearchTextBox
         {
+            /// <summary>
+            /// Any time the text box receives key events (even while masked).
+            /// </summary>
+            public Action TypingStarted;
+
             protected override Color4 SelectionColour => Color4.Gray;
 
             public BeatmapSearchTextBox()
             {
                 PlaceholderText = @"type in keywords...";
+            }
+
+            protected override bool OnKeyDown(KeyDownEvent e)
+            {
+                TypingStarted?.Invoke();
+                return base.OnKeyDown(e);
             }
         }
     }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -160,8 +160,11 @@ namespace osu.Game.Overlays.BeatmapListing
 
             protected override bool OnKeyDown(KeyDownEvent e)
             {
+                if (!base.OnKeyDown(e))
+                    return false;
+
                 TypingStarted?.Invoke();
-                return base.OnKeyDown(e);
+                return true;
             }
         }
     }

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Overlays
                             Header,
                             filterControl = new BeatmapListingFilterControl
                             {
+                                TypingStarted = onTypingStarted,
                                 SearchStarted = onSearchStarted,
                                 SearchFinished = onSearchFinished,
                             },
@@ -100,6 +101,12 @@ namespace osu.Game.Overlays
                     }
                 }
             };
+        }
+
+        private void onTypingStarted()
+        {
+            // temporary until the textbox/header is updated to always stay on screen.
+            resultScrollContainer.ScrollToStart();
         }
 
         protected override void OnFocus(FocusEvent e)


### PR DESCRIPTION
Not the cleanest solution, but works for now. Will eventually be replaced after the header is updated to reflect the latest designs (which keeps it on screen in all cases).

Hard to handle in a better way due to parent masking.

Closes https://github.com/ppy/osu/issues/10703.