### PR TITLE
Remove OnParentReceived() from DrawableHitObject

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -4,20 +4,19 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSliderHead : DrawableHitCircle
     {
+        protected DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
+
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 
         protected override OsuSkinComponents CirclePieceComponent => OsuSkinComponents.SliderHeadHitCircle;
 
-        private DrawableSlider drawableSlider;
-
-        private Slider slider => drawableSlider?.HitObject;
+        private Slider slider => DrawableSlider?.HitObject;
 
         public DrawableSliderHead()
         {
@@ -39,24 +38,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.OnFree();
 
-            pathVersion.UnbindFrom(drawableSlider.PathVersion);
-        }
-
-        protected override void OnParentReceived(DrawableHitObject parent)
-        {
-            base.OnParentReceived(parent);
-
-            drawableSlider = (DrawableSlider)parent;
+            pathVersion.UnbindFrom(DrawableSlider.PathVersion);
         }
 
         protected override void OnApply()
         {
             base.OnApply();
 
-            pathVersion.BindTo(drawableSlider.PathVersion);
+            pathVersion.BindTo(DrawableSlider.PathVersion);
 
-            OnShake = drawableSlider.Shake;
-            CheckHittable = (d, t) => drawableSlider.CheckHittable?.Invoke(d, t) ?? true;
+            OnShake = DrawableSlider.Shake;
+            CheckHittable = (d, t) => DrawableSlider.CheckHittable?.Invoke(d, t) ?? true;
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -47,6 +47,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.OnParentReceived(parent);
 
             drawableSlider = (DrawableSlider)parent;
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
 
             pathVersion.BindTo(drawableSlider.PathVersion);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     {
         public new SliderRepeat HitObject => (SliderRepeat)base.HitObject;
 
+        protected DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
+
         private double animDuration;
 
         public Drawable CirclePiece { get; private set; }
@@ -25,8 +27,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private ReverseArrowPiece arrow;
 
         public override bool DisplayResult => false;
-
-        private DrawableSlider drawableSlider;
 
         public DrawableSliderRepeat()
             : base(null)
@@ -60,24 +60,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue));
         }
 
-        protected override void OnParentReceived(DrawableHitObject parent)
-        {
-            base.OnParentReceived(parent);
-
-            drawableSlider = (DrawableSlider)parent;
-        }
-
         protected override void OnApply()
         {
             base.OnApply();
 
-            Position = HitObject.Position - drawableSlider.Position;
+            Position = HitObject.Position - DrawableSlider.Position;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (HitObject.StartTime <= Time.Current)
-                ApplyResult(r => r.Type = drawableSlider.Tracking.Value ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                ApplyResult(r => r.Type = DrawableSlider.Tracking.Value ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateInitialTransforms()
@@ -119,7 +112,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (IsHit) return;
 
             bool isRepeatAtEnd = HitObject.RepeatIndex % 2 == 0;
-            List<Vector2> curve = ((PlaySliderBody)drawableSlider.Body.Drawable).CurrentCurve;
+            List<Vector2> curve = ((PlaySliderBody)DrawableSlider.Body.Drawable).CurrentCurve;
 
             Position = isRepeatAtEnd ? end : start;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -65,6 +65,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.OnParentReceived(parent);
 
             drawableSlider = (DrawableSlider)parent;
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
 
             Position = HitObject.Position - drawableSlider.Position;
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public override bool DisplayResult => false;
 
         private SkinnableDrawable scaleContainer;
+        private DrawableSlider drawableSlider;
 
         public DrawableSliderTick()
             : base(null)
@@ -66,7 +67,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.OnParentReceived(parent);
 
-            Position = HitObject.Position - ((DrawableSlider)parent).HitObject.Position;
+            drawableSlider = (DrawableSlider)parent;
+        }
+
+        protected override void OnApply()
+        {
+            base.OnApply();
+
+            Position = HitObject.Position - drawableSlider.HitObject.Position;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -22,8 +22,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public override bool DisplayResult => false;
 
+        protected DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
+
         private SkinnableDrawable scaleContainer;
-        private DrawableSlider drawableSlider;
 
         public DrawableSliderTick()
             : base(null)
@@ -63,18 +64,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue));
         }
 
