### PR TITLE
Add bindables for osu!catch hit object states

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         private Drawable createDrawableFruit(FruitVisualRepresentation rep, bool hyperdash = false) =>
-            setProperties(new TestDrawableFruit(new Fruit(), rep), hyperdash);
+            SetProperties(new TestDrawableFruit(new Fruit(), rep), hyperdash);
 
-        private Drawable createDrawableDroplet(bool hyperdash = false) => setProperties(new DrawableDroplet(new Droplet()), hyperdash);
+        private Drawable createDrawableDroplet(bool hyperdash = false) => SetProperties(new DrawableDroplet(new Droplet()), hyperdash);
 
-        private Drawable createDrawableTinyDroplet() => setProperties(new DrawableTinyDroplet(new TinyDroplet()));
+        private Drawable createDrawableTinyDroplet() => SetProperties(new DrawableTinyDroplet(new TinyDroplet()));
 
-        private DrawableCatchHitObject setProperties(DrawableCatchHitObject d, bool hyperdash = false)
+        protected virtual DrawableCatchHitObject SetProperties(DrawableCatchHitObject d, bool hyperdash = false)
         {
             var hitObject = d.HitObject;
             hitObject.StartTime = 1000000000000;

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -3,6 +3,8 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osuTK;
@@ -55,9 +57,9 @@ namespace osu.Game.Rulesets.Catch.Tests
         protected virtual DrawableCatchHitObject SetProperties(DrawableCatchHitObject d)
         {
             var hitObject = d.HitObject;
+            hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = 0 });
             hitObject.StartTime = 1000000000000;
             hitObject.Scale = 1.5f;
-            hitObject.Samples.Clear(); // otherwise crash due to samples not loaded
 
             d.Anchor = Anchor.Centre;
             d.RelativePositionAxes = Axes.None;

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         private Drawable createDrawableFruit(FruitVisualRepresentation rep, bool hyperdash = false) =>
-            setProperties(new DrawableFruit(new TestCatchFruit(rep)), hyperdash);
+            setProperties(new TestDrawableFruit(new Fruit(), rep), hyperdash);
 
         private Drawable createDrawableDroplet(bool hyperdash = false) => setProperties(new DrawableDroplet(new Droplet()), hyperdash);
 
@@ -56,14 +56,17 @@ namespace osu.Game.Rulesets.Catch.Tests
             return d;
         }
 
