### PR TITLE
Implement follow point pooling

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
@@ -95,9 +95,19 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             addMultipleObjectsStep();
 
-            AddStep("move hitobject", () => getObject(2).HitObject.Position = new Vector2(300, 100));
+            AddStep("move hitobject", () =>
+            {
+                var manualClock = new ManualClock();
+                followPointRenderer.Clock = new FramedClock(manualClock);
+
+                manualClock.CurrentTime = getObject(1).HitObject.StartTime;
+                followPointRenderer.UpdateSubTree();
+
+                getObject(2).HitObject.Position = new Vector2(300, 100);
+            });
 
             assertGroups();
+            assertDirections();
         }
 
         [TestCase(0, 0)] // Start -> Start

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     }
 
                     hitObjectContainer.Add(drawableObject);
-                    followPointRenderer.AddFollowPoints2(objects[i]);
+                    followPointRenderer.AddFollowPoints(objects[i]);
                 }
             });
         }
@@ -194,7 +194,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 var drawableObject = getFunc.Invoke();
 
                 hitObjectContainer.Remove(drawableObject);
-                followPointRenderer.RemoveFollowPoints2(drawableObject.HitObject);
+                followPointRenderer.RemoveFollowPoints(drawableObject.HitObject);
             });
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
@@ -272,7 +272,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private DrawableOsuHitObject getObject(int index) => hitObjectContainer[index];
 
