### PR TITLE
Fully cover bidirectional legacy mod conversions

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchLegacyModConversionTest.cs
@@ -12,17 +12,32 @@ namespace osu.Game.Rulesets.Catch.Tests
     [TestFixture]
     public class CatchLegacyModConversionTest : LegacyModConversionTest
     {
-        [TestCase(LegacyMods.Easy, new[] { typeof(CatchModEasy) })]
-        [TestCase(LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(CatchModHardRock), typeof(CatchModDoubleTime) })]
-        [TestCase(LegacyMods.DoubleTime, new[] { typeof(CatchModDoubleTime) })]
-        [TestCase(LegacyMods.Nightcore, new[] { typeof(CatchModNightcore) })]
+        private static readonly object[][] catch_mod_mapping =
+        {
+            new object[] { LegacyMods.NoFail, new[] { typeof(CatchModNoFail) } },
+            new object[] { LegacyMods.Easy, new[] { typeof(CatchModEasy) } },
+            new object[] { LegacyMods.Hidden, new[] { typeof(CatchModHidden) } },
+            new object[] { LegacyMods.HardRock, new[] { typeof(CatchModHardRock) } },
+            new object[] { LegacyMods.SuddenDeath, new[] { typeof(CatchModSuddenDeath) } },
+            new object[] { LegacyMods.DoubleTime, new[] { typeof(CatchModDoubleTime) } },
+            new object[] { LegacyMods.Relax, new[] { typeof(CatchModRelax) } },
+            new object[] { LegacyMods.HalfTime, new[] { typeof(CatchModHalfTime) } },
+            new object[] { LegacyMods.Nightcore, new[] { typeof(CatchModNightcore) } },
+            new object[] { LegacyMods.Flashlight, new[] { typeof(CatchModFlashlight) } },
+            new object[] { LegacyMods.Autoplay, new[] { typeof(CatchModAutoplay) } },
+            new object[] { LegacyMods.Perfect, new[] { typeof(CatchModPerfect) } },
+            new object[] { LegacyMods.Cinema, new[] { typeof(CatchModCinema) } },
+            new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(CatchModHardRock), typeof(CatchModDoubleTime) } }
+        };
+
+        [TestCaseSource(nameof(catch_mod_mapping))]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(CatchModCinema) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(CatchModNightcore) })]
-        [TestCase(LegacyMods.Flashlight | LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(CatchModFlashlight), typeof(CatchModNightcore) })]
-        [TestCase(LegacyMods.Perfect, new[] { typeof(CatchModPerfect) })]
-        [TestCase(LegacyMods.SuddenDeath, new[] { typeof(CatchModSuddenDeath) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(CatchModPerfect) })]
-        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(CatchModDoubleTime), typeof(CatchModPerfect) })]
         public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
+
+        [TestCaseSource(nameof(catch_mod_mapping))]
+        public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new CatchRuleset();
     }

--- a/osu.Game.Rulesets.Catch.Tests/CatchLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchLegacyModConversionTest.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [TestCase(LegacyMods.SuddenDeath, new[] { typeof(CatchModSuddenDeath) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(CatchModPerfect) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(CatchModDoubleTime), typeof(CatchModPerfect) })]
-        public new void Test(LegacyMods legacyMods, Type[] expectedMods) => base.Test(legacyMods, expectedMods);
+        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         protected override Ruleset CreateRuleset() => new CatchRuleset();
     }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