-        public class TestCatchFruit : Fruit
+        public class TestDrawableFruit : DrawableFruit
         {
-            public TestCatchFruit(FruitVisualRepresentation rep)
-            {
-                VisualRepresentation = rep;
-            }
+            private readonly FruitVisualRepresentation visualRepresentation;
 
-            public override FruitVisualRepresentation VisualRepresentation { get; }
+            protected override FruitVisualRepresentation GetVisualRepresentation(int indexInBeatmap) => visualRepresentation;
+
+            public TestDrawableFruit(Fruit fruit, FruitVisualRepresentation rep)
+                : base(fruit)
+            {
+                visualRepresentation = rep;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
@@ -17,33 +16,48 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             base.LoadComplete();
 
-            foreach (FruitVisualRepresentation rep in Enum.GetValues(typeof(FruitVisualRepresentation)))
-                AddStep($"show {rep}", () => SetContents(() => createDrawableFruit(rep)));
+            AddStep("show pear", () => SetContents(() => createDrawableFruit(0)));
+            AddStep("show grape", () => SetContents(() => createDrawableFruit(1)));
+            AddStep("show pineapple / apple", () => SetContents(() => createDrawableFruit(2)));
+            AddStep("show raspberry / orange", () => SetContents(() => createDrawableFruit(3)));
+
+            AddStep("show banana", () => SetContents(createDrawableBanana));
 
             AddStep("show droplet", () => SetContents(() => createDrawableDroplet()));
             AddStep("show tiny droplet", () => SetContents(createDrawableTinyDroplet));
 
-            foreach (FruitVisualRepresentation rep in Enum.GetValues(typeof(FruitVisualRepresentation)))
-                AddStep($"show hyperdash {rep}", () => SetContents(() => createDrawableFruit(rep, true)));
+            AddStep("show hyperdash pear", () => SetContents(() => createDrawableFruit(0, true)));
+            AddStep("show hyperdash grape", () => SetContents(() => createDrawableFruit(1, true)));
+            AddStep("show hyperdash pineapple / apple", () => SetContents(() => createDrawableFruit(2, true)));
+            AddStep("show hyperdash raspberry / orange", () => SetContents(() => createDrawableFruit(3, true)));
 
             AddStep("show hyperdash droplet", () => SetContents(() => createDrawableDroplet(true)));
         }
 
-        private Drawable createDrawableFruit(FruitVisualRepresentation rep, bool hyperdash = false) =>
-            SetProperties(new TestDrawableFruit(new Fruit(), rep), hyperdash);
+        private Drawable createDrawableFruit(int indexInBeatmap, bool hyperdash = false) =>
+            SetProperties(new DrawableFruit(new Fruit
+            {
+                IndexInBeatmap = indexInBeatmap,
+                HyperDashBindable = { Value = hyperdash }
+            }));
 
-        private Drawable createDrawableDroplet(bool hyperdash = false) => SetProperties(new DrawableDroplet(new Droplet()), hyperdash);
+        private Drawable createDrawableBanana() =>
+            SetProperties(new DrawableBanana(new Banana()));
+
+        private Drawable createDrawableDroplet(bool hyperdash = false) =>
+            SetProperties(new DrawableDroplet(new Droplet
+            {
+                HyperDashBindable = { Value = hyperdash }
+            }));
 
         private Drawable createDrawableTinyDroplet() => SetProperties(new DrawableTinyDroplet(new TinyDroplet()));
 
-        protected virtual DrawableCatchHitObject SetProperties(DrawableCatchHitObject d, bool hyperdash = false)
+        protected virtual DrawableCatchHitObject SetProperties(DrawableCatchHitObject d)
         {
             var hitObject = d.HitObject;
             hitObject.StartTime = 1000000000000;
             hitObject.Scale = 1.5f;
-
-            if (hyperdash)
-                ((PalpableCatchHitObject)hitObject).HyperDashTarget = new Banana();
+            hitObject.Samples.Clear(); // otherwise crash due to samples not loaded
 
             d.Anchor = Anchor.Centre;
             d.RelativePositionAxes = Axes.None;
@@ -54,19 +68,6 @@ namespace osu.Game.Rulesets.Catch.Tests
                 d.LifetimeEnd = double.PositiveInfinity;
             };
             return d;
-        }
-
-        public class TestDrawableFruit : DrawableFruit
-        {
-            private readonly FruitVisualRepresentation visualRepresentation;
-
-            protected override FruitVisualRepresentation GetVisualRepresentation(int indexInBeatmap) => visualRepresentation;
-
-            public TestDrawableFruit(Fruit fruit, FruitVisualRepresentation rep)
-                : base(fruit)
-            {
-                visualRepresentation = rep;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitVisualChange.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitVisualChange.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public class TestSceneFruitVisualChange : TestSceneFruitObjects
+    {
+        private readonly Bindable<int> indexInBeatmap = new Bindable<int>();
+        private readonly Bindable<bool> hyperDash = new Bindable<bool>();
+
+        protected override void LoadComplete()
+        {
+            AddStep("fruit changes visual and hyper", () => SetContents(() => SetProperties(new DrawableFruit(new Fruit
+            {
+                IndexInBeatmapBindable = { BindTarget = indexInBeatmap },
+                HyperDashBindable = { BindTarget = hyperDash },
+            }))));
+
+            AddStep("droplet changes hyper", () => SetContents(() => SetProperties(new DrawableDroplet(new Droplet
+            {
+                HyperDashBindable = { BindTarget = hyperDash },
+            }))));
+
+            Scheduler.AddDelayed(() => indexInBeatmap.Value++, 250, true);
+            Scheduler.AddDelayed(() => hyperDash.Value = !hyperDash.Value, 1000, true);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// </summary>
         public int BananaIndex;
 
-        public override FruitVisualRepresentation VisualRepresentation => FruitVisualRepresentation.Banana;
-
         public override Judgement CreateJudgement() => new CatchBananaJudgement();
 
         private static readonly List<HitSampleInfo> samples = new List<HitSampleInfo> { new BananaHitSampleInfo() };

--- a/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/BananaShower.cs
@@ -9,8 +9,6 @@ namespace osu.Game.Rulesets.Catch.Objects
 {
     public class BananaShower : CatchHitObject, IHasDuration
     {
-        public override FruitVisualRepresentation VisualRepresentation => FruitVisualRepresentation.Banana;
-
         public override bool LastInCombo => true;
 
         public override Judgement CreateJudgement() => new IgnoreJudgement();

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -58,8 +58,6 @@ namespace osu.Game.Rulesets.Catch.Objects
             set => IndexInBeatmapBindable.Value = value;
         }
 
-        public virtual FruitVisualRepresentation VisualRepresentation => (FruitVisualRepresentation)(IndexInBeatmap % 4);
-
         public virtual bool NewCombo { get; set; }
 
         public int ComboOffset { get; set; }
@@ -114,14 +112,5 @@ namespace osu.Game.Rulesets.Catch.Objects
         {
             XBindable.BindValueChanged(x => originalX = x.NewValue - xOffset);
         }
-    }
-
-    public enum FruitVisualRepresentation
-    {
-        Pear,
-        Grape,
-        Pineapple,
-        Raspberry,
-        Banana // banananananannaanana
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -8,6 +8,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableBanana : DrawableFruit
     {
+        protected override FruitVisualRepresentation GetVisualRepresentation(int indexInBeatmap) => FruitVisualRepresentation.Banana;
+
         public DrawableBanana(Banana h)
             : base(h)
         {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -10,6 +11,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public abstract class DrawableCatchHitObject : DrawableHitObject<CatchHitObject>
     {
+        public readonly Bindable<float> XBindable = new Bindable<float>();
+
         protected override double InitialLifetimeOffset => HitObject.TimePreempt;
 
         public float DisplayRadius => DrawSize.X / 2 * Scale.X * HitObject.Scale;
@@ -19,8 +22,24 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         protected DrawableCatchHitObject(CatchHitObject hitObject)
             : base(hitObject)
         {
-            X = hitObject.X;
+            if (hitObject != null)
+                XBindable.Value = hitObject.X;
+
             Anchor = Anchor.BottomLeft;
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
+
+            XBindable.BindTo(HitObject.XBindable);
+        }
+
+        protected override void OnFree()
+        {
+            base.OnFree();
+
+            XBindable.UnbindFrom(HitObject.XBindable);
         }
 
         public Func<CatchHitObject, bool> CheckPosition;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.UI;
@@ -19,12 +20,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected override float SamplePlaybackPosition => HitObject.X / CatchPlayfield.WIDTH;
 
-        protected DrawableCatchHitObject(CatchHitObject hitObject)
+        protected DrawableCatchHitObject([CanBeNull] CatchHitObject hitObject)
             : base(hitObject)
         {
-            if (hitObject != null)
-                XBindable.Value = hitObject.X;
-
             Anchor = Anchor.BottomLeft;
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -21,7 +21,17 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            ScaleContainer.Child = new SkinnableDrawable(new CatchSkinComponent(CatchSkinComponents.Droplet), _ => new DropletPiece());
+            HyperDash.BindValueChanged(_ => updatePiece(), true);
+        }
+
+        private void updatePiece()
+        {
+            ScaleContainer.Child = new SkinnableDrawable(
+                new CatchSkinComponent(CatchSkinComponents.Droplet),
+                _ => new DropletPiece
+                {
+                    HyperDash = { BindTarget = HyperDash }
+                });
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -36,15 +36,19 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 VisualRepresentation.Value = GetVisualRepresentation(change.NewValue);
             }, true);
 
-            VisualRepresentation.BindValueChanged(change =>
-            {
-                ScaleContainer.Child = new SkinnableDrawable(
-                    new CatchSkinComponent(getComponent(change.NewValue)),
-                    _ => fruitPiece = new FruitPiece
-                    {
-                        VisualRepresentation = { BindTarget = VisualRepresentation },
-                    });
-            }, true);
+            VisualRepresentation.BindValueChanged(_ => updatePiece());
+            HyperDash.BindValueChanged(_ => updatePiece(), true);
+        }
+
+        private void updatePiece()
+        {
+            ScaleContainer.Child = new SkinnableDrawable(
+                new CatchSkinComponent(getComponent(VisualRepresentation.Value)),
+                _ => fruitPiece = new FruitPiece
+                {
+                    VisualRepresentation = { BindTarget = VisualRepresentation },
+                    HyperDash = { BindTarget = HyperDash },
+                });
         }
 
         protected override void OnApply()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -12,8 +12,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableFruit : DrawablePalpableCatchHitObject
     {
-        public readonly Bindable<int> IndexInBeatmap = new Bindable<int>();
-
         public readonly Bindable<FruitVisualRepresentation> VisualRepresentation = new Bindable<FruitVisualRepresentation>();
 
         protected virtual FruitVisualRepresentation GetVisualRepresentation(int indexInBeatmap) => (FruitVisualRepresentation)(indexInBeatmap % 4);
@@ -23,7 +21,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public DrawableFruit(CatchHitObject h)
             : base(h)
         {
-            IndexInBeatmap.Value = h.IndexInBeatmap;
         }
 
         [BackgroundDependencyLoader]
@@ -49,20 +46,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                     VisualRepresentation = { BindTarget = VisualRepresentation },
                     HyperDash = { BindTarget = HyperDash },
                 });
-        }
-
-        protected override void OnApply()
-        {
-            base.OnApply();
-
-            IndexInBeatmap.BindTo(HitObject.IndexInBeatmapBindable);
-        }
-
-        protected override void OnFree()
-        {
-            IndexInBeatmap.UnbindFrom(HitObject.IndexInBeatmapBindable);
-
-            base.OnFree();
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected virtual FruitVisualRepresentation GetVisualRepresentation(int indexInBeatmap) => (FruitVisualRepresentation)(indexInBeatmap % 4);
 
-        private FruitPiece fruitPiece;
-
         public DrawableFruit(CatchHitObject h)
             : base(h)
         {
@@ -41,19 +39,11 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
             ScaleContainer.Child = new SkinnableDrawable(
                 new CatchSkinComponent(getComponent(VisualRepresentation.Value)),
-                _ => fruitPiece = new FruitPiece
+                _ => new FruitPiece
                 {
                     VisualRepresentation = { BindTarget = VisualRepresentation },
                     HyperDash = { BindTarget = HyperDash },
                 });
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (fruitPiece != null)
-                fruitPiece.Border.Alpha = (float)Math.Clamp((StartTimeBindable.Value - Time.Current) / 500, 0, 1);
         }
 
         private CatchSkinComponents getComponent(FruitVisualRepresentation hitObjectVisualRepresentation)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -17,6 +17,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         public Bindable<float> ScaleBindable { get; } = new Bindable<float>(1);
 
+        public readonly Bindable<int> IndexInBeatmap = new Bindable<int>();
+
         /// <summary>
         /// The multiplicative factor applied to <see cref="ScaleContainer"/> scale relative to <see cref="HitObject"/> scale.
         /// </summary>
@@ -41,6 +43,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
             });
+
+            IndexInBeatmap.Value = h.IndexInBeatmap;
         }
 
         [BackgroundDependencyLoader]
@@ -55,6 +59,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             {
                 ScaleContainer.Scale = new Vector2(scale.NewValue * ScaleFactor);
             }, true);
+
+            IndexInBeatmap.BindValueChanged(_ => UpdateComboColour());
         }
 
         protected override void OnApply()
