### PR TITLE
Prevent editor from crashing for rulesets with no compose screen implementation

### DIFF
--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -32,7 +32,8 @@ namespace osu.Game.Screens.Edit.Compose
             composer = ruleset?.CreateHitObjectComposer();
 
             // make the composer available to the timeline and other components in this screen.
-            dependencies.CacheAs(composer);
+            if (composer != null)
+                dependencies.CacheAs(composer);
 
             return dependencies;
         }


### PR DESCRIPTION
Closes #10912.

"Regressed" in https://github.com/ppy/osu/commit/53b3d238427d456be3e5acbd79d221b7d1937136. All generic (ruleset-independent) resolutions via DI should be null-tolerant I believe.