### PR TITLE
Limit room name to 100 characters

### DIFF
--- a/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/Match/Components/MatchSettingsOverlay.cs
@@ -135,6 +135,7 @@ namespace osu.Game.Screens.Multi.Match.Components
                                                                     {
                                                                         RelativeSizeAxes = Axes.X,
                                                                         TabbableContentContainer = this,
+                                                                        LengthLimit = 100
                                                                     },
                                                                 },
                                                                 new Section("Duration")


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/11000

```
mysql> describe multiplayer_rooms;
+-------------------+---------------------------------------+------+-----+-------------------+-------------------+
| Field             | Type                                  | Null | Key | Default           | Extra             |
+-------------------+---------------------------------------+------+-----+-------------------+-------------------+
| name              | varchar(100)                          | NO   |     | NULL              |                   |
```