### PR TITLE
Fix frame stable playback not being set correctly

### DIFF
--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.UI
             get => frameStablePlayback;
             set
             {
-                frameStablePlayback = false;
+                frameStablePlayback = value;
                 if (frameStabilityContainer != null)
                     frameStabilityContainer.FrameStablePlayback = value;
             }


### PR DESCRIPTION
Would only (currently) happen in cases where this value is set pre-`load()`, such as in my upcoming hitobject pooling tests.