### PR TITLE
Use `dotnet tool` for InspectCode build script

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,24 @@
       "commands": [
         "dotnet-format"
       ]
+    },
+    "jetbrains.resharper.globaltools": {
+      "version": "2020.2.4",
+      "commands": [
+        "jb"
+      ]
+    },
+    "nvika": {
+      "version": "2.0.0",
+      "commands": [
+        "nvika"
+      ]
+    },
+    "codefilesanity": {
+      "version": "15.0.0",
+      "commands": [
+        "CodeFileSanity"
+      ]
     }
   }
 }


### PR DESCRIPTION
Same as ppy/osu-framework#4002 but fortunately no additional warnings are generated by the version difference of ReSharper.

I wonder if `cake` is necessary if the script is this simple.