### PR TITLE
Adjust judgement animations to match stable

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
@@ -24,10 +24,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                 if (hitWindows.IsHitResultAllowed(result))
                 {
                     AddStep("Show " + result.GetDescription(), () => SetContents(() =>
-                        new DrawableManiaJudgement(new JudgementResult(new HitObject
+                        new DrawableManiaJudgement(new JudgementResult(new HitObject { StartTime = Time.Current }, new Judgement())
                         {
-                            StartTime = Time.Current
-                        }, new Judgement()) { Type = result }, null)
+                            Type = result
+                        }, null)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
@@ -24,7 +24,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                 if (hitWindows.IsHitResultAllowed(result))
                 {
                     AddStep("Show " + result.GetDescription(), () => SetContents(() =>
-                        new DrawableManiaJudgement(new JudgementResult(new HitObject(), new Judgement()) { Type = result }, null)
+                        new DrawableManiaJudgement(new JudgementResult(new HitObject
+                        {
+                            StartTime = Time.Current
+                        }, new Judgement()) { Type = result }, null)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
@@ -19,6 +20,27 @@ namespace osu.Game.Rulesets.Mania.UI
         {
         }
 
+        protected override void ApplyMissAnimations()
+        {
+            if (!(JudgementBody.Drawable is DefaultManiaJudgementPiece))
+            {
+                // this is temporary logic until mania's skin transformer returns IAnimatableJudgements
+                JudgementBody.ScaleTo(1.6f);
+                JudgementBody.ScaleTo(1, 100, Easing.In);
+
+                JudgementBody.MoveTo(Vector2.Zero);
+                JudgementBody.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+
+                JudgementBody.RotateTo(0);
+                JudgementBody.RotateTo(40, 800, Easing.InQuint);
+                JudgementBody.FadeOutFromOne(800);
+
+                LifetimeEnd = JudgementBody.LatestTransformEndTime;
+            }
+
+            base.ApplyMissAnimations();
+        }
+
         protected override void ApplyHitAnimations()
         {
             JudgementBody.ScaleTo(0.8f);
@@ -29,11 +51,11 @@ namespace osu.Game.Rulesets.Mania.UI
                          .FadeOut(200);
         }
 
-        protected override Drawable CreateDefaultJudgement(HitResult result) => new ManiaJudgementPiece(result);
+        protected override Drawable CreateDefaultJudgement(HitResult result) => new DefaultManiaJudgementPiece(result);
 
-        private class ManiaJudgementPiece : DefaultJudgementPiece
+        private class DefaultManiaJudgementPiece : DefaultJudgementPiece
         {
-            public ManiaJudgementPiece(HitResult result)
+            public DefaultManiaJudgementPiece(HitResult result)
                 : base(result)
             {
             }

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -19,15 +19,14 @@ namespace osu.Game.Rulesets.Mania.UI
         {
         }
 
-        protected override double FadeInDuration => 50;
-
         protected override void ApplyHitAnimations()
         {
             JudgementBody.ScaleTo(0.8f);
             JudgementBody.ScaleTo(1, 250, Easing.OutElastic);
 
-            JudgementBody.Delay(FadeInDuration).ScaleTo(0.75f, 250);
-            this.Delay(FadeInDuration).FadeOut(200);
+            JudgementBody.Delay(50)
+                         .ScaleTo(0.75f, 250)
+                         .FadeOut(200);
         }
 
         protected override Drawable CreateDefaultJudgement(HitResult result) => new ManiaJudgementPiece(result);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -43,10 +43,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             showResult(HitResult.Great);
 
             AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
-            AddAssert("judgement body immediately visible",
-                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.JudgementBody.Alpha == 1));
             AddAssert("hit lighting hidden",
-                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.Lighting.Alpha == 0));
+                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => !judgement.Lighting.Transforms.Any()));
         }
 
         [Test]
@@ -57,10 +55,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             showResult(HitResult.Great);
 
             AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
-            AddAssert("judgement body not immediately visible",
-                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.JudgementBody.Alpha > 0 && judgement.JudgementBody.Alpha < 1));
             AddAssert("hit lighting shown",
-                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.Lighting.Alpha > 0));
+                () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any(judgement => judgement.Lighting.Transforms.Any()));
         }
 
         private void showResult(HitResult result)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -89,7 +89,13 @@ namespace osu.Game.Rulesets.Osu.Tests
                         Children = new Drawable[]
                         {
                             pool,
-                            pool.Get(j => j.Apply(new JudgementResult(new HitObject(), new Judgement()) { Type = result }, null)).With(j =>
+                            pool.Get(j => j.Apply(new JudgementResult(new HitObject
+                            {
+                                StartTime = Time.Current
+                            }, new Judgement())
+                            {
+                                Type = result,
+                            }, null)).With(j =>
                             {
                                 j.Anchor = Anchor.Centre;
                                 j.Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private class TestDrawableOsuJudgement : DrawableOsuJudgement
         {
             public new SkinnableSprite Lighting => base.Lighting;
-            public new Container JudgementBody => base.JudgementBody;
+            public new SkinnableDrawable JudgementBody => base.JudgementBody;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -43,8 +43,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             showResult(HitResult.Great);
 
             AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
-            AddAssert("hit lighting hidden",
-                () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => !judgement.Lighting.Transforms.Any()));
+            AddAssert("hit lighting has no transforms", () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => !judgement.Lighting.Transforms.Any()));
+            AddAssert("hit lighting hidden", () => this.ChildrenOfType<TestDrawableOsuJudgement>().All(judgement => judgement.Lighting.Alpha == 0));
         }
 
         [Test]
@@ -55,8 +55,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             showResult(HitResult.Great);
 
             AddUntilStep("judgements shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any());
-            AddAssert("hit lighting shown",
-                () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any(judgement => judgement.Lighting.Transforms.Any()));
+            AddUntilStep("hit lighting shown", () => this.ChildrenOfType<TestDrawableOsuJudgement>().Any(judgement => judgement.Lighting.Alpha > 0));
         }
 
         private void showResult(HitResult result)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (hitLightingEnabled && Lighting.Drawable != null)
             {
+                // todo: this animation changes slightly based on new/old legacy skin versions.
                 Lighting.ScaleTo(0.8f).ScaleTo(1.2f, 600, Easing.Out);
                 Lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             bool hitLightingEnabled = config.Get<bool>(OsuSetting.HitLighting);
 
-            if (hitLightingEnabled)
+            if (hitLightingEnabled && Lighting.Drawable != null)
             {
                 Lighting.ScaleTo(0.8f).ScaleTo(1.2f, 600, Easing.Out);
                 Lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             bool hitLightingEnabled = config.Get<bool>(OsuSetting.HitLighting);
 
+            Lighting.Alpha = 0;
+
             if (hitLightingEnabled && Lighting.Drawable != null)
             {
                 // todo: this animation changes slightly based on new/old legacy skin versions.

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -44,26 +44,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        private double fadeOutDelay;
-        protected override double FadeOutDelay => fadeOutDelay;
-
         protected override void ApplyHitAnimations()
         {
             bool hitLightingEnabled = config.Get<bool>(OsuSetting.HitLighting);
 
             if (hitLightingEnabled)
             {
-                JudgementBody.FadeIn().Delay(FadeInDuration).FadeOut(400);
-
                 Lighting.ScaleTo(0.8f).ScaleTo(1.2f, 600, Easing.Out);
                 Lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);
-            }
-            else
-            {
-                JudgementBody.Alpha = 1;
-            }
 
-            fadeOutDelay = hitLightingEnabled ? 1400 : base.FadeOutDelay;
+                // extend the lifetime to cover lighting fade
+                LifetimeEnd = 1400;
+            }
 
             base.ApplyHitAnimations();
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 Lighting.FadeIn(200).Then().Delay(200).FadeOut(1000);
 
                 // extend the lifetime to cover lighting fade
-                LifetimeEnd = 1400;
+                LifetimeEnd = Lighting.LatestTransformEndTime;
             }
 
             base.ApplyHitAnimations();

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -47,18 +47,18 @@ namespace osu.Game.Rulesets.Judgements
 
         public virtual void PlayAnimation()
         {
-            this.RotateTo(0);
-            this.MoveTo(Vector2.Zero);
-
             switch (Result)
             {
                 case HitResult.Miss:
                     this.ScaleTo(1.6f);
                     this.ScaleTo(1, 100, Easing.In);
 
+                    this.MoveTo(Vector2.Zero);
                     this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
 
+                    this.RotateTo(0);
                     this.RotateTo(40, 800, Easing.InQuint);
+
                     break;
 
                 default:
@@ -66,6 +66,8 @@ namespace osu.Game.Rulesets.Judgements
                     this.ScaleTo(1, 500, Easing.OutElastic);
                     break;
             }
+
+            this.FadeOutFromOne(800);
         }
     }
 }

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -90,8 +90,7 @@ namespace osu.Game.Rulesets.Judgements
 
         /// <summary>
         /// Apply top-level animations to the current judgement when successfully hit.
-        /// Generally used for fading, defaulting to a simple fade out based on <see cref="FadeOutDelay"/>.
-        /// This will be used to calculate the lifetime of the judgement.
+        /// If displaying components which require lifetime extensions, manually adjusting <see cref="Drawable.LifetimeEnd"/> is required.
         /// </summary>
         /// <remarks>
         /// For animating the actual "default skin" judgement itself, it is recommended to use <see cref="CreateDefaultJudgement"/>.
@@ -103,8 +102,7 @@ namespace osu.Game.Rulesets.Judgements
 
         /// <summary>
         /// Apply top-level animations to the current judgement when missed.
-        /// Generally used for fading, defaulting to a simple fade out based on <see cref="FadeOutDelay"/>.
-        /// This will be used to calculate the lifetime of the judgement.
+        /// If displaying components which require lifetime extensions, manually adjusting <see cref="Drawable.LifetimeEnd"/> is required.
         /// </summary>
         /// <remarks>
         /// For animating the actual "default skin" judgement itself, it is recommended to use <see cref="CreateDefaultJudgement"/>.

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -139,12 +139,14 @@ namespace osu.Game.Rulesets.Judgements
 
                     animatable.PlayAnimation();
 
-                    drawableAnimation.Expire(true);
-
                     // a derived version of DrawableJudgement may be adjusting lifetime.
                     // if not adjusted (or the skinned portion requires greater bounds than calculated) use the skinned source's lifetime.
-                    if (LifetimeEnd == double.MaxValue || drawableAnimation.LifetimeEnd > LifetimeEnd)
-                        LifetimeEnd = drawableAnimation.LifetimeEnd;
+                    double lastTransformTime = drawableAnimation.LatestTransformEndTime;
+
+                    if (LifetimeEnd == double.MaxValue || lastTransformTime > LifetimeEnd)
+                    {
+                        LifetimeEnd = lastTransformTime;
+                    }
                 }
             }
         }

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
@@ -26,11 +25,9 @@ namespace osu.Game.Rulesets.Judgements
 
         public DrawableHitObject JudgedObject { get; private set; }
 
