### PR TITLE
Hide confine mode dropdown when full-screen

### DIFF
--- a/osu.Game.Tests/Input/ConfineMouseTrackerTest.cs
+++ b/osu.Game.Tests/Input/ConfineMouseTrackerTest.cs
@@ -28,8 +28,6 @@ namespace osu.Game.Tests.Input
             setWindowModeTo(windowMode);
             setGameSideModeTo(OsuConfineMouseMode.Never);
 
-            gameSideConfineModeDisabled(false);
-
             setLocalUserPlayingTo(false);
             frameworkSideModeIs(ConfineMouseMode.Never);
 
@@ -43,8 +41,6 @@ namespace osu.Game.Tests.Input
         {
             setWindowModeTo(windowMode);
             setGameSideModeTo(OsuConfineMouseMode.DuringGameplay);
-
-            gameSideConfineModeDisabled(false);
 
             setLocalUserPlayingTo(false);
             frameworkSideModeIs(ConfineMouseMode.Never);
@@ -60,8 +56,6 @@ namespace osu.Game.Tests.Input
             setWindowModeTo(windowMode);
             setGameSideModeTo(OsuConfineMouseMode.Always);
 
-            gameSideConfineModeDisabled(false);
-
             setLocalUserPlayingTo(false);
             frameworkSideModeIs(ConfineMouseMode.Always);
 
@@ -75,20 +69,18 @@ namespace osu.Game.Tests.Input
             setGameSideModeTo(OsuConfineMouseMode.Never);
 
             setWindowModeTo(WindowMode.Fullscreen);
-            gameSideConfineModeDisabled(true);
 
             setLocalUserPlayingTo(false);
-            frameworkSideModeIs(ConfineMouseMode.Always);
+            frameworkSideModeIs(ConfineMouseMode.Fullscreen);
 
             setLocalUserPlayingTo(true);
-            frameworkSideModeIs(ConfineMouseMode.Always);
+            frameworkSideModeIs(ConfineMouseMode.Fullscreen);
 
             setWindowModeTo(WindowMode.Windowed);
 
             // old state is restored
             gameSideModeIs(OsuConfineMouseMode.Never);
             frameworkSideModeIs(ConfineMouseMode.Never);
-            gameSideConfineModeDisabled(false);
         }
 
         private void setWindowModeTo(WindowMode mode)
@@ -106,9 +98,5 @@ namespace osu.Game.Tests.Input
 
         private void frameworkSideModeIs(ConfineMouseMode mode)
             => AddAssert($"mode is {mode} framework-side", () => frameworkConfigManager.Get<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode) == mode);
-
-        private void gameSideConfineModeDisabled(bool disabled)
-            => AddAssert($"game-side confine mode {(disabled ? "disabled" : "enabled")}",
-                () => Game.LocalConfig.GetBindable<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode).Disabled == disabled);
     }
 }

--- a/osu.Game.Tests/Input/ConfineMouseTrackerTest.cs
+++ b/osu.Game.Tests/Input/ConfineMouseTrackerTest.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Game.Configuration;
+using osu.Game.Input;
+using osu.Game.Tests.Visual.Navigation;
+
+namespace osu.Game.Tests.Input
+{
+    [HeadlessTest]
+    public class ConfineMouseTrackerTest : OsuGameTestScene
+    {
+        [Resolved]
+        private FrameworkConfigManager frameworkConfigManager { get; set; }
+
+        [Resolved]
+        private OsuConfigManager osuConfigManager { get; set; }
+
+        [TestCase(WindowMode.Windowed)]
+        [TestCase(WindowMode.Borderless)]
+        public void TestDisableConfining(WindowMode windowMode)
+        {
+            setWindowModeTo(windowMode);
+            setGameSideModeTo(OsuConfineMouseMode.Never);
+
+            gameSideConfineModeDisabled(false);
+
+            setLocalUserPlayingTo(false);
+            frameworkSideModeIs(ConfineMouseMode.Never);
+
+            setLocalUserPlayingTo(true);
+            frameworkSideModeIs(ConfineMouseMode.Never);
+        }
+
+        [TestCase(WindowMode.Windowed)]
+        [TestCase(WindowMode.Borderless)]
+        public void TestConfiningDuringGameplay(WindowMode windowMode)
+        {
+            setWindowModeTo(windowMode);
+            setGameSideModeTo(OsuConfineMouseMode.DuringGameplay);
+
+            gameSideConfineModeDisabled(false);
+
+            setLocalUserPlayingTo(false);
+            frameworkSideModeIs(ConfineMouseMode.Never);
+
+            setLocalUserPlayingTo(true);
+            frameworkSideModeIs(ConfineMouseMode.Always);
+        }
+
+        [TestCase(WindowMode.Windowed)]
+        [TestCase(WindowMode.Borderless)]
+        public void TestConfineAlwaysUserSetting(WindowMode windowMode)
+        {
+            setWindowModeTo(windowMode);
+            setGameSideModeTo(OsuConfineMouseMode.Always);
+
+            gameSideConfineModeDisabled(false);
+
+            setLocalUserPlayingTo(false);
+            frameworkSideModeIs(ConfineMouseMode.Always);
+
+            setLocalUserPlayingTo(true);
+            frameworkSideModeIs(ConfineMouseMode.Always);
+        }
+
+        [Test]
+        public void TestConfineAlwaysInFullscreen()
+        {
+            setGameSideModeTo(OsuConfineMouseMode.Never);
+
+            setWindowModeTo(WindowMode.Fullscreen);
+            gameSideConfineModeDisabled(true);
+
+            setLocalUserPlayingTo(false);
+            frameworkSideModeIs(ConfineMouseMode.Always);
+
+            setLocalUserPlayingTo(true);
+            frameworkSideModeIs(ConfineMouseMode.Always);
+
+            setWindowModeTo(WindowMode.Windowed);
+
+            // old state is restored
+            gameSideModeIs(OsuConfineMouseMode.Never);
+            frameworkSideModeIs(ConfineMouseMode.Never);
+            gameSideConfineModeDisabled(false);
+        }
+
+        private void setWindowModeTo(WindowMode mode)
+            // needs to go through .GetBindable().Value instead of .Set() due to default overrides
+            => AddStep($"make window {mode}", () => frameworkConfigManager.GetBindable<WindowMode>(FrameworkSetting.WindowMode).Value = mode);
+
+        private void setGameSideModeTo(OsuConfineMouseMode mode)
+            => AddStep($"set {mode} game-side", () => Game.LocalConfig.Set(OsuSetting.ConfineMouseMode, mode));
+
+        private void setLocalUserPlayingTo(bool playing)
+            => AddStep($"local user {(playing ? "playing" : "not playing")}", () => Game.LocalUserPlaying.Value = playing);
+
+        private void gameSideModeIs(OsuConfineMouseMode mode)
+            => AddAssert($"mode is {mode} game-side", () => Game.LocalConfig.Get<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode) == mode);
+
+        private void frameworkSideModeIs(ConfineMouseMode mode)
+            => AddAssert($"mode is {mode} framework-side", () => frameworkConfigManager.Get<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode) == mode);
+
+        private void gameSideConfineModeDisabled(bool disabled)
+            => AddAssert($"game-side confine mode {(disabled ? "disabled" : "enabled")}",
+                () => Game.LocalConfig.GetBindable<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode).Disabled == disabled);
+    }
+}

--- a/osu.Game/Input/ConfineMouseTracker.cs
+++ b/osu.Game/Input/ConfineMouseTracker.cs
@@ -28,37 +28,26 @@ namespace osu.Game.Input
         {
             frameworkConfineMode = frameworkConfigManager.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode);
             frameworkWindowMode = frameworkConfigManager.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
-            frameworkWindowMode.BindValueChanged(_ => updateGameConfineMode());
+            frameworkWindowMode.BindValueChanged(_ => updateConfineMode());
 
             osuConfineMode = osuConfigManager.GetBindable<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode);
             localUserPlaying = game.LocalUserPlaying.GetBoundCopy();
 
-            osuConfineMode.ValueChanged += _ => updateFrameworkConfineMode();
-            localUserPlaying.BindValueChanged(_ => updateFrameworkConfineMode(), true);
+            osuConfineMode.ValueChanged += _ => updateConfineMode();
+            localUserPlaying.BindValueChanged(_ => updateConfineMode(), true);
         }
 
-        private LeasedBindable<OsuConfineMouseMode> leasedOsuConfineMode;
-
-        private void updateGameConfineMode()
-        {
-            if (frameworkWindowMode.Value == WindowMode.Fullscreen && leasedOsuConfineMode == null)
-            {
-                leasedOsuConfineMode = osuConfineMode.BeginLease(true);
-                leasedOsuConfineMode.Value = OsuConfineMouseMode.Always;
-            }
-
-            if (frameworkWindowMode.Value != WindowMode.Fullscreen && leasedOsuConfineMode != null)
-            {
-                leasedOsuConfineMode.Return();
-                leasedOsuConfineMode = null;
-            }
-        }
-
-        private void updateFrameworkConfineMode()
+        private void updateConfineMode()
         {
             // confine mode is unavailable on some platforms
             if (frameworkConfineMode.Disabled)
                 return;
+
+            if (frameworkWindowMode.Value == WindowMode.Fullscreen)
+            {
+                frameworkConfineMode.Value = ConfineMouseMode.Fullscreen;
+                return;
+            }
 
             switch (osuConfineMode.Value)
             {

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -20,6 +20,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private Bindable<double> sensitivityBindable = new BindableDouble();
         private Bindable<string> ignoredInputHandlers;
 
+        private Bindable<WindowMode> windowMode;
+        private SettingsEnumDropdown<OsuConfineMouseMode> confineMouseModeSetting;
+
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager osuConfig, FrameworkConfigManager config)
         {
@@ -29,6 +32,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             sensitivityBindable = configSensitivity.GetUnboundCopy();
             configSensitivity.BindValueChanged(val => sensitivityBindable.Value = val.NewValue);
             sensitivityBindable.BindValueChanged(val => configSensitivity.Value = val.NewValue);
+
+            windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
+            windowMode.BindValueChanged(mode => confineMouseModeSetting.Alpha = mode.NewValue == WindowMode.Fullscreen ? 0 : 1);
 
             Children = new Drawable[]
             {
@@ -47,7 +53,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     LabelText = "Map absolute input to window",
                     Current = config.GetBindable<bool>(FrameworkSetting.MapAbsoluteInputToWindow)
                 },
-                new SettingsEnumDropdown<OsuConfineMouseMode>
+                confineMouseModeSetting = new SettingsEnumDropdown<OsuConfineMouseMode>
                 {
                     LabelText = "Confine mouse cursor to window",
                     Current = osuConfig.GetBindable<OsuConfineMouseMode>(OsuSetting.ConfineMouseMode)


### PR DESCRIPTION
Closes #11097.

# Summary

After hard-locking the mouse confine mode to `Always` in full-screen to prevent confine issues from popping up, the confine mode dropdown in settings had confusing UX due to seemingly having no effect when full-screen.

This change aims to block modification to said dropdown when (and only when) the game is in full-screen.

# Remarks

The method of achieving the underlying functionality has changed slightly (framework-side `Always` will be set instead of `Fullscreen` while full-screen), but I think leasing was a good pattern to use here.

Additionally added test coverage to this, due to growing levels of complexity around confine logic.