@@ -12,19 +12,44 @@ namespace osu.Game.Rulesets.Mania.Tests
     [TestFixture]
     public class ManiaLegacyModConversionTest : LegacyModConversionTest
     {
-        [TestCase(LegacyMods.Easy, new[] { typeof(ManiaModEasy) })]
-        [TestCase(LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(ManiaModHardRock), typeof(ManiaModDoubleTime) })]
-        [TestCase(LegacyMods.DoubleTime, new[] { typeof(ManiaModDoubleTime) })]
-        [TestCase(LegacyMods.Nightcore, new[] { typeof(ManiaModNightcore) })]
+        private static readonly object[][] mania_mod_mapping =
+        {
+            new object[] { LegacyMods.NoFail, new[] { typeof(ManiaModNoFail) } },
+            new object[] { LegacyMods.Easy, new[] { typeof(ManiaModEasy) } },
+            new object[] { LegacyMods.Hidden, new[] { typeof(ManiaModHidden) } },
+            new object[] { LegacyMods.HardRock, new[] { typeof(ManiaModHardRock) } },
+            new object[] { LegacyMods.SuddenDeath, new[] { typeof(ManiaModSuddenDeath) } },
+            new object[] { LegacyMods.DoubleTime, new[] { typeof(ManiaModDoubleTime) } },
+            new object[] { LegacyMods.HalfTime, new[] { typeof(ManiaModHalfTime) } },
+            new object[] { LegacyMods.Nightcore, new[] { typeof(ManiaModNightcore) } },
+            new object[] { LegacyMods.Flashlight, new[] { typeof(ManiaModFlashlight) } },
+            new object[] { LegacyMods.Autoplay, new[] { typeof(ManiaModAutoplay) } },
+            new object[] { LegacyMods.Perfect, new[] { typeof(ManiaModPerfect) } },
+            new object[] { LegacyMods.Key4, new[] { typeof(ManiaModKey4) } },
+            new object[] { LegacyMods.Key5, new[] { typeof(ManiaModKey5) } },
+            new object[] { LegacyMods.Key6, new[] { typeof(ManiaModKey6) } },
+            new object[] { LegacyMods.Key7, new[] { typeof(ManiaModKey7) } },
+            new object[] { LegacyMods.Key8, new[] { typeof(ManiaModKey8) } },
+            new object[] { LegacyMods.FadeIn, new[] { typeof(ManiaModFadeIn) } },
+            new object[] { LegacyMods.Random, new[] { typeof(ManiaModRandom) } },
+            new object[] { LegacyMods.Cinema, new[] { typeof(ManiaModCinema) } },
+            new object[] { LegacyMods.Key9, new[] { typeof(ManiaModKey9) } },
+            new object[] { LegacyMods.KeyCoop, new[] { typeof(ManiaModDualStages) } },
+            new object[] { LegacyMods.Key1, new[] { typeof(ManiaModKey1) } },
+            new object[] { LegacyMods.Key3, new[] { typeof(ManiaModKey3) } },
+            new object[] { LegacyMods.Key2, new[] { typeof(ManiaModKey2) } },
+            new object[] { LegacyMods.Mirror, new[] { typeof(ManiaModMirror) } },
+            new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(ManiaModHardRock), typeof(ManiaModDoubleTime) } }
+        };
+
+        [TestCaseSource(nameof(mania_mod_mapping))]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(ManiaModCinema) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(ManiaModNightcore) })]
-        [TestCase(LegacyMods.Flashlight | LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(ManiaModFlashlight), typeof(ManiaModNightcore) })]
-        [TestCase(LegacyMods.Perfect, new[] { typeof(ManiaModPerfect) })]
-        [TestCase(LegacyMods.SuddenDeath, new[] { typeof(ManiaModSuddenDeath) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(ManiaModPerfect) })]
-        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(ManiaModDoubleTime), typeof(ManiaModPerfect) })]
-        [TestCase(LegacyMods.Random | LegacyMods.SuddenDeath, new[] { typeof(ManiaModRandom), typeof(ManiaModSuddenDeath) })]
-        [TestCase(LegacyMods.Flashlight | LegacyMods.Mirror, new[] { typeof(ManiaModFlashlight), typeof(ManiaModMirror) })]
         public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
