### PR TITLE
Select recommended beatmap if last selection is filtered

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Select.Carousel
 
         protected override CarouselItem GetNextToSelect()
         {
-            if (LastSelected == null)
+            if (LastSelected == null || LastSelected.Filtered.Value)
             {
                 if (GetRecommendedBeatmap?.Invoke(Children.OfType<CarouselBeatmap>().Where(b => !b.Filtered.Value).Select(b => b.Beatmap)) is BeatmapInfo recommended)
                     return Children.OfType<CarouselBeatmap>().First(b => b.Beatmap == recommended);


### PR DESCRIPTION
Closes #8757

Tests are passing so I guess this isn't a major change to how beatmap carousel works. Only unintuitive thing I can imagine that could happen is if you somehow manage to filter out only the selected difficulty from others, the recommended difficulty is selected instead of next.

Can write tests if this feature is deemed important enough.

Edit: Or can PR something like https://github.com/ppy/osu/compare/master...LittleEndu:ruleset-change-recommended instead if this should only run on ruleset change