### PR TITLE
Initial implementation of hit object pooling in osu!catch ruleset

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
@@ -2,39 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.IO.Stores;
-using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
     [TestFixture]
-    public class TestSceneCatchPlayerLegacySkin : PlayerTestScene
+    public class TestSceneCatchPlayerLegacySkin : LegacySkinPlayerTestScene
     {
-        private ISkinSource legacySkinSource;
-
-        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new SkinProvidingPlayer(legacySkinSource);
-
-        [BackgroundDependencyLoader]
-        private void load(AudioManager audio, OsuGameBase game)
-        {
-            var legacySkin = new DefaultLegacySkin(new NamespacedResourceStore<byte[]>(game.Resources, "Skins/Legacy"), audio);
-            legacySkinSource = new SkinProvidingContainer(legacySkin);
-        }
-
         protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
-
-        public class SkinProvidingPlayer : TestPlayer
-        {
-            [Cached(typeof(ISkinSource))]
-            private readonly ISkinSource skinSource;
-
-            public SkinProvidingPlayer(ISkinSource skinSource)
-            {
-                this.skinSource = skinSource;
-            }
-        }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
@@ -28,18 +28,12 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         public class SkinProvidingPlayer : TestPlayer
         {
+            [Cached(typeof(ISkinSource))]
             private readonly ISkinSource skinSource;
 
             public SkinProvidingPlayer(ISkinSource skinSource)
             {
                 this.skinSource = skinSource;
-            }
-
-            protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
-            {
-                var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
-                dependencies.CacheAs(skinSource);
-                return dependencies;
             }
         }
     }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.IO.Stores;
+using osu.Game.Skinning;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    [TestFixture]
+    public class TestSceneCatchPlayerLegacySkin : PlayerTestScene
+    {
+        private ISkinSource legacySkinSource;
+
+        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new SkinProvidingPlayer(legacySkinSource);
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio, OsuGameBase game)
+        {
+            var legacySkin = new DefaultLegacySkin(new NamespacedResourceStore<byte[]>(game.Resources, "Skins/Legacy"), audio);
+            legacySkinSource = new SkinProvidingContainer(legacySkin);
+        }
+
+        protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
+
+        public class SkinProvidingPlayer : TestPlayer
+        {
+            private readonly ISkinSource skinSource;
+
+            public SkinProvidingPlayer(ISkinSource skinSource)
+            {
+                this.skinSource = skinSource;
+            }
+
+            protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+            {
+                var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+                dependencies.CacheAs(skinSource);
+                return dependencies;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -103,7 +103,6 @@ namespace osu.Game.Rulesets.Catch.Tests
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.TopCentre,
-                    CreateDrawableRepresentation = ((DrawableRuleset<CatchHitObject>)catchRuleset.CreateInstance().CreateDrawableRulesetWith(new CatchBeatmap())).CreateDrawableRepresentation
                 },
             });
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -10,14 +10,12 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
-using osu.Game.Rulesets.Catch.Beatmaps;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneDrawableHitObjects.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             if (juice.NestedHitObjects.Last() is CatchHitObject tail)
                 tail.LastInCombo = true; // usually the (Catch)BeatmapProcessor would do this for us when necessary
 
-            addToPlayfield(new DrawableJuiceStream(juice, drawableRuleset.CreateDrawableRepresentation));
+            addToPlayfield(new DrawableJuiceStream(juice));
         }
 
         private void spawnBananas(bool hit = false)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 
