### PR TITLE
Improve LogoVisualisation looks when MenuGlow colors are used

### DIFF
--- a/osu.Game/Screens/Menu/IntroWelcome.cs
+++ b/osu.Game/Screens/Menu/IntroWelcome.cs
@@ -113,8 +113,7 @@ namespace osu.Game.Screens.Menu
                                 RelativeSizeAxes = Axes.Both,
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                Alpha = 0.5f,
-                                AccentColour = Color4.DarkBlue,
+                                Colour = Color4.DarkBlue,
                                 Size = new Vector2(0.96f)
                             },
                             new Circle

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -20,6 +20,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Utils;
+using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Game.Screens.Menu
 {
@@ -67,7 +68,7 @@ namespace osu.Game.Screens.Menu
 
         private int indexOffset;
 
-        public Color4 AccentColour { get; set; }
+        public Color4 AccentColour { get; set; } = Color4.White.Opacity(.2f);
 
         /// <summary>
         /// The relative movement of bars based on input amplification. Defaults to 1.

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Screens.Menu
             // Assuming the logo is a circle, we don't need a second dimension.
             private float size;
 
-            private readonly Color4 colour = Color4.White.Opacity(.2f);
+            private readonly Color4 colour = Color4.White.Opacity(0.2f);
 
             private float[] audioData;
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics;
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
@@ -27,7 +26,7 @@ namespace osu.Game.Screens.Menu
     /// <summary>
     /// A visualiser that reacts to music coming from beatmaps.
     /// </summary>
-    public class LogoVisualisation : Drawable, IHasAccentColour
+    public class LogoVisualisation : Drawable
     {
         private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
 
@@ -67,8 +66,6 @@ namespace osu.Game.Screens.Menu
         private const float amplitude_dead_zone = 1f / bar_length;
 
         private int indexOffset;
-
-        public Color4 AccentColour { get; set; } = Color4.White.Opacity(.2f);
 
         /// <summary>
         /// The relative movement of bars based on input amplification. Defaults to 1.
@@ -177,7 +174,7 @@ namespace osu.Game.Screens.Menu
             // Assuming the logo is a circle, we don't need a second dimension.
             private float size;
 
-            private Color4 colour;
+            private Color4 colour = Color4.White.Opacity(.2f);
             private float[] audioData;
 
             private readonly QuadBatch<TexturedVertex2D> vertexBatch = new QuadBatch<TexturedVertex2D>(100, 10);
@@ -194,7 +191,6 @@ namespace osu.Game.Screens.Menu
                 shader = Source.shader;
                 texture = Source.texture;
                 size = Source.DrawSize.X;
-                colour = Source.AccentColour;
                 audioData = Source.frequencyAmplitudes;
             }
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Screens.Menu
             // Assuming the logo is a circle, we don't need a second dimension.
             private float size;
 
-            private static readonly Color4 transparent_white = Color4.White.Opacity(0.1f);
+            private static readonly Color4 transparent_white = Color4.White.Opacity(0.2f);
 
             private float[] audioData;
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Screens.Menu
             // Assuming the logo is a circle, we don't need a second dimension.
             private float size;
 
-            private readonly Color4 colour = Color4.White.Opacity(0.2f);
+            private static readonly Color4 transparent_white = Color4.White.Opacity(0.1f);
 
             private float[] audioData;
 
@@ -204,7 +204,7 @@ namespace osu.Game.Screens.Menu
                 Vector2 inflation = DrawInfo.MatrixInverse.ExtractScale().Xy;
 
                 ColourInfo colourInfo = DrawColourInfo.Colour;
-                colourInfo.ApplyChild(colour);
+                colourInfo.ApplyChild(transparent_white);
 
                 if (audioData != null)
                 {

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -174,7 +174,8 @@ namespace osu.Game.Screens.Menu
             // Assuming the logo is a circle, we don't need a second dimension.
             private float size;
 
-            private Color4 colour = Color4.White.Opacity(.2f);
+            private readonly Color4 colour = Color4.White.Opacity(.2f);
+
             private float[] audioData;
 
             private readonly QuadBatch<TexturedVertex2D> vertexBatch = new QuadBatch<TexturedVertex2D>(100, 10);

--- a/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
@@ -27,12 +27,10 @@ namespace osu.Game.Screens.Menu
 
         private void updateColour()
         {
-            Color4 defaultColour = Color4.White;
-
             if (user.Value?.IsSupporter ?? false)
-                Colour = skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? defaultColour;
+                Colour = skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? Color4.White;
             else
-                Colour = defaultColour;
+                Colour = Color4.White;
         }
     }
 }

