### PR TITLE
Implement top-level hitobject pooling

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleApplication.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 Position = new Vector2(128, 128),
                 ComboIndex = 1,
-            })));
+            }), null));
         }
 
         private HitCircle prepareObject(HitCircle circle)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     new Vector2(300, 0),
                 }),
                 RepeatCount = 1
-            })));
+            }), null));
         }
 
         private Slider prepareObject(Slider slider)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerApplication.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Position = new Vector2(256, 192),
                 ComboIndex = 1,
                 Duration = 1000,
-            })));
+            }), null));
         }
 
         private Spinner prepareObject(Spinner circle)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/MainCirclePiece.cs
@@ -51,9 +51,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             var drawableOsuObject = (DrawableOsuHitObject)drawableObject;
 
             state.BindTo(drawableObject.State);
-            state.BindValueChanged(updateState, true);
-
             accentColour.BindTo(drawableObject.AccentColour);
+            indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            state.BindValueChanged(updateState, true);
             accentColour.BindValueChanged(colour =>
             {
                 explode.Colour = colour.NewValue;
@@ -61,7 +67,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                 circle.Colour = colour.NewValue;
             }, true);
 
-            indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
             indexInCurrentCombo.BindValueChanged(index => number.Text = (index.NewValue + 1).ToString(), true);
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
@@ -1,0 +1,247 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Legacy;
+using osu.Game.Rulesets.UI;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public class TestScenePoolingRuleset : OsuTestScene
+    {
+        private const double time_between_objects = 1000;
+
+        private TestDrawablePoolingRuleset drawableRuleset;
+
+        [Test]
+        public void TestReusedWithHitObjectsSpacedFarApart()
+        {
+            ManualClock clock = null;
+
+            createTest(new Beatmap
+            {
+                HitObjects =
+                {
+                    new HitObject(),
+                    new HitObject { StartTime = time_between_objects }
+                }
+            }, 1, () => new FramedClock(clock = new ManualClock()));
+
+            DrawableTestHitObject firstObject = null;
+            AddUntilStep("first object shown", () => this.ChildrenOfType<DrawableTestHitObject>().SingleOrDefault()?.HitObject == drawableRuleset.Beatmap.HitObjects[0]);
+            AddStep("get DHO", () => firstObject = this.ChildrenOfType<DrawableTestHitObject>().Single());
+
+            AddStep("fast forward to second object", () => clock.CurrentTime = drawableRuleset.Beatmap.HitObjects[1].StartTime);
+
+            AddUntilStep("second object shown", () => this.ChildrenOfType<DrawableTestHitObject>().SingleOrDefault()?.HitObject == drawableRuleset.Beatmap.HitObjects[1]);
+            AddAssert("DHO reused", () => this.ChildrenOfType<DrawableTestHitObject>().Single() == firstObject);
+        }
+
+        [Test]
+        public void TestNotReusedWithHitObjectsSpacedClose()
+        {
+            ManualClock clock = null;
+
+            createTest(new Beatmap
+            {
+                HitObjects =
+                {
+                    new HitObject(),
+                    new HitObject { StartTime = 250 }
+                }
+            }, 2, () => new FramedClock(clock = new ManualClock()));
+
+            AddStep("fast forward to second object", () => clock.CurrentTime = drawableRuleset.Beatmap.HitObjects[1].StartTime);
+
+            AddUntilStep("two DHOs shown", () => this.ChildrenOfType<DrawableTestHitObject>().Count() == 2);
+            AddAssert("DHOs have different hitobjects",
+                () => this.ChildrenOfType<DrawableTestHitObject>().ElementAt(0).HitObject != this.ChildrenOfType<DrawableTestHitObject>().ElementAt(1).HitObject);
+        }
+
+        [Test]
+        public void TestManyHitObjects()
+        {
+            var beatmap = new Beatmap();
+
+            for (int i = 0; i < 500; i++)
+                beatmap.HitObjects.Add(new HitObject { StartTime = i * 10 });
+
+            createTest(beatmap, 100);
+
+            AddUntilStep("any DHOs shown", () => this.ChildrenOfType<DrawableTestHitObject>().Any());
+            AddUntilStep("no DHOs shown", () => !this.ChildrenOfType<DrawableTestHitObject>().Any());
+        }
+
+        private void createTest(IBeatmap beatmap, int poolSize, Func<IFrameBasedClock> createClock = null) => AddStep("create test", () =>
+        {
+            var ruleset = new TestPoolingRuleset();
+
+            drawableRuleset = (TestDrawablePoolingRuleset)ruleset.CreateDrawableRulesetWith(CreateWorkingBeatmap(beatmap).GetPlayableBeatmap(ruleset.RulesetInfo));
+            drawableRuleset.FrameStablePlayback = true;
+            drawableRuleset.PoolSize = poolSize;
+
+            Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Clock = createClock?.Invoke() ?? new FramedOffsetClock(Clock, false) { Offset = -Clock.CurrentTime },
+                Child = drawableRuleset
+            };
+        });
+
+        #region Ruleset
+
+        private class TestPoolingRuleset : Ruleset
+        {
+            public override IEnumerable<Mod> GetModsFor(ModType type) => throw new NotImplementedException();
+
+            public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => new TestDrawablePoolingRuleset(this, beatmap, mods);
+
+            public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new TestBeatmapConverter(beatmap, this);
+
+            public override DifficultyCalculator CreateDifficultyCalculator(WorkingBeatmap beatmap) => throw new NotImplementedException();
+
+            public override string Description { get; } = string.Empty;
+
+            public override string ShortName { get; } = string.Empty;
+        }
+
+        private class TestDrawablePoolingRuleset : DrawableRuleset<TestHitObject>
+        {
+            public int PoolSize;
+
+            public TestDrawablePoolingRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
+                : base(ruleset, beatmap, mods)
+            {
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                RegisterPool<TestHitObject, DrawableTestHitObject>(PoolSize);
+            }
+
+            protected override bool PoolHitObjects => true;
+
+            protected override HitObjectLifetimeEntry CreateLifetimeEntry(TestHitObject hitObject) => new TestHitObjectLifetimeEntry(hitObject);
+
+            protected override PassThroughInputManager CreateInputManager() => new PassThroughInputManager();
+
+            protected override Playfield CreatePlayfield() => new TestPlayfield();
+
+            private class TestHitObjectLifetimeEntry : HitObjectLifetimeEntry
+            {
+                public TestHitObjectLifetimeEntry(HitObject hitObject)
+                    : base(hitObject)
+                {
+                }
+
+                protected override double InitialLifetimeOffset => 0;
+            }
+        }
+
+        private class TestPlayfield : Playfield
+        {
+            public TestPlayfield()
+            {
+                AddInternal(HitObjectContainer);
+            }
+
+            protected override GameplayCursorContainer CreateCursor() => null;
+        }
+
+        private class TestBeatmapConverter : BeatmapConverter<TestHitObject>
+        {
+            public TestBeatmapConverter(IBeatmap beatmap, Ruleset ruleset)
+                : base(beatmap, ruleset)
+            {
+            }
+
+            public override bool CanConvert() => true;
+
+            protected override IEnumerable<TestHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
+            {
+                yield return new TestHitObject
+                {
+                    StartTime = original.StartTime,
+                    Duration = 250
+                };
+            }
+        }
+
+        #endregion
+
+        #region HitObject
+
+        private class TestHitObject : ConvertHitObject
+        {
+            public double EndTime => StartTime + Duration;
+
+            public double Duration { get; set; }
+        }
+
+        private class DrawableTestHitObject : DrawableHitObject<TestHitObject>
+        {
+            public DrawableTestHitObject()
+                : base(null)
+            {
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                Position = new Vector2(RNG.Next(-200, 200), RNG.Next(-200, 200));
+                Size = new Vector2(50, 50);
+
+                Colour = new Color4(RNG.NextSingle(), RNG.NextSingle(), RNG.NextSingle(), 1f);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                AddInternal(new Circle
+                {
+                    RelativeSizeAxes = Axes.Both,
+                });
+            }
+
+            protected override void CheckForResult(bool userTriggered, double timeOffset)
+            {
+                if (timeOffset > HitObject.Duration)
+                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
+            }
+
+            protected override void UpdateHitStateTransforms(ArmedState state)
+            {
+                base.UpdateHitStateTransforms(state);
+
+                switch (state)
+                {
+                    case ArmedState.Hit:
+                    case ArmedState.Miss:
+                        this.FadeOut(250);
+                        break;
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
@@ -142,6 +142,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             protected override HitObjectLifetimeEntry CreateLifetimeEntry(TestHitObject hitObject) => new TestHitObjectLifetimeEntry(hitObject);
 
+            public override DrawableHitObject<TestHitObject> CreateDrawableRepresentation(TestHitObject h) => null;
+
             protected override PassThroughInputManager CreateInputManager() => new PassThroughInputManager();
 
             protected override Playfield CreatePlayfield() => new TestPlayfield();

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
@@ -140,8 +140,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                 RegisterPool<TestHitObject, DrawableTestHitObject>(PoolSize);
             }
 
-            protected override bool PoolHitObjects => true;
-
             protected override HitObjectLifetimeEntry CreateLifetimeEntry(TestHitObject hitObject) => new TestHitObjectLifetimeEntry(hitObject);
 
             protected override PassThroughInputManager CreateInputManager() => new PassThroughInputManager();

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </remarks>
         protected virtual float SamplePlaybackPosition => 0.5f;
 
-        private readonly Bindable<double> startTimeBindable = new Bindable<double>();
+        public readonly Bindable<double> StartTimeBindable = new Bindable<double>();
         private readonly BindableList<HitSampleInfo> samplesBindable = new BindableList<HitSampleInfo>();
         private readonly Bindable<bool> userPositionalHitSounds = new Bindable<bool>();
         private readonly Bindable<int> comboIndexBindable = new Bindable<int>();
@@ -156,7 +156,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             base.LoadComplete();
 
-            startTimeBindable.BindValueChanged(_ => updateState(State.Value, true));
+            StartTimeBindable.BindValueChanged(_ => updateState(State.Value, true));
             comboIndexBindable.BindValueChanged(_ => updateComboColour(), true);
 
             updateState(ArmedState.Idle, true);
@@ -205,7 +205,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
                 AddNestedHitObject(drawableNested);
             }
 
-            startTimeBindable.BindTo(HitObject.StartTimeBindable);
+            StartTimeBindable.BindTo(HitObject.StartTimeBindable);
             if (HitObject is IHasComboInformation combo)
                 comboIndexBindable.BindTo(combo.ComboIndexBindable);
 
@@ -231,7 +231,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             if (!hasHitObjectApplied)
                 return;
 
-            startTimeBindable.UnbindFrom(HitObject.StartTimeBindable);
+            StartTimeBindable.UnbindFrom(HitObject.StartTimeBindable);
             if (HitObject is IHasComboInformation combo)
                 comboIndexBindable.UnbindFrom(combo.ComboIndexBindable);
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -259,6 +259,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             OnFree(HitObject);
 
             HitObject = null;
+            lifetimeEntry = null;
+
             hasHitObjectApplied = false;
         }
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -613,13 +613,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// The time at which state transforms should be applied that line up to <see cref="HitObject"/>'s StartTime.
         /// This is used to offset calls to <see cref="UpdateStateTransforms"/>.
         /// </summary>