-        private FollowPointRenderer.FollowPointLifetimeEntry getEntry(int index) => followPointRenderer.Entries[index];
+        private FollowPointLifetimeEntry getEntry(int index) => followPointRenderer.Entries[index];
 
         private FollowPointConnection getGroup(int index) => followPointRenderer.ChildrenOfType<FollowPointConnection>().Single(c => c.Entry == getEntry(index));
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
@@ -1,276 +1,276 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
-using System;
-using System.Linq;
-using NUnit.Framework;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Testing;
-using osu.Framework.Utils;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.Objects.Drawables;
-using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
-using osu.Game.Tests.Visual;
-using osuTK;
-
-namespace osu.Game.Rulesets.Osu.Tests
-{
-    public class TestSceneFollowPoints : OsuTestScene
-    {
-        private Container<DrawableOsuHitObject> hitObjectContainer;
-        private FollowPointRenderer followPointRenderer;
-
-        [SetUp]
-        public void Setup() => Schedule(() =>
-        {
-            Children = new Drawable[]
-            {
-                hitObjectContainer = new TestHitObjectContainer { RelativeSizeAxes = Axes.Both },
-                followPointRenderer = new FollowPointRenderer { RelativeSizeAxes = Axes.Both }
-            };
-        });
-
-        [Test]
-        public void TestAddObject()
-        {
-            addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
-
-            assertGroups();
-        }
-
-        [Test]
-        public void TestRemoveObject()
-        {
-            addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
-
-            removeObjectStep(() => getObject(0));
-
-            assertGroups();
-        }
-
-        [Test]
-        public void TestAddMultipleObjects()
-        {
-            addMultipleObjectsStep();
-
-            assertGroups();
-        }
-
-        [Test]
-        public void TestRemoveEndObject()
-        {
-            addMultipleObjectsStep();
-
-            removeObjectStep(() => getObject(4));
-
-            assertGroups();
-        }
-
-        [Test]
-        public void TestRemoveStartObject()
-        {
-            addMultipleObjectsStep();
-
-            removeObjectStep(() => getObject(0));
-
-            assertGroups();
-        }
-
-        [Test]
-        public void TestRemoveMiddleObject()
-        {
-            addMultipleObjectsStep();
-
-            removeObjectStep(() => getObject(2));
-
-            assertGroups();
-        }
-
-        [Test]
-        public void TestMoveObject()
-        {
-            addMultipleObjectsStep();
-
-            AddStep("move hitobject", () => getObject(2).HitObject.Position = new Vector2(300, 100));
-
-            assertGroups();
-        }
-
-        [TestCase(0, 0)] // Start -> Start
-        [TestCase(0, 2)] // Start -> Middle
-        [TestCase(0, 5)] // Start -> End
-        [TestCase(2, 0)] // Middle -> Start
-        [TestCase(1, 3)] // Middle -> Middle (forwards)
-        [TestCase(3, 1)] // Middle -> Middle (backwards)
-        [TestCase(4, 0)] // End -> Start
-        [TestCase(4, 2)] // End -> Middle
-        [TestCase(4, 4)] // End -> End
-        public void TestReorderObjects(int startIndex, int endIndex)
-        {
-            addMultipleObjectsStep();
-
-            reorderObjectStep(startIndex, endIndex);
-
-            assertGroups();
-        }
-
-        [Test]
-        public void TestStackedObjects()
-        {
-            addObjectsStep(() => new OsuHitObject[]
-            {
-                new HitCircle { Position = new Vector2(300, 100) },
-                new HitCircle
-                {
-                    Position = new Vector2(300, 300),
-                    StackHeight = 20
-                },
-            });
-
-            assertDirections();
-        }
-
-        private void addMultipleObjectsStep() => addObjectsStep(() => new OsuHitObject[]
-        {
-            new HitCircle { Position = new Vector2(100, 100) },
-            new HitCircle { Position = new Vector2(200, 200) },
-            new HitCircle { Position = new Vector2(300, 300) },
-            new HitCircle { Position = new Vector2(400, 400) },
-            new HitCircle { Position = new Vector2(500, 500) },
-        });
-
-        private void addObjectsStep(Func<OsuHitObject[]> ctorFunc)
-        {
-            AddStep("add hitobjects", () =>
-            {
-                var objects = ctorFunc();
-
-                for (int i = 0; i < objects.Length; i++)
-                {
-                    objects[i].StartTime = Time.Current + 1000 + 500 * (i + 1);
-                    objects[i].ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-
-                    DrawableOsuHitObject drawableObject = null;
-
-                    switch (objects[i])
-                    {
-                        case HitCircle circle:
-                            drawableObject = new DrawableHitCircle(circle);
-                            break;
-
-                        case Slider slider:
-                            drawableObject = new DrawableSlider(slider);
-                            break;
-
-                        case Spinner spinner:
-                            drawableObject = new DrawableSpinner(spinner);
-                            break;
-                    }
-
-                    hitObjectContainer.Add(drawableObject);
-                    followPointRenderer.AddFollowPoints(objects[i]);
-                }
-            });
-        }
-
-        private void removeObjectStep(Func<DrawableOsuHitObject> getFunc)
-        {
-            AddStep("remove hitobject", () =>
-            {
-                var drawableObject = getFunc.Invoke();
-
-                hitObjectContainer.Remove(drawableObject);
-                followPointRenderer.RemoveFollowPoints(drawableObject.HitObject);
-            });
-        }
-
-        private void reorderObjectStep(int startIndex, int endIndex)
-        {
-            AddStep($"move object {startIndex} to {endIndex}", () =>
-            {
-                DrawableOsuHitObject toReorder = getObject(startIndex);
-
-                double targetTime;
-                if (endIndex < hitObjectContainer.Count)
-                    targetTime = getObject(endIndex).HitObject.StartTime - 1;
-                else
-                    targetTime = getObject(hitObjectContainer.Count - 1).HitObject.StartTime + 1;
-
-                hitObjectContainer.Remove(toReorder);
-                toReorder.HitObject.StartTime = targetTime;
-                hitObjectContainer.Add(toReorder);
-            });
-        }
-
-        private void assertGroups()
-        {
-            AddAssert("has correct group count", () => followPointRenderer.Connections.Count == hitObjectContainer.Count);
-            AddAssert("group endpoints are correct", () =>
-            {
-                for (int i = 0; i < hitObjectContainer.Count; i++)
-                {
-                    DrawableOsuHitObject expectedStart = getObject(i);
-                    DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
-
-                    if (getGroup(i).Start != expectedStart.HitObject)
-                        throw new AssertionException($"Object {i} expected to be the start of group {i}.");
-
-                    if (getGroup(i).End != expectedEnd?.HitObject)
-                        throw new AssertionException($"Object {(expectedEnd == null ? "null" : i.ToString())} expected to be the end of group {i}.");
-                }
-
-                return true;
-            });
-        }
-
-        private void assertDirections()
-        {
-            AddAssert("group directions are correct", () =>
-            {
-                for (int i = 0; i < hitObjectContainer.Count; i++)
-                {
-                    DrawableOsuHitObject expectedStart = getObject(i);
-                    DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
-
-                    if (expectedEnd == null)
-                        continue;
-
-                    var points = getGroup(i).ChildrenOfType<FollowPoint>().ToArray();
-                    if (points.Length == 0)
-                        continue;
-
-                    float expectedDirection = MathF.Atan2(expectedStart.Position.Y - expectedEnd.Position.Y, expectedStart.Position.X - expectedEnd.Position.X);
-                    float realDirection = MathF.Atan2(expectedStart.Position.Y - points[^1].Position.Y, expectedStart.Position.X - points[^1].Position.X);
-
-                    if (!Precision.AlmostEquals(expectedDirection, realDirection))
-                        throw new AssertionException($"Expected group {i} in direction {expectedDirection}, but was {realDirection}.");
-                }
-
-                return true;
-            });
-        }
-
-        private DrawableOsuHitObject getObject(int index) => hitObjectContainer[index];
-
-        private FollowPointConnection getGroup(int index) => followPointRenderer.Connections[index];
-
-        private class TestHitObjectContainer : Container<DrawableOsuHitObject>
-        {
-            protected override int Compare(Drawable x, Drawable y)
-            {
-                var osuX = (DrawableOsuHitObject)x;
-                var osuY = (DrawableOsuHitObject)y;
-
-                int compare = osuX.HitObject.StartTime.CompareTo(osuY.HitObject.StartTime);
-
-                if (compare == 0)
-                    return base.Compare(x, y);
-
-                return compare;
-            }
-        }
-    }
-}
+// // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// // See the LICENCE file in the repository root for full licence text.
+//
+// using System;
+// using System.Linq;
+// using NUnit.Framework;
+// using osu.Framework.Graphics;
+// using osu.Framework.Graphics.Containers;
+// using osu.Framework.Testing;
+// using osu.Framework.Utils;
+// using osu.Game.Beatmaps;
+// using osu.Game.Beatmaps.ControlPoints;
+// using osu.Game.Rulesets.Osu.Objects;
+// using osu.Game.Rulesets.Osu.Objects.Drawables;
+// using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
+// using osu.Game.Tests.Visual;
+// using osuTK;
+//
+// namespace osu.Game.Rulesets.Osu.Tests
+// {
+//     public class TestSceneFollowPoints : OsuTestScene
+//     {
+//         private Container<DrawableOsuHitObject> hitObjectContainer;
+//         private FollowPointRenderer followPointRenderer;
+//
+//         [SetUp]
+//         public void Setup() => Schedule(() =>
+//         {
+//             Children = new Drawable[]
+//             {
+//                 hitObjectContainer = new TestHitObjectContainer { RelativeSizeAxes = Axes.Both },
+//                 followPointRenderer = new FollowPointRenderer { RelativeSizeAxes = Axes.Both }
+//             };
+//         });
+//
+//         [Test]
+//         public void TestAddObject()
+//         {
+//             addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
+//
+//             assertGroups();
+//         }
+//
+//         [Test]
+//         public void TestRemoveObject()
+//         {
+//             addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
+//
+//             removeObjectStep(() => getObject(0));
+//
+//             assertGroups();
+//         }
+//
+//         [Test]
+//         public void TestAddMultipleObjects()
+//         {
+//             addMultipleObjectsStep();
+//
+//             assertGroups();
+//         }
+//
+//         [Test]
+//         public void TestRemoveEndObject()
+//         {
+//             addMultipleObjectsStep();
+//
+//             removeObjectStep(() => getObject(4));
+//
+//             assertGroups();
+//         }
+//
+//         [Test]
+//         public void TestRemoveStartObject()
+//         {
+//             addMultipleObjectsStep();
+//
+//             removeObjectStep(() => getObject(0));
+//
+//             assertGroups();
+//         }
+//
+//         [Test]
+//         public void TestRemoveMiddleObject()
+//         {
+//             addMultipleObjectsStep();
+//
+//             removeObjectStep(() => getObject(2));
+//
+//             assertGroups();
+//         }
+//
+//         [Test]
+//         public void TestMoveObject()
+//         {
+//             addMultipleObjectsStep();
+//
+//             AddStep("move hitobject", () => getObject(2).HitObject.Position = new Vector2(300, 100));
+//
+//             assertGroups();
+//         }
+//
+//         [TestCase(0, 0)] // Start -> Start
+//         [TestCase(0, 2)] // Start -> Middle
+//         [TestCase(0, 5)] // Start -> End
+//         [TestCase(2, 0)] // Middle -> Start
+//         [TestCase(1, 3)] // Middle -> Middle (forwards)
+//         [TestCase(3, 1)] // Middle -> Middle (backwards)
+//         [TestCase(4, 0)] // End -> Start
+//         [TestCase(4, 2)] // End -> Middle
+//         [TestCase(4, 4)] // End -> End
+//         public void TestReorderObjects(int startIndex, int endIndex)
+//         {
+//             addMultipleObjectsStep();
+//
+//             reorderObjectStep(startIndex, endIndex);
+//
+//             assertGroups();
+//         }
+//
+//         [Test]
+//         public void TestStackedObjects()
+//         {
+//             addObjectsStep(() => new OsuHitObject[]
+//             {
+//                 new HitCircle { Position = new Vector2(300, 100) },
+//                 new HitCircle
+//                 {
+//                     Position = new Vector2(300, 300),
+//                     StackHeight = 20
+//                 },
+//             });
+//
+//             assertDirections();
+//         }
+//
+//         private void addMultipleObjectsStep() => addObjectsStep(() => new OsuHitObject[]
+//         {
+//             new HitCircle { Position = new Vector2(100, 100) },
+//             new HitCircle { Position = new Vector2(200, 200) },
+//             new HitCircle { Position = new Vector2(300, 300) },
+//             new HitCircle { Position = new Vector2(400, 400) },
+//             new HitCircle { Position = new Vector2(500, 500) },
+//         });
+//
+//         private void addObjectsStep(Func<OsuHitObject[]> ctorFunc)
+//         {
+//             AddStep("add hitobjects", () =>
+//             {
+//                 var objects = ctorFunc();
+//
+//                 for (int i = 0; i < objects.Length; i++)
+//                 {
+//                     objects[i].StartTime = Time.Current + 1000 + 500 * (i + 1);
+//                     objects[i].ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+//
+//                     DrawableOsuHitObject drawableObject = null;
+//
+//                     switch (objects[i])
+//                     {
+//                         case HitCircle circle:
+//                             drawableObject = new DrawableHitCircle(circle);
+//                             break;
+//
+//                         case Slider slider:
+//                             drawableObject = new DrawableSlider(slider);
+//                             break;
+//
+//                         case Spinner spinner:
+//                             drawableObject = new DrawableSpinner(spinner);
+//                             break;
+//                     }
+//
+//                     hitObjectContainer.Add(drawableObject);
+//                     followPointRenderer.AddFollowPoints(objects[i]);
+//                 }
+//             });
+//         }
+//
+//         private void removeObjectStep(Func<DrawableOsuHitObject> getFunc)
+//         {
+//             AddStep("remove hitobject", () =>
+//             {
+//                 var drawableObject = getFunc.Invoke();
+//
+//                 hitObjectContainer.Remove(drawableObject);
+//                 followPointRenderer.RemoveFollowPoints(drawableObject.HitObject);
+//             });
+//         }
+//
+//         private void reorderObjectStep(int startIndex, int endIndex)
+//         {
+//             AddStep($"move object {startIndex} to {endIndex}", () =>
+//             {
+//                 DrawableOsuHitObject toReorder = getObject(startIndex);
+//
+//                 double targetTime;
+//                 if (endIndex < hitObjectContainer.Count)
+//                     targetTime = getObject(endIndex).HitObject.StartTime - 1;
+//                 else
+//                     targetTime = getObject(hitObjectContainer.Count - 1).HitObject.StartTime + 1;
+//
+//                 hitObjectContainer.Remove(toReorder);
+//                 toReorder.HitObject.StartTime = targetTime;
+//                 hitObjectContainer.Add(toReorder);
+//             });
+//         }
+//
+//         private void assertGroups()
+//         {
+//             AddAssert("has correct group count", () => followPointRenderer.Connections.Count == hitObjectContainer.Count);
+//             AddAssert("group endpoints are correct", () =>
+//             {
+//                 for (int i = 0; i < hitObjectContainer.Count; i++)
+//                 {
+//                     DrawableOsuHitObject expectedStart = getObject(i);
+//                     DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
+//
+//                     if (getGroup(i).Start != expectedStart.HitObject)
+//                         throw new AssertionException($"Object {i} expected to be the start of group {i}.");
+//
+//                     if (getGroup(i).End != expectedEnd?.HitObject)
+//                         throw new AssertionException($"Object {(expectedEnd == null ? "null" : i.ToString())} expected to be the end of group {i}.");
+//                 }
+//
+//                 return true;
+//             });
+//         }
+//
+//         private void assertDirections()
+//         {
+//             AddAssert("group directions are correct", () =>
+//             {
+//                 for (int i = 0; i < hitObjectContainer.Count; i++)
+//                 {
+//                     DrawableOsuHitObject expectedStart = getObject(i);
+//                     DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
+//
+//                     if (expectedEnd == null)
+//                         continue;
+//
+//                     var points = getGroup(i).ChildrenOfType<FollowPoint>().ToArray();
+//                     if (points.Length == 0)
+//                         continue;
+//
+//                     float expectedDirection = MathF.Atan2(expectedStart.Position.Y - expectedEnd.Position.Y, expectedStart.Position.X - expectedEnd.Position.X);
+//                     float realDirection = MathF.Atan2(expectedStart.Position.Y - points[^1].Position.Y, expectedStart.Position.X - points[^1].Position.X);
+//
+//                     if (!Precision.AlmostEquals(expectedDirection, realDirection))
+//                         throw new AssertionException($"Expected group {i} in direction {expectedDirection}, but was {realDirection}.");
+//                 }
+//
+//                 return true;
+//             });
+//         }
+//
+//         private DrawableOsuHitObject getObject(int index) => hitObjectContainer[index];
+//
+//         private FollowPointConnection getGroup(int index) => followPointRenderer.Connections[index];
+//
+//         private class TestHitObjectContainer : Container<DrawableOsuHitObject>
+//         {
+//             protected override int Compare(Drawable x, Drawable y)
+//             {
+//                 var osuX = (DrawableOsuHitObject)x;
+//                 var osuY = (DrawableOsuHitObject)y;
+//
+//                 int compare = osuX.HitObject.StartTime.CompareTo(osuY.HitObject.StartTime);
+//
+//                 if (compare == 0)
+//                     return base.Compare(x, y);
+//
+//                 return compare;
+//             }
+//         }
+//     }
+// }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneFollowPoints.cs
@@ -1,276 +1,285 @@
-// // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// // See the LICENCE file in the repository root for full licence text.
-//
-// using System;
-// using System.Linq;
-// using NUnit.Framework;
-// using osu.Framework.Graphics;
-// using osu.Framework.Graphics.Containers;
-// using osu.Framework.Testing;
-// using osu.Framework.Utils;
-// using osu.Game.Beatmaps;
-// using osu.Game.Beatmaps.ControlPoints;
-// using osu.Game.Rulesets.Osu.Objects;
-// using osu.Game.Rulesets.Osu.Objects.Drawables;
-// using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
-// using osu.Game.Tests.Visual;
-// using osuTK;
-//
-// namespace osu.Game.Rulesets.Osu.Tests
-// {
-//     public class TestSceneFollowPoints : OsuTestScene
-//     {
-//         private Container<DrawableOsuHitObject> hitObjectContainer;
-//         private FollowPointRenderer followPointRenderer;
-//
-//         [SetUp]
-//         public void Setup() => Schedule(() =>
-//         {
-//             Children = new Drawable[]
-//             {
-//                 hitObjectContainer = new TestHitObjectContainer { RelativeSizeAxes = Axes.Both },
-//                 followPointRenderer = new FollowPointRenderer { RelativeSizeAxes = Axes.Both }
-//             };
-//         });
-//
-//         [Test]
-//         public void TestAddObject()
-//         {
-//             addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
-//
-//             assertGroups();
-//         }
-//
-//         [Test]
-//         public void TestRemoveObject()
-//         {
-//             addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
-//
-//             removeObjectStep(() => getObject(0));
-//
-//             assertGroups();
-//         }
-//
-//         [Test]
-//         public void TestAddMultipleObjects()
-//         {
-//             addMultipleObjectsStep();
-//
-//             assertGroups();
-//         }
-//
-//         [Test]
-//         public void TestRemoveEndObject()
-//         {
-//             addMultipleObjectsStep();
-//
-//             removeObjectStep(() => getObject(4));
-//
-//             assertGroups();
-//         }
-//
-//         [Test]
-//         public void TestRemoveStartObject()
-//         {
-//             addMultipleObjectsStep();
-//
-//             removeObjectStep(() => getObject(0));
-//
-//             assertGroups();
-//         }
-//
-//         [Test]
-//         public void TestRemoveMiddleObject()
-//         {
-//             addMultipleObjectsStep();
-//
-//             removeObjectStep(() => getObject(2));
-//
-//             assertGroups();
-//         }
-//
-//         [Test]
-//         public void TestMoveObject()
-//         {
-//             addMultipleObjectsStep();
-//
-//             AddStep("move hitobject", () => getObject(2).HitObject.Position = new Vector2(300, 100));
-//
-//             assertGroups();
-//         }
-//
-//         [TestCase(0, 0)] // Start -> Start
-//         [TestCase(0, 2)] // Start -> Middle
-//         [TestCase(0, 5)] // Start -> End
-//         [TestCase(2, 0)] // Middle -> Start
-//         [TestCase(1, 3)] // Middle -> Middle (forwards)
-//         [TestCase(3, 1)] // Middle -> Middle (backwards)
-//         [TestCase(4, 0)] // End -> Start
-//         [TestCase(4, 2)] // End -> Middle
-//         [TestCase(4, 4)] // End -> End
-//         public void TestReorderObjects(int startIndex, int endIndex)
-//         {
-//             addMultipleObjectsStep();
-//
-//             reorderObjectStep(startIndex, endIndex);
-//
-//             assertGroups();
-//         }
-//
-//         [Test]
-//         public void TestStackedObjects()
-//         {
-//             addObjectsStep(() => new OsuHitObject[]
-//             {
-//                 new HitCircle { Position = new Vector2(300, 100) },
-//                 new HitCircle
-//                 {
-//                     Position = new Vector2(300, 300),
-//                     StackHeight = 20
-//                 },
-//             });
-//
-//             assertDirections();
-//         }
-//
-//         private void addMultipleObjectsStep() => addObjectsStep(() => new OsuHitObject[]
-//         {
-//             new HitCircle { Position = new Vector2(100, 100) },
-//             new HitCircle { Position = new Vector2(200, 200) },
-//             new HitCircle { Position = new Vector2(300, 300) },
-//             new HitCircle { Position = new Vector2(400, 400) },
-//             new HitCircle { Position = new Vector2(500, 500) },
-//         });
-//
-//         private void addObjectsStep(Func<OsuHitObject[]> ctorFunc)
-//         {
-//             AddStep("add hitobjects", () =>
-//             {
-//                 var objects = ctorFunc();
-//
-//                 for (int i = 0; i < objects.Length; i++)
-//                 {
-//                     objects[i].StartTime = Time.Current + 1000 + 500 * (i + 1);
-//                     objects[i].ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-//
-//                     DrawableOsuHitObject drawableObject = null;
-//
-//                     switch (objects[i])
-//                     {
-//                         case HitCircle circle:
-//                             drawableObject = new DrawableHitCircle(circle);
-//                             break;
-//
-//                         case Slider slider:
-//                             drawableObject = new DrawableSlider(slider);
-//                             break;
-//
-//                         case Spinner spinner:
-//                             drawableObject = new DrawableSpinner(spinner);
-//                             break;
-//                     }
-//
-//                     hitObjectContainer.Add(drawableObject);
-//                     followPointRenderer.AddFollowPoints(objects[i]);
-//                 }
-//             });
-//         }
-//
-//         private void removeObjectStep(Func<DrawableOsuHitObject> getFunc)
-//         {
-//             AddStep("remove hitobject", () =>
-//             {
-//                 var drawableObject = getFunc.Invoke();
-//
-//                 hitObjectContainer.Remove(drawableObject);
-//                 followPointRenderer.RemoveFollowPoints(drawableObject.HitObject);
-//             });
-//         }
-//
-//         private void reorderObjectStep(int startIndex, int endIndex)
-//         {
-//             AddStep($"move object {startIndex} to {endIndex}", () =>
-//             {
-//                 DrawableOsuHitObject toReorder = getObject(startIndex);
-//
-//                 double targetTime;
-//                 if (endIndex < hitObjectContainer.Count)
-//                     targetTime = getObject(endIndex).HitObject.StartTime - 1;
-//                 else
-//                     targetTime = getObject(hitObjectContainer.Count - 1).HitObject.StartTime + 1;
-//
-//                 hitObjectContainer.Remove(toReorder);
-//                 toReorder.HitObject.StartTime = targetTime;
-//                 hitObjectContainer.Add(toReorder);
-//             });
-//         }
-//
-//         private void assertGroups()
-//         {
-//             AddAssert("has correct group count", () => followPointRenderer.Connections.Count == hitObjectContainer.Count);
-//             AddAssert("group endpoints are correct", () =>
-//             {
-//                 for (int i = 0; i < hitObjectContainer.Count; i++)
-//                 {
-//                     DrawableOsuHitObject expectedStart = getObject(i);
-//                     DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
-//
-//                     if (getGroup(i).Start != expectedStart.HitObject)
-//                         throw new AssertionException($"Object {i} expected to be the start of group {i}.");
-//
-//                     if (getGroup(i).End != expectedEnd?.HitObject)
-//                         throw new AssertionException($"Object {(expectedEnd == null ? "null" : i.ToString())} expected to be the end of group {i}.");
-//                 }
-//
-//                 return true;
-//             });
-//         }
-//
-//         private void assertDirections()
-//         {
-//             AddAssert("group directions are correct", () =>
-//             {
-//                 for (int i = 0; i < hitObjectContainer.Count; i++)
-//                 {
-//                     DrawableOsuHitObject expectedStart = getObject(i);
-//                     DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
-//
-//                     if (expectedEnd == null)
-//                         continue;
-//
-//                     var points = getGroup(i).ChildrenOfType<FollowPoint>().ToArray();
-//                     if (points.Length == 0)
-//                         continue;
-//
-//                     float expectedDirection = MathF.Atan2(expectedStart.Position.Y - expectedEnd.Position.Y, expectedStart.Position.X - expectedEnd.Position.X);
-//                     float realDirection = MathF.Atan2(expectedStart.Position.Y - points[^1].Position.Y, expectedStart.Position.X - points[^1].Position.X);
-//
-//                     if (!Precision.AlmostEquals(expectedDirection, realDirection))
-//                         throw new AssertionException($"Expected group {i} in direction {expectedDirection}, but was {realDirection}.");
-//                 }
-//
-//                 return true;
-//             });
-//         }
-//
-//         private DrawableOsuHitObject getObject(int index) => hitObjectContainer[index];
-//
-//         private FollowPointConnection getGroup(int index) => followPointRenderer.Connections[index];
-//
-//         private class TestHitObjectContainer : Container<DrawableOsuHitObject>
-//         {
-//             protected override int Compare(Drawable x, Drawable y)
-//             {
-//                 var osuX = (DrawableOsuHitObject)x;
-//                 var osuY = (DrawableOsuHitObject)y;
-//
-//                 int compare = osuX.HitObject.StartTime.CompareTo(osuY.HitObject.StartTime);
-//
-//                 if (compare == 0)
-//                     return base.Compare(x, y);
-//
-//                 return compare;
-//             }
-//         }
-//     }
-// }
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables.Connections;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public class TestSceneFollowPoints : OsuTestScene
+    {
+        private Container<DrawableOsuHitObject> hitObjectContainer;
+        private FollowPointRenderer followPointRenderer;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Children = new Drawable[]
+            {
+                hitObjectContainer = new TestHitObjectContainer { RelativeSizeAxes = Axes.Both },
+                followPointRenderer = new FollowPointRenderer { RelativeSizeAxes = Axes.Both }
+            };
+        });
+
+        [Test]
+        public void TestAddObject()
+        {
+            addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
+
+            assertGroups();
+        }
+
+        [Test]
+        public void TestRemoveObject()
+        {
+            addObjectsStep(() => new OsuHitObject[] { new HitCircle { Position = new Vector2(100, 100) } });
+
+            removeObjectStep(() => getObject(0));
+
+            assertGroups();
+        }
+
+        [Test]
+        public void TestAddMultipleObjects()
+        {
+            addMultipleObjectsStep();
+
+            assertGroups();
+        }
+
+        [Test]
+        public void TestRemoveEndObject()
+        {
+            addMultipleObjectsStep();
+
+            removeObjectStep(() => getObject(4));
+
+            assertGroups();
+        }
+
+        [Test]
+        public void TestRemoveStartObject()
+        {
+            addMultipleObjectsStep();
+
+            removeObjectStep(() => getObject(0));
+
+            assertGroups();
+        }
+
+        [Test]
+        public void TestRemoveMiddleObject()
+        {
+            addMultipleObjectsStep();
+
+            removeObjectStep(() => getObject(2));
+
+            assertGroups();
+        }
+
+        [Test]
+        public void TestMoveObject()
+        {
+            addMultipleObjectsStep();
+
+            AddStep("move hitobject", () => getObject(2).HitObject.Position = new Vector2(300, 100));
+
+            assertGroups();
+        }
+
+        [TestCase(0, 0)] // Start -> Start
+        [TestCase(0, 2)] // Start -> Middle
+        [TestCase(0, 5)] // Start -> End
+        [TestCase(2, 0)] // Middle -> Start
+        [TestCase(1, 3)] // Middle -> Middle (forwards)
+        [TestCase(3, 1)] // Middle -> Middle (backwards)
+        [TestCase(4, 0)] // End -> Start
+        [TestCase(4, 2)] // End -> Middle
+        [TestCase(4, 4)] // End -> End
+        public void TestReorderObjects(int startIndex, int endIndex)
+        {
+            addMultipleObjectsStep();
+
+            reorderObjectStep(startIndex, endIndex);
+
+            assertGroups();
+        }
+
+        [Test]
+        public void TestStackedObjects()
+        {
+            addObjectsStep(() => new OsuHitObject[]
+            {
+                new HitCircle { Position = new Vector2(300, 100) },
+                new HitCircle
+                {
+                    Position = new Vector2(300, 300),
+                    StackHeight = 20
+                },
+            });
+
+            assertDirections();
+        }
+
+        private void addMultipleObjectsStep() => addObjectsStep(() => new OsuHitObject[]
+        {
+            new HitCircle { Position = new Vector2(100, 100) },
+            new HitCircle { Position = new Vector2(200, 200) },
+            new HitCircle { Position = new Vector2(300, 300) },
+            new HitCircle { Position = new Vector2(400, 400) },
+            new HitCircle { Position = new Vector2(500, 500) },
+        });
+
+        private void addObjectsStep(Func<OsuHitObject[]> ctorFunc)
+        {
+            AddStep("add hitobjects", () =>
+            {
+                var objects = ctorFunc();
+
+                for (int i = 0; i < objects.Length; i++)
+                {
+                    objects[i].StartTime = Time.Current + 1000 + 500 * (i + 1);
+                    objects[i].ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+                    DrawableOsuHitObject drawableObject = null;
+
+                    switch (objects[i])
+                    {
+                        case HitCircle circle:
+                            drawableObject = new DrawableHitCircle(circle);
+                            break;
+
+                        case Slider slider:
+                            drawableObject = new DrawableSlider(slider);
+                            break;
+
+                        case Spinner spinner:
+                            drawableObject = new DrawableSpinner(spinner);
+                            break;
+                    }
+
+                    hitObjectContainer.Add(drawableObject);
+                    followPointRenderer.AddFollowPoints2(objects[i]);
+                }
+            });
+        }
+
+        private void removeObjectStep(Func<DrawableOsuHitObject> getFunc)
+        {
+            AddStep("remove hitobject", () =>
+            {
+                var drawableObject = getFunc.Invoke();
+
+                hitObjectContainer.Remove(drawableObject);
+                followPointRenderer.RemoveFollowPoints2(drawableObject.HitObject);
+            });
+        }
+
+        private void reorderObjectStep(int startIndex, int endIndex)
+        {
+            AddStep($"move object {startIndex} to {endIndex}", () =>
+            {
+                DrawableOsuHitObject toReorder = getObject(startIndex);
+
+                double targetTime;
+                if (endIndex < hitObjectContainer.Count)
+                    targetTime = getObject(endIndex).HitObject.StartTime - 1;
+                else
+                    targetTime = getObject(hitObjectContainer.Count - 1).HitObject.StartTime + 1;
+
+                hitObjectContainer.Remove(toReorder);
+                toReorder.HitObject.StartTime = targetTime;
+                hitObjectContainer.Add(toReorder);
+            });
+        }
+
+        private void assertGroups()
+        {
+            AddAssert("has correct group count", () => followPointRenderer.Entries.Count == hitObjectContainer.Count);
+            AddAssert("group endpoints are correct", () =>
+            {
+                for (int i = 0; i < hitObjectContainer.Count; i++)
+                {
+                    DrawableOsuHitObject expectedStart = getObject(i);
+                    DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
+
+                    if (getEntry(i).Start != expectedStart.HitObject)
+                        throw new AssertionException($"Object {i} expected to be the start of group {i}.");
+
+                    if (getEntry(i).End != expectedEnd?.HitObject)
+                        throw new AssertionException($"Object {(expectedEnd == null ? "null" : i.ToString())} expected to be the end of group {i}.");
+                }
+
+                return true;
+            });
+        }
+
+        private void assertDirections()
+        {
+            AddAssert("group directions are correct", () =>
+            {
+                for (int i = 0; i < hitObjectContainer.Count; i++)
+                {
+                    DrawableOsuHitObject expectedStart = getObject(i);
+                    DrawableOsuHitObject expectedEnd = i < hitObjectContainer.Count - 1 ? getObject(i + 1) : null;
+
+                    if (expectedEnd == null)
+                        continue;
+
+                    var manualClock = new ManualClock();
+                    followPointRenderer.Clock = new FramedClock(manualClock);
+
+                    manualClock.CurrentTime = expectedStart.HitObject.StartTime;
+                    followPointRenderer.UpdateSubTree();
+
+                    var points = getGroup(i).ChildrenOfType<FollowPoint>().ToArray();
+                    if (points.Length == 0)
+                        continue;
+
+                    float expectedDirection = MathF.Atan2(expectedStart.Position.Y - expectedEnd.Position.Y, expectedStart.Position.X - expectedEnd.Position.X);
+                    float realDirection = MathF.Atan2(expectedStart.Position.Y - points[^1].Position.Y, expectedStart.Position.X - points[^1].Position.X);
+
+                    if (!Precision.AlmostEquals(expectedDirection, realDirection))
+                        throw new AssertionException($"Expected group {i} in direction {expectedDirection}, but was {realDirection}.");
+                }
+
+                return true;
+            });
+        }
+
+        private DrawableOsuHitObject getObject(int index) => hitObjectContainer[index];
+
+        private FollowPointRenderer.FollowPointLifetimeEntry getEntry(int index) => followPointRenderer.Entries[index];
+
+        private FollowPointConnection getGroup(int index) => followPointRenderer.ChildrenOfType<FollowPointConnection>().Single(c => c.Entry == getEntry(index));
+
+        private class TestHitObjectContainer : Container<DrawableOsuHitObject>
+        {
+            protected override int Compare(Drawable x, Drawable y)
+            {
+                var osuX = (DrawableOsuHitObject)x;
+                var osuY = (DrawableOsuHitObject)y;
+
+                int compare = osuX.HitObject.StartTime.CompareTo(osuY.HitObject.StartTime);
+
+                if (compare == 0)
+                    return base.Compare(x, y);
+
+                return compare;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Skinning;
 
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
     /// <summary>
     /// A single follow point positioned between two adjacent <see cref="DrawableOsuHitObject"/>s.
     /// </summary>
-    public class FollowPoint : Container, IAnimationTimeReference
+    public class FollowPoint : PoolableDrawable, IAnimationTimeReference
     {
         private const float width = 8;
 
@@ -25,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         {
             Origin = Anchor.Centre;
 
-            Child = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.FollowPoint), _ => new CircularContainer
+            InternalChild = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.FollowPoint), _ => new CircularContainer
             {
                 Masking = true,
                 AutoSizeAxes = Axes.Both,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -55,12 +55,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
             Vector2 startPosition = start.StackedEndPosition;
             Vector2 endPosition = end.StackedPosition;
-            double endTime = end.StartTime;
 
             Vector2 distanceVector = endPosition - startPosition;
             int distance = (int)distanceVector.Length;
             float rotation = (float)(Math.Atan2(distanceVector.Y, distanceVector.X) * (180 / Math.PI));
-            double duration = endTime - startTime;
 
             double finalTransformEndTime = startTime;
 
@@ -69,8 +67,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
                 float fraction = (float)d / distance;
                 Vector2 pointStartPosition = startPosition + (fraction - 0.1f) * distanceVector;
                 Vector2 pointEndPosition = startPosition + fraction * distanceVector;
-                double fadeOutTime = startTime + fraction * duration;
-                double fadeInTime = fadeOutTime - PREEMPT;
+
+                GetFadeTimes(start, end, (float)d / distance, out var fadeInTime, out var fadeOutTime);
 
                 FollowPoint fp;
 
@@ -97,6 +95,23 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
             // todo: use Expire() on FollowPoints and take lifetime from them when https://github.com/ppy/osu-framework/issues/3300 is fixed.
             Entry.LifetimeEnd = finalTransformEndTime;
+        }
+
+        /// <summary>
+        /// Computes the fade time of follow point positioned between two hitobjects.
+        /// </summary>
+        /// <param name="start">The first <see cref="OsuHitObject"/>, where follow points should originate from.</param>
+        /// <param name="end">The second <see cref="OsuHitObject"/>, which follow points should target.</param>
+        /// <param name="fraction">The fractional distance along <paramref name="start"/> and <paramref name="end"/> at which the follow point is to be located.</param>
+        /// <param name="fadeInTime">The fade-in time of the follow point/</param>
+        /// <param name="fadeOutTime">The fade-out time of the follow point.</param>
+        public static void GetFadeTimes(OsuHitObject start, OsuHitObject end, float fraction, out double fadeInTime, out double fadeOutTime)
+        {
+            double startTime = start.GetEndTime();
+            double duration = end.StartTime - startTime;
+
+            fadeOutTime = startTime + fraction * duration;
+            fadeInTime = fadeOutTime - PREEMPT;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -21,15 +21,32 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         public FollowPointRenderer.FollowPointLifetimeEntry Entry;
         public DrawablePool<FollowPoint> Pool;
 
-        protected override void FreeAfterUse()
-        {
-            base.FreeAfterUse();
-            ClearInternal(false);
-        }
-
         protected override void PrepareForUse()
         {
             base.PrepareForUse();
+
+            Entry.Invalidated += onEntryInvalidated;
+
+            refreshPoints();
+        }
+
+        protected override void FreeAfterUse()
+        {
+            base.FreeAfterUse();
+
+            Entry.Invalidated -= onEntryInvalidated;
+
+            // Return points to the pool.
+            ClearInternal(false);
+
+            Entry = null;
+        }
+
+        private void onEntryInvalidated() => refreshPoints();
+
+        private void refreshPoints()
+        {
+            ClearInternal(false);
 
             OsuHitObject start = Entry.Start;
             OsuHitObject end = Entry.End;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -53,9 +53,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
             double startTime = start.GetEndTime();
 
-            if (end == null || end.NewCombo || start is Spinner || end is Spinner)
-                return;
-
             Vector2 startPosition = start.StackedEndPosition;
             Vector2 endPosition = end.StackedPosition;
             double endTime = end.StartTime;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -2,11 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
-using JetBrains.Annotations;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
 using osuTK;
 
@@ -15,150 +12,77 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
     /// <summary>
     /// Visualises the <see cref="FollowPoint"/>s between two <see cref="DrawableOsuHitObject"/>s.
     /// </summary>
-    public class FollowPointConnection : CompositeDrawable
+    public class FollowPointConnection : PoolableDrawable
     {
         // Todo: These shouldn't be constants
-        private const int spacing = 32;
-        private const double preempt = 800;
+        public const int SPACING = 32;
+        public const double PREEMPT = 800;
 
-        public override bool RemoveWhenNotAlive => false;
+        public FollowPointRenderer.FollowPointLifetimeEntry Entry;
+        public DrawablePool<FollowPoint> Pool;
 
-        /// <summary>
-        /// The start time of <see cref="Start"/>.
-        /// </summary>
-        public readonly Bindable<double> StartTime = new BindableDouble();
-
-        /// <summary>
-        /// The <see cref="DrawableOsuHitObject"/> which <see cref="FollowPoint"/>s will exit from.
-        /// </summary>
-        [NotNull]
-        public readonly OsuHitObject Start;
-
-        /// <summary>
-        /// Creates a new <see cref="FollowPointConnection"/>.
-        /// </summary>
-        /// <param name="start">The <see cref="DrawableOsuHitObject"/> which <see cref="FollowPoint"/>s will exit from.</param>
-        public FollowPointConnection([NotNull] OsuHitObject start)
+        protected override void FreeAfterUse()
         {
-            Start = start;
-
-            RelativeSizeAxes = Axes.Both;
-
-            StartTime.BindTo(start.StartTimeBindable);
+            base.FreeAfterUse();
+            ClearInternal(false);
         }
 
-        protected override void LoadComplete()
+        protected override void PrepareForUse()
         {
-            base.LoadComplete();
-            bindEvents(Start);
-        }
+            base.PrepareForUse();
 
-        private OsuHitObject end;
+            OsuHitObject start = Entry.Start;
+            OsuHitObject end = Entry.End;
 
-        /// <summary>
-        /// The <see cref="DrawableOsuHitObject"/> which <see cref="FollowPoint"/>s will enter.
-        /// </summary>
-        [CanBeNull]
-        public OsuHitObject End
-        {
-            get => end;
-            set
-            {
-                end = value;
+            double startTime = start.GetEndTime();
 
-                if (end != null)
-                    bindEvents(end);
-
-                if (IsLoaded)
-                    scheduleRefresh();
-                else
-                    refresh();
-            }
-        }
-
-        private void bindEvents(OsuHitObject obj)
-        {
-            obj.PositionBindable.BindValueChanged(_ => scheduleRefresh());
-            obj.DefaultsApplied += _ => scheduleRefresh();
-        }
-
-        private void scheduleRefresh()
-        {
-            Scheduler.AddOnce(refresh);
-        }
-
-        private void refresh()
-        {
-            double startTime = Start.GetEndTime();
-
-            LifetimeStart = startTime;
-
-            if (End == null || End.NewCombo || Start is Spinner || End is Spinner)
-            {
-                // ensure we always set a lifetime for full LifetimeManagementContainer benefits
-                LifetimeEnd = LifetimeStart;
+            if (end == null || end.NewCombo || start is Spinner || end is Spinner)
                 return;
-            }
 
-            Vector2 startPosition = Start.StackedEndPosition;
-            Vector2 endPosition = End.StackedPosition;
-            double endTime = End.StartTime;
+            Vector2 startPosition = start.StackedEndPosition;
+            Vector2 endPosition = end.StackedPosition;
+            double endTime = end.StartTime;
 
             Vector2 distanceVector = endPosition - startPosition;
             int distance = (int)distanceVector.Length;
             float rotation = (float)(Math.Atan2(distanceVector.Y, distanceVector.X) * (180 / Math.PI));
             double duration = endTime - startTime;
 
-            double? firstTransformStartTime = null;
             double finalTransformEndTime = startTime;
 
-            int point = 0;
-
-            ClearInternal();
-
-            for (int d = (int)(spacing * 1.5); d < distance - spacing; d += spacing)
+            for (int d = (int)(SPACING * 1.5); d < distance - SPACING; d += SPACING)
             {
                 float fraction = (float)d / distance;
                 Vector2 pointStartPosition = startPosition + (fraction - 0.1f) * distanceVector;
                 Vector2 pointEndPosition = startPosition + fraction * distanceVector;
                 double fadeOutTime = startTime + fraction * duration;
-                double fadeInTime = fadeOutTime - preempt;
+                double fadeInTime = fadeOutTime - PREEMPT;
 
                 FollowPoint fp;
 
-                AddInternal(fp = new FollowPoint());
+                AddInternal(fp = Pool.Get());
 
-                Debug.Assert(End != null);
-
+                fp.ClearTransforms();
                 fp.Position = pointStartPosition;
                 fp.Rotation = rotation;
                 fp.Alpha = 0;
-                fp.Scale = new Vector2(1.5f * End.Scale);
-
-                firstTransformStartTime ??= fadeInTime;
+                fp.Scale = new Vector2(1.5f * end.Scale);
 
                 fp.AnimationStartTime = fadeInTime;
 
                 using (fp.BeginAbsoluteSequence(fadeInTime))
                 {
-                    fp.FadeIn(End.TimeFadeIn);
-                    fp.ScaleTo(End.Scale, End.TimeFadeIn, Easing.Out);
-                    fp.MoveTo(pointEndPosition, End.TimeFadeIn, Easing.Out);
-                    fp.Delay(fadeOutTime - fadeInTime).FadeOut(End.TimeFadeIn);
+                    fp.FadeIn(end.TimeFadeIn);
+                    fp.ScaleTo(end.Scale, end.TimeFadeIn, Easing.Out);
+                    fp.MoveTo(pointEndPosition, end.TimeFadeIn, Easing.Out);
+                    fp.Delay(fadeOutTime - fadeInTime).FadeOut(end.TimeFadeIn);
 
-                    finalTransformEndTime = fadeOutTime + End.TimeFadeIn;
+                    finalTransformEndTime = fadeOutTime + end.TimeFadeIn;
                 }
-
-                point++;
             }
 
-            int excessPoints = InternalChildren.Count - point;
-            for (int i = 0; i < excessPoints; i++)
-                RemoveInternal(InternalChildren[^1]);
-
             // todo: use Expire() on FollowPoints and take lifetime from them when https://github.com/ppy/osu-framework/issues/3300 is fixed.
-            LifetimeStart = firstTransformStartTime ?? startTime;
-            LifetimeEnd = finalTransformEndTime;
+            Entry.LifetimeEnd = finalTransformEndTime;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         public const int SPACING = 32;
         public const double PREEMPT = 800;
 
-        public FollowPointRenderer.FollowPointLifetimeEntry Entry;
+        public FollowPointLifetimeEntry Entry;
         public DrawablePool<FollowPoint> Pool;
 
         protected override void PrepareForUse()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -1,0 +1,98 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Performance;
+using osu.Game.Rulesets.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
+{
+    public class FollowPointLifetimeEntry : LifetimeEntry
+    {
+        public event Action Invalidated;
+        public readonly OsuHitObject Start;
+
+        public FollowPointLifetimeEntry(OsuHitObject start)
+        {
+            Start = start;
+            LifetimeStart = Start.StartTime;
+
+            bindEvents();
+        }
+
+        private OsuHitObject end;
+
+        public OsuHitObject End
+        {
+            get => end;
+            set
+            {
+                UnbindEvents();
+
+                end = value;
+
+                bindEvents();
+
+                refreshLifetimes();
+            }
+        }
+
+        private void bindEvents()
+        {
+            UnbindEvents();
+
+            // Note: Positions are bound for instantaneous feedback from positional changes from the editor, before ApplyDefaults() is called on hitobjects.
+            Start.DefaultsApplied += onDefaultsApplied;
+            Start.PositionBindable.ValueChanged += onPositionChanged;
+
+            if (End != null)
+            {
+                End.DefaultsApplied += onDefaultsApplied;
+                End.PositionBindable.ValueChanged += onPositionChanged;
+            }
+        }
+
+        public void UnbindEvents()
+        {
+            if (Start != null)
+            {
+                Start.DefaultsApplied -= onDefaultsApplied;
+                Start.PositionBindable.ValueChanged -= onPositionChanged;
+            }
+
+            if (End != null)
+            {
+                End.DefaultsApplied -= onDefaultsApplied;
+                End.PositionBindable.ValueChanged -= onPositionChanged;
+            }
+        }
+
+        private void onDefaultsApplied(HitObject obj) => refreshLifetimes();
+
+        private void onPositionChanged(ValueChangedEvent<Vector2> obj) => refreshLifetimes();
+
+        private void refreshLifetimes()
+        {
+            if (End == null || End.NewCombo || Start is Spinner || End is Spinner)
+            {
+                LifetimeEnd = LifetimeStart;
+                return;
+            }
+
+            Vector2 startPosition = Start.StackedEndPosition;
+            Vector2 endPosition = End.StackedPosition;
+            Vector2 distanceVector = endPosition - startPosition;
+
+            // The lifetime start will match the fade-in time of the first follow point.
+            float fraction = (int)(FollowPointConnection.SPACING * 1.5) / distanceVector.Length;
+            FollowPointConnection.GetFadeTimes(Start, End, fraction, out var fadeInTime, out _);
+
+            LifetimeStart = fadeInTime;
+            LifetimeEnd = double.MaxValue; // This will be set by the connection.
+
+            Invalidated?.Invoke();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -248,12 +248,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
                 Vector2 startPosition = Start.StackedEndPosition;
                 Vector2 endPosition = End.StackedPosition;
                 Vector2 distanceVector = endPosition - startPosition;
+
+                // The lifetime start will match the fade-in time of the first follow point.
                 float fraction = (int)(FollowPointConnection.SPACING * 1.5) / distanceVector.Length;
-
-                double duration = End.StartTime - Start.GetEndTime();
-
-                double fadeOutTime = Start.StartTime + fraction * duration;
-                double fadeInTime = fadeOutTime - FollowPointConnection.PREEMPT;
+                FollowPointConnection.GetFadeTimes(Start, End, fraction, out var fadeInTime, out _);
 
                 LifetimeStart = fadeInTime;
                 LifetimeEnd = double.MaxValue; // This will be set by the connection.

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -143,8 +143,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             public FollowPointLifetimeEntry(OsuHitObject start)
             {
                 Start = start;
-
-                LifetimeStart = LifetimeEnd = Start.StartTime;
+                LifetimeStart = Start.StartTime;
             }
 
             private OsuHitObject end;
@@ -178,6 +177,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
                 double fadeInTime = fadeOutTime - FollowPointConnection.PREEMPT;
 
                 LifetimeStart = fadeInTime;
+                LifetimeEnd = double.MaxValue; // This will be set by the connection.
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             MakeChildAlive(pointPool);
         }
 
-        public void AddFollowPoints2(OsuHitObject hitObject)
+        public void AddFollowPoints(OsuHitObject hitObject)
         {
             addEntry(hitObject);
 
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             startTimeMap[hitObject] = startTimeBindable;
         }
 
-        public void RemoveFollowPoints2(OsuHitObject hitObject)
+        public void RemoveFollowPoints(OsuHitObject hitObject)
         {
             removeEntry(hitObject);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
     {
         public override bool RemoveCompletedTransforms => false;
 
+        public IReadOnlyList<FollowPointLifetimeEntry> Entries => lifetimeEntries;
+
         private DrawablePool<FollowPointConnection> connectionPool;
         private DrawablePool<FollowPoint> pointPool;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -11,7 +10,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Performance;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
@@ -182,93 +180,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             public DrawablePoolNoLifetime(int initialSize, int? maximumSize = null)
                 : base(initialSize, maximumSize)
             {
-            }
-        }
-
-        public class FollowPointLifetimeEntry : LifetimeEntry
-        {
-            public event Action Invalidated;
-            public readonly OsuHitObject Start;
-
-            public FollowPointLifetimeEntry(OsuHitObject start)
-            {
-                Start = start;
-                LifetimeStart = Start.StartTime;
-
-                bindEvents();
-            }
-
-            private OsuHitObject end;
-
-            public OsuHitObject End
-            {
-                get => end;
-                set
-                {
-                    UnbindEvents();
-
-                    end = value;
-
-                    bindEvents();
-
-                    refreshLifetimes();
-                }
-            }
-
-            private void bindEvents()
-            {
-                UnbindEvents();
-
-                // Note: Positions are bound for instantaneous feedback from positional changes from the editor, before ApplyDefaults() is called on hitobjects.
-                Start.DefaultsApplied += onDefaultsApplied;
-                Start.PositionBindable.ValueChanged += onPositionChanged;
-
-                if (End != null)
-                {
-                    End.DefaultsApplied += onDefaultsApplied;
-                    End.PositionBindable.ValueChanged += onPositionChanged;
-                }
-            }
-
-            public void UnbindEvents()
-            {
-                if (Start != null)
-                {
-                    Start.DefaultsApplied -= onDefaultsApplied;
-                    Start.PositionBindable.ValueChanged -= onPositionChanged;
-                }
-
-                if (End != null)
-                {
-                    End.DefaultsApplied -= onDefaultsApplied;
-                    End.PositionBindable.ValueChanged -= onPositionChanged;
-                }
-            }
-
-            private void onDefaultsApplied(HitObject obj) => refreshLifetimes();
-
-            private void onPositionChanged(ValueChangedEvent<Vector2> obj) => refreshLifetimes();
-
-            private void refreshLifetimes()
-            {
-                if (End == null || End.NewCombo || Start is Spinner || End is Spinner)
-                {
-                    LifetimeEnd = LifetimeStart;
-                    return;
-                }
-
-                Vector2 startPosition = Start.StackedEndPosition;
-                Vector2 endPosition = End.StackedPosition;
-                Vector2 distanceVector = endPosition - startPosition;
-
-                // The lifetime start will match the fade-in time of the first follow point.
-                float fraction = (int)(FollowPointConnection.SPACING * 1.5) / distanceVector.Length;
-                FollowPointConnection.GetFadeTimes(Start, End, fraction, out var fadeInTime, out _);
-
-                LifetimeStart = fadeInTime;
-                LifetimeEnd = double.MaxValue; // This will be set by the connection.
-
-                Invalidated?.Invoke();
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointRenderer.cs
@@ -239,7 +239,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 
             private void refreshLifetimes()
             {
-                if (end == null)
+                if (End == null || End.NewCombo || Start is Spinner || End is Spinner)
                 {
                     LifetimeEnd = LifetimeStart;
                     return;

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -125,13 +125,13 @@ namespace osu.Game.Rulesets.Osu.UI
         protected override void OnHitObjectAdded(HitObject hitObject)
         {
             base.OnHitObjectAdded(hitObject);
-            followPoints.AddFollowPoints2((OsuHitObject)hitObject);
+            followPoints.AddFollowPoints((OsuHitObject)hitObject);
         }
 
         protected override void OnHitObjectRemoved(HitObject hitObject)
         {
             base.OnHitObjectRemoved(hitObject);
-            followPoints.RemoveFollowPoints2((OsuHitObject)hitObject);
+            followPoints.RemoveFollowPoints((OsuHitObject)hitObject);
         }
 
         public void OnHitObjectLoaded(Drawable drawable)

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -125,13 +125,13 @@ namespace osu.Game.Rulesets.Osu.UI
         protected override void OnHitObjectAdded(HitObject hitObject)
         {
             base.OnHitObjectAdded(hitObject);
-            followPoints.AddFollowPoints((OsuHitObject)hitObject);
+            followPoints.AddFollowPoints2((OsuHitObject)hitObject);
         }
 
         protected override void OnHitObjectRemoved(HitObject hitObject)
         {
             base.OnHitObjectRemoved(hitObject);
-            followPoints.RemoveFollowPoints((OsuHitObject)hitObject);
+            followPoints.RemoveFollowPoints2((OsuHitObject)hitObject);
         }
 
         public void OnHitObjectLoaded(Drawable drawable)


### PR DESCRIPTION
This is basically a complete rewrite of `FollowPointRenderer` to delegate instantiation through `FollowPointLifetimeEntry`, in a similar way as done for `DrawableHitObject`s.

The pool limits are fairly lax, but I think that's alright and at maximum capacity followpoints + connections only account for 10MB of memory usage overall. Centipede gets pretty close to/exceeds the maximum capacities I've set.

Top memory usage now after a run of Centipede (sitting at on result screen):
![Screenshot_2020-11-20_17-08-17](https://user-images.githubusercontent.com/1329837/99775669-01f44e00-2b53-11eb-873b-03b599bd0bdc.png)
