### PR TITLE
Move skin deletion logic to OsuGameBase to promote thread safety

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -199,9 +199,12 @@ namespace osu.Game
             {
                 if (weakRemovedInfo.NewValue.TryGetTarget(out var removedInfo))
                 {
-                    // check the removed skin is not the current user choice. if it is, switch back to default.
-                    if (removedInfo.ID == SkinManager.CurrentSkinInfo.Value.ID)
-                        Schedule(() => SkinManager.CurrentSkinInfo.Value = SkinInfo.Default);
+                    Schedule(() =>
+                    {
+                        // check the removed skin is not the current user choice. if it is, switch back to default.
+                        if (removedInfo.ID == SkinManager.CurrentSkinInfo.Value.ID)
+                            SkinManager.CurrentSkinInfo.Value = SkinInfo.Default;
+                    });
                 }
             });
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -194,6 +194,17 @@ namespace osu.Game
             dependencies.Cache(SkinManager = new SkinManager(Storage, contextFactory, Host, Audio, new NamespacedResourceStore<byte[]>(Resources, "Skins/Legacy")));
             dependencies.CacheAs<ISkinSource>(SkinManager);
 
+            // needs to be done here rather than inside SkinManager to ensure thread safety of CurrentSkinInfo.
+            SkinManager.ItemRemoved.BindValueChanged(weakRemovedInfo =>
+            {
+                if (weakRemovedInfo.NewValue.TryGetTarget(out var removedInfo))
+                {
+                    // check the removed skin is not the current user choice. if it is, switch back to default.
+                    if (removedInfo.ID == SkinManager.CurrentSkinInfo.Value.ID)
+                        Schedule(() => SkinManager.CurrentSkinInfo.Value = SkinInfo.Default);
+                }
+            });
+
             dependencies.CacheAs(API ??= new APIAccess(LocalConfig));
 
             dependencies.CacheAs(spectatorStreaming = new SpectatorStreamingClient());

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -48,16 +48,6 @@ namespace osu.Game.Skinning
             this.audio = audio;
             this.legacyDefaultResources = legacyDefaultResources;
 
-            ItemRemoved.BindValueChanged(weakRemovedInfo =>
-            {
-                if (weakRemovedInfo.NewValue.TryGetTarget(out var removedInfo))
-                {
-                    // check the removed skin is not the current user choice. if it is, switch back to default.
-                    if (removedInfo.ID == CurrentSkinInfo.Value.ID)
-                        CurrentSkinInfo.Value = SkinInfo.Default;
-                }
-            });
-
             CurrentSkinInfo.ValueChanged += skin => CurrentSkin.Value = GetSkin(skin.NewValue);
             CurrentSkin.ValueChanged += skin =>
             {


### PR DESCRIPTION
`CurrentSkinInfo` is used in multiple places expecting thread safety, while ItemRemoved events are explicitly mentioning they are not thread safe. As SkinManager itself doesn't have the ability to schedule to the update thread, I've just moved the logic to `OsuGameBase`. We may want to move the current skin bindable out of the manager class in the future to match things like `BeatmapManager`.

Closes https://github.com/ppy/osu/issues/10837.