### PR TITLE
Fix bananas not playing sounds

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using osu.Framework.Utils;
@@ -8,6 +10,7 @@ using osu.Game.Audio;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Utils;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects
@@ -53,19 +56,22 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         private class BananaHitSampleInfo : HitSampleInfo, IEquatable<BananaHitSampleInfo>
         {
-            private static readonly string[] lookup_names = { "metronomelow", "catch-banana" };
+            private static readonly string[] lookup_names = { "Gameplay/metronomelow", "Gameplay/catch-banana" };
 
             public override IEnumerable<string> LookupNames => lookup_names;
 
-            public BananaHitSampleInfo()
-                : base(string.Empty)
+            public BananaHitSampleInfo(int volume = 0)
+                : base(string.Empty, volume: volume)
             {
             }
 
-            public bool Equals(BananaHitSampleInfo other)
+            public sealed override HitSampleInfo With(Optional<string> newName = default, Optional<string?> newBank = default, Optional<string?> newSuffix = default, Optional<int> newVolume = default)
+                => new BananaHitSampleInfo(newVolume.GetOr(Volume));
+
+            public bool Equals(BananaHitSampleInfo? other)
                 => other != null;
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
                 => obj is BananaHitSampleInfo other && Equals(other);
 
             public override int GetHashCode() => lookup_names.GetHashCode();


### PR DESCRIPTION
Noticed while working on the previous sample PRs that the prefixes weren't added to the lookup names. I think this worked once upon a time but the prefixes have since been removed from their previous location.

Note that `LegacySkin` will remove the `Gameplay/` prefix itself, so this is only for fallbacks to the osu-resources samples, which is generally the case including for the osu!classic skin.

The rest is a regression from the sample PR - `With` needs to return a new `BananaHitSample` object.