### PR TITLE
Disable pressed/released hold note logic when rewinding

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -249,6 +249,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (action != Action.Value)
                 return false;
 
+            // do not run any of this logic when rewinding, as it inverts order of presses/releases.
+            if (Time.Elapsed < 0)
+                return false;
+
             if (CheckHittable?.Invoke(this, Time.Current) == false)
                 return false;
 
@@ -279,6 +283,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 return;
 
             if (action != Action.Value)
+                return;
+
+            // do not run any of this logic when rewinding, as it inverts order of presses/releases.
+            if (Time.Elapsed < 0)
                 return;
 
             // Make sure a hold was started


### PR DESCRIPTION
Resolves #8082.

# Summary

Wasn't necessarily intending to fix this, but it popped up along the way. As noted in the issue, sometimes replay playback would end every hold note with a 50 after a rewind. The immediate reason was this conditional:

https://github.com/ppy/osu/blob/ae1a5b89558fc6abddd11832cb44aa9b03060b8c/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs#L55-L56

`holdNote.HasBroken` would be left in a state wherein it was equal to `true`. The reason for that was that during a rewind `OnPressed` fires at the end of the hold note, and `OnReleased` at the start, completely upending the whole logic, and causing `HasBroken` to be set to true at each hold note's start time during.

Since the entirety of those two methods was depending on proper ordering, I just disabled them altogether. The check in `OnReleased` might seem superfluous but I'm relatively certain it is required due to possibly starting a rewind while a key is held down.