### PR TITLE
Disable kiai hit explosions on legacy skins

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneKiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneKiaiHitExplosion.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.UI;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
+{
+    [TestFixture]
+    public class TestSceneKiaiHitExplosion : TaikoSkinnableTestScene
+    {
+        [Test]
+        public void TestKiaiHits()
+        {
+            AddStep("rim hit", () => SetContents(() => getContentFor(createHit(HitType.Rim))));
+            AddStep("centre hit", () => SetContents(() => getContentFor(createHit(HitType.Centre))));
+        }
+
+        private Drawable getContentFor(DrawableTestHit hit)
+        {
+            return new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new KiaiHitExplosion(hit, hit.HitObject.Type)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
+        }
+
+        private DrawableTestHit createHit(HitType type) => new DrawableTestHit(new Hit { StartTime = Time.Current, Type = type });
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -114,6 +114,13 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
                     return null;
 
+                case TaikoSkinComponents.TaikoExplosionKiai:
+                    // suppress the default kiai explosion if the skin brings its own sprites.
+                    if (hasExplosion.Value)
+                        return Drawable.Empty();
+
+                    return null;
+
                 case TaikoSkinComponents.Scroller:
                     if (GetTexture("taiko-slider") != null)
                         return new LegacyTaikoScroller();

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -116,8 +116,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning
 
                 case TaikoSkinComponents.TaikoExplosionKiai:
                     // suppress the default kiai explosion if the skin brings its own sprites.
+                    // the drawable needs to expire as soon as possible to avoid accumulating empty drawables on the playfield.
                     if (hasExplosion.Value)
-                        return Drawable.Empty();
+                        return KiaiHitExplosion.EmptyExplosion();
 
                     return null;
 

--- a/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/TaikoLegacySkinTransformer.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning
                     // suppress the default kiai explosion if the skin brings its own sprites.
                     // the drawable needs to expire as soon as possible to avoid accumulating empty drawables on the playfield.
                     if (hasExplosion.Value)
-                        return KiaiHitExplosion.EmptyExplosion();
+                        return Drawable.Empty().With(d => d.LifetimeEnd = double.MinValue);
 
                     return null;
 

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Rulesets.Taiko
         TaikoExplosionMiss,
         TaikoExplosionOk,
         TaikoExplosionGreat,
+        TaikoExplosionKiai,
         Scroller,
         Mascot,
     }

--- a/osu.Game.Rulesets.Taiko/UI/DefaultKiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DefaultKiaiHitExplosion.cs
@@ -13,14 +13,14 @@ using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
-    public class KiaiHitExplosion : CircularContainer
+    public class DefaultKiaiHitExplosion : CircularContainer
     {
         public override bool RemoveWhenNotAlive => true;
 
         public readonly DrawableHitObject JudgedObject;
         private readonly HitType type;
 
-        public KiaiHitExplosion(DrawableHitObject judgedObject, HitType type)
+        public DefaultKiaiHitExplosion(DrawableHitObject judgedObject, HitType type)
         {
             JudgedObject = judgedObject;
             this.type = type;

--- a/osu.Game.Rulesets.Taiko/UI/DefaultKiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DefaultKiaiHitExplosion.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.UI
@@ -17,19 +16,13 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         public override bool RemoveWhenNotAlive => true;
 
-        public readonly DrawableHitObject JudgedObject;
         private readonly HitType type;
 
-        public DefaultKiaiHitExplosion(DrawableHitObject judgedObject, HitType type)
+        public DefaultKiaiHitExplosion(HitType type)
         {
-            JudgedObject = judgedObject;
             this.type = type;
 
-            Anchor = Anchor.CentreLeft;
-            Origin = Anchor.Centre;
-
             RelativeSizeAxes = Axes.Both;
-            Size = new Vector2(TaikoHitObject.DEFAULT_SIZE, 1);
 
             Blending = BlendingParameters.Additive;
 

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Rulesets.Taiko.UI
+{
+    public class KiaiHitExplosion : Container
+    {
+        public override bool RemoveWhenNotAlive => true;
+
+        [Cached(typeof(DrawableHitObject))]
+        public readonly DrawableHitObject JudgedObject;
+
+        private readonly HitType hitType;
+
+        private SkinnableDrawable skinnable;
+
+        public override double LifetimeStart => skinnable.Drawable.LifetimeStart;
+
+        public override double LifetimeEnd => skinnable.Drawable.LifetimeEnd;
+
+        public KiaiHitExplosion(DrawableHitObject judgedObject, HitType hitType)
+        {
+            JudgedObject = judgedObject;
+            this.hitType = hitType;
+
+            Anchor = Anchor.CentreLeft;
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+            Size = new Vector2(TaikoHitObject.DEFAULT_SIZE, 1);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = skinnable = new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoExplosionKiai), _ => new DefaultKiaiHitExplosion(hitType));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
@@ -43,5 +43,11 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             Child = skinnable = new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoExplosionKiai), _ => new DefaultKiaiHitExplosion(hitType));
         }
+
+        /// <summary>
+        /// Helper function to use when an explosion is not desired.
+        /// Lifetime is set to avoid accumulating empty drawables in the parent container.
+        /// </summary>
+        public static Drawable EmptyExplosion() => Empty().With(d => d.LifetimeEnd = double.MinValue);
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
@@ -43,11 +43,5 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             Child = skinnable = new SkinnableDrawable(new TaikoSkinComponent(TaikoSkinComponents.TaikoExplosionKiai), _ => new DefaultKiaiHitExplosion(hitType));
         }
-
-        /// <summary>
-        /// Helper function to use when an explosion is not desired.
-        /// Lifetime is set to avoid accumulating empty drawables in the parent container.
-        /// </summary>
-        public static Drawable EmptyExplosion() => Empty().With(d => d.LifetimeEnd = double.MinValue);
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         public const float DEFAULT_HEIGHT = 178;
 
         private Container<HitExplosion> hitExplosionContainer;
-        private Container<KiaiHitExplosion> kiaiExplosionContainer;
+        private Container<DefaultKiaiHitExplosion> kiaiExplosionContainer;
         private JudgementContainer<DrawableTaikoJudgement> judgementContainer;
         private ScrollingHitObjectContainer drumRollHitContainer;
         internal Drawable HitTarget;
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                                         drumRollHitContainer = new DrumRollHitContainer()
                                     }
                                 },
