### PR TITLE
Create "User Interface" settings section

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/AudioSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/AudioSection.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Overlays.Settings.Sections
                 new AudioDevicesSettings(),
                 new VolumeSettings(),
                 new OffsetSettings(),
-                new MainMenuSettings()
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -5,7 +5,6 @@ using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Overlays.Settings.Sections.Gameplay
@@ -64,12 +63,6 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = "Always show key overlay",
                     Current = config.GetBindable<bool>(OsuSetting.KeyOverlay)
                 },
-                new SettingsSlider<float, TimeSlider>
-                {
-                    LabelText = "Hold-to-confirm activation time",
-                    Current = config.GetBindable<float>(OsuSetting.UIHoldActivationDelay),
-                    KeyboardStep = 50
-                },
                 new SettingsCheckbox
                 {
                     LabelText = "Positional hitsounds",
@@ -101,11 +94,6 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     Current = config.GetBindable<bool>(OsuSetting.GameplayDisableWinKey)
                 });
             }
-        }
-
-        private class TimeSlider : OsuSliderBar<float>
-        {
-            public override string TooltipText => Current.Value.ToString("N0") + "ms";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -5,6 +5,7 @@ using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Overlays.Settings.Sections.Gameplay
@@ -63,6 +64,12 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = "Always show key overlay",
                     Current = config.GetBindable<bool>(OsuSetting.KeyOverlay)
                 },
+                new SettingsSlider<float, TimeSlider>
+                {
+                    LabelText = "Hold-to-confirm activation time",
+                    Current = config.GetBindable<float>(OsuSetting.UIHoldActivationDelay),
+                    KeyboardStep = 50
+                },
                 new SettingsCheckbox
                 {
                     LabelText = "Positional hitsounds",
@@ -94,6 +101,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     Current = config.GetBindable<bool>(OsuSetting.GameplayDisableWinKey)
                 });
             }
+        }
+
+        private class TimeSlider : OsuSliderBar<float>
+        {
+            public override string TooltipText => Current.Value.ToString("N0") + "ms";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
@@ -26,7 +26,6 @@ namespace osu.Game.Overlays.Settings.Sections
             Children = new Drawable[]
             {
                 new GeneralSettings(),
-                new SongSelectSettings(),
                 new ModsSettings(),
             };
         }

--- a/osu.Game/Overlays/Settings/Sections/GraphicsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GraphicsSection.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Overlays.Settings.Sections
                 new RendererSettings(),
                 new LayoutSettings(),
                 new DetailSettings(),
-                new UserInterfaceSettings(),
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/SizeSlider.cs
+++ b/osu.Game/Overlays/Settings/Sections/SizeSlider.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Overlays.Settings.Sections
+{
+    /// <summary>
+    /// A slider intended to show a "size" multiplier number, where 1x is 1.0.
+    /// </summary>
+    internal class SizeSlider : OsuSliderBar<float>
+    {
+        public override string TooltipText => Current.Value.ToString(@"0.##x");
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -55,12 +55,6 @@ namespace osu.Game.Overlays.Settings.Sections
                 new ExportSkinButton(),
                 new SettingsSlider<float, SizeSlider>
                 {
-                    LabelText = "Menu cursor size",
-                    Current = config.GetBindable<float>(OsuSetting.MenuCursorSize),
-                    KeyboardStep = 0.01f
-                },
-                new SettingsSlider<float, SizeSlider>
-                {
                     LabelText = "Gameplay cursor size",
                     Current = config.GetBindable<float>(OsuSetting.GameplayCursorSize),
                     KeyboardStep = 0.01f
@@ -134,11 +128,6 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             if (weakItem.NewValue.TryGetTarget(out var item))
                 Schedule(() => skinDropdown.Items = skinDropdown.Items.Where(i => i.ID != item.ID).ToArray());
-        }
-
-        private class SizeSlider : OsuSliderBar<float>
-        {
-            public override string TooltipText => Current.Value.ToString(@"0.##x");
         }
 
         private class SkinSettingsDropdown : SettingsDropdown<SkinInfo>

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -21,6 +21,12 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     LabelText = "Rotate cursor when dragging",
                     Current = config.GetBindable<bool>(OsuSetting.CursorRotation)
                 },
+                new SettingsSlider<float, SizeSlider>
+                {
+                    LabelText = "Menu cursor size",
+                    Current = config.GetBindable<float>(OsuSetting.MenuCursorSize),
+                    KeyboardStep = 0.01f
+                },
                 new SettingsCheckbox
                 {
                     LabelText = "Parallax",

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
@@ -32,7 +33,18 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     LabelText = "Parallax",
                     Current = config.GetBindable<bool>(OsuSetting.MenuParallax)
                 },
+                new SettingsSlider<float, TimeSlider>
+                {
+                    LabelText = "Hold-to-confirm activation time",
+                    Current = config.GetBindable<float>(OsuSetting.UIHoldActivationDelay),
+                    KeyboardStep = 50
+                },
             };
