### PR TITLE
Fix beatmap carousel panels getting masked away when out of scroll bounds

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -914,6 +914,9 @@ namespace osu.Game.Screens.Select
             {
                 // size is determined by the carousel itself, due to not all content necessarily being loaded.
                 ScrollContent.AutoSizeAxes = Axes.None;
+
+                // the scroll container may get pushed off-screen by global screen changes, but we still want panels to display outside of the bounds.
+                Masking = false;
             }
 
             // ReSharper disable once OptionalParameterHierarchyMismatch 2020.3 EAP4 bug. (https://youtrack.jetbrains.com/issue/RSRP-481535?p=RIDER-51910)


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/10973 due to removed masking specification.

Closes #11067.