### PR TITLE
Fix SkinnableSprite initialising a drawable even when the texture is not available

### DIFF
--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -24,7 +24,15 @@ namespace osu.Game.Skinning
         {
         }
 
-        protected override Drawable CreateDefault(ISkinComponent component) => new Sprite { Texture = textures.Get(component.LookupName) };
+        protected override Drawable CreateDefault(ISkinComponent component)
+        {
+            var texture = textures.Get(component.LookupName);
+
+            if (texture == null)
+                return null;
+
+            return new Sprite { Texture = texture };
+        }
 
         private class SpriteComponent : ISkinComponent
         {


### PR DESCRIPTION
We sometimes need to test whether a skinnable element was actually retrieved, and this makes it quite hard to do so (especially for `SkinnableSprite`s where the default skin may not have one).