### PR TITLE
Make HitSampleInfo immutable

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                     NewCombo = i % 8 == 0,
                     Samples = new List<HitSampleInfo>(new[]
                     {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "normal")
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "normal", volume: 100)
                     })
                 });
             }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                     NewCombo = i % 8 == 0,
                     Samples = new List<HitSampleInfo>(new[]
                     {
-                        new HitSampleInfo { Bank = "normal", Name = "hitnormal", Volume = 100 }
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "normal")
                     })
                 });
             }

--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Rulesets.Catch.Objects
             private static string[] lookupNames { get; } = { "metronomelow", "catch-banana" };
 
             public override IEnumerable<string> LookupNames => lookupNames;
+
+            public BananaHitSampleInfo()
+                : base(string.Empty)
+            {
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.Catch.Objects
                 => other != null;
 
             public override bool Equals(object obj)
-                => Equals((BananaHitSampleInfo)obj);
+                => obj is BananaHitSampleInfo other && Equals(other);
 
             public override int GetHashCode() => lookup_names.GetHashCode();
         }

--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Utils;
 using osu.Game.Audio;
@@ -50,16 +51,24 @@ namespace osu.Game.Rulesets.Catch.Objects
             }
         }
 
-        private class BananaHitSampleInfo : HitSampleInfo
+        private class BananaHitSampleInfo : HitSampleInfo, IEquatable<BananaHitSampleInfo>
         {
-            private static string[] lookupNames { get; } = { "metronomelow", "catch-banana" };
+            private static readonly string[] lookup_names = { "metronomelow", "catch-banana" };
 
-            public override IEnumerable<string> LookupNames => lookupNames;
+            public override IEnumerable<string> LookupNames => lookup_names;
 
             public BananaHitSampleInfo()
                 : base(string.Empty)
             {
             }
+
+            public bool Equals(BananaHitSampleInfo other)
+                => other != null;
+
+            public override bool Equals(object obj)
+                => Equals((BananaHitSampleInfo)obj);
+
+            public override int GetHashCode() => lookup_names.GetHashCode();
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -50,12 +50,7 @@ namespace osu.Game.Rulesets.Catch.Objects
         {
             base.CreateNestedHitObjects(cancellationToken);
 
-            var dropletSamples = Samples.Select(s => new HitSampleInfo
-            {
-                Bank = s.Bank,
-                Name = @"slidertick",
-                Volume = s.Volume
-            }).ToList();
+            var dropletSamples = Samples.Select(s => s.With(@"slidertick")).ToList();
 
             int nodeIndex = 0;
             SliderEventDescriptor? lastEvent = null;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -108,8 +108,8 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddStep("change samples", () => slider.HitObject.Samples = new[]
             {
-                new HitSampleInfo { Name = HitSampleInfo.HIT_CLAP },
-                new HitSampleInfo { Name = HitSampleInfo.HIT_WHISTLE },
+                new HitSampleInfo(HitSampleInfo.HIT_CLAP),
+                new HitSampleInfo(HitSampleInfo.HIT_WHISTLE),
             });
 
             AddAssert("head samples updated", () => assertSamples(slider.HitObject.HeadCircle));
@@ -136,15 +136,15 @@ namespace osu.Game.Rulesets.Osu.Tests
                 slider = (DrawableSlider)createSlider(repeats: 1);
 
                 for (int i = 0; i < 2; i++)
-                    slider.HitObject.NodeSamples.Add(new List<HitSampleInfo> { new HitSampleInfo { Name = HitSampleInfo.HIT_FINISH } });
+                    slider.HitObject.NodeSamples.Add(new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_FINISH) });
 
                 Add(slider);
             });
 
             AddStep("change samples", () => slider.HitObject.Samples = new[]
             {
-                new HitSampleInfo { Name = HitSampleInfo.HIT_CLAP },
-                new HitSampleInfo { Name = HitSampleInfo.HIT_WHISTLE },
+                new HitSampleInfo(HitSampleInfo.HIT_CLAP),
+                new HitSampleInfo(HitSampleInfo.HIT_WHISTLE),
             });
 
             AddAssert("head samples not updated", () => assertSamples(slider.HitObject.HeadCircle));

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -115,8 +115,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (firstSample != null)
             {
-                var clone = HitObject.SampleControlPoint.ApplyTo(firstSample);
-                clone.Name = "sliderslide";
+                var clone = HitObject.SampleControlPoint.ApplyTo(firstSample).With("sliderslide");
 
                 samplesContainer.Add(slidingSample = new PausableSkinnableSound(clone)
                 {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -110,8 +110,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (firstSample != null)
             {
-                var clone = HitObject.SampleControlPoint.ApplyTo(firstSample);
-                clone.Name = "spinnerspin";
+                var clone = HitObject.SampleControlPoint.ApplyTo(firstSample).With("spinnerspin");
 
                 samplesContainer.Add(spinningSample = new PausableSkinnableSound(clone)
                 {

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -221,14 +221,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             var sampleList = new List<HitSampleInfo>();
 
             if (firstSample != null)
-            {
-                sampleList.Add(new HitSampleInfo
-                {
-                    Bank = firstSample.Bank,
-                    Volume = firstSample.Volume,
-                    Name = @"slidertick",
-                });
-            }
+                sampleList.Add(firstSample.With("slidertick"));
 
             foreach (var tick in NestedHitObjects.OfType<SliderTick>())
                 tick.Samples = sampleList;

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerBonusTick.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Osu.Objects
     {
         public SpinnerBonusTick()
         {
-            Samples.Add(new HitSampleInfo { Name = "spinnerbonus" });
+            Samples.Add(new HitSampleInfo("spinnerbonus"));
         }
 
         public override Judgement CreateJudgement() => new OsuSpinnerBonusTickJudgement();

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (isRimType != rimSamples.Any())
             {
                 if (isRimType)
-                    HitObject.Samples.Add(new HitSampleInfo { Name = HitSampleInfo.HIT_CLAP });
+                    HitObject.Samples.Add(new HitSampleInfo(HitSampleInfo.HIT_CLAP));
                 else
                 {
                     foreach (var sample in rimSamples)
@@ -125,9 +125,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     if (s.Name != HitSampleInfo.HIT_FINISH)
                         continue;
 
-                    var sClone = s.Clone();
-                    sClone.Name = HitSampleInfo.HIT_WHISTLE;
-                    corrected[i] = sClone;
+                    corrected[i] = s.With(HitSampleInfo.HIT_WHISTLE);
                 }
 
                 return corrected;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (isStrong.Value != strongSamples.Any())
             {
                 if (isStrong.Value)
-                    HitObject.Samples.Add(new HitSampleInfo { Name = HitSampleInfo.HIT_FINISH });
+                    HitObject.Samples.Add(new HitSampleInfo(HitSampleInfo.HIT_FINISH));
                 else
                 {
                     foreach (var sample in strongSamples)

--- a/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
+++ b/osu.Game.Tests/Editing/LegacyEditorBeatmapPatcherTest.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Tests.Editing
                 HitObjects =
                 {
                     (OsuHitObject)current.HitObjects[0],
-                    new HitCircle { StartTime = 2000, Samples = { new HitSampleInfo { Name = HitSampleInfo.HIT_FINISH } } },
+                    new HitCircle { StartTime = 2000, Samples = { new HitSampleInfo(HitSampleInfo.HIT_FINISH) } },
                     (OsuHitObject)current.HitObjects[2],
                 }
             };
@@ -268,12 +268,12 @@ namespace osu.Game.Tests.Editing
                 HitObjects =
                 {
                     (OsuHitObject)current.HitObjects[0],
-                    new HitCircle { StartTime = 1000, Samples = { new HitSampleInfo { Name = HitSampleInfo.HIT_FINISH } } },
+                    new HitCircle { StartTime = 1000, Samples = { new HitSampleInfo(HitSampleInfo.HIT_FINISH) } },
                     (OsuHitObject)current.HitObjects[2],
                     (OsuHitObject)current.HitObjects[3],
-                    new HitCircle { StartTime = 2250, Samples = { new HitSampleInfo { Name = HitSampleInfo.HIT_WHISTLE } } },
+                    new HitCircle { StartTime = 2250, Samples = { new HitSampleInfo(HitSampleInfo.HIT_WHISTLE) } },
                     (OsuHitObject)current.HitObjects[5],
-                    new HitCircle { StartTime = 3000, Samples = { new HitSampleInfo { Name = HitSampleInfo.HIT_CLAP } } },
+                    new HitCircle { StartTime = 3000, Samples = { new HitSampleInfo(HitSampleInfo.HIT_CLAP) } },
                     (OsuHitObject)current.HitObjects[7],
                 }
             };

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Audio
             => other != null && Name == other.Name && Bank == other.Bank && Suffix == other.Suffix;
 
         public override bool Equals(object? obj)
-            => Equals((HitSampleInfo?)obj);
+            => obj is HitSampleInfo other && Equals(other);
 
         public override int GetHashCode() => HashCode.Combine(Name, Bank, Suffix);
     }

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -72,13 +72,13 @@ namespace osu.Game.Audio
         /// <summary>
         /// Creates a new <see cref="HitSampleInfo"/> with overridden values.
         /// </summary>
-        /// <param name="name">An optional new sample name.</param>
-        /// <param name="bank">An optional new sample bank.</param>
-        /// <param name="suffix">An optional new lookup suffix.</param>
-        /// <param name="volume">An optional new volume.</param>
+        /// <param name="newName">An optional new sample name.</param>
+        /// <param name="newBank">An optional new sample bank.</param>
+        /// <param name="newSuffix">An optional new lookup suffix.</param>
+        /// <param name="newVolume">An optional new volume.</param>
         /// <returns>The new <see cref="HitSampleInfo"/>.</returns>
-        public virtual HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
-            => new HitSampleInfo(name.GetOr(Name), bank.GetOr(Bank), suffix.GetOr(Suffix), volume.GetOr(Volume));
+        public virtual HitSampleInfo With(Optional<string> newName = default, Optional<string?> newBank = default, Optional<string?> newSuffix = default, Optional<int> newVolume = default)
+            => new HitSampleInfo(newName.GetOr(Name), newBank.GetOr(Bank), newSuffix.GetOr(Suffix), newVolume.GetOr(Volume));
 
         public bool Equals(HitSampleInfo? other)
             => other != null && Name == other.Name && Bank == other.Bank && Suffix == other.Suffix;

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using osu.Game.Utils;
 
 namespace osu.Game.Audio
 {
@@ -23,24 +26,32 @@ namespace osu.Game.Audio
         public static IEnumerable<string> AllAdditions => new[] { HIT_WHISTLE, HIT_CLAP, HIT_FINISH };
 
         /// <summary>
-        /// The bank to load the sample from.
-        /// </summary>
-        public string Bank;
-
-        /// <summary>
         /// The name of the sample to load.
         /// </summary>
-        public string Name;
+        public readonly string Name;
+
+        /// <summary>
+        /// The bank to load the sample from.
+        /// </summary>
+        public readonly string? Bank;
 
         /// <summary>
         /// An optional suffix to provide priority lookup. Falls back to non-suffixed <see cref="Name"/>.
         /// </summary>
-        public string Suffix;
+        public readonly string? Suffix;
 
         /// <summary>
         /// The sample volume.
         /// </summary>
-        public int Volume { get; set; }
+        public int Volume { get; }
+
+        public HitSampleInfo(string name, string? bank = null, string? suffix = null, int volume = 100)
+        {
+            Name = name;
+            Bank = bank;
+            Suffix = suffix;
+            Volume = volume;
+        }
 
         /// <summary>
         /// Retrieve all possible filenames that can be used as a source, returned in order of preference (highest first).
@@ -56,6 +67,15 @@ namespace osu.Game.Audio
             }
         }
 
-        public HitSampleInfo Clone() => (HitSampleInfo)MemberwiseClone();
+        /// <summary>
+        /// Creates a new <see cref="HitSampleInfo"/> with overridden values.
+        /// </summary>
+        /// <param name="name">An optional new sample name.</param>
+        /// <param name="bank">An optional new sample bank.</param>
+        /// <param name="suffix">An optional new lookup suffix.</param>
+        /// <param name="volume">An optional new volume.</param>
+        /// <returns>The new <see cref="HitSampleInfo"/>.</returns>
+        public virtual HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
+            => new HitSampleInfo(name.GetOr(Name), bank.GetOr(Bank), suffix.GetOr(Suffix), volume.GetOr(Volume));
     }
 }

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Audio
         /// <summary>
         /// Retrieve all possible filenames that can be used as a source, returned in order of preference (highest first).
         /// </summary>
+        [JsonIgnore]
         public virtual IEnumerable<string> LookupNames
         {
             get

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Audio
     /// Describes a gameplay hit sample.
     /// </summary>
     [Serializable]
-    public class HitSampleInfo : ISampleInfo
+    public class HitSampleInfo : ISampleInfo, IEquatable<HitSampleInfo>
     {
         public const string HIT_WHISTLE = @"hitwhistle";
         public const string HIT_FINISH = @"hitfinish";
@@ -77,5 +77,13 @@ namespace osu.Game.Audio
         /// <returns>The new <see cref="HitSampleInfo"/>.</returns>
         public virtual HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
             => new HitSampleInfo(name.GetOr(Name), bank.GetOr(Bank), suffix.GetOr(Suffix), volume.GetOr(Volume));
+
+        public bool Equals(HitSampleInfo? other)
+            => other != null && Name == other.Name && Bank == other.Bank && Suffix == other.Suffix;
+
+        public override bool Equals(object? obj)
+            => Equals((HitSampleInfo?)obj);
+
+        public override int GetHashCode() => HashCode.Combine(Name, Bank, Suffix);
     }
 }

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using osu.Game.Utils;
 
 namespace osu.Game.Audio
@@ -45,7 +46,7 @@ namespace osu.Game.Audio
         /// </summary>
         public int Volume { get; }
 
-        public HitSampleInfo(string name, string? bank = null, string? suffix = null, int volume = 100)
+        public HitSampleInfo(string name, string? bank = null, string? suffix = null, int volume = 0)
         {
             Name = name;
             Bank = bank;

--- a/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
@@ -58,12 +58,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         /// <param name="sampleName">The name of the same.</param>
         /// <returns>A populated <see cref="HitSampleInfo"/>.</returns>
-        public HitSampleInfo GetSampleInfo(string sampleName = HitSampleInfo.HIT_NORMAL) => new HitSampleInfo
-        {
-            Bank = SampleBank,
-            Name = sampleName,
-            Volume = SampleVolume,
-        };
+        public HitSampleInfo GetSampleInfo(string sampleName = HitSampleInfo.HIT_NORMAL) => new HitSampleInfo(sampleName, SampleBank, volume: SampleVolume);
 
         /// <summary>
         /// Applies <see cref="SampleBank"/> and <see cref="SampleVolume"/> to a <see cref="HitSampleInfo"/> if necessary, returning the modified <see cref="HitSampleInfo"/>.
@@ -71,12 +66,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// <param name="hitSampleInfo">The <see cref="HitSampleInfo"/>. This will not be modified.</param>
         /// <returns>The modified <see cref="HitSampleInfo"/>. This does not share a reference with <paramref name="hitSampleInfo"/>.</returns>
         public virtual HitSampleInfo ApplyTo(HitSampleInfo hitSampleInfo)
-        {
-            var newSampleInfo = hitSampleInfo.Clone();
-            newSampleInfo.Bank = hitSampleInfo.Bank ?? SampleBank;
-            newSampleInfo.Volume = hitSampleInfo.Volume > 0 ? hitSampleInfo.Volume : SampleVolume;
-            return newSampleInfo;
-        }
+            => hitSampleInfo.With(bank: hitSampleInfo.Bank ?? SampleBank, volume: hitSampleInfo.Volume > 0 ? hitSampleInfo.Volume : SampleVolume);
 
         public override bool IsRedundant(ControlPoint existing)
             => existing is SampleControlPoint existingSample

--- a/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/SampleControlPoint.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// <param name="hitSampleInfo">The <see cref="HitSampleInfo"/>. This will not be modified.</param>
         /// <returns>The modified <see cref="HitSampleInfo"/>. This does not share a reference with <paramref name="hitSampleInfo"/>.</returns>
         public virtual HitSampleInfo ApplyTo(HitSampleInfo hitSampleInfo)
-            => hitSampleInfo.With(bank: hitSampleInfo.Bank ?? SampleBank, volume: hitSampleInfo.Volume > 0 ? hitSampleInfo.Volume : SampleVolume);
+            => hitSampleInfo.With(newBank: hitSampleInfo.Bank ?? SampleBank, newVolume: hitSampleInfo.Volume > 0 ? hitSampleInfo.Volume : SampleVolume);
 
         public override bool IsRedundant(ControlPoint existing)
             => existing is SampleControlPoint existingSample

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -192,7 +192,7 @@ namespace osu.Game.Beatmaps.Formats
                 var effectPoint = beatmap.ControlPointInfo.EffectPointAt(time);
 
                 // Apply the control point to a hit sample to uncover legacy properties (e.g. suffix)
-                HitSampleInfo tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo());
+                HitSampleInfo tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty));
 
                 // Convert effect flags to the legacy format
                 LegacyEffectFlags effectFlags = LegacyEffectFlags.None;

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -182,11 +182,8 @@ namespace osu.Game.Beatmaps.Formats
             {
                 var baseInfo = base.ApplyTo(hitSampleInfo);
 
-                if (baseInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacy
-                    && legacy.CustomSampleBank == 0)
-                {
-                    legacy.CustomSampleBank = CustomSampleBank;
-                }
+                if (baseInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacy && legacy.CustomSampleBank == 0)
+                    return legacy.With(customSampleBank: CustomSampleBank);
 
                 return baseInfo;
             }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -183,7 +183,7 @@ namespace osu.Game.Beatmaps.Formats
                 var baseInfo = base.ApplyTo(hitSampleInfo);
 
                 if (baseInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacy && legacy.CustomSampleBank == 0)
-                    return legacy.With(customSampleBank: CustomSampleBank);
+                    return legacy.With(newCustomSampleBank: CustomSampleBank);
 
                 return baseInfo;
             }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -486,12 +486,12 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 IsLayered = isLayered;
             }
 
