### PR TITLE
Add playlist length to match settings overlay

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Online.API.Requests.Responses
                 StarDifficulty = starDifficulty,
                 OnlineBeatmapID = OnlineBeatmapID,
                 Version = version,
+                // this is actually an incorrect mapping (Length is calculated as drain length in lazer's import process, see BeatmapManager.calculateLength).
                 Length = TimeSpan.FromSeconds(length).TotalMilliseconds,
                 Status = Status,
                 BeatmapSet = set,

--- a/osu.Game/Online/Multiplayer/PlaylistExtensions.cs
+++ b/osu.Game/Online/Multiplayer/PlaylistExtensions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using Humanizer;
+using Humanizer.Localisation;
+using osu.Framework.Bindables;
+
+namespace osu.Game.Online.Multiplayer
+{
+    public static class PlaylistExtensions
+    {
+        public static string GetTotalDuration(this BindableList<PlaylistItem> playlist) =>
+            playlist.Select(p => p.Beatmap.Value.Length).Sum().Milliseconds().Humanize(minUnit: TimeUnit.Second, maxUnit: TimeUnit.Hour, precision: 2);
+    }
+}

--- a/osu.Game/Screens/Multi/Components/OverlinedPlaylistHeader.cs
+++ b/osu.Game/Screens/Multi/Components/OverlinedPlaylistHeader.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Multi.Components
         {
             base.LoadComplete();
 
-            Playlist.BindCollectionChanged((_, __) => Details.Value = Playlist.GetTotalDuration());
+            Playlist.BindCollectionChanged((_, __) => Details.Value = Playlist.GetTotalDuration(), true);
         }
     }
 }

--- a/osu.Game/Screens/Multi/Components/OverlinedPlaylistHeader.cs
+++ b/osu.Game/Screens/Multi/Components/OverlinedPlaylistHeader.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.Multiplayer;
+
+namespace osu.Game.Screens.Multi.Components
+{
+    public class OverlinedPlaylistHeader : OverlinedHeader
+    {
+        public OverlinedPlaylistHeader()
+            : base("Playlist")
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Playlist.BindCollectionChanged((_, __) => Details.Value = Playlist.GetTotalDuration());
+        }
+    }
+}

--- a/osu.Game/Screens/Multi/Lounge/Components/RoomInspector.cs
+++ b/osu.Game/Screens/Multi/Lounge/Components/RoomInspector.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Multi.Lounge.Components
                                     }
                                 }
                             },
-                            new Drawable[] { new OverlinedHeader("Playlist"), },
+                            new Drawable[] { new OverlinedPlaylistHeader(), },
                             new Drawable[]
                             {
                                 new DrawableRoomPlaylist(false, false)

--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -2,7 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Specialized;
+using System.Linq;
 using Humanizer;
+using Humanizer.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -69,6 +72,7 @@ namespace osu.Game.Screens.Multi.Match.Components
             private OsuSpriteText typeLabel;
             private LoadingLayer loadingLayer;
             private DrawableRoomPlaylist playlist;
+            private OsuSpriteText playlistLength;
 
             [Resolved(CanBeNull = true)]
             private IRoomManager manager { get; set; }
@@ -230,6 +234,15 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                                             },
                                                                             new Drawable[]
                                                                             {
+                                                                                playlistLength = new OsuSpriteText
+                                                                                {
+                                                                                    Margin = new MarginPadding { Vertical = 5 },
+                                                                                    Colour = colours.Yellow,
+                                                                                    Font = OsuFont.GetFont(size: 12),
+                                                                                }
+                                                                            },
+                                                                            new Drawable[]
+                                                                            {
                                                                                 new PurpleTriangleButton
                                                                                 {
                                                                                     RelativeSizeAxes = Axes.X,
@@ -242,6 +255,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                                         RowDimensions = new[]
                                                                         {
                                                                             new Dimension(),
+                                                                            new Dimension(GridSizeMode.AutoSize),
                                                                             new Dimension(GridSizeMode.AutoSize),
                                                                         }
                                                                     }
@@ -315,6 +329,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                 Duration.BindValueChanged(duration => DurationField.Current.Value = duration.NewValue, true);
 
                 playlist.Items.BindTo(Playlist);
+                Playlist.BindCollectionChanged(onPlaylistChanged, true);
             }
 
             protected override void Update()
@@ -322,6 +337,12 @@ namespace osu.Game.Screens.Multi.Match.Components
                 base.Update();
 
                 ApplyButton.Enabled.Value = hasValidSettings;
+            }
+
+            private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e)
+            {
+                double totalLength = Playlist.Select(p => p.Beatmap.Value.Length).Sum();
+                playlistLength.Text = $"Length: {totalLength.Milliseconds().Humanize(minUnit: TimeUnit.Second, maxUnit: TimeUnit.Hour, precision: 2)}";
             }
 
             private bool hasValidSettings => RoomID.Value == null && NameField.Text.Length > 0 && Playlist.Count > 0;

