### PR TITLE
Add ability to customise key binding for in-game overlay toggle

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Configuration
             return new TrackedSettings
             {
                 new TrackedSetting<bool>(OsuSetting.MouseDisableButtons, v => new SettingDescription(!v, "gameplay mouse buttons", v ? "disabled" : "enabled", LookupKeyBindings(GlobalAction.ToggleGameplayMouseButtons))),
-                new TrackedSetting<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode, m => new SettingDescription(m, "HUD Visibility", m.GetDescription(), $"cycle: shift-tab quick view: {LookupKeyBindings(GlobalAction.HoldForHUD)}")),
+                new TrackedSetting<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode, m => new SettingDescription(m, "HUD Visibility", m.GetDescription(), $"cycle: {LookupKeyBindings(GlobalAction.ToggleInGameInterface)} quick view: {LookupKeyBindings(GlobalAction.HoldForHUD)}")),
                 new TrackedSetting<ScalingMode>(OsuSetting.Scaling, m => new SettingDescription(m, "scaling", m.GetDescription())),
                 new TrackedSetting<int>(OsuSetting.Skin, m =>
                 {

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.Tilde }, GlobalAction.QuickExit),
             new KeyBinding(new[] { InputKey.Control, InputKey.Plus }, GlobalAction.IncreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.Control, InputKey.Minus }, GlobalAction.DecreaseScrollSpeed),
+            new KeyBinding(InputKey.I, GlobalAction.ToggleInGameInterface),
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
             new KeyBinding(InputKey.Space, GlobalAction.TogglePauseReplay),
             new KeyBinding(InputKey.Control, GlobalAction.HoldForHUD),
@@ -144,6 +145,9 @@ namespace osu.Game.Input.Bindings
 
         [Description("Decrease scroll speed")]
         DecreaseScrollSpeed,
+
+        [Description("Toggle in-game interface")]
+        ToggleInGameInterface,
 
         [Description("Select")]
         Select,

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.Tilde }, GlobalAction.QuickExit),
             new KeyBinding(new[] { InputKey.Control, InputKey.Plus }, GlobalAction.IncreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.Control, InputKey.Minus }, GlobalAction.DecreaseScrollSpeed),
-            new KeyBinding(InputKey.I, GlobalAction.ToggleInGameInterface),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.Tab }, GlobalAction.ToggleInGameInterface),
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
             new KeyBinding(InputKey.Space, GlobalAction.TogglePauseReplay),
             new KeyBinding(InputKey.Control, GlobalAction.HoldForHUD),
@@ -146,9 +146,6 @@ namespace osu.Game.Input.Bindings
         [Description("Decrease scroll speed")]
         DecreaseScrollSpeed,
 
-        [Description("Toggle in-game interface")]
-        ToggleInGameInterface,
-
         [Description("Select")]
         Select,
 
@@ -204,5 +201,8 @@ namespace osu.Game.Input.Bindings
 
         [Description("Pause / resume replay")]
         TogglePauseReplay,
+
+        [Description("Toggle in-game interface")]
+        ToggleInGameInterface,
     }
 }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -181,7 +181,7 @@ namespace osu.Game.Screens.Play
 
                 notificationOverlay?.Post(new SimpleNotification
                 {
-                    Text = @"The score overlay is currently disabled. You can toggle this by pressing Shift+Tab."
+                    Text = $"The score overlay is currently disabled. You can toggle this by pressing {config.LookupKeyBindings(GlobalAction.ToggleInGameInterface)}."
                 });
             }
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -282,20 +282,7 @@ namespace osu.Game.Screens.Play
                 switch (e.Key)
                 {
                     case Key.Tab:
-                        switch (configVisibilityMode.Value)
-                        {
-                            case HUDVisibilityMode.Never:
-                                configVisibilityMode.Value = HUDVisibilityMode.HideDuringGameplay;
-                                break;
 
-                            case HUDVisibilityMode.HideDuringGameplay:
-                                configVisibilityMode.Value = HUDVisibilityMode.Always;
-                                break;
-
-                            case HUDVisibilityMode.Always:
-                                configVisibilityMode.Value = HUDVisibilityMode.Never;
-                                break;
-                        }
 
                         return true;
                 }
@@ -375,6 +362,24 @@ namespace osu.Game.Screens.Play
             {
                 case GlobalAction.HoldForHUD:
                     holdingForHUD = true;
+                    updateVisibility();
+                    return true;
+
+                case GlobalAction.ToggleInGameInterface:
+                    switch (configVisibilityMode.Value)
+                    {
+                        case HUDVisibilityMode.Never:
+                            configVisibilityMode.Value = HUDVisibilityMode.HideDuringGameplay;
+                            break;
+
+                        case HUDVisibilityMode.HideDuringGameplay:
+                            configVisibilityMode.Value = HUDVisibilityMode.Always;
+                            break;
+
+                        case HUDVisibilityMode.Always:
+                            configVisibilityMode.Value = HUDVisibilityMode.Never;
+                            break;
+                    }
                     updateVisibility();
                     return true;
             }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -273,6 +273,24 @@ namespace osu.Game.Screens.Play
             Progress.BindDrawableRuleset(drawableRuleset);
         }
 
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Repeat) return false;
+
+            if (e.ShiftPressed)
+            {
+                switch (e.Key)
+                {
+                    case Key.Tab:
+
+
+                        return true;
+                }
+            }
+
+            return base.OnKeyDown(e);
+        }
+
         protected virtual SkinnableAccuracyCounter CreateAccuracyCounter() => new SkinnableAccuracyCounter();
 
         protected virtual SkinnableScoreCounter CreateScoreCounter() => new SkinnableScoreCounter();

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -361,7 +361,6 @@ namespace osu.Game.Screens.Play
                             break;
                     }
 
-                    updateVisibility();
                     return true;
             }
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -9,7 +9,6 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
 using osu.Game.Configuration;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
@@ -19,7 +18,6 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play.HUD;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Screens.Play
 {
@@ -362,6 +360,7 @@ namespace osu.Game.Screens.Play
                             configVisibilityMode.Value = HUDVisibilityMode.Never;
                             break;
                     }
+
                     updateVisibility();
                     return true;
             }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -273,24 +273,6 @@ namespace osu.Game.Screens.Play
             Progress.BindDrawableRuleset(drawableRuleset);
         }
 
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (e.Repeat) return false;
-
-            if (e.ShiftPressed)
-            {
-                switch (e.Key)
-                {
-                    case Key.Tab:
-
-
-                        return true;
-                }
-            }
-
-            return base.OnKeyDown(e);
-        }
-
         protected virtual SkinnableAccuracyCounter CreateAccuracyCounter() => new SkinnableAccuracyCounter();
 
         protected virtual SkinnableScoreCounter CreateScoreCounter() => new SkinnableScoreCounter();


### PR DESCRIPTION
closes #10887 
creates a keybind for toggling the in-game overlay as opposed to it only being shift-tab, keybind defaults to "i"

let me know if anything is wrong with my code, this is my first PR and I'm not very familiar yet 😄 