### PR TITLE
Attempt to reduce settings visual clutter with better paddings

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osuTK;
-using osuTK.Graphics;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using System.Collections.Generic;
-using System.Linq;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Settings
 {

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.Settings
         public virtual IEnumerable<string> FilterTerms => new[] { Header };
 
         private const int header_size = 26;
-        private const int header_margin = 25;
+        private const int margin = 20;
         private const int border_size = 2;
 
         public bool MatchingFilter
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.Settings
 
         protected SettingsSection()
         {
-            Margin = new MarginPadding { Top = 20 };
+            Margin = new MarginPadding { Top = margin };
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
 
@@ -46,10 +46,9 @@ namespace osu.Game.Overlays.Settings
             {
                 Margin = new MarginPadding
                 {
-                    Top = header_size + header_margin
+                    Top = header_size
                 },
                 Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 30),
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,
             };
@@ -70,7 +69,7 @@ namespace osu.Game.Overlays.Settings
                 {
                     Padding = new MarginPadding
                     {
-                        Top = 20 + border_size,
+                        Top = margin + border_size,
                         Bottom = 10,
                     },
                     RelativeSizeAxes = Axes.X,
@@ -82,7 +81,11 @@ namespace osu.Game.Overlays.Settings
                             Font = OsuFont.GetFont(size: header_size),
                             Text = Header,
                             Colour = colours.Yellow,
-                            Margin = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS }
+                            Margin = new MarginPadding
+                            {
+                                Left = SettingsPanel.CONTENT_MARGINS,
+                                Right = SettingsPanel.CONTENT_MARGINS
+                            }
                         },
                         FlowContent
                     }

--- a/osu.Game/Overlays/Settings/SettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSubsection.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Settings
             FlowContent = new FillFlowContainer
             {
                 Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 5),
+                Spacing = new Vector2(0, 8),
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
             };
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays.Settings
                 new OsuSpriteText
                 {
                     Text = Header.ToUpperInvariant(),
-                    Margin = new MarginPadding { Bottom = 10, Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS },
+                    Margin = new MarginPadding { Vertical = 30, Left = SettingsPanel.CONTENT_MARGINS, Right = SettingsPanel.CONTENT_MARGINS },
                     Font = OsuFont.GetFont(weight: FontWeight.Bold),
                 },
                 FlowContent


### PR DESCRIPTION
Before (left) vs After (right)
![image](https://user-images.githubusercontent.com/191335/100587632-2c54c100-3334-11eb-9cb2-4f95a6cf3ea7.png)

- [x] Depends on #11008
