### PR TITLE
Remove hitObject argument from DHO.OnApply and OnFree

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -53,9 +53,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             });
         }
 
-        protected override void OnApply(HitObject hitObject)
+        protected override void OnApply()
         {
-            base.OnApply(hitObject);
+            base.OnApply();
 
             IndexInCurrentComboBindable.BindTo(HitObject.IndexInCurrentComboBindable);
             PositionBindable.BindTo(HitObject.PositionBindable);
@@ -70,9 +70,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             LifetimeEnd = HitObject.GetEndTime() + HitObject.HitWindows.WindowFor(HitResult.Miss) + 1000;
         }
 
-        protected override void OnFree(HitObject hitObject)
+        protected override void OnFree()
         {
-            base.OnFree(hitObject);
+            base.OnFree();
 
             IndexInCurrentComboBindable.UnbindFrom(HitObject.IndexInCurrentComboBindable);
             PositionBindable.UnbindFrom(HitObject.PositionBindable);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -86,18 +86,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Tracking.BindValueChanged(updateSlidingSample);
         }
 
-        protected override void OnApply(HitObject hitObject)
+        protected override void OnApply()
         {
-            base.OnApply(hitObject);
+            base.OnApply();
 
             // Ensure that the version will change after the upcoming BindTo().
             pathVersion.Value = int.MaxValue;
             PathVersion.BindTo(HitObject.Path.Version);
         }
 
-        protected override void OnFree(HitObject hitObject)
+        protected override void OnFree()
         {
-            base.OnFree(hitObject);
+            base.OnFree();
 
             PathVersion.UnbindFrom(HitObject.Path.Version);
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -36,9 +36,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             pathVersion.BindValueChanged(_ => updatePosition());
         }
 
-        protected override void OnFree(HitObject hitObject)
+        protected override void OnFree()
         {
-            base.OnFree(hitObject);
+            base.OnFree();
 
             pathVersion.UnbindFrom(drawableSlider.PathVersion);
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
@@ -261,9 +261,9 @@ namespace osu.Game.Tests.Visual.Gameplay
                 });
             }
 
-            protected override void OnApply(HitObject hitObject)
+            protected override void OnApply()
             {
-                base.OnApply(hitObject);
+                base.OnApply();
                 Position = new Vector2(RNG.Next(-200, 200), RNG.Next(-200, 200));
             }
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -260,7 +260,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             HitObject.DefaultsApplied += onDefaultsApplied;
 
-            OnApply(hitObject);
+            OnApply();
             HitObjectApplied?.Invoke(this);
 
             // If not loaded, the state update happens in LoadComplete(). Otherwise, the update is scheduled to allow for lifetime updates.
@@ -315,7 +315,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             HitObject.DefaultsApplied -= onDefaultsApplied;
 
-            OnFree(HitObject);
+            OnFree();
 
             HitObject = null;
             Result = null;
@@ -340,16 +340,14 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <summary>
         /// Invoked for this <see cref="DrawableHitObject"/> to take on any values from a newly-applied <see cref="HitObject"/>.
         /// </summary>
-        /// <param name="hitObject">The <see cref="HitObject"/> being applied.</param>
-        protected virtual void OnApply(HitObject hitObject)
+        protected virtual void OnApply()
         {
         }
 
         /// <summary>
         /// Invoked for this <see cref="DrawableHitObject"/> to revert any values previously taken on from the currently-applied <see cref="HitObject"/>.
         /// </summary>
-        /// <param name="hitObject">The currently-applied <see cref="HitObject"/>.</param>
-        protected virtual void OnFree(HitObject hitObject)
+        protected virtual void OnFree()
         {
         }
 


### PR DESCRIPTION
### Motivation of this change

- A DHO can use `HitObject` property instead.
- The argument is unused in all existing instances.
- `HitObject` property has more specific `TObj` type parameter type instead of `HitObject` type.
- Often `osu.Game.Rulesets.Objects` namespace has to be imported just because of this `HitObject` type.
