### PR TITLE
Fix crashes if animation sprite path does not match a file

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -118,24 +118,8 @@ namespace osu.Game.Storyboards.Drawables
             for (int frame = 0; frame < Animation.FrameCount; frame++)
             {
                 string framePath = Animation.Path.Replace(".", frame + ".");
-                Drawable sprite = storyboard.CreateSpriteFromResourcePath(framePath, textureStore);
-
-                if (sprite != null)
-                {
-                    AddFrame(sprite, Animation.FrameDelay);
-                    continue;
-                }
-
-                framePath = Animation.Path.Replace("0.", frame + ".");
-                sprite = storyboard.CreateSpriteFromResourcePath(framePath, textureStore);
-
-                if (sprite != null)
-                {
-                    AddFrame(sprite, Animation.FrameDelay);
-                }
-
-                // todo: handle animation intentionally declared with more frames than sprites to cause a blinking effect
-                // e.g. beatmap 5381's "spr\play-skip.png"
+                Drawable sprite = storyboard.CreateSpriteFromResourcePath(framePath, textureStore) ?? Drawable.Empty();
+                AddFrame(sprite, Animation.FrameDelay);
             }
 
             Animation.ApplyTransforms(this);

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -118,8 +118,24 @@ namespace osu.Game.Storyboards.Drawables
             for (int frame = 0; frame < Animation.FrameCount; frame++)
             {
                 string framePath = Animation.Path.Replace(".", frame + ".");
+                Drawable sprite = storyboard.CreateSpriteFromResourcePath(framePath, textureStore);
 
-                AddFrame(storyboard.CreateSpriteFromResourcePath(framePath, textureStore), Animation.FrameDelay);
+                if (sprite != null)
+                {
+                    AddFrame(sprite, Animation.FrameDelay);
+                    continue;
+                }
+
+                framePath = Animation.Path.Replace("0.", frame + ".");
+                sprite = storyboard.CreateSpriteFromResourcePath(framePath, textureStore);
+
+                if (sprite != null)
+                {
+                    AddFrame(sprite, Animation.FrameDelay);
+                }
+
+                // todo: handle animation intentionally declared with more frames than sprites to cause a blinking effect
+                // e.g. beatmap 5381's "spr\play-skip.png"
             }
 
             Animation.ApplyTransforms(this);

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Storyboards.Drawables
             for (int frameIndex = 0; frameIndex < Animation.FrameCount; frameIndex++)
             {
                 string framePath = Animation.Path.Replace(".", frameIndex + ".");
-                Drawable frame = storyboard.CreateSpriteFromResourcePath(framePath, textureStore) ?? Drawable.Empty();
+                Drawable frame = storyboard.CreateSpriteFromResourcePath(framePath, textureStore) ?? Empty();
                 AddFrame(frame, Animation.FrameDelay);
             }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -115,11 +115,11 @@ namespace osu.Game.Storyboards.Drawables
         [BackgroundDependencyLoader]
         private void load(TextureStore textureStore, Storyboard storyboard)
         {
-            for (int frame = 0; frame < Animation.FrameCount; frame++)
+            for (int frameIndex = 0; frameIndex < Animation.FrameCount; frameIndex++)
             {
-                string framePath = Animation.Path.Replace(".", frame + ".");
-                Drawable sprite = storyboard.CreateSpriteFromResourcePath(framePath, textureStore) ?? Drawable.Empty();
-                AddFrame(sprite, Animation.FrameDelay);
+                string framePath = Animation.Path.Replace(".", frameIndex + ".");
+                Drawable frame = storyboard.CreateSpriteFromResourcePath(framePath, textureStore) ?? Drawable.Empty();
+                AddFrame(frame, Animation.FrameDelay);
             }
 
             Animation.ApplyTransforms(this);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10748 (see issue for discussion)

Are drawables typically only covered by visual tests? Feel free to point out an example if I should get this covered by an automated test as well

This can be tested by loading [beatmap 5381](https://osu.ppy.sh/beatmapsets/5381) into the storyboard visual test. You should see the custom "Skip" flashing in the bottom right - may not be visible if window size is small. Without these changes it will crash after loading