### PR TITLE
Add `StatelessRNG` to be used for randomly-looking visual elements

### DIFF
--- a/osu.Game/Utils/StatelessRNG.cs
+++ b/osu.Game/Utils/StatelessRNG.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Utils
+{
+    /// Provides a fast stateless function that can be used in randomly-looking visual elements.
+    public static class StatelessRNG
+    {
+        private static ulong mix(ulong x)
+        {
+            unchecked
+            {
+                x ^= x >> 33;
+                x *= 0xff51afd7ed558ccd;
+                x ^= x >> 33;
+                x *= 0xc4ceb9fe1a85ec53;
+                x ^= x >> 33;
+                return x;
+            }
+        }
+
+        /// Compute an integer from given seed and series number.
+        /// <param name="seed">
+        /// The seed value of this random number generator.
+        /// </param>
+        /// <param name="series">
+        /// The series number.
+        /// Different values are computed for the same seed in different series.
+        /// </param>
+        public static ulong Get(int seed, int series = 0) =>
+            unchecked(mix(((ulong)(uint)series << 32) | ((uint)seed ^ 0x12345678)));
+
+        /// Compute a floating point value between 0 and 1 (excluding 1) from given seed and series number.
+        /// <param name="seed">
+        /// The seed value of this random number generator.
+        /// </param>
+        /// <param name="series">
+        /// The series number.
+        /// Different values are computed for the same seed in different series.
+        /// </param>
+        public static float GetSingle(int seed, int series = 0) =>
+            (float)(Get(seed, series) & ((1 << 24) - 1)) / (1 << 24); // float has 24-bit precision
+    }
+}

--- a/osu.Game/Utils/StatelessRNG.cs
+++ b/osu.Game/Utils/StatelessRNG.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Game.Utils
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace osu.Game.Utils
         }
 
         /// <summary>
-        /// Compute an integer from given seed and series number.
+        /// Generate a random 64-bit unsigned integer from given seed.
         /// </summary>
         /// <param name="seed">
         /// The seed value of this random number generator.
@@ -31,11 +33,39 @@ namespace osu.Game.Utils
         /// The series number.
         /// Different values are computed for the same seed in different series.
         /// </param>
-        public static ulong Get(int seed, int series = 0) =>
-            unchecked(mix(((ulong)(uint)series << 32) | ((uint)seed ^ 0x12345678)));
+        public static ulong NextUlong(int seed, int series = 0)
+        {
+            unchecked
+            {
+                //
+                var combined = ((ulong)(uint)series << 32) | (uint)seed;
+                // The xor operation is to not map (0, 0) to 0.
+                return mix(combined ^ 0x12345678);
+            }
+        }
 
         /// <summary>
-        /// Compute a floating point value between 0 and 1 (excluding 1) from given seed and series number.
+        /// Generate a random integer in range [0, maxValue) from given seed.
+        /// </summary>
+        /// <param name="maxValue">
+        /// The number of possible results.
+        /// </param>
+        /// <param name="seed">
+        /// The seed value of this random number generator.
+        /// </param>
+        /// <param name="series">
+        /// The series number.
+        /// Different values are computed for the same seed in different series.
+        /// </param>
+        public static int NextInt(int maxValue, int seed, int series = 0)
+        {
+            if (maxValue <= 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
+
+            return (int)(NextUlong(seed, series) % (ulong)maxValue);
+        }
+
+        /// <summary>
+        /// Compute a random floating point value between 0 and 1 (excluding 1) from given seed and series number.
         /// </summary>
         /// <param name="seed">
         /// The seed value of this random number generator.
@@ -44,7 +74,7 @@ namespace osu.Game.Utils
         /// The series number.
         /// Different values are computed for the same seed in different series.
         /// </param>
-        public static float GetSingle(int seed, int series = 0) =>
-            (float)(Get(seed, series) & ((1 << 24) - 1)) / (1 << 24); // float has 24-bit precision
+        public static float NextSingle(int seed, int series = 0) =>
+            (float)(NextUlong(seed, series) & ((1 << 24) - 1)) / (1 << 24); // float has 24-bit precision
     }
 }

