### PR TITLE
Add back setting to toggle "always play first combo break"

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -68,6 +68,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = "Positional hitsounds",
                     Current = config.GetBindable<bool>(OsuSetting.PositionalHitSounds)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = "Always play first combo break sound",
+                    Current = config.GetBindable<bool>(OsuSetting.AlwaysPlayFirstComboBreak)
+                },
                 new SettingsEnumDropdown<ScoreMeterType>
                 {
                     LabelText = "Score meter type",


### PR DESCRIPTION
I removed this in https://github.com/ppy/osu/pull/8802/commits/956980ee9055738a73dd9791ca52ff1a3de2ab18 but not 100% on my reasoning for doing so. Best have it exposed in the current state for now, I think.

Optimally this would have description or tooltip text that explains this better, but that will come with a larger refactor of settings (we don't really support this kind of text yet).