### PR TITLE
Fix state application always checking newest state for early abort, rather than current

### DIFF
--- a/osu.Game.Tests/Editing/EditorChangeHandlerTest.cs
+++ b/osu.Game.Tests/Editing/EditorChangeHandlerTest.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Tests.Editing
 
             string hash = handler.CurrentStateHash;
 
-            // save a save without making any changes
+            // undo a change without saving
             handler.RestoreState(-1);
 
             Assert.That(originalHash, Is.EqualTo(handler.CurrentStateHash));

--- a/osu.Game.Tests/Editing/EditorChangeHandlerTest.cs
+++ b/osu.Game.Tests/Editing/EditorChangeHandlerTest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit;
@@ -42,6 +41,36 @@ namespace osu.Game.Tests.Editing
             Assert.That(handler.CanRedo.Value, Is.True);
 
             Assert.That(stateChangedFired, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestApplyThenUndoThenApplySameChange()
+        {
+            var (handler, beatmap) = createChangeHandler();
+
+            Assert.That(handler.CanUndo.Value, Is.False);
+            Assert.That(handler.CanRedo.Value, Is.False);
+
+            string originalHash = handler.CurrentStateHash;
+
+            addArbitraryChange(beatmap);
+            handler.SaveState();
+
+            Assert.That(handler.CanUndo.Value, Is.True);
+            Assert.That(handler.CanRedo.Value, Is.False);
+            Assert.That(stateChangedFired, Is.EqualTo(1));
+
+            string hash = handler.CurrentStateHash;
+
+            // save a save without making any changes
+            handler.RestoreState(-1);
+
+            Assert.That(originalHash, Is.EqualTo(handler.CurrentStateHash));
+            Assert.That(stateChangedFired, Is.EqualTo(2));
+
+            addArbitraryChange(beatmap);
+            handler.SaveState();
+            Assert.That(hash, Is.EqualTo(handler.CurrentStateHash));
         }
 
         [Test]
@@ -139,7 +168,7 @@ namespace osu.Game.Tests.Editing
 
         private void addArbitraryChange(EditorBeatmap beatmap)
         {
-            beatmap.Add(new HitCircle { StartTime = RNG.Next(0, 100000) });
+            beatmap.Add(new HitCircle { StartTime = 2760 });
         }
     }
 }

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Screens.Edit
                 var newState = stream.ToArray();
 
                 // if the previous state is binary equal we don't need to push a new one, unless this is the initial state.
-                if (savedStates.Count > 0 && newState.SequenceEqual(savedStates.Last())) return;
+                if (savedStates.Count > 0 && newState.SequenceEqual(savedStates[currentState])) return;
 
                 if (currentState < savedStates.Count - 1)
                     savedStates.RemoveRange(currentState + 1, savedStates.Count - currentState - 1);


### PR DESCRIPTION
Applying a change, undoing that change, then applying the same change would result in the second state change not being saved. Oversight in lookup index.