### PR TITLE
Clear DrawableHitObject transforms on return to pool

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -287,6 +287,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             HitObject = null;
             lifetimeEntry = null;
 
+            clearExistingStateTransforms();
+
             hasHitObjectApplied = false;
         }
 
@@ -403,8 +405,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             double transformTime = HitObject.StartTime - InitialLifetimeOffset;
 
-            base.ApplyTransformsAt(double.MinValue, true);
-            base.ClearTransformsAfter(double.MinValue, true);
+            clearExistingStateTransforms();
 
             using (BeginAbsoluteSequence(transformTime, true))
                 UpdateInitialTransforms();
@@ -430,6 +431,12 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             if (!force && newState == ArmedState.Hit)
                 PlaySamples();
+        }
+
+        private void clearExistingStateTransforms()
+        {
+            base.ApplyTransformsAt(double.MinValue, true);
+            base.ClearTransformsAfter(double.MinValue, true);
         }
 
         /// <summary>


### PR DESCRIPTION
- Resolves #10848
- Supersedes #10851

The main misdirection and root cause of the linked issue was that a transform was applied to a property that was being updated on the next hitobject application - namely, `Position`. Due to this, even though the `BindValueChanged` callback fired properly, `updateState` would start off by applying transforms at `double.MinValue` and clearing them to start off from what would be a sane state pre-pooling:

https://github.com/ppy/osu/blob/67db278864f596c3d72de99f8512b2d8a3f24e5d/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L406-L407

and as the `MoveToOffset` transform had read the first HO's position into itself, the position change had no practical effect.

It could well be argued that `DrawablePool` should clear transforms on its own on return, but I kinda feel like its present state of not assuming anything and placing the burden on the user gives some extra flexibility (i.e. you could have a pool of drawables with looping rewindable transforms, and just apply said transform once for each drawable in the pool instead of on every `Get()`). Aside from that, it's probably safer to have this logic in DHO as well, as it's a bit custom and also messes with framework features a bit (see the base-suppressing override of `ClearTransforms()`, which threw me for a bit of a loop while investigating this).