--- a/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
@@ -28,12 +28,12 @@ namespace osu.Game.Screens.Menu
 
         private void updateColour()
         {
-            Color4 defaultColour = Color4.White.Opacity(0.2f);
+            Color4 defaultColour = Color4.White;
 
             if (user.Value?.IsSupporter ?? false)
-                AccentColour = skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? defaultColour;
+                Colour = skin.Value.GetConfig<GlobalSkinColours, Color4>(GlobalSkinColours.MenuGlow)?.Value ?? defaultColour;
             else
-                AccentColour = defaultColour;
+                Colour = defaultColour;
         }
     }
 }

--- a/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
@@ -7,7 +7,6 @@ using osu.Game.Online.API;
 using osu.Game.Users;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Game.Screens.Menu
 {

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -144,7 +144,6 @@ namespace osu.Game.Screens.Menu
                                                     RelativeSizeAxes = Axes.Both,
                                                     Origin = Anchor.Centre,
                                                     Anchor = Anchor.Centre,
-                                                    Alpha = 0.5f,
                                                     Size = new Vector2(0.96f)
                                                 },
                                                 new Container

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -81,6 +81,8 @@ namespace osu.Game.Screens.Menu
             set => rippleContainer.FadeTo(value ? 1 : 0, transition_length, Easing.OutQuint);
         }
 
+        private const float visualizer_default_alpha = 0.5f;
+
         private readonly Box flashLayer;
 
         private readonly Container impactContainer;
@@ -144,6 +146,7 @@ namespace osu.Game.Screens.Menu
                                                     RelativeSizeAxes = Axes.Both,
                                                     Origin = Anchor.Centre,
                                                     Anchor = Anchor.Centre,
+                                                    Alpha = visualizer_default_alpha,
                                                     Size = new Vector2(0.96f)
                                                 },
                                                 new Container
@@ -281,8 +284,7 @@ namespace osu.Game.Screens.Menu
                 this.Delay(early_activation).Schedule(() => sampleBeat.Play());
 
             logoBeatContainer
-                .ScaleTo(1 - 0.02f * amplitudeAdjust, early_activation, Easing.Out)
-                .Then()
+                .ScaleTo(1 - 0.02f * amplitudeAdjust, early_activation, Easing.Out).Then()
                 .ScaleTo(1, beatLength * 2, Easing.OutQuint);
 
             ripple.ClearTransforms();
@@ -295,15 +297,13 @@ namespace osu.Game.Screens.Menu
             {
                 flashLayer.ClearTransforms();
                 flashLayer
-                    .FadeTo(0.2f * amplitudeAdjust, early_activation, Easing.Out)
-                    .Then()
+                    .FadeTo(0.2f * amplitudeAdjust, early_activation, Easing.Out).Then()
                     .FadeOut(beatLength);
 
                 visualizer.ClearTransforms();
                 visualizer
-                    .FadeTo(0.9f * amplitudeAdjust, early_activation, Easing.Out)
-                    .Then()
-                    .FadeTo(0.5f, beatLength);
+                    .FadeTo(visualizer_default_alpha * 1.8f * amplitudeAdjust, early_activation, Easing.Out).Then()
+                    .FadeTo(visualizer_default_alpha, beatLength);
             }
         }
 


### PR DESCRIPTION
Resolves #10875

With this change, skin colours won't be as bright as they are in the current release, and it avoid the problem of the moire effects mentioned in the linked issue.

Before(left) and after:
![tmp](https://user-images.githubusercontent.com/12001167/99908784-d4d7a500-2ce4-11eb-947b-f14fc38a7e49.png)

Default on latest release as baseline:
![Screenshot (477)](https://user-images.githubusercontent.com/12001167/99908802-fdf83580-2ce4-11eb-8bd3-95f5c176dbc6.png)