### PR TITLE
WIP: Exclude non-movable hitobjects from selection boxes

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -232,7 +232,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// <param name="points">The points to calculate a quad for.</param>
         private Quad getSurroundingQuad(IEnumerable<Vector2> points)
         {
-            if (!EditorBeatmap.SelectedHitObjects.Any())
+            if (!points.Any())
                 return new Quad();
 
             Vector2 minPosition = new Vector2(float.MaxValue, float.MaxValue);
@@ -255,7 +255,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// </summary>
         private OsuHitObject[] selectedMovableObjects => EditorBeatmap.SelectedHitObjects
                                                                       .OfType<OsuHitObject>()
-                                                                      .Where(h => !(h is Spinner))
+                                                                      .Where(h => h.Movable)
                                                                       .ToArray();
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -99,6 +99,8 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => LastInComboBindable.Value = value;
         }
 
+        public override bool Movable => true;
+
         protected OsuHitObject()
         {
             StackHeightBindable.BindValueChanged(height =>

--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Rulesets.Osu.Objects
             set => Duration = value - StartTime;
         }
 
+        public override bool Movable => false;
+
         public double Duration { get; set; }
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -46,6 +46,12 @@ namespace osu.Game.Rulesets.Objects
             set => StartTimeBindable.Value = value;
         }
 
+        /// <summary>
+        /// Whether the <see cref="HitObject"/> is movable in the play-space.
+        /// </summary>
+        /// <returns>True if the <see cref="HitObject"/> is movable, else false.</returns>
+        public virtual bool Movable => false;
+
         public readonly BindableList<HitSampleInfo> SamplesBindable = new BindableList<HitSampleInfo>();
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -434,16 +434,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         private void prepareSelectionMovement()
         {
-            if (!SelectionHandler.SelectedBlueprints.Any())
+            var blueprints = SelectionHandler.SelectedBlueprints.Where(b => b.HitObject.Movable);
+
+            if (!blueprints.Any())
                 return;
 
             // Any selected blueprint that is hovered can begin the movement of the group, however only the earliest hitobject is used for movement
             // A special case is added for when a click selection occurred before the drag
-            if (!clickSelectionBegan && !SelectionHandler.SelectedBlueprints.Any(b => b.IsHovered))
+            if (!clickSelectionBegan && !blueprints.Any(b => b.IsHovered))
                 return;
 
             // Movement is tracked from the blueprint of the earliest hitobject, since it only makes sense to distance snap from that hitobject
-            movementBlueprint = SelectionHandler.SelectedBlueprints.OrderBy(b => b.HitObject.StartTime).First();
+            movementBlueprint = blueprints.OrderBy(b => b.HitObject.StartTime).First();
             movementBlueprintOriginalPosition = movementBlueprint.ScreenSpaceSelectionPoint; // todo: unsure if correct
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -297,10 +297,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
             var topLeft = new Vector2(float.MaxValue, float.MaxValue);
             var bottomRight = new Vector2(float.MinValue, float.MinValue);
 
+            bool noneMovable = selectedBlueprints.All(b => !b.HitObject.Movable);
+
             foreach (var blueprint in selectedBlueprints)
             {
-                topLeft = Vector2.ComponentMin(topLeft, ToLocalSpace(blueprint.SelectionQuad.TopLeft));
-                bottomRight = Vector2.ComponentMax(bottomRight, ToLocalSpace(blueprint.SelectionQuad.BottomRight));
+                if (noneMovable || blueprint.HitObject.Movable)
+                {
+                    topLeft = Vector2.ComponentMin(topLeft, ToLocalSpace(blueprint.SelectionQuad.TopLeft));
+                    bottomRight = Vector2.ComponentMax(bottomRight, ToLocalSpace(blueprint.SelectionQuad.BottomRight));
+                }
             }
 
             topLeft -= new Vector2(5);


### PR DESCRIPTION
As @bdach mentioned in #10812 resizing selections with spinners in them results in very strange behavior and UI wise it doesn't work well since the resize handles are in the very corners of the playfield and the other selection box buttons are off screen.

This PR attempts to fix that by excluding non-movable hitobjects from selection boxes (but not from the selection itself) except when they are the only thing selected. This allows moving the rest of the object as if the spinner wasn't selected.

Since spinners can't be moved anyway I think this seems like a fairly intuitive/useful way of handling this.
I noticed after I got this working that the code I modified in BlueprintContainer also handles movement in time so currently this breaks moving spinners in time, any tips on how this should be fixed properly are appreciated.

https://streamable.com/vx48wk