-        protected override void OnParentReceived(DrawableHitObject parent)
-        {
-            base.OnParentReceived(parent);
-
-            drawableSlider = (DrawableSlider)parent;
-        }
-
         protected override void OnApply()
         {
             base.OnApply();
 
-            Position = HitObject.Position - drawableSlider.HitObject.Position;
+            Position = HitObject.Position - DrawableSlider.HitObject.Position;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -1,13 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Objects.Drawables;
-
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSpinnerTick : DrawableOsuHitObject
     {
         public override bool DisplayResult => false;
+
+        protected DrawableSpinner DrawableSpinner => (DrawableSpinner)ParentHitObject;
 
         public DrawableSpinnerTick()
             : base(null)
@@ -19,16 +19,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
         }
 
-        private DrawableSpinner drawableSpinner;
-
-        protected override void OnParentReceived(DrawableHitObject parent)
-        {
-            base.OnParentReceived(parent);
-
-            drawableSpinner = (DrawableSpinner)parent;
-        }
-
-        protected override double MaximumJudgementOffset => drawableSpinner.HitObject.Duration;
+        protected override double MaximumJudgementOffset => DrawableSpinner.HitObject.Duration;
 
         /// <summary>
         /// Apply a judgement result.

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void OnParentReceived(DrawableHitObject parent)
         {
             base.OnParentReceived(parent);
+
             drawableSpinner = (DrawableSpinner)parent;
         }
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -44,6 +44,12 @@ namespace osu.Game.Rulesets.Objects.Drawables
         public HitObject HitObject { get; private set; }
 
         /// <summary>
+        /// The parenting <see cref="DrawableHitObject"/>, if any.
+        /// </summary>
+        [CanBeNull]
+        protected internal DrawableHitObject ParentHitObject { get; internal set; }
+
+        /// <summary>
         /// The colour used for various elements of this DrawableHitObject.
         /// </summary>
         public readonly Bindable<Color4> AccentColour = new Bindable<Color4>(Color4.Gray);
@@ -243,9 +249,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
                 drawableNested.OnRevertResult += onRevertResult;
                 drawableNested.ApplyCustomUpdateState += onApplyCustomUpdateState;
 
-                // ApplyParent() should occur before Apply() in all cases, so it's invoked before the nested DHO is added to the hierarchy below, but after its events are initialised.
-                if (pooledDrawableNested == null)
-                    drawableNested.ApplyParent(this);
+                // This is only necessary for non-pooled DHOs. For pooled DHOs, this is handled inside GetPooledDrawableRepresentation().
+                // Must be done before the nested DHO is added to occur before the nested Apply()!
+                drawableNested.ParentHitObject = this;
 
                 nestedHitObjects.Value.Add(drawableNested);
                 AddNestedHitObject(drawableNested);
@@ -317,6 +323,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             OnFree();
 
             HitObject = null;
+            ParentHitObject = null;
             Result = null;
             lifetimeEntry = null;
 
@@ -347,20 +354,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// Invoked for this <see cref="DrawableHitObject"/> to revert any values previously taken on from the currently-applied <see cref="HitObject"/>.
         /// </summary>
         protected virtual void OnFree()
-        {
-        }
-
-        /// <summary>
-        /// Applies a parenting <see cref="DrawableHitObject"/> to this <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <param name="parent">The parenting <see cref="DrawableHitObject"/>.</param>
-        public void ApplyParent(DrawableHitObject parent) => OnParentReceived(parent);
-
-        /// <summary>
-        /// Invoked when this <see cref="DrawableHitObject"/> receives a new parenting <see cref="DrawableHitObject"/>.
-        /// </summary>
-        /// <param name="parent">The parenting <see cref="DrawableHitObject"/>.</param>
-        protected virtual void OnParentReceived(DrawableHitObject parent)
         {
         }
 

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.UI
         {
             Debug.Assert(!drawableMap.ContainsKey(entry));
 
-            var drawable = pooledObjectProvider?.GetPooledDrawableRepresentation(entry.HitObject);
+            var drawable = pooledObjectProvider?.GetPooledDrawableRepresentation(entry.HitObject, null);
             if (drawable == null)
                 throw new InvalidOperationException($"A drawable representation could not be retrieved for hitobject type: {entry.HitObject.GetType().ReadableName()}.");
 

--- a/osu.Game/Rulesets/UI/IPooledHitObjectProvider.cs
+++ b/osu.Game/Rulesets/UI/IPooledHitObjectProvider.cs
@@ -13,8 +13,9 @@ namespace osu.Game.Rulesets.UI
         /// Attempts to retrieve the poolable <see cref="DrawableHitObject"/> representation of a <see cref="HitObject"/>.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> to retrieve the <see cref="DrawableHitObject"/> representation of.</param>
+        /// <param name="parent">The parenting <see cref="DrawableHitObject"/>, if any.</param>
         /// <returns>The <see cref="DrawableHitObject"/> representing <see cref="HitObject"/>, or <c>null</c> if no poolable representation exists.</returns>
         [CanBeNull]
-        DrawableHitObject GetPooledDrawableRepresentation([NotNull] HitObject hitObject);
+        DrawableHitObject GetPooledDrawableRepresentation([NotNull] HitObject hitObject, [CanBeNull] DrawableHitObject parent);
     }
 }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -323,7 +323,7 @@ namespace osu.Game.Rulesets.UI
             AddInternal(pool);
         }
 
-        DrawableHitObject IPooledHitObjectProvider.GetPooledDrawableRepresentation(HitObject hitObject)
+        DrawableHitObject IPooledHitObjectProvider.GetPooledDrawableRepresentation(HitObject hitObject, DrawableHitObject parent)
         {
             var lookupType = hitObject.GetType();
 
@@ -359,6 +359,8 @@ namespace osu.Game.Rulesets.UI
                 if (!lifetimeEntryMap.TryGetValue(hitObject, out var entry))
                     lifetimeEntryMap[hitObject] = entry = CreateLifetimeEntry(hitObject);
 
+                if (parent != null)
+                    dho.ApplyParent(parent);
                 dho.Apply(hitObject, entry);
             });
         }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -359,8 +359,7 @@ namespace osu.Game.Rulesets.UI
                 if (!lifetimeEntryMap.TryGetValue(hitObject, out var entry))
                     lifetimeEntryMap[hitObject] = entry = CreateLifetimeEntry(hitObject);
 
-                if (parent != null)
-                    dho.ApplyParent(parent);
+                dho.ParentHitObject = parent;
                 dho.Apply(hitObject, entry);
             });
         }


### PR DESCRIPTION
`nested.OnParentReceived()` would be called after `nested.Apply()`, which was a weird ordering - `OsuModHidden` depends on knowing the parenting DHO by the time `ApplyCustomUpdateState` is invoked.

Now, the new `ParentHitObject` property is assigned pre-`Apply()` such that the DHO has access to both the local object (via `HitObject`) and the parent object (via `ParentHitObject`) inside `OnApply()`. Any code that previously existed inside `OnParentReceived()` can now be safely moved into `OnApply()`.

The order of method calls is now the following:

```
Parent.Apply()
    Nested.Apply()
        Nested.OnApply()
        Nested.updateState()*
    Parent.OnApply()
    Parent.updateState()*

* The order of updateState() can vary depending on the IsLoaded state.
  If not loaded, then updateState() happens at a later point in time (first update) and in hierarchical order.
```