### PR TITLE
Remove ability to pool DHOs in parent playfields

### DIFF
--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -218,9 +218,6 @@ namespace osu.Game.Rulesets.UI
 
         #region Pooling support
 
-        [Resolved(CanBeNull = true)]
-        private IPooledHitObjectProvider parentPooledObjectProvider { get; set; }
-
         private readonly Dictionary<Type, IDrawablePool> pools = new Dictionary<Type, IDrawablePool>();
 
         /// <summary>
@@ -320,10 +317,7 @@ namespace osu.Game.Rulesets.UI
                 }
             }
 
-            if (pool == null)
-                return parentPooledObjectProvider?.GetPooledDrawableRepresentation(hitObject);
-
-            return (DrawableHitObject)pool.Get(d =>
+            return (DrawableHitObject)pool?.Get(d =>
             {
                 var dho = (DrawableHitObject)d;
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/10849

I don't think this is a pattern we want, as it means parents are changing to potentially completely different playfields and DHOs don't have the ability to handle to such changes (e.g. with resolved dependencies).