@@ -10,7 +11,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     {
         protected override FruitVisualRepresentation GetVisualRepresentation(int indexInBeatmap) => FruitVisualRepresentation.Banana;
 
-        public DrawableBanana(Banana h)
+        public DrawableBanana()
+            : this(null)
+        {
+        }
+
+        public DrawableBanana([CanBeNull] Banana h)
             : base(h)
         {
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBananaShower.cs
@@ -1,26 +1,27 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableBananaShower : DrawableCatchHitObject
     {
-        private readonly Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation;
         private readonly Container bananaContainer;
 
-        public DrawableBananaShower(BananaShower s, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation = null)
+        public DrawableBananaShower()
+            : this(null)
+        {
+        }
+
+        public DrawableBananaShower([CanBeNull] BananaShower s)
             : base(s)
         {
-            this.createDrawableRepresentation = createDrawableRepresentation;
             RelativeSizeAxes = Axes.X;
             Origin = Anchor.BottomLeft;
-            X = 0;
 
             AddInternal(bananaContainer = new Container { RelativeSizeAxes = Axes.Both });
         }
@@ -34,18 +35,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            bananaContainer.Clear();
-        }
-
-        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
-        {
-            switch (hitObject)
-            {
-                case Banana banana:
-                    return createDrawableRepresentation?.Invoke(banana);
-            }
-
-            return base.CreateNestedHitObject(hitObject);
+            bananaContainer.Clear(false);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
@@ -13,7 +14,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     {
         public override bool StaysOnPlate => false;
 
-        public DrawableDroplet(CatchHitObject h)
+        public DrawableDroplet()
+            : this(null)
+        {
+        }
+
+        public DrawableDroplet([CanBeNull] CatchHitObject h)
             : base(h)
         {
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Utils;
@@ -16,7 +17,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected virtual FruitVisualRepresentation GetVisualRepresentation(int indexInBeatmap) => (FruitVisualRepresentation)(indexInBeatmap % 4);
 
-        public DrawableFruit(CatchHitObject h)
+        public DrawableFruit()
+            : this(null)
+        {
+        }
+
+        public DrawableFruit([CanBeNull] Fruit h)
             : base(h)
         {
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableJuiceStream.cs
@@ -1,37 +1,33 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableJuiceStream : DrawableCatchHitObject
     {
-        private readonly Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation;
         private readonly Container dropletContainer;
 
-        public override Vector2 OriginPosition => base.OriginPosition - new Vector2(0, CatchHitObject.OBJECT_RADIUS);
+        public DrawableJuiceStream()
+            : this(null)
+        {
+        }
 
-        public DrawableJuiceStream(JuiceStream s, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation = null)
+        public DrawableJuiceStream([CanBeNull] JuiceStream s)
             : base(s)
         {
-            this.createDrawableRepresentation = createDrawableRepresentation;
             RelativeSizeAxes = Axes.X;
             Origin = Anchor.BottomLeft;
-            X = 0;
 
             AddInternal(dropletContainer = new Container { RelativeSizeAxes = Axes.Both, });
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
         {
-            hitObject.Origin = Anchor.BottomCentre;
-
             base.AddNestedHitObject(hitObject);
             dropletContainer.Add(hitObject);
         }
@@ -39,18 +35,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            dropletContainer.Clear();
-        }
-
-        protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)
-        {
-            switch (hitObject)
-            {
-                case CatchHitObject catchObject:
-                    return createDrawableRepresentation?.Invoke(catchObject);
-            }
-
-            throw new ArgumentException($"{nameof(hitObject)} must be of type {nameof(CatchHitObject)}.");
+            dropletContainer.Clear(false);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableTinyDroplet.cs
@@ -1,13 +1,20 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
+
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableTinyDroplet : DrawableDroplet
     {
         protected override float ScaleFactor => base.ScaleFactor / 2;
 
-        public DrawableTinyDroplet(TinyDroplet h)
+        public DrawableTinyDroplet()
+            : this(null)
+        {
+        }
+
+        public DrawableTinyDroplet([CanBeNull] TinyDroplet h)
             : base(h)
         {
         }

--- a/osu.Game.Rulesets.Catch/Skinning/LegacyFruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/LegacyFruitPiece.cs
@@ -19,7 +19,8 @@ namespace osu.Game.Rulesets.Catch.Skinning
     {
         private readonly string lookupName;
 
-        private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
+        private readonly Bindable<Color4> accentColour = new Bindable<Color4>();
+        private readonly Bindable<bool> hyperDash = new Bindable<bool>();
         private Sprite colouredSprite;
 
         public LegacyFruitPiece(string lookupName)
@@ -34,6 +35,7 @@ namespace osu.Game.Rulesets.Catch.Skinning
             var drawableCatchObject = (DrawablePalpableCatchHitObject)drawableObject;
 
             accentColour.BindTo(drawableCatchObject.AccentColour);
+            hyperDash.BindTo(drawableCatchObject.HyperDash);
 
             InternalChildren = new Drawable[]
             {
@@ -51,9 +53,9 @@ namespace osu.Game.Rulesets.Catch.Skinning
                 },
             };
 
-            if (drawableCatchObject.HitObject.HyperDash)
+            if (hyperDash.Value)
             {
-                var hyperDash = new Sprite
+                var hyperDashOverlay = new Sprite
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -67,7 +69,7 @@ namespace osu.Game.Rulesets.Catch.Skinning
                              Catcher.DEFAULT_HYPER_DASH_COLOUR,
                 };
 
-                AddInternal(hyperDash);
+                AddInternal(hyperDashOverlay);
             }
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             RegisterPool<Droplet, DrawableDroplet>(1);
             RegisterPool<TinyDroplet, DrawableTinyDroplet>(1);
+            RegisterPool<Fruit, DrawableFruit>(1);
+            RegisterPool<Banana, DrawableBanana>(1);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
@@ -54,6 +55,13 @@ namespace osu.Game.Rulesets.Catch.UI
                 HitObjectContainer,
                 CatcherArea,
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RegisterPool<Droplet, DrawableDroplet>(1);
+            RegisterPool<TinyDroplet, DrawableTinyDroplet>(1);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -65,6 +65,7 @@ namespace osu.Game.Rulesets.Catch.UI
             RegisterPool<Fruit, DrawableFruit>(1);
             RegisterPool<Banana, DrawableBanana>(1);
             RegisterPool<JuiceStream, DrawableJuiceStream>(1);
+            RegisterPool<BananaShower, DrawableBananaShower>(1);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -60,12 +60,12 @@ namespace osu.Game.Rulesets.Catch.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            RegisterPool<Droplet, DrawableDroplet>(1);
-            RegisterPool<TinyDroplet, DrawableTinyDroplet>(1);
-            RegisterPool<Fruit, DrawableFruit>(1);
-            RegisterPool<Banana, DrawableBanana>(1);
-            RegisterPool<JuiceStream, DrawableJuiceStream>(1);
-            RegisterPool<BananaShower, DrawableBananaShower>(1);
+            RegisterPool<Droplet, DrawableDroplet>(50);
+            RegisterPool<TinyDroplet, DrawableTinyDroplet>(50);
+            RegisterPool<Fruit, DrawableFruit>(100);
+            RegisterPool<Banana, DrawableBanana>(100);
+            RegisterPool<JuiceStream, DrawableJuiceStream>(10);
+            RegisterPool<BananaShower, DrawableBananaShower>(2);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -42,7 +42,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
             CatcherArea = new CatcherArea(difficulty)
             {
-                CreateDrawableRepresentation = createDrawableRepresentation,
                 ExplodingFruitTarget = explodingFruitContainer,
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.TopLeft,

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Rulesets.Catch.UI
             RegisterPool<TinyDroplet, DrawableTinyDroplet>(1);
             RegisterPool<Fruit, DrawableFruit>(1);
             RegisterPool<Banana, DrawableBanana>(1);
+            RegisterPool<JuiceStream, DrawableJuiceStream>(1);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -127,14 +127,23 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private DrawableCatchHitObject createCaughtFruit(DrawablePalpableCatchHitObject hitObject)
         {
-            return hitObject.HitObject switch
+            switch (hitObject.HitObject)
             {
-                Banana banana => new DrawableBanana(banana),
-                Fruit fruit => new DrawableFruit(fruit),
-                TinyDroplet tiny => new DrawableTinyDroplet(tiny),
-                Droplet droplet => new DrawableDroplet(droplet),
-                _ => null
-            };
+                case Banana banana:
+                    return new DrawableBanana(banana);
+
+                case Fruit fruit:
+                    return new DrawableFruit(fruit);
+
+                case TinyDroplet tiny:
+                    return new DrawableTinyDroplet(tiny);
+
+                case Droplet droplet:
+                    return new DrawableDroplet(droplet);
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -10,7 +10,6 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -20,8 +19,6 @@ namespace osu.Game.Rulesets.Catch.UI
     public class CatcherArea : Container
     {
         public const float CATCHER_SIZE = 106.75f;
-
-        public Func<CatchHitObject, DrawableHitObject<CatchHitObject>> CreateDrawableRepresentation;
 
         public readonly Catcher MovableCatcher;
         private readonly CatchComboDisplay comboDisplay;
@@ -72,7 +69,7 @@ namespace osu.Game.Rulesets.Catch.UI
             if (result.IsHit && hitObject is DrawablePalpableCatchHitObject fruit)
             {
                 // create a new (cloned) fruit to stay on the plate. the original is faded out immediately.
-                var caughtFruit = (DrawableCatchHitObject)CreateDrawableRepresentation?.Invoke(fruit.HitObject);
+                var caughtFruit = createCaughtFruit(fruit);
 
                 if (caughtFruit == null) return;
 
@@ -126,6 +123,18 @@ namespace osu.Game.Rulesets.Catch.UI
                 MovableCatcher.X = state.CatcherX.Value;
 
             comboDisplay.X = MovableCatcher.X;
+        }
+
+        private DrawableCatchHitObject createCaughtFruit(DrawablePalpableCatchHitObject hitObject)
+        {
+            return hitObject.HitObject switch
+            {
+                Banana banana => new DrawableBanana(banana),
+                Fruit fruit => new DrawableFruit(fruit),
+                TinyDroplet tiny => new DrawableTinyDroplet(tiny),
+                Droplet droplet => new DrawableDroplet(droplet),
+                _ => null
+            };
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
@@ -44,9 +44,6 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             switch (h)
             {
-                case JuiceStream stream:
-                    return new DrawableJuiceStream(stream, CreateDrawableRepresentation);
-
                 case BananaShower shower:
                     return new DrawableBananaShower(shower, CreateDrawableRepresentation);
             }

--- a/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
@@ -55,12 +55,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 case BananaShower shower:
                     return new DrawableBananaShower(shower, CreateDrawableRepresentation);
-
-                case TinyDroplet tiny:
-                    return new DrawableTinyDroplet(tiny);
-
-                case Droplet droplet:
-                    return new DrawableDroplet(droplet);
             }
 
             return null;

--- a/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
@@ -8,7 +8,6 @@ using osu.Game.Configuration;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Catch.Objects;
-using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -40,15 +39,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
         protected override PassThroughInputManager CreateInputManager() => new CatchInputManager(Ruleset.RulesetInfo);
 
-        public override DrawableHitObject<CatchHitObject> CreateDrawableRepresentation(CatchHitObject h)
-        {
-            switch (h)
-            {
-                case BananaShower shower:
-                    return new DrawableBananaShower(shower, CreateDrawableRepresentation);
-            }
-
-            return null;
-        }
+        public override DrawableHitObject<CatchHitObject> CreateDrawableRepresentation(CatchHitObject h) => null;
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
@@ -44,12 +44,6 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             switch (h)
             {
-                case Banana banana:
-                    return new DrawableBanana(banana);
-
-                case Fruit fruit:
-                    return new DrawableFruit(fruit);
-
                 case JuiceStream stream:
                     return new DrawableJuiceStream(stream, CreateDrawableRepresentation);
 

--- a/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.IO.Stores;
+using osu.Game.Rulesets;
+using osu.Game.Skinning;
+
+namespace osu.Game.Tests.Visual
+{
+    [TestFixture]
+    public abstract class LegacySkinPlayerTestScene : PlayerTestScene
+    {
+        private ISkinSource legacySkinSource;
+
+        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new SkinProvidingPlayer(legacySkinSource);
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio, OsuGameBase game)
+        {
+            var legacySkin = new DefaultLegacySkin(new NamespacedResourceStore<byte[]>(game.Resources, "Skins/Legacy"), audio);
+            legacySkinSource = new SkinProvidingContainer(legacySkin);
+        }
+
+        public class SkinProvidingPlayer : TestPlayer
+        {
+            [Cached(typeof(ISkinSource))]
+            private readonly ISkinSource skinSource;
+
+            public SkinProvidingPlayer(ISkinSource skinSource)
+            {
+                this.skinSource = skinSource;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the initial implementation of hit object pooling in osu!catch. All hit objects, `Palpable` or not, nested or not, are pooled through the pool in the `CatchPlayfield`, and recycled for multiple hit objects.

The idea of hit object pooling is because only a small number of `DrawableHitObject`s (DHO for short) are alive (i.e. on-screen) compared to the total number of `HitObject` (HO for short) in a beatmap, recycling a DHO for multiple HO will reduce allocation and initialization time.

The loading time and memory usage is greatly reduced by this PR. I roughly tested on this beatmap <https://osu.ppy.sh/beatmapsets/1023806#fruits/2141652>, and I got:

- Before: 5s loading time, 1.3G memory.
- After: 1s loading time, 675M memory.

The difficulty of the hit object pooling is a DHO has to react to changes of HO. This reactivity is usually implemented using `Bindable`s. In-place changes are preferred to reduce allocation.

### What is not implemented?

- A `DrawableFruit` currently recreates either `FruitPiece` or `LegacyFruitPiece` when the DHO is recycled to a different hit object. To remove this allocation,
  - For `FruitPice`: I have a draft of pooling `Pulp` #11007. But the PR has still unsolved issues.
  - For `LegacyFruitPiece`: I think we should replace `Texture` in-place, but where to store the textures?
- Currently, when a hit object is caught, a new DHO is created from the hit object and placed on the plate.
  - A plan is to use non-DHO `Drawable`s for the objects on the plate (using `FruitPiece` etc.).
  - Then, the caught objects should be pooled separately.

`TestSceneCatchPlayerLegacySkin` is added because legacy skin takes a different code path and I had a bug in `LegacyFruitPiece`.