### PR TITLE
Make beatmap selection blur editable

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -372,7 +372,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public void TriggerOnHover() => OnHover(new HoverEvent(new InputState()));
 
-            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BACKGROUND_BLUR);
+            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BackgroundBlur);
 
             protected override BackgroundScreen CreateBackground() => new FadeAccessibleBackground(Beatmap.Value);
         }

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -307,7 +307,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public bool IsBackgroundVisible() => ((FadeAccessibleBackground)Background).CurrentAlpha == 1;
 
-            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BACKGROUND_BLUR);
+            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BackgroundBlur);
 
             /// <summary>
             /// Make sure every time a screen gets pushed, the background doesn't get replaced

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -306,7 +306,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public bool IsBackgroundVisible() => ((FadeAccessibleBackground)Background).CurrentAlpha == 1;
 
-            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BACKGROUND_BLUR);
+            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BackgroundBlur);
 
             /// <summary>
             /// Make sure every time a screen gets pushed, the background doesn't get replaced

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -160,10 +160,10 @@ namespace osu.Game.Tests.Visual.Background
                 player.ReplacesBackground.Value = true;
                 player.StoryboardEnabled.Value = true;
             });
-            AddStep("Enable user dim", () => player.DimmableStoryboard.EnableUserDim.Value = true);
+            AddStep("Enable user dim", () => player.DimmableStoryboard.EnableGameplayDim.Value = true);
             AddStep("Set dim level to 1", () => songSelect.DimLevel.Value = 1f);
             AddUntilStep("Storyboard is invisible", () => !player.IsStoryboardVisible);
-            AddStep("Disable user dim", () => player.DimmableStoryboard.EnableUserDim.Value = false);
+            AddStep("Disable user dim", () => player.DimmableStoryboard.EnableGameplayDim.Value = false);
             AddUntilStep("Storyboard is visible", () => player.IsStoryboardVisible);
         }
 
@@ -277,7 +277,7 @@ namespace osu.Game.Tests.Visual.Background
             protected override BackgroundScreen CreateBackground()
             {
                 FadeAccessibleBackground background = new FadeAccessibleBackground(Beatmap.Value);
-                DimEnabled.BindTo(background.EnableUserDim);
+                DimEnabled.BindTo(background.EnableGameplayDim);
                 return background;
             }
 
@@ -298,7 +298,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public bool IsBackgroundUndimmed() => ((FadeAccessibleBackground)Background).CurrentColour == Color4.White;
 
-            public bool IsUserBlurApplied() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2((float)BlurLevel.Value * BackgroundScreenBeatmap.USER_BLUR_FACTOR);
+            public bool IsUserBlurApplied() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2((float)BlurLevel.Value * BackgroundScreenBeatmap.GAMEPLAY_BLUR_FACTOR);
 
             public bool IsUserBlurDisabled() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(0);
 
@@ -306,7 +306,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public bool IsBackgroundVisible() => ((FadeAccessibleBackground)Background).CurrentAlpha == 1;
 
-            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BackgroundBlur);
+            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BACKGROUND_BLUR);
 
             /// <summary>
             /// Make sure every time a screen gets pushed, the background doesn't get replaced

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -371,7 +371,7 @@ namespace osu.Game.Tests.Visual.Background
 
             public void TriggerOnHover() => OnHover(new HoverEvent(new InputState()));
 