-            public sealed override HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
-                => With(name, bank, volume);
+            public sealed override HitSampleInfo With(Optional<string> newName = default, Optional<string?> newBank = default, Optional<string?> newSuffix = default, Optional<int> newVolume = default)
+                => With(newName, newBank, newVolume);
 
-            public virtual LegacyHitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<int> volume = default, Optional<int> customSampleBank = default,
-                                                    Optional<bool> isLayered = default)
-                => new LegacyHitSampleInfo(name.GetOr(Name), bank.GetOr(Bank), volume.GetOr(Volume), customSampleBank.GetOr(CustomSampleBank), isLayered.GetOr(IsLayered));
+            public virtual LegacyHitSampleInfo With(Optional<string> newName = default, Optional<string?> newBank = default, Optional<int> newVolume = default, Optional<int> newCustomSampleBank = default,
+                                                    Optional<bool> newIsLayered = default)
+                => new LegacyHitSampleInfo(newName.GetOr(Name), newBank.GetOr(Bank), newVolume.GetOr(Volume), newCustomSampleBank.GetOr(CustomSampleBank), newIsLayered.GetOr(IsLayered));
 
             public bool Equals(LegacyHitSampleInfo? other)
                 => base.Equals(other) && CustomSampleBank == other.CustomSampleBank && IsLayered == other.IsLayered;
