### PR TITLE
Fix current beatmap temporarily becoming empty during ruleset change

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -644,6 +644,54 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestChangingRulesetOnMultiRulesetBeatmap()
+        {
+            int changeCount = 0;
+
+            AddStep("change convert setting", () => config.Set(OsuSetting.ShowConvertedBeatmaps, false));
+            AddStep("bind beatmap changed", () =>
+            {
+                Beatmap.ValueChanged += onChange;
+                changeCount = 0;
+            });
+
+            changeRuleset(0);
+
+            createSongSelect();
+
+            AddStep("import multi-ruleset map", () =>
+            {
+                var usableRulesets = rulesets.AvailableRulesets.Where(r => r.ID != 2).ToArray();
+                manager.Import(createTestBeatmapSet(usableRulesets)).Wait();
+            });
+
+            int previousSetID = 0;
+
+            AddUntilStep("wait for selection", () => !Beatmap.IsDefault);
+
+            AddStep("record set ID", () => previousSetID = Beatmap.Value.BeatmapSetInfo.ID);
+            AddAssert("selection changed once", () => changeCount == 1);
+
+            AddAssert("Check ruleset is osu!", () => Ruleset.Value.ID == 0);
+
+            changeRuleset(3);
+
+            AddUntilStep("Check ruleset changed to mania", () => Ruleset.Value.ID == 3);
+
+            AddUntilStep("selection changed", () => changeCount > 1);
+
+            AddAssert("Selected beatmap still same set", () => Beatmap.Value.BeatmapSetInfo.ID == previousSetID);
+            AddAssert("Selected beatmap is mania", () => Beatmap.Value.BeatmapInfo.Ruleset.ID == 3);
+
+            AddAssert("selection changed only fired twice", () => changeCount == 2);
+
+            AddStep("unbind beatmap changed", () => Beatmap.ValueChanged -= onChange);
+            AddStep("change convert setting", () => config.Set(OsuSetting.ShowConvertedBeatmaps, true));
+
+            void onChange(ValueChangedEvent<WorkingBeatmap> valueChangedEvent) => changeCount++;
+        }
+
+        [Test]
         public void TestDifficultyIconSelectingForDifferentRuleset()
         {
             changeRuleset(0);

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -688,6 +688,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("unbind beatmap changed", () => Beatmap.ValueChanged -= onChange);
             AddStep("change convert setting", () => config.Set(OsuSetting.ShowConvertedBeatmaps, true));
 
+            // ReSharper disable once AccessToModifiedClosure
             void onChange(ValueChangedEvent<WorkingBeatmap> valueChangedEvent) => changeCount++;
         }
 


### PR DESCRIPTION
When changing the ruleset at song select, there was a scenario where it would be set to default (empty) for one debounce length where this was not actually required. This occurs when the currently selected beatmap set has other difficulties which match the target ruleset, specifically. 

Closes https://github.com/ppy/osu/issues/10987