-            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BACKGROUND_BLUR);
+            public bool IsBlurCorrect() => ((FadeAccessibleBackground)Background).CurrentBlur == new Vector2(BackgroundBlur);
 
             protected override BackgroundScreen CreateBackground() => new FadeAccessibleBackground(Beatmap.Value);
         }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Configuration
             // Gameplay
             Set(OsuSetting.DimLevel, 0.8, 0, 1, 0.01);
             Set(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
-            Set(OsuSetting.MenuBlurLevel, 0.8f, 0f, 1f, 0.01f);
+            Set(OsuSetting.MenuBlurLevel, 0.8, 0, 1, 0.01);
             Set(OsuSetting.LightenDuringBreaks, true);
 
             Set(OsuSetting.HitLighting, true);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -88,6 +88,7 @@ namespace osu.Game.Configuration
             // Gameplay
             Set(OsuSetting.DimLevel, 0.8, 0, 1, 0.01);
             Set(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
+            Set(OsuSetting.MenuBlurLevel, 0.8f, 0f, 1f, 0.01f);
             Set(OsuSetting.LightenDuringBreaks, true);
 
             Set(OsuSetting.HitLighting, true);
@@ -189,6 +190,7 @@ namespace osu.Game.Configuration
         AutoCursorSize,
         DimLevel,
         BlurLevel,
+        MenuBlurLevel,
         LightenDuringBreaks,
         ShowStoryboard,
         KeyOverlay,

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Configuration
             // Gameplay
             Set(OsuSetting.DimLevel, 0.8, 0, 1, 0.01);
             Set(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
+            Set(OsuSetting.MenuBlurLevel, 0.8f, 0f, 1f, 0.01f);
             Set(OsuSetting.LightenDuringBreaks, true);
 
             Set(OsuSetting.HitLighting, true);
@@ -183,6 +184,7 @@ namespace osu.Game.Configuration
         AutoCursorSize,
         DimLevel,
         BlurLevel,
+        MenuBlurLevel,
         LightenDuringBreaks,
         ShowStoryboard,
         KeyOverlay,

--- a/osu.Game/Graphics/Containers/UserDimContainer.cs
+++ b/osu.Game/Graphics/Containers/UserDimContainer.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Graphics.Containers
         /// <summary>
         /// Whether or not user-configured dim levels should be applied to the container.
         /// </summary>
-        public readonly Bindable<bool> EnableUserDim = new Bindable<bool>(true);
+        public readonly Bindable<bool> EnableGameplayDim = new Bindable<bool>(true);
 
         /// <summary>
         /// Whether or not user-configured settings relating to brightness of elements should be ignored
@@ -57,7 +57,7 @@ namespace osu.Game.Graphics.Containers
 
         private float breakLightening => LightenDuringBreaks.Value && IsBreakTime.Value ? BREAK_LIGHTEN_AMOUNT : 0;
 
-        protected float DimLevel => Math.Max(EnableUserDim.Value && !IgnoreUserSettings.Value ? (float)UserDimLevel.Value - breakLightening : 0, 0);
+        protected float DimLevel => Math.Max(EnableGameplayDim.Value && !IgnoreUserSettings.Value ? (float)UserDimLevel.Value - breakLightening : 0, 0);
 
         protected override Container<Drawable> Content => dimContent;
 
@@ -78,7 +78,7 @@ namespace osu.Game.Graphics.Containers
             LightenDuringBreaks = config.GetBindable<bool>(OsuSetting.LightenDuringBreaks);
             ShowStoryboard = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
 
-            EnableUserDim.ValueChanged += _ => UpdateVisuals();
+            EnableGameplayDim.ValueChanged += _ => UpdateVisuals();
             UserDimLevel.ValueChanged += _ => UpdateVisuals();
             LightenDuringBreaks.ValueChanged += _ => UpdateVisuals();
             IsBreakTime.ValueChanged += _ => UpdateVisuals();

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/SongSelectSettings.cs
@@ -56,7 +56,14 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 {
                     LabelText = "Random selection algorithm",
                     Current = config.GetBindable<RandomSelectAlgorithm>(OsuSetting.RandomSelectAlgorithm),
-                }
+                },
+                new SettingsSlider<float>
+                {
+                    LabelText = "Menu background blur",
+                    Current = config.GetBindable<float>(OsuSetting.MenuBlurLevel),
+                    KeyboardStep = 0.01f,
+                    DisplayAsPercentage = true
+                },
             };
         }
 

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/SongSelectSettings.cs
@@ -57,10 +57,10 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = "Random selection algorithm",
                     Current = config.GetBindable<RandomSelectAlgorithm>(OsuSetting.RandomSelectAlgorithm),
                 },
-                new SettingsSlider<float>
+                new SettingsSlider<double>
                 {
                     LabelText = "Menu background blur",
-                    Current = config.GetBindable<float>(OsuSetting.MenuBlurLevel),
+                    Current = config.GetBindable<double>(OsuSetting.MenuBlurLevel),
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
                 },

