### PR TITLE
Workaround TestSceneCatchModRelax flaky failure

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
@@ -38,17 +38,17 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                     new Fruit
                     {
                         X = 0,
-                        StartTime = 250
+                        StartTime = 1000
                     },
                     new Fruit
                     {
                         X = CatchPlayfield.WIDTH,
-                        StartTime = 500
+                        StartTime = 2000
                     },
                     new JuiceStream
                     {
                         X = CatchPlayfield.CENTER_X,
-                        StartTime = 750,
+                        StartTime = 3000,
                         Path = new SliderPath(PathType.Linear, new[] { Vector2.Zero, Vector2.UnitY * 200 })
                     }
                 }


### PR DESCRIPTION
This test fails depending on the frame time.
It is easy to reproduce local visual testing on master by setting speed to 200%.
Example: <https://ci.appveyor.com/project/peppy/osu/builds/36518240/tests> I'm pretty sure the changes of that PR doesn't affect this test.