### PR TITLE
Fix song select panels not loading if partially offscreen

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -100,8 +100,14 @@ namespace osu.Game.Screens.Select.Carousel
                 background = new DelayedLoadWrapper(() => new SetPanelBackground(manager.GetWorkingBeatmap(beatmapSet.Beatmaps.FirstOrDefault()))
                 {
                     RelativeSizeAxes = Axes.Both,
-                }, 300),
-                mainFlow = new DelayedLoadWrapper(() => new SetPanelContent((CarouselBeatmapSet)Item), 100),
+                }, 300)
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                mainFlow = new DelayedLoadWrapper(() => new SetPanelContent((CarouselBeatmapSet)Item), 100)
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
             };
 
             background.DelayedLoadComplete += fadeContentIn;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/10745

The DLW starts with 0 size because the construction of the content is delayed until the DLW starts loading. This gives it an initial size (`RelativeSizeAxes = Both`).