### PR TITLE
Avoid updating hitobjects unnecessarily for start time changes

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -496,10 +496,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 double offset = result.Time.Value - movementBlueprints.First().HitObject.StartTime;
 
                 foreach (HitObject obj in Beatmap.SelectedHitObjects)
-                {
                     obj.StartTime += offset;
-                    Beatmap.Update(obj);
-                }
             }
 
             return true;


### PR DESCRIPTION
This was firing regardless of whether the start time was changed, such as where beat snap provided the same time the object already has.

The case where a change actually occurs is already handled by EditorBeatmap (see `startTimeBindables`), so it turns out this local handling is not required at all.