### PR TITLE
Fix osu!catch combo counter not showing after 1 combo

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Rulesets.Catch.UI
                 HitObjectContainer,
                 CatcherArea,
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
 
             NewResult += onNewResult;
             RevertResult += onRevertResult;

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -61,6 +61,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             base.LoadComplete();
 
+            // these subscriptions need to be done post constructor to ensure externally bound components have a chance to populate required fields (ScoreProcessor / ComboAtJudgement in this case).
             NewResult += onNewResult;
             RevertResult += onRevertResult;
         }


### PR DESCRIPTION
Closes #10929. May be considered a temporary fix until we figure out a permanent solution to this.