### PR TITLE
Fix user profile best performance weighting being out of order

### DIFF
--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
 
         protected override void OnItemsReceived(List<APILegacyScoreInfo> items)
         {
+            if (VisiblePages == 0)
+                drawableItemIndex = 0;
+
             base.OnItemsReceived(items);
 
             if (type == ScoreType.Recent)
@@ -55,6 +58,8 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
         protected override APIRequest<List<APILegacyScoreInfo>> CreateRequest() =>
             new GetUserScoresRequest(User.Value.Id, type, VisiblePages++, ItemsPerPage);
 
+        private int drawableItemIndex;
+
         protected override Drawable CreateDrawableItem(APILegacyScoreInfo model)
         {
             switch (type)
@@ -63,7 +68,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                     return new DrawableProfileScore(model.CreateScoreInfo(Rulesets));
 
                 case ScoreType.Best:
-                    return new DrawableProfileWeightedScore(model.CreateScoreInfo(Rulesets), Math.Pow(0.95, ItemsContainer.Count));
+                    return new DrawableProfileWeightedScore(model.CreateScoreInfo(Rulesets), Math.Pow(0.95, drawableItemIndex++));
             }
         }
     }


### PR DESCRIPTION
Was somehow relying on good luck to decide indices.

Closes https://github.com/ppy/osu/issues/10783.