### PR TITLE
Temporarily fix crash on deleting control point groups

### DIFF
--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -85,12 +85,13 @@ namespace osu.Game.Screens.Edit.Timing
                 {
                     textBox.Text = string.Empty;
 
-                    textBox.Current.Disabled = true;
+                    // cannot use textBox.Current.Disabled due to https://github.com/ppy/osu-framework/issues/3919
+                    textBox.ReadOnly = true;
                     button.Enabled.Value = false;
                     return;
                 }
 
-                textBox.Current.Disabled = false;
+                textBox.ReadOnly = false;
                 button.Enabled.Value = true;
 
                 textBox.Text = $"{group.NewValue.Time:n0}";


### PR DESCRIPTION
Band-aid closes #10456.

Just getting a temporary patch out as-is in its current state as it's a relatively high-impact crash that's getting duplicates submitted.

I had also suggested a [temporary framework-side resolution](https://github.com/ppy/osu-framework/compare/master...bdach:fix-disable-textbox-crash) but unsure if piling more hacks onto `TextBox` is much better than this.