--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Specialized;
-using System.Linq;
 using Humanizer;
-using Humanizer.Localisation;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -339,11 +337,8 @@ namespace osu.Game.Screens.Multi.Match.Components
                 ApplyButton.Enabled.Value = hasValidSettings;
             }
 
-            private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e)
-            {
-                double totalLength = Playlist.Select(p => p.Beatmap.Value.Length).Sum();
-                playlistLength.Text = $"Length: {totalLength.Milliseconds().Humanize(minUnit: TimeUnit.Second, maxUnit: TimeUnit.Hour, precision: 2)}";
-            }
+            private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e) =>
+                playlistLength.Text = $"Length: {Playlist.GetTotalDuration()}";
 
             private bool hasValidSettings => RoomID.Value == null && NameField.Text.Length > 0 && Playlist.Count > 0;
 

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Screens.Multi.Match
 
         private IBindable<WeakReference<BeatmapSetInfo>> managerUpdated;
         private OverlinedHeader participantsHeader;
+        private OverlinedHeader playlistHeader;
 
         public MatchSubScreen(Room room)
         {
@@ -135,7 +136,7 @@ namespace osu.Game.Screens.Multi.Match
                                                                 RelativeSizeAxes = Axes.Both,
                                                                 Content = new[]
                                                                 {
-                                                                    new Drawable[] { new OverlinedHeader("Playlist"), },
+                                                                    new Drawable[] { playlistHeader = new OverlinedHeader("Playlist"), },
                                                                     new Drawable[]
                                                                     {
                                                                         new DrawableRoomPlaylistWithResults
@@ -243,6 +244,8 @@ namespace osu.Game.Screens.Multi.Match
 
             managerUpdated = beatmapManager.ItemUpdated.GetBoundCopy();
             managerUpdated.BindValueChanged(beatmapUpdated);
+
+            playlist.BindCollectionChanged((_, __) => playlistHeader.Details.Value = playlist.GetTotalDuration(), true);
         }
 
         public override bool OnExiting(IScreen next)

--- a/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/MatchSubScreen.cs
@@ -57,7 +57,6 @@ namespace osu.Game.Screens.Multi.Match
 
         private IBindable<WeakReference<BeatmapSetInfo>> managerUpdated;
         private OverlinedHeader participantsHeader;
-        private OverlinedHeader playlistHeader;
 
         public MatchSubScreen(Room room)
         {
@@ -136,7 +135,7 @@ namespace osu.Game.Screens.Multi.Match
                                                                 RelativeSizeAxes = Axes.Both,
                                                                 Content = new[]
                                                                 {
-                                                                    new Drawable[] { playlistHeader = new OverlinedHeader("Playlist"), },
+                                                                    new Drawable[] { new OverlinedPlaylistHeader(), },
                                                                     new Drawable[]
                                                                     {
                                                                         new DrawableRoomPlaylistWithResults
@@ -244,8 +243,6 @@ namespace osu.Game.Screens.Multi.Match
 
             managerUpdated = beatmapManager.ItemUpdated.GetBoundCopy();
             managerUpdated.BindValueChanged(beatmapUpdated);
-
-            playlist.BindCollectionChanged((_, __) => playlistHeader.Details.Value = playlist.GetTotalDuration(), true);
         }
 
         public override bool OnExiting(IScreen next)

--- a/osu.Game/Tests/Beatmaps/TestBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestBeatmap.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Tests.Beatmaps
             BeatmapInfo.BeatmapSet.Metadata = BeatmapInfo.Metadata;
             BeatmapInfo.BeatmapSet.Files = new List<BeatmapSetFileInfo>();
             BeatmapInfo.BeatmapSet.Beatmaps = new List<BeatmapInfo> { BeatmapInfo };
+            BeatmapInfo.Length = 75000;
             BeatmapInfo.BeatmapSet.OnlineInfo = new BeatmapSetOnlineInfo
             {
                 Status = BeatmapSetOnlineStatus.Ranked,


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/11002 ?

Various displays at different lengths:
![Screenshot_2020-12-01_19-59-08](https://user-images.githubusercontent.com/1329837/100732236-cf2e3d80-340f-11eb-95a5-ded8aa67a94c.png)

![Screenshot_2020-12-01_19-59-20](https://user-images.githubusercontent.com/1329837/100732252-d2292e00-340f-11eb-9d2b-6884cbfbf9a8.png)

![Screenshot_2020-12-01_19-59-34](https://user-images.githubusercontent.com/1329837/100732256-d35a5b00-340f-11eb-98b5-0af35f0d0207.png)
