### PR TITLE
Add ability for skins to have more control over judgement transforms

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -1,10 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
@@ -19,13 +19,6 @@ namespace osu.Game.Rulesets.Mania.UI
         {
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            if (JudgementText != null)
-                JudgementText.Font = JudgementText.Font.With(size: 25);
-        }
-
         protected override double FadeInDuration => 50;
 
         protected override void ApplyHitAnimations()
@@ -35,6 +28,18 @@ namespace osu.Game.Rulesets.Mania.UI
 
             JudgementBody.Delay(FadeInDuration).ScaleTo(0.75f, 250);
             this.Delay(FadeInDuration).FadeOut(200);
+        }
+
+        protected override Drawable CreateDefaultJudgement(HitResult type)
+            => new ManiaJudgementPiece();
+
+        private class ManiaJudgementPiece : DefaultJudgementPiece
+        {
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                JudgementText.Font = JudgementText.Font.With(size: 25);
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -30,14 +30,19 @@ namespace osu.Game.Rulesets.Mania.UI
             this.Delay(FadeInDuration).FadeOut(200);
         }
 
-        protected override Drawable CreateDefaultJudgement(HitResult type)
-            => new ManiaJudgementPiece();
+        protected override Drawable CreateDefaultJudgement(HitResult result) => new ManiaJudgementPiece(result);
 
         private class ManiaJudgementPiece : DefaultJudgementPiece
         {
+            public ManiaJudgementPiece(HitResult result)
+                : base(result)
+            {
+            }
+
             protected override void LoadComplete()
             {
                 base.LoadComplete();
+
                 JudgementText.Font = JudgementText.Font.With(size: 25);
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -4,9 +4,9 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
-using osuTK;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -65,8 +65,20 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             fadeOutDelay = hitLightingEnabled ? 1400 : base.FadeOutDelay;
 
-            JudgementText?.TransformSpacingTo(Vector2.Zero).Then().TransformSpacingTo(new Vector2(14, 0), 1800, Easing.OutQuint);
             base.ApplyHitAnimations();
+        }
+
+        protected override Drawable CreateDefaultJudgement(HitResult type) => new OsuJudgementPiece();
+
+        private class OsuJudgementPiece : DefaultJudgementPiece
+        {
+            public override void PlayAnimation(HitResult resultType)
+            {
+                base.PlayAnimation(resultType);
+
+                if (resultType != HitResult.Miss)
+                    JudgementText.TransformSpacingTo(Vector2.Zero).Then().TransformSpacingTo(new Vector2(14, 0), 1800, Easing.OutQuint);
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -68,15 +68,20 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.ApplyHitAnimations();
         }
 
-        protected override Drawable CreateDefaultJudgement(HitResult type) => new OsuJudgementPiece();
+        protected override Drawable CreateDefaultJudgement(HitResult result) => new OsuJudgementPiece(result);
 
         private class OsuJudgementPiece : DefaultJudgementPiece
         {
-            public override void PlayAnimation(HitResult resultType)
+            public OsuJudgementPiece(HitResult result)
+                : base(result)
             {
-                base.PlayAnimation(resultType);
+            }
 
-                if (resultType != HitResult.Miss)
+            public override void PlayAnimation()
+            {
+                base.PlayAnimation();
+
+                if (Result != HitResult.Miss)
                     JudgementText.TransformSpacingTo(Vector2.Zero).Then().TransformSpacingTo(new Vector2(14, 0), 1800, Easing.OutQuint);
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -39,23 +39,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             });
         }
 
-        public override void Apply(JudgementResult result, DrawableHitObject judgedObject)
-        {
-            base.Apply(result, judgedObject);
-
-            if (judgedObject?.HitObject is OsuHitObject osuObject)
-            {
-                Position = osuObject.StackedPosition;
-                Scale = new Vector2(osuObject.Scale);
-            }
-        }
-
         protected override void PrepareForUse()
         {
             base.PrepareForUse();
 
             Lighting.ResetAnimation();
             Lighting.SetColourFrom(JudgedObject, Result);
+
+            if (JudgedObject?.HitObject is OsuHitObject osuObject)
+            {
+                Position = osuObject.StackedPosition;
+                Scale = new Vector2(osuObject.Scale);
+            }
         }
 
         private double fadeOutDelay;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -17,15 +17,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        public DrawableOsuJudgement(JudgementResult result, DrawableHitObject judgedObject)
-            : base(result, judgedObject)
-        {
-        }
-
-        public DrawableOsuJudgement()
-        {
-        }
-
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Objects.Drawables;
-using osu.Framework.Allocation;
-using osu.Game.Graphics;
-using osu.Game.Rulesets.Judgements;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
@@ -23,21 +20,6 @@ namespace osu.Game.Rulesets.Taiko.UI
         public DrawableTaikoJudgement(JudgementResult result, DrawableHitObject judgedObject)
             : base(result, judgedObject)
         {
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            switch (Result.Type)
-            {
-                case HitResult.Ok:
-                    JudgementBody.Colour = colours.GreenLight;
-                    break;
-
-                case HitResult.Great:
-                    JudgementBody.Colour = colours.BlueLight;
-                    break;
-            }
         }
 
         protected override void ApplyHitAnimations()

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -15,36 +15,42 @@ namespace osu.Game.Rulesets.Judgements
 {
     public class DefaultJudgementPiece : CompositeDrawable, IAnimatableJudgement
     {
-        protected SpriteText JudgementText { get; }
+        protected readonly HitResult Result;
+
+        protected SpriteText JudgementText { get; private set; }
 
         [Resolved]
         private OsuColour colours { get; set; }
 
-        public DefaultJudgementPiece()
+        public DefaultJudgementPiece(HitResult result)
         {
+            this.Result = result;
             Origin = Anchor.Centre;
+        }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             AutoSizeAxes = Axes.Both;
 
             InternalChildren = new Drawable[]
             {
                 JudgementText = new OsuSpriteText
                 {
+                    Text = Result.GetDescription().ToUpperInvariant(),
+                    Colour = colours.ForHitResult(Result),
                     Font = OsuFont.Numeric.With(size: 20),
                     Scale = new Vector2(0.85f, 1),
                 }
             };
         }
 
-        public virtual void PlayAnimation(HitResult result)
+        public virtual void PlayAnimation()
         {
-            JudgementText.Text = result.GetDescription().ToUpperInvariant();
-            JudgementText.Colour = colours.ForHitResult(result);
-
             this.RotateTo(0);
             this.MoveTo(Vector2.Zero);
 
-            switch (result)
+            switch (Result)
             {
                 case HitResult.Miss:
                     this.ScaleTo(1.6f);

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Judgements
 
         public DefaultJudgementPiece(HitResult result)
         {
-            this.Result = result;
+            Result = result;
             Origin = Anchor.Centre;
         }
 

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Rulesets.Judgements
+{
+    public class DefaultJudgementPiece : CompositeDrawable, IAnimatableJudgement
+    {
+        protected SpriteText JudgementText { get; }
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        public DefaultJudgementPiece()
+        {
+            Origin = Anchor.Centre;
+
+            AutoSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                JudgementText = new OsuSpriteText
+                {
+                    Font = OsuFont.Numeric.With(size: 20),
+                    Scale = new Vector2(0.85f, 1),
+                }
+            };
+        }
+
+        public virtual void PlayAnimation(HitResult result)
+        {
+            JudgementText.Text = result.GetDescription().ToUpperInvariant();
+            JudgementText.Colour = colours.ForHitResult(result);
+
+            this.RotateTo(0);
+            this.MoveTo(Vector2.Zero);
+
+            switch (result)
+            {
+                case HitResult.Miss:
+                    this.ScaleTo(1.6f);
+                    this.ScaleTo(1, 100, Easing.In);
+
+                    this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+
+                    this.RotateTo(40, 800, Easing.InQuint);
+                    break;
+
+                default:
+                    this.ScaleTo(0.9f);
+                    this.ScaleTo(1, 500, Easing.OutElastic);
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Judgements
             this.Delay(FadeOutDelay).FadeOut(400);
         }
 
-        public virtual void Apply([NotNull] JudgementResult result, [CanBeNull] DrawableHitObject judgedObject)
+        public void Apply([NotNull] JudgementResult result, [CanBeNull] DrawableHitObject judgedObject)
         {
             Result = result;
             JudgedObject = judgedObject;

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -3,18 +3,14 @@
 
 using System.Diagnostics;
 using JetBrains.Annotations;
-using osuTK;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Judgements
 {
@@ -25,16 +21,13 @@ namespace osu.Game.Rulesets.Judgements
     {
         private const float judgement_size = 128;
 
-        [Resolved]
-        private OsuColour colours { get; set; }
-
         public JudgementResult Result { get; private set; }
+
         public DrawableHitObject JudgedObject { get; private set; }
 
         protected Container JudgementBody { get; private set; }
-        protected SpriteText JudgementText { get; private set; }
 
-        private SkinnableDrawable bodyDrawable;
+        private SkinnableDrawable skinnableJudgement;
 
         /// <summary>
         /// Duration of initial fade in.
@@ -69,12 +62,32 @@ namespace osu.Game.Rulesets.Judgements
             prepareDrawables();
         }
 
+        /// <summary>
+        /// Apply top-level animations to the current judgement when successfully hit.
+        /// Generally used for fading, defaulting to a simple fade out based on <see cref="FadeOutDelay"/>.
+        /// This will be used to calculate the lifetime of the judgement.
+        /// </summary>
+        /// <remarks>
+        /// For animating the actual "default skin" judgement itself, it is recommended to use <see cref="CreateDefaultJudgement"/>.
+        /// This allows applying animations which don't affect custom skins.
+        /// </remarks>
         protected virtual void ApplyHitAnimations()
         {
-            JudgementBody.ScaleTo(0.9f);
-            JudgementBody.ScaleTo(1, 500, Easing.OutElastic);
-
             this.Delay(FadeOutDelay).FadeOut(400);
+        }
+
+        /// <summary>
+        /// Apply top-level animations to the current judgement when missed.
+        /// Generally used for fading, defaulting to a simple fade out based on <see cref="FadeOutDelay"/>.
+        /// This will be used to calculate the lifetime of the judgement.
+        /// </summary>
+        /// <remarks>
+        /// For animating the actual "default skin" judgement itself, it is recommended to use <see cref="CreateDefaultJudgement"/>.
+        /// This allows applying animations which don't affect custom skins.
+        /// </remarks>
+        protected virtual void ApplyMissAnimations()
+        {
+            this.Delay(600).FadeOut(200);
         }
 
         public void Apply([NotNull] JudgementResult result, [CanBeNull] DrawableHitObject judgedObject)
@@ -91,12 +104,9 @@ namespace osu.Game.Rulesets.Judgements
 
             prepareDrawables();
 
-            bodyDrawable.ResetAnimation();
+            skinnableJudgement.ResetAnimation();
 
             this.FadeInFromZero(FadeInDuration, Easing.OutQuint);
-            JudgementBody.ScaleTo(1);
-            JudgementBody.RotateTo(0);
-            JudgementBody.MoveTo(Vector2.Zero);
 
             switch (Result.Type)
             {
@@ -104,18 +114,18 @@ namespace osu.Game.Rulesets.Judgements
                     break;
 
                 case HitResult.Miss:
-                    JudgementBody.ScaleTo(1.6f);
-                    JudgementBody.ScaleTo(1, 100, Easing.In);
-
-                    JudgementBody.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
-                    JudgementBody.RotateTo(40, 800, Easing.InQuint);
-
-                    this.Delay(600).FadeOut(200);
+                    ApplyMissAnimations();
                     break;
 
                 default:
                     ApplyHitAnimations();
                     break;
+            }
+
+            if (skinnableJudgement.Drawable is IAnimatableJudgement animatable)
+            {
+                using (BeginAbsoluteSequence(Result.TimeAbsolute))
+                    animatable.PlayAnimation(Result.Type);
             }
 
             Expire(true);
@@ -139,16 +149,13 @@ namespace osu.Game.Rulesets.Judgements
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-                Child = bodyDrawable = new SkinnableDrawable(new GameplaySkinComponent<HitResult>(type), _ => JudgementText = new OsuSpriteText
-                {
-                    Text = type.GetDescription().ToUpperInvariant(),
-                    Font = OsuFont.Numeric.With(size: 20),
-                    Colour = colours.ForHitResult(type),
-                    Scale = new Vector2(0.85f, 1),
-                }, confineMode: ConfineMode.NoScaling)
+                Child = skinnableJudgement = new SkinnableDrawable(new GameplaySkinComponent<HitResult>(type), _ =>
+                    CreateDefaultJudgement(type), confineMode: ConfineMode.NoScaling)
             });
 
             currentDrawableType = type;
         }
+
+        protected virtual Drawable CreateDefaultJudgement(HitResult type) => new DefaultJudgementPiece();
     }
 }

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -90,6 +90,11 @@ namespace osu.Game.Rulesets.Judgements
             this.Delay(600).FadeOut(200);
         }
 
+        /// <summary>
+        /// Associate a new result / object with this judgement. Should be called when retrieving a judgement from a pool.
+        /// </summary>
+        /// <param name="result">The applicable judgement.</param>
+        /// <param name="judgedObject">The drawable object.</param>
         public void Apply([NotNull] JudgementResult result, [CanBeNull] DrawableHitObject judgedObject)
         {
             Result = result;
@@ -104,6 +109,7 @@ namespace osu.Game.Rulesets.Judgements
 
             prepareDrawables();
 
+            // not sure if this should remain going forward.
             skinnableJudgement.ResetAnimation();
 
             this.FadeInFromZero(FadeInDuration, Easing.OutQuint);

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Rulesets.Judgements
             if (skinnableJudgement.Drawable is IAnimatableJudgement animatable)
             {
                 using (BeginAbsoluteSequence(Result.TimeAbsolute))
-                    animatable.PlayAnimation(Result.Type);
+                    animatable.PlayAnimation();
             }
 
             Expire(true);
@@ -143,6 +143,7 @@ namespace osu.Game.Rulesets.Judgements
         {
             var type = Result?.Type ?? HitResult.Perfect; //TODO: better default type from ruleset
 
+            // todo: this should be removed once judgements are always pooled.
             if (type == currentDrawableType)
                 return;
 
@@ -162,6 +163,6 @@ namespace osu.Game.Rulesets.Judgements
             currentDrawableType = type;
         }
 
-        protected virtual Drawable CreateDefaultJudgement(HitResult type) => new DefaultJudgementPiece();
+        protected virtual Drawable CreateDefaultJudgement(HitResult result) => new DefaultJudgementPiece(result);
     }
 }

--- a/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Scoring;
-
 namespace osu.Game.Rulesets.Judgements
 {
     /// <summary>
@@ -10,6 +8,6 @@ namespace osu.Game.Rulesets.Judgements
     /// </summary>
     public interface IAnimatableJudgement
     {
-        void PlayAnimation(HitResult result);
+        void PlayAnimation();
     }
 }

--- a/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Judgements
+{
+    /// <summary>
+    /// A skinnable judgement element which supports playing an animation from the current point in time.
+    /// </summary>
+    public interface IAnimatableJudgement
+    {
+        void PlayAnimation(HitResult result);
+    }
+}

--- a/osu.Game/Skinning/LegacyJudgementPiece.cs
+++ b/osu.Game/Skinning/LegacyJudgementPiece.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Skinning
+{
+    public class LegacyJudgementPiece : CompositeDrawable, IAnimatableJudgement
+    {
+        private readonly HitResult result;
+
+        public LegacyJudgementPiece(HitResult result, Drawable texture)
+        {
+            this.result = result;
+
+            AutoSizeAxes = Axes.Both;
+            Origin = Anchor.Centre;
+
+            InternalChild = texture;
+        }
+
+        public virtual void PlayAnimation()
+        {
+            var animation = InternalChild as IFramedAnimation;
+
+            animation?.GotoFrame(0);
+
+            this.RotateTo(0);
+            this.MoveTo(Vector2.Zero);
+
+            // legacy judgements don't play any transforms if they are an animation.
+            if (animation?.FrameCount > 1)
+                return;
+
+            switch (result)
+            {
+                case HitResult.Miss:
+                    this.ScaleTo(1.6f);
+                    this.ScaleTo(1, 100, Easing.In);
+
+                    this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+
+                    this.RotateTo(40, 800, Easing.InQuint);
+                    break;
+
+                default:
+                    this.ScaleTo(0.9f);
+                    this.ScaleTo(1, 500, Easing.OutElastic);
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game/Skinning/LegacyJudgementPiece.cs
+++ b/osu.Game/Skinning/LegacyJudgementPiece.cs
@@ -14,14 +14,14 @@ namespace osu.Game.Skinning
     {
         private readonly HitResult result;
 
-        public LegacyJudgementPiece(HitResult result, Drawable texture)
+        public LegacyJudgementPiece(HitResult result, Drawable drawable)
         {
             this.result = result;
 
             AutoSizeAxes = Axes.Both;
             Origin = Anchor.Centre;
 
-            InternalChild = texture;
+            InternalChild = drawable;
         }
 
         public virtual void PlayAnimation()

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -371,25 +371,34 @@ namespace osu.Game.Skinning
                 }
 
                 case GameplaySkinComponent<HitResult> resultComponent:
-                    switch (resultComponent.Component)
-                    {
-                        case HitResult.Miss:
-                            return this.GetAnimation("hit0", true, false);
-
-                        case HitResult.Meh:
-                            return this.GetAnimation("hit50", true, false);
-
-                        case HitResult.Ok:
-                            return this.GetAnimation("hit100", true, false);
-
-                        case HitResult.Great:
-                            return this.GetAnimation("hit300", true, false);
-                    }
+                    var drawable = getJudgementAnimation(resultComponent.Component);
+                    if (drawable != null)
+                        return new LegacyJudgementPiece(resultComponent.Component, drawable);
 
                     break;
             }
 
             return this.GetAnimation(component.LookupName, false, false);
+        }
+
+        private Drawable getJudgementAnimation(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Miss:
+                    return this.GetAnimation("hit0", true, false);
+
+                case HitResult.Meh:
+                    return this.GetAnimation("hit50", true, false);
+
+                case HitResult.Ok:
+                    return this.GetAnimation("hit100", true, false);
+
+                case HitResult.Great:
+                    return this.GetAnimation("hit300", true, false);
+            }
+
+            return null;
         }
 
         public override Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)


### PR DESCRIPTION
Closes #10195.

Can be tested with existing test scene (`osu.Game.Rulesets.Osu.Tests.TestSceneDrawableJudgement`) – special skin is animated and should no longer show a scale transform on misses *or* hits. All others should remain as previous.

Ended up implementing this in a non-breaking way (I believe).

![2020-11-17 15 51 53](https://user-images.githubusercontent.com/191335/99356070-d8d28400-28ec-11eb-923c-bf327e412121.gif)
