### PR TITLE
Fix hold note judgements displaying incorrectly

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public class DrawableHoldNoteTick : DrawableManiaHitObject<HoldNoteTick>
     {
-        public override bool DisplayResult => false;
-
         /// <summary>
         /// References the time at which the user started holding the hold note.
         /// </summary>

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Mania.UI
             if (result.IsHit)
                 hitPolicy.HandleHit(judgedObject);
 
-            if (!result.IsHit || !DisplayJudgements.Value)
+            if (!result.IsHit || !judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 
             HitObjectArea.Explosions.Add(hitExplosionPool.Get(e => e.Apply(result)));

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -167,6 +167,10 @@ namespace osu.Game.Rulesets.Mania.UI
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 
+            // Tick judgements should not display text.
+            if (judgedObject is DrawableHoldNoteTick)
+                return;
+
             judgements.Clear(false);
             judgements.Add(judgementPool.Get(j =>
             {


### PR DESCRIPTION
Two overlapping issues here:
1. Hold note judgement explosions were always displayed (they always get `IgnoreHit`), so `judgedObject.DisplayResult` needs to be used.
2. By applying (1), `HoldNoteTick`s would not display judgement explosions, so I've removed their override and added a case specifically for them in the `Stage` to stop the text from displaying.