### PR TITLE
Refactor "perform from menu" logic to be aware of dialog prompts

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
+++ b/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [SetUpSteps]
-        public void SetUpSteps()
+        public virtual void SetUpSteps()
         {
             AddStep("Create new game instance", () =>
             {

--- a/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
@@ -2,23 +2,33 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Screens;
+using osu.Game.Overlays;
+using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Navigation
 {
     public class TestScenePerformFromScreen : OsuGameTestScene
     {
+        private bool actionPerformed;
+
+        public override void SetUpSteps()
+        {
+            AddStep("reset status", () => actionPerformed = false);
+
+            base.SetUpSteps();
+        }
+
         [Test]
         public void TestPerformAtMenu()
         {
-            AddAssert("could perform immediately", () =>
-            {
-                bool actionPerformed = false;
-                Game.PerformFromScreen(_ => actionPerformed = true);
-                return actionPerformed;
-            });
+            AddStep("perform immediately", () => Game.PerformFromScreen(_ => actionPerformed = true));
+            AddAssert("did perform", () => actionPerformed);
         }
 
         [Test]
@@ -26,12 +36,9 @@ namespace osu.Game.Tests.Visual.Navigation
         {
             PushAndConfirm(() => new PlaySongSelect());
 
-            AddAssert("could perform immediately", () =>
-            {
-                bool actionPerformed = false;
-                Game.PerformFromScreen(_ => actionPerformed = true, new[] { typeof(PlaySongSelect) });
-                return actionPerformed;
-            });
+            AddStep("perform immediately", () => Game.PerformFromScreen(_ => actionPerformed = true, new[] { typeof(PlaySongSelect) }));
+            AddAssert("did perform", () => actionPerformed);
+            AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
         }
 
         [Test]
@@ -39,7 +46,6 @@ namespace osu.Game.Tests.Visual.Navigation
         {
             PushAndConfirm(() => new PlaySongSelect());
 
-            bool actionPerformed = false;
             AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
             AddUntilStep("returned to menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
             AddAssert("did perform", () => actionPerformed);
@@ -51,7 +57,6 @@ namespace osu.Game.Tests.Visual.Navigation
             PushAndConfirm(() => new PlaySongSelect());
             PushAndConfirm(() => new PlayerLoader(() => new Player()));
 
-            bool actionPerformed = false;
             AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true, new[] { typeof(PlaySongSelect) }));
             AddUntilStep("returned to song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
             AddAssert("did perform", () => actionPerformed);
@@ -63,10 +68,105 @@ namespace osu.Game.Tests.Visual.Navigation
             PushAndConfirm(() => new PlaySongSelect());
             PushAndConfirm(() => new PlayerLoader(() => new Player()));
 
-            bool actionPerformed = false;
             AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
             AddUntilStep("returned to song select", () => Game.ScreenStack.CurrentScreen is MainMenu);
             AddAssert("did perform", () => actionPerformed);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestPerformBlockedByDialog(bool confirmed)
+        {
+            DialogBlockingScreen blocker = null;
+
+            PushAndConfirm(() => blocker = new DialogBlockingScreen());
+            AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
+
+            AddWaitStep("wait a bit", 10);
+
+            AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen is DialogBlockingScreen);
+            AddAssert("did not perform", () => !actionPerformed);
+            AddAssert("only one exit attempt", () => blocker.ExitAttempts == 1);
+
+            AddUntilStep("wait for dialog display", () => Game.Dependencies.Get<DialogOverlay>().IsLoaded);
+
+            if (confirmed)
+            {
+                AddStep("accept dialog", () => InputManager.Key(Key.Number1));
+                AddUntilStep("wait for dialog dismissed", () => Game.Dependencies.Get<DialogOverlay>().CurrentDialog == null);
+                AddUntilStep("did perform", () => actionPerformed);
+            }
+            else
+            {
+                AddStep("cancel dialog", () => InputManager.Key(Key.Number2));
+                AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen is DialogBlockingScreen);
+                AddAssert("did not perform", () => !actionPerformed);
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestPerformBlockedByDialogNested(bool confirmSecond)
+        {
+            DialogBlockingScreen blocker = null;
+            DialogBlockingScreen blocker2 = null;
+
+            PushAndConfirm(() => blocker = new DialogBlockingScreen());
+            PushAndConfirm(() => blocker2 = new DialogBlockingScreen());
+
+            AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
+
+            AddUntilStep("wait for dialog", () => blocker2.ExitAttempts == 1);
+
+            AddWaitStep("wait a bit", 10);
+
+            AddUntilStep("wait for dialog display", () => Game.Dependencies.Get<DialogOverlay>().IsLoaded);
+
+            AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen == blocker2);
+            AddAssert("did not perform", () => !actionPerformed);
+            AddAssert("only one exit attempt", () => blocker2.ExitAttempts == 1);
+
+            AddStep("accept dialog", () => InputManager.Key(Key.Number1));
+            AddUntilStep("screen changed", () => Game.ScreenStack.CurrentScreen == blocker);
+
+            AddUntilStep("wait for second dialog", () => blocker.ExitAttempts == 1);
+            AddAssert("did not perform", () => !actionPerformed);
+            AddAssert("only one exit attempt", () => blocker.ExitAttempts == 1);
+
+            if (confirmSecond)
+            {
+                AddStep("accept dialog", () => InputManager.Key(Key.Number1));
+                AddUntilStep("did perform", () => actionPerformed);
+            }
+            else
+            {
+                AddStep("cancel dialog", () => InputManager.Key(Key.Number2));
+                AddAssert("screen didn't change", () => Game.ScreenStack.CurrentScreen == blocker);
+                AddAssert("did not perform", () => !actionPerformed);
+            }
+        }
+
+        public class DialogBlockingScreen : OsuScreen
+        {
+            [Resolved]
+            private DialogOverlay dialogOverlay { get; set; }
+
+            private int dialogDisplayCount;
+
+            public int ExitAttempts { get; private set; }
+
+            public override bool OnExiting(IScreen next)
+            {
+                ExitAttempts++;
+
+                if (dialogDisplayCount++ < 1)
+                {
+                    dialogOverlay.Push(new ConfirmExitDialog(this.Exit, () => { }));
+                    return true;
+                }
+
+                return base.OnExiting(next);
+            }
         }
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -463,7 +463,7 @@ namespace osu.Game
 
         #endregion
 
-        private ScheduledDelegate performFromMainMenuTask;
+        private PerformFromMenuRunner performFromMainMenuTask;
 
         /// <summary>
         /// Perform an action only after returning to a specific screen as indicated by <paramref name="validScreens"/>.
@@ -474,34 +474,7 @@ namespace osu.Game
         public void PerformFromScreen(Action<IScreen> action, IEnumerable<Type> validScreens = null)
         {
             performFromMainMenuTask?.Cancel();
-
-            validScreens ??= Enumerable.Empty<Type>();
-            validScreens = validScreens.Append(typeof(MainMenu));
-
-            CloseAllOverlays(false);
-
-            // we may already be at the target screen type.
-            if (validScreens.Contains(ScreenStack.CurrentScreen?.GetType()) && !Beatmap.Disabled)
-            {
-                action(ScreenStack.CurrentScreen);
-                return;
-            }
-
-            // find closest valid target
-            IScreen screen = ScreenStack.CurrentScreen;
-
-            while (screen != null)
-            {
-                if (validScreens.Contains(screen.GetType()))
-                {
-                    screen.MakeCurrent();
-                    break;
-                }
-
-                screen = screen.GetParentScreen();
-            }
-
-            performFromMainMenuTask = Schedule(() => PerformFromScreen(action, validScreens));
+            Add(performFromMainMenuTask = new PerformFromMenuRunner(action, validScreens, () => ScreenStack.CurrentScreen));
         }
 
         /// <summary>

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -1,0 +1,145 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Screens;
+using osu.Framework.Threading;
+using osu.Game.Beatmaps;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Dialog;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Screens.Menu;
+
+namespace osu.Game
+{
+    internal class PerformFromMenuRunner : Component
+    {
+        private readonly Action<IScreen> finalAction;
+        private readonly IEnumerable<Type> validScreens;
+        private readonly Func<IScreen> getCurrentScreen;
+
+        [Resolved]
+        private NotificationOverlay notifications { get; set; }
+
+        [Resolved]
+        private DialogOverlay dialogOverlay { get; set; }
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; }
+
+        [Resolved(canBeNull: true)]
+        private OsuGame game { get; set; }
+
+        private readonly ScheduledDelegate task;
+
+        private PopupDialog lastEncounteredDialog;
+        private IScreen lastEncounteredDialogScreen;
+
+        /// <summary>
+        /// Perform an action only after returning to a specific screen as indicated by <paramref name="validScreens"/>.
+        /// Eagerly tries to exit the current screen until it succeeds.
+        /// </summary>
+        /// <param name="finalAction">The action to perform once we are in the correct state.</param>
+        /// <param name="validScreens">An optional collection of valid screen types. If any of these screens are already current we can perform the action immediately, else the first valid parent will be made current before performing the action. <see cref="MainMenu"/> is used if not specified.</param>
+        /// <param name="getCurrentScreen">A function to retrieve the currently displayed game screen.</param>
+        public PerformFromMenuRunner(Action<IScreen> finalAction, IEnumerable<Type> validScreens, Func<IScreen> getCurrentScreen)
+        {
+            validScreens ??= Enumerable.Empty<Type>();
+            validScreens = validScreens.Append(typeof(MainMenu));
+
+            this.finalAction = finalAction;
+            this.validScreens = validScreens;
+            this.getCurrentScreen = getCurrentScreen;
+
+            Scheduler.Add(task = new ScheduledDelegate(checkCanComplete, 0, 200));
+        }
+
+        /// <summary>
+        /// Cancel this runner from running.
+        /// </summary>
+        public void Cancel()
+        {
+            task.Cancel();
+            Expire();
+        }
+
+        private void checkCanComplete()
+        {
+            // find closest valid target
+            IScreen current = getCurrentScreen();
+
+            // a dialog may be blocking the execution for now.
+            if (checkForDialog(current)) return;
+
+            // we may already be at the target screen type.
+            if (validScreens.Contains(getCurrentScreen().GetType()) && !beatmap.Disabled)
+            {
+                complete();
+                return;
+            }
+
+            game.CloseAllOverlays(false);
+
+            while (current != null)
+            {
+                if (validScreens.Contains(current.GetType()))
+                {
+                    current.MakeCurrent();
+                    break;
+                }
+
+                current = current.GetParentScreen();
+            }
+        }
+
+        /// <summary>
+        /// Check whether there is currently a dialog requiring user interaction.
+        /// </summary>
+        /// <param name="current"></param>
+        /// <returns>Whether a dialog blocked interaction.</returns>
+        private bool checkForDialog(IScreen current)
+        {
+            var currentDialog = dialogOverlay.CurrentDialog;
+
+            if (lastEncounteredDialog != null)
+            {
+                if (lastEncounteredDialog == currentDialog)
+                    // still waiting on user interaction
+                    return true;
+
+                if (lastEncounteredDialogScreen != current)
+                {
+                    // a dialog was previously encountered but has since been dismissed.
+                    // if the screen changed, the user likely confirmed an exit dialog and we should continue attempting the action.
+                    lastEncounteredDialog = null;
+                    lastEncounteredDialogScreen = null;
+                    return false;
+                }
+
+                // the last dialog encountered has been dismissed but the screen has not changed, abort.
+                Cancel();
+                notifications.Post(new SimpleNotification { Text = @"An action was interrupted due to a dialog being displayed." });
+                return true;
+            }
+
+            if (currentDialog == null)
+                return false;
+
+            // a new dialog was encountered.
+            lastEncounteredDialog = currentDialog;
+            lastEncounteredDialogScreen = current;
+            return true;
+        }
+
+        private void complete()
+        {
+            finalAction(getCurrentScreen());
+            Cancel();
+        }
+    }
+}

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -20,7 +20,7 @@ namespace osu.Game
     internal class PerformFromMenuRunner : Component
     {
         private readonly Action<IScreen> finalAction;
-        private readonly IEnumerable<Type> validScreens;
+        private readonly Type[] validScreens;
         private readonly Func<IScreen> getCurrentScreen;
 
         [Resolved]
@@ -53,7 +53,7 @@ namespace osu.Game
             validScreens = validScreens.Append(typeof(MainMenu));
 
             this.finalAction = finalAction;
-            this.validScreens = validScreens;
+            this.validScreens = validScreens.ToArray();
             this.getCurrentScreen = getCurrentScreen;
 
             Scheduler.Add(task = new ScheduledDelegate(checkCanComplete, 0, 200));


### PR DESCRIPTION
Until now, a request to perform an action from the main menu would keep trying until it was manually cancelled or reached its target screen. This change allows pausing when a dialog is being presented to the user.

- While a dialog is presented, parent screen navigation will stop
- If the dialog is dismissed and the screen changed (ie. user confirmed exiting a screen), navigation upwards will continue
- If the dialog was dismissed and the screen hasn't changed, the action is cancelled and the user is informed.

This is allowed to repeat each time an confirmation-causing-upwards-navigation occurs.

Closes https://github.com/ppy/osu/issues/10761

Also feels like a good improvement for code quality, moving this complex logic out of `OsuGame` itself.