### PR TITLE
Add nested hitobject pooling

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -19,6 +19,7 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.UI;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Objects.Drawables
@@ -126,6 +127,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
         [CanBeNull]
         private HitObjectLifetimeEntry lifetimeEntry;
 
+        [Resolved(CanBeNull = true)]
+        private DrawableRuleset drawableRuleset { get; set; }
+
         /// <summary>
         /// Creates a new <see cref="DrawableHitObject"/>.
         /// </summary>
@@ -195,7 +199,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             foreach (var h in HitObject.NestedHitObjects)
             {
-                var drawableNested = CreateNestedHitObject(h) ?? throw new InvalidOperationException($"{nameof(CreateNestedHitObject)} returned null for {h.GetType().ReadableName()}.");
+                var drawableNested = drawableRuleset?.GetPooledDrawableRepresentation(h)
+                                     ?? CreateNestedHitObject(h)
+                                     ?? throw new InvalidOperationException($"{nameof(CreateNestedHitObject)} returned null for {h.GetType().ReadableName()}.");
 
                 drawableNested.OnNewResult += onNewResult;
                 drawableNested.OnRevertResult += onRevertResult;
@@ -203,6 +209,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
                 nestedHitObjects.Value.Add(drawableNested);
                 AddNestedHitObject(drawableNested);
+
+                drawableNested.OnParentReceived(this);
             }
 
             StartTimeBindable.BindTo(HitObject.StartTimeBindable);
@@ -288,6 +296,14 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </summary>
         /// <param name="hitObject">The currently-applied <see cref="HitObject"/>.</param>
         protected virtual void OnFree(HitObject hitObject)
+        {
+        }
+
+        /// <summary>
+        /// Invoked when this <see cref="DrawableHitObject"/> receives a new parenting <see cref="DrawableHitObject"/>.
+        /// </summary>
+        /// <param name="parent">The parenting <see cref="DrawableHitObject"/>.</param>
+        protected virtual void OnParentReceived(DrawableHitObject parent)
         {
         }
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/10797

`DrawableHitObject` looks up nested hitobjects via `DrawableRuleset.GetPooledDrawableRepresentation` first, before falling back to their own `CreateNestedHitObject` implementation. Note that it's still desirable to implement `CreateNestedHitObject` for testing purposes - in cases where there is no `DrawableRuleset` such as skinning tests, you would still want to have nested hitobjects.

When used, it also requires `ClearNestedHitObjects` to call `Clear(false)` instead of `Clear()` which is done in `DrawableSlider`/`DrawableSpinner`, etc - basically never dispose the poolable drawables. Maybe this is something we can address later framework-side...

Accepting suggestions for the `OnParentReceived` method... I don't really like the name `OnParentApplied` as an alternative since it can be confused with occurring _after_ a parent's `Apply()` but this is not the case. The order of calls is currently:
```
Parent.Apply()
Nested.Apply()
Nested.OnApply() (virtual)
Nested.OnParentReceived() (virtual)
Parent.OnApply() (virtual)
```