### PR TITLE
Fix crash on shift+right-click deleting objects

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -28,6 +28,9 @@ namespace osu.Game.Tests.Visual.Editing
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
 
+        private BlueprintContainer blueprintContainer
+            => Editor.ChildrenOfType<BlueprintContainer>().First();
+
         [Test]
         public void TestQuickDeleteRemovesObject()
         {
@@ -39,7 +42,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse to object", () =>
             {
-                var pos = getBlueprintContainer.SelectionBlueprints
+                var pos = blueprintContainer.SelectionBlueprints
                             .ChildrenOfType<HitCircleSelectionBlueprint>().First()
                             .ChildrenOfType<HitCirclePiece>().First().ScreenSpaceDrawQuad.Centre;
                 InputManager.MoveMouseTo(pos);
@@ -73,7 +76,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse to controlpoint", () =>
             {
-                var pos = getBlueprintContainer.SelectionBlueprints
+                var pos = blueprintContainer.SelectionBlueprints
                             .ChildrenOfType<SliderSelectionBlueprint>().First()
                             .ChildrenOfType<PathControlPointVisualiser>().First()
                             .ChildrenOfType<PathControlPointPiece>().ElementAt(1).ScreenSpaceDrawQuad.Centre;
@@ -85,9 +88,5 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddAssert("slider has 2 points", () => slider.Path.ControlPoints.Count == 2);
         }
-
-        private BlueprintContainer getBlueprintContainer => Editor.ChildrenOfType<ComposeScreen>().First()
-                                                                  .ChildrenOfType<HitObjectComposer>().First()
-                                                                  .ChildrenOfType<BlueprintContainer>().First();
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Editing
         {
             Slider slider = new Slider { StartTime = 1000 };
 
-            PathControlPoint[] points = new PathControlPoint[]
+            PathControlPoint[] points =
             {
                 new PathControlPoint(),
                 new PathControlPoint(new Vector2(50, 0)),

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -9,13 +9,9 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
-using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Tests.Beatmaps;
-using osu.Game.Rulesets.Edit;
-using osu.Game.Screens.Edit.Compose;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 using osuTK.Input;
@@ -42,9 +38,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse to object", () =>
             {
-                var pos = blueprintContainer.SelectionBlueprints
-                            .ChildrenOfType<HitCircleSelectionBlueprint>().First()
-                            .ChildrenOfType<HitCirclePiece>().First().ScreenSpaceDrawQuad.Centre;
+                var pos = blueprintContainer.ChildrenOfType<HitCirclePiece>().First().ScreenSpaceDrawQuad.Centre;
                 InputManager.MoveMouseTo(pos);
             });
             AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));
@@ -76,10 +70,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse to controlpoint", () =>
             {
-                var pos = blueprintContainer.SelectionBlueprints
-                            .ChildrenOfType<SliderSelectionBlueprint>().First()
-                            .ChildrenOfType<PathControlPointVisualiser>().First()
-                            .ChildrenOfType<PathControlPointPiece>().ElementAt(1).ScreenSpaceDrawQuad.Centre;
+                var pos = blueprintContainer.ChildrenOfType<PathControlPointPiece>().ElementAt(1).ScreenSpaceDrawQuad.Centre;
                 InputManager.MoveMouseTo(pos);
             });
             AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual.Editing
                 InputManager.MoveMouseTo(pos);
             });
             AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));
-            AddStep("rightclick", () => InputManager.Click(MouseButton.Right));
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
             AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
 
             AddAssert("no hitobjects in beatmap", () => EditorBeatmap.HitObjects.Count == 0);
@@ -74,10 +74,15 @@ namespace osu.Game.Tests.Visual.Editing
                 InputManager.MoveMouseTo(pos);
             });
             AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));
-            AddStep("rightclick", () => InputManager.Click(MouseButton.Right));
-            AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
 
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
             AddAssert("slider has 2 points", () => slider.Path.ControlPoints.Count == 2);
+
+            // second click should nuke the object completely.
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+            AddAssert("no hitobjects in beatmap", () => EditorBeatmap.HitObjects.Count == 0);
+
+            AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Compose;
@@ -72,11 +73,10 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("move mouse to controlpoint", () =>
             {
-                // This doesn't get the HitCirclePiece corresponding to the last control point on consecutive runs,
-                // causing the slider to translate by 50 every time and go off the screen after about 10 runs.
                 var pos = getBlueprintContainer.SelectionBlueprints
                             .ChildrenOfType<SliderSelectionBlueprint>().First()
-                            .ChildrenOfType<HitCirclePiece>().Last().ScreenSpaceDrawQuad.Centre;
+                            .ChildrenOfType<PathControlPointVisualiser>().First()
+                            .ChildrenOfType<PathControlPointPiece>().ElementAt(1).ScreenSpaceDrawQuad.Centre;
                 InputManager.MoveMouseTo(pos);
             });
             AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit.Compose;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneEditorQuickDelete : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        [Test]
