### PR TITLE
Fix combo break sound not playing a second time after rewinding before it

### DIFF
--- a/osu.Game/Screens/Play/ComboEffects.cs
+++ b/osu.Game/Screens/Play/ComboEffects.cs
@@ -17,8 +17,9 @@ namespace osu.Game.Screens.Play
 
         private SkinnableSound comboBreakSample;
 
-        private Bindable<bool> alwaysPlay;
-        private bool firstTime = true;
+        private Bindable<bool> alwaysPlayFirst;
+
+        private double? firstBreakTime;
 
         public ComboEffects(ScoreProcessor processor)
         {
@@ -29,7 +30,7 @@ namespace osu.Game.Screens.Play
         private void load(OsuConfigManager config)
         {
             InternalChild = comboBreakSample = new SkinnableSound(new SampleInfo("Gameplay/combobreak"));
-            alwaysPlay = config.GetBindable<bool>(OsuSetting.AlwaysPlayFirstComboBreak);
+            alwaysPlayFirst = config.GetBindable<bool>(OsuSetting.AlwaysPlayFirstComboBreak);
         }
 
         protected override void LoadComplete()
@@ -41,11 +42,21 @@ namespace osu.Game.Screens.Play
         [Resolved(canBeNull: true)]
         private ISamplePlaybackDisabler samplePlaybackDisabler { get; set; }
 
+        [Resolved]
+        private GameplayClock gameplayClock { get; set; }
+
         private void onComboChange(ValueChangedEvent<int> combo)
         {
-            if (combo.NewValue == 0 && (combo.OldValue > 20 || (alwaysPlay.Value && firstTime)))
+            // handle the case of rewinding before the first combo break time.
+            if (gameplayClock.CurrentTime < firstBreakTime)
+                firstBreakTime = null;
+
+            if (gameplayClock.ElapsedFrameTime < 0)
+                return;
+
+            if (combo.NewValue == 0 && (combo.OldValue > 20 || (alwaysPlayFirst.Value && firstBreakTime == null)))
             {
-                firstTime = false;
+                firstBreakTime = gameplayClock.CurrentTime;
 
                 // combo break isn't a pausable sound itself as we want to let it play out.
                 // we still need to disable during seeks, though.

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -302,12 +302,12 @@ namespace osu.Game.Screens.Play
                     {
                         ScoreProcessor,
                         HealthProcessor,
+                        new ComboEffects(ScoreProcessor),
                         breakTracker = new BreakTracker(DrawableRuleset.GameplayStartTime, ScoreProcessor)
                         {
                             Breaks = working.Beatmap.Breaks
                         }
                     }),
-                new ComboEffects(ScoreProcessor)
             }
         };
 


### PR DESCRIPTION
- [x] Depends on #10817 for ease of merge
- Moved to frame stable context so the `GameplayClock` matches the incoming events (from combo bindable).

Should probably have tests, can add is it's deemed required.