-        public double StateUpdateTime => HitObject.StartTime;
+        public double StateUpdateTime => HitObject?.StartTime ?? 0;
 
         /// <summary>
         /// The time at which judgement dependent state transforms should be applied. This is equivalent of the (end) time of the object, in addition to any judgement offset.
         /// This is used to offset calls to <see cref="UpdateHitStateTransforms"/>.
         /// </summary>
-        public double HitStateUpdateTime => Result?.TimeAbsolute ?? HitObject.GetEndTime();
+        public double HitStateUpdateTime => Result?.TimeAbsolute ?? HitObject?.GetEndTime() ?? 0;
 
         /// <summary>
         /// Will be called at least once after this <see cref="DrawableHitObject"/> has become not alive.

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -613,13 +613,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// The time at which state transforms should be applied that line up to <see cref="HitObject"/>'s StartTime.
         /// This is used to offset calls to <see cref="UpdateStateTransforms"/>.
         /// </summary>
-        public double StateUpdateTime => HitObject?.StartTime ?? 0;
+        public double StateUpdateTime => HitObject.StartTime;
 
         /// <summary>
         /// The time at which judgement dependent state transforms should be applied. This is equivalent of the (end) time of the object, in addition to any judgement offset.
         /// This is used to offset calls to <see cref="UpdateHitStateTransforms"/>.
         /// </summary>
-        public double HitStateUpdateTime => Result?.TimeAbsolute ?? HitObject?.GetEndTime() ?? 0;
+        public double HitStateUpdateTime => Result?.TimeAbsolute ?? HitObject.GetEndTime();
 
         /// <summary>
         /// Will be called at least once after this <see cref="DrawableHitObject"/> has become not alive.

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
@@ -126,6 +127,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         [CanBeNull]
         private HitObjectLifetimeEntry lifetimeEntry;
 
+        private Container<PausableSkinnableSound> samplesContainer;
+
         /// <summary>
         /// Creates a new <see cref="DrawableHitObject"/>.
         /// </summary>
@@ -142,6 +145,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
         private void load(OsuConfigManager config)
         {
             config.BindWith(OsuSetting.PositionalHitSounds, userPositionalHitSounds);
+
+            // Explicit non-virtual function call.
+            base.AddInternal(samplesContainer = new Container<PausableSkinnableSound> { RelativeSizeAxes = Axes.Both });
         }
 
         protected override void LoadAsyncComplete()
@@ -296,11 +302,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </summary>
         protected virtual void LoadSamples()
         {
-            if (Samples != null)
-            {
-                RemoveInternal(Samples);
-                Samples = null;
-            }
+            samplesContainer.Clear();
+            Samples = null;
 
             var samples = GetSamples().ToArray();
 
@@ -313,8 +316,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
                                                     + $" This is an indication that {nameof(HitObject.ApplyDefaults)} has not been invoked on {this}.");
             }
 
-            Samples = new PausableSkinnableSound(samples.Select(s => HitObject.SampleControlPoint.ApplyTo(s)));
-            AddInternal(Samples);
+            samplesContainer.Add(Samples = new PausableSkinnableSound(samples.Select(s => HitObject.SampleControlPoint.ApplyTo(s))));
         }
 
         private void onSamplesChanged(object sender, NotifyCollectionChangedEventArgs e) => LoadSamples();

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -170,7 +170,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             base.LoadComplete();
 
-            StartTimeBindable.BindValueChanged(_ => updateState(State.Value, true));
             comboIndexBindable.BindValueChanged(_ => updateComboColour(), true);
 
             updateState(ArmedState.Idle, true);
@@ -220,6 +219,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             StartTimeBindable.BindTo(HitObject.StartTimeBindable);
+            StartTimeBindable.BindValueChanged(onStartTimeChanged);
+
             if (HitObject is IHasComboInformation combo)
                 comboIndexBindable.BindTo(combo.ComboIndexBindable);
 
@@ -249,8 +250,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
             StartTimeBindable.UnbindFrom(HitObject.StartTimeBindable);
             if (HitObject is IHasComboInformation combo)
                 comboIndexBindable.UnbindFrom(combo.ComboIndexBindable);
-
             samplesBindable.UnbindFrom(HitObject.SamplesBindable);
+
+            // Changes in start time trigger state updates. When a new hitobject is applied, OnApply() automatically performs a state update anyway.
+            StartTimeBindable.ValueChanged -= onStartTimeChanged;
 
             // When a new hitobject is applied, the samples will be cleared before re-populating.
             // In order to stop this needless update, the event is unbound and re-bound as late as possible in Apply().
@@ -329,6 +332,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         }
 
         private void onSamplesChanged(object sender, NotifyCollectionChangedEventArgs e) => LoadSamples();