@@ -520,9 +520,9 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 Path.ChangeExtension(Filename, null)
             };
 
-            public sealed override LegacyHitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<int> volume = default, Optional<int> customSampleBank = default,
-                                                            Optional<bool> isLayered = default)
-                => new FileHitSampleInfo(Filename, volume.GetOr(Volume));
+            public sealed override LegacyHitSampleInfo With(Optional<string> newName = default, Optional<string?> newBank = default, Optional<int> newVolume = default, Optional<int> newCustomSampleBank = default,
+                                                            Optional<bool> newIsLayered = default)
+                => new FileHitSampleInfo(Filename, newVolume.GetOr(Volume));
 
             public bool Equals(FileHitSampleInfo? other)
                 => base.Equals(other) && Filename == other.Filename;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -479,7 +479,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             /// </remarks>
             public readonly bool IsLayered;
 
-            public LegacyHitSampleInfo([NotNull] string name, string? bank = null, int volume = 100, int customSampleBank = 0, bool isLayered = false)
+            public LegacyHitSampleInfo(string name, string? bank = null, int volume = 0, int customSampleBank = 0, bool isLayered = false)
                 : base(name, bank, customSampleBank >= 2 ? customSampleBank.ToString() : null, volume)
             {
                 CustomSampleBank = customSampleBank;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -520,10 +520,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             };
 
             public override HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
