### PR TITLE
Don't play flair animations / sounds when watching autoplay or viewing a result directly

### DIFF
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -16,6 +16,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Online.API;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Play;
@@ -149,7 +150,12 @@ namespace osu.Game.Screens.Ranking
             };
 
             if (Score != null)
-                ScorePanelList.AddScore(Score, true);
+            {
+                // only show flair / animation when arriving after watching a play that isn't autoplay.
+                bool shouldFlair = player != null && !Score.Mods.Any(m => m is ModAutoplay);
+
+                ScorePanelList.AddScore(Score, shouldFlair);
+            }
 
             if (player != null && allowRetry)
             {


### PR DESCRIPTION
I think this is a pretty good place to be for now. The flair will play if you just watched a play (local, replay or spectator) but will not play if you are coming from song select (viewing a replay's result screen from the leaderboard) or in the case of autoplay.

Closes #10762.