### PR TITLE
Fix possible null reference in MouseSettings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             };
 
             windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
-            windowMode.BindValueChanged(mode => confineMouseModeSetting.Alpha = mode.NewValue == WindowMode.Fullscreen ? 0 : 1);
+            windowMode.BindValueChanged(mode => confineMouseModeSetting.Alpha = mode.NewValue == WindowMode.Fullscreen ? 0 : 1, true);
 
             if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
             {

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -33,9 +33,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             configSensitivity.BindValueChanged(val => sensitivityBindable.Value = val.NewValue);
             sensitivityBindable.BindValueChanged(val => configSensitivity.Value = val.NewValue);
 
-            windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
-            windowMode.BindValueChanged(mode => confineMouseModeSetting.Alpha = mode.NewValue == WindowMode.Fullscreen ? 0 : 1);
-
             Children = new Drawable[]
             {
                 new SettingsCheckbox
@@ -69,6 +66,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     Current = osuConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons)
                 },
             };
+
+            windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
+            windowMode.BindValueChanged(mode => confineMouseModeSetting.Alpha = mode.NewValue == WindowMode.Fullscreen ? 0 : 1);
 
             if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
             {


### PR DESCRIPTION
When bindable change event is invoked before variable is initialized, it will be a null reference.
Found in CI <https://ci.appveyor.com/project/peppy/osu/builds/36690846/tests>.