### PR TITLE
Hide slider body immediately on successful hit when snaking is enabled

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -295,7 +295,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 case ArmedState.Hit:
                     Ball.ScaleTo(HitObject.Scale * 1.4f, fade_out_time, Easing.Out);
                     if (sliderBody?.SnakingOut.Value == true)
-                        Body.FadeOut();
+                        Body.FadeOut(40); // short fade to allow for any body colour to smoothly disappear.
                     break;
             }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -294,6 +294,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 case ArmedState.Hit:
                     Ball.ScaleTo(HitObject.Scale * 1.4f, fade_out_time, Easing.Out);
+                    if (sliderBody?.SnakingOut.Value == true)
+                        Body.FadeOut();
                     break;
             }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -300,8 +300,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             this.FadeOut(fade_out_time, Easing.OutQuint).Expire();
         }
 
-        public Drawable ProxiedLayer => HeadCircle.ProxiedLayer;
-
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => sliderBody?.ReceivePositionalInputAt(screenSpacePos) ?? base.ReceivePositionalInputAt(screenSpacePos);
 
         private class DefaultSliderBody : PlaySliderBody


### PR DESCRIPTION
This is something that has been bothering me for a while now.

Note that this currently plays on both hit and miss. Will be fixed in a coming PR. It also only applies when (end) snaking is disabled, to maintain classic behaviour.

## Before (note the remaining body behind the explosion, making it look like one circle got forgotten about):

![2020-12-01 15 13 10](https://user-images.githubusercontent.com/191335/100703909-dfcabd80-33e7-11eb-8ced-184160d222e9.gif)

![2020-12-01 15 14 48](https://user-images.githubusercontent.com/191335/100703992-0688f400-33e8-11eb-8dce-e9779b9f8855.gif)

## After:

![2020-12-01 15 16 34](https://user-images.githubusercontent.com/191335/100704091-3a641980-33e8-11eb-989c-37e52a6124f5.gif)

![2020-12-01 15 16 59](https://user-images.githubusercontent.com/191335/100704135-510a7080-33e8-11eb-9928-208d11159db2.gif)

