### PR TITLE
Improve scroll tracking of selected item

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -917,7 +917,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 get
                 {
-                    foreach (var item in ScrollableContent)
+                    foreach (var item in Scroll.Children)
                     {
                         yield return item;
 

--- a/osu.Game/Graphics/Containers/OsuScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuScrollContainer.cs
@@ -12,7 +12,19 @@ using osuTK.Input;
 
 namespace osu.Game.Graphics.Containers
 {
-    public class OsuScrollContainer : ScrollContainer<Drawable>
+    public class OsuScrollContainer : OsuScrollContainer<Drawable>
+    {
+        public OsuScrollContainer()
+        {
+        }
+
+        public OsuScrollContainer(Direction direction)
+            : base(direction)
+        {
+        }
+    }
+
+    public class OsuScrollContainer<T> : ScrollContainer<T> where T : Drawable
     {
         public const float SCROLL_BAR_HEIGHT = 10;
         public const float SCROLL_BAR_PADDING = 3;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -618,16 +618,6 @@ namespace osu.Game.Screens.Select
                 }
             }
 
-            // Finally, if the filtered items have changed, animate drawables to their new locations.
-            // This is common if a selected/collapsed state has changed.
-            if (revalidateItems)
-            {
-                foreach (DrawableCarouselItem panel in ScrollableContent.Children)
-                {
-                    panel.MoveToY(panel.Item.CarouselYPosition, 800, Easing.OutQuint);
-                }
-            }
-
             // Update externally controlled state of currently visible items (e.g. x-offset and opacity).
             // This is a per-frame update on all drawable panels.
             foreach (DrawableCarouselItem item in Scroll.Children)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -573,6 +573,9 @@ namespace osu.Game.Screens.Select
             if (revalidateItems)
                 updateYPositions();
 
+            if (!scrollPositionCache.IsValid)
+                updateScrollPosition();
+
             // This data is consumed to find the currently displayable range.
             // This is the range we want to keep drawables for, and should exceed the visible range slightly to avoid drawable churn.
             var newDisplayRange = getDisplayRange();
@@ -651,14 +654,6 @@ namespace osu.Game.Screens.Select
             lastIndex = Math.Clamp(lastIndex + 1, firstIndex, Math.Max(0, visibleItems.Count - 1));
 
             return (firstIndex, lastIndex);
-        }
-
-        protected override void UpdateAfterChildren()
-        {
-            base.UpdateAfterChildren();
-
-            if (!scrollPositionCache.IsValid)
-                updateScrollPosition();
         }
 
         private void beatmapRemoved(ValueChangedEvent<WeakReference<BeatmapSetInfo>> weakItem)

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.UserInterface;
@@ -58,6 +59,25 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (beatmapOverlay != null)
                 viewDetails = beatmapOverlay.FetchAndShowBeatmapSet;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // position updates should not occur if the item is filtered away.
+            // this avoids panels flying across the screen only to be eventually off-screen or faded out.
+            if (!Item.Visible)
+                return;
+
+            float targetY = Item.CarouselYPosition;
+
+            if (Precision.AlmostEquals(targetY, Y))
+                Y = targetY;
+            else
+                // algorithm for this is taken from ScrollContainer.
+                // while it doesn't necessarily need to match 1:1, as we are emulating scroll in some cases this feels most correct.
+                Y = (float)Interpolation.Lerp(targetY, Y, Math.Exp(-0.01 * Time.Elapsed));
         }
 
         protected override void UpdateItem()


### PR DESCRIPTION
Fixes many of the animation edge cases / glitches of song select along the way.

I've described each change in detail in the commit messages, so suggest you read those during review to better understand reasoning (although there is also inline commenting which hopefully covers most of what is going on).

Closes #10934.
Supersedes and closes #10955. I went in a different direction to that version when implementing this.

master:
![2020-11-24 19 00 31](https://user-images.githubusercontent.com/191335/100079038-90383f00-2e87-11eb-9714-dc2818010800.gif)

this PR:
![2020-11-26 18 51 44](https://user-images.githubusercontent.com/191335/100335607-8560e400-3018-11eb-9dca-87e835f20c79.gif)


Previous worst case scenario (last beatmap in list, meaning largest Y value for panel):
![2020-11-26 18 53 07](https://user-images.githubusercontent.com/191335/100335861-ca851600-3018-11eb-9ee3-8343d64204e1.gif)

