### PR TITLE
Rewind pooled DHOs into better states

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/MainCirclePiece.cs
@@ -38,7 +38,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             };
         }
 
-        private readonly IBindable<ArmedState> state = new Bindable<ArmedState>();
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
         private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
 
@@ -50,7 +49,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         {
             var drawableOsuObject = (DrawableOsuHitObject)drawableObject;
 
-            state.BindTo(drawableObject.State);
             accentColour.BindTo(drawableObject.AccentColour);
             indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
         }
@@ -59,7 +57,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
         {
             base.LoadComplete();
 
-            state.BindValueChanged(updateState, true);
             accentColour.BindValueChanged(colour =>
             {
                 explode.Colour = colour.NewValue;
@@ -68,15 +65,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             }, true);
 
             indexInCurrentCombo.BindValueChanged(index => number.Text = (index.NewValue + 1).ToString(), true);
+
+            drawableObject.ApplyCustomUpdateState += updateState;
+            updateState(drawableObject, drawableObject.State.Value);
         }
 
-        private void updateState(ValueChangedEvent<ArmedState> state)
+        private void updateState(DrawableHitObject drawableObject, ArmedState state)
         {
             using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime, true))
             {
                 glow.FadeOut(400);
 
-                switch (state.NewValue)
+                switch (state)
                 {
                     case ArmedState.Hit:
                         const double flash_in = 40;

--- a/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/LegacyMainCirclePiece.cs
@@ -38,7 +38,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         private SkinnableSpriteText hitCircleText;
 
-        private readonly IBindable<ArmedState> state = new Bindable<ArmedState>();
         private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
         private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
 
@@ -113,7 +112,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
             if (overlayAboveNumber)
                 AddInternal(hitCircleOverlay.CreateProxy());
 
-            state.BindTo(drawableObject.State);
             accentColour.BindTo(drawableObject.AccentColour);
             indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
 
@@ -137,19 +135,21 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             base.LoadComplete();
 
-            state.BindValueChanged(updateState, true);
             accentColour.BindValueChanged(colour => hitCircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue), true);
             if (hasNumber)
                 indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
+
+            drawableObject.ApplyCustomUpdateState += updateState;
+            updateState(drawableObject, drawableObject.State.Value);
         }
 
-        private void updateState(ValueChangedEvent<ArmedState> state)
+        private void updateState(DrawableHitObject drawableObject, ArmedState state)
         {
             const double legacy_fade_duration = 240;
 
             using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime, true))
             {
-                switch (state.NewValue)
+                switch (state)
                 {
                     case ArmedState.Hit:
                         circleSprites.FadeOut(legacy_fade_duration, Easing.Out);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -128,6 +128,12 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         private readonly Bindable<ArmedState> state = new Bindable<ArmedState>();
 
+        /// <summary>
+        /// The state of this <see cref="DrawableHitObject"/>.
+        /// </summary>
+        /// <remarks>
+        /// For pooled hitobjects, <see cref="ApplyCustomUpdateState"/> is recommended to be used instead for better editor/rewinding support.
+        /// </remarks>
         public IBindable<ArmedState> State => state;
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -259,7 +259,17 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             // If not loaded, the state update happens in LoadComplete(). Otherwise, the update is scheduled to allow for lifetime updates.
             if (IsLoaded)
-                Schedule(() => updateState(ArmedState.Idle, true));
+            {
+                Scheduler.Add(() =>
+                {
+                    if (Result.IsHit)
+                        updateState(ArmedState.Hit, true);
+                    else if (Result.HasResult)
+                        updateState(ArmedState.Miss, true);
+                    else
+                        updateState(ArmedState.Idle, true);
+                });
+            }
 
             hasHitObjectApplied = true;
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/10893

Should be tested with https://github.com/ppy/osu-framework/pull/4035

The MainCirclePiece/LegacyMainCirclePiece changes are as discussed in Discord. Not sure on adding the new armed state just yet, and this is standard across all other skinning usages/rulesets.