### PR TITLE
Stop mod select overlay hotkeys handling input when control is pressed

### DIFF
--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Overlays.Mods
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            if (e.ControlPressed) return false;
+
             if (ToggleKeys != null)
             {
                 var index = Array.IndexOf(ToggleKeys, e.Key);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10766 in about the best way we can for now.