### PR TITLE
Remove unnecessary schedule logic from Apply's local updateState call

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -263,18 +263,15 @@ namespace osu.Game.Rulesets.Objects.Drawables
             OnApply();
             HitObjectApplied?.Invoke(this);
 
-            // If not loaded, the state update happens in LoadComplete(). Otherwise, the update is scheduled to allow for lifetime updates.
+            // If not loaded, the state update happens in LoadComplete().
             if (IsLoaded)
             {
-                Scheduler.Add(() =>
-                {
-                    if (Result.IsHit)
-                        updateState(ArmedState.Hit, true);
-                    else if (Result.HasResult)
-                        updateState(ArmedState.Miss, true);
-                    else
-                        updateState(ArmedState.Idle, true);
-                });
+                if (Result.IsHit)
+                    updateState(ArmedState.Hit, true);
+                else if (Result.HasResult)
+                    updateState(ArmedState.Miss, true);
+                else
+                    updateState(ArmedState.Idle, true);
             }
 
             hasHitObjectApplied = true;


### PR DESCRIPTION
There were cases in the editor where rewinding of transforms would leave the `DrawableHitObject` in a non-`IsPresent` state, resulting in this scheduled logic never running.

This would in turn cause ghost hitobjects, which disappear under certain circumstances.

Reproduction:

- Open editor to empty beatmap
- Place single hitcircle at current point in time
- Drag editor timeline backwards to seek before zero, and wait for return to zero
- Select hitcircle in playfield
- Drag hitcircle to right in timeline, triggering a start time change

![2020-11-27 16 35 57](https://user-images.githubusercontent.com/191335/100423030-ae43b080-30ce-11eb-8739-9c589e589a47.gif)

Closes https://github.com/ppy/osu/issues/10939