+
+        private void onStartTimeChanged(ValueChangedEvent<double> startTime) => updateState(State.Value, true);
 
         private void onNewResult(DrawableHitObject drawableHitObject, JudgementResult result) => OnNewResult?.Invoke(drawableHitObject, result);
 

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -1,0 +1,98 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Performance;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Objects
+{
+    /// <summary>
+    /// A <see cref="LifetimeEntry"/> that stores the lifetime for a <see cref="HitObject"/>.
+    /// </summary>
+    public class HitObjectLifetimeEntry : LifetimeEntry
+    {
+        /// <summary>
+        /// The <see cref="HitObject"/>.
+        /// </summary>
+        public readonly HitObject HitObject;
+
+        /// <summary>
+        /// Creates a new <see cref="HitObjectLifetimeEntry"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to store the lifetime of.</param>
+        public HitObjectLifetimeEntry(HitObject hitObject)
+        {
+            HitObject = hitObject;
+            ResetLifetimeStart();
+        }
+
+        // The lifetime start, as set by the hitobject.
+        private double realLifetimeStart = double.MinValue;
+
+        /// <summary>
+        /// The time at which the <see cref="HitObject"/> should become alive.
+        /// </summary>
+        public new double LifetimeStart
+        {
+            get => realLifetimeStart;
+            set => setLifetime(realLifetimeStart = value, LifetimeEnd);
+        }
+
+        // The lifetime end, as set by the hitobject.
+        private double realLifetimeEnd = double.MaxValue;
+
+        /// <summary>
+        /// The time at which the <see cref="HitObject"/> should become dead.
+        /// </summary>
+        public new double LifetimeEnd
+        {
+            get => realLifetimeEnd;
+            set => setLifetime(LifetimeStart, realLifetimeEnd = value);
+        }
+
+        private void setLifetime(double start, double end)
+        {
+            if (keepAlive)
+            {
+                start = double.MinValue;
+                end = double.MaxValue;
+            }
+
+            base.LifetimeStart = start;
+            base.LifetimeEnd = end;
+        }
+
+        private bool keepAlive;
+
+        /// <summary>
+        /// Whether the <see cref="HitObject"/> should be kept always alive.
+        /// </summary>
+        internal bool KeepAlive
+        {
+            set
+            {
+                if (keepAlive == value)
+                    return;
+
+                keepAlive = value;
+                setLifetime(realLifetimeStart, realLifetimeEnd);
+            }
+        }
+
+        /// <summary>
+        /// A safe offset prior to the start time of <see cref="HitObject"/> at which it may begin displaying contents.
+        /// By default, <see cref="HitObject"/>s are assumed to display their contents within 10 seconds prior to their start time.
+        /// </summary>
+        /// <remarks>
+        /// This is only used as an optimisation to delay the initial update of the <see cref="HitObject"/> and may be tuned more aggressively if required.
+        /// It is indirectly used to decide the automatic transform offset provided to <see cref="DrawableHitObject.UpdateInitialTransforms"/>.
+        /// A more accurate <see cref="LifetimeStart"/> should be set for further optimisation (in <see cref="DrawableHitObject.LoadComplete"/>, for example).
+        /// </remarks>
+        protected virtual double InitialLifetimeOffset => 10000;
+
+        /// <summary>
+        /// Resets <see cref="LifetimeStart"/> according to the start time of the <see cref="HitObject"/>.
+        /// </summary>
+        internal void ResetLifetimeStart() => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
+    }
+}

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Performance;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Objects
@@ -17,13 +19,23 @@ namespace osu.Game.Rulesets.Objects
         public readonly HitObject HitObject;
 
         /// <summary>
+        /// The result that <see cref="HitObject"/> was judged with.
+        /// This is set by the accompanying <see cref="DrawableHitObject"/>, and reused when required for rewinding.
+        /// </summary>
+        internal JudgementResult Result;
+
+        private readonly IBindable<double> startTimeBindable = new BindableDouble();
+
+        /// <summary>
         /// Creates a new <see cref="HitObjectLifetimeEntry"/>.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> to store the lifetime of.</param>
         public HitObjectLifetimeEntry(HitObject hitObject)
         {
             HitObject = hitObject;
-            ResetLifetimeStart();
+
+            startTimeBindable.BindTo(HitObject.StartTimeBindable);
+            startTimeBindable.BindValueChanged(onStartTimeChanged, true);
         }
 
         // The lifetime start, as set by the hitobject.
@@ -91,8 +103,8 @@ namespace osu.Game.Rulesets.Objects
         protected virtual double InitialLifetimeOffset => 10000;
 
         /// <summary>
-        /// Resets <see cref="LifetimeStart"/> according to the start time of the <see cref="HitObject"/>.
+        /// Resets <see cref="LifetimeStart"/> according to the change in start time of the <see cref="HitObject"/>.
         /// </summary>
-        internal void ResetLifetimeStart() => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
+        private void onStartTimeChanged(ValueChangedEvent<double> startTime) => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
     }
 }

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -559,23 +559,22 @@ namespace osu.Game.Rulesets.UI
         protected void RegisterPool<TObject, TDrawable>(int initialSize, int? maximumSize = null)
             where TObject : HitObject
             where TDrawable : DrawableHitObject, new()
+            => RegisterPool<TObject, TDrawable>(new DrawablePool<TDrawable>(initialSize, maximumSize));
+
+        /// <summary>
+        /// Registers a <see cref="DrawableHitObject"/> pool with this <see cref="DrawableRuleset"/> which is to be used whenever
+        /// <see cref="DrawableHitObject"/> representations are requested for the given <typeparamref name="TObject"/> type (via <see cref="GetPooledDrawableRepresentation"/>).
+        /// </summary>
+        /// <param name="pool">The <see cref="DrawablePool{T}"/> to register.</param>
+        /// <typeparam name="TObject">The <see cref="HitObject"/> type.</typeparam>
+        /// <typeparam name="TDrawable">The <see cref="DrawableHitObject"/> receiver for <typeparamref name="TObject"/>s.</typeparam>
+        protected void RegisterPool<TObject, TDrawable>([NotNull] DrawablePool<TDrawable> pool)
+            where TObject : HitObject
+            where TDrawable : DrawableHitObject, new()
         {
-            var pool = CreatePool<TDrawable>(initialSize, maximumSize);
             pools[typeof(TObject)] = pool;
             AddInternal(pool);
         }
-
-        /// <summary>
-        /// Creates the <see cref="DrawablePool{T}"/> to retrieve <see cref="DrawableHitObject"/>s of the given type from.
-        /// </summary>
-        /// <param name="initialSize">The number of hitobject to be prepared for initial consumption.</param>
-        /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
-        /// <typeparam name="TDrawable">The type of <see cref="DrawableHitObject"/> retrievable from this pool.</typeparam>
-        /// <returns>The <see cref="DrawablePool{T}"/>.</returns>
-        [NotNull]
-        protected virtual DrawablePool<TDrawable> CreatePool<TDrawable>(int initialSize, int? maximumSize = null)
-            where TDrawable : DrawableHitObject, new()
-            => new DrawablePool<TDrawable>(initialSize, maximumSize);
 
         /// <summary>
         /// Attempts to retrieve the poolable <see cref="DrawableHitObject"/> representation of a <see cref="HitObject"/>.

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -526,6 +526,9 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         public abstract void CancelResume();
 
+        private readonly Dictionary<Type, IDrawablePool> pools = new Dictionary<Type, IDrawablePool>();
+        private readonly Dictionary<HitObject, HitObjectLifetimeEntry> lifetimeEntries = new Dictionary<HitObject, HitObjectLifetimeEntry>();
+
         /// <summary>
         /// Whether this <see cref="DrawableRuleset"/> should retrieve pooled <see cref="DrawableHitObject"/>s.
         /// </summary>
@@ -534,8 +537,14 @@ namespace osu.Game.Rulesets.UI
         /// </remarks>
         protected virtual bool PoolHitObjects => false;
 
-        private readonly Dictionary<Type, IDrawablePool> pools = new Dictionary<Type, IDrawablePool>();
-
+        /// <summary>
+        /// Registers a <see cref="DrawableHitObject"/> pool with this <see cref="DrawableRuleset"/> which is to be used whenever
+        /// <see cref="DrawableHitObject"/> representations are requested for the given <typeparamref name="TObject"/> type (via <see cref="GetDrawableRepresentation"/>).
+        /// </summary>
+        /// <param name="initialSize">The number of drawables to be prepared for initial consumption.</param>
+        /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
+        /// <typeparam name="TObject">The <see cref="HitObject"/> type.</typeparam>
+        /// <typeparam name="TDrawable">The <see cref="DrawableHitObject"/> receiver for <typeparamref name="TObject"/>s.</typeparam>
         protected void RegisterPool<TObject, TDrawable>(int initialSize, int? maximumSize = null)
             where TObject : HitObject
             where TDrawable : DrawableHitObject, new()
@@ -582,10 +591,21 @@ namespace osu.Game.Rulesets.UI
             });
         }
 
+        /// <summary>
+        /// Creates the <see cref="HitObjectLifetimeEntry"/> for a given <see cref="HitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// This may be overridden to provide custom lifetime control (e.g. via <see cref="HitObjectLifetimeEntry.InitialLifetimeOffset"/>.
+        /// </remarks>
+        /// <param name="hitObject">The <see cref="HitObject"/> to create the entry for.</param>
+        /// <returns>The <see cref="HitObjectLifetimeEntry"/>.</returns>
         protected abstract HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject);
 
