### PR TITLE
Prevent SelectionBox handles from appearing for stacks

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -21,12 +21,12 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             base.OnSelectionChanged();
 
-            bool canOperate = EditorBeatmap.SelectedHitObjects.Count > 1 || EditorBeatmap.SelectedHitObjects.Any(s => s is Slider);
+            Quad quad = selectedMovableObjects.Length > 0 ? getSurroundingQuad(selectedMovableObjects) : new Quad();
 
-            SelectionBox.CanRotate = canOperate;
-            SelectionBox.CanScaleX = canOperate;
-            SelectionBox.CanScaleY = canOperate;
-            SelectionBox.CanReverse = canOperate;
+            SelectionBox.CanRotate = quad.Width > 0 || quad.Height > 0;
+            SelectionBox.CanScaleX = quad.Width > 0;
+            SelectionBox.CanScaleY = quad.Height > 0;
+            SelectionBox.CanReverse = EditorBeatmap.SelectedHitObjects.Count > 1 || EditorBeatmap.SelectedHitObjects.Any(s => s is Slider);
         }
 
         protected override void OnOperationEnded()


### PR DESCRIPTION
Stacks were able to be scaled, resulting in division by 0 and a crash when the BlueprintPiece Position property is updated with NaN values. This prevents stacked circles from being scaled and also rotated because they're all at the same position anyway.