### PR TITLE
Use stateless RNG for osu!catch hit objects

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitObjects.cs
@@ -3,11 +3,12 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
-using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
@@ -37,39 +38,50 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         private Drawable createDrawableFruit(int indexInBeatmap, bool hyperdash = false) =>
-            SetProperties(new DrawableFruit(new Fruit
+            new TestDrawableCatchHitObjectSpecimen(new DrawableFruit(new Fruit
             {
                 IndexInBeatmap = indexInBeatmap,
                 HyperDashBindable = { Value = hyperdash }
             }));
 
         private Drawable createDrawableBanana() =>
-            SetProperties(new DrawableBanana(new Banana()));
+            new TestDrawableCatchHitObjectSpecimen(new DrawableBanana(new Banana()));
 
         private Drawable createDrawableDroplet(bool hyperdash = false) =>
-            SetProperties(new DrawableDroplet(new Droplet
+            new TestDrawableCatchHitObjectSpecimen(new DrawableDroplet(new Droplet
             {
                 HyperDashBindable = { Value = hyperdash }
             }));
 
-        private Drawable createDrawableTinyDroplet() => SetProperties(new DrawableTinyDroplet(new TinyDroplet()));
+        private Drawable createDrawableTinyDroplet() => new TestDrawableCatchHitObjectSpecimen(new DrawableTinyDroplet(new TinyDroplet()));
+    }
 
-        protected virtual DrawableCatchHitObject SetProperties(DrawableCatchHitObject d)
+    public class TestDrawableCatchHitObjectSpecimen : CompositeDrawable
+    {
+        public readonly ManualClock ManualClock;
+
+        public TestDrawableCatchHitObjectSpecimen(DrawableCatchHitObject d)
         {
+            AutoSizeAxes = Axes.Both;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            ManualClock = new ManualClock();
+            Clock = new FramedClock(ManualClock);
+
             var hitObject = d.HitObject;
-            hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { CircleSize = 0 });
-            hitObject.StartTime = 1000000000000;
+            hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
             hitObject.Scale = 1.5f;
+            hitObject.StartTime = 500;
 
             d.Anchor = Anchor.Centre;
-            d.RelativePositionAxes = Axes.None;
-            d.Position = Vector2.Zero;
             d.HitObjectApplied += _ =>
             {
                 d.LifetimeStart = double.NegativeInfinity;
                 d.LifetimeEnd = double.PositiveInfinity;
             };
-            return d;
+
+            InternalChild = d;
         }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Tests.Visual;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
@@ -31,6 +32,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             float fruitRotation = 0;
             float bananaRotation = 0;
             float bananaScale = 0;
+            Color4 bananaColour = new Color4();
 
             AddStep("set random seed to 0", () =>
             {
@@ -40,16 +42,19 @@ namespace osu.Game.Rulesets.Catch.Tests
                 fruitRotation = drawableFruit.InnerRotation;
                 bananaRotation = drawableBanana.InnerRotation;
                 bananaScale = drawableBanana.InnerScale;
+                bananaColour = drawableBanana.AccentColour.Value;
             });
 
             AddStep("change random seed", () =>
             {
+                // Use a seed value such that the banana colour is different (2/3 of the seed values are okay).
                 randomSeed.Value = 10;
             });
 
             AddAssert("fruit rotation is changed", () => drawableFruit.InnerRotation != fruitRotation);
             AddAssert("banana rotation is changed", () => drawableBanana.InnerRotation != bananaRotation);
             AddAssert("banana scale is changed", () => drawableBanana.InnerScale != bananaScale);
+            AddAssert("banana colour is changed", () => drawableBanana.AccentColour.Value != bananaColour);
 
             AddStep("reset random seed", () =>
             {
@@ -59,7 +64,8 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddAssert("rotation and scale restored", () =>
                 drawableFruit.InnerRotation == fruitRotation &&
                 drawableBanana.InnerRotation == bananaRotation &&
-                drawableBanana.InnerScale == bananaScale);
+                drawableBanana.InnerScale == bananaScale &&
+                drawableBanana.AccentColour.Value == bananaColour);
 
             AddStep("change start time", () =>
             {

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public class TestSceneFruitRandomness : OsuTestScene
+    {
+        [Test]
+        public void TestFruitRandomness()
+        {
+            Bindable<int> randomSeed = new Bindable<int>();
+
+            TestDrawableFruit drawableFruit;
+            TestDrawableBanana drawableBanana;
+
+            Add(new TestDrawableCatchHitObjectSpecimen(drawableFruit = new TestDrawableFruit(new Fruit())
+            {
+                RandomSeed = { BindTarget = randomSeed }
+            }) { X = -200 });
+            Add(new TestDrawableCatchHitObjectSpecimen(drawableBanana = new TestDrawableBanana(new Banana())
+            {
+                RandomSeed = { BindTarget = randomSeed }
+            }));
+
+            float fruitRotation = 0;
+            float bananaRotation = 0;
+            float bananaScale = 0;
+
+            AddStep("set random seed to 0", () =>
+            {
+                drawableFruit.HitObject.StartTime = 500;
+                randomSeed.Value = 0;
+
+                fruitRotation = drawableFruit.InnerRotation;
+                bananaRotation = drawableBanana.InnerRotation;
+                bananaScale = drawableBanana.InnerScale;
+            });
+
+            AddStep("change random seed", () =>
+            {
+                randomSeed.Value = 10;
+            });
+
+            AddAssert("fruit rotation is changed", () => drawableFruit.InnerRotation != fruitRotation);
+            AddAssert("banana rotation is changed", () => drawableBanana.InnerRotation != bananaRotation);
+            AddAssert("banana scale is changed", () => drawableBanana.InnerScale != bananaScale);
+
+            AddStep("reset random seed", () =>
+            {
+                randomSeed.Value = 0;
+            });
+
+            AddAssert("rotation and scale restored", () =>
+                drawableFruit.InnerRotation == fruitRotation &&
+                drawableBanana.InnerRotation == bananaRotation &&
+                drawableBanana.InnerScale == bananaScale);
+
+            AddStep("change start time", () =>
+            {
+                drawableFruit.HitObject.StartTime = 1000;
+            });
+
+            AddAssert("random seed is changed", () => randomSeed.Value == 1000);
+
+            AddSliderStep("random seed", 0, 100, 0, x => randomSeed.Value = x);
+        }
+
+        private class TestDrawableFruit : DrawableFruit
+        {
+            public float InnerRotation => ScaleContainer.Rotation;
+
+            public TestDrawableFruit(Fruit h)
+                : base(h)
+            {
+            }
+        }
+
+        private class TestDrawableBanana : DrawableBanana
+        {
+            public float InnerRotation => ScaleContainer.Rotation;
+            public float InnerScale => ScaleContainer.Scale.X;
+
+            public TestDrawableBanana(Banana h)
+                : base(h)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
@@ -17,17 +17,14 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             Bindable<int> randomSeed = new Bindable<int>();
 
-            TestDrawableFruit drawableFruit;
-            TestDrawableBanana drawableBanana;
+            var drawableFruit = new TestDrawableFruit(new Fruit());
+            var drawableBanana = new TestDrawableBanana(new Banana());
 
-            Add(new TestDrawableCatchHitObjectSpecimen(drawableFruit = new TestDrawableFruit(new Fruit())
-            {
-                RandomSeed = { BindTarget = randomSeed }
-            }) { X = -200 });
-            Add(new TestDrawableCatchHitObjectSpecimen(drawableBanana = new TestDrawableBanana(new Banana())
-            {
-                RandomSeed = { BindTarget = randomSeed }
-            }));
+            drawableFruit.RandomSeed.BindTo(randomSeed);
+            drawableBanana.RandomSeed.BindTo(randomSeed);
+
+            Add(new TestDrawableCatchHitObjectSpecimen(drawableFruit) { X = -200 });
+            Add(new TestDrawableCatchHitObjectSpecimen(drawableBanana));
 
             float fruitRotation = 0;
             float bananaRotation = 0;

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
@@ -12,13 +12,14 @@ namespace osu.Game.Rulesets.Catch.Tests
 {
     public class TestSceneFruitRandomness : OsuTestScene
     {
-        [Test]
-        public void TestFruitRandomness()
-        {
-            Bindable<int> randomSeed = new Bindable<int>();
+        private readonly Bindable<int> randomSeed = new Bindable<int>();
+        private readonly TestDrawableFruit drawableFruit;
+        private readonly TestDrawableBanana drawableBanana;
 
-            var drawableFruit = new TestDrawableFruit(new Fruit());
-            var drawableBanana = new TestDrawableBanana(new Banana());
+        public TestSceneFruitRandomness()
+        {
+            drawableFruit = new TestDrawableFruit(new Fruit());
+            drawableBanana = new TestDrawableBanana(new Banana());
 
             drawableFruit.RandomSeed.BindTo(randomSeed);
             drawableBanana.RandomSeed.BindTo(randomSeed);
@@ -26,6 +27,12 @@ namespace osu.Game.Rulesets.Catch.Tests
             Add(new TestDrawableCatchHitObjectSpecimen(drawableFruit) { X = -200 });
             Add(new TestDrawableCatchHitObjectSpecimen(drawableBanana));
 
+            AddSliderStep("random seed", 0, 100, 0, x => randomSeed.Value = x);
+        }
+
+        [Test]
+        public void TestFruitRandomness()
+        {
             float fruitRotation = 0;
             float bananaRotation = 0;
             float bananaScale = 0;
@@ -70,8 +77,6 @@ namespace osu.Game.Rulesets.Catch.Tests
             });
 
             AddAssert("random seed is changed", () => randomSeed.Value == 1000);
-
-            AddSliderStep("random seed", 0, 100, 0, x => randomSeed.Value = x);
         }
 
         private class TestDrawableFruit : DrawableFruit

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitVisualChange.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitVisualChange.cs
@@ -14,13 +14,13 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         protected override void LoadComplete()
         {
-            AddStep("fruit changes visual and hyper", () => SetContents(() => SetProperties(new DrawableFruit(new Fruit
+            AddStep("fruit changes visual and hyper", () => SetContents(() => new TestDrawableCatchHitObjectSpecimen(new DrawableFruit(new Fruit
             {
                 IndexInBeatmapBindable = { BindTarget = indexInBeatmap },
                 HyperDashBindable = { BindTarget = hyperDash },
             }))));
 
-            AddStep("droplet changes hyper", () => SetContents(() => SetProperties(new DrawableDroplet(new Droplet
+            AddStep("droplet changes hyper", () => SetContents(() => new TestDrawableCatchHitObjectSpecimen(new DrawableDroplet(new Droplet
             {
                 HyperDashBindable = { BindTarget = hyperDash },
             }))));

--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -3,11 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Utils;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects
@@ -28,17 +28,12 @@ namespace osu.Game.Rulesets.Catch.Objects
             Samples = samples;
         }
 
-        private Color4? colour;
-
-        Color4 IHasComboInformation.GetComboColour(IReadOnlyList<Color4> comboColours)
-        {
-            // override any external colour changes with banananana
-            return colour ??= getBananaColour();
-        }
+        // override any external colour changes with banananana
+        Color4 IHasComboInformation.GetComboColour(IReadOnlyList<Color4> comboColours) => getBananaColour();
 
         private Color4 getBananaColour()
         {
-            switch (RNG.Next(0, 3))
+            switch (StatelessRNG.NextInt(3, RandomSeed.Value))
             {
                 default:
                     return new Color4(255, 240, 0, 255);

--- a/osu.Game.Rulesets.Catch/Objects/Banana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Banana.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         private Color4 getBananaColour()
         {
-            switch (StatelessRNG.NextInt(3, RandomSeed.Value))
+            switch (StatelessRNG.NextInt(3, RandomSeed))
             {
                 default:
                     return new Color4(255, 240, 0, 255);

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -97,6 +97,12 @@ namespace osu.Game.Rulesets.Catch.Objects
             set => ScaleBindable.Value = value;
         }
 
+        /// <summary>
+        /// The seed value used for visual randomness such as fruit rotation.
+        /// By default, <see cref="HitObject.StartTime"/> truncated to an integer is used.
+        /// </summary>
+        public Bindable<int> RandomSeed = new Bindable<int>();
+
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
         {
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
@@ -111,6 +117,10 @@ namespace osu.Game.Rulesets.Catch.Objects
         protected CatchHitObject()
         {
             XBindable.BindValueChanged(x => originalX = x.NewValue - xOffset);
+            StartTimeBindable.BindValueChanged(change =>
+            {
+                RandomSeed.Value = (int)change.NewValue;
+            }, true);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -99,9 +99,9 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         /// <summary>
         /// The seed value used for visual randomness such as fruit rotation.
-        /// By default, <see cref="HitObject.StartTime"/> truncated to an integer is used.
+        /// The value is <see cref="HitObject.StartTime"/> truncated to an integer.
         /// </summary>
-        public Bindable<int> RandomSeed = new Bindable<int>();
+        public int RandomSeed => (int)StartTime;
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
         {
@@ -117,10 +117,6 @@ namespace osu.Game.Rulesets.Catch.Objects
         protected CatchHitObject()
         {
             XBindable.BindValueChanged(x => originalX = x.NewValue - xOffset);
-            StartTimeBindable.BindValueChanged(change =>
-            {
-                RandomSeed.Value = (int)change.NewValue;
-            }, true);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using osu.Framework.Graphics;
-using osu.Framework.Utils;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
@@ -21,6 +20,17 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            RandomSeed.BindValueChanged(_ =>
+            {
+                UpdateComboColour();
+                UpdateInitialTransforms();
+            });
+        }
+
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
@@ -28,14 +38,14 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             const float end_scale = 0.6f;
             const float random_scale_range = 1.6f;
 
-            ScaleContainer.ScaleTo(HitObject.Scale * (end_scale + random_scale_range * RNG.NextSingle()))
+            ScaleContainer.ScaleTo(HitObject.Scale * (end_scale + random_scale_range * RandomSingle(3)))
                           .Then().ScaleTo(HitObject.Scale * end_scale, HitObject.TimePreempt);
 
-            ScaleContainer.RotateTo(getRandomAngle())
+            ScaleContainer.RotateTo(getRandomAngle(1))
                           .Then()
-                          .RotateTo(getRandomAngle(), HitObject.TimePreempt);
+                          .RotateTo(getRandomAngle(2), HitObject.TimePreempt);
 
-            float getRandomAngle() => 180 * (RNG.NextSingle() * 2 - 1);
+            float getRandomAngle(int series) => 180 * (RandomSingle(series) * 2 - 1);
         }
 
         public override void PlaySamples()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -24,11 +24,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
             base.LoadComplete();
 
-            RandomSeed.BindValueChanged(_ =>
-            {
-                UpdateComboColour();
-                UpdateInitialTransforms();
-            });
+            // start time affects the random seed which is used to determine the banana colour
+            StartTimeBindable.BindValueChanged(_ => UpdateComboColour());
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -3,10 +3,13 @@
 
 using System;
 using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
@@ -20,11 +23,31 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected override float SamplePlaybackPosition => HitObject.X / CatchPlayfield.WIDTH;
 
+        /// <summary>
+        /// The seed value used for visual randomness such as fruit rotation.
+        /// By default, <see cref="HitObject.StartTime"/> truncated to an integer is used.
+        /// </summary>
+        public Bindable<int> RandomSeed = new Bindable<int>();
+
         protected DrawableCatchHitObject([CanBeNull] CatchHitObject hitObject)
             : base(hitObject)
         {
             Anchor = Anchor.BottomLeft;
         }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            StartTimeBindable.BindValueChanged(change =>
+            {
+                RandomSeed.Value = (int)change.NewValue;
+            }, true);
+        }
+
+        /// <summary>
+        /// Get a random number in range [0,1) based on seed <see cref="RandomSeed"/>.
+        /// </summary>
+        public float RandomSingle(int series) => StatelessRNG.NextSingle(RandomSeed.Value, series);
 
         protected override void OnApply()
         {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected override float SamplePlaybackPosition => HitObject.X / CatchPlayfield.WIDTH;
 
-        public Bindable<int> RandomSeed = new Bindable<int>();
+        public int RandomSeed => HitObject?.RandomSeed ?? 0;
 
         protected DrawableCatchHitObject([CanBeNull] CatchHitObject hitObject)
             : base(hitObject)
@@ -32,14 +32,13 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         /// <summary>
         /// Get a random number in range [0,1) based on seed <see cref="RandomSeed"/>.
         /// </summary>
-        public float RandomSingle(int series) => StatelessRNG.NextSingle(RandomSeed.Value, series);
+        public float RandomSingle(int series) => StatelessRNG.NextSingle(RandomSeed, series);
 
         protected override void OnApply()
         {
             base.OnApply();
 
             XBindable.BindTo(HitObject.XBindable);
-            RandomSeed.BindTo(HitObject.RandomSeed);
         }
 
         protected override void OnFree()
@@ -47,7 +46,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             base.OnFree();
 
             XBindable.UnbindFrom(HitObject.XBindable);
-            RandomSeed.UnbindFrom(HitObject.RandomSeed);
         }
 
         public Func<CatchHitObject, bool> CheckPosition;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -3,11 +3,9 @@
 
 using System;
 using JetBrains.Annotations;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.UI;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Utils;
 
@@ -23,25 +21,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected override float SamplePlaybackPosition => HitObject.X / CatchPlayfield.WIDTH;
 
-        /// <summary>
-        /// The seed value used for visual randomness such as fruit rotation.
-        /// By default, <see cref="HitObject.StartTime"/> truncated to an integer is used.
-        /// </summary>
         public Bindable<int> RandomSeed = new Bindable<int>();
 
         protected DrawableCatchHitObject([CanBeNull] CatchHitObject hitObject)
             : base(hitObject)
         {
             Anchor = Anchor.BottomLeft;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            StartTimeBindable.BindValueChanged(change =>
-            {
-                RandomSeed.Value = (int)change.NewValue;
-            }, true);
         }
 
         /// <summary>
@@ -54,6 +39,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             base.OnApply();
 
             XBindable.BindTo(HitObject.XBindable);
+            RandomSeed.BindTo(HitObject.RandomSeed);
         }
 
         protected override void OnFree()
@@ -61,6 +47,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             base.OnFree();
 
             XBindable.UnbindFrom(HitObject.XBindable);
+            RandomSeed.UnbindFrom(HitObject.RandomSeed);
         }
 
         public Func<CatchHitObject, bool> CheckPosition;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -4,7 +4,6 @@
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
@@ -45,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             base.UpdateInitialTransforms();
 
             // roughly matches osu-stable
-            float startRotation = RNG.NextSingle() * 20;
+            float startRotation = RandomSingle(1) * 20;
             double duration = HitObject.TimePreempt + 2000;
 
             ScaleContainer.RotateTo(startRotation).RotateTo(startRotation + 720, duration);

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -36,11 +36,13 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
             VisualRepresentation.BindValueChanged(_ => updatePiece());
             HyperDash.BindValueChanged(_ => updatePiece(), true);
+        }
 
-            RandomSeed.BindValueChanged(_ =>
-            {
-                ScaleContainer.Rotation = (RandomSingle(1) - 0.5f) * 40;
-            }, true);
+        protected override void UpdateInitialTransforms()
+        {
+            base.UpdateInitialTransforms();
+
+            ScaleContainer.Rotation = (RandomSingle(1) - 0.5f) * 40;
         }
 
         private void updatePiece()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -5,6 +5,7 @@ using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
@@ -42,7 +43,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
             base.UpdateInitialTransforms();
 
-            ScaleContainer.Rotation = (RandomSingle(1) - 0.5f) * 40;
+            ScaleContainer.RotateTo((RandomSingle(1) - 0.5f) * 40);
         }
 
         private void updatePiece()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -5,7 +5,6 @@ using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Catch.Objects.Drawables.Pieces;
 using osu.Game.Skinning;
 
@@ -30,8 +29,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            ScaleContainer.Rotation = (float)(RNG.NextDouble() - 0.5f) * 40;
-
             IndexInBeatmap.BindValueChanged(change =>
             {
                 VisualRepresentation.Value = GetVisualRepresentation(change.NewValue);
@@ -39,6 +36,11 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
             VisualRepresentation.BindValueChanged(_ => updatePiece());
             HyperDash.BindValueChanged(_ => updatePiece(), true);
+
+            RandomSeed.BindValueChanged(_ =>
+            {
+                ScaleContainer.Rotation = (RandomSingle(1) - 0.5f) * 40;
+            }, true);
         }
 
         private void updatePiece()


### PR DESCRIPTION
Motivation: It makes the randomness consistent when a replay is rewound, or a replay is played multiple times.

- Fix random rotation not updated when a DHO is reused <https://github.com/ppy/osu/pull/10979#issuecomment-734626713>.
