### PR TITLE
Added a Spectate button in the UserProfileOverlay

### DIFF
--- a/osu.Game/Overlays/Profile/Sections/SpectateSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/SpectateSection.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Screens;
+using osu.Game.Screens.Multi.Match.Components;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Overlays.Profile.Sections
+{
+    public class SpectateSection : ProfileSection
+    {
+        public override string Title => "Spectate";
+        public override string Identifier => "spectate";
+
+        [Resolved(canBeNull: true)]
+        private OsuGame game { get; set; }
+
+        public SpectateSection()
+        {
+            Children = new[]
+            {
+                new PurpleTriangleButton
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Text = "Watch",
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Action = () => game?.PerformFromScreen(s => s.Push(new Spectator(User.Value))),
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -134,6 +134,11 @@ namespace osu.Game.Overlays
         {
             Header.User.Value = user;
 
+            SpectateSection spectateSection = new SpectateSection();
+            spectateSection.User.Value = user;
+            sectionsContainer.Add(spectateSection);
+            tabs.AddItem(spectateSection);
+
             if (user.ProfileOrder != null)
             {
                 foreach (string id in user.ProfileOrder)


### PR DESCRIPTION
I found that a spectate button on the UserProfileOverlay would be very useful because it can allow players to easily spectate their friends. I created a new SpectateSection class that has a PurpleTriangleButton class (the same button used in the CurrentlyPlayingDisplay). The PurpleTriangleButton will switch the game to the Spectator view while passing the User object from the UserProfileOverlay.

P.S. This is my first pull request to a public repository and so what you see in this pull request might be awful.