### PR TITLE
Reduce the opacity of the default skin slider ball

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/SliderBall.cs
@@ -248,7 +248,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Pieces
             }
 
             private void trackingChanged(ValueChangedEvent<bool> tracking) =>
-                box.FadeTo(tracking.NewValue ? 0.6f : 0.05f, 200, Easing.OutQuint);
+                box.FadeTo(tracking.NewValue ? 0.3f : 0.05f, 200, Easing.OutQuint);
         }
     }
 }


### PR DESCRIPTION
Previous value was [hitting pure white on some brighter combo colours](https://github.com/ppy/osu/issues/10910#issuecomment-734354812). Wasn't really supposed to get this bright.

Default (before)
![image](https://user-images.githubusercontent.com/191335/100417671-cadaeb00-30c4-11eb-9fc2-f1d3c7af3797.png)

Default (after)
![image](https://user-images.githubusercontent.com/191335/100417588-99fab600-30c4-11eb-835b-2dd7f9b7db6d.png)

Bright (before)
![image](https://user-images.githubusercontent.com/191335/100417697-d5958000-30c4-11eb-93f5-a287abb6ca2c.png)

Bright (after)
![image](https://user-images.githubusercontent.com/191335/100417628-b0a10d00-30c4-11eb-94ae-6c7105570b8c.png)
