### PR TITLE
Fix broken fail judgement test

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailJudgement.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -21,8 +22,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected override void AddCheckSteps()
         {
             AddUntilStep("wait for fail", () => Player.HasFailed);
-            AddUntilStep("wait for multiple judged objects", () => ((FailPlayer)Player).DrawableRuleset.Playfield.AllHitObjects.Count(h => h.AllJudged) > 1);
-            AddAssert("total judgements == 1", () => ((FailPlayer)Player).HealthProcessor.JudgedHits >= 1);
+            AddUntilStep("wait for multiple judgements", () => ((FailPlayer)Player).ScoreProcessor.JudgedHits > 1);
+            AddAssert("total number of results == 1", () =>
+            {
+                var score = new ScoreInfo();
+                ((FailPlayer)Player).ScoreProcessor.PopulateScore(score);
+
+                return score.Statistics.Values.Sum() == 1;
+            });
         }
 
         private class FailPlayer : TestPlayer


### PR DESCRIPTION
This wasn't doing what it set out to do. It's trying to enforce that multiple judgements can occur but only the ones up to the failure actually get counted.