### PR TITLE
Define blueprint order similarly to hitobjects

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -118,8 +118,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        protected virtual SelectionBlueprintContainer CreateSelectionBlueprintContainer() =>
-            new SelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
+        protected virtual Container<SelectionBlueprint> CreateSelectionBlueprintContainer() => new HitObjectOrderedSelectionContainer { RelativeSizeAxes = Axes.Both };
 
         /// <summary>
         /// Creates a <see cref="Components.SelectionHandler"/> which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -337,6 +337,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a selection was performed.</returns>
         private bool beginClickSelection(MouseButtonEvent e)
         {
+            // Iterate from the top of the input stack (blueprints closest to the front of the screen first).
             foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren.Reverse())
             {
                 if (!blueprint.IsHovered) continue;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -118,8 +118,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        protected virtual Container<SelectionBlueprint> CreateSelectionBlueprintContainer() =>
-            new Container<SelectionBlueprint> { RelativeSizeAxes = Axes.Both };
+        protected virtual SelectionBlueprintContainer CreateSelectionBlueprintContainer() =>
+            new SelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
 
         /// <summary>
         /// Creates a <see cref="Components.SelectionHandler"/> which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.
@@ -338,7 +338,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a selection was performed.</returns>
         private bool beginClickSelection(MouseButtonEvent e)
         {
-            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren)
+            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren.Reverse())
             {
                 if (!blueprint.IsHovered) continue;
 

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
@@ -6,9 +6,13 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
+    /// <summary>
+    /// A container for <see cref="SelectionBlueprint"/> ordered by their <see cref="HitObject"/> start times.
+    /// </summary>
     public sealed class HitObjectOrderedSelectionContainer : Container<SelectionBlueprint>
     {
         public override void Add(SelectionBlueprint drawable)

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
@@ -9,14 +9,12 @@ using osu.Game.Rulesets.Edit;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
-    public class SelectionBlueprintContainer : Container<SelectionBlueprint>
+    public sealed class HitObjectOrderedSelectionContainer : Container<SelectionBlueprint>
     {
         public override void Add(SelectionBlueprint drawable)
         {
             base.Add(drawable);
-
-            if (Content == this)
-                bindStartTime(drawable);
+            bindStartTime(drawable);
         }
 
         public override bool Remove(SelectionBlueprint drawable)
@@ -24,8 +22,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (!base.Remove(drawable))
                 return false;
 
-            if (Content == this)
-                unbindStartTime(drawable);
+            unbindStartTime(drawable);
             return true;
         }
 
@@ -65,8 +62,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override int Compare(Drawable x, Drawable y)
         {
-            if (!(x is SelectionBlueprint xObj) || !(y is SelectionBlueprint yObj))
-                return base.Compare(x, y);
+            var xObj = (SelectionBlueprint)x;
+            var yObj = (SelectionBlueprint)y;
 
             // Put earlier blueprints towards the end of the list, so they handle input first
             int i = yObj.HitObject.StartTime.CompareTo(xObj.HitObject.StartTime);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBlueprintContainer.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Edit;
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public class SelectionBlueprintContainer : Container<SelectionBlueprint>
+    {
+        public override void Add(SelectionBlueprint drawable)
+        {
+            base.Add(drawable);
+
+            if (Content == this)
+                bindStartTime(drawable);
+        }
+
+        public override bool Remove(SelectionBlueprint drawable)
+        {
+            if (!base.Remove(drawable))
+                return false;
+
+            if (Content == this)
+                unbindStartTime(drawable);
+            return true;
+        }
+
+        public override void Clear(bool disposeChildren)
+        {
+            base.Clear(disposeChildren);
+            unbindAllStartTimes();
+        }
+
+        private readonly Dictionary<SelectionBlueprint, IBindable> startTimeMap = new Dictionary<SelectionBlueprint, IBindable>();
+
+        private void bindStartTime(SelectionBlueprint blueprint)
+        {
+            var bindable = blueprint.HitObject.StartTimeBindable.GetBoundCopy();
+
+            bindable.BindValueChanged(_ =>
+            {
+                if (LoadState >= LoadState.Ready)
+                    SortInternal();
+            });
+
+            startTimeMap[blueprint] = bindable;
+        }
+
+        private void unbindStartTime(SelectionBlueprint blueprint)
+        {
+            startTimeMap[blueprint].UnbindAll();
+            startTimeMap.Remove(blueprint);
+        }
+
+        private void unbindAllStartTimes()
+        {
+            foreach (var kvp in startTimeMap)
+                kvp.Value.UnbindAll();
+            startTimeMap.Clear();
+        }
+
+        protected override int Compare(Drawable x, Drawable y)
+        {
+            if (!(x is SelectionBlueprint xObj) || !(y is SelectionBlueprint yObj))
+                return base.Compare(x, y);
+
+            // Put earlier blueprints towards the end of the list, so they handle input first
+            int i = yObj.HitObject.StartTime.CompareTo(xObj.HitObject.StartTime);
+            return i == 0 ? CompareReverseChildID(x, y) : i;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
         }
 
-        protected override Container<SelectionBlueprint> CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
+        protected override SelectionBlueprintContainer CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
 
         protected override void OnDrag(DragEvent e)
         {
@@ -195,13 +195,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
         }
 
-        protected class TimelineSelectionBlueprintContainer : Container<SelectionBlueprint>
+        protected class TimelineSelectionBlueprintContainer : SelectionBlueprintContainer
         {
             protected override Container<SelectionBlueprint> Content { get; }
 
             public TimelineSelectionBlueprintContainer()
             {
-                AddInternal(new TimelinePart<SelectionBlueprint>(Content = new Container<SelectionBlueprint> { RelativeSizeAxes = Axes.Both }) { RelativeSizeAxes = Axes.Both });
+                AddInternal(new TimelinePart<SelectionBlueprint>(Content = new SelectionBlueprintContainer { RelativeSizeAxes = Axes.Both }) { RelativeSizeAxes = Axes.Both });
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
         }
 
-        protected override SelectionBlueprintContainer CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
+        protected override Container<SelectionBlueprint> CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
 
         protected override void OnDrag(DragEvent e)
         {
@@ -195,13 +195,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
         }
 
-        protected class TimelineSelectionBlueprintContainer : SelectionBlueprintContainer
+        protected class TimelineSelectionBlueprintContainer : Container<SelectionBlueprint>
         {
             protected override Container<SelectionBlueprint> Content { get; }
 
             public TimelineSelectionBlueprintContainer()
             {
-                AddInternal(new TimelinePart<SelectionBlueprint>(Content = new SelectionBlueprintContainer { RelativeSizeAxes = Axes.Both }) { RelativeSizeAxes = Axes.Both });
+                AddInternal(new TimelinePart<SelectionBlueprint>(Content = new HitObjectOrderedSelectionContainer { RelativeSizeAxes = Axes.Both }) { RelativeSizeAxes = Axes.Both });
             }
         }
     }


### PR DESCRIPTION
Fixes the ordering issue I mentioned in https://github.com/ppy/osu/issues/10857

Implementation is similar to that of `HitObjectContainer`, although `SelectionBlueprintContainer` doesn't need to worry about binding directly to hitobject start times since they are tied directly to the lifetime of a DHO already.

Most noticeable in the timeline, with this PR: https://drive.google.com/file/d/1WbOfqEwYFqS4I7K3yztZqMEtjzGxXwPS/view?usp=sharing