### PR TITLE
Remove type parameter from DrawableCatchHitObject

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBananaShower.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableBananaShower : DrawableCatchHitObject<BananaShower>
+    public class DrawableBananaShower : DrawableCatchHitObject
     {
         private readonly Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation;
         private readonly Container bananaContainer;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -13,12 +13,11 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public abstract class PalpableDrawableCatchHitObject<TObject> : DrawableCatchHitObject<TObject>
-        where TObject : PalpableCatchHitObject
+    public abstract class PalpableDrawableCatchHitObject : DrawableCatchHitObject
     {
         protected Container ScaleContainer { get; private set; }
 
-        protected PalpableDrawableCatchHitObject(TObject hitObject)
+        protected PalpableDrawableCatchHitObject(CatchHitObject hitObject)
             : base(hitObject)
         {
             Origin = Anchor.Centre;
@@ -46,19 +45,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             comboColours[(HitObject.IndexInBeatmap + 1) % comboColours.Count];
     }
 
-    public abstract class DrawableCatchHitObject<TObject> : DrawableCatchHitObject
-        where TObject : CatchHitObject
-    {
-        public new TObject HitObject;
-
-        protected DrawableCatchHitObject(TObject hitObject)
-            : base(hitObject)
-        {
-            HitObject = hitObject;
-            Anchor = Anchor.BottomLeft;
-        }
-    }
-
     public abstract class DrawableCatchHitObject : DrawableHitObject<CatchHitObject>
     {
         protected override double InitialLifetimeOffset => HitObject.TimePreempt;
@@ -73,6 +59,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             : base(hitObject)
         {
             X = hitObject.X;
+            Anchor = Anchor.BottomLeft;
         }
 
         public Func<CatchHitObject, bool> CheckPosition;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -8,11 +8,11 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableDroplet : PalpableDrawableCatchHitObject<Droplet>
+    public class DrawableDroplet : PalpableDrawableCatchHitObject
     {
         public override bool StaysOnPlate => false;
 
-        public DrawableDroplet(Droplet h)
+        public DrawableDroplet(CatchHitObject h)
             : base(h)
         {
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -8,9 +8,9 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableFruit : PalpableDrawableCatchHitObject<Fruit>
+    public class DrawableFruit : PalpableDrawableCatchHitObject
     {
-        public DrawableFruit(Fruit h)
+        public DrawableFruit(CatchHitObject h)
             : base(h)
         {
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableJuiceStream.cs
@@ -10,7 +10,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableJuiceStream : DrawableCatchHitObject<JuiceStream>
+    public class DrawableJuiceStream : DrawableCatchHitObject
     {
         private readonly Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation;
         private readonly Container dropletContainer;


### PR DESCRIPTION
### Motivation of this change

- It cannot represent `PalpableDrawableCatchHitObject<anything>` and we have to introduce an interface to represent it. I'm planning to use `PalpableDrawableCatchHitObject` casting in following PRs.
- The type parameter is not used anywhere.
- Osu ruleset doesn't have this type parameter in the DHO classes.