+
+        [TestCaseSource(nameof(mania_mod_mapping))]
+        public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new ManiaRuleset();
     }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaLegacyModConversionTest.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(ManiaModDoubleTime), typeof(ManiaModPerfect) })]
         [TestCase(LegacyMods.Random | LegacyMods.SuddenDeath, new[] { typeof(ManiaModRandom), typeof(ManiaModSuddenDeath) })]
         [TestCase(LegacyMods.Flashlight | LegacyMods.Mirror, new[] { typeof(ManiaModFlashlight), typeof(ManiaModMirror) })]
-        public new void Test(LegacyMods legacyMods, Type[] expectedMods) => base.Test(legacyMods, expectedMods);
+        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         protected override Ruleset CreateRuleset() => new ManiaRuleset();
     }

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -119,6 +119,9 @@ namespace osu.Game.Rulesets.Mania
             if (mods.HasFlag(LegacyMods.Key9))
                 yield return new ManiaModKey9();
 
+            if (mods.HasFlag(LegacyMods.KeyCoop))
+                yield return new ManiaModDualStages();
+
             if (mods.HasFlag(LegacyMods.NoFail))
                 yield return new ManiaModNoFail();
 
@@ -173,12 +176,21 @@ namespace osu.Game.Rulesets.Mania
                         value |= LegacyMods.Key9;
                         break;
 
+                    case ManiaModDualStages _:
+                        value |= LegacyMods.KeyCoop;
+                        break;
+
                     case ManiaModFadeIn _:
                         value |= LegacyMods.FadeIn;
+                        value &= ~LegacyMods.Hidden; // due to inheritance
                         break;
 
                     case ManiaModMirror _:
                         value |= LegacyMods.Mirror;
+                        break;
+
+                    case ManiaModRandom _:
+                        value |= LegacyMods.Random;
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Mania
 
                     case ManiaModFadeIn _:
                         value |= LegacyMods.FadeIn;
-                        value &= ~LegacyMods.Hidden; // due to inheritance
+                        value &= ~LegacyMods.Hidden; // this is toggled on in the base call due to inheritance, but we don't want that.
                         break;
 
                     case ManiaModMirror _:

--- a/osu.Game.Rulesets.Osu.Tests/OsuLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuLegacyModConversionTest.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(OsuModPerfect) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(OsuModDoubleTime), typeof(OsuModPerfect) })]
         [TestCase(LegacyMods.SpunOut | LegacyMods.Easy, new[] { typeof(OsuModSpunOut), typeof(OsuModEasy) })]
-        public new void Test(LegacyMods legacyMods, Type[] expectedMods) => base.Test(legacyMods, expectedMods);
+        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         protected override Ruleset CreateRuleset() => new OsuRuleset();
     }