--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Mods
 
         public void ApplyToPlayer(Player player)
         {
-            player.Background.EnableUserDim.Value = false;
+            player.Background.EnableGameplayDim.Value = false;
 
             player.DimmableStoryboard.IgnoreUserSettings.Value = true;
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -444,7 +444,7 @@ namespace osu.Game.Screens.Edit
             // todo: temporary. we want to be applying dim using the UserDimContainer eventually.
             Background.FadeColour(Color4.DarkGray, 500);
 
-            Background.EnableUserDim.Value = false;
+            Background.EnableGameplayDim.Value = false;
             Background.BlurAmount.Value = 0;
 
             resetTrack(true);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -672,7 +672,8 @@ namespace osu.Game.Screens.Play
                 .Delay(250)
                 .FadeIn(250);
 
-            Background.EnableUserDim.Value = true;
+            Background.EnableGameplayDim.Value = true;
+            Background.EnableUIBlur.Value = false;
             Background.BlurAmount.Value = 0;
 
             // bind component bindables.
@@ -779,7 +780,7 @@ namespace osu.Game.Screens.Play
             float fadeOutDuration = instant ? 0 : 250;
             this.FadeOut(fadeOutDuration);
 
-            Background.EnableUserDim.Value = false;
+            Background.EnableGameplayDim.Value = false;
             storyboardReplacesBackground.Value = false;
         }
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Play
 {
     public class PlayerLoader : ScreenWithBeatmapBackground
     {
-        protected const float BACKGROUND_BLUR = 15;
+        protected float BackgroundBlur = 15;
 
         public override bool HideOverlaysOnEnter => hideOverlays;
 
@@ -102,6 +102,12 @@ namespace osu.Game.Screens.Play
         public PlayerLoader(Func<Player> createPlayer)
         {
             this.createPlayer = createPlayer;
+        }
+
+        public PlayerLoader(Func<Player> createPlayer, float backgroundBlur)
+        {
+            this.createPlayer = createPlayer;
+            this.BackgroundBlur = backgroundBlur;
         }
 
         [BackgroundDependencyLoader]
@@ -242,7 +248,7 @@ namespace osu.Game.Screens.Play
             {
                 // Returns background dim and blur to the values specified by PlayerLoader.
                 Background.EnableUserDim.Value = false;
-                Background.BlurAmount.Value = BACKGROUND_BLUR;
+                Background.BlurAmount.Value = BackgroundBlur;
 
                 BackgroundBrightnessReduction = true;
             }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -268,7 +268,7 @@ namespace osu.Game.Screens.Play
                 // Returns background dim and blur to the values specified by PlayerLoader.
                 Background.EnableGameplayDim.Value = false;
                 Background.EnableUIBlur.Value = true;
-                Background.BlurAmount.Value = 0.5f;
+                Background.BlurAmount.Value = 0.75f;
 
                 BackgroundBrightnessReduction = true;
             }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Play
 {
     public class PlayerLoader : ScreenWithBeatmapBackground
     {
-        protected const float BACKGROUND_BLUR = 15;
+        protected float BackgroundBlur = 15;
 
         public override bool HideOverlaysOnEnter => hideOverlays;
 
@@ -109,6 +109,12 @@ namespace osu.Game.Screens.Play
         public PlayerLoader(Func<Player> createPlayer)
         {
             this.createPlayer = createPlayer;
+        }
+
+        public PlayerLoader(Func<Player> createPlayer, float backgroundBlur)
+        {
+            this.createPlayer = createPlayer;
+            this.BackgroundBlur = backgroundBlur;
         }
 
         [BackgroundDependencyLoader]
@@ -268,7 +274,7 @@ namespace osu.Game.Screens.Play
             {
                 // Returns background dim and blur to the values specified by PlayerLoader.
                 Background.EnableUserDim.Value = false;
-                Background.BlurAmount.Value = BACKGROUND_BLUR;
+                Background.BlurAmount.Value = BackgroundBlur;
 
                 BackgroundBrightnessReduction = true;
             }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Screens.Play
 {
     public class PlayerLoader : ScreenWithBeatmapBackground
     {
-        protected float BackgroundBlur = 15;
-
         public override bool HideOverlaysOnEnter => hideOverlays;
 
         public override bool DisallowExternalBeatmapRulesetChanges => true;
@@ -109,12 +107,6 @@ namespace osu.Game.Screens.Play
         public PlayerLoader(Func<Player> createPlayer)
         {
             this.createPlayer = createPlayer;
-        }
-
-        public PlayerLoader(Func<Player> createPlayer, float backgroundBlur)
-        {
-            this.createPlayer = createPlayer;
-            this.BackgroundBlur = backgroundBlur;
         }
 
         [BackgroundDependencyLoader]
@@ -220,7 +212,7 @@ namespace osu.Game.Screens.Play
             content.ScaleTo(0.7f, 150, Easing.InQuint);
             this.FadeOut(150);
 
-            Background.EnableUserDim.Value = false;
+            Background.EnableGameplayDim.Value = false;
             BackgroundBrightnessReduction = false;
             Beatmap.Value.Track.RemoveAdjustment(AdjustableProperty.Volume, volumeAdjustment);
 
@@ -265,7 +257,8 @@ namespace osu.Game.Screens.Play
             if (inputManager.HoveredDrawables.Contains(VisualSettings))
             {
                 // Preview user-defined background dim and blur when hovered on the visual settings panel.
-                Background.EnableUserDim.Value = true;
+                Background.EnableGameplayDim.Value = true;
+                Background.EnableUIBlur.Value = false;
                 Background.BlurAmount.Value = 0;
 
                 BackgroundBrightnessReduction = false;
@@ -273,8 +266,9 @@ namespace osu.Game.Screens.Play
             else
             {
                 // Returns background dim and blur to the values specified by PlayerLoader.
-                Background.EnableUserDim.Value = false;
-                Background.BlurAmount.Value = BackgroundBlur;
+                Background.EnableGameplayDim.Value = false;
+                Background.EnableUIBlur.Value = true;
+                Background.BlurAmount.Value = 0.5f;
 
                 BackgroundBrightnessReduction = true;
             }

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -228,7 +228,8 @@ namespace osu.Game.Screens.Ranking
         {
             base.OnEntering(last);
 
-            ((BackgroundScreenBeatmap)Background).BlurAmount.Value = BACKGROUND_BLUR;
+            ((BackgroundScreenBeatmap)Background).EnableUIBlur.Value = true;
+            ((BackgroundScreenBeatmap)Background).BlurAmount.Value = 1;
 
             Background.FadeTo(0.5f, 250);
             bottomPanel.FadeTo(1, 250);

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Screens.Select
 
             SampleConfirm?.Play();
 
-            this.Push(player = new PlayerLoader(() => new Player()));
+            this.Push(player = new PlayerLoader(() => new Player(), BackgroundBlur * 0.75f));
 
             return true;
         }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Select
 
             SampleConfirm?.Play();
 
-            this.Push(player = new PlayerLoader(() => new Player(), BackgroundBlur * 0.75f));
+            this.Push(player = new PlayerLoader(() => new Player()));
 
             return true;
         }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Select
 
             SampleConfirm?.Play();
 
-            this.Push(player = new PlayerLoader(() => new Player()));
+            this.Push(player = new PlayerLoader(() => new Player(), BackgroundBlur * 0.75f));
 
             return true;
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -35,6 +35,7 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Game.Collections;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Scoring;
 using System.Diagnostics;
@@ -45,8 +46,10 @@ namespace osu.Game.Screens.Select
     {
         public static readonly float WEDGE_HEIGHT = 245;
 
-        protected const float BACKGROUND_BLUR = 20;
+        protected float BackgroundBlur = 20;
         private const float left_area_padding = 20;
+
+        private Bindable<float> backgroundBlurBindable { get; set; }
 
         public FilterControl FilterControl { get; private set; }
 
@@ -105,7 +108,7 @@ namespace osu.Game.Screens.Select
         private MusicController music { get; set; }
 
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores, CollectionManager collections, ManageCollectionsDialog manageCollectionsDialog)
+        private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores, CollectionManager collections, ManageCollectionsDialog manageCollectionsDialog, OsuConfigManager config)
         {
             // initial value transfer is required for FilterControl (it uses our re-cached bindables in its async load for the initial filter).
             transferRulesetValue();
@@ -307,6 +310,26 @@ namespace osu.Game.Screens.Select
                         }));
                     }
                 });
