### PR TITLE
Always store standardised score when populating ScoreInfo

### DIFF
--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -290,7 +290,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         public virtual void PopulateScore(ScoreInfo score)
         {
-            score.TotalScore = (long)Math.Round(TotalScore.Value);
+            score.TotalScore = (long)Math.Round(GetStandardisedScore());
             score.Combo = Combo.Value;
             score.MaxCombo = HighestCombo.Value;
             score.Accuracy = Math.Round(Accuracy.Value, 4);


### PR DESCRIPTION
Resolves #10752 (albeit in a slightly roundabout way).

The rationale is that the mania difficulty calculation is partially based on the score, which it takes in from the `ScoreInfo` passed in. If the play was registered with classic scoring, it'd take that instead and potentially balloon out of control past the expected 1M mark, which after this PR won't be possible. Note that this will not retroactively "fix" "broken" scores.

I think this is a good thing to have going forward given that we already do dynamic conversion. Hesitant to also add a local recalculation in the mania diffcalc component as that might break backward compatibility, and is sorta generally wasteful, but I'll do it on request.

I also noticed that sometimes replaying a replay will end up with a different score at the end than stored, but that'll probably be best addressed separately anyway as it's not likely to be specific to this change. I'm investigating that right now.