### PR TITLE
Set settings section as selected if user presses the sidebar button

### DIFF
--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Graphics.Containers
 
         protected override Container<T> Content => scrollContentContainer;
 
-        private readonly OsuScrollContainer scrollContainer;
+        private readonly UserTrackingScrollContainer scrollContainer;
         private readonly Container headerBackgroundContainer;
         private readonly MarginPadding originalSectionsMargin;
         private Drawable expandableHeader, fixedHeader, footer, headerBackground;
@@ -139,7 +139,7 @@ namespace osu.Game.Graphics.Containers
         public void ScrollToTop() => scrollContainer.ScrollTo(0);
 
         [NotNull]
-        protected virtual OsuScrollContainer CreateScrollContainer() => new OsuScrollContainer();
+        protected virtual UserTrackingScrollContainer CreateScrollContainer() => new UserTrackingScrollContainer();
 
         [NotNull]
         protected virtual FlowContainer<T> CreateScrollContentContainer() =>
@@ -201,9 +201,9 @@ namespace osu.Game.Graphics.Containers
                 {
                     SelectedSection.Value = Children.LastOrDefault();
                 }
-                else
+                else if (scrollContainer.UserScrolling)
                 {
-                    SelectedSection.Value = Children.TakeWhile(section => diff(section) <= section.Margin.Top).LastOrDefault()
+                    SelectedSection.Value = Children.TakeWhile(section => diff(section) <= 1).LastOrDefault()
                                             ?? Children.FirstOrDefault();
                 }
             }

--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Graphics.Containers
                 }
                 else
                 {
-                    SelectedSection.Value = Children.TakeWhile(section => diff(section) <= 0).LastOrDefault()
+                    SelectedSection.Value = Children.TakeWhile(section => diff(section) <= section.Margin.Top).LastOrDefault()
                                             ?? Children.FirstOrDefault();
                 }
             }

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Graphics.Containers
+{
+    public class UserTrackingScrollContainer : OsuScrollContainer
+    {
+        /// <summary>
+        /// Whether the last scroll event was user triggered, directly on the scroll container.
+        /// </summary>
+        public bool UserScrolling { get; private set; }
+
+        protected override void OnUserScroll(float value, bool animated = true, double? distanceDecay = default)
+        {
+            UserScrolling = true;
+            base.OnUserScroll(value, animated, distanceDecay);
+        }
+
+        public new void ScrollTo(float value, bool animated = true, double? distanceDecay = null)
+        {
+            UserScrolling = false;
+            base.ScrollTo(value, animated, distanceDecay);
+        }
+    }
+}

--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -17,9 +17,9 @@ using osuTK.Graphics;
 namespace osu.Game.Overlays
 {
     /// <summary>
-    /// <see cref="OsuScrollContainer"/> which provides <see cref="ScrollToTopButton"/>. Mostly used in <see cref="FullscreenOverlay{T}"/>.
+    /// <see cref="UserTrackingScrollContainer"/> which provides <see cref="ScrollToTopButton"/>. Mostly used in <see cref="FullscreenOverlay{T}"/>.
     /// </summary>
-    public class OverlayScrollContainer : OsuScrollContainer
+    public class OverlayScrollContainer : UserTrackingScrollContainer
     {
         /// <summary>
         /// Scroll position at which the <see cref="ScrollToTopButton"/> will be shown.

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -126,6 +126,7 @@ namespace osu.Game.Overlays
                     Action = () =>
                     {
                         SectionsContainer.ScrollTo(section);
+                        SectionsContainer.SelectedSection.Value = section;
                         Sidebar.State = ExpandedState.Contracted;
                     },
                 };

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Overlays
                 RelativeSizeAxes = Axes.Both;
             }
 
-            protected override OsuScrollContainer CreateScrollContainer() => new OverlayScrollContainer();
+            protected override UserTrackingScrollContainer CreateScrollContainer() => new OverlayScrollContainer();
 
             protected override FlowContainer<ProfileSection> CreateScrollContentContainer() => new FillFlowContainer<ProfileSection>
             {

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -889,27 +889,9 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private class CarouselScrollContainer : OsuScrollContainer
+        private class CarouselScrollContainer : UserTrackingScrollContainer
         {
             private bool rightMouseScrollBlocked;
-
-            /// <summary>
-            /// Whether the last scroll event was user triggered, directly on the scroll container.
-            /// </summary>
-            public bool UserScrolling { get; private set; }
-
-            // ReSharper disable once OptionalParameterHierarchyMismatch 2020.3 EAP4 bug. (https://youtrack.jetbrains.com/issue/RSRP-481535?p=RIDER-51910)
-            protected override void OnUserScroll(float value, bool animated = true, double? distanceDecay = default)
-            {
-                UserScrolling = true;
-                base.OnUserScroll(value, animated, distanceDecay);
-            }
-
-            public new void ScrollTo(float value, bool animated = true, double? distanceDecay = null)
-            {
-                UserScrolling = false;
-                base.ScrollTo(value, animated, distanceDecay);
-            }
 
             protected override bool OnMouseDown(MouseDownEvent e)
             {


### PR DESCRIPTION
Closes #9196

![settings](https://user-images.githubusercontent.com/11320483/100555208-8b69f580-32a2-11eb-8098-479e3539b8b7.gif)

~~I assume the section we scroll to has to reach the search box to be considered selected but currently it will never reach that (at least not high enough to always satisfy ``<= 0``)~~

~~Considering the margin when deciding what section is selected sounds most reasonable, but maybe this should be even more than ``51`` because users would consider the section reached well before.~~