-                                kiaiExplosionContainer = new Container<KiaiHitExplosion>
+                                kiaiExplosionContainer = new Container<DefaultKiaiHitExplosion>
                                 {
                                     Name = "Kiai hit explosions",
                                     RelativeSizeAxes = Axes.Both,
@@ -219,7 +219,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             hitExplosionContainer.Add(new HitExplosion(drawableObject, result));
             if (drawableObject.HitObject.Kiai)
-                kiaiExplosionContainer.Add(new KiaiHitExplosion(drawableObject, type));
+                kiaiExplosionContainer.Add(new DefaultKiaiHitExplosion(drawableObject, type));
         }
 
         private class ProxyContainer : LifetimeManagementContainer

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         public const float DEFAULT_HEIGHT = 178;
 
         private Container<HitExplosion> hitExplosionContainer;
-        private Container<DefaultKiaiHitExplosion> kiaiExplosionContainer;
+        private Container<KiaiHitExplosion> kiaiExplosionContainer;
         private JudgementContainer<DrawableTaikoJudgement> judgementContainer;
         private ScrollingHitObjectContainer drumRollHitContainer;
         internal Drawable HitTarget;
@@ -97,7 +97,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                                         drumRollHitContainer = new DrumRollHitContainer()
                                     }
                                 },
-                                kiaiExplosionContainer = new Container<DefaultKiaiHitExplosion>
+                                kiaiExplosionContainer = new Container<KiaiHitExplosion>
                                 {
                                     Name = "Kiai hit explosions",
                                     RelativeSizeAxes = Axes.Both,
@@ -219,7 +219,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             hitExplosionContainer.Add(new HitExplosion(drawableObject, result));
             if (drawableObject.HitObject.Kiai)
-                kiaiExplosionContainer.Add(new DefaultKiaiHitExplosion(drawableObject, type));
+                kiaiExplosionContainer.Add(new KiaiHitExplosion(drawableObject, type));
         }
 
         private class ProxyContainer : LifetimeManagementContainer


### PR DESCRIPTION
Closes #10083.

Mostly mirrors `HitExplosion` in structure, although the layout is (and was) a little bit weirder, and the `EmptyExplosion` thing sticks out like a sore thumb - but I need to expire the `Empty()` to avoid accumulating them in the parent container.

Comparison of the draw hierarchy before/after, for reference:

| before | after |
| :-: | :-: |
| ![2020-11-10-141416_1920x1060_scrot](https://user-images.githubusercontent.com/20418176/98688817-8ed92380-236b-11eb-8b2a-e176e13d5991.png) | ![2020-11-10-141600_1920x1060_scrot](https://user-images.githubusercontent.com/20418176/98688832-94cf0480-236b-11eb-8d24-b1d868385cbb.png) |