--- a/osu.Game/Utils/StatelessRNG.cs
+++ b/osu.Game/Utils/StatelessRNG.cs
@@ -3,7 +3,9 @@
 
 namespace osu.Game.Utils
 {
+    /// <summary>
     /// Provides a fast stateless function that can be used in randomly-looking visual elements.
+    /// </summary>
     public static class StatelessRNG
     {
         private static ulong mix(ulong x)
@@ -19,7 +21,9 @@ namespace osu.Game.Utils
             }
         }
 
+        /// <summary>
         /// Compute an integer from given seed and series number.
+        /// </summary>
         /// <param name="seed">
         /// The seed value of this random number generator.
         /// </param>
@@ -30,7 +34,9 @@ namespace osu.Game.Utils
         public static ulong Get(int seed, int series = 0) =>
             unchecked(mix(((ulong)(uint)series << 32) | ((uint)seed ^ 0x12345678)));
 
+        /// <summary>
         /// Compute a floating point value between 0 and 1 (excluding 1) from given seed and series number.
+        /// </summary>
         /// <param name="seed">
         /// The seed value of this random number generator.
         /// </param>

--- a/osu.Game/Utils/StatelessRNG.cs
+++ b/osu.Game/Utils/StatelessRNG.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Utils
         /// The series number.
         /// Different values are computed for the same seed in different series.
         /// </param>
-        public static ulong NextUlong(int seed, int series = 0)
+        public static ulong NextULong(int seed, int series = 0)
         {
             unchecked
             {
@@ -60,7 +60,7 @@ namespace osu.Game.Utils
         {
             if (maxValue <= 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
 
-            return (int)(NextUlong(seed, series) % (ulong)maxValue);
+            return (int)(NextULong(seed, series) % (ulong)maxValue);
         }
 
         /// <summary>
@@ -74,6 +74,6 @@ namespace osu.Game.Utils
         /// Different values are computed for the same seed in different series.
         /// </param>
         public static float NextSingle(int seed, int series = 0) =>
-            (float)(NextUlong(seed, series) & ((1 << 24) - 1)) / (1 << 24); // float has 24-bit precision
+            (float)(NextULong(seed, series) & ((1 << 24) - 1)) / (1 << 24); // float has 24-bit precision
     }
 }

--- a/osu.Game/Utils/StatelessRNG.cs
+++ b/osu.Game/Utils/StatelessRNG.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Utils
         {
             unchecked
             {
-                //
                 var combined = ((ulong)(uint)series << 32) | (uint)seed;
                 // The xor operation is to not map (0, 0) to 0.
                 return mix(combined ^ 0x12345678);


### PR DESCRIPTION
### Motivation for this change

Existing call to global `RNG` like <https://github.com/ppy/osu/blob/60b6b56c045d77284a968a984d7ecab7f8e9169d/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs#L25> is

- Not consistent across different gameplay, which might not be desired for testing purposes, or to the player (the player may be distracted from having different randomness for each replay).
- When pooling is used, the same object will have different when a replay is rewound or in the editor.

There is also code like <https://github.com/ppy/osu/blob/c0c197501e3f794e6582c0744270a268c1a21163/osu.Game.Rulesets.Catch/Objects/Banana.cs#L37> to get stability.

Another way is to use seeded `Random` but:

- Only one integer argument is used. It leads to a situation of different visual element "correlates" each other if the same seed is used. Solving it requires some ad-hoc code.
- It is a small but non-zero allocation.
- The stateful nature requires some consideration of when to create a new `Random` and when the random values can be generated.

This PR introduces `StatelessRNG` as an abstract function of "scrambling" input seed number. The desired property of this function is that it "looks random" for humans, as it is for visual elements, and no cryptographic security is needed. Also, the good performance of the function is nice-to-have.

`mix` function is adopted from [MurmurHash3](https://github.com/aappleby/smhasher/blob/61a0530f28277f2e850bfc39600ce61d02b518de/src/MurmurHash3.cpp#L81-L89) (public domain declared).