-        private readonly Dictionary<HitObject, HitObjectLifetimeEntry> lifetimeEntries = new Dictionary<HitObject, HitObjectLifetimeEntry>();
-
+        /// <summary>
+        /// Retrieves or creates the <see cref="HitObjectLifetimeEntry"/> for a given <see cref="HitObject"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to retrieve or create the <see cref="HitObjectLifetimeEntry"/> for.</param>
+        /// <returns>The <see cref="HitObjectLifetimeEntry"/> for <paramref name="hitObject"/>.</returns>
         protected HitObjectLifetimeEntry GetLifetimeEntry(HitObject hitObject)
         {
             if (lifetimeEntries.TryGetValue(hitObject, out var entry))

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -383,6 +383,7 @@ namespace osu.Game.Rulesets.UI
     /// Once IDrawable is a thing, this can also become an interface.
     /// </remarks>
     /// </summary>
+    [Cached(typeof(DrawableRuleset))]
     public abstract class DrawableRuleset : CompositeDrawable
     {
         /// <summary>

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -314,9 +314,6 @@ namespace osu.Game.Rulesets.UI
             }
         }
 
-        public sealed override DrawableHitObject GetDrawableRepresentation(HitObject hitObject)
-            => base.GetDrawableRepresentation(hitObject) ?? CreateDrawableRepresentation((TObject)hitObject);
-
         /// <summary>
         /// Creates a DrawableHitObject from a HitObject.
         /// </summary>
@@ -552,7 +549,7 @@ namespace osu.Game.Rulesets.UI
 
         /// <summary>
         /// Registers a <see cref="DrawableHitObject"/> pool with this <see cref="DrawableRuleset"/> which is to be used whenever
-        /// <see cref="DrawableHitObject"/> representations are requested for the given <typeparamref name="TObject"/> type (via <see cref="GetDrawableRepresentation"/>).
+        /// <see cref="DrawableHitObject"/> representations are requested for the given <typeparamref name="TObject"/> type (via <see cref="GetPooledDrawableRepresentation"/>).
         /// </summary>
         /// <param name="initialSize">The number of drawables to be prepared for initial consumption.</param>
         /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
@@ -574,16 +571,18 @@ namespace osu.Game.Rulesets.UI
         /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
         /// <typeparam name="TDrawable">The type of <see cref="DrawableHitObject"/> retrievable from this pool.</typeparam>
         /// <returns>The <see cref="DrawablePool{T}"/>.</returns>
+        [NotNull]
         protected virtual DrawablePool<TDrawable> CreatePool<TDrawable>(int initialSize, int? maximumSize = null)
             where TDrawable : DrawableHitObject, new()
             => new DrawablePool<TDrawable>(initialSize, maximumSize);
 
         /// <summary>
-        /// Retrieves the drawable representation of a <see cref="HitObject"/>.
+        /// Attempts to retrieve the poolable <see cref="DrawableHitObject"/> representation of a <see cref="HitObject"/>.
         /// </summary>
-        /// <param name="hitObject">The <see cref="HitObject"/> to retrieve the drawable representation of.</param>
-        /// <returns>The <see cref="DrawableHitObject"/> representing <see cref="HitObject"/>.</returns>
-        public virtual DrawableHitObject GetDrawableRepresentation(HitObject hitObject)
+        /// <param name="hitObject">The <see cref="HitObject"/> to retrieve the <see cref="DrawableHitObject"/> representation of.</param>
+        /// <returns>The <see cref="DrawableHitObject"/> representing <see cref="HitObject"/>, or <c>null</c> if no poolable representation exists.</returns>
+        [CanBeNull]
+        public DrawableHitObject GetPooledDrawableRepresentation([NotNull] HitObject hitObject)
         {
             if (!pools.TryGetValue(hitObject.GetType(), out var pool))
                 return null;
@@ -612,14 +611,16 @@ namespace osu.Game.Rulesets.UI
         /// </remarks>
         /// <param name="hitObject">The <see cref="HitObject"/> to create the entry for.</param>
         /// <returns>The <see cref="HitObjectLifetimeEntry"/>.</returns>
-        protected abstract HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject);
+        [NotNull]
+        protected abstract HitObjectLifetimeEntry CreateLifetimeEntry([NotNull] HitObject hitObject);
 
         /// <summary>
         /// Retrieves or creates the <see cref="HitObjectLifetimeEntry"/> for a given <see cref="HitObject"/>.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> to retrieve or create the <see cref="HitObjectLifetimeEntry"/> for.</param>
         /// <returns>The <see cref="HitObjectLifetimeEntry"/> for <paramref name="hitObject"/>.</returns>
-        protected HitObjectLifetimeEntry GetLifetimeEntry(HitObject hitObject)
+        [NotNull]
+        protected HitObjectLifetimeEntry GetLifetimeEntry([NotNull] HitObject hitObject)
         {
             if (lifetimeEntries.TryGetValue(hitObject, out var entry))
                 return entry;

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -549,11 +549,15 @@ namespace osu.Game.Rulesets.UI
         private readonly Dictionary<HitObject, HitObjectLifetimeEntry> lifetimeEntries = new Dictionary<HitObject, HitObjectLifetimeEntry>();
 
         /// <summary>
-        /// Registers a <see cref="DrawableHitObject"/> pool with this <see cref="DrawableRuleset"/> which is to be used whenever
+        /// Registers a default <see cref="DrawableHitObject"/> pool with this <see cref="DrawableRuleset"/> which is to be used whenever
         /// <see cref="DrawableHitObject"/> representations are requested for the given <typeparamref name="TObject"/> type (via <see cref="GetPooledDrawableRepresentation"/>).
         /// </summary>
-        /// <param name="initialSize">The number of drawables to be prepared for initial consumption.</param>
-        /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
+        /// <param name="initialSize">The number of <see cref="DrawableHitObject"/>s to be initially stored in the pool.</param>
+        /// <param name="maximumSize">
+        /// The maximum number of <see cref="DrawableHitObject"/>s that can be stored in the pool.
+        /// If this limit is exceeded, every subsequent <see cref="DrawableHitObject"/> will be created anew instead of being retrieved from the pool,
+        /// until some of the existing <see cref="DrawableHitObject"/>s are returned to the pool.
+        /// </param>
         /// <typeparam name="TObject">The <see cref="HitObject"/> type.</typeparam>
         /// <typeparam name="TDrawable">The <see cref="DrawableHitObject"/> receiver for <typeparamref name="TObject"/>s.</typeparam>
         protected void RegisterPool<TObject, TDrawable>(int initialSize, int? maximumSize = null)
@@ -562,7 +566,7 @@ namespace osu.Game.Rulesets.UI
             => RegisterPool<TObject, TDrawable>(new DrawablePool<TDrawable>(initialSize, maximumSize));
 
         /// <summary>
-        /// Registers a <see cref="DrawableHitObject"/> pool with this <see cref="DrawableRuleset"/> which is to be used whenever
+        /// Registers a custom <see cref="DrawableHitObject"/> pool with this <see cref="DrawableRuleset"/> which is to be used whenever
         /// <see cref="DrawableHitObject"/> representations are requested for the given <typeparamref name="TObject"/> type (via <see cref="GetPooledDrawableRepresentation"/>).
         /// </summary>
         /// <param name="pool">The <see cref="DrawablePool{T}"/> to register.</param>

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -233,6 +233,13 @@ namespace osu.Game.Rulesets.UI
             ResumeOverlay?.Hide();
         }
 
+        /// <summary>
+        /// Adds a <see cref="HitObject"/> to this <see cref="DrawableRuleset"/>.
+        /// </summary>
+        /// <remarks>
+        /// This does not add the <see cref="HitObject"/> to the beatmap.
+        /// </remarks>
+        /// <param name="hitObject">The <see cref="HitObject"/> to add.</param>
         public void AddHitObject(TObject hitObject)
         {
             if (PoolHitObjects)
@@ -241,6 +248,13 @@ namespace osu.Game.Rulesets.UI
                 Playfield.Add(CreateDrawableRepresentation(hitObject));
         }
 
+        /// <summary>
+        /// Removes a <see cref="HitObject"/> from this <see cref="HitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// This does not remove the <see cref="HitObject"/> from the beatmap.
+        /// </remarks>
+        /// <param name="hitObject">The <see cref="HitObject"/> to remove.</param>
         public void RemoveHitObject(TObject hitObject)
         {
             if (PoolHitObjects)
@@ -380,7 +394,6 @@ namespace osu.Game.Rulesets.UI
     /// Displays an interactive ruleset gameplay instance.
     /// <remarks>
     /// This type is required only for adding non-generic type to the draw hierarchy.
-    /// Once IDrawable is a thing, this can also become an interface.
     /// </remarks>
     /// </summary>
     [Cached(typeof(DrawableRuleset))]

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -324,11 +324,16 @@ namespace osu.Game.Rulesets.UI
         }
 
         /// <summary>