+            }
+
+            backgroundBlurBindable = config.GetBindable<float>(OsuSetting.MenuBlurLevel);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            backgroundBlurBindable.ValueChanged += _ => updateBackgroundBlur();
+            updateBackgroundBlur(); // for first time opening beatmap selection
+        }
+
+        private void updateBackgroundBlur()
+        {
+            BackgroundBlur = backgroundBlurBindable.Value * 25;
+
+            if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
+            {
+                backgroundModeBeatmap.BlurAmount.Value = BackgroundBlur;
             }
         }
 
@@ -679,7 +702,7 @@ namespace osu.Game.Screens.Select
             if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
             {
                 backgroundModeBeatmap.Beatmap = beatmap;
-                backgroundModeBeatmap.BlurAmount.Value = BACKGROUND_BLUR;
+                backgroundModeBeatmap.BlurAmount.Value = BackgroundBlur;
                 backgroundModeBeatmap.FadeColour(Color4.White, 250);
             }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -519,6 +519,12 @@ namespace osu.Game.Screens.Select
             this.FadeInFromZero(250);
             FilterControl.Activate();
 
+            if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
+            {
+                backgroundModeBeatmap.BlurAmount.Value = 1;
+                backgroundModeBeatmap.EnableUIBlur.Value = true;
+            }
+
             ModSelect.SelectedMods.BindTo(selectedMods);
 
             beginLooping();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -35,6 +35,7 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Game.Collections;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Scoring;
 
