### PR TITLE
Rewind judgement transforms before clearing

### DIFF
--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -149,8 +149,10 @@ namespace osu.Game.Rulesets.Judgements
 
         private void runAnimation()
         {
+            // undo any transforms applies in ApplyMissAnimations/ApplyHitAnimations to get a sane initial state.
             ApplyTransformsAt(double.MinValue, true);
             ClearTransforms(true);
+
             LifetimeStart = Result.TimeAbsolute;
 
             using (BeginAbsoluteSequence(Result.TimeAbsolute, true))

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -149,6 +149,7 @@ namespace osu.Game.Rulesets.Judgements
 
         private void runAnimation()
         {
+            ApplyTransformsAt(double.MinValue, true);
             ClearTransforms(true);
             LifetimeStart = Result.TimeAbsolute;
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -439,6 +439,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         private void clearExistingStateTransforms()
         {
             base.ApplyTransformsAt(double.MinValue, true);
+
+            // has to call this method directly (not ClearTransforms) to bypass the local ClearTransformsAfter override.
             base.ClearTransformsAfter(double.MinValue, true);
         }
 


### PR DESCRIPTION
Resolves #10933.

Regressed in https://github.com/ppy/osu/pull/10890 (unsurprisingly). The immediate cause of the bug was that `DrawableManiaJudgement` used a `FadeOut` instead of a `FadeOutFromOne`, therefore polluting a pooled judgement's state after the first time the animation plays out:

https://github.com/ppy/osu/blob/194f2e621b75003ed1a5027a33b49eeb7c679e7f/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs#L49-L51

but after some thought it occurred to me that fixing locally is definitely too low a level, as this is bound to happen again with different properties of other pooled judgements. Therefore the proposed resolution is to leverage the fact that judgement transforms are now rewindable since the linked PR and rewind to a sane state before proceeding with clearing, in a similar way that `DrawableHitObject` does.

This is turning out to be quite a popular type of bug, so maybe even this resolution is on too low a level and we should be looking into embedding it into `DrawablePool` framework-side. The type of resolution that is done here would only be applicable for drawables with rewindable transforms, however, so it might be a bit awkward to move this behaviour to framework as it'll be a little edge-casey.

Not sure what sort of automated testing I could do here, but I could include some if requested.