### PR TITLE
Fix slider control point connections not being updated

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
@@ -20,17 +20,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private readonly Path path;
         private readonly Slider slider;
-        private int controlPointIndex;
-
-        public int ControlPointIndex
-        {
-            get => controlPointIndex;
-            set
-            {
-                controlPointIndex = value;
-                updateConnectingPath();
-            }
-        }
+        public int ControlPointIndex { get; set; }
 
         private IBindable<Vector2> sliderPosition;
         private IBindable<int> pathVersion;
@@ -38,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         public PathControlPointConnectionPiece(Slider slider, int controlPointIndex)
         {
             this.slider = slider;
-            this.controlPointIndex = controlPointIndex;
+            ControlPointIndex = controlPointIndex;
 
             Origin = Anchor.Centre;
             AutoSizeAxes = Axes.Both;
@@ -74,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
             path.ClearVertices();
 
-            int nextIndex = controlPointIndex + 1;
+            int nextIndex = ControlPointIndex + 1;
             if (nextIndex == 0 || nextIndex >= slider.Path.ControlPoints.Count)
                 return;
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
@@ -20,7 +20,17 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private readonly Path path;
         private readonly Slider slider;
-        private readonly int controlPointIndex;
+        private int controlPointIndex;
+
+        public int ControlPointIndex
+        {
+            get => controlPointIndex;
+            set
+            {
+                controlPointIndex = value;
+                updateConnectingPath();
+            }
+        }
 
         private IBindable<Vector2> sliderPosition;
         private IBindable<int> pathVersion;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -66,6 +66,17 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
+                    // If inserting in the the path (not appending),
+                    // update indices of existing connections after insert location
+                    if (e.NewStartingIndex < Pieces.Count)
+                    {
+                        foreach (var connection in Connections)
+                        {
+                            if (connection.ControlPointIndex >= e.NewStartingIndex)
+                                connection.ControlPointIndex += e.NewItems.Count;
+                        }
+                    }
+
                     for (int i = 0; i < e.NewItems.Count; i++)
                     {
                         var point = (PathControlPoint)e.NewItems[i];
@@ -82,10 +93,23 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
+                    int oldSize = Pieces.Count;
+
                     foreach (var point in e.OldItems.Cast<PathControlPoint>())
                     {
                         Pieces.RemoveAll(p => p.ControlPoint == point);
                         Connections.RemoveAll(c => c.ControlPoint == point);
+                    }
+
+                    // If removing before the end of the path,
+                    // update indices of connections after remove location
+                    if (e.OldStartingIndex + e.OldItems.Count < oldSize)
+                    {
+                        foreach (var connection in Connections)
+                        {
+                            if (connection.ControlPointIndex >= e.OldStartingIndex)
+                                connection.ControlPointIndex -= e.OldItems.Count;
+                        }
                     }
 
                     break;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
                     // If removing before the end of the path,
                     // update indices of connections after remove location
-                    if (e.OldStartingIndex + e.OldItems.Count < Pieces.Count + e.OldItems.Count)
+                    if (e.OldStartingIndex < Pieces.Count)
                     {
                         foreach (var connection in Connections)
                         {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    // If inserting in the the path (not appending),
+                    // If inserting in the path (not appending),
                     // update indices of existing connections after insert location
                     if (e.NewStartingIndex < Pieces.Count)
                     {
@@ -93,8 +93,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
-                    int oldSize = Pieces.Count;
-
                     foreach (var point in e.OldItems.Cast<PathControlPoint>())
                     {
                         Pieces.RemoveAll(p => p.ControlPoint == point);
@@ -103,7 +101,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
                     // If removing before the end of the path,
                     // update indices of connections after remove location
-                    if (e.OldStartingIndex + e.OldItems.Count < oldSize)
+                    if (e.OldStartingIndex + e.OldItems.Count < Pieces.Count + e.OldItems.Count)
                     {
                         foreach (var connection in Connections)
                         {


### PR DESCRIPTION
The indices stored in `PathControlPointConnectionPiece`s weren't being updated, leading to incorrect behaviour when adding points to or removing points from the middle of a slider, for example:
![image](https://user-images.githubusercontent.com/15140758/99304582-d58aba00-2852-11eb-9ea7-cbff9068d240.png)