@@ -44,8 +45,10 @@ namespace osu.Game.Screens.Select
     {
         public static readonly float WEDGE_HEIGHT = 245;
 
-        protected const float BACKGROUND_BLUR = 20;
+        protected float BackgroundBlur = 20;
         private const float left_area_padding = 20;
+
+        private Bindable<float> backgroundBlurBindable { get; set; }
 
         public FilterControl FilterControl { get; private set; }
 
@@ -104,7 +107,7 @@ namespace osu.Game.Screens.Select
         private MusicController music { get; set; }
 
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores, CollectionManager collections, ManageCollectionsDialog manageCollectionsDialog)
+        private void load(AudioManager audio, DialogOverlay dialog, OsuColour colours, SkinManager skins, ScoreManager scores, CollectionManager collections, ManageCollectionsDialog manageCollectionsDialog, OsuConfigManager config)
         {
             // initial value transfer is required for FilterControl (it uses our re-cached bindables in its async load for the initial filter).
             transferRulesetValue();
@@ -306,6 +309,26 @@ namespace osu.Game.Screens.Select
                         }));
                     }
                 });
+            }
+
+            backgroundBlurBindable = config.GetBindable<float>(OsuSetting.MenuBlurLevel);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            backgroundBlurBindable.ValueChanged += _ => updateBackgroundBlur();
+            updateBackgroundBlur(); // for first time opening beatmap selection
+        }
+
+        private void updateBackgroundBlur()
+        {
+            BackgroundBlur = backgroundBlurBindable.Value * 25;
+
+            if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
+            {
+                backgroundModeBeatmap.BlurAmount.Value = BackgroundBlur;
             }
         }
 
@@ -658,7 +681,7 @@ namespace osu.Game.Screens.Select
             if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
             {
                 backgroundModeBeatmap.Beatmap = beatmap;
-                backgroundModeBeatmap.BlurAmount.Value = BACKGROUND_BLUR;
+                backgroundModeBeatmap.BlurAmount.Value = BackgroundBlur;
                 backgroundModeBeatmap.FadeColour(Color4.White, 250);
             }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -46,10 +46,8 @@ namespace osu.Game.Screens.Select
     {
         public static readonly float WEDGE_HEIGHT = 245;
 
-        protected float BackgroundBlur = 20;
+        protected const float BACKGROUND_BLUR = 20;
         private const float left_area_padding = 20;
-
-        private Bindable<float> backgroundBlurBindable { get; set; }
 
         public FilterControl FilterControl { get; private set; }
 
@@ -310,26 +308,6 @@ namespace osu.Game.Screens.Select
                         }));
                     }
                 });
-            }
-
-            backgroundBlurBindable = config.GetBindable<float>(OsuSetting.MenuBlurLevel);
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            backgroundBlurBindable.ValueChanged += _ => updateBackgroundBlur();
-            updateBackgroundBlur(); // for first time opening beatmap selection
-        }
-
-        private void updateBackgroundBlur()
-        {
-            BackgroundBlur = backgroundBlurBindable.Value * 25;
-
-            if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
-            {
-                backgroundModeBeatmap.BlurAmount.Value = BackgroundBlur;
             }
         }
 
@@ -702,7 +680,8 @@ namespace osu.Game.Screens.Select
             if (Background is BackgroundScreenBeatmap backgroundModeBeatmap)
             {
                 backgroundModeBeatmap.Beatmap = beatmap;
-                backgroundModeBeatmap.BlurAmount.Value = BackgroundBlur;
+                backgroundModeBeatmap.BlurAmount.Value = 1;
+                backgroundModeBeatmap.EnableUIBlur.Value = true;
                 backgroundModeBeatmap.FadeColour(Color4.White, 250);
             }
 


### PR DESCRIPTION
Adds a slider to the options menu to change the menu blur (Personally I don't like it so its 0%)
It defaults to 80% (The slider is out of 25) which matches osu's blur beforehand.

[Default Blur](https://cdn.nuker.dev/khcpq5ii/2020-11-10T17:14:11.png) (Slider at 80% - blur int 20)
[30% Blur](https://cdn.nuker.dev/khcqd1yb/2020-11-10T17:31:51.png) (Slider at 30% - blur int 6
[Without Blur](https://cdn.nuker.dev/khcpw1vy/2020-11-10T17:17:48.png)

Personally I just don't really like the blur, so I have it disabled