-        /// Creates a DrawableHitObject from a HitObject.
+        /// Creates a <see cref="DrawableHitObject{TObject}"/> to represent a <see cref="HitObject"/>.
         /// </summary>
-        /// <param name="h">The HitObject to make drawable.</param>
-        /// <returns>The DrawableHitObject.</returns>
-        public virtual DrawableHitObject<TObject> CreateDrawableRepresentation(TObject h) => null;
+        /// <remarks>
+        /// If this method returns <c>null</c>, then this <see cref="DrawableRuleset"/> will assume the requested <see cref="HitObject"/> type is being pooled,
+        /// and will instead attempt to retrieve the <see cref="DrawableHitObject"/>s at the point they should become alive via pools registered through
+        /// <see cref="DrawableRuleset.RegisterPool{TObject, TDrawable}(int, int?)"/> or  <see cref="DrawableRuleset.RegisterPool{TObject, TDrawable}(DrawablePool{TDrawable})"/>.
+        /// </remarks>
+        /// <param name="h">The <see cref="HitObject"/> to represent.</param>
+        /// <returns>The representing <see cref="DrawableHitObject{TObject}"/>.</returns>
+        public abstract DrawableHitObject<TObject> CreateDrawableRepresentation(TObject h);
 
         public void Attach(KeyCounterDisplay keyCounter) =>
             (KeyBindingInputManager as ICanAttachKeyCounter)?.Attach(keyCounter);

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Performance;
@@ -71,6 +72,9 @@ namespace osu.Game.Rulesets.UI
             Debug.Assert(!drawableMap.ContainsKey(entry));
 
             var drawable = drawableRuleset.GetPooledDrawableRepresentation(entry.HitObject);
+            if (drawable == null)
+                throw new InvalidOperationException($"A drawable representation could not be retrieved for hitobject type: {entry.HitObject.GetType().ReadableName()}.");
+
             drawable.OnNewResult += onNewResult;
             drawable.OnRevertResult += onRevertResult;
 

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -1,35 +1,132 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Performance;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.UI
 {
     public class HitObjectContainer : LifetimeManagementContainer
     {
-        public IEnumerable<DrawableHitObject> Objects => InternalChildren.Cast<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
-        public IEnumerable<DrawableHitObject> AliveObjects => AliveInternalChildren.Cast<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
+        /// <summary>
+        /// All currently in-use <see cref="DrawableHitObject"/>s.
+        /// </summary>
+        public IEnumerable<DrawableHitObject> Objects => InternalChildren.OfType<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
 
-        private readonly Dictionary<DrawableHitObject, (IBindable<double> bindable, double timeAtAdd)> startTimeMap = new Dictionary<DrawableHitObject, (IBindable<double>, double)>();
+        /// <summary>
+        /// All currently in-use <see cref="DrawableHitObject"/>s that are alive.
+        /// </summary>
+        /// <remarks>
+        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this is equivalent to <see cref="Objects"/>.
+        /// </remarks>
+        public IEnumerable<DrawableHitObject> AliveObjects => AliveInternalChildren.OfType<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
+
+        public event Action<DrawableHitObject, JudgementResult> NewResult;
+        public event Action<DrawableHitObject, JudgementResult> RevertResult;
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> becomes used by a <see cref="DrawableHitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become alive.
+        /// </remarks>
+        public event Action<HitObject> HitObjectUsageBegan;
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> becomes unused by a <see cref="DrawableHitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become dead.
+        /// </remarks>
+        public event Action<HitObject> HitObjectUsageFinished;
+
+        /// <summary>
+        /// The amount of time prior to the current time within which <see cref="HitObject"/>s should be considered alive.
+        /// </summary>
+        public double PastLifetimeExtension { get; set; }
+
+        /// <summary>
+        /// The amount of time after the current time within which <see cref="HitObject"/>s should be considered alive.
+        /// </summary>
+        public double FutureLifetimeExtension { get; set; }
+
+        private readonly Dictionary<DrawableHitObject, IBindable> startTimeMap = new Dictionary<DrawableHitObject, IBindable>();
+        private readonly Dictionary<HitObjectLifetimeEntry, DrawableHitObject> drawableMap = new Dictionary<HitObjectLifetimeEntry, DrawableHitObject>();
+        private readonly LifetimeEntryManager lifetimeManager = new LifetimeEntryManager();
+
+        [Resolved(CanBeNull = true)]
+        private DrawableRuleset drawableRuleset { get; set; }
 
         public HitObjectContainer()
         {
             RelativeSizeAxes = Axes.Both;
+
+            lifetimeManager.EntryBecameAlive += entryBecameAlive;
+            lifetimeManager.EntryBecameDead += entryBecameDead;
         }
+
+        #region Pooling support
+
+        public void Add(HitObjectLifetimeEntry entry) => lifetimeManager.AddEntry(entry);
+
+        public void Remove(HitObjectLifetimeEntry entry) => lifetimeManager.RemoveEntry(entry);
+
+        private void entryBecameAlive(LifetimeEntry entry) => addDrawable((HitObjectLifetimeEntry)entry);
+
+        private void entryBecameDead(LifetimeEntry entry) => removeDrawable((HitObjectLifetimeEntry)entry);
+
+        private void addDrawable(HitObjectLifetimeEntry entry)
+        {
+            Debug.Assert(!drawableMap.ContainsKey(entry));
+
+            var drawable = drawableRuleset.GetDrawableRepresentation(entry.HitObject);
+            drawable.OnNewResult += onNewResult;
+            drawable.OnRevertResult += onRevertResult;
+
+            bindStartTime(drawable);
+            AddInternal(drawableMap[entry] = drawable, false);
+
+            HitObjectUsageBegan?.Invoke(entry.HitObject);
+        }
+
+        private void removeDrawable(HitObjectLifetimeEntry entry)
+        {
+            Debug.Assert(drawableMap.ContainsKey(entry));
+
+            var drawable = drawableMap[entry];
+            drawable.OnNewResult -= onNewResult;
+            drawable.OnRevertResult -= onRevertResult;
+            drawable.OnKilled();
+
+            drawableMap.Remove(entry);
+
+            unbindStartTime(drawable);
+            RemoveInternal(drawable);
+
+            HitObjectUsageFinished?.Invoke(entry.HitObject);
+        }
+
+        #endregion
+
+        #region Non-pooling support
 
         public virtual void Add(DrawableHitObject hitObject)
         {
-            // Added first for the comparer to remain ordered during AddInternal
-            startTimeMap[hitObject] = (hitObject.HitObject.StartTimeBindable.GetBoundCopy(), hitObject.HitObject.StartTime);
-            startTimeMap[hitObject].bindable.BindValueChanged(_ => onStartTimeChanged(hitObject));
-
+            bindStartTime(hitObject);
             AddInternal(hitObject);
+
+            hitObject.OnNewResult += onNewResult;
+            hitObject.OnRevertResult += onRevertResult;
         }
 
         public virtual bool Remove(DrawableHitObject hitObject)
@@ -37,53 +134,15 @@ namespace osu.Game.Rulesets.UI
             if (!RemoveInternal(hitObject))
                 return false;
 
-            // Removed last for the comparer to remain ordered during RemoveInternal
-            startTimeMap[hitObject].bindable.UnbindAll();
-            startTimeMap.Remove(hitObject);
+            hitObject.OnNewResult -= onNewResult;
+            hitObject.OnRevertResult -= onRevertResult;
+
+            unbindStartTime(hitObject);
 
             return true;
         }
 
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-            unbindStartTimeMap();
-        }
-
-        public virtual void Clear(bool disposeChildren = true)
-        {
-            ClearInternal(disposeChildren);
-            unbindStartTimeMap();
-        }
-
-        private void unbindStartTimeMap()
-        {
-            foreach (var kvp in startTimeMap)
-                kvp.Value.bindable.UnbindAll();
-            startTimeMap.Clear();
-        }
-
         public int IndexOf(DrawableHitObject hitObject) => IndexOfInternal(hitObject);