@@ -63,12 +69,14 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
             HyperDash.BindTo(HitObject.HyperDashBindable);
             ScaleBindable.BindTo(HitObject.ScaleBindable);
+            IndexInBeatmap.BindTo(HitObject.IndexInBeatmapBindable);
         }
 
         protected override void OnFree()
         {
             HyperDash.UnbindFrom(HitObject.HyperDashBindable);
             ScaleBindable.UnbindFrom(HitObject.ScaleBindable);
+            IndexInBeatmap.UnbindFrom(HitObject.IndexInBeatmapBindable);
 
             base.OnFree();
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -14,9 +14,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     {
         public new PalpableCatchHitObject HitObject => (PalpableCatchHitObject)base.HitObject;
 
-        public Bindable<bool> HyperDash { get; } = new Bindable<bool>();
+        public readonly Bindable<bool> HyperDash = new Bindable<bool>();
 
-        public Bindable<float> ScaleBindable { get; } = new Bindable<float>(1);
+        public readonly Bindable<float> ScaleBindable = new Bindable<float>(1);
 
         public readonly Bindable<int> IndexInBeatmap = new Bindable<int>();
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -31,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected readonly Container ScaleContainer;
 
-        protected DrawablePalpableCatchHitObject(CatchHitObject h)
+        protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)
             : base(h)
         {
             Origin = Anchor.Centre;
@@ -43,8 +44,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
             });
