### PR TITLE
Fix sliders playing hit animations when completely missed

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -255,7 +255,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (userTriggered || Time.Current < HitObject.EndTime)
                 return;
 
-            ApplyResult(r => r.Type = r.Judgement.MaxResult);
+            ApplyResult(r => r.Type = NestedHitObjects.Any(h => h.Result.IsHit) ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         public override void PlaySamples()


### PR DESCRIPTION
Fixes slider ball exploding when missing every tick (and head and tail) of a slider. Now it will only play if at least one of these was hit. Also applies to newly added body fade animation in #11028.

(Optionally, this could be tied directly to hitting the tail, but the implementation in this PR matches how stable handles it so probably saner for now?)