### PR TITLE
Pool catcher trail sprite

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
@@ -19,6 +20,8 @@ namespace osu.Game.Rulesets.Catch.UI
     public class CatcherTrailDisplay : CompositeDrawable
     {
         private readonly Catcher catcher;
+
+        private readonly DrawablePool<CatcherTrailSprite> trailPool;
 
         private readonly Container<CatcherTrailSprite> dashTrails;
         private readonly Container<CatcherTrailSprite> hyperDashTrails;
@@ -80,8 +83,9 @@ namespace osu.Game.Rulesets.Catch.UI
 
             RelativeSizeAxes = Axes.Both;
 
-            InternalChildren = new[]
+            InternalChildren = new Drawable[]
             {
+                trailPool = new DrawablePool<CatcherTrailSprite>(30),
                 dashTrails = new Container<CatcherTrailSprite> { RelativeSizeAxes = Axes.Both },
                 hyperDashTrails = new Container<CatcherTrailSprite> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
                 endGlowSprites = new Container<CatcherTrailSprite> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
@@ -118,14 +122,14 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             var texture = (catcher.CurrentDrawableCatcher as TextureAnimation)?.CurrentFrame ?? ((Sprite)catcher.CurrentDrawableCatcher).Texture;
 
-            var sprite = new CatcherTrailSprite(texture)
-            {
-                Anchor = catcher.Anchor,
-                Scale = catcher.Scale,
-                Blending = BlendingParameters.Additive,
-                RelativePositionAxes = catcher.RelativePositionAxes,
-                Position = catcher.Position
-            };
+            CatcherTrailSprite sprite = trailPool.Get();
+
+            sprite.Texture = texture;
+            sprite.Anchor = catcher.Anchor;
+            sprite.Scale = catcher.Scale;
+            sprite.Blending = BlendingParameters.Additive;
+            sprite.RelativePositionAxes = catcher.RelativePositionAxes;
+            sprite.Position = catcher.Position;
 
             target.Add(sprite);
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailSprite.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailSprite.cs
@@ -1,17 +1,29 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public class CatcherTrailSprite : Sprite
+    public class CatcherTrailSprite : PoolableDrawable
     {
-        public CatcherTrailSprite(Texture texture)
+        public Texture Texture
         {
-            Texture = texture;
+            set => sprite.Texture = value;
+        }
+
+        private readonly Sprite sprite;
+
+        public CatcherTrailSprite()
+        {
+            InternalChild = sprite = new Sprite
+            {
+                RelativeSizeAxes = Axes.Both
+            };
 
             Size = new Vector2(CatcherArea.CATCHER_SIZE);
 


### PR DESCRIPTION
20 catcher trails are created per second when the catcher is dashing. I guess pooling it makes sense.
Unfortunately I had to wrap `Sprite` to a composite drawable to make it `PoolableDrawable`.