### PR TITLE
Fix legacy follow point animations not playing after a while

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
@@ -49,6 +49,5 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
         }
 
         public Bindable<double> AnimationStartTime { get; } = new BindableDouble();
-        IBindable<double> IAnimationTimeReference.AnimationStartTime => AnimationStartTime;
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPoint.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
@@ -47,6 +48,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             });
         }
 
-        public double AnimationStartTime { get; set; }
+        public Bindable<double> AnimationStartTime { get; } = new BindableDouble();
+        IBindable<double> IAnimationTimeReference.AnimationStartTime => AnimationStartTime;
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
                 fp.Alpha = 0;
                 fp.Scale = new Vector2(1.5f * end.Scale);
 
-                fp.AnimationStartTime = fadeInTime;
+                fp.AnimationStartTime.Value = fadeInTime;
 
                 using (fp.BeginAbsoluteSequence(fadeInTime))
                 {

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
@@ -68,7 +68,6 @@ namespace osu.Game.Tests.NonVisual.Skinning
             public ManualClock ManualClock { get; }
             public IFrameBasedClock Clock { get; }
             public Bindable<double> AnimationStartTime { get; } = new BindableDouble();
-            IBindable<double> IAnimationTimeReference.AnimationStartTime => AnimationStartTime;
 
             public TestAnimationTimeReference()
             {

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Game.Audio;
+using osu.Game.Skinning;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.NonVisual.Skinning
+{
+    [HeadlessTest]
+    public class LegacySkinAnimationTest : OsuTestScene
+    {
+        private const string animation_name = "animation";
+        private const int frame_count = 6;
+
+        [Cached(typeof(IAnimationTimeReference))]
+        private TestAnimationTimeReference animationTimeReference = new TestAnimationTimeReference();
+
+        private TextureAnimation animation;
+
+        [Test]
+        public void TestAnimationTimeReferenceChange()
+        {
+            ISkin skin = new TestSkin();
+
+            AddStep("get animation", () => Add(animation = (TextureAnimation)skin.GetAnimation(animation_name, true, false)));
+            AddAssert("frame count correct", () => animation.FrameCount == frame_count);
+            assertPlaybackPosition(0);
+
+            AddStep("set start time to 1000", () => animationTimeReference.AnimationStartTime = 1000);
+            assertPlaybackPosition(-1000);
+
+            AddStep("set current time to 500", () => animationTimeReference.ManualClock.CurrentTime = 500);
+            assertPlaybackPosition(-500);
+        }
+
+        private void assertPlaybackPosition(double expectedPosition)
+            => AddAssert($"playback position is {expectedPosition}", () => animation.PlaybackPosition == expectedPosition);
+
+        private class TestSkin : ISkin
+        {
+            private static readonly string[] lookup_names = Enumerable.Range(0, frame_count).Select(frame => $"{animation_name}-{frame}").ToArray();
+
+            public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
+            {
+                return lookup_names.Contains(componentName) ? Texture.WhitePixel : null;
+            }
+
+            public Drawable GetDrawableComponent(ISkinComponent component) => throw new NotSupportedException();
+            public SampleChannel GetSample(ISampleInfo sampleInfo) => throw new NotSupportedException();
+            public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => throw new NotSupportedException();
+        }
+
+        private class TestAnimationTimeReference : IAnimationTimeReference
+        {
+            public ManualClock ManualClock { get; }
+            public IFrameBasedClock Clock { get; }
+            public double AnimationStartTime { get; set; }
+
+            public TestAnimationTimeReference()
+            {
+                ManualClock = new ManualClock();
+                Clock = new FramedClock(ManualClock);
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinAnimationTest.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.NonVisual.Skinning
             AddAssert("frame count correct", () => animation.FrameCount == frame_count);
             assertPlaybackPosition(0);
 
-            AddStep("set start time to 1000", () => animationTimeReference.AnimationStartTime = 1000);
+            AddStep("set start time to 1000", () => animationTimeReference.AnimationStartTime.Value = 1000);
             assertPlaybackPosition(-1000);
 
             AddStep("set current time to 500", () => animationTimeReference.ManualClock.CurrentTime = 500);
@@ -67,7 +67,8 @@ namespace osu.Game.Tests.NonVisual.Skinning
         {
             public ManualClock ManualClock { get; }
             public IFrameBasedClock Clock { get; }
-            public double AnimationStartTime { get; set; }
+            public Bindable<double> AnimationStartTime { get; } = new BindableDouble();
+            IBindable<double> IAnimationTimeReference.AnimationStartTime => AnimationStartTime;
 
             public TestAnimationTimeReference()
             {

--- a/osu.Game/Skinning/IAnimationTimeReference.cs
+++ b/osu.Game/Skinning/IAnimationTimeReference.cs
@@ -26,6 +26,6 @@ namespace osu.Game.Skinning
         /// <summary>
         /// The time which animations should be started from, relative to <see cref="Clock"/>.
         /// </summary>
-        IBindable<double> AnimationStartTime { get; }
+        Bindable<double> AnimationStartTime { get; }
     }
 }

--- a/osu.Game/Skinning/IAnimationTimeReference.cs
+++ b/osu.Game/Skinning/IAnimationTimeReference.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Timing;
 
@@ -25,6 +26,6 @@ namespace osu.Game.Skinning
         /// <summary>
         /// The time which animations should be started from, relative to <see cref="Clock"/>.
         /// </summary>
-        double AnimationStartTime { get; }
+        IBindable<double> AnimationStartTime { get; }
     }
 }

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.OpenGL.Textures;
@@ -70,6 +71,8 @@ namespace osu.Game.Skinning
             [Resolved(canBeNull: true)]
             private IAnimationTimeReference timeReference { get; set; }
 
+            private readonly Bindable<double> animationStartTime = new BindableDouble();
+
             public SkinnableTextureAnimation(bool startAtCurrentTime = true)
                 : base(startAtCurrentTime)
             {
@@ -82,8 +85,18 @@ namespace osu.Game.Skinning
                 if (timeReference != null)
                 {
                     Clock = timeReference.Clock;
-                    PlaybackPosition = timeReference.Clock.CurrentTime - timeReference.AnimationStartTime;
+                    ((IBindable<double>)animationStartTime).BindTo(timeReference.AnimationStartTime);
                 }
+
+                animationStartTime.BindValueChanged(_ => updatePlaybackPosition(), true);
+            }
+
+            private void updatePlaybackPosition()
+            {
+                if (timeReference == null)
+                    return;
+
+                PlaybackPosition = timeReference.Clock.CurrentTime - timeReference.AnimationStartTime.Value;
             }
         }
 

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Skinning
                 if (timeReference != null)
                 {
                     Clock = timeReference.Clock;
-                    ((IBindable<double>)animationStartTime).BindTo(timeReference.AnimationStartTime);
+                    animationStartTime.BindTo(timeReference.AnimationStartTime);
                 }
 
                 animationStartTime.BindValueChanged(_ => updatePlaybackPosition(), true);


### PR DESCRIPTION
Resolves #10930.

"Regressed" in #10923, although the underlying structure was not really helping spot this earlier. In short, the following set failed for pooled follow points:

https://github.com/ppy/osu/blob/f77ca4ac3accf22e6c313d7b2e5302e0665db969/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs#L83

because the value of `PlaybackPosition` is only ever read in `LoadComplete()` in current `master`:

https://github.com/ppy/osu/blob/194f2e621b75003ed1a5027a33b49eeb7c679e7f/osu.Game/Skinning/LegacySkinExtensions.cs#L78-L87

To resolve, `IAnimationTimeReference.AnimationStartTime` is made bindable and `PlaybackPosition` is updated on every change of that bindable. I also briefly considered running in `Update()` and think this solution is slightly better, but if you have differing opinions, I can also go for that instead.