### PR TITLE
Don't scroll NowPlayingOverlay background while it's fading out

### DIFF
--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -212,11 +212,14 @@ namespace osu.Game.Overlays
             dragContainer.ScaleTo(1, transition_length, Easing.OutElastic);
         }
 
+        private bool fadingOut;
+
         protected override void PopOut()
         {
+            fadingOut = true;
             base.PopOut();
 
-            this.FadeOut(transition_length, Easing.OutQuint);
+            this.FadeOut(transition_length, Easing.OutQuint).OnComplete(_ => fadingOut = false);
             dragContainer.ScaleTo(0.9f, transition_length, Easing.OutQuint);
         }
 
@@ -232,7 +235,7 @@ namespace osu.Game.Overlays
         {
             base.Update();
 
-            if (pendingBeatmapSwitch != null)
+            if (pendingBeatmapSwitch != null && !fadingOut)
             {
                 pendingBeatmapSwitch();
                 pendingBeatmapSwitch = null;

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Overlays
             fadingOut = true;
             base.PopOut();
 
-            this.FadeOut(transition_length, Easing.OutQuint).OnComplete(_ => fadingOut = false);
+            this.FadeOut(transition_length, Easing.OutQuint).Finally(_ => fadingOut = false);
             dragContainer.ScaleTo(0.9f, transition_length, Easing.OutQuint);
         }
 


### PR DESCRIPTION
Closes #8393
Supersedes and closes #8397

I think the real issue here is that I was hitting the next song in song select before the overlay was fully faded out, and not ``audioEquals`` as peppy thought [here](https://github.com/ppy/osu/issues/8393#issuecomment-602091026). I debugged ``audioEquals`` a little bit just in case and it seems to work correctly.

Testing the PR out here: [youtube link](https://youtu.be/tTPfdWaOJ_o). Double clicking on the random bottom, first click closes the overlay, second picks next song while the overlay is (hopefully, the transition is 800ms) still fading out.

Can create tests if deemed necessary by adapting from #8397 to fit this behaviour instead.