### PR TITLE
Add HUD Visibility dropdown to Visual Settings panel

### DIFF
--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsDropdown.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsDropdown.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsDropdown.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsDropdown.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsDropdown.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlayerSettingsDropdown.cs
@@ -1,0 +1,36 @@
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Play.PlayerSettings
+{
+    public class PlayerSettingsDropdown<T> : OsuEnumDropdown<T>
+        where T : struct, Enum
+    {
+        protected override DropdownHeader CreateHeader() => new PlayerSettingsDropdownHeader();
+
+        protected override DropdownMenu CreateMenu() => new PlayerSettingsDropdownMenu();
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            AccentColour = colours.Yellow;
+        }
+
+        private class PlayerSettingsDropdownHeader : OsuDropdownHeader
+        {
+            public PlayerSettingsDropdownHeader()
+            {
+                Height = 25;
+                Foreground.Padding = new MarginPadding { Top = 4, Bottom = 4, Left = 8, Right = 8 };
+            }
+        }
+
+        private class PlayerSettingsDropdownMenu : OsuDropdownMenu
+        {
+        }
+    }
+}

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -12,6 +12,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
     {
         private readonly PlayerSliderBar<double> dimSliderBar;
         private readonly PlayerSliderBar<double> blurSliderBar;
+        private readonly PlayerSettingsDropdown<HUDVisibilityMode> hudVisibilityModeDropdown;
         private readonly PlayerCheckbox showStoryboardToggle;
         private readonly PlayerCheckbox beatmapSkinsToggle;
         private readonly PlayerCheckbox beatmapHitsoundsToggle;
@@ -39,6 +40,14 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
                 new OsuSpriteText
                 {
+                    Text = "HUD Visibility:"
+                },
+                hudVisibilityModeDropdown = new PlayerSettingsDropdown<HUDVisibilityMode>
+                {
+                    RelativeSizeAxes = Axes.X
+                },
+                new OsuSpriteText
+                {
                     Text = "Toggles:"
                 },
                 showStoryboardToggle = new PlayerCheckbox { LabelText = "Storyboard / Video" },
@@ -52,6 +61,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             dimSliderBar.Current = config.GetBindable<double>(OsuSetting.DimLevel);
             blurSliderBar.Current = config.GetBindable<double>(OsuSetting.BlurLevel);
+            hudVisibilityModeDropdown.Current = config.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode);
             showStoryboardToggle.Current = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
             beatmapSkinsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapSkins);
             beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);


### PR DESCRIPTION
Added a dropdown for the HUD visibility setting in the visual settings panel in the pre-gameplay screen.
It is included in the same settings group in the regular settings panel and figured it would work quite well here as well.