### PR TITLE
Remove `--no-restore` from VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Desktop",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -24,7 +23,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Desktop",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -40,7 +38,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Tests",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -55,7 +52,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Tests",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -71,7 +67,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Tournament.Tests",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -86,7 +81,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Tournament.Tests",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -102,7 +96,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Benchmarks",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -111,16 +104,6 @@
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Restore (netcoreapp3.1)",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "restore",
-                "build/Desktop.proj"
-            ],
-            "problemMatcher": []
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ git pull
 Build configurations for the recommended IDEs (listed above) are included. You should use the provided Build/Run functionality of your IDE to get things going. When testing or building new components, it's highly encouraged you use the `VisualTests` project/configuration. More information on this is provided [below](#contributing).
 
 - Visual Studio / Rider users should load the project via one of the platform-specific `.slnf` files, rather than the main `.sln.` This will allow access to template run configurations.
-- Visual Studio Code users must run the `Restore` task before any build attempt.
 
 You can also build and run *osu!* from the command-line with a single command:
 

--- a/osu.Game.Rulesets.Catch.Tests/.vscode/tasks.json
+++ b/osu.Game.Rulesets.Catch.Tests/.vscode/tasks.json
@@ -9,7 +9,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Catch.Tests.csproj",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -24,7 +23,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Catch.Tests.csproj",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -33,15 +31,6 @@
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Restore",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "restore"
-            ],
-            "problemMatcher": []
         }
     ]
 }

--- a/osu.Game.Rulesets.Mania.Tests/.vscode/tasks.json
+++ b/osu.Game.Rulesets.Mania.Tests/.vscode/tasks.json
@@ -9,7 +9,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Mania.Tests.csproj",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -24,7 +23,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Mania.Tests.csproj",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -33,15 +31,6 @@
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Restore",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "restore"
-            ],
-            "problemMatcher": []
         }
     ]
 }

--- a/osu.Game.Rulesets.Osu.Tests/.vscode/tasks.json
+++ b/osu.Game.Rulesets.Osu.Tests/.vscode/tasks.json
@@ -9,7 +9,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Osu.Tests.csproj",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -24,7 +23,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Osu.Tests.csproj",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -33,15 +31,6 @@
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Restore",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "restore"
-            ],
-            "problemMatcher": []
         }
     ]
 }

--- a/osu.Game.Rulesets.Taiko.Tests/.vscode/tasks.json
+++ b/osu.Game.Rulesets.Taiko.Tests/.vscode/tasks.json
@@ -9,7 +9,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Taiko.Tests.csproj",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -24,7 +23,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Rulesets.Taiko.Tests.csproj",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -33,15 +31,6 @@
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Restore",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "restore"
-            ],
-            "problemMatcher": []
         }
     ]
 }

--- a/osu.Game.Tournament.Tests/.vscode/tasks.json
+++ b/osu.Game.Tournament.Tests/.vscode/tasks.json
@@ -9,7 +9,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Tournament.Tests.csproj",
                 "-p:GenerateFullPaths=true",
                 "-m",
@@ -24,7 +23,6 @@
             "command": "dotnet",
             "args": [
                 "build",
-                "--no-restore",
                 "osu.Game.Tournament.Tests.csproj",
                 "-p:Configuration=Release",
                 "-p:GenerateFullPaths=true",
@@ -33,15 +31,6 @@
             ],
             "group": "build",
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Restore",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "restore"
-            ],
-            "problemMatcher": []
         }
     ]
 }


### PR DESCRIPTION
Requiring manual use of the restore task is error-prone and it can cause a difficult-to-debug "bug" that does not actually exist, by using stale dependencies.
The original motivation of using `--no-restore` was it reduces the build time a bit, but nowadays the .Net tool is optimized and it only takes less than 30ms in my machine (in case of no restoration needed).
This PR removes `--no-restore` flags from all VSCode build tasks and also remove now-unneeded "Restore" VSCode tasks.