-
-        private void onStartTimeChanged(DrawableHitObject hitObject)
-        {
-            if (!RemoveInternal(hitObject))
-                return;
-
-            // Update the stored time, preserving the existing bindable
-            startTimeMap[hitObject] = (startTimeMap[hitObject].bindable, hitObject.HitObject.StartTime);
-            AddInternal(hitObject);
-        }
-
-        protected override int Compare(Drawable x, Drawable y)
-        {
-            if (!(x is DrawableHitObject xObj) || !(y is DrawableHitObject yObj))
-                return base.Compare(x, y);
-
-            // Put earlier hitobjects towards the end of the list, so they handle input first
-            int i = startTimeMap[yObj].timeAtAdd.CompareTo(startTimeMap[xObj].timeAtAdd);
-            return i == 0 ? CompareReverseChildID(x, y) : i;
-        }
 
         protected override void OnChildLifetimeBoundaryCrossed(LifetimeBoundaryCrossedEvent e)
         {
@@ -95,6 +154,62 @@ namespace osu.Game.Rulesets.UI
             {
                 hitObject.OnKilled();
             }
+        }
+
+        #endregion
+
+        public virtual void Clear(bool disposeChildren = true)
+        {
+            lifetimeManager.ClearEntries();
+
+            ClearInternal(disposeChildren);
+            unbindAllStartTimes();
+        }
+
+        protected override bool CheckChildrenLife() => base.CheckChildrenLife() | lifetimeManager.Update(Time.Current - PastLifetimeExtension, Time.Current + FutureLifetimeExtension);
+
+        private void onNewResult(DrawableHitObject d, JudgementResult r) => NewResult?.Invoke(d, r);
+        private void onRevertResult(DrawableHitObject d, JudgementResult r) => RevertResult?.Invoke(d, r);
+
+        #region Comparator + StartTime tracking
+
+        private void bindStartTime(DrawableHitObject hitObject)
+        {
+            var bindable = hitObject.StartTimeBindable.GetBoundCopy();
+            bindable.BindValueChanged(_ => SortInternal());
+
+            startTimeMap[hitObject] = bindable;
+        }
+
+        private void unbindStartTime(DrawableHitObject hitObject)
+        {
+            startTimeMap[hitObject].UnbindAll();
+            startTimeMap.Remove(hitObject);
+        }
+
+        private void unbindAllStartTimes()
+        {
+            foreach (var kvp in startTimeMap)
+                kvp.Value.UnbindAll();
+            startTimeMap.Clear();
+        }
+
+        protected override int Compare(Drawable x, Drawable y)
+        {
+            if (!(x is DrawableHitObject xObj) || !(y is DrawableHitObject yObj))
+                return base.Compare(x, y);
+
+            // Put earlier hitobjects towards the end of the list, so they handle input first
+            int i = yObj.HitObject.StartTime.CompareTo(xObj.HitObject.StartTime);
+            return i == 0 ? CompareReverseChildID(x, y) : i;
+        }
+
+        #endregion
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            unbindAllStartTimes();
         }
     }
 }

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.UI
         {
             Debug.Assert(!drawableMap.ContainsKey(entry));
 
-            var drawable = drawableRuleset.GetDrawableRepresentation(entry.HitObject);
+            var drawable = drawableRuleset.GetPooledDrawableRepresentation(entry.HitObject);
             drawable.OnNewResult += onNewResult;
             drawable.OnRevertResult += onRevertResult;
 

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -100,10 +100,11 @@ namespace osu.Game.Rulesets.UI
         public virtual void Add(DrawableHitObject hitObject)
         {
             bindStartTime(hitObject);
-            AddInternal(hitObject);
 
             hitObject.OnNewResult += onNewResult;
             hitObject.OnRevertResult += onRevertResult;
+
+            AddInternal(hitObject);
         }
 
         public virtual bool Remove(DrawableHitObject hitObject)
@@ -143,7 +144,12 @@ namespace osu.Game.Rulesets.UI
             unbindAllStartTimes();
         }
 
-        protected override bool CheckChildrenLife() => base.CheckChildrenLife() | lifetimeManager.Update(Time.Current, Time.Current);
+        protected override bool CheckChildrenLife()
+        {
+            bool aliveChanged = base.CheckChildrenLife();
+            aliveChanged |= lifetimeManager.Update(Time.Current, Time.Current);
+            return aliveChanged;
+        }
 
         private void onNewResult(DrawableHitObject d, JudgementResult r) => NewResult?.Invoke(d, r);
         private void onRevertResult(DrawableHitObject d, JudgementResult r) => RevertResult?.Invoke(d, r);

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -57,6 +57,14 @@ namespace osu.Game.Rulesets.UI
             lifetimeManager.EntryBecameDead += entryBecameDead;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // Application of hitobject during load() may have changed their start times, so ensure the correct sorting order.
+            SortInternal();
+        }
+
         #region Pooling support
 
         public void Add(HitObjectLifetimeEntry entry) => lifetimeManager.AddEntry(entry);
@@ -163,7 +171,12 @@ namespace osu.Game.Rulesets.UI
         private void bindStartTime(DrawableHitObject hitObject)
         {
             var bindable = hitObject.StartTimeBindable.GetBoundCopy();
-            bindable.BindValueChanged(_ => SortInternal());
+
+            bindable.BindValueChanged(_ =>
+            {
+                if (IsLoaded)
+                    SortInternal();
+            });
 
             startTimeMap[hitObject] = bindable;
         }

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -41,32 +41,6 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         public event Action<DrawableHitObject, JudgementResult> RevertResult;
 
-        /// <summary>
-        /// Invoked when a <see cref="HitObject"/> becomes used by a <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become alive.
-        /// </remarks>
-        public event Action<HitObject> HitObjectUsageBegan;
-
-        /// <summary>
-        /// Invoked when a <see cref="HitObject"/> becomes unused by a <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become dead.
-        /// </remarks>
-        public event Action<HitObject> HitObjectUsageFinished;
-
-        /// <summary>
-        /// The amount of time prior to the current time within which <see cref="HitObject"/>s should be considered alive.
-        /// </summary>
-        public double PastLifetimeExtension { get; set; }
-
-        /// <summary>
-        /// The amount of time after the current time within which <see cref="HitObject"/>s should be considered alive.
-        /// </summary>
-        public double FutureLifetimeExtension { get; set; }
-
         private readonly Dictionary<DrawableHitObject, IBindable> startTimeMap = new Dictionary<DrawableHitObject, IBindable>();
         private readonly Dictionary<HitObjectLifetimeEntry, DrawableHitObject> drawableMap = new Dictionary<HitObjectLifetimeEntry, DrawableHitObject>();
         private readonly LifetimeEntryManager lifetimeManager = new LifetimeEntryManager();
@@ -102,8 +76,6 @@ namespace osu.Game.Rulesets.UI
 
             bindStartTime(drawable);
             AddInternal(drawableMap[entry] = drawable, false);
-
-            HitObjectUsageBegan?.Invoke(entry.HitObject);
         }
 
         private void removeDrawable(HitObjectLifetimeEntry entry)
@@ -119,8 +91,6 @@ namespace osu.Game.Rulesets.UI
 
             unbindStartTime(drawable);
             RemoveInternal(drawable);
-
-            HitObjectUsageFinished?.Invoke(entry.HitObject);
         }
 
         #endregion
@@ -173,7 +143,7 @@ namespace osu.Game.Rulesets.UI
             unbindAllStartTimes();
         }
 
-        protected override bool CheckChildrenLife() => base.CheckChildrenLife() | lifetimeManager.Update(Time.Current - PastLifetimeExtension, Time.Current + FutureLifetimeExtension);
+        protected override bool CheckChildrenLife() => base.CheckChildrenLife() | lifetimeManager.Update(Time.Current, Time.Current);
 
         private void onNewResult(DrawableHitObject d, JudgementResult r) => NewResult?.Invoke(d, r);
         private void onRevertResult(DrawableHitObject d, JudgementResult r) => RevertResult?.Invoke(d, r);

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -57,11 +57,11 @@ namespace osu.Game.Rulesets.UI
             lifetimeManager.EntryBecameDead += entryBecameDead;
         }
 
-        protected override void LoadComplete()
+        protected override void LoadAsyncComplete()
         {
-            base.LoadComplete();
+            base.LoadAsyncComplete();
 
-            // Application of hitobject during load() may have changed their start times, so ensure the correct sorting order.
+            // Application of hitobjects during load() may have changed their start times, so ensure the correct sorting order.
             SortInternal();
         }
 
@@ -174,7 +174,7 @@ namespace osu.Game.Rulesets.UI
 
             bindable.BindValueChanged(_ =>
             {
-                if (IsLoaded)
+                if (LoadState >= LoadState.Ready)
                     SortInternal();
             });
 

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -31,7 +31,14 @@ namespace osu.Game.Rulesets.UI
         /// </remarks>
         public IEnumerable<DrawableHitObject> AliveObjects => AliveInternalChildren.OfType<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
 
