### PR TITLE
Refactor TestSceneHitCircle to show judgements

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.Objects.Drawables;
-using osuTK;
-using osu.Game.Rulesets.Mods;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
@@ -39,12 +39,36 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private Drawable testSingle(float circleSize, bool auto = false, double timeOffset = 0, Vector2? positionOffset = null)
         {
+            var drawable = createSingle(circleSize, auto, timeOffset, positionOffset);
+
+            var playfield = new TestOsuPlayfield();
+            playfield.Add(drawable);
+            return playfield;
+        }
+
+        private Drawable testStream(float circleSize, bool auto = false)
+        {
+            var playfield = new TestOsuPlayfield();
+
+            Vector2 pos = new Vector2(-250, 0);
+
+            for (int i = 0; i <= 1000; i += 100)
+            {
+                playfield.Add(createSingle(circleSize, auto, i, pos));
+                pos.X += 50;
+            }
+
+            return playfield;
+        }
+
+        private TestDrawableHitCircle createSingle(float circleSize, bool auto, double timeOffset, Vector2? positionOffset)
+        {
             positionOffset ??= Vector2.Zero;
 
             var circle = new HitCircle
             {
                 StartTime = Time.Current + 1000 + timeOffset,
-                Position = positionOffset.Value,
+                Position = OsuPlayfield.BASE_SIZE / 4 + positionOffset.Value,
             };
 
             circle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = circleSize });
@@ -53,30 +77,13 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObjects>())
                 mod.ApplyToDrawableHitObjects(new[] { drawable });
-
             return drawable;
         }
 
         protected virtual TestDrawableHitCircle CreateDrawableHitCircle(HitCircle circle, bool auto) => new TestDrawableHitCircle(circle, auto)
         {
-            Anchor = Anchor.Centre,
             Depth = depthIndex++
         };
-
-        private Drawable testStream(float circleSize, bool auto = false)
-        {
-            var container = new Container { RelativeSizeAxes = Axes.Both };
-
-            Vector2 pos = new Vector2(-250, 0);
-
-            for (int i = 0; i <= 1000; i += 100)
-            {
-                container.Add(testSingle(circleSize, auto, i, pos));
-                pos.X += 50;
-            }
-
-            return container;
-        }
 
         protected class TestDrawableHitCircle : DrawableHitCircle
         {
@@ -99,6 +106,14 @@ namespace osu.Game.Rulesets.Osu.Tests
                 }
                 else
                     base.CheckForResult(userTriggered, timeOffset);
+            }
+        }
+
+        protected class TestOsuPlayfield : OsuPlayfield
+        {
+            public TestOsuPlayfield()
+            {
+                RelativeSizeAxes = Axes.Both;
             }
         }
     }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneShaking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneShaking.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Diagnostics;
+using osu.Framework.Threading;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 
@@ -10,6 +13,19 @@ namespace osu.Game.Rulesets.Osu.Tests
 {
     public class TestSceneShaking : TestSceneHitCircle
     {
+        private readonly List<ScheduledDelegate> scheduledTasks = new List<ScheduledDelegate>();
+
+        protected override IBeatmap CreateBeatmapForSkinProvider()
+        {
+            // best way to run cleanup before a new step is run
+            foreach (var task in scheduledTasks)
+                task.Cancel();
+
+            scheduledTasks.Clear();
+
+            return base.CreateBeatmapForSkinProvider();
+        }
+
         protected override TestDrawableHitCircle CreateDrawableHitCircle(HitCircle circle, bool auto)
         {
             var drawableHitObject = base.CreateDrawableHitCircle(circle, auto);
@@ -17,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             Debug.Assert(drawableHitObject.HitObject.HitWindows != null);
 
             double delay = drawableHitObject.HitObject.StartTime - (drawableHitObject.HitObject.HitWindows.WindowFor(HitResult.Miss) + RNG.Next(0, 300)) - Time.Current;
-            Scheduler.AddDelayed(() => drawableHitObject.TriggerJudgement(), delay);
+            scheduledTasks.Add(Scheduler.AddDelayed(() => drawableHitObject.TriggerJudgement(), delay));
 
             return drawableHitObject;
         }


### PR DESCRIPTION
Better allows viewing interactions between hitcircles and judgements, when skinning is becoming more involved.

If necessary I can split this out into its own test scene (multiple other scenes derive from this one) but likely not required?