### PR TITLE
Fix slider control point dragging not correctly accounting for drag deadzone

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -143,6 +143,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         protected override bool OnClick(ClickEvent e) => RequestSelection != null;
 
+        private Vector2 dragStartPosition;
+
         protected override bool OnDragStart(DragStartEvent e)
         {
             if (RequestSelection == null)
@@ -150,6 +152,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
             if (e.Button == MouseButton.Left)
             {
+                dragStartPosition = ControlPoint.Position.Value;
                 changeHandler?.BeginChange();
                 return true;
             }
@@ -174,7 +177,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     slider.Path.ControlPoints[i].Position.Value -= movementDelta;
             }
             else
-                ControlPoint.Position.Value += e.Delta;
+                ControlPoint.Position.Value = dragStartPosition + (e.MousePosition - e.MouseDownPosition);
         }
 
         protected override void OnDragEnd(DragEndEvent e) => changeHandler?.EndChange();


### PR DESCRIPTION
Before:
![2020-12-01 13 49 42](https://user-images.githubusercontent.com/191335/100698550-18649a00-33dc-11eb-9c7a-a05de5b5e294.gif)

After:
![2020-12-01 13 48 04](https://user-images.githubusercontent.com/191335/100698475-dfc4c080-33db-11eb-90fd-2454dfbb1cbd.gif)
