### PR TITLE
Fix timeline not updating ticks correctly after arbitrary timing control point changes

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private BindableBeatDivisor beatDivisor { get; set; }
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
         private IEditorChangeHandler changeHandler { get; set; }
 
         [Resolved]
@@ -43,8 +43,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             beatDivisor.BindValueChanged(_ => invalidateTicks());
 
-            // currently this is the best way to handle any kind of timing changes.
-            changeHandler.OnStateChange += invalidateTicks;
+            if (changeHandler != null)
+                // currently this is the best way to handle any kind of timing changes.
+                changeHandler.OnStateChange += invalidateTicks;
         }
 
         private void invalidateTicks()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private BindableBeatDivisor beatDivisor { get; set; }
 
         [Resolved]
+        private IEditorChangeHandler changeHandler { get; set; }
+
+        [Resolved]
         private OsuColour colours { get; set; }
 
         public TimelineTickDisplay()
@@ -38,7 +41,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [BackgroundDependencyLoader]
         private void load()
         {
-            beatDivisor.BindValueChanged(_ => tickCache.Invalidate());
+            beatDivisor.BindValueChanged(_ => invalidateTicks());
+
+            // currently this is the best way to handle any kind of timing changes.
+            changeHandler.OnStateChange += invalidateTicks;
+        }
+
+        private void invalidateTicks()
+        {
+            tickCache.Invalidate();
         }
 
         /// <summary>
@@ -164,6 +175,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 return point;
             }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (changeHandler != null)
+                changeHandler.OnStateChange -= invalidateTicks;
         }
     }
 }


### PR DESCRIPTION
Done using change handler as we don't yet have an easy way of monitoring `ControlPointInfo` for all changes (without bindings on three or four levels).