-        protected Container JudgementBody { get; private set; }
-
         public override bool RemoveCompletedTransforms => false;
 
-        private SkinnableDrawable skinnableJudgement;
+        protected SkinnableDrawable JudgementBody { get; private set; }
 
         [Resolved]
         private ISkinSource skinSource { get; set; }
@@ -147,7 +144,7 @@ namespace osu.Game.Rulesets.Judgements
             using (BeginAbsoluteSequence(Result.TimeAbsolute, true))
             {
                 // not sure if this should remain going forward.
-                skinnableJudgement.ResetAnimation();
+                JudgementBody.ResetAnimation();
 
                 switch (Result.Type)
                 {
@@ -163,7 +160,7 @@ namespace osu.Game.Rulesets.Judgements
                         break;
                 }
 
-                if (skinnableJudgement.Drawable is IAnimatableJudgement animatable)
+                if (JudgementBody.Drawable is IAnimatableJudgement animatable)
                 {
                     var drawableAnimation = (Drawable)animatable;
 
@@ -192,13 +189,11 @@ namespace osu.Game.Rulesets.Judgements
             if (JudgementBody != null)
                 RemoveInternal(JudgementBody);
 
-            AddInternal(JudgementBody = new Container
+            AddInternal(JudgementBody = new SkinnableDrawable(new GameplaySkinComponent<HitResult>(type), _ =>
+                CreateDefaultJudgement(type), confineMode: ConfineMode.NoScaling)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.Both,
-                Child = skinnableJudgement = new SkinnableDrawable(new GameplaySkinComponent<HitResult>(type), _ =>
-                    CreateDefaultJudgement(type), confineMode: ConfineMode.NoScaling)
             });
 
             currentDrawableType = type;

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -85,7 +85,9 @@ namespace osu.Game.Rulesets.Judgements
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            skinSource.SourceChanged -= onSkinChanged;
+
+            if (skinSource != null)
+                skinSource.SourceChanged -= onSkinChanged;
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -32,11 +33,13 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// Duration of initial fade in.
         /// </summary>
+        [Obsolete("Apply any animations manually via ApplyHitAnimations / ApplyMissAnimations. Defaults were moved inside skinned components.")]
         protected virtual double FadeInDuration => 100;
 
         /// <summary>
         /// Duration to wait until fade out begins. Defaults to <see cref="FadeInDuration"/>.
         /// </summary>
+        [Obsolete("Apply any animations manually via ApplyHitAnimations / ApplyMissAnimations. Defaults were moved inside skinned components.")]
         protected virtual double FadeOutDelay => FadeInDuration;
 
         /// <summary>
@@ -73,7 +76,6 @@ namespace osu.Game.Rulesets.Judgements
         /// </remarks>
         protected virtual void ApplyHitAnimations()
         {
-            this.Delay(FadeOutDelay).FadeOut(400);
         }
 
         /// <summary>
@@ -112,8 +114,6 @@ namespace osu.Game.Rulesets.Judgements
             // not sure if this should remain going forward.
             skinnableJudgement.ResetAnimation();
 
-            this.FadeInFromZero(FadeInDuration, Easing.OutQuint);
-
             switch (Result.Type)
             {
                 case HitResult.None:
@@ -134,7 +134,10 @@ namespace osu.Game.Rulesets.Judgements
                     animatable.PlayAnimation();
             }
 
-            Expire(true);
+            JudgementBody.Expire(true);
+
+            LifetimeStart = JudgementBody.LifetimeStart;
+            LifetimeEnd = JudgementBody.LifetimeEnd;
         }
 
         private HitResult? currentDrawableType;

--- a/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
@@ -1,12 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+
 namespace osu.Game.Rulesets.Judgements
 {
     /// <summary>
     /// A skinnable judgement element which supports playing an animation from the current point in time.
     /// </summary>
-    public interface IAnimatableJudgement
+    public interface IAnimatableJudgement : IDrawable
     {
         void PlayAnimation();
     }

--- a/osu.Game/Skinning/LegacyJudgementPiece.cs
+++ b/osu.Game/Skinning/LegacyJudgementPiece.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Skinning
     {
         private readonly HitResult result;
 
+        private bool hasParticle;
+
         public LegacyJudgementPiece(HitResult result, Drawable drawable)
         {
             this.result = result;
@@ -37,6 +39,8 @@ namespace osu.Game.Skinning
             if (animation?.FrameCount > 1)
                 return;
 
+            const double animation_length = 500;
+
             switch (result)
             {
                 case HitResult.Miss:
@@ -49,8 +53,19 @@ namespace osu.Game.Skinning
                     break;
 
                 default:
-                    this.ScaleTo(0.9f);
-                    this.ScaleTo(1, 500, Easing.OutElastic);
+                    if (!hasParticle)
+                    {
+                        this.ScaleTo(0.6f).Then()
+                            .ScaleTo(1.1f, animation_length * 0.8f).Then()
+                            .ScaleTo(0.9f, animation_length * 0.4f).Then()
+                            .ScaleTo(1f, animation_length * 0.2f);
+                    }
+                    else
+                    {
+                        this.ScaleTo(0.9f);
+                        this.ScaleTo(1.05f, animation_length);
+                    }
+
                     break;
             }
         }

--- a/osu.Game/Skinning/LegacyJudgementPieceNew.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceNew.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Skinning
 
         private readonly Drawable mainPiece;
 
-        public LegacyJudgementPieceNew(HitResult result, Func<Drawable> createMainDrawable, Drawable particleDrawable)
+        public LegacyJudgementPieceNew(HitResult result, Func<Drawable> createMainDrawable, Func<Drawable> createParticleDrawable)
         {
             this.result = result;
 

--- a/osu.Game/Skinning/LegacyJudgementPieceNew.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceNew.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Skinning
+{
+    public class LegacyJudgementPieceNew : CompositeDrawable, IAnimatableJudgement
+    {
+        private readonly HitResult result;
+
+        private readonly LegacyJudgementPieceOld temporaryOldStyle;
+
+        private readonly Drawable mainPiece;
+
+        public LegacyJudgementPieceNew(HitResult result, Func<Drawable> createMainDrawable, Drawable particleDrawable)
+        {
+            this.result = result;
+
+            AutoSizeAxes = Axes.Both;
+            Origin = Anchor.Centre;
+
+            InternalChildren = new[]
+            {
+                mainPiece = createMainDrawable().With(d =>
+                {
+                    d.Anchor = Anchor.Centre;
+                    d.Origin = Anchor.Centre;
+                })
+            };
+
+            if (result != HitResult.Miss)
+            {
+                //new judgement shows old as a temporary effect
+                AddInternal(temporaryOldStyle = new LegacyJudgementPieceOld(result, createMainDrawable, 1.05f)
+                {
+                    Blending = BlendingParameters.Additive,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                });
+            }
+        }
+
+        public void PlayAnimation()
+        {
+            var animation = mainPiece as IFramedAnimation;
+
+            animation?.GotoFrame(0);
+
+            this.RotateTo(0);
+            this.MoveTo(Vector2.Zero);
+
+            if (temporaryOldStyle != null)
+            {
+                temporaryOldStyle.PlayAnimation();
+
+                temporaryOldStyle.Hide();
+                temporaryOldStyle.Delay(-16)
+                                 .FadeTo(0.5f, 56, Easing.Out).Then()
+                                 .FadeOut(300);
+            }
+
+            // legacy judgements don't play any transforms if they are an animation.
+            if (animation?.FrameCount > 1)
+                return;
+
+            switch (result)
+            {
+                case HitResult.Miss:
+                    mainPiece.ScaleTo(1.6f);
+                    mainPiece.ScaleTo(1, 100, Easing.In);
+
+                    mainPiece.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+
+                    mainPiece.RotateTo(40, 800, Easing.InQuint);
+                    break;
+
+                default:
+                    const double animation_length = 1100;
+
+                    mainPiece.ScaleTo(0.9f);
+                    mainPiece.ScaleTo(1.05f, animation_length);
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game/Skinning/LegacyJudgementPieceNew.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceNew.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -53,9 +54,14 @@ namespace osu.Game.Skinning
 
             animation?.GotoFrame(0);
 
-            this.RotateTo(0);
-            this.MoveTo(Vector2.Zero);
+            const double fade_in_length = 120;
+            const double fade_out_delay = 500;
+            const double fade_out_length = 600;
 
+            this.FadeInFromZero(fade_in_length);
+            this.Delay(fade_out_delay).FadeOut(fade_out_length);
+
+            // new style non-miss judgements show the original style temporarily, with additive colour.
             if (temporaryOldStyle != null)
             {
                 temporaryOldStyle.PlayAnimation();
@@ -73,19 +79,23 @@ namespace osu.Game.Skinning
             switch (result)
             {
                 case HitResult.Miss:
-                    mainPiece.ScaleTo(1.6f);
-                    mainPiece.ScaleTo(1, 100, Easing.In);
+                    this.ScaleTo(1.6f);
+                    this.ScaleTo(1, 100, Easing.In);
 
-                    mainPiece.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+                    //todo: this only applies to osu! ruleset apparently.
+                    this.MoveTo(new Vector2(0, -2));
+                    this.MoveToOffset(new Vector2(0, 20), fade_out_delay + fade_out_length, Easing.In);
 
-                    mainPiece.RotateTo(40, 800, Easing.InQuint);
+                    float rotation = RNG.NextSingle(-8.6f, 8.6f);
+
+                    this.RotateTo(0);
+                    this.RotateTo(rotation, fade_in_length)
+                        .Then().RotateTo(rotation * 2, fade_out_delay + fade_out_length - fade_in_length, Easing.In);
                     break;
 
                 default:
-                    const double animation_length = 1100;
-
                     mainPiece.ScaleTo(0.9f);
-                    mainPiece.ScaleTo(1.05f, animation_length);
+                    mainPiece.ScaleTo(1.05f, fade_out_delay + fade_out_length);
                     break;
             }
         }

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -5,9 +5,9 @@ using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osuTK;
 
 namespace osu.Game.Skinning
 {
@@ -34,8 +34,12 @@ namespace osu.Game.Skinning
 
             animation?.GotoFrame(0);
 
-            this.RotateTo(0);
-            this.MoveTo(Vector2.Zero);
+            const double fade_in_length = 120;
+            const double fade_out_delay = 500;
+            const double fade_out_length = 600;
+
+            this.FadeInFromZero(fade_in_length);
+            this.Delay(fade_out_delay).FadeOut(fade_out_length);
 
             // legacy judgements don't play any transforms if they are an animation.
             if (animation?.FrameCount > 1)
@@ -47,20 +51,21 @@ namespace osu.Game.Skinning
                     this.ScaleTo(1.6f);
                     this.ScaleTo(1, 100, Easing.In);
 
-                    this.MoveToOffset(new Vector2(0, 100), 800, Easing.InQuint);
+                    float rotation = RNG.NextSingle(-8.6f, 8.6f);
 
-                    this.RotateTo(40, 800, Easing.InQuint);
+                    this.RotateTo(0);
+                    this.RotateTo(rotation, fade_in_length)
+                        .Then().RotateTo(rotation * 2, fade_out_delay + fade_out_length - fade_in_length, Easing.In);
                     break;
 
                 default:
-                    const double animation_length = 120;
 
                     this.ScaleTo(0.6f).Then()
-                        .ScaleTo(1.1f, animation_length * 0.8f).Then()
+                        .ScaleTo(1.1f, fade_in_length * 0.8f).Then()
                         // this is actually correct to match stable; there were overlapping transforms.
-                        .ScaleTo(0.9f).Delay(animation_length * 0.2f)
-                        .ScaleTo(1.1f).ScaleTo(0.9f, animation_length * 0.2f).Then()
-                        .ScaleTo(0.95f).ScaleTo(finalScale, animation_length * 0.2f);
+                        .ScaleTo(0.9f).Delay(fade_in_length * 0.2f)
+                        .ScaleTo(1.1f).ScaleTo(0.9f, fade_in_length * 0.2f).Then()
+                        .ScaleTo(0.95f).ScaleTo(finalScale, fade_in_length * 0.2f);
                     break;
             }
         }

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
@@ -10,20 +11,21 @@ using osuTK;
 
 namespace osu.Game.Skinning
 {
-    public class LegacyJudgementPiece : CompositeDrawable, IAnimatableJudgement
+    public class LegacyJudgementPieceOld : CompositeDrawable, IAnimatableJudgement
     {
         private readonly HitResult result;
 
-        private bool hasParticle;
+        private readonly float finalScale;
 
-        public LegacyJudgementPiece(HitResult result, Drawable drawable)
+        public LegacyJudgementPieceOld(HitResult result, Func<Drawable> createMainDrawable, float finalScale = 1f)
         {
             this.result = result;
+            this.finalScale = finalScale;
 
             AutoSizeAxes = Axes.Both;
             Origin = Anchor.Centre;
 
-            InternalChild = drawable;
+            InternalChild = createMainDrawable();
         }
 
         public virtual void PlayAnimation()
@@ -39,8 +41,6 @@ namespace osu.Game.Skinning
             if (animation?.FrameCount > 1)
                 return;
 
-            const double animation_length = 500;
-
             switch (result)
             {
                 case HitResult.Miss:
@@ -53,19 +53,14 @@ namespace osu.Game.Skinning
                     break;
 
                 default:
-                    if (!hasParticle)
-                    {
-                        this.ScaleTo(0.6f).Then()
-                            .ScaleTo(1.1f, animation_length * 0.8f).Then()
-                            .ScaleTo(0.9f, animation_length * 0.4f).Then()
-                            .ScaleTo(1f, animation_length * 0.2f);
-                    }
-                    else
-                    {
-                        this.ScaleTo(0.9f);
-                        this.ScaleTo(1.05f, animation_length);
-                    }
+                    const double animation_length = 120;
 
+                    this.ScaleTo(0.6f).Then()
+                        .ScaleTo(1.1f, animation_length * 0.8f).Then()
+                        // this is actually correct to match stable; there were overlapping transforms.
+                        .ScaleTo(0.9f).Delay(animation_length * 0.2f)
+                        .ScaleTo(1.1f).ScaleTo(0.9f, animation_length * 0.2f).Then()
+                        .ScaleTo(0.95f).ScaleTo(finalScale, animation_length * 0.2f);
                     break;
             }
         }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -373,11 +373,11 @@ namespace osu.Game.Skinning
                 case GameplaySkinComponent<HitResult> resultComponent:
                     Func<Drawable> createDrawable = () => getJudgementAnimation(resultComponent.Component);
 
+                    // kind of wasteful that we throw this away, but should do for now.
                     if (createDrawable() != null)
                     {
-                        var particles = getParticleTexture(resultComponent.Component);
-                        if (particles != null)
-                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, getParticleTexture(resultComponent.Component));
+                        if (Configuration.LegacyVersion > 1)
+                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, getParticleDrawable(resultComponent.Component));
                         else
                             return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
                     }
@@ -388,7 +388,7 @@ namespace osu.Game.Skinning
             return this.GetAnimation(component.LookupName, false, false);
         }
 
-        private Drawable getParticleTexture(HitResult result)
+        private Drawable getParticleDrawable(HitResult result)
         {
             switch (result)
             {

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -371,14 +371,38 @@ namespace osu.Game.Skinning
                 }
 
                 case GameplaySkinComponent<HitResult> resultComponent:
-                    var drawable = getJudgementAnimation(resultComponent.Component);
-                    if (drawable != null)
-                        return new LegacyJudgementPiece(resultComponent.Component, drawable);
+                    Func<Drawable> createDrawable = () => getJudgementAnimation(resultComponent.Component);
+
+                    if (createDrawable() != null)
+                    {
+                        var particles = getParticleTexture(resultComponent.Component);
+                        if (particles != null)
+                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, getParticleTexture(resultComponent.Component));
+                        else
+                            return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
+                    }
 
                     break;
             }
 
             return this.GetAnimation(component.LookupName, false, false);
+        }
+
+        private Drawable getParticleTexture(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Meh:
+                    return this.GetAnimation("particle50", false, false);
+
+                case HitResult.Ok:
+                    return this.GetAnimation("particle100", false, false);
+
+                case HitResult.Great:
+                    return this.GetAnimation("particle300", false, false);
+            }
+
+            return null;
         }
 
         private Drawable getJudgementAnimation(HitResult result)

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -377,7 +377,7 @@ namespace osu.Game.Skinning
                     if (createDrawable() != null)
                     {
                         if (Configuration.LegacyVersion > 1)
-                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, getParticleDrawable(resultComponent.Component));
+                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, () => getParticleDrawable(resultComponent.Component));
                         else
                             return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
                     }

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -24,7 +24,15 @@ namespace osu.Game.Skinning
         {
         }
 
-        protected override Drawable CreateDefault(ISkinComponent component) => new Sprite { Texture = textures.Get(component.LookupName) };
+        protected override Drawable CreateDefault(ISkinComponent component)
+        {
+            var texture = textures.Get(component.LookupName);
+
+            if (texture == null)
+                return null;
+
+            return new Sprite { Texture = texture };
+        }
 
         private class SpriteComponent : ISkinComponent
         {


### PR DESCRIPTION
This adds complete coverage of new and old style legacy skin judgements. Until now, we were applying a single set of transforms (based on lazer's default skin) across the board, as it was a bit difficulty to correctly insert the transforms in place (resolved in https://github.com/ppy/osu/pull/10878).

Particles are still not implemented; that will come in a follow-up PR.

- [x] Depends on #10878 
- [x] Depends on #10889
- Closes #10172
- Closes #10195