-                => With(volume: volume);
-
-            public FileHitSampleInfo With(Optional<string> filename = default, Optional<int> volume = default)
-                => new FileHitSampleInfo(filename.GetOr(Filename), volume.GetOr(Volume));
+                => new FileHitSampleInfo(Filename, volume.GetOr(Volume));
 
             public bool Equals(FileHitSampleInfo? other)
                 => base.Equals(other) && Filename == other.Filename;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -496,7 +496,8 @@ namespace osu.Game.Rulesets.Objects.Legacy
             public bool Equals(LegacyHitSampleInfo? other)
                 => base.Equals(other) && CustomSampleBank == other.CustomSampleBank && IsLayered == other.IsLayered;
 
-            public override bool Equals(object? obj) => Equals((LegacyHitSampleInfo?)obj);
+            public override bool Equals(object? obj)
+                => obj is LegacyHitSampleInfo other && Equals(other);
 
             public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), CustomSampleBank, IsLayered);
         }
@@ -526,7 +527,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 => base.Equals(other) && Filename == other.Filename;
 
             public override bool Equals(object? obj)
-                => Equals((FileHitSampleInfo?)obj);
+                => obj is FileHitSampleInfo other && Equals(other);
 
             public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Filename);
         }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -466,7 +466,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
 #nullable enable
 
