### PR TITLE
Move catcher state changing logic to OnNewResult and OnRevertResult

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -57,7 +57,36 @@ namespace osu.Game.Rulesets.Catch.Tests
         });
 
         [Test]
-        public void TestCatcherStateRevert()
+        public void TestCatcherHyperStateReverted()
+        {
+            DrawableCatchHitObject drawableObject1 = null;
+            DrawableCatchHitObject drawableObject2 = null;
+            JudgementResult result1 = null;
+            JudgementResult result2 = null;
+            AddStep("catch hyper fruit", () =>
+            {
+                drawableObject1 = createDrawableObject(new Fruit { HyperDashTarget = new Fruit { X = 100 } });
+                result1 = attemptCatch(drawableObject1);
+            });
+            AddStep("catch normal fruit", () =>
+            {
+                drawableObject2 = createDrawableObject(new Fruit());
+                result2 = attemptCatch(drawableObject2);
+            });
+            AddStep("revert second result", () =>
+            {
+                catcher.OnRevertResult(drawableObject2, result2);
+            });
+            checkHyperDash(true);
+            AddStep("revert first result", () =>
+            {
+                catcher.OnRevertResult(drawableObject1, result1);
+            });
+            checkHyperDash(false);
+        }
+
+        [Test]
+        public void TestCatcherAnimationStateReverted()
         {
             DrawableCatchHitObject drawableObject = null;
             JudgementResult result = null;

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -12,8 +13,11 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Catch.Tests
@@ -169,7 +173,32 @@ namespace osu.Game.Rulesets.Catch.Tests
             hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
             for (var i = 0; i < count; i++)
-                catcher.AttemptCatch(hitObject);
+            {
+                var drawableObject = createDrawableObject(hitObject);
+                var result = new JudgementResult(hitObject, new CatchJudgement())
+                {
+                    Type = catcher.CanCatch(hitObject) ? HitResult.Great : HitResult.Miss
+                };
+                catcher.OnNewResult(drawableObject, result);
+            }
+        }
+
+        private DrawableCatchHitObject createDrawableObject(CatchHitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case Banana banana:
+                    return new DrawableBanana(banana);
+
+                case Droplet droplet:
+                    return new DrawableDroplet(droplet);
+
+                case Fruit fruit:
+                    return new DrawableFruit(fruit);
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(hitObject));
+            }
         }
 
         public class TestCatcher : Catcher

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -15,7 +15,6 @@ using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.UI;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Catch.Tests
@@ -58,7 +57,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
                 Schedule(() =>
                 {
-                    area.OnNewResult(drawable, new JudgementResult(fruit, new CatchJudgement())
+                    area.OnNewResult(drawable, new CatchJudgementResult(fruit, new CatchJudgement())
                     {
                         Type = area.MovableCatcher.CanCatch(fruit) ? HitResult.Great : HitResult.Miss
                     });

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -58,10 +58,9 @@ namespace osu.Game.Rulesets.Catch.Tests
 
                 Schedule(() =>
                 {
-                    bool caught = area.AttemptCatch(fruit);
                     area.OnNewResult(drawable, new JudgementResult(fruit, new CatchJudgement())
                     {
-                        Type = caught ? HitResult.Great : HitResult.Miss
+                        Type = area.MovableCatcher.CanCatch(fruit) ? HitResult.Great : HitResult.Miss
                     });
 
                     drawable.Expire();

--- a/osu.Game.Rulesets.Catch/Judgements/CatchJudgementResult.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchJudgementResult.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Catch.Judgements
+{
+    public class CatchJudgementResult : JudgementResult
+    {
+        /// <summary>
+        /// The catcher animation state prior to this judgement.
+        /// </summary>
+        public CatcherAnimationState CatcherAnimationState;
+
+        public CatchJudgementResult([NotNull] HitObject hitObject, [NotNull] Judgement judgement)
+            : base(hitObject, judgement)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Judgements/CatchJudgementResult.cs
+++ b/osu.Game.Rulesets.Catch/Judgements/CatchJudgementResult.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Rulesets.Catch.Judgements
         /// </summary>
         public CatcherAnimationState CatcherAnimationState;
 
+        /// <summary>
+        /// Whether the catcher was hyper dashing prior to this judgement.
+        /// </summary>
+        public bool CatcherHyperDash;
+
         public CatchJudgementResult([NotNull] HitObject hitObject, [NotNull] Judgement judgement)
             : base(hitObject, judgement)
         {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -5,7 +5,9 @@ using System;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Utils;
 
@@ -51,6 +53,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public bool IsOnPlate;
 
         public override bool RemoveWhenNotAlive => IsOnPlate;
+
+        protected override JudgementResult CreateResult(Judgement judgement) => new CatchJudgementResult(HitObject, judgement);
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Catch.UI
             ((DrawableCatchHitObject)d).CheckPosition = checkIfWeCanCatch;
         }
 
-        private bool checkIfWeCanCatch(CatchHitObject obj) => CatcherArea.AttemptCatch(obj);
+        private bool checkIfWeCanCatch(CatchHitObject obj) => CatcherArea.MovableCatcher.CanCatch(obj);
 
         private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
             => CatcherArea.OnNewResult((DrawableCatchHitObject)judgedObject, result);

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -14,6 +14,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.Catch.Judgements;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Skinning;
@@ -210,6 +211,9 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void OnNewResult(DrawableCatchHitObject drawableObject, JudgementResult result)
         {
+            var catchResult = (CatchJudgementResult)result;
+            catchResult.CatcherAnimationState = CurrentState;
+
             if (!(drawableObject.HitObject is PalpableCatchHitObject hitObject)) return;
 
             if (result.IsHit)
@@ -238,6 +242,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void OnRevertResult(DrawableCatchHitObject fruit, JudgementResult result)
         {
+            var catchResult = (CatchJudgementResult)result;
+            updateState(catchResult.CatcherAnimationState);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -241,7 +241,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 updateState(CatcherAnimationState.Fail);
         }
 
-        public void OnRevertResult(DrawableCatchHitObject fruit, JudgementResult result)
+        public void OnRevertResult(DrawableCatchHitObject drawableObject, JudgementResult result)
         {
             var catchResult = (CatchJudgementResult)result;
 
@@ -255,6 +255,9 @@ namespace osu.Game.Rulesets.Catch.UI
                 else
                     SetHyperDashState();
             }
+
+            caughtFruitContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
+            droppedObjectTarget.RemoveAll(d => (d as DrawableCatchHitObject)?.HitObject == drawableObject.HitObject);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -213,6 +213,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             var catchResult = (CatchJudgementResult)result;
             catchResult.CatcherAnimationState = CurrentState;
+            catchResult.CatcherHyperDash = HyperDashing;
 
             if (!(drawableObject.HitObject is PalpableCatchHitObject hitObject)) return;
 
@@ -243,7 +244,17 @@ namespace osu.Game.Rulesets.Catch.UI
         public void OnRevertResult(DrawableCatchHitObject fruit, JudgementResult result)
         {
             var catchResult = (CatchJudgementResult)result;
-            updateState(catchResult.CatcherAnimationState);
+
+            if (CurrentState != catchResult.CatcherAnimationState)
+                updateState(catchResult.CatcherAnimationState);
+
+            if (HyperDashing != catchResult.CatcherHyperDash)
+            {
+                if (catchResult.CatcherHyperDash)
+                    SetHyperDashState(2);
+                else
+                    SetHyperDashState();
+            }
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -258,6 +258,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             caughtFruitContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
             droppedObjectTarget.RemoveAll(d => (d as DrawableCatchHitObject)?.HitObject == drawableObject.HitObject);
+            hitExplosionContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
         }
 
         /// <summary>
@@ -489,6 +490,7 @@ namespace osu.Game.Rulesets.Catch.UI
             if (!hitLighting.Value) return;
 
             HitExplosion hitExplosion = hitExplosionPool.Get();
+            hitExplosion.HitObject = caughtObject.HitObject;
             hitExplosion.X = caughtObject.X;
             hitExplosion.Scale = new Vector2(caughtObject.HitObject.Scale);
             hitExplosion.ObjectColour = caughtObject.AccentColour.Value;

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -5,7 +5,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Judgements;
-using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Replays;
 using osu.Game.Rulesets.Judgements;
@@ -42,6 +41,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public void OnNewResult(DrawableCatchHitObject hitObject, JudgementResult result)
         {
+            MovableCatcher.OnNewResult(hitObject, result);
+
             if (!result.Type.IsScorable())
                 return;
 
@@ -56,12 +57,10 @@ namespace osu.Game.Rulesets.Catch.UI
             comboDisplay.OnNewResult(hitObject, result);
         }
 
-        public void OnRevertResult(DrawableCatchHitObject fruit, JudgementResult result)
-            => comboDisplay.OnRevertResult(fruit, result);
-
-        public bool AttemptCatch(CatchHitObject obj)
+        public void OnRevertResult(DrawableCatchHitObject hitObject, JudgementResult result)
         {
-            return MovableCatcher.AttemptCatch(obj);
+            comboDisplay.OnRevertResult(hitObject, result);
+            MovableCatcher.OnRevertResult(hitObject, result);
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Catch/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosion.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Catch.Objects;
 using osuTK;
 using osuTK.Graphics;
 
@@ -15,6 +16,7 @@ namespace osu.Game.Rulesets.Catch.UI
     public class HitExplosion : PoolableDrawable
     {
         private Color4 objectColour;
+        public CatchHitObject HitObject;
 
         public Color4 ObjectColour
         {


### PR DESCRIPTION
`Catcher.AttemptCatch` was not pure, as it is changing the catcher state internally.
I made `Catcher.CanCatch` a pure method and moved all state-changing logic to `OnNewResult`.
Then, I implemented `OnRevertResult` to restore some catcher states.

- Fix catcher state is not restored when a replay is rewound.
- Fix hit explosion and caught objects are duplicated when a replay is rewound.
