### PR TITLE
Refactor common code of border piece of fruits

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/BananaPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/BananaPiece.cs
@@ -2,10 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osuTK;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public class BananaPiece : PulpFormation
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/BorderPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/BorderPiece.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
+{
+    public class BorderPiece : Circle
+    {
+        public BorderPiece()
+        {
+            Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2);
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            BorderColour = Color4.White;
+            BorderThickness = 6f * FruitPiece.RADIUS_ADJUST;
+
+            // Border is drawn only when there is a child drawable.
+            Child = new Box
+            {
+                AlwaysPresent = true,
+                Alpha = 0,
+                RelativeSizeAxes = Axes.Both,
+            };
+        }
+    }
+}
+

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/DropletPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/DropletPiece.cs
@@ -5,12 +5,11 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public class DropletPiece : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/DropletPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/DropletPiece.cs
@@ -4,8 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 
@@ -31,36 +29,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 
             if (drawableCatchObject.HitObject.HyperDash)
             {
-                AddInternal(new Container
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(2f),
-                    Depth = 1,
-                    Children = new Drawable[]
-                    {
-                        new Circle
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            BorderColour = Catcher.DEFAULT_HYPER_DASH_COLOUR,
-                            BorderThickness = 6,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    AlwaysPresent = true,
-                                    Alpha = 0.3f,
-                                    Blending = BlendingParameters.Additive,
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR,
-                                }
-                            }
-                        }
-                    }
-                });
+                AddInternal(new HyperDropletBorderPiece());
             }
         }
     }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
@@ -5,10 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects.Drawables;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
@@ -19,7 +16,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
         /// </summary>
         public const float RADIUS_ADJUST = 1.1f;
 
-        private Circle border;
+        private BorderPiece border;
         private PalpableCatchHitObject hitObject;
 
         public FruitPiece()
@@ -36,46 +33,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
             AddRangeInternal(new[]
             {
                 getFruitFor(hitObject.VisualRepresentation),
-                border = new Circle
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    BorderColour = Color4.White,
-                    BorderThickness = 6f * RADIUS_ADJUST,
-                    Children = new Drawable[]
-                    {
-                        new Box
-                        {
-                            AlwaysPresent = true,
-                            Alpha = 0,
-                            RelativeSizeAxes = Axes.Both
-                        }
-                    }
-                },
+                border = new BorderPiece(),
             });
 
             if (hitObject.HyperDash)
             {
-                AddInternal(new Circle
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    BorderColour = Catcher.DEFAULT_HYPER_DASH_COLOUR,
-                    BorderThickness = 12f * RADIUS_ADJUST,
-                    Children = new Drawable[]
-                    {
-                        new Box
-                        {
-                            AlwaysPresent = true,
-                            Alpha = 0.3f,
-                            Blending = BlendingParameters.Additive,
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR,
-                        }
-                    }
-                });
+                AddInternal(new HyperBorderPiece());
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     internal class FruitPiece : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/GrapePiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/GrapePiece.cs
@@ -2,10 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osuTK;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public class GrapePiece : PulpFormation
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/HyperBorderPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/HyperBorderPiece.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Catch.UI;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
+{
+    public class HyperBorderPiece : BorderPiece
+    {
+        public HyperBorderPiece()
+        {
+            BorderColour = Catcher.DEFAULT_HYPER_DASH_COLOUR;
+            BorderThickness = 12f * FruitPiece.RADIUS_ADJUST;
+
+            Child.Alpha = 0.3f;
+            Child.Blending = BlendingParameters.Additive;
+            Child.Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR;
+        }
+    }
+}
+

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/HyperDropletBorderPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/HyperDropletBorderPiece.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
+{
+    public class HyperDropletBorderPiece : HyperBorderPiece
+    {
+        public HyperDropletBorderPiece()
+        {
+            Size /= 2;
+            BorderThickness = 6f;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/PearPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/PearPiece.cs
@@ -2,10 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osuTK;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public class PearPiece : PulpFormation
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/PineapplePiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/PineapplePiece.cs
@@ -2,10 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osuTK;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public class PineapplePiece : PulpFormation
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/PulpFormation.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/PulpFormation.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public abstract class PulpFormation : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/RaspberryPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/RaspberryPiece.cs
@@ -2,10 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osuTK;
 
-namespace osu.Game.Rulesets.Catch.Objects.Drawables
+namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public class RaspberryPiece : PulpFormation
     {


### PR DESCRIPTION
1. Move relevant files to `Pieces` namespace (it was there but used only for one file).
2. Refactor common codes of `FruitPiece` and `DropletPiece` to `BorderPiece` class and derived classes.
