### PR TITLE
Always confine mouse to screen when running fullscreen

### DIFF
--- a/osu.Game/Input/ConfineMouseTracker.cs
+++ b/osu.Game/Input/ConfineMouseTracker.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Input
     public class ConfineMouseTracker : Component
     {
         private Bindable<ConfineMouseMode> frameworkConfineMode;
+        private Bindable<WindowMode> frameworkWindowMode;
+
         private Bindable<OsuConfineMouseMode> osuConfineMode;
         private IBindable<bool> localUserPlaying;
 
@@ -25,6 +27,9 @@ namespace osu.Game.Input
         private void load(OsuGame game, FrameworkConfigManager frameworkConfigManager, OsuConfigManager osuConfigManager)
         {
             frameworkConfineMode = frameworkConfigManager.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode);
+            frameworkWindowMode = frameworkConfigManager.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
+            frameworkWindowMode.BindValueChanged(_ => updateConfineMode());
+
             osuConfineMode = osuConfigManager.GetBindable<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode);
             localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
 
@@ -38,14 +43,16 @@ namespace osu.Game.Input
             if (frameworkConfineMode.Disabled)
                 return;
 
+            if (frameworkWindowMode.Value == WindowMode.Fullscreen)
+            {
+                frameworkConfineMode.Value = ConfineMouseMode.Fullscreen;
+                return;
+            }
+
             switch (osuConfineMode.Value)
             {
                 case OsuConfineMouseMode.Never:
                     frameworkConfineMode.Value = ConfineMouseMode.Never;
-                    break;
-
-                case OsuConfineMouseMode.Fullscreen:
-                    frameworkConfineMode.Value = ConfineMouseMode.Fullscreen;
                     break;
 
                 case OsuConfineMouseMode.DuringGameplay:

--- a/osu.Game/Input/OsuConfineMouseMode.cs
+++ b/osu.Game/Input/OsuConfineMouseMode.cs
@@ -18,11 +18,6 @@ namespace osu.Game.Input
         Never,
 
         /// <summary>
-        /// The mouse cursor will be locked to the window bounds while in fullscreen mode.
-        /// </summary>
-        Fullscreen,
-
-        /// <summary>
         /// The mouse cursor will be locked to the window bounds during gameplay,
         /// but may otherwise move freely.
         /// </summary>


### PR DESCRIPTION
It doesn't make sense to offer non-confining mode when running (exclusive) fullscreen. There's no way to govern cursor bounds in this scenario as the OS no longer limits to the window.

I'm not sure if this should be changed framework side, but for now hotfixing this locally is quite important considering how many users are hitting this issue (and how badly it breaks the game).

Closes https://github.com/ppy/osu/issues/10465