### PR TITLE
Update DiscordRichPresence with fix for startup crashes

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="DiscordRichPresence" Version="1.0.166" />
+    <PackageReference Include="DiscordRichPresence" Version="1.0.169" />
     <!-- .NET 3.1 SDK seems to cause issues with a runtime specification. This will likely be resolved in .NET 5. -->
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />


### PR DESCRIPTION
Includes [fix](https://github.com/Lachee/discord-rpc-csharp/issues/109) for startup crashes when running with low process IDs.

Closes https://github.com/ppy/osu/issues/11103.