### PR TITLE
Fix BlueprintContainer triggering assert when left and right mouse button are pressed together

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -295,21 +295,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a selection was performed.</returns>
         private bool beginClickSelection(MouseButtonEvent e)
         {
-            Debug.Assert(!clickSelectionBegan);
-
-            bool selectedPerformed = true;
-
             foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
             {
-                if (blueprint.IsHovered)
-                {
-                    selectedPerformed &= SelectionHandler.HandleSelectionRequested(blueprint, e);
-                    clickSelectionBegan = true;
-                    break;
-                }
+                if (!blueprint.IsHovered) continue;
+
+                if (SelectionHandler.HandleSelectionRequested(blueprint, e))
+                    return clickSelectionBegan = true;
             }
 
-            return selectedPerformed;
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/10764 (for merging ease)

The assertion can't exist here (and doesn't really need to IMO) as selection is allowed using both left and mouse button (when shift isn't held).

Reproduction of assert:
- `TestSceneTimelineBlueprintContainer`
- Press left mouse button on blueprint
- Press right mouse button on blueprint without releasing left