--- a/osu.Game.Rulesets.Osu.Tests/OsuLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuLegacyModConversionTest.cs
@@ -12,18 +12,36 @@ namespace osu.Game.Rulesets.Osu.Tests
     [TestFixture]
     public class OsuLegacyModConversionTest : LegacyModConversionTest
     {
-        [TestCase(LegacyMods.Easy, new[] { typeof(OsuModEasy) })]
-        [TestCase(LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(OsuModHardRock), typeof(OsuModDoubleTime) })]
-        [TestCase(LegacyMods.DoubleTime, new[] { typeof(OsuModDoubleTime) })]
-        [TestCase(LegacyMods.Nightcore, new[] { typeof(OsuModNightcore) })]
+        private static readonly object[][] osu_mod_mapping =
+        {
+            new object[] { LegacyMods.NoFail, new[] { typeof(OsuModNoFail) } },
+            new object[] { LegacyMods.Easy, new[] { typeof(OsuModEasy) } },
+            new object[] { LegacyMods.TouchDevice, new[] { typeof(OsuModTouchDevice) } },
+            new object[] { LegacyMods.Hidden, new[] { typeof(OsuModHidden) } },
+            new object[] { LegacyMods.HardRock, new[] { typeof(OsuModHardRock) } },
+            new object[] { LegacyMods.SuddenDeath, new[] { typeof(OsuModSuddenDeath) } },
+            new object[] { LegacyMods.DoubleTime, new[] { typeof(OsuModDoubleTime) } },
+            new object[] { LegacyMods.Relax, new[] { typeof(OsuModRelax) } },
+            new object[] { LegacyMods.HalfTime, new[] { typeof(OsuModHalfTime) } },
+            new object[] { LegacyMods.Nightcore, new[] { typeof(OsuModNightcore) } },
+            new object[] { LegacyMods.Flashlight, new[] { typeof(OsuModFlashlight) } },
+            new object[] { LegacyMods.Autoplay, new[] { typeof(OsuModAutoplay) } },
+            new object[] { LegacyMods.SpunOut, new[] { typeof(OsuModSpunOut) } },
+            new object[] { LegacyMods.Autopilot, new[] { typeof(OsuModAutopilot) } },
+            new object[] { LegacyMods.Perfect, new[] { typeof(OsuModPerfect) } },
+            new object[] { LegacyMods.Cinema, new[] { typeof(OsuModCinema) } },
+            new object[] { LegacyMods.Target, new[] { typeof(OsuModTarget) } },
+            new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(OsuModHardRock), typeof(OsuModDoubleTime) } }
+        };
+
+        [TestCaseSource(nameof(osu_mod_mapping))]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(OsuModCinema) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(OsuModNightcore) })]
-        [TestCase(LegacyMods.Flashlight | LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(OsuModFlashlight), typeof(OsuModFlashlight) })]
-        [TestCase(LegacyMods.Perfect, new[] { typeof(OsuModPerfect) })]
-        [TestCase(LegacyMods.SuddenDeath, new[] { typeof(OsuModSuddenDeath) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(OsuModPerfect) })]
-        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(OsuModDoubleTime), typeof(OsuModPerfect) })]
-        [TestCase(LegacyMods.SpunOut | LegacyMods.Easy, new[] { typeof(OsuModSpunOut), typeof(OsuModEasy) })]
         public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
+
+        [TestCaseSource(nameof(osu_mod_mapping))]
+        public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new OsuRuleset();
     }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -107,6 +107,35 @@ namespace osu.Game.Rulesets.Osu
                 yield return new OsuModTouchDevice();
         }
 
+        public override LegacyMods ConvertToLegacyMods(Mod[] mods)
+        {
+            var value = base.ConvertToLegacyMods(mods);
+
+            foreach (var mod in mods)
+            {
+                switch (mod)
+                {
+                    case OsuModAutopilot _:
+                        value |= LegacyMods.Autopilot;
+                        break;
+
+                    case OsuModSpunOut _:
+                        value |= LegacyMods.SpunOut;
+                        break;
+
+                    case OsuModTarget _:
+                        value |= LegacyMods.Target;
+                        break;
+
+                    case OsuModTouchDevice _:
+                        value |= LegacyMods.TouchDevice;
+                        break;
+                }
+            }
+
+            return value;
+        }
+
         public override IEnumerable<Mod> GetModsFor(ModType type)
         {
             switch (type)

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoLegacyModConversionTest.cs
@@ -12,17 +12,33 @@ namespace osu.Game.Rulesets.Taiko.Tests
     [TestFixture]
     public class TaikoLegacyModConversionTest : LegacyModConversionTest
     {
-        [TestCase(LegacyMods.Easy, new[] { typeof(TaikoModEasy) })]
-        [TestCase(LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(TaikoModHardRock), typeof(TaikoModDoubleTime) })]
-        [TestCase(LegacyMods.DoubleTime, new[] { typeof(TaikoModDoubleTime) })]
-        [TestCase(LegacyMods.Nightcore, new[] { typeof(TaikoModNightcore) })]
+        private static readonly object[][] taiko_mod_mapping =
+        {
+            new object[] { LegacyMods.NoFail, new[] { typeof(TaikoModNoFail) } },
+            new object[] { LegacyMods.Easy, new[] { typeof(TaikoModEasy) } },
+            new object[] { LegacyMods.Hidden, new[] { typeof(TaikoModHidden) } },
+            new object[] { LegacyMods.HardRock, new[] { typeof(TaikoModHardRock) } },
+            new object[] { LegacyMods.SuddenDeath, new[] { typeof(TaikoModSuddenDeath) } },
+            new object[] { LegacyMods.DoubleTime, new[] { typeof(TaikoModDoubleTime) } },
+            new object[] { LegacyMods.Relax, new[] { typeof(TaikoModRelax) } },
+            new object[] { LegacyMods.HalfTime, new[] { typeof(TaikoModHalfTime) } },
+            new object[] { LegacyMods.Nightcore, new[] { typeof(TaikoModNightcore) } },
+            new object[] { LegacyMods.Flashlight, new[] { typeof(TaikoModFlashlight) } },
+            new object[] { LegacyMods.Autoplay, new[] { typeof(TaikoModAutoplay) } },
+            new object[] { LegacyMods.Perfect, new[] { typeof(TaikoModPerfect) } },
+            new object[] { LegacyMods.Random, new[] { typeof(TaikoModRandom) } },
+            new object[] { LegacyMods.Cinema, new[] { typeof(TaikoModCinema) } },
+            new object[] { LegacyMods.HardRock | LegacyMods.DoubleTime, new[] { typeof(TaikoModHardRock), typeof(TaikoModDoubleTime) } }
+        };
+
+        [TestCaseSource(nameof(taiko_mod_mapping))]
+        [TestCase(LegacyMods.Cinema | LegacyMods.Autoplay, new[] { typeof(TaikoModCinema) })]
         [TestCase(LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(TaikoModNightcore) })]