+        }
+
+        private class TimeSlider : OsuSliderBar<float>
+        {
+            public override string TooltipText => Current.Value.ToString("N0") + "ms";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -6,11 +6,11 @@ using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 
-namespace osu.Game.Overlays.Settings.Sections.Graphics
+namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
-    public class UserInterfaceSettings : SettingsSubsection
+    public class GeneralSettings : SettingsSubsection
     {
-        protected override string Header => "User Interface";
+        protected override string Header => "General";
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
-using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
@@ -27,18 +26,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     LabelText = "Parallax",
                     Current = config.GetBindable<bool>(OsuSetting.MenuParallax)
                 },
-                new SettingsSlider<float, TimeSlider>
-                {
-                    LabelText = "Hold-to-confirm activation time",
-                    Current = config.GetBindable<float>(OsuSetting.UIHoldActivationDelay),
-                    KeyboardStep = 50
-                },
             };
-        }
-
-        private class TimeSlider : OsuSliderBar<float>
-        {
-            public override string TooltipText => Current.Value.ToString("N0") + "ms";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
@@ -7,7 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
 
-namespace osu.Game.Overlays.Settings.Sections.Audio
+namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
     public class MainMenuSettings : SettingsSubsection
     {

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 
-namespace osu.Game.Overlays.Settings.Sections.Gameplay
+namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
     public class SongSelectSettings : SettingsSubsection
     {

--- a/osu.Game/Overlays/Settings/Sections/UserInterfaceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterfaceSection.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Overlays.Settings.Sections.UserInterface;
+
+namespace osu.Game.Overlays.Settings.Sections
+{
+    public class UserInterfaceSection : SettingsSection
+    {
+        public override string Header => "User Interface";
+
+        public override Drawable CreateIcon() => new SpriteIcon
+        {
+            Icon = FontAwesome.Solid.LayerGroup
+        };
+
+        public UserInterfaceSection()
+        {
+            Children = new Drawable[]
+            {
+                new GeneralSettings(),
+                new MainMenuSettings(),
+                new SongSelectSettings()
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -23,11 +23,11 @@ namespace osu.Game.Overlays
         {
             new GeneralSection(),
             new GraphicsSection(),
+            new AudioSection(),
+            new InputSection(createSubPanel(new KeyBindingPanel())),
             new UserInterfaceSection(),
             new GameplaySection(),
-            new AudioSection(),
             new SkinSection(),
-            new InputSection(createSubPanel(new KeyBindingPanel())),
             new OnlineSection(),
             new MaintenanceSection(),
             new DebugSection(),

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Overlays
         {
             new GeneralSection(),
             new GraphicsSection(),
+            new UserInterfaceSection(),
             new GameplaySection(),
             new AudioSection(),
             new SkinSection(),


### PR DESCRIPTION
Noticed this thing during discussion in #10990. In the existing setup we had:

- an *User Interface* section in *Graphics*,
- a *Main Menu* section in *Audio* (most of settings in which weren't even audio-related),
- a *Song Select* section in *Gameplay* (sorta makes sense but not really).

This PR proposes to unify them all under a new *User Interface* section which should hopefully make a bit more sense, with the exception of the hold-to-confirm setting which remained in *Gameplay* as it seems more apt there.

Icon is slightly random but had no better ideas.

![2020-11-29-223818_274x103_scrot](https://user-images.githubusercontent.com/20418176/100554233-a2edb200-3293-11eb-91c3-99b4d3322cf0.png)

![2020-11-29-223924_515x889_scrot](https://user-images.githubusercontent.com/20418176/100554252-bf89ea00-3293-11eb-933d-5fb085260608.png)