+        public void TestQuickDeleteRemovesObject()
+        {
+            var addedObject = new HitCircle { StartTime = 1000 };
+
+            AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
+
+            AddStep("select added object", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
+
+            AddStep("move mouse to object", () =>
+            {
+                var pos = getBlueprintContainer.SelectionBlueprints
+                            .ChildrenOfType<HitCircleSelectionBlueprint>().First()
+                            .ChildrenOfType<HitCirclePiece>().First().ScreenSpaceDrawQuad.Centre;
+                InputManager.MoveMouseTo(pos);
+            });
+            AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));
+            AddStep("rightclick", () => InputManager.Click(MouseButton.Right));
+            AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
+
+            AddAssert("no hitobjects in beatmap", () => EditorBeatmap.HitObjects.Count == 0);
+        }
+
+        [Test]
+        public void TestQuickDeleteRemovesSliderControlPoint()
+        {
+            Slider slider = new Slider { StartTime = 1000 };
+
+            PathControlPoint[] points = new PathControlPoint[]
+            {
+                new PathControlPoint(),
+                new PathControlPoint(new Vector2(50, 0)),
+                new PathControlPoint(new Vector2(100, 0))
+            };
+
+            AddStep("add slider", () =>
+            {
+                slider.Path = new SliderPath(points);
+                EditorBeatmap.Add(slider);
+            });
+
+            AddStep("select added slider", () => EditorBeatmap.SelectedHitObjects.Add(slider));
+
+            AddStep("move mouse to controlpoint", () =>
+            {
+                // This doesn't get the HitCirclePiece corresponding to the last control point on consecutive runs,
+                // causing the slider to translate by 50 every time and go off the screen after about 10 runs.
+                var pos = getBlueprintContainer.SelectionBlueprints
+                            .ChildrenOfType<SliderSelectionBlueprint>().First()
+                            .ChildrenOfType<HitCirclePiece>().Last().ScreenSpaceDrawQuad.Centre;
+                InputManager.MoveMouseTo(pos);
+            });
+            AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));
+            AddStep("rightclick", () => InputManager.Click(MouseButton.Right));
+            AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
+
+            AddAssert("slider has 2 points", () => slider.Path.ControlPoints.Count == 2);
+        }
+
+        private BlueprintContainer getBlueprintContainer => Editor.ChildrenOfType<ComposeScreen>().First()
+                                                                  .ChildrenOfType<HitObjectComposer>().First()
+                                                                  .ChildrenOfType<BlueprintContainer>().First();
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -338,7 +338,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a selection was performed.</returns>
         private bool beginClickSelection(MouseButtonEvent e)
         {
-            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
+            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren.ToList())
             {
                 if (!blueprint.IsHovered) continue;
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -338,18 +338,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a selection was performed.</returns>
         private bool beginClickSelection(MouseButtonEvent e)
         {
-            bool selectedPerformed = true;
-
             foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
             {
                 if (!blueprint.IsHovered) continue;
 
-                selectedPerformed &= SelectionHandler.HandleSelectionRequested(blueprint, e);
-                clickSelectionBegan = true;
-                break;
+                return clickSelectionBegan = SelectionHandler.HandleSelectionRequested(blueprint, e);
             }
 
-            return selectedPerformed;
+            return false;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -338,15 +338,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a selection was performed.</returns>
         private bool beginClickSelection(MouseButtonEvent e)
         {
-            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren.ToList())
+            bool selectedPerformed = true;
+
+            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
             {
                 if (!blueprint.IsHovered) continue;
 
-                if (SelectionHandler.HandleSelectionRequested(blueprint, e))
-                    return clickSelectionBegan = true;
+                selectedPerformed &= SelectionHandler.HandleSelectionRequested(blueprint, e);
+                clickSelectionBegan = true;
+                break;
             }
 
-            return false;
+            return selectedPerformed;
         }
 
         /// <summary>


### PR DESCRIPTION
This regressed in #10767

```
Exception has occurred: CLR/System.InvalidOperationException
An exception of type 'System.InvalidOperationException' occurred in System.Private.CoreLib.dll but was not handled in user code: 'Collection was modified; enumeration operation may not execute.'
   at System.ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion()
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at osu.Game.Screens.Edit.Compose.Components.BlueprintContainer.beginClickSelection(MouseButtonEvent e) in E:\dev\osuFork\osu\osu.Game\Screens\Edit\Compose\Components\BlueprintContainer.cs:line 341
   at osu.Game.Screens.Edit.Compose.Components.BlueprintContainer.OnMouseDown(MouseDownEvent e) in E:\dev\osuFork\osu\osu.Game\Screens\Edit\Compose\Components\BlueprintContainer.cs:line 139
   at osu.Framework.Input.ButtonEventManager`1.<>c__DisplayClass14_0.<PropagateButtonEvent>b__0(Drawable target)
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at osu.Framework.Input.ButtonEventManager`1.PropagateButtonEvent(IEnumerable`1 drawables, UIEvent e)
   at osu.Framework.Input.MouseButtonEventManager.HandleButtonDown(InputState state, List`1 targets)
   at osu.Framework.Input.ButtonEventManager`1.handleButtonDown(InputState state)
   at osu.Framework.Input.ButtonEventManager`1.HandleButtonStateChange(InputState state, ButtonStateChangeKind kind)
   at osu.Framework.Input.InputManager.HandleMouseButtonStateChange(ButtonStateChangeEvent`1 e)
   at osu.Framework.Input.UserInputManager.HandleInputStateChange(InputStateChangeEvent inputStateChange)
   at osu.Framework.Input.StateChanges.ButtonInput`1.Apply(InputState state, IInputStateChangeHandler handler)
   at osu.Framework.Input.InputManager.Update()
   at osu.Framework.Input.PassThroughInputManager.Update()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Platform.GameHost.UpdateFrame()
   at osu.Framework.Threading.GameThread.ProcessFrame()
```