### PR TITLE
Add null checks to unguarded resolved-as-possibly-null fields

### DIFF
--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -144,9 +144,9 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
                 if (selected)
                 {
                     selectionBox.Show();
-                    if (editor)
+                    if (editor && editorInfo != null)
                         editorInfo.Selected.Value = Match;
-                    else
+                    else if (ladderInfo != null)
                         ladderInfo.CurrentMatch.Value = Match;
                 }
                 else

--- a/osu.Game/Online/DownloadTrackingComposite.cs
+++ b/osu.Game/Online/DownloadTrackingComposite.cs
@@ -46,11 +46,14 @@ namespace osu.Game.Online
             {
                 if (modelInfo.NewValue == null)
                     attachDownload(null);
-                else if (manager.IsAvailableLocally(modelInfo.NewValue))
+                else if (manager?.IsAvailableLocally(modelInfo.NewValue) == true)
                     State.Value = DownloadState.LocallyAvailable;
                 else
-                    attachDownload(manager.GetExistingDownload(modelInfo.NewValue));
+                    attachDownload(manager?.GetExistingDownload(modelInfo.NewValue));
             }, true);
+
+            if (manager == null)
+                return;
 
             managerDownloadBegan = manager.DownloadBegan.GetBoundCopy();
             managerDownloadBegan.BindValueChanged(downloadBegan);

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -248,7 +248,9 @@ namespace osu.Game.Online.Leaderboards
         [BackgroundDependencyLoader]
         private void load()
         {
-            apiState.BindTo(api.State);
+            if (api != null)
+                apiState.BindTo(api.State);
+
             apiState.BindValueChanged(onlineStateChanged, true);
         }
 
@@ -303,7 +305,7 @@ namespace osu.Game.Online.Leaderboards
                     PlaceholderState = PlaceholderState.NetworkFailure;
                 });
 
-                api.Queue(getScoresRequest);
+                api?.Queue(getScoresRequest);
             });
         }
 

--- a/osu.Game/Overlays/AccountCreation/ScreenWarning.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenWarning.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Overlays.AccountCreation
 
         public override void OnEntering(IScreen last)
         {
-            if (string.IsNullOrEmpty(api.ProvidedUsername))
+            if (string.IsNullOrEmpty(api?.ProvidedUsername))
             {
                 this.FadeOut();
                 this.Push(new ScreenEntry());
@@ -43,7 +43,7 @@ namespace osu.Game.Overlays.AccountCreation
         [BackgroundDependencyLoader(true)]
         private void load(OsuColour colours, OsuGame game, TextureStore textures)
         {
-            if (string.IsNullOrEmpty(api.ProvidedUsername))
+            if (string.IsNullOrEmpty(api?.ProvidedUsername))
                 return;
 
             InternalChildren = new Drawable[]

--- a/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LoginSettings.cs
@@ -217,7 +217,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
             private void performLogin()
             {
                 if (!string.IsNullOrEmpty(username.Text) && !string.IsNullOrEmpty(password.Text))
-                    api.Login(username.Text, password.Text);
+                    api?.Login(username.Text, password.Text);
                 else
                     shakeSignIn.Shake();
             }

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -76,7 +76,7 @@ namespace osu.Game
             // a dialog may be blocking the execution for now.
             if (checkForDialog(current)) return;
 
-            game.CloseAllOverlays(false);
+            game?.CloseAllOverlays(false);
 
             // we may already be at the target screen type.
             if (validScreens.Contains(getCurrentScreen().GetType()) && !beatmap.Disabled)

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.UI
         {
             Debug.Assert(!drawableMap.ContainsKey(entry));
 
-            var drawable = pooledObjectProvider.GetPooledDrawableRepresentation(entry.HitObject);
+            var drawable = pooledObjectProvider?.GetPooledDrawableRepresentation(entry.HitObject);
             if (drawable == null)
                 throw new InvalidOperationException($"A drawable representation could not be retrieved for hitobject type: {entry.HitObject.GetType().ReadableName()}.");
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -457,6 +457,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (movementBlueprint == null)
                 return false;
 
+            if (snapProvider == null)
+                return true;
+
             Debug.Assert(movementBlueprintOriginalPosition != null);
 
             HitObject draggedObject = movementBlueprint.HitObject;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         protected virtual void OnOperationBegan()
         {
-            ChangeHandler.BeginChange();
+            ChangeHandler?.BeginChange();
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         protected virtual void OnOperationEnded()
         {
-            ChangeHandler.EndChange();
+            ChangeHandler?.EndChange();
         }
 
         #region User Input Handling

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             if (lastDragEvent != null)
                 OnDrag(lastDragEvent);
 
-            if (Composer != null)
+            if (Composer != null && timeline != null)
             {
                 Composer.Playfield.PastLifetimeExtension = timeline.VisibleRange / 2;
                 Composer.Playfield.FutureLifetimeExtension = timeline.VisibleRange / 2;

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.Edit.Timing
                 controlPointGroups.BindCollectionChanged((sender, args) =>
                 {
                     table.ControlGroups = controlPointGroups;
-                    changeHandler.SaveState();
+                    changeHandler?.SaveState();
                 }, true);
             }
 

--- a/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
+++ b/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
@@ -59,6 +59,9 @@ namespace osu.Game.Screens.Multi.Lounge.Components
         {
             scheduledFilterUpdate?.Cancel();
 
+            if (filter == null)
+                return;
+
             filter.Value = new FilterCriteria
             {
                 SearchString = Search.Current.Value ?? string.Empty,


### PR DESCRIPTION
One case was [reported in discord](https://discord.com/channels/188630481301012481/188630652340404224/777156928765689866), but I figured I'd do a full sweep and caught a few more. A few are relatively recent, actually.

I would love for this to be enforced by CI, but it doesn't seem feasible without a roslyn analyser. I gave it a meek attempt at making framework also accept the `JetBrains.Annotations.CanBeNull` attribute as indication that nulls are permitted, but it's not really open to extensibility in that regard...

![2020-11-14-151921_536x182_scrot](https://user-images.githubusercontent.com/20418176/99149265-25b81f80-268d-11eb-96b8-2b4cebb164ae.png)