-        public class LegacyHitSampleInfo : HitSampleInfo
+        public class LegacyHitSampleInfo : HitSampleInfo, IEquatable<LegacyHitSampleInfo>
         {
             public readonly int CustomSampleBank;
 
@@ -492,9 +492,16 @@ namespace osu.Game.Rulesets.Objects.Legacy
             public LegacyHitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<int> volume = default, Optional<int> customSampleBank = default,
                                             Optional<bool> isLayered = default)
                 => new LegacyHitSampleInfo(name.GetOr(Name), bank.GetOr(Bank), volume.GetOr(Volume), customSampleBank.GetOr(CustomSampleBank), isLayered.GetOr(IsLayered));
+
+            public bool Equals(LegacyHitSampleInfo? other)
+                => base.Equals(other) && CustomSampleBank == other.CustomSampleBank && IsLayered == other.IsLayered;
+
+            public override bool Equals(object? obj) => Equals((LegacyHitSampleInfo?)obj);
+
+            public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), CustomSampleBank, IsLayered);
         }
 
-        private class FileHitSampleInfo : LegacyHitSampleInfo
+        private class FileHitSampleInfo : LegacyHitSampleInfo, IEquatable<FileHitSampleInfo>
         {
             public readonly string Filename;
 
@@ -517,6 +524,14 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             public FileHitSampleInfo With(Optional<string> filename = default, Optional<int> volume = default)
                 => new FileHitSampleInfo(filename.GetOr(Filename), volume.GetOr(Volume));
+
+            public bool Equals(FileHitSampleInfo? other)
+                => base.Equals(other) && Filename == other.Filename;
+
+            public override bool Equals(object? obj)
+                => Equals((FileHitSampleInfo?)obj);
+
+            public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Filename);
         }
 
 #nullable disable

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -486,11 +486,11 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 IsLayered = isLayered;
             }
 