-        [TestCase(LegacyMods.Flashlight | LegacyMods.Nightcore | LegacyMods.DoubleTime, new[] { typeof(TaikoModFlashlight), typeof(TaikoModNightcore) })]
-        [TestCase(LegacyMods.Perfect, new[] { typeof(TaikoModPerfect) })]
-        [TestCase(LegacyMods.SuddenDeath, new[] { typeof(TaikoModSuddenDeath) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(TaikoModPerfect) })]
-        [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(TaikoModDoubleTime), typeof(TaikoModPerfect) })]
         public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
+
+        [TestCaseSource(nameof(taiko_mod_mapping))]
+        public new void TestToLegacy(LegacyMods legacyMods, Type[] givenMods) => base.TestToLegacy(legacyMods, givenMods);
 
         protected override Ruleset CreateRuleset() => new TaikoRuleset();
     }

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoLegacyModConversionTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoLegacyModConversionTest.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         [TestCase(LegacyMods.SuddenDeath, new[] { typeof(TaikoModSuddenDeath) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath, new[] { typeof(TaikoModPerfect) })]
         [TestCase(LegacyMods.Perfect | LegacyMods.SuddenDeath | LegacyMods.DoubleTime, new[] { typeof(TaikoModDoubleTime), typeof(TaikoModPerfect) })]
-        public new void Test(LegacyMods legacyMods, Type[] expectedMods) => base.Test(legacyMods, expectedMods);
+        public new void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods) => base.TestFromLegacy(legacyMods, expectedMods);
 
         protected override Ruleset CreateRuleset() => new TaikoRuleset();
     }

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -92,6 +92,19 @@ namespace osu.Game.Rulesets.Taiko
 
             if (mods.HasFlag(LegacyMods.Relax))
                 yield return new TaikoModRelax();
+
+            if (mods.HasFlag(LegacyMods.Random))
+                yield return new TaikoModRandom();
+        }
+
+        public override LegacyMods ConvertToLegacyMods(Mod[] mods)
+        {
+            var value = base.ConvertToLegacyMods(mods);
+
+            if (mods.OfType<TaikoModRandom>().Any())
+                value |= LegacyMods.Random;
+
+            return value;
         }
 
         public override IEnumerable<Mod> GetModsFor(ModType type)

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -18,14 +18,17 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModNightcore<TObject> : ModDoubleTime, IApplicableToDrawableRuleset<TObject>
-        where TObject : HitObject
+    public abstract class ModNightcore : ModDoubleTime
     {
         public override string Name => "Nightcore";
         public override string Acronym => "NC";
         public override IconUsage? Icon => OsuIcon.ModNightcore;
         public override string Description => "Uguuuuuuuu...";
+    }
 
