### PR TITLE
Fix triangles disappearing after a while

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs
@@ -13,6 +13,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class CirclePiece : CompositeDrawable
     {
+        [Resolved]
+        private DrawableHitObject drawableObject { get; set; }
+
+        private TrianglesPiece triangles;
+
         public CirclePiece()
         {
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
@@ -26,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures, DrawableHitObject drawableHitObject)
+        private void load(TextureStore textures)
         {
             InternalChildren = new Drawable[]
             {
@@ -36,13 +41,32 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
                     Origin = Anchor.Centre,
                     Texture = textures.Get(@"Gameplay/osu/disc"),
                 },
-                new TrianglesPiece(drawableHitObject.GetHashCode())
+                triangles = new TrianglesPiece
                 {
                     RelativeSizeAxes = Axes.Both,
                     Blending = BlendingParameters.Additive,
                     Alpha = 0.5f,
                 }
             };
+
+            drawableObject.HitObjectApplied += onHitObjectApplied;
+            onHitObjectApplied(drawableObject);
+        }
+
+        private void onHitObjectApplied(DrawableHitObject obj)
+        {
+            if (obj.HitObject == null)
+                return;
+
+            triangles.Reset((int)obj.HitObject.StartTime);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableObject != null)
+                drawableObject.HitObjectApplied -= onHitObjectApplied;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ExplodePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/ExplodePiece.cs
@@ -1,14 +1,21 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class ExplodePiece : Container
     {
+        [Resolved]
+        private DrawableHitObject drawableObject { get; set; }
+
+        private TrianglesPiece triangles;
+
         public ExplodePiece()
         {
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
@@ -18,13 +25,36 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 
             Blending = BlendingParameters.Additive;
             Alpha = 0;
+        }
 
-            Child = new TrianglesPiece
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = triangles = new TrianglesPiece
             {
                 Blending = BlendingParameters.Additive,
                 RelativeSizeAxes = Axes.Both,
                 Alpha = 0.2f,
             };
+
+            drawableObject.HitObjectApplied += onHitObjectApplied;
+            onHitObjectApplied(drawableObject);
+        }
+
+        private void onHitObjectApplied(DrawableHitObject obj)
+        {
+            if (obj.HitObject == null)
+                return;
+
+            triangles.Reset((int)obj.HitObject.StartTime);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableObject != null)
+                drawableObject.HitObjectApplied -= onHitObjectApplied;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/TrianglesPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/TrianglesPiece.cs
@@ -7,8 +7,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class TrianglesPiece : Triangles
     {
-        protected override bool ExpireOffScreenTriangles => false;
-        protected override bool CreateNewTriangles => false;
         protected override float SpawnRatio => 0.5f;
 
         public TrianglesPiece(int? seed = null)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/TrianglesPiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/TrianglesPiece.cs
@@ -7,6 +7,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
 {
     public class TrianglesPiece : Triangles
     {
+        protected override bool CreateNewTriangles => false;
         protected override float SpawnRatio => 0.5f;
 
         public TrianglesPiece(int? seed = null)

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -87,12 +87,9 @@ namespace osu.Game.Graphics.Backgrounds
         /// </summary>
         public float Velocity = 1;
 
-        private readonly Random stableRandom;
-
-        private float nextRandom() => (float)(stableRandom?.NextDouble() ?? RNG.NextSingle());
-
         private readonly SortedList<TriangleParticle> parts = new SortedList<TriangleParticle>(Comparer<TriangleParticle>.Default);
 
+        private Random stableRandom;
         private IShader shader;
         private readonly Texture texture;
 
@@ -173,7 +170,20 @@ namespace osu.Game.Graphics.Backgrounds
             }
         }
 
-        protected int AimCount;
+        /// <summary>
+        /// Clears and re-initialises triangles according to a given seed.
+        /// </summary>
+        /// <param name="seed">An optional seed to stabilise random positions / attributes. Note that this does not guarantee stable playback when seeking in time.</param>
+        public void Reset(int? seed = null)
+        {
+            if (seed != null)
+                stableRandom = new Random(seed.Value);
+
+            parts.Clear();
+            addTriangles(true);
+        }
+
+        protected int AimCount { get; private set; }
 
         private void addTriangles(bool randomY)
         {
@@ -226,6 +236,8 @@ namespace osu.Game.Graphics.Backgrounds
                 parts[i] = newParticle;
             }
         }
+
+        private float nextRandom() => (float)(stableRandom?.NextDouble() ?? RNG.NextSingle());
 
         protected override DrawNode CreateDrawNode() => new TrianglesDrawNode(this);
 

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -60,6 +60,7 @@ namespace osu.Game.Graphics.Backgrounds
         /// <summary>
         /// Whether we want to expire triangles as they exit our draw area completely.
         /// </summary>
+        [Obsolete("Unused.")] // Can be removed 20210518
         protected virtual bool ExpireOffScreenTriangles => true;
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/10858

Apart from spinners, it also occurs with normal hitobjects where their explosion's triangles stop showing up after a little while.