-            public override HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
+            public sealed override HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
                 => With(name, bank, volume);
 
-            public LegacyHitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<int> volume = default, Optional<int> customSampleBank = default,
-                                            Optional<bool> isLayered = default)
+            public virtual LegacyHitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<int> volume = default, Optional<int> customSampleBank = default,
+                                                    Optional<bool> isLayered = default)
                 => new LegacyHitSampleInfo(name.GetOr(Name), bank.GetOr(Bank), volume.GetOr(Volume), customSampleBank.GetOr(CustomSampleBank), isLayered.GetOr(IsLayered));
 
             public bool Equals(LegacyHitSampleInfo? other)
@@ -520,7 +520,8 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 Path.ChangeExtension(Filename, null)
             };
 
-            public override HitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<string?> suffix = default, Optional<int> volume = default)
+            public sealed override LegacyHitSampleInfo With(Optional<string> name = default, Optional<string?> bank = default, Optional<int> volume = default, Optional<int> customSampleBank = default,
+                                                            Optional<bool> isLayered = default)
                 => new FileHitSampleInfo(Filename, volume.GetOr(Volume));
 
             public bool Equals(FileHitSampleInfo? other)

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                 case TernaryState.True:
                     if (existingSample == null)
-                        samples.Add(new HitSampleInfo { Name = sampleName });
+                        samples.Add(new HitSampleInfo(sampleName));
                     break;
             }
         }
