### PR TITLE
Add support for previewing tracks on spectator screen

### DIFF
--- a/osu.Game/Audio/PreviewTrackManager.cs
+++ b/osu.Game/Audio/PreviewTrackManager.cs
@@ -11,6 +11,7 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 
 namespace osu.Game.Audio
@@ -76,7 +77,7 @@ namespace osu.Game.Audio
         /// <param name="source">The <see cref="IPreviewTrackOwner"/> which may be the owner of the <see cref="PreviewTrack"/>.</param>
         public void StopAnyPlaying(IPreviewTrackOwner source)
         {
-            if (CurrentTrack == null || CurrentTrack.Owner != source)
+            if (CurrentTrack == null || (CurrentTrack.Owner != null && CurrentTrack.Owner != source))
                 return;
 
             CurrentTrack.Stop();
@@ -86,11 +87,12 @@ namespace osu.Game.Audio
         /// <summary>
         /// Creates the <see cref="TrackManagerPreviewTrack"/>.
         /// </summary>
-        protected virtual TrackManagerPreviewTrack CreatePreviewTrack(BeatmapSetInfo beatmapSetInfo, ITrackStore trackStore) => new TrackManagerPreviewTrack(beatmapSetInfo, trackStore);
+        protected virtual TrackManagerPreviewTrack CreatePreviewTrack(BeatmapSetInfo beatmapSetInfo, ITrackStore trackStore) =>
+            new TrackManagerPreviewTrack(beatmapSetInfo, trackStore);
 
         public class TrackManagerPreviewTrack : PreviewTrack
         {
-            [Resolved]
+            [Resolved(canBeNull: true)]
             public IPreviewTrackOwner Owner { get; private set; }
 
             private readonly BeatmapSetInfo beatmapSetInfo;
@@ -100,6 +102,12 @@ namespace osu.Game.Audio
             {
                 this.beatmapSetInfo = beatmapSetInfo;
                 this.trackManager = trackManager;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                Logger.Log($"A {nameof(PreviewTrack)} was created without a containing {nameof(IPreviewTrackOwner)}. An owner should be added for correct behaviour.");
             }
 
             protected override Track GetTrack() => trackManager.Get($"https://b.ppy.sh/preview/{beatmapSetInfo?.OnlineBeatmapSetID}.mp3");

--- a/osu.Game/Screens/Play/Spectator.cs
+++ b/osu.Game/Screens/Play/Spectator.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Screens;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -35,7 +36,8 @@ using osuTK;
 
 namespace osu.Game.Screens.Play
 {
-    public class Spectator : OsuScreen
+    [Cached(typeof(IPreviewTrackOwner))]
+    public class Spectator : OsuScreen, IPreviewTrackOwner
     {
         private readonly User targetUser;
 
@@ -61,6 +63,9 @@ namespace osu.Game.Screens.Play
 
         [Resolved]
         private RulesetStore rulesets { get; set; }
+
+        [Resolved]
+        private PreviewTrackManager previewTrackManager { get; set; }
 
         private Score score;
 
@@ -275,6 +280,7 @@ namespace osu.Game.Screens.Play
         {
             watchButton.Enabled.Value = false;
             beatmapPanelContainer.Clear();
+            previewTrackManager.StopAnyPlaying(this);
         }
 
         private void attemptStart()
@@ -326,7 +332,6 @@ namespace osu.Game.Screens.Play
         {
             if (state?.BeatmapID == null)
             {
-                beatmapPanelContainer.Clear();
                 onlineBeatmap = null;
                 return;
             }
@@ -357,6 +362,12 @@ namespace osu.Game.Screens.Play
                 return;
 
             beatmaps.Download(onlineBeatmap);
+        }
+
+        public override bool OnExiting(IScreen next)
+        {
+            previewTrackManager.StopAnyPlaying(this);
+            return base.OnExiting(next);
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Resolves #10836.

Seems like a useful change on its own as players might not know absolutely every map they see anyway. There are no tests here because it's quite cumbersome to test (would have to rely on online preview track retrieval to succeed), but this can be semi-manually tested using the test scene and the right steps, and in the game, obviously. Will try to figure out an automated test on request.

I also removed one container clear in `showBeatmapPanel()` as it looks redundant (only call to method always unconditionally follows a `clearDisplay()`, which clears anyway).