### PR TITLE
Ensure equality member consistency for SampleInfo

### DIFF
--- a/osu.Game.Tests/Audio/SampleInfoEqualityTest.cs
+++ b/osu.Game.Tests/Audio/SampleInfoEqualityTest.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Audio;
+
+namespace osu.Game.Tests.Audio
+{
+    [TestFixture]
+    public class SampleInfoEqualityTest
+    {
+        [Test]
+        public void TestSameSingleSamplesAreEqual()
+        {
+            var first = new SampleInfo("sample");
+            var second = new SampleInfo("sample");
+
+            assertEquality(first, second);
+        }
+
+        [Test]
+        public void TestDifferentSingleSamplesAreNotEqual()
+        {
+            var first = new SampleInfo("first");
+            var second = new SampleInfo("second");
+
+            assertNonEquality(first, second);
+        }
+
+        [Test]
+        public void TestDifferentCountSampleSetsAreNotEqual()
+        {
+            var first = new SampleInfo("sample", "extra");
+            var second = new SampleInfo("sample");
+
+            assertNonEquality(first, second);
+        }
+
+        [Test]
+        public void TestDifferentSampleSetsOfSameCountAreNotEqual()
+        {
+            var first = new SampleInfo("first", "common");
+            var second = new SampleInfo("common", "second");
+
+            assertNonEquality(first, second);
+        }
+
+        [Test]
+        public void TestSameOrderSameSampleSetsAreEqual()
+        {
+            var first = new SampleInfo("first", "second");
+            var second = new SampleInfo("first", "second");
+
+            assertEquality(first, second);
+        }
+
+        [Test]
+        public void TestDifferentOrderSameSampleSetsAreEqual()
+        {
+            var first = new SampleInfo("first", "second");
+            var second = new SampleInfo("second", "first");
+
+            assertEquality(first, second);
+        }
+
+        private void assertEquality(SampleInfo first, SampleInfo second)
+        {
+            Assert.That(first.Equals(second), Is.True);
+            Assert.That(first.GetHashCode(), Is.EqualTo(second.GetHashCode()));
+        }
+
+        private void assertNonEquality(SampleInfo first, SampleInfo second)
+        {
+            Assert.That(first.Equals(second), Is.False);
+            Assert.That(first.GetHashCode(), Is.Not.EqualTo(second.GetHashCode()));
+        }
+    }
+}

--- a/osu.Game/Audio/SampleInfo.cs
+++ b/osu.Game/Audio/SampleInfo.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,6 +18,7 @@ namespace osu.Game.Audio
         public SampleInfo(params string[] sampleNames)
         {
             this.sampleNames = sampleNames;
+            Array.Sort(sampleNames);
         }
 
         public IEnumerable<string> LookupNames => sampleNames;
@@ -25,7 +27,9 @@ namespace osu.Game.Audio
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(sampleNames, Volume);
+            return HashCode.Combine(
+                StructuralComparisons.StructuralEqualityComparer.GetHashCode(sampleNames),
+                Volume);
         }
 
         public bool Equals(SampleInfo other)


### PR DESCRIPTION
Resolves #11079.

# Summary

The previous implementation of `SampleInfo`'s equality members was not completely correct in its treatment of the `sampleNames` array. While `Equals()` compared the values of `sampleNames` using `SequenceEqual()`, therefore performing a structural check that inspects the contents of both arrays, `GetHashCode()` used `HashCode.Combine()` directly on the arrays, therefore operating on reference equality. This could cause the pooling mechanism of samples to fail, as pointed out in #11079.

To resolve, change the `GetHashCode()` implementation such that it also considers the contents of the array rather than just the reference to the array itself. This is achieved by leveraging `StructuralEqualityComparer`.

# Remarks

Additionally, as a bonus, an array sort was added to the constructor of `SampleInfo`. This is intended to be a "canonicalisation" processing step for the array of sample names. Thanks to that sort, two instances of `SampleInfo` that have the same sample names but permutated will also turn out to be equal and have the same hash codes, given the
implementation of both equality members. This gives `SampleInfo` set-like semantics.

Test coverage included.