@@ -212,7 +212,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (blueprint != null)
             {
                 // doing this post-creations as adding the default hit sample should be the case regardless of the ruleset.
-                blueprint.HitObject.Samples.Add(new HitSampleInfo { Name = HitSampleInfo.HIT_NORMAL });
+                blueprint.HitObject.Samples.Add(new HitSampleInfo(HitSampleInfo.HIT_NORMAL));
 
                 placementBlueprintContainer.Child = currentPlacement = blueprint;
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -328,7 +328,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (h.Samples.Any(s => s.Name == sampleName))
                     continue;
 
-                h.Samples.Add(new HitSampleInfo { Name = sampleName });
+                h.Samples.Add(new HitSampleInfo(sampleName));
             }
 
             EditorBeatmap.EndChange();

--- a/osu.Game/Utils/Optional.cs
+++ b/osu.Game/Utils/Optional.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+namespace osu.Game.Utils
+{
+    /// <summary>
+    /// A wrapper over a value and a boolean denoting whether the value is valid.
+    /// </summary>
+    /// <typeparam name="T">The type of value stored.</typeparam>
+    public readonly ref struct Optional<T>
+    {
+        /// <summary>
+        /// The stored value.
+        /// </summary>
+        public readonly T Value;
+
+        /// <summary>
+        /// Whether <see cref="Value"/> is valid.
+        /// </summary>
+        /// <remarks>
+        /// If <typeparamref name="T"/> is a reference type, <c>null</c> may be valid for <see cref="Value"/>.
+        /// </remarks>
+        public readonly bool HasValue;
+
+        private Optional(T value)
+        {
+            Value = value;
+            HasValue = true;
+        }
+
+        /// <summary>
+        /// Returns <see cref="Value"/> if it's valid, or a given fallback value otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Shortcase for: <c>optional.HasValue ? optional.Value : fallback</c>.
+        /// </remarks>
+        /// <param name="fallback">The fallback value to return if <see cref="HasValue"/> is <c>false</c>.</param>
+        /// <returns></returns>
+        public T GetOr(T fallback) => HasValue ? Value : fallback;
+
+        public static implicit operator Optional<T>(T value) => new Optional<T>(value);
+    }
+}


### PR DESCRIPTION
I'm a little bit hesitant to PR this, but I want to hear your thoughts.

In https://github.com/ppy/osu/pull/10905, I had to add inspection disables to `GetHashCode()` implementations because they reference mutable properties (`Name`, `Bank`,  etc). With the editor, I think having mutable samples is also pretty unsafe as it means we can't respond to changes unless we make their properties into bindables which in turn blows the complexity of hitsamples out of proportion.

Both of the above point towards making `HitSampleInfo` (and its derivatives) immutable. Ideally I'd also like to make them structs, but that's not possible due to `LookupNames` overrides. The usage then becomes similar to that of `FontUsage` - ctor params + `With()` method to return a new instance with any overridden properties.

One distinction between this and `FontUsage` is the usage of the new `Optional` struct, because I think we may want to do something like `sample.With(bank: null)` in the future. I believe we may want this in o!f itself for places like `FontUsage`, so if the direction of this PR is okay, I can move that struct to o!f.

I think when we update to C# 9 in the future, [records](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/records) may be usable to simplify the implementation, which have their own `with` syntax, although this syntax doesn't seem well supported in Rider EAP either.

# Breaking Changes

## `HitSampleInfo` has been made immutable

* Use constructor arguments instead of object initialisers.
* To change a property, use `sample.With(...)` (returns a new instance).
* If overridden, make sure to implement `IEquatable` and also override `With()`.