-
-            IndexInBeatmap.Value = h.IndexInBeatmap;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
@@ -1,21 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableTinyDroplet : DrawableDroplet
     {
+        protected override float ScaleFactor => base.ScaleFactor / 2;
+
         public DrawableTinyDroplet(TinyDroplet h)
             : base(h)
         {
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            ScaleContainer.Scale /= 2;
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/DropletPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/DropletPiece.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -11,6 +12,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
     public class DropletPiece : CompositeDrawable
     {
+        public readonly Bindable<bool> HyperDash = new Bindable<bool>();
+
         public DropletPiece()
         {
             Size = new Vector2(CatchHitObject.OBJECT_RADIUS / 2);
@@ -19,15 +22,13 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject drawableObject)
         {
-            var drawableCatchObject = (DrawablePalpableCatchHitObject)drawableObject;
-
             InternalChild = new Pulp
             {
                 RelativeSizeAxes = Axes.Both,
                 AccentColour = { BindTarget = drawableObject.AccentColour }
             };
 
-            if (drawableCatchObject.HitObject.HyperDash)
+            if (HyperDash.Value)
             {
                 AddInternal(new HyperDropletBorderPiece());
             }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 {
@@ -16,8 +15,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
         /// </summary>
         public const float RADIUS_ADJUST = 1.1f;
 
-        private BorderPiece border;
-        private PalpableCatchHitObject hitObject;
+        public readonly Bindable<FruitVisualRepresentation> VisualRepresentation = new Bindable<FruitVisualRepresentation>();
+        public readonly Bindable<bool> HyperDash = new Bindable<bool>();
+
+        public BorderPiece Border;
 
         public FruitPiece()
         {
@@ -25,27 +26,18 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
         }
 
         [BackgroundDependencyLoader]
-        private void load(DrawableHitObject drawableObject)
+        private void load()
         {
-            var drawableCatchObject = (DrawablePalpableCatchHitObject)drawableObject;
-            hitObject = drawableCatchObject.HitObject;
-
             AddRangeInternal(new[]
             {
-                getFruitFor(hitObject.VisualRepresentation),
-                border = new BorderPiece(),
+                getFruitFor(VisualRepresentation.Value),
+                Border = new BorderPiece(),
             });
 
-            if (hitObject.HyperDash)
+            if (HyperDash.Value)
             {
                 AddInternal(new HyperBorderPiece());
             }
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-            border.Alpha = (float)Math.Clamp((hitObject.StartTime - Time.Current) / 500, 0, 1);
         }
 
         private Drawable getFruitFor(FruitVisualRepresentation representation)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
 
         protected override void Update()
         {
-            if (borderPiece != null && drawableHitObject.HitObject != null)
+            if (borderPiece != null && drawableHitObject?.HitObject != null)
                 borderPiece.Alpha = (float)Math.Clamp((drawableHitObject.HitObject.StartTime - Time.Current) / 500, 0, 1);
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/Pieces/FruitPiece.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables.Pieces
         public readonly Bindable<FruitVisualRepresentation> VisualRepresentation = new Bindable<FruitVisualRepresentation>();
         public readonly Bindable<bool> HyperDash = new Bindable<bool>();
 
-        public BorderPiece Border;
+        public BorderPiece Border { get; private set; }
 
         public FruitPiece()
         {

--- a/osu.Game.Rulesets.Catch/Objects/PalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/PalpableCatchHitObject.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Types;
 using osuTK.Graphics;
 
@@ -20,15 +21,27 @@ namespace osu.Game.Rulesets.Catch.Objects
         /// </summary>
         public float DistanceToHyperDash { get; set; }
 
+        public readonly Bindable<bool> HyperDashBindable = new Bindable<bool>();
+
         /// <summary>
         /// Whether this fruit can initiate a hyperdash.
         /// </summary>
-        public bool HyperDash => HyperDashTarget != null;
+        public bool HyperDash => HyperDashBindable.Value;
+
+        private CatchHitObject hyperDashTarget;
 
         /// <summary>
         /// The target fruit if we are to initiate a hyperdash.
         /// </summary>
-        public CatchHitObject HyperDashTarget;
+        public CatchHitObject HyperDashTarget
+        {
+            get => hyperDashTarget;
+            set
+            {
+                hyperDashTarget = value;
+                HyperDashBindable.Value = value != null;
+            }
+        }
 
         Color4 IHasComboInformation.GetComboColour(IReadOnlyList<Color4> comboColours) => comboColours[(IndexInBeatmap + 1) % comboColours.Count];
     }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             base.LoadComplete();
 
-            comboIndexBindable.BindValueChanged(_ => updateComboColour(), true);
+            comboIndexBindable.BindValueChanged(_ => UpdateComboColour(), true);
 
             updateState(ArmedState.Idle, true);
         }
@@ -533,7 +533,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         {
             base.SkinChanged(skin, allowFallback);
 
-            updateComboColour();
+            UpdateComboColour();
 
             ApplySkin(skin, allowFallback);
 
@@ -541,7 +541,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
                 updateState(State.Value, true);
         }
 
-        private void updateComboColour()
+        protected void UpdateComboColour()
         {
             if (!(HitObject is IHasComboInformation combo)) return;
 


### PR DESCRIPTION
### Motivation of this change

A step to support hit object pooling in osu!catch.

### Known issues

It is currently allocating new `Drawable`s (`FruitPiece` and `DropletPiece`) when state changes, and thus it is not maximally efficient if pooling is used. This will be addressed in future PRs.