### PR TITLE
Ensure legacy skin judgements display in front of hitobjects

### DIFF
--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -70,6 +70,6 @@ namespace osu.Game.Rulesets.Judgements
             this.FadeOutFromOne(800);
         }
 
-        public Drawable GetAboveHitObjectsProxiedContent() => this.CreateProxy();
+        public Drawable GetAboveHitObjectsProxiedContent() => null;
     }
 }

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -69,5 +69,7 @@ namespace osu.Game.Rulesets.Judgements
 
             this.FadeOutFromOne(800);
         }
+
+        public Drawable GetAboveHitObjectsProxiedContent() => this.CreateProxy();
     }
 }

--- a/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 
 namespace osu.Game.Rulesets.Judgements
@@ -18,6 +19,7 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// Get proxied content which should be displayed above all hitobjects.
         /// </summary>
+        [CanBeNull]
         Drawable GetAboveHitObjectsProxiedContent();
     }
 }

--- a/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/IAnimatableJudgement.cs
@@ -10,6 +10,14 @@ namespace osu.Game.Rulesets.Judgements
     /// </summary>
     public interface IAnimatableJudgement : IDrawable
     {
+        /// <summary>
+        /// Start the animation for this judgement from the current point in time.
+        /// </summary>
         void PlayAnimation();
+
+        /// <summary>
+        /// Get proxied content which should be displayed above all hitobjects.
+        /// </summary>
+        Drawable GetAboveHitObjectsProxiedContent();
     }
 }

--- a/osu.Game/Skinning/LegacyJudgementPieceNew.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceNew.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
@@ -121,5 +122,8 @@ namespace osu.Game.Skinning
                     break;
             }
         }
+
+        [CanBeNull]
+        public Drawable GetAboveHitObjectsProxiedContent() => temporaryOldStyle?.CreateProxy(); // for new style judgements, only the old style temporary display is in front of objects.
     }
 }

--- a/osu.Game/Skinning/LegacyJudgementPieceNew.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceNew.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
@@ -123,7 +122,6 @@ namespace osu.Game.Skinning
             }
         }
 
-        [CanBeNull]
         public Drawable GetAboveHitObjectsProxiedContent() => temporaryOldStyle?.CreateProxy(); // for new style judgements, only the old style temporary display is in front of objects.
     }
 }

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -69,5 +69,7 @@ namespace osu.Game.Skinning
                     break;
             }
         }
+
+        public Drawable GetAboveHitObjectsProxiedContent() => CreateProxy();
     }
 }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/10921 (for testability)
- [x] Depends on https://github.com/ppy/osu/pull/10903 (to add correct layering support of the new display types)
- [x] Depends on https://github.com/ppy/osu/pull/10919 (for easy merging)
- Closes https://github.com/ppy/osu/issues/7584
- Supersedes and closes https://github.com/ppy/osu/pull/10262

![2020-11-20 16 36 48](https://user-images.githubusercontent.com/191335/99772766-ba6bc300-2b4e-11eb-8bac-4f9cc9be20ae.gif)

Note that as mentioned [in this comment thread](https://github.com/ppy/osu/issues/7584#issuecomment-697117549), this behaviour does not match stable 1:1. Doing so would be quite hard due to each judgement needing to be nested inside (or drawn alongside) their relevant `DrawableHitObject`. Going to go with this because it's better than what we have on master (judgements are not visible in streams, for instance) and judge the reaction. If it's decided we need to match the original behaviour, further investigation will be required.