+        /// <summary>
+        /// Invoked when a <see cref="DrawableHitObject"/> is judged.
+        /// </summary>
         public event Action<DrawableHitObject, JudgementResult> NewResult;
+
+        /// <summary>
+        /// Invoked when a <see cref="DrawableHitObject"/> judgement is reverted.
+        /// </summary>
         public event Action<DrawableHitObject, JudgementResult> RevertResult;
 
         /// <summary>
@@ -79,7 +86,7 @@ namespace osu.Game.Rulesets.UI
 
         public void Add(HitObjectLifetimeEntry entry) => lifetimeManager.AddEntry(entry);
 
-        public void Remove(HitObjectLifetimeEntry entry) => lifetimeManager.RemoveEntry(entry);
+        public bool Remove(HitObjectLifetimeEntry entry) => lifetimeManager.RemoveEntry(entry);
 
         private void entryBecameAlive(LifetimeEntry entry) => addDrawable((HitObjectLifetimeEntry)entry);
 

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// All currently in-use <see cref="DrawableHitObject"/>s.
         /// </summary>
-        public IEnumerable<DrawableHitObject> Objects => InternalChildren.OfType<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
+        public IEnumerable<DrawableHitObject> Objects => InternalChildren.Cast<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
 
         /// <summary>
         /// All currently in-use <see cref="DrawableHitObject"/>s that are alive.
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.UI
         /// <remarks>
         /// If this <see cref="HitObjectContainer"/> uses pooled objects, this is equivalent to <see cref="Objects"/>.
         /// </remarks>
-        public IEnumerable<DrawableHitObject> AliveObjects => AliveInternalChildren.OfType<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
+        public IEnumerable<DrawableHitObject> AliveObjects => AliveInternalChildren.Cast<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
 
         /// <summary>
         /// Invoked when a <see cref="DrawableHitObject"/> is judged.

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -120,10 +120,6 @@ namespace osu.Game.Rulesets.UI
         public virtual void Add(DrawableHitObject h)
         {
             HitObjectContainer.Add(h);
-
-            h.OnNewResult += (d, r) => NewResult?.Invoke(d, r);
-            h.OnRevertResult += (d, r) => RevertResult?.Invoke(d, r);
-
             OnHitObjectAdded(h.HitObject);
         }
 

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.UI
         /// Adds a <see cref="HitObjectLifetimeEntry"/> for a pooled <see cref="HitObject"/> to this <see cref="Playfield"/>.
         /// </summary>
         /// <param name="entry">The <see cref="HitObjectLifetimeEntry"/> controlling the lifetime of the <see cref="HitObject"/>.</param>
-        public void Add(HitObjectLifetimeEntry entry)
+        public virtual void Add(HitObjectLifetimeEntry entry)
         {
             HitObjectContainer.Add(entry);
             lifetimeEntryMap[entry.HitObject] = entry;
@@ -154,7 +154,7 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         /// <param name="entry">The <see cref="HitObjectLifetimeEntry"/> controlling the lifetime of the <see cref="HitObject"/>.</param>
         /// <returns>Whether the <see cref="HitObject"/> was successfully removed.</returns>
-        public bool Remove(HitObjectLifetimeEntry entry)
+        public virtual bool Remove(HitObjectLifetimeEntry entry)
         {
             if (lifetimeEntryMap.Remove(entry.HitObject))
             {

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -10,13 +10,41 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osuTK;
 
 namespace osu.Game.Rulesets.UI
 {
     public abstract class Playfield : CompositeDrawable
     {
+        /// <summary>
+        /// Invoked when a <see cref="DrawableHitObject"/> is judged.
+        /// </summary>
+        public event Action<DrawableHitObject, JudgementResult> NewResult;
+
+        /// <summary>
+        /// Invoked when a <see cref="DrawableHitObject"/> judgement is reverted.
+        /// </summary>
+        public event Action<DrawableHitObject, JudgementResult> RevertResult;
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> becomes used by a <see cref="DrawableHitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become alive.
+        /// </remarks>
+        public event Action<HitObject> HitObjectUsageBegan;
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> becomes unused by a <see cref="DrawableHitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become dead.
+        /// </remarks>
+        public event Action<HitObject> HitObjectUsageFinished;
+
         /// <summary>
         /// The <see cref="DrawableHitObject"/> contained in this Playfield.
         /// </summary>
@@ -72,7 +100,13 @@ namespace osu.Game.Rulesets.UI
         {
             RelativeSizeAxes = Axes.Both;
 
-            hitObjectContainerLazy = new Lazy<HitObjectContainer>(CreateHitObjectContainer);
+            hitObjectContainerLazy = new Lazy<HitObjectContainer>(() => CreateHitObjectContainer().With(h =>
+            {
+                h.NewResult += (d, r) => NewResult?.Invoke(d, r);
+                h.RevertResult += (d, r) => RevertResult?.Invoke(d, r);
+                h.HitObjectUsageBegan += o => HitObjectUsageBegan?.Invoke(o);
+                h.HitObjectUsageFinished += o => HitObjectUsageFinished?.Invoke(o);
+            }));
         }
 
         [Resolved(CanBeNull = true)]
@@ -101,13 +135,103 @@ namespace osu.Game.Rulesets.UI
         /// Adds a DrawableHitObject to this Playfield.
         /// </summary>
         /// <param name="h">The DrawableHitObject to add.</param>
-        public virtual void Add(DrawableHitObject h) => HitObjectContainer.Add(h);
+        public virtual void Add(DrawableHitObject h)
+        {
+            HitObjectContainer.Add(h);
+
+            h.OnNewResult += (d, r) => NewResult?.Invoke(d, r);
+            h.OnRevertResult += (d, r) => RevertResult?.Invoke(d, r);
+
+            OnHitObjectAdded(h.HitObject);
+        }
 
         /// <summary>
         /// Remove a DrawableHitObject from this Playfield.
         /// </summary>
         /// <param name="h">The DrawableHitObject to remove.</param>
-        public virtual bool Remove(DrawableHitObject h) => HitObjectContainer.Remove(h);
+        public virtual bool Remove(DrawableHitObject h)
+        {
+            if (!HitObjectContainer.Remove(h))
+                return false;
+
+            OnHitObjectRemoved(h.HitObject);
+            return false;
+        }
+
+        private readonly Dictionary<HitObject, HitObjectLifetimeEntry> lifetimeEntryMap = new Dictionary<HitObject, HitObjectLifetimeEntry>();
+
+        /// <summary>
+        /// Adds a <see cref="HitObject"/> to this <see cref="Playfield"/>.
+        /// </summary>
+        /// <param name="entry">The <see cref="HitObjectLifetimeEntry"/> controlling the lifetime of the <see cref="HitObject"/>.</param>
+        public void Add(HitObjectLifetimeEntry entry)
+        {
+            HitObjectContainer.Add(entry);
+            lifetimeEntryMap[entry.HitObject] = entry;
+            OnHitObjectAdded(entry.HitObject);
+        }
+
+        /// <summary>
+        /// Removes a <see cref="HitObject"/> to this <see cref="Playfield"/>.
+        /// </summary>
+        /// <param name="entry">The <see cref="HitObjectLifetimeEntry"/> controlling the lifetime of the <see cref="HitObject"/>.</param>
+        public void Remove(HitObjectLifetimeEntry entry)
+        {
+            if (HitObjectContainer.Remove(entry))
+                OnHitObjectRemoved(entry.HitObject);
+            lifetimeEntryMap.Remove(entry.HitObject);
+        }
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> is added to this <see cref="Playfield"/>.
+        /// </summary>
+        /// <param name="hitObject">The added <see cref="HitObject"/>.</param>
+        protected virtual void OnHitObjectAdded(HitObject hitObject)
+        {
+        }
+
+        /// <summary>
+        /// Invoked when a <see cref="HitObject"/> is removed from this <see cref="Playfield"/>.
+        /// </summary>
+        /// <param name="hitObject">The removed <see cref="HitObject"/>.</param>
+        protected virtual void OnHitObjectRemoved(HitObject hitObject)
+        {
+        }
+
+        /// <summary>
+        /// Sets whether to keep a given <see cref="HitObject"/> always alive within this or any nested <see cref="Playfield"/>.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> to set.</param>
+        /// <param name="keepAlive">Whether to keep <paramref name="hitObject"/> always alive.</param>
+        public void SetKeepAlive(HitObject hitObject, bool keepAlive)
+        {
+            if (lifetimeEntryMap.TryGetValue(hitObject, out var entry))
+            {
+                entry.KeepAlive = keepAlive;
+                return;
+            }
+
+            if (!nestedPlayfields.IsValueCreated)
+                return;
+
+            foreach (var p in nestedPlayfields.Value)
+                p.SetKeepAlive(hitObject, keepAlive);
+        }
+
+        /// <summary>
+        /// Keeps all <see cref="HitObject"/>s alive within this and all nested <see cref="Playfield"/>s.
+        /// </summary>
+        public void KeepAllAlive()
+        {
+            foreach (var (_, entry) in lifetimeEntryMap)
+                entry.KeepAlive = true;
+
+            if (!nestedPlayfields.IsValueCreated)
+                return;
+
+            foreach (var p in nestedPlayfields.Value)
+                p.KeepAllAlive();
+        }
 
         /// <summary>
         /// The cursor currently being used by this <see cref="Playfield"/>. May be null if no cursor is provided.
@@ -131,6 +255,12 @@ namespace osu.Game.Rulesets.UI
         protected void AddNested(Playfield otherPlayfield)
         {
             otherPlayfield.DisplayJudgements.BindTo(DisplayJudgements);
+
+            otherPlayfield.NewResult += (d, r) => NewResult?.Invoke(d, r);
+            otherPlayfield.RevertResult += (d, r) => RevertResult?.Invoke(d, r);
+            otherPlayfield.HitObjectUsageBegan += h => HitObjectUsageBegan?.Invoke(h);
+            otherPlayfield.HitObjectUsageFinished += h => HitObjectUsageFinished?.Invoke(h);
+
             nestedPlayfields.Value.Add(otherPlayfield);
         }
 

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -30,22 +30,6 @@ namespace osu.Game.Rulesets.UI
         public event Action<DrawableHitObject, JudgementResult> RevertResult;
 
         /// <summary>
-        /// Invoked when a <see cref="HitObject"/> becomes used by a <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become alive.
-        /// </remarks>
-        public event Action<HitObject> HitObjectUsageBegan;
-
-        /// <summary>
-        /// Invoked when a <see cref="HitObject"/> becomes unused by a <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <remarks>
-        /// If this <see cref="HitObjectContainer"/> uses pooled objects, this represents the time when the <see cref="HitObject"/>s become dead.
-        /// </remarks>
-        public event Action<HitObject> HitObjectUsageFinished;
-
-        /// <summary>
         /// The <see cref="DrawableHitObject"/> contained in this Playfield.
         /// </summary>
         public HitObjectContainer HitObjectContainer => hitObjectContainerLazy.Value;
@@ -104,8 +88,6 @@ namespace osu.Game.Rulesets.UI
             {
                 h.NewResult += (d, r) => NewResult?.Invoke(d, r);
                 h.RevertResult += (d, r) => RevertResult?.Invoke(d, r);
-                h.HitObjectUsageBegan += o => HitObjectUsageBegan?.Invoke(o);
-                h.HitObjectUsageFinished += o => HitObjectUsageFinished?.Invoke(o);
             }));
         }
 
@@ -199,41 +181,6 @@ namespace osu.Game.Rulesets.UI
         }
 
         /// <summary>
-        /// Sets whether to keep a given <see cref="HitObject"/> always alive within this or any nested <see cref="Playfield"/>.
-        /// </summary>
-        /// <param name="hitObject">The <see cref="HitObject"/> to set.</param>
-        /// <param name="keepAlive">Whether to keep <paramref name="hitObject"/> always alive.</param>
-        public void SetKeepAlive(HitObject hitObject, bool keepAlive)
-        {
-            if (lifetimeEntryMap.TryGetValue(hitObject, out var entry))
-            {
-                entry.KeepAlive = keepAlive;
-                return;
-            }
-
-            if (!nestedPlayfields.IsValueCreated)
-                return;
-
-            foreach (var p in nestedPlayfields.Value)
-                p.SetKeepAlive(hitObject, keepAlive);
-        }
-
-        /// <summary>
-        /// Keeps all <see cref="HitObject"/>s alive within this and all nested <see cref="Playfield"/>s.
-        /// </summary>
-        public void KeepAllAlive()
-        {
-            foreach (var (_, entry) in lifetimeEntryMap)
-                entry.KeepAlive = true;
-
-            if (!nestedPlayfields.IsValueCreated)
-                return;
-
-            foreach (var p in nestedPlayfields.Value)
-                p.KeepAllAlive();
-        }
-
-        /// <summary>
         /// The cursor currently being used by this <see cref="Playfield"/>. May be null if no cursor is provided.
         /// </summary>
         public GameplayCursorContainer Cursor { get; private set; }
@@ -258,8 +205,6 @@ namespace osu.Game.Rulesets.UI
 
             otherPlayfield.NewResult += (d, r) => NewResult?.Invoke(d, r);
             otherPlayfield.RevertResult += (d, r) => RevertResult?.Invoke(d, r);
-            otherPlayfield.HitObjectUsageBegan += h => HitObjectUsageBegan?.Invoke(h);
-            otherPlayfield.HitObjectUsageFinished += h => HitObjectUsageFinished?.Invoke(h);
 
             nestedPlayfields.Value.Add(otherPlayfield);
         }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -136,8 +136,6 @@ namespace osu.Game.Rulesets.UI
             return false;
         }
 
-        private readonly Dictionary<HitObject, HitObjectLifetimeEntry> lifetimeEntryMap = new Dictionary<HitObject, HitObjectLifetimeEntry>();
-
         /// <summary>
         /// Adds a <see cref="HitObjectLifetimeEntry"/> for a pooled <see cref="HitObject"/> to this <see cref="Playfield"/>.
         /// </summary>
@@ -145,7 +143,6 @@ namespace osu.Game.Rulesets.UI
         public virtual void Add(HitObjectLifetimeEntry entry)
         {
             HitObjectContainer.Add(entry);
-            lifetimeEntryMap[entry.HitObject] = entry;
             OnHitObjectAdded(entry.HitObject);
         }
 
@@ -156,9 +153,8 @@ namespace osu.Game.Rulesets.UI
         /// <returns>Whether the <see cref="HitObject"/> was successfully removed.</returns>
         public virtual bool Remove(HitObjectLifetimeEntry entry)
         {
-            if (lifetimeEntryMap.Remove(entry.HitObject))
+            if (HitObjectContainer.Remove(entry))
             {
-                HitObjectContainer.Remove(entry);
                 OnHitObjectRemoved(entry.HitObject);
                 return true;
             }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -159,6 +159,7 @@ namespace osu.Game.Rulesets.UI
             if (lifetimeEntryMap.Remove(entry.HitObject))
             {
                 HitObjectContainer.Remove(entry);
+                OnHitObjectRemoved(entry.HitObject);
                 return true;
             }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -261,14 +261,14 @@ namespace osu.Game.Screens.Play
             // bind clock into components that require it
             DrawableRuleset.IsPaused.BindTo(GameplayClockContainer.IsPaused);
 
-            DrawableRuleset.OnNewResult += r =>
+            DrawableRuleset.NewResult += r =>
             {
                 HealthProcessor.ApplyResult(r);
                 ScoreProcessor.ApplyResult(r);
                 gameplayBeatmap.ApplyResult(r);
             };
 
-            DrawableRuleset.OnRevertResult += r =>
+            DrawableRuleset.RevertResult += r =>
             {
                 HealthProcessor.RevertResult(r);
                 ScoreProcessor.RevertResult(r);


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/10796 (for the test to work)
- [x] https://github.com/ppy/osu/pull/10802

I won't be PRing the osu! changes until nested hitobject pooling + editor support is added as there would be quite a lot of allocations, but this branch has been implemented for osu! here: https://github.com/smoogipoo/osu/tree/osu-hitobject-pooling if you desire some early centipede-ing.

I've omitted a few things here from the full set of changes https://github.com/smoogipoo/osu/tree/hitobject-pooling, notable:
1. No lifetime extensions (removed in https://github.com/ppy/osu/commit/7d020181343f942159ae21df57b3ca8d07aad9f6)
2. No events for DHOs coming "in use" (or "current" in that branch above). (removed in https://github.com/ppy/osu/commit/7d020181343f942159ae21df57b3ca8d07aad9f6)
3. No editor support for keeping DHOs alive. (removed in https://github.com/ppy/osu/commit/7d020181343f942159ae21df57b3ca8d07aad9f6)
4. No editor/blueprint support whatsoever.