### PR TITLE
Fix perform from menu not hiding overlays if already on target screen

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePerformFromScreen.cs
@@ -1,9 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
@@ -71,6 +74,22 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
             AddUntilStep("returned to song select", () => Game.ScreenStack.CurrentScreen is MainMenu);
             AddAssert("did perform", () => actionPerformed);
+        }
+
+        [Test]
+        public void TestOverlaysAlwaysClosed()
+        {
+            ChatOverlay chat = null;
+            AddUntilStep("is at menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
+            AddUntilStep("wait for chat load", () => (chat = Game.ChildrenOfType<ChatOverlay>().SingleOrDefault()) != null);
+
+            AddStep("show chat", () => InputManager.Key(Key.F8));
+
+            AddStep("try to perform", () => Game.PerformFromScreen(_ => actionPerformed = true));
+
+            AddUntilStep("still at menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
+            AddAssert("did perform", () => actionPerformed);
+            AddAssert("chat closed", () => chat.State.Value == Visibility.Hidden);
         }
 
         [TestCase(true)]

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -76,14 +76,14 @@ namespace osu.Game
             // a dialog may be blocking the execution for now.
             if (checkForDialog(current)) return;
 
+            game.CloseAllOverlays(false);
+
             // we may already be at the target screen type.
             if (validScreens.Contains(getCurrentScreen().GetType()) && !beatmap.Disabled)
             {
                 complete();
                 return;
             }
-
-            game.CloseAllOverlays(false);
 
             while (current != null)
             {


### PR DESCRIPTION
Regressed with the recent changes to this component.

To test manually, try jumping to a beatmap using the beatmap listing while already at song select.