### PR TITLE
Nerf PP awarded for AR11 on short maps in the osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -101,9 +101,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
-              approachRateFactor += 0.4 * (Attributes.ApproachRate - 10.33);
+                approachRateFactor += 0.4 * (Attributes.ApproachRate - 10.33);
             else if (Attributes.ApproachRate < 8.0)
-              approachRateFactor += 0.1 * (8.0 - Attributes.ApproachRate);
+                approachRateFactor += 0.1 * (8.0 - Attributes.ApproachRate);
 
             aimValue *= 1.0 + Math.Min(approachRateFactor, approachRateFactor * (totalHits / 1000.0));
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -99,16 +99,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (Attributes.MaxCombo > 0)
                 aimValue *= Math.Min(Math.Pow(scoreMaxCombo, 0.8) / Math.Pow(Attributes.MaxCombo, 0.8), 1.0);
 
-            double approachRateFactor = 1.0;
-
+            double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
-                approachRateFactor += 0.3 * (Attributes.ApproachRate - 10.33);
+              approachRateFactor += 0.4 * (Attributes.ApproachRate - 10.33);
             else if (Attributes.ApproachRate < 8.0)
-            {
-                approachRateFactor += 0.01 * (8.0 - Attributes.ApproachRate);
-            }
+              approachRateFactor += 0.1 * (8.0 - Attributes.ApproachRate);
 
-            aimValue *= approachRateFactor;
+            aimValue *= 1.0 + Math.Min(approachRateFactor, approachRateFactor * (totalHits / 1000.0));
 
             // We want to give more reward for lower AR when it comes to aim and HD. This nerfs high AR and buffs lower AR.
             if (mods.Any(h => h is OsuModHidden))
@@ -137,8 +134,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double speedValue = Math.Pow(5.0 * Math.Max(1.0, Attributes.SpeedStrain / 0.0675) - 4.0, 3.0) / 100000.0;
 
             // Longer maps are worth more
-            speedValue *= 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                          (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
+            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
+                                 (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
+            speedValue *= lengthBonus;
 
             // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
             speedValue *= Math.Pow(0.97, countMiss);
@@ -147,11 +145,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (Attributes.MaxCombo > 0)
                 speedValue *= Math.Min(Math.Pow(scoreMaxCombo, 0.8) / Math.Pow(Attributes.MaxCombo, 0.8), 1.0);
 
-            double approachRateFactor = 1.0;
+            double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
-                approachRateFactor += 0.3 * (Attributes.ApproachRate - 10.33);
+                approachRateFactor += 0.4 * (Attributes.ApproachRate - 10.33);
 
-            speedValue *= approachRateFactor;
+            speedValue *= 1.0 + Math.Min(approachRateFactor, approachRateFactor * (totalHits / 1000.0));
 
             if (mods.Any(m => m is OsuModHidden))
                 speedValue *= 1.0 + 0.04 * (12.0 - Attributes.ApproachRate);


### PR DESCRIPTION
Hello All. This is part of a series of small changes I am suggesting to be implemented to keep the current competitive scene alive until a more robust solution is introduced, or until I get fed up enough to start attempting to work on DiffCalc. The goal for these changes is to create a series of easily implementable changes that will help to improve the competitive scene at all levels of play. 

**The Problem**
In PerformanceCalc, there exists a scaling buff for all maps with approach rate (AR) exceeding 10.33. As there has been an increase in top level play regarding AR11, I believe it is appropriate to re-examine this buff and adjust its usage. For the sake of keeping the differences easier to quantify, I'll just be referring to the amount of points that will be rewarded with AR11, but know all of this applies in a linearly decreasing fashion for AR's 11 through 10.33.

Currently, the buff is simply a 20% buff to speedPP and aimPP. The reason I am addressing this as problematic is that a large portion of the skill involved with reading AR11 is the length and complexity of the song. If we look at top scores on AR11 maps, they are almost exclusively on short maps. 

**The Solution**
My belief is that AR11 is very similar to FL, as it is a skill that is significantly more difficulty the longer a map is. Hence, I have introduced a buff and a nerf for AR11 maps. The details of the code can be viewed in the changes, but in summary, the change simply makes the AR buff scale from 0% at 0 objects, to 26.66% at 1000 objects for AR11, thus putting a 20% buff on 750 objects. These numbers are based on my own personal observations of map difficulties and length in several cases, as well as communicating with several members of the community. I also decided to buff higher than 750 objects as there are very few AR11 plays that have that many objects, but this can theoretically be reverted.

**Top Player Results**
Whitecat: http://puu.sh/GUW1A/ed6c31c828.txt
badeu: http://puu.sh/GUW3l/a0772ef216.txt
idke: http://puu.sh/GUW42/c02beaf4e4.txt
chocomint: http://puu.sh/GUW1L/846fbb2118.txt
fgsky: http://puu.sh/GUW4j/6dc9896053.txt

These are sort of hard to read as puush didnt like the unicode, but you can still figure out what it showing... albeit its not ideal. Run them yourselves if you want to see it in the proper format.

For those who are wondering, I made the change to the lengthBonus in the speedPP calculation to match the format of aimPP. If its preferred it can be refactored in aimPP to be the format of speedPP.