### PR TITLE
Improve scroll tracking of selected item

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.Select
             AddRangeInternal(new Drawable[]
             {
                 recommender,
-                new ResetScrollContainer(() => Carousel.ScrollToSelected())
+                new ResetScrollContainer(() => Carousel.TrackSelectedItem())
                 {
                     RelativeSizeAxes = Axes.Y,
                     Width = 250,


### PR DESCRIPTION
As pointed out in #10934, during searching/filtering, the scroll position can get out of sync with the current item, causing massive visual noise while it catches up.

This PR changes the way we track the active item, by keeping a reference to the active panel rather than its position, allowing correctly tracking the vertical transform as panels move around each other.

Note that this doesn't track 1:1 (likely due to an off-by-one update?) but this is actually for the best, and leaves a bit of play in the animation. I tried making it track perfectly and it doesn't look or feel as good.

Also does a good job cleaning up the tracking code.

master:
![2020-11-24 19 00 31](https://user-images.githubusercontent.com/191335/100079038-90383f00-2e87-11eb-9714-dc2818010800.gif)

this PR:
![2020-11-24 18 58 33](https://user-images.githubusercontent.com/191335/100078964-75fe6100-2e87-11eb-9621-296ea51b962e.gif)


Closes #10934.