### PR TITLE
Fix spinner ticks getting increased visibility state in hidden mod

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModHidden.cs
@@ -2,12 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Play;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests.Mods
@@ -17,15 +20,15 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         [Test]
         public void TestDefaultBeatmapTest() => CreateModTest(new ModTestData
         {
-            Mod = new OsuModHidden(),
+            Mod = new TestOsuModHidden(),
             Autoplay = true,
-            PassCondition = checkSomeHit
+            PassCondition = () => checkSomeHit() && objectWithIncreasedVisibilityHasIndex(0)
         });
 
         [Test]
         public void FirstCircleAfterTwoSpinners() => CreateModTest(new ModTestData
         {
-            Mod = new OsuModHidden(),
+            Mod = new TestOsuModHidden(),
             Autoplay = true,
             Beatmap = new Beatmap
             {
@@ -54,13 +57,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                     }
                 }
             },
-            PassCondition = checkSomeHit
+            PassCondition = () => checkSomeHit() && objectWithIncreasedVisibilityHasIndex(2)
         });
 
         [Test]
         public void FirstSliderAfterTwoSpinners() => CreateModTest(new ModTestData
         {
-            Mod = new OsuModHidden(),
+            Mod = new TestOsuModHidden(),
             Autoplay = true,
             Beatmap = new Beatmap
             {
@@ -89,13 +92,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                     }
                 }
             },
-            PassCondition = checkSomeHit
+            PassCondition = () => checkSomeHit() && objectWithIncreasedVisibilityHasIndex(2)
         });
 
         [Test]
         public void TestWithSliderReuse() => CreateModTest(new ModTestData
         {
-            Mod = new OsuModHidden(),
+            Mod = new TestOsuModHidden(),
             Autoplay = true,
             Beatmap = new Beatmap
             {
@@ -116,9 +119,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             PassCondition = checkSomeHit
         });
 
-        private bool checkSomeHit()
+        private bool checkSomeHit() => Player.ScoreProcessor.JudgedHits >= 4;
+
+        private bool objectWithIncreasedVisibilityHasIndex(int index)
+            => Player.Mods.Value.OfType<TestOsuModHidden>().Single().FirstObject == Player.ChildrenOfType<GameplayBeatmap>().Single().HitObjects[index];
+
+        private class TestOsuModHidden : OsuModHidden
         {
-            return Player.ScoreProcessor.JudgedHits >= 4;
+            public new HitObject FirstObject => base.FirstObject;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         private const double fade_in_duration_multiplier = 0.4;
         private const double fade_out_duration_multiplier = 0.3;
 
-        protected override bool IsFirstAdjustableObject(HitObject hitObject) => !(hitObject is Spinner);
+        protected override bool IsFirstAdjustableObject(HitObject hitObject) => !(hitObject is Spinner || hitObject is SpinnerTick);
 
         public override void ApplyToBeatmap(IBeatmap beatmap)
         {


### PR DESCRIPTION
- [x] Depends on #11073 (first in chain).
- [x] Depends on #11069 (for ease of mergeability).

Noticed while reviewing the aforementioned PR(s).

# Summary

The increased visibility logic for osu! hidden has regressed in #10696. The old `IsFirstHideableObject()` method did not
consider nested hitobjects, while its replacement - `IsFirstAdjustableObject()` - did. Therefore, spinner ticks could be
considered first adjustable objects, breaking the old logic.

To resolve, exclude ticks from being considered for increased vislibility.

# Remarks

There is no need to match over `SpinnerBonusTick`, as it inherits from `SpinnerTick`.

This now has actual automated test coverage, as this is the second time this has regressed. Previous coverage was purely visual.

As for the test code,`GameplayBeatmap` has to be used instead of the normal bindable `Beatmap`, beecause the former uses osu!-specific hitobjects, while the latter returns convert objects (i.e. `ConvertSlider`s).

Similarly, the mod has to be fetched from the player instead of the global bindable, as `Player` has its own cloned instance of the mod, to which the beatmap is applied. The global bindable instance does not have `FirstObject` set.