### PR TITLE
Refactor fruit catching logic

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [BackgroundDependencyLoader]
         private void load()
         {
-            SetContents(() => new Catcher(new Container())
+            SetContents(() => new Catcher(new Container(), new Container())
             {
                 RelativePositionAxes = Axes.None,
                 Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -1,26 +1,192 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
     [TestFixture]
-    public class TestSceneCatcher : CatchSkinnableTestScene
+    public class TestSceneCatcher : OsuTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
+        private Container droppedObjectContainer;
+
+        private TestCatcher catcher;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
-            SetContents(() => new Catcher(new Container(), new Container())
+            var difficulty = new BeatmapDifficulty
             {
-                RelativePositionAxes = Axes.None,
+                CircleSize = 0,
+            };
+
+            var trailContainer = new Container();
+            droppedObjectContainer = new Container();
+            catcher = new TestCatcher(trailContainer, droppedObjectContainer, difficulty);
+
+            Child = new Container
+            {
                 Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
+                Children = new Drawable[]
+                {
+                    trailContainer,
+                    droppedObjectContainer,
+                    catcher
+                }
+            };
+        });
+
+        [Test]
+        public void TestCatcherCatchWidth()
+        {
+            var halfWidth = Catcher.CalculateCatchWidth(new BeatmapDifficulty { CircleSize = 0 }) / 2;
+            AddStep("catch fruit", () =>
+            {
+                attemptCatch(new Fruit { X = -halfWidth + 1 });
+                attemptCatch(new Fruit { X = halfWidth - 1 });
             });
+            checkPlate(2);
+            AddStep("miss fruit", () =>
+            {
+                attemptCatch(new Fruit { X = -halfWidth - 1 });
+                attemptCatch(new Fruit { X = halfWidth + 1 });
+            });
+            checkPlate(2);
+        }
+
+        [Test]
+        public void TestCatcherStateFruit()
+        {
+            AddStep("miss fruit", () => attemptCatch(new Fruit { X = 100 }));
+            checkState(CatcherAnimationState.Fail);
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            checkState(CatcherAnimationState.Idle);
+            AddStep("catch kiai fruit", () => attemptCatch(new TestKiaiFruit()));
+            checkState(CatcherAnimationState.Kiai);
+        }
+
+        [Test]
+        public void TestCatcherStateTinyDroplet()
+        {
+            AddStep("catch hyper kiai fruit", () => attemptCatch(new TestKiaiFruit
+            {
+                HyperDashTarget = new Fruit { X = 100 }
+            }));
+            AddStep("catch tiny droplet", () => attemptCatch(new TinyDroplet()));
+            AddStep("miss tiny droplet", () => attemptCatch(new TinyDroplet { X = 100 }));
+            checkState(CatcherAnimationState.Kiai);
+            checkHyperDash(true);
+        }
+
+        [Test]
+        public void TestCatcherStateBanana()
+        {
+            AddStep("catch hyper kiai fruit", () => attemptCatch(new TestKiaiFruit
+            {
+                HyperDashTarget = new Fruit { X = 100 }
+            }));
+            AddStep("miss banana", () => attemptCatch(new Banana()));
+            checkState(CatcherAnimationState.Idle);
+            checkHyperDash(false);
+        }
+
+        [Test]
+        public void TestCatcherStacking()
+        {
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            checkPlate(1);
+            AddStep("catch more fruits", () => attemptCatch(new Fruit(), 9));
+            checkPlate(10);
+            AddAssert("caught objects are stacked", () =>
+                catcher.CaughtObjects.All(obj => obj.Y <= 0) &&
+                catcher.CaughtObjects.Any(obj => obj.Y == 0) &&
+                catcher.CaughtObjects.Any(obj => obj.Y < -20));
+        }
+
+        [Test]
+        public void TestCatcherExplosionAndDropping()
+        {
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            AddStep("catch tiny droplet", () => attemptCatch(new TinyDroplet()));
+            AddAssert("tiny droplet is exploded", () => catcher.CaughtObjects.Count() == 1 && droppedObjectContainer.Count == 1);
+            AddUntilStep("wait explosion", () => !droppedObjectContainer.Any());
+            AddStep("catch more fruits", () => attemptCatch(new Fruit(), 9));
+            AddStep("explode", () => catcher.Explode());
+            AddAssert("fruits are exploded", () => !catcher.CaughtObjects.Any() && droppedObjectContainer.Count == 10);
+            AddUntilStep("wait explosion", () => !droppedObjectContainer.Any());
+            AddStep("catch fruits", () => attemptCatch(new Fruit(), 10));
+            AddStep("drop", () => catcher.Drop());
+            AddAssert("fruits are dropped", () => !catcher.CaughtObjects.Any() && droppedObjectContainer.Count == 10);
+        }
+
+        [Test]
+        public void TestHyperFruitHyperDash()
+        {
+            AddStep("catch hyper fruit", () => attemptCatch(new Fruit
+            {
+                HyperDashTarget = new Fruit { X = 100 }
+            }));
+            checkHyperDash(true);
+            AddStep("catch normal fruit", () => attemptCatch(new Fruit()));
+            checkHyperDash(false);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestHitLighting(bool enabled)
+        {
+            AddStep($"{(enabled ? "enable" : "disable")} hit lighting", () => config.Set(OsuSetting.HitLighting, enabled));
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            AddAssert("check hit lighting", () => catcher.ChildrenOfType<HitExplosion>().Any() == enabled);
+        }
+
+        private void checkPlate(int count) => AddAssert($"{count} objects on the plate", () => catcher.CaughtObjects.Count() == count);
+
+        private void checkState(CatcherAnimationState state) => AddAssert($"catcher state is {state}", () => catcher.CurrentState == state);
+
+        private void checkHyperDash(bool state) => AddAssert($"catcher is {(state ? "" : "not ")}hyper dashing", () => catcher.HyperDashing == state);
+
+        private void attemptCatch(CatchHitObject hitObject, int count = 1)
+        {
+            hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            for (var i = 0; i < count; i++)
+                catcher.AttemptCatch(hitObject);
+        }
+
+        public class TestCatcher : Catcher
+        {
+            public IEnumerable<DrawablePalpableCatchHitObject> CaughtObjects => this.ChildrenOfType<DrawablePalpableCatchHitObject>();
+
+            public TestCatcher(Container trailsTarget, Container droppedObjectTarget, BeatmapDifficulty difficulty)
+                : base(trailsTarget, droppedObjectTarget, difficulty)
+            {
+            }
+        }
+
+        public class TestKiaiFruit : Fruit
+        {
+            protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
+            {
+                controlPointInfo.Add(0, new EffectControlPoint { KiaiMode = true });
+                base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestCatcherStateFruit()
+        public void TestFruitChangesCatcherState()
         {
             AddStep("miss fruit", () => attemptCatch(new Fruit { X = 100 }));
             checkState(CatcherAnimationState.Fail);
@@ -82,7 +82,19 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestCatcherStateTinyDroplet()
+        public void TestNormalFruitResetsHyperDashState()
+        {
+            AddStep("catch hyper fruit", () => attemptCatch(new Fruit
+            {
+                HyperDashTarget = new Fruit { X = 100 }
+            }));
+            checkHyperDash(true);
+            AddStep("catch normal fruit", () => attemptCatch(new Fruit()));
+            checkHyperDash(false);
+        }
+
+        [Test]
+        public void TestTinyDropletMissPreservesCatcherState()
         {
             AddStep("catch hyper kiai fruit", () => attemptCatch(new TestKiaiFruit
             {
@@ -90,19 +102,21 @@ namespace osu.Game.Rulesets.Catch.Tests
             }));
             AddStep("catch tiny droplet", () => attemptCatch(new TinyDroplet()));
             AddStep("miss tiny droplet", () => attemptCatch(new TinyDroplet { X = 100 }));
+            // catcher state and hyper dash state is preserved
             checkState(CatcherAnimationState.Kiai);
             checkHyperDash(true);
         }
 
         [Test]
-        public void TestCatcherStateBanana()
+        public void TestBananaMissPreservesCatcherState()
         {
             AddStep("catch hyper kiai fruit", () => attemptCatch(new TestKiaiFruit
             {
                 HyperDashTarget = new Fruit { X = 100 }
             }));
-            AddStep("miss banana", () => attemptCatch(new Banana()));
-            checkState(CatcherAnimationState.Idle);
+            AddStep("miss banana", () => attemptCatch(new Banana { X = 100 }));
+            // catcher state is preserved but hyper dash state is reset
+            checkState(CatcherAnimationState.Kiai);
             checkHyperDash(false);
         }
 
@@ -133,18 +147,6 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddStep("catch fruits", () => attemptCatch(new Fruit(), 10));
             AddStep("drop", () => catcher.Drop());
             AddAssert("fruits are dropped", () => !catcher.CaughtObjects.Any() && droppedObjectContainer.Count == 10);
-        }
-
-        [Test]
-        public void TestHyperFruitHyperDash()
-        {
-            AddStep("catch hyper fruit", () => attemptCatch(new Fruit
-            {
-                HyperDashTarget = new Fruit { X = 100 }
-            }));
-            checkHyperDash(true);
-            AddStep("catch normal fruit", () => attemptCatch(new Fruit()));
-            checkHyperDash(false);
         }
 
         [TestCase(true)]

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -27,73 +27,51 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        private Catcher catcher => this.ChildrenOfType<CatcherArea>().First().MovableCatcher;
+        private Catcher catcher => this.ChildrenOfType<Catcher>().First();
+
+        private float circleSize;
 
         public TestSceneCatcherArea()
         {
-            AddSliderStep<float>("CircleSize", 0, 8, 5, createCatcher);
-            AddToggleStep("Hyperdash", t =>
-                CreatedDrawables.OfType<CatchInputManager>().Select(i => i.Child)
-                                .OfType<TestCatcherArea>().ForEach(c => c.ToggleHyperDash(t)));
+            AddSliderStep<float>("circle size", 0, 8, 5, createCatcher);
+            AddToggleStep("hyper dash", t => this.ChildrenOfType<TestCatcherArea>().ForEach(area => area.ToggleHyperDash(t)));
 
-            AddRepeatStep("catch fruit", () => catchFruit(new TestFruit(false)
-            {
-                X = catcher.X
-            }), 20);
-            AddRepeatStep("catch fruit last in combo", () => catchFruit(new TestFruit(false)
-            {
-                X = catcher.X,
-                LastInCombo = true,
-            }), 20);
-            AddRepeatStep("catch kiai fruit", () => catchFruit(new TestFruit(true)
-            {
-                X = catcher.X
-            }), 20);
-            AddRepeatStep("miss fruit", () => catchFruit(new Fruit
-            {
-                X = catcher.X + 100,
-                LastInCombo = true,
-            }, true), 20);
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            AddStep("catch fruit last in combo", () => attemptCatch(new Fruit { LastInCombo = true }));
+            AddStep("catch kiai fruit", () => attemptCatch(new TestSceneCatcher.TestKiaiFruit()));
+            AddStep("miss last in combo", () => attemptCatch(new Fruit { X = 100, LastInCombo = true }));
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void TestHitLighting(bool enable)
+        private void attemptCatch(Fruit fruit)
         {
-            AddStep("create catcher", () => createCatcher(5));
-
-            AddStep("toggle hit lighting", () => config.Set(OsuSetting.HitLighting, enable));
-            AddStep("catch fruit", () => catchFruit(new TestFruit(false)
+            fruit.X += catcher.X;
+            fruit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty
             {
-                X = catcher.X
-            }));
-            AddStep("catch fruit last in combo", () => catchFruit(new TestFruit(false)
-            {
-                X = catcher.X,
-                LastInCombo = true
-            }));
-            AddAssert("check hit explosion", () => catcher.ChildrenOfType<HitExplosion>().Any() == enable);
-        }
+                CircleSize = circleSize
+            });
 
-        private void catchFruit(Fruit fruit, bool miss = false)
-        {
-            this.ChildrenOfType<CatcherArea>().ForEach(area =>
+            foreach (var area in this.ChildrenOfType<CatcherArea>())
             {
                 DrawableFruit drawable = new DrawableFruit(fruit);
                 area.Add(drawable);
 
                 Schedule(() =>
                 {
-                    area.AttemptCatch(fruit);
-                    area.OnNewResult(drawable, new JudgementResult(fruit, new CatchJudgement()) { Type = miss ? HitResult.Miss : HitResult.Great });
+                    bool caught = area.AttemptCatch(fruit);
+                    area.OnNewResult(drawable, new JudgementResult(fruit, new CatchJudgement())
+                    {
+                        Type = caught ? HitResult.Great : HitResult.Miss
+                    });
 
                     drawable.Expire();
                 });
-            });
+            }
         }
 
         private void createCatcher(float size)
         {
+            circleSize = size;
+
             SetContents(() => new CatchInputManager(catchRuleset)
             {
                 RelativeSizeAxes = Axes.Both,
@@ -111,25 +89,12 @@ namespace osu.Game.Rulesets.Catch.Tests
             catchRuleset = rulesets.GetRuleset(2);
         }
 
-        public class TestFruit : Fruit
-        {
-            public TestFruit(bool kiai)
-            {
-                var kiaiCpi = new ControlPointInfo();
-                kiaiCpi.Add(0, new EffectControlPoint { KiaiMode = kiai });
-
-                ApplyDefaultsToSelf(kiaiCpi, new BeatmapDifficulty());
-            }
-        }
-
         private class TestCatcherArea : CatcherArea
         {
             public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
                 : base(beatmapDifficulty)
             {
             }
-
-            public new Catcher MovableCatcher => base.MovableCatcher;
 
             public void ToggleHyperDash(bool status) => MovableCatcher.SetHyperDashState(status ? 2 : 1);
         }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -72,14 +73,23 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             circleSize = size;
 
-            SetContents(() => new CatchInputManager(catchRuleset)
+            SetContents(() =>
             {
-                RelativeSizeAxes = Axes.Both,
-                Child = new TestCatcherArea(new BeatmapDifficulty { CircleSize = size })
+                var droppedObjectContainer = new Container();
+
+                return new CatchInputManager(catchRuleset)
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.TopCentre,
-                },
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        droppedObjectContainer,
+                        new TestCatcherArea(droppedObjectContainer, new BeatmapDifficulty { CircleSize = size })
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.TopCentre,
+                        }
+                    }
+                };
             });
         }
 
@@ -91,8 +101,8 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private class TestCatcherArea : CatcherArea
         {
-            public TestCatcherArea(BeatmapDifficulty beatmapDifficulty)
-                : base(beatmapDifficulty)
+            public TestCatcherArea(Container droppedObjectContainer, BeatmapDifficulty beatmapDifficulty)
+                : base(droppedObjectContainer, beatmapDifficulty)
             {
             }
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                Child = setupSkinHierarchy(catcherArea = new CatcherArea
+                Child = setupSkinHierarchy(catcherArea = new CatcherArea(new Container())
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected override double InitialLifetimeOffset => HitObject.TimePreempt;
 
-        public float DisplayRadius => DrawSize.X / 2 * Scale.X * HitObject.Scale;
-
         protected override float SamplePlaybackPosition => HitObject.X / CatchPlayfield.WIDTH;
 
         protected DrawableCatchHitObject([CanBeNull] CatchHitObject hitObject)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         /// </summary>
         public virtual bool StaysOnPlate => true;
 
+        public float DisplayRadius => CatchHitObject.OBJECT_RADIUS * HitObject.Scale * ScaleFactor;
+
         protected readonly Container ScaleContainer;
 
         protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -43,7 +43,6 @@ namespace osu.Game.Rulesets.Catch.UI
 
             CatcherArea = new CatcherArea(difficulty)
             {
-                ExplodingFruitTarget = explodingFruitContainer,
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.TopLeft,
             };

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -36,12 +36,12 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfield(BeatmapDifficulty difficulty, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation)
         {
-            var explodingFruitContainer = new Container
+            var droppedObjectContainer = new Container
             {
                 RelativeSizeAxes = Axes.Both,
             };
 
-            CatcherArea = new CatcherArea(difficulty)
+            CatcherArea = new CatcherArea(droppedObjectContainer, difficulty)
             {
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.TopLeft,
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             InternalChildren = new[]
             {
-                explodingFruitContainer,
+                droppedObjectContainer,
                 CatcherArea.MovableCatcher.CreateProxiedContent(),
                 HitObjectContainer,
                 CatcherArea,

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -204,8 +204,7 @@ namespace osu.Game.Rulesets.Catch.UI
             const float allowance = 10;
 
             while (caughtFruitContainer.Any(f =>
-                f.LifetimeEnd == double.MaxValue &&
-                Vector2Extensions.Distance(f.Position, fruit.Position) < (ourRadius + (theirRadius = f.DrawSize.X / 2 * f.Scale.X)) / (allowance / 2)))
+                Vector2Extensions.Distance(f.Position, fruit.Position) < (ourRadius + (theirRadius = CatchHitObject.OBJECT_RADIUS / 2)) / (allowance / 2)))
             {
                 var diff = (ourRadius + theirRadius) / allowance;
                 fruit.X += (RNG.NextSingle() - 0.5f) * diff * 2;

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -49,11 +49,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public Container ExplodingFruitTarget;
 
-        private Container<DrawableHitObject> caughtFruitContainer { get; } = new Container<DrawableHitObject>
-        {
-            Anchor = Anchor.TopCentre,
-            Origin = Anchor.BottomCentre,
-        };
+        private readonly Container<DrawableHitObject> caughtFruitContainer;
 
         [NotNull]
         private readonly Container trailsTarget;
@@ -92,9 +88,9 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         private readonly float catchWidth;
 
-        private CatcherSprite catcherIdle;
-        private CatcherSprite catcherKiai;
-        private CatcherSprite catcherFail;
+        private readonly CatcherSprite catcherIdle;
+        private readonly CatcherSprite catcherKiai;
+        private readonly CatcherSprite catcherFail;
 
         private CatcherSprite currentCatcher;
 
@@ -108,8 +104,8 @@ namespace osu.Game.Rulesets.Catch.UI
         private float hyperDashTargetPosition;
         private Bindable<bool> hitLighting;
 
-        private DrawablePool<HitExplosion> hitExplosionPool;
-        private Container<HitExplosion> hitExplosionContainer;
+        private readonly DrawablePool<HitExplosion> hitExplosionPool;
+        private readonly Container<HitExplosion> hitExplosionContainer;
 
         public Catcher([NotNull] Container trailsTarget, BeatmapDifficulty difficulty = null)
         {
@@ -122,17 +118,15 @@ namespace osu.Game.Rulesets.Catch.UI
                 Scale = calculateScale(difficulty);
 
             catchWidth = CalculateCatchWidth(Scale);
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
-        {
-            hitLighting = config.GetBindable<bool>(OsuSetting.HitLighting);
 
             InternalChildren = new Drawable[]
             {
                 hitExplosionPool = new DrawablePool<HitExplosion>(10),
-                caughtFruitContainer,
+                caughtFruitContainer = new Container<DrawableHitObject>
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.BottomCentre,
+                },
                 catcherIdle = new CatcherSprite(CatcherAnimationState.Idle)
                 {
                     Anchor = Anchor.TopCentre,
@@ -154,7 +148,12 @@ namespace osu.Game.Rulesets.Catch.UI
                     Origin = Anchor.BottomCentre,
                 },
             };
+        }
 
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            hitLighting = config.GetBindable<bool>(OsuSetting.HitLighting);
             trails = new CatcherTrailDisplay(this);
 
             updateCatcher();

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -245,29 +245,28 @@ namespace osu.Game.Rulesets.Catch.UI
                 catchObjectPosition >= catcherPosition - halfCatchWidth &&
                 catchObjectPosition <= catcherPosition + halfCatchWidth;
 
-            // droplet doesn't affect the catcher state
-            if (!(fruit is TinyDroplet))
-            {
-                if (validCatch && fruit.HyperDash)
-                {
-                    var target = fruit.HyperDashTarget;
-                    var timeDifference = target.StartTime - fruit.StartTime;
-                    double positionDifference = target.X - catcherPosition;
-                    var velocity = positionDifference / Math.Max(1.0, timeDifference - 1000.0 / 60.0);
-
-                    SetHyperDashState(Math.Abs(velocity), target.X);
-                }
-                else
-                    SetHyperDashState();
-
-                if (validCatch)
-                    updateState(fruit.Kiai ? CatcherAnimationState.Kiai : CatcherAnimationState.Idle);
-                else if (!(fruit is Banana))
-                    updateState(CatcherAnimationState.Fail);
-            }
-
             if (validCatch)
                 placeCaughtObject(fruit);
+
+            // droplet doesn't affect the catcher state
+            if (fruit is TinyDroplet) return validCatch;
+
+            if (validCatch && fruit.HyperDash)
+            {
+                var target = fruit.HyperDashTarget;
+                var timeDifference = target.StartTime - fruit.StartTime;
+                double positionDifference = target.X - catcherPosition;
+                var velocity = positionDifference / Math.Max(1.0, timeDifference - 1000.0 / 60.0);
+
+                SetHyperDashState(Math.Abs(velocity), target.X);
+            }
+            else
+                SetHyperDashState();
+
+            if (validCatch)
+                updateState(fruit.Kiai ? CatcherAnimationState.Kiai : CatcherAnimationState.Idle);
+            else if (!(fruit is Banana))
+                updateState(CatcherAnimationState.Fail);
 
             return validCatch;
         }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -552,11 +552,11 @@ namespace osu.Game.Rulesets.Catch.UI
 
             d.Expire();
         }
-    }
 
-    public enum DroppedObjectAnimation
-    {
-        Drop,
-        Explode
+        private enum DroppedObjectAnimation
+        {
+            Drop,
+            Explode
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public Container ExplodingFruitTarget;
 
-        private readonly Container<DrawableHitObject> caughtFruitContainer;
+        private readonly Container<DrawablePalpableCatchHitObject> caughtFruitContainer;
 
         [NotNull]
         private readonly Container trailsTarget;
@@ -122,7 +122,7 @@ namespace osu.Game.Rulesets.Catch.UI
             InternalChildren = new Drawable[]
             {
                 hitExplosionPool = new DrawablePool<HitExplosion>(10),
-                caughtFruitContainer = new Container<DrawableHitObject>
+                caughtFruitContainer = new Container<DrawablePalpableCatchHitObject>
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.BottomCentre,
@@ -196,7 +196,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// Add a caught fruit to the catcher's stack.
         /// </summary>
         /// <param name="fruit">The fruit that was caught.</param>
-        public void PlaceOnPlate(DrawableCatchHitObject fruit)
+        public void PlaceOnPlate(DrawablePalpableCatchHitObject fruit)
         {
             var ourRadius = fruit.DisplayRadius;
             float theirRadius = 0;
@@ -385,7 +385,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 Explode(f);
         }
 
-        public void Drop(DrawableHitObject fruit)
+        public void Drop(DrawablePalpableCatchHitObject fruit)
         {
             removeFromPlateWithTransform(fruit, f =>
             {
@@ -394,7 +394,7 @@ namespace osu.Game.Rulesets.Catch.UI
             });
         }
 
-        public void Explode(DrawableHitObject fruit)
+        public void Explode(DrawablePalpableCatchHitObject fruit)
         {
             var originalX = fruit.X * Scale.X;
 
@@ -478,7 +478,7 @@ namespace osu.Game.Rulesets.Catch.UI
             updateCatcher();
         }
 
-        private void removeFromPlateWithTransform(DrawableHitObject fruit, Action<DrawableHitObject> action)
+        private void removeFromPlateWithTransform(DrawablePalpableCatchHitObject fruit, Action<DrawablePalpableCatchHitObject> action)
         {
             if (ExplodingFruitTarget != null)
             {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -266,23 +266,16 @@ namespace osu.Game.Rulesets.Catch.UI
             }
         }
 
-        private void runHyperDashStateTransition(bool hyperDashing)
+        public void UpdatePosition(float position)
         {
-            updateTrailVisibility();
+            position = Math.Clamp(position, 0, CatchPlayfield.WIDTH);
 
-            if (hyperDashing)
-            {
-                this.FadeColour(hyperDashColour, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-                this.FadeTo(0.2f, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-            }
-            else
-            {
-                this.FadeColour(Color4.White, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-                this.FadeTo(1f, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-            }
+            if (position == X)
+                return;
+
+            Scale = new Vector2(Math.Abs(Scale.X) * (position > X ? 1 : -1), Scale.Y);
+            X = position;
         }
-
-        private void updateTrailVisibility() => trails.DisplayTrail = Dashing || HyperDashing;
 
         public bool OnPressed(CatchAction action)
         {
@@ -322,17 +315,6 @@ namespace osu.Game.Rulesets.Catch.UI
             }
         }
 
-        public void UpdatePosition(float position)
-        {
-            position = Math.Clamp(position, 0, CatchPlayfield.WIDTH);
-
-            if (position == X)
-                return;
-
-            Scale = new Vector2(Math.Abs(Scale.X) * (position > X ? 1 : -1), Scale.Y);
-            X = position;
-        }
-
         /// <summary>
         /// Drop any fruit off the plate.
         /// </summary>
@@ -342,6 +324,24 @@ namespace osu.Game.Rulesets.Catch.UI
         /// Explode all fruit off the plate.
         /// </summary>
         public void Explode() => clearPlate(DroppedObjectAnimation.Explode);
+
+        private void runHyperDashStateTransition(bool hyperDashing)
+        {
+            updateTrailVisibility();
+
+            if (hyperDashing)
+            {
+                this.FadeColour(hyperDashColour, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
+                this.FadeTo(0.2f, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
+            }
+            else
+            {
+                this.FadeColour(Color4.White, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
+                this.FadeTo(1f, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
+            }
+        }
+
+        private void updateTrailVisibility() => trails.DisplayTrail = Dashing || HyperDashing;
 
         protected override void SkinChanged(ISkinSource skin, bool allowFallback)
         {

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Catch.UI
             comboDisplay.X = MovableCatcher.X;
         }
 
-        private DrawableCatchHitObject createCaughtFruit(DrawablePalpableCatchHitObject hitObject)
+        private DrawablePalpableCatchHitObject createCaughtFruit(DrawablePalpableCatchHitObject hitObject)
         {
             switch (hitObject.HitObject)
             {

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
@@ -28,8 +27,6 @@ namespace osu.Game.Rulesets.Catch.UI
             set => MovableCatcher.ExplodingFruitTarget = value;
         }
 
-        private DrawableCatchHitObject lastPlateableFruit;
-
         public CatcherArea(BeatmapDifficulty difficulty = null)
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
@@ -53,19 +50,6 @@ namespace osu.Game.Rulesets.Catch.UI
             if (!result.Type.IsScorable())
                 return;
 
-            void runAfterLoaded(Action action)
-            {
-                if (lastPlateableFruit == null)
-                    return;
-
-                // this is required to make this run after the last caught fruit runs updateState() at least once.
-                // TODO: find a better alternative
-                if (lastPlateableFruit.IsLoaded)
-                    action();
-                else
-                    lastPlateableFruit.OnLoadComplete += _ => action();
-            }
-
             if (result.IsHit && hitObject is DrawablePalpableCatchHitObject fruit)
             {
                 // create a new (cloned) fruit to stay on the plate. the original is faded out immediately.
@@ -84,16 +68,15 @@ namespace osu.Game.Rulesets.Catch.UI
                 caughtFruit.LifetimeEnd = double.MaxValue;
 
                 MovableCatcher.PlaceOnPlate(caughtFruit);
-                lastPlateableFruit = caughtFruit;
 
                 if (!fruit.StaysOnPlate)
-                    runAfterLoaded(() => MovableCatcher.Explode(caughtFruit));
+                    MovableCatcher.Explode(caughtFruit);
             }
 
             if (hitObject.HitObject.LastInCombo)
             {
                 if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
-                    runAfterLoaded(() => MovableCatcher.Explode());
+                    MovableCatcher.Explode();
                 else
                     MovableCatcher.Drop();
             }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -22,11 +22,6 @@ namespace osu.Game.Rulesets.Catch.UI
         public readonly Catcher MovableCatcher;
         private readonly CatchComboDisplay comboDisplay;
 
-        public Container ExplodingFruitTarget
-        {
-            set => MovableCatcher.ExplodingFruitTarget = value;
-        }
-
         public CatcherArea(BeatmapDifficulty difficulty = null)
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
@@ -41,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     Margin = new MarginPadding { Bottom = 350f },
                     X = CatchPlayfield.CENTER_X
                 },
-                MovableCatcher = new Catcher(this, difficulty) { X = CatchPlayfield.CENTER_X },
+                MovableCatcher = new Catcher(this, this, difficulty) { X = CatchPlayfield.CENTER_X },
             };
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Catch.UI
         public readonly Catcher MovableCatcher;
         private readonly CatchComboDisplay comboDisplay;
 
-        public CatcherArea(BeatmapDifficulty difficulty = null)
+        public CatcherArea(Container droppedObjectContainer, BeatmapDifficulty difficulty = null)
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
             Children = new Drawable[]
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     Margin = new MarginPadding { Bottom = 350f },
                     X = CatchPlayfield.CENTER_X
                 },
-                MovableCatcher = new Catcher(this, this, difficulty) { X = CatchPlayfield.CENTER_X },
+                MovableCatcher = new Catcher(this, droppedObjectContainer, difficulty) { X = CatchPlayfield.CENTER_X },
             };
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -45,29 +45,6 @@ namespace osu.Game.Rulesets.Catch.UI
             if (!result.Type.IsScorable())
                 return;
 
-            if (result.IsHit && hitObject is DrawablePalpableCatchHitObject fruit)
-            {
-                // create a new (cloned) fruit to stay on the plate. the original is faded out immediately.
-                var caughtFruit = createCaughtFruit(fruit);
-
-                if (caughtFruit == null) return;
-
-                caughtFruit.RelativePositionAxes = Axes.None;
-                caughtFruit.Position = new Vector2(MovableCatcher.ToLocalSpace(hitObject.ScreenSpaceDrawQuad.Centre).X - MovableCatcher.DrawSize.X / 2, 0);
-                caughtFruit.IsOnPlate = true;
-
-                caughtFruit.Anchor = Anchor.TopCentre;
-                caughtFruit.Origin = Anchor.Centre;
-                caughtFruit.Scale *= 0.5f;
-                caughtFruit.LifetimeStart = caughtFruit.HitObject.StartTime;
-                caughtFruit.LifetimeEnd = double.MaxValue;
-
-                MovableCatcher.PlaceOnPlate(caughtFruit);
-
-                if (!fruit.StaysOnPlate)
-                    MovableCatcher.Explode(caughtFruit);
-            }
-
             if (hitObject.HitObject.LastInCombo)
             {
                 if (result.Judgement is CatchJudgement catchJudgement && catchJudgement.ShouldExplodeFor(result))
@@ -97,27 +74,6 @@ namespace osu.Game.Rulesets.Catch.UI
                 MovableCatcher.X = state.CatcherX.Value;
 
             comboDisplay.X = MovableCatcher.X;
-        }
-
-        private DrawablePalpableCatchHitObject createCaughtFruit(DrawablePalpableCatchHitObject hitObject)
-        {
-            switch (hitObject.HitObject)
-            {
-                case Banana banana:
-                    return new DrawableBanana(banana);
-
-                case Fruit fruit:
-                    return new DrawableFruit(fruit);
-
-                case TinyDroplet tiny:
-                    return new DrawableTinyDroplet(tiny);
-
-                case Droplet droplet:
-                    return new DrawableDroplet(droplet);
-
-                default:
-                    return null;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -87,10 +87,6 @@ namespace osu.Game.Rulesets.Catch.UI
         public void OnRevertResult(DrawableCatchHitObject fruit, JudgementResult result)
             => comboDisplay.OnRevertResult(fruit, result);
 
-        public void OnReleased(CatchAction action)
-        {
-        }
-
         public bool AttemptCatch(CatchHitObject obj)
         {
             return MovableCatcher.AttemptCatch(obj);


### PR DESCRIPTION
To make the future implementation of caught object pooling easier.

- Move fruit catching logic to `Catcher`.
  - I think it is more logical.
- Simplify fruit catching code.
  - No longer wait for DHO loading until the fruit is dropped.
- Found a possibly-unintended behavior in fruit stacking logic
  - `f.DrawSize.X / 2 * f.Scale.X` was always equal to constant `CatchHitObject.OBJECT_RADIUS / 2`, because fruit scaling is done in the child `ScalingContainer`.
- Simplify fruit dropping code.
  - There was a repeated `Remove` call which has a quadratic time complexity, it should be near-linear time now.
- `CatcherArea` tests are moved to `Catcher` test scene, as the relevant code is moved.
- Add more `Catcher` tests.
  - Found another possibly-unintended behavior: circle size scaling is applied twice to the fruits on the plate.
    - This can be changed when a caught object is no longer a DHO.