+    public abstract class ModNightcore<TObject> : ModNightcore, IApplicableToDrawableRuleset<TObject>
+        where TObject : HitObject
+    {
         private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
         private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -81,8 +81,16 @@ namespace osu.Game.Rulesets
                         value |= LegacyMods.HardRock;
                         break;
 
+                    case ModPerfect _:
+                        value |= LegacyMods.Perfect;
+                        break;
+
                     case ModSuddenDeath _:
                         value |= LegacyMods.SuddenDeath;
+                        break;
+
+                    case ModNightcore _:
+                        value |= LegacyMods.Nightcore;
                         break;
 
                     case ModDoubleTime _:
@@ -99,6 +107,14 @@ namespace osu.Game.Rulesets
 
                     case ModFlashlight _:
                         value |= LegacyMods.Flashlight;
+                        break;
+
+                    case ModCinema _:
+                        value |= LegacyMods.Cinema;
+                        break;
+
+                    case ModAutoplay _:
+                        value |= LegacyMods.Autoplay;
                         break;
                 }
             }

--- a/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
@@ -31,5 +31,15 @@ namespace osu.Game.Tests.Beatmaps
                 Assert.IsNotNull(mods.SingleOrDefault(mod => mod.GetType() == modType));
             }
         }
+
+        protected void TestToLegacy(LegacyMods expectedLegacyMods, Type[] providedModTypes)
+        {
+            var ruleset = CreateRuleset();
+            var modInstances = ruleset.GetAllMods()
+                                      .Where(mod => providedModTypes.Contains(mod.GetType()))
+                                      .ToArray();
+            var actualLegacyMods = ruleset.ConvertToLegacyMods(modInstances);
+            Assert.AreEqual(expectedLegacyMods, actualLegacyMods);
+        }
     }
 }

--- a/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyModConversionTest.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Beatmaps
         /// <returns></returns>
         protected abstract Ruleset CreateRuleset();
 
-        protected void Test(LegacyMods legacyMods, Type[] expectedMods)
+        protected void TestFromLegacy(LegacyMods legacyMods, Type[] expectedMods)
         {
             var ruleset = CreateRuleset();
             var mods = ruleset.ConvertFromLegacyMods(legacyMods).ToList();


### PR DESCRIPTION
Spurred by catching a potential regression in #10846, but after adding the test coverage I noticed several issues in the mapping, which are all fixed here.

This will be dreadful reviewing but hopefully commits are split such that it might be a bit easier. The most head-turning change would be the addition of non-generic `ModNightcore` in 5ace7ab such that I can pattern-match over it.

In the inheritance cases (nightcore, cinema...) order of pattern matches matters - more derived type must be first, then the less derived label will be ignored. [sharplab for reference](https://sharplab.io/#v2:C4LgTgrgdgPgAgJgIwFgBQcAMACOSAsA3OuogMzYDe62tuFi2AgldgL412e1wMLYAhbCGasOaOtm64E/ahMl0AMgEsAzsAA8TAHzYANuuDYAvNigBTAO7ZVG7XsrnrzABQBKADTObAj+2IFRSkgxQAzAHswCwBDAGMAC2xXADcYsGwY7BUoAyN3Kmlg2jUrFWBE5JiC+WK67DiYtQtBbAB9ECL64LwATlcAInKAcjVMwQBCAfdA7u6AI2iYgGtZubqu7sbm0Q7N9dwkfqHgUczcpimZ/fXF2NWbunE656f0NiA==), but if it wasn't the case, then the tests would also fail. I did have to hack one case locally (`ManiaModFadeIn`).