### PR TITLE
Pool objects caught by the catcher

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Catch.Tests
@@ -65,13 +66,11 @@ namespace osu.Game.Rulesets.Catch.Tests
             JudgementResult result2 = null;
             AddStep("catch hyper fruit", () =>
             {
-                drawableObject1 = createDrawableObject(new Fruit { HyperDashTarget = new Fruit { X = 100 } });
-                result1 = attemptCatch(drawableObject1);
+                attemptCatch(new Fruit { HyperDashTarget = new Fruit { X = 100 } }, out drawableObject1, out result1);
             });
             AddStep("catch normal fruit", () =>
             {
-                drawableObject2 = createDrawableObject(new Fruit());
-                result2 = attemptCatch(drawableObject2);
+                attemptCatch(new Fruit(), out drawableObject2, out result2);
             });
             AddStep("revert second result", () =>
             {
@@ -92,8 +91,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             JudgementResult result = null;
             AddStep("catch kiai fruit", () =>
             {
-                drawableObject = createDrawableObject(new TestKiaiFruit());
-                result = attemptCatch(drawableObject);
+                attemptCatch(new TestKiaiFruit(), out drawableObject, out result);
             });
             checkState(CatcherAnimationState.Kiai);
             AddStep("revert result", () =>
@@ -200,13 +198,22 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddAssert("fruits are dropped", () => !catcher.CaughtObjects.Any() && droppedObjectContainer.Count == 10);
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void TestHitLighting(bool enabled)
+        [Test]
+        public void TestHitLightingColour()
         {
-            AddStep($"{(enabled ? "enable" : "disable")} hit lighting", () => config.Set(OsuSetting.HitLighting, enabled));
+            var fruitColour = SkinConfiguration.DefaultComboColours[1];
+            AddStep("enable hit lighting", () => config.Set(OsuSetting.HitLighting, true));
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
-            AddAssert("check hit lighting", () => catcher.ChildrenOfType<HitExplosion>().Any() == enabled);
+            AddAssert("correct hit lighting colour", () =>
+                catcher.ChildrenOfType<HitExplosion>().First()?.ObjectColour == fruitColour);
+        }
+
+        [Test]
+        public void TestHitLightingDisabled()
+        {
+            AddStep("disable hit lighting", () => config.Set(OsuSetting.HitLighting, false));
+            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            AddAssert("no hit lighting", () => !catcher.ChildrenOfType<HitExplosion>().Any());
         }
 
         private void checkPlate(int count) => AddAssert($"{count} objects on the plate", () => catcher.CaughtObjects.Count() == count);
@@ -218,18 +225,34 @@ namespace osu.Game.Rulesets.Catch.Tests
         private void attemptCatch(CatchHitObject hitObject, int count = 1)
         {
             for (var i = 0; i < count; i++)
-                attemptCatch(createDrawableObject(hitObject));
+                attemptCatch(hitObject, out _, out _);
         }
 
-        private JudgementResult attemptCatch(DrawableCatchHitObject drawableObject)
+        private void attemptCatch(CatchHitObject hitObject, out DrawableCatchHitObject drawableObject, out JudgementResult result)
         {
-            drawableObject.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-            var result = new CatchJudgementResult(drawableObject.HitObject, drawableObject.HitObject.CreateJudgement())
+            hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            drawableObject = createDrawableObject(hitObject);
+            result = createResult(hitObject);
+            applyResult(drawableObject, result);
+        }
+
+        private void applyResult(DrawableCatchHitObject drawableObject, JudgementResult result)
+        {
+            // Load DHO to set colour of hit explosion correctly
+            Add(drawableObject);
+            drawableObject.OnLoadComplete += _ =>
             {
-                Type = catcher.CanCatch(drawableObject.HitObject) ? HitResult.Great : HitResult.Miss
+                catcher.OnNewResult(drawableObject, result);
+                drawableObject.Expire();
             };
-            catcher.OnNewResult(drawableObject, result);
-            return result;
+        }
+
+        private JudgementResult createResult(CatchHitObject hitObject)
+        {
+            return new CatchJudgementResult(hitObject, hitObject.CreateJudgement())
+            {
+                Type = catcher.CanCatch(hitObject) ? HitResult.Great : HitResult.Miss
+            };
         }
 
         private DrawableCatchHitObject createDrawableObject(CatchHitObject hitObject)

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         public class TestCatcher : Catcher
         {
-            public IEnumerable<DrawablePalpableCatchHitObject> CaughtObjects => this.ChildrenOfType<DrawablePalpableCatchHitObject>();
+            public IEnumerable<CaughtObject> CaughtObjects => this.ChildrenOfType<CaughtObject>();
 
             public TestCatcher(Container trailsTarget, Container droppedObjectTarget, BeatmapDifficulty difficulty)
                 : base(trailsTarget, droppedObjectTarget, difficulty)

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Resolved]
         private OsuConfigManager config { get; set; }
 
-        private Container droppedObjectContainer;
+        private Container<CaughtObject> droppedObjectContainer;
 
         private TestCatcher catcher;
 
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             };
 
             var trailContainer = new Container();
-            droppedObjectContainer = new Container();
+            droppedObjectContainer = new Container<CaughtObject>();
             catcher = new TestCatcher(trailContainer, droppedObjectContainer, difficulty);
 
             Child = new Container
@@ -277,7 +277,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             public IEnumerable<CaughtObject> CaughtObjects => this.ChildrenOfType<CaughtObject>();
 
-            public TestCatcher(Container trailsTarget, Container droppedObjectTarget, BeatmapDifficulty difficulty)
+            public TestCatcher(Container trailsTarget, Container<CaughtObject> droppedObjectTarget, BeatmapDifficulty difficulty)
                 : base(trailsTarget, droppedObjectTarget, difficulty)
             {
             }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             SetContents(() =>
             {
-                var droppedObjectContainer = new Container
+                var droppedObjectContainer = new Container<CaughtObject>
                 {
                     RelativeSizeAxes = Axes.Both
                 };
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private class TestCatcherArea : CatcherArea
         {
-            public TestCatcherArea(Container droppedObjectContainer, BeatmapDifficulty beatmapDifficulty)
+            public TestCatcherArea(Container<CaughtObject> droppedObjectContainer, BeatmapDifficulty beatmapDifficulty)
                 : base(droppedObjectContainer, beatmapDifficulty)
             {
             }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -73,7 +73,10 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             SetContents(() =>
             {
-                var droppedObjectContainer = new Container();
+                var droppedObjectContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                };
 
                 return new CatchInputManager(catchRuleset)
                 {

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
@@ -11,13 +11,13 @@ namespace osu.Game.Rulesets.Catch.Tests
 {
     public class TestSceneFruitRandomness : OsuTestScene
     {
-        private readonly TestDrawableFruit drawableFruit;
-        private readonly TestDrawableBanana drawableBanana;
+        private readonly DrawableFruit drawableFruit;
+        private readonly DrawableBanana drawableBanana;
 
         public TestSceneFruitRandomness()
         {
-            drawableFruit = new TestDrawableFruit(new Fruit());
-            drawableBanana = new TestDrawableBanana(new Banana());
+            drawableFruit = new DrawableFruit(new Fruit());
+            drawableBanana = new DrawableBanana(new Banana());
 
             Add(new TestDrawableCatchHitObjectSpecimen(drawableFruit) { X = -200 });
             Add(new TestDrawableCatchHitObjectSpecimen(drawableBanana));
@@ -44,9 +44,9 @@ namespace osu.Game.Rulesets.Catch.Tests
             {
                 drawableFruit.HitObject.StartTime = drawableBanana.HitObject.StartTime = initial_start_time;
 
-                fruitRotation = drawableFruit.InnerRotation;
-                bananaRotation = drawableBanana.InnerRotation;
-                bananaScale = drawableBanana.InnerScale;
+                fruitRotation = drawableFruit.Rotation;
+                bananaRotation = drawableBanana.Rotation;
+                bananaScale = drawableBanana.Scale.X;
                 bananaColour = drawableBanana.AccentColour.Value;
             });
 
@@ -55,9 +55,9 @@ namespace osu.Game.Rulesets.Catch.Tests
                 drawableFruit.HitObject.StartTime = drawableBanana.HitObject.StartTime = another_start_time;
             });
 
-            AddAssert("fruit rotation is changed", () => drawableFruit.InnerRotation != fruitRotation);
-            AddAssert("banana rotation is changed", () => drawableBanana.InnerRotation != bananaRotation);
-            AddAssert("banana scale is changed", () => drawableBanana.InnerScale != bananaScale);
+            AddAssert("fruit rotation is changed", () => drawableFruit.Rotation != fruitRotation);
+            AddAssert("banana rotation is changed", () => drawableBanana.Rotation != bananaRotation);
+            AddAssert("banana scale is changed", () => drawableBanana.Scale.X != bananaScale);
             AddAssert("banana colour is changed", () => drawableBanana.AccentColour.Value != bananaColour);
 
             AddStep("reset start time", () =>
@@ -66,31 +66,10 @@ namespace osu.Game.Rulesets.Catch.Tests
             });
 
             AddAssert("rotation and scale restored", () =>
-                drawableFruit.InnerRotation == fruitRotation &&
-                drawableBanana.InnerRotation == bananaRotation &&
-                drawableBanana.InnerScale == bananaScale &&
+                drawableFruit.Rotation == fruitRotation &&
+                drawableBanana.Rotation == bananaRotation &&
+                drawableBanana.Scale.X == bananaScale &&
                 drawableBanana.AccentColour.Value == bananaColour);
-        }
-
-        private class TestDrawableFruit : DrawableFruit
-        {
-            public float InnerRotation => ScaleContainer.Rotation;
-
-            public TestDrawableFruit(Fruit h)
-                : base(h)
-            {
-            }
-        }
-
-        private class TestDrawableBanana : DrawableBanana
-        {
-            public float InnerRotation => ScaleContainer.Rotation;
-            public float InnerScale => ScaleContainer.Scale.X;
-
-            public TestDrawableBanana(Banana h)
-                : base(h)
-            {
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneFruitRandomness.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Tests.Visual;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Tests
@@ -37,16 +38,16 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             float fruitRotation = 0;
             float bananaRotation = 0;
-            float bananaScale = 0;
+            Vector2 bananaSize = new Vector2();
             Color4 bananaColour = new Color4();
 
             AddStep("Initialize start time", () =>
             {
                 drawableFruit.HitObject.StartTime = drawableBanana.HitObject.StartTime = initial_start_time;
 
-                fruitRotation = drawableFruit.Rotation;
-                bananaRotation = drawableBanana.Rotation;
-                bananaScale = drawableBanana.Scale.X;
+                fruitRotation = drawableFruit.DisplayRotation;
+                bananaRotation = drawableBanana.DisplayRotation;
+                bananaSize = drawableBanana.DisplaySize;
                 bananaColour = drawableBanana.AccentColour.Value;
             });
 
@@ -55,9 +56,9 @@ namespace osu.Game.Rulesets.Catch.Tests
                 drawableFruit.HitObject.StartTime = drawableBanana.HitObject.StartTime = another_start_time;
             });
 
-            AddAssert("fruit rotation is changed", () => drawableFruit.Rotation != fruitRotation);
-            AddAssert("banana rotation is changed", () => drawableBanana.Rotation != bananaRotation);
-            AddAssert("banana scale is changed", () => drawableBanana.Scale.X != bananaScale);
+            AddAssert("fruit rotation is changed", () => drawableFruit.DisplayRotation != fruitRotation);
+            AddAssert("banana rotation is changed", () => drawableBanana.DisplayRotation != bananaRotation);
+            AddAssert("banana size is changed", () => drawableBanana.DisplaySize != bananaSize);
             AddAssert("banana colour is changed", () => drawableBanana.AccentColour.Value != bananaColour);
 
             AddStep("reset start time", () =>
@@ -65,10 +66,10 @@ namespace osu.Game.Rulesets.Catch.Tests
                 drawableFruit.HitObject.StartTime = drawableBanana.HitObject.StartTime = initial_start_time;
             });
 
-            AddAssert("rotation and scale restored", () =>
-                drawableFruit.Rotation == fruitRotation &&
-                drawableBanana.Rotation == bananaRotation &&
-                drawableBanana.Scale.X == bananaScale &&
+            AddAssert("rotation and size restored", () =>
+                drawableFruit.DisplayRotation == fruitRotation &&
+                drawableBanana.DisplayRotation == bananaRotation &&
+                drawableBanana.DisplaySize == bananaSize &&
                 drawableBanana.AccentColour.Value == bananaColour);
         }
     }

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDashColouring.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Catch.Tests
 
             AddStep("create hyper-dashing catcher", () =>
             {
-                Child = setupSkinHierarchy(catcherArea = new CatcherArea(new Container())
+                Child = setupSkinHierarchy(catcherArea = new CatcherArea(new Container<CaughtObject>())
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtBanana.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Skinning.Default;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    /// <summary>
+    /// Represents a <see cref="Banana"/> caught by the catcher.
+    /// </summary>
+    public class CaughtBanana : CaughtObject
+    {
+        public CaughtBanana()
+            : base(CatchSkinComponents.Banana, _ => new BananaPiece())
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtDroplet.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Catch.Skinning.Default;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    /// <summary>
+    /// Represents a <see cref="Droplet"/> caught by the catcher.
+    /// </summary>
+    public class CaughtDroplet : CaughtObject
+    {
+        public override bool StaysOnPlate => false;
+
+        public CaughtDroplet()
+            : base(CatchSkinComponents.Droplet, _ => new DropletPiece())
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtFruit.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Catch.Skinning.Default;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    /// <summary>
+    /// Represents a <see cref="Fruit"/> caught by the catcher.
+    /// </summary>
+    public class CaughtFruit : CaughtObject, IHasFruitState
+    {
+        public Bindable<FruitVisualRepresentation> VisualRepresentation { get; } = new Bindable<FruitVisualRepresentation>();
+
+        public CaughtFruit()
+            : base(CatchSkinComponents.Fruit, _ => new FruitPiece())
+        {
+        }
+
+        public override void CopyStateFrom(IHasCatchObjectState objectState)
+        {
+            base.CopyStateFrom(objectState);
+
+            var fruitState = (IHasFruitState)objectState;
+            VisualRepresentation.Value = fruitState.VisualRepresentation.Value;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     [Cached(typeof(IHasCatchObjectState))]
     public abstract class CaughtObject : SkinnableDrawable, IHasCatchObjectState
     {
-        public CatchHitObject HitObject { get; private set; }
+        public PalpableCatchHitObject HitObject { get; private set; }
         public Bindable<Color4> AccentColour { get; } = new Bindable<Color4>();
         public Bindable<bool> HyperDash { get; } = new Bindable<bool>();
 
@@ -29,7 +29,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         protected CaughtObject(CatchSkinComponents skinComponent, Func<ISkinComponent, Drawable> defaultImplementation)
             : base(new CatchSkinComponent(skinComponent), defaultImplementation)
         {
-            Anchor = Anchor.TopCentre;
             Origin = Anchor.Centre;
 
             RelativeSizeAxes = Axes.None;
@@ -43,6 +42,17 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             Rotation = objectState.Rotation;
             AccentColour.Value = objectState.AccentColour.Value;
             HyperDash.Value = objectState.HyperDash.Value;
+        }
+
+        protected override void FreeAfterUse()
+        {
+            ClearTransforms();
+
+            Alpha = 1;
+            LifetimeStart = double.MinValue;
+            LifetimeEnd = double.MaxValue;
+
+            base.FreeAfterUse();
         }
     }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public Bindable<Color4> AccentColour { get; } = new Bindable<Color4>();
         public Bindable<bool> HyperDash { get; } = new Bindable<bool>();
 
+        float IHasCatchObjectState.Scale => Scale.X;
+
         /// <summary>
         /// Whether this hit object should stay on the catcher plate when the object is caught by the catcher.
         /// </summary>
@@ -43,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public virtual void CopyStateFrom(IHasCatchObjectState objectState)
         {
             HitObject = objectState.HitObject;
-            Scale = objectState.Scale;
+            Scale = new Vector2(objectState.Scale);
             Rotation = objectState.Rotation;
             AccentColour.Value = objectState.AccentColour.Value;
             HyperDash.Value = objectState.HyperDash.Value;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -12,6 +12,9 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
+    /// <summary>
+    /// Represents a <see cref="PalpableCatchHitObject"/> caught by the catcher.
+    /// </summary>
     [Cached(typeof(IHasCatchObjectState))]
     public abstract class CaughtObject : SkinnableDrawable, IHasCatchObjectState
     {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -21,7 +21,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public Bindable<Color4> AccentColour { get; } = new Bindable<Color4>();
         public Bindable<bool> HyperDash { get; } = new Bindable<bool>();
 
-        float IHasCatchObjectState.Scale => Scale.X;
+        public Vector2 DisplaySize => Size * Scale;
+
+        public float DisplayRotation => Rotation;
 
         /// <summary>
         /// Whether this hit object should stay on the catcher plate when the object is caught by the catcher.
@@ -45,8 +47,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public virtual void CopyStateFrom(IHasCatchObjectState objectState)
         {
             HitObject = objectState.HitObject;
-            Scale = new Vector2(objectState.Scale);
-            Rotation = objectState.Rotation;
+            Scale = Vector2.Divide(objectState.DisplaySize, Size);
+            Rotation = objectState.DisplayRotation;
             AccentColour.Value = objectState.AccentColour.Value;
             HyperDash.Value = objectState.HyperDash.Value;
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -12,12 +12,12 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    [Cached(typeof(CaughtObject))]
-    public abstract class CaughtObject : SkinnableDrawable
+    [Cached(typeof(IHasCatchObjectState))]
+    public abstract class CaughtObject : SkinnableDrawable, IHasCatchObjectState
     {
-        public readonly Bindable<Color4> AccentColour = new Bindable<Color4>();
-
         public CatchHitObject HitObject { get; private set; }
+        public Bindable<Color4> AccentColour { get; } = new Bindable<Color4>();
+        public Bindable<bool> HyperDash { get; } = new Bindable<bool>();
 
         /// <summary>
         /// Whether this hit object should stay on the catcher plate when the object is caught by the catcher.
@@ -36,30 +36,31 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2);
         }
 
-        public virtual void CopyFrom(DrawablePalpableCatchHitObject drawableObject)
+        public virtual void CopyFrom(IHasCatchObjectState objectState)
         {
-            HitObject = drawableObject.HitObject;
-            Scale = drawableObject.Scale / 2;
-            Rotation = drawableObject.Rotation;
-            AccentColour.Value = drawableObject.AccentColour.Value;
+            HitObject = objectState.HitObject;
+            Scale = objectState.Scale;
+            Rotation = objectState.Rotation;
+            AccentColour.Value = objectState.AccentColour.Value;
+            HyperDash.Value = objectState.HyperDash.Value;
         }
     }
 
-    public class CaughtFruit : CaughtObject
+    public class CaughtFruit : CaughtObject, IHasFruitState
     {
-        public readonly Bindable<FruitVisualRepresentation> VisualRepresentation = new Bindable<FruitVisualRepresentation>();
+        public Bindable<FruitVisualRepresentation> VisualRepresentation { get; } = new Bindable<FruitVisualRepresentation>();
 
         public CaughtFruit()
             : base(CatchSkinComponents.Fruit, _ => new FruitPiece())
         {
         }
 
-        public override void CopyFrom(DrawablePalpableCatchHitObject drawableObject)
+        public override void CopyFrom(IHasCatchObjectState objectState)
         {
-            base.CopyFrom(drawableObject);
+            base.CopyFrom(objectState);
 
-            var drawableFruit = (DrawableFruit)drawableObject;
-            VisualRepresentation.Value = drawableFruit.VisualRepresentation.Value;
+            var fruitState = (IHasFruitState)objectState;
+            VisualRepresentation.Value = fruitState.VisualRepresentation.Value;
         }
     }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Rulesets.Catch.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -59,42 +58,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             LifetimeEnd = double.MaxValue;
 
             base.FreeAfterUse();
-        }
-    }
-
-    public class CaughtFruit : CaughtObject, IHasFruitState
-    {
-        public Bindable<FruitVisualRepresentation> VisualRepresentation { get; } = new Bindable<FruitVisualRepresentation>();
-
-        public CaughtFruit()
-            : base(CatchSkinComponents.Fruit, _ => new FruitPiece())
-        {
-        }
-
-        public override void CopyStateFrom(IHasCatchObjectState objectState)
-        {
-            base.CopyStateFrom(objectState);
-
-            var fruitState = (IHasFruitState)objectState;
-            VisualRepresentation.Value = fruitState.VisualRepresentation.Value;
-        }
-    }
-
-    public class CaughtBanana : CaughtObject
-    {
-        public CaughtBanana()
-            : base(CatchSkinComponents.Banana, _ => new BananaPiece())
-        {
-        }
-    }
-
-    public class CaughtDroplet : CaughtObject
-    {
-        public override bool StaysOnPlate => false;
-
-        public CaughtDroplet()
-            : base(CatchSkinComponents.Droplet, _ => new DropletPiece())
-        {
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -52,10 +52,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         protected override void FreeAfterUse()
         {
             ClearTransforms();
-
             Alpha = 1;
-            LifetimeStart = double.MinValue;
-            LifetimeEnd = double.MaxValue;
 
             base.FreeAfterUse();
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -1,0 +1,83 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Catch.Skinning.Default;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    [Cached(typeof(CaughtObject))]
+    public abstract class CaughtObject : SkinnableDrawable
+    {
+        public readonly Bindable<Color4> AccentColour = new Bindable<Color4>();
+
+        public CatchHitObject HitObject { get; private set; }
+
+        /// <summary>
+        /// Whether this hit object should stay on the catcher plate when the object is caught by the catcher.
+        /// </summary>
+        public virtual bool StaysOnPlate => true;
+
+        public override bool RemoveWhenNotAlive => true;
+
+        protected CaughtObject(CatchSkinComponents skinComponent, Func<ISkinComponent, Drawable> defaultImplementation)
+            : base(new CatchSkinComponent(skinComponent), defaultImplementation)
+        {
+            Anchor = Anchor.TopCentre;
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.None;
+            Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2);
+        }
+
+        public virtual void CopyFrom(DrawablePalpableCatchHitObject drawableObject)
+        {
+            HitObject = drawableObject.HitObject;
+            Scale = drawableObject.Scale / 2;
+            Rotation = drawableObject.Rotation;
+            AccentColour.Value = drawableObject.AccentColour.Value;
+        }
+    }
+
+    public class CaughtFruit : CaughtObject
+    {
+        public readonly Bindable<FruitVisualRepresentation> VisualRepresentation = new Bindable<FruitVisualRepresentation>();
+
+        public CaughtFruit()
+            : base(CatchSkinComponents.Fruit, _ => new FruitPiece())
+        {
+        }
+
+        public override void CopyFrom(DrawablePalpableCatchHitObject drawableObject)
+        {
+            base.CopyFrom(drawableObject);
+
+            var drawableFruit = (DrawableFruit)drawableObject;
+            VisualRepresentation.Value = drawableFruit.VisualRepresentation.Value;
+        }
+    }
+
+    public class CaughtBanana : CaughtObject
+    {
+        public CaughtBanana()
+            : base(CatchSkinComponents.Banana, _ => new BananaPiece())
+        {
+        }
+    }
+
+    public class CaughtDroplet : CaughtObject
+    {
+        public override bool StaysOnPlate => false;
+
+        public CaughtDroplet()
+            : base(CatchSkinComponents.Droplet, _ => new DropletPiece())
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -38,7 +38,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2);
         }
 
-        public virtual void CopyFrom(IHasCatchObjectState objectState)
+        /// <summary>
+        /// Copies the hit object visual state from another <see cref="IHasCatchObjectState"/> object.
+        /// </summary>
+        public virtual void CopyStateFrom(IHasCatchObjectState objectState)
         {
             HitObject = objectState.HitObject;
             Scale = objectState.Scale;
@@ -68,9 +71,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
         }
 
-        public override void CopyFrom(IHasCatchObjectState objectState)
+        public override void CopyStateFrom(IHasCatchObjectState objectState)
         {
-            base.CopyFrom(objectState);
+            base.CopyStateFrom(objectState);
 
             var fruitState = (IHasFruitState)objectState;
             VisualRepresentation.Value = fruitState.VisualRepresentation.Value;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -24,9 +24,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(new SkinnableDrawable(
+            ScalingContainer.Child = new SkinnableDrawable(
                 new CatchSkinComponent(CatchSkinComponents.Banana),
-                _ => new BananaPiece()));
+                _ => new BananaPiece());
         }
 
         protected override void LoadComplete()
@@ -44,12 +44,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             const float end_scale = 0.6f;
             const float random_scale_range = 1.6f;
 
-            this.ScaleTo(HitObject.Scale * (end_scale + random_scale_range * RandomSingle(3)))
-                .Then().ScaleTo(HitObject.Scale * end_scale, HitObject.TimePreempt);
+            ScalingContainer.ScaleTo(HitObject.Scale * (end_scale + random_scale_range * RandomSingle(3)))
+                            .Then().ScaleTo(HitObject.Scale * end_scale, HitObject.TimePreempt);
 
-            this.RotateTo(getRandomAngle(1))
-                .Then()
-                .RotateTo(getRandomAngle(2), HitObject.TimePreempt);
+            ScalingContainer.RotateTo(getRandomAngle(1))
+                            .Then()
+                            .RotateTo(getRandomAngle(2), HitObject.TimePreempt);
 
             float getRandomAngle(int series) => 180 * (RandomSingle(series) * 2 - 1);
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -24,9 +24,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            ScaleContainer.Child = new SkinnableDrawable(
+            AddInternal(new SkinnableDrawable(
                 new CatchSkinComponent(CatchSkinComponents.Banana),
-                _ => new BananaPiece());
+                _ => new BananaPiece()));
         }
 
         protected override void LoadComplete()
@@ -44,12 +44,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             const float end_scale = 0.6f;
             const float random_scale_range = 1.6f;
 
-            ScaleContainer.ScaleTo(HitObject.Scale * (end_scale + random_scale_range * RandomSingle(3)))
-                          .Then().ScaleTo(HitObject.Scale * end_scale, HitObject.TimePreempt);
+            this.ScaleTo(HitObject.Scale * (end_scale + random_scale_range * RandomSingle(3)))
+                .Then().ScaleTo(HitObject.Scale * end_scale, HitObject.TimePreempt);
 
-            ScaleContainer.RotateTo(getRandomAngle(1))
-                          .Then()
-                          .RotateTo(getRandomAngle(2), HitObject.TimePreempt);
+            this.RotateTo(getRandomAngle(1))
+                .Then()
+                .RotateTo(getRandomAngle(2), HitObject.TimePreempt);
 
             float getRandomAngle(int series) => 180 * (RandomSingle(series) * 2 - 1);
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -9,7 +9,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableBanana : DrawablePalpableCatchHitObject
+    public class DrawableBanana : DrawablePalpableHasCatchHitObject
     {
         public DrawableBanana()
             : this(null)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -9,7 +9,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableBanana : DrawablePalpableHasCatchHitObject
+    public class DrawableBanana : DrawablePalpableCatchHitObject
     {
         public DrawableBanana()
             : this(null)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -50,10 +50,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         public Func<CatchHitObject, bool> CheckPosition;
 
-        public bool IsOnPlate;
-
-        public override bool RemoveWhenNotAlive => IsOnPlate;
-
         protected override JudgementResult CreateResult(Judgement judgement) => new CatchJudgementResult(HitObject, judgement);
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -26,9 +26,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            ScaleContainer.Child = new SkinnableDrawable(
+            AddInternal(new SkinnableDrawable(
                 new CatchSkinComponent(CatchSkinComponents.Droplet),
-                _ => new DropletPiece());
+                _ => new DropletPiece()));
         }
 
         protected override void UpdateInitialTransforms()
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             float startRotation = RandomSingle(1) * 20;
             double duration = HitObject.TimePreempt + 2000;
 
-            ScaleContainer.RotateTo(startRotation).RotateTo(startRotation + 720, duration);
+            this.RotateTo(startRotation).RotateTo(startRotation + 720, duration);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -9,7 +9,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableDroplet : DrawablePalpableHasCatchHitObject
+    public class DrawableDroplet : DrawablePalpableCatchHitObject
     {
         public DrawableDroplet()
             : this(null)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -11,8 +11,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public class DrawableDroplet : DrawablePalpableCatchHitObject
     {
-        public override bool StaysOnPlate => false;
-
         public DrawableDroplet()
             : this(null)
         {

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -24,9 +24,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(new SkinnableDrawable(
+            ScalingContainer.Child = new SkinnableDrawable(
                 new CatchSkinComponent(CatchSkinComponents.Droplet),
-                _ => new DropletPiece()));
+                _ => new DropletPiece());
         }
 
         protected override void UpdateInitialTransforms()
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             float startRotation = RandomSingle(1) * 20;
             double duration = HitObject.TimePreempt + 2000;
 
-            this.RotateTo(startRotation).RotateTo(startRotation + 720, duration);
+            ScalingContainer.RotateTo(startRotation).RotateTo(startRotation + 720, duration);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -9,7 +9,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableDroplet : DrawablePalpableCatchHitObject
+    public class DrawableDroplet : DrawablePalpableHasCatchHitObject
     {
         public DrawableDroplet()
             : this(null)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -10,9 +10,9 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableFruit : DrawablePalpableCatchHitObject
+    public class DrawableFruit : DrawablePalpableHasCatchHitObject, IHasFruitState
     {
-        public readonly Bindable<FruitVisualRepresentation> VisualRepresentation = new Bindable<FruitVisualRepresentation>();
+        public Bindable<FruitVisualRepresentation> VisualRepresentation { get; } = new Bindable<FruitVisualRepresentation>();
 
         public DrawableFruit()
             : this(null)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -32,16 +32,16 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 VisualRepresentation.Value = (FruitVisualRepresentation)(change.NewValue % 4);
             }, true);
 
-            ScaleContainer.Child = new SkinnableDrawable(
+            AddInternal(new SkinnableDrawable(
                 new CatchSkinComponent(CatchSkinComponents.Fruit),
-                _ => new FruitPiece());
+                _ => new FruitPiece()));
         }
 
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
 
-            ScaleContainer.RotateTo((RandomSingle(1) - 0.5f) * 40);
+            this.RotateTo((RandomSingle(1) - 0.5f) * 40);
         }
     }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -32,16 +32,16 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 VisualRepresentation.Value = (FruitVisualRepresentation)(change.NewValue % 4);
             }, true);
 
-            AddInternal(new SkinnableDrawable(
+            ScalingContainer.Child = new SkinnableDrawable(
                 new CatchSkinComponent(CatchSkinComponents.Fruit),
-                _ => new FruitPiece()));
+                _ => new FruitPiece());
         }
 
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
 
-            this.RotateTo((RandomSingle(1) - 0.5f) * 40);
+            ScalingContainer.RotateTo((RandomSingle(1) - 0.5f) * 40);
         }
     }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -10,7 +10,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public class DrawableFruit : DrawablePalpableHasCatchHitObject, IHasFruitState
+    public class DrawableFruit : DrawablePalpableCatchHitObject, IHasFruitState
     {
         public Bindable<FruitVisualRepresentation> VisualRepresentation { get; } = new Bindable<FruitVisualRepresentation>();
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -5,7 +5,6 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
@@ -21,7 +20,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public readonly Bindable<int> IndexInBeatmap = new Bindable<int>();
 
         /// <summary>
-        /// The multiplicative factor applied to <see cref="ScaleContainer"/> scale relative to <see cref="HitObject"/> scale.
+        /// The multiplicative factor applied to <see cref="Drawable.Scale"/> relative to <see cref="HitObject"/> scale.
         /// </summary>
         protected virtual float ScaleFactor => 1;
 
@@ -32,20 +31,11 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         public float DisplayRadius => CatchHitObject.OBJECT_RADIUS * HitObject.Scale * ScaleFactor;
 
-        protected readonly Container ScaleContainer;
-
         protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)
             : base(h)
         {
             Origin = Anchor.Centre;
             Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2);
-
-            AddInternal(ScaleContainer = new Container
-            {
-                RelativeSizeAxes = Axes.Both,
-                Origin = Anchor.Centre,
-                Anchor = Anchor.Centre,
-            });
         }
 
         [BackgroundDependencyLoader]
@@ -58,7 +48,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
             ScaleBindable.BindValueChanged(scale =>
             {
-                ScaleContainer.Scale = new Vector2(scale.NewValue * ScaleFactor);
+                Scale = new Vector2(scale.NewValue * ScaleFactor);
             }, true);
 
             IndexInBeatmap.BindValueChanged(_ => UpdateComboColour());

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osuTK;
 using osuTK.Graphics;
 
@@ -30,11 +31,27 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         public float DisplayRadius => CatchHitObject.OBJECT_RADIUS * HitObject.Scale * ScaleFactor;
 
+        /// <summary>
+        /// The container internal transforms (such as scaling based on the circle size) are applied to.
+        /// </summary>
+        protected readonly Container ScalingContainer;
+
+        float IHasCatchObjectState.Scale => HitObject.Scale * ScaleFactor;
+
+        float IHasCatchObjectState.Rotation => ScalingContainer.Rotation;
+
         protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)
             : base(h)
         {
             Origin = Anchor.Centre;
             Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2);
+
+            AddInternal(ScalingContainer = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2)
+            });
         }
 
         [BackgroundDependencyLoader]
@@ -47,7 +64,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
             ScaleBindable.BindValueChanged(scale =>
             {
-                Scale = new Vector2(scale.NewValue * ScaleFactor);
+                ScalingContainer.Scale = new Vector2(scale.NewValue * ScaleFactor);
+                Size = ScalingContainer.Size * ScalingContainer.Scale;
             }, true);
 
             IndexInBeatmap.BindValueChanged(_ => UpdateComboColour());

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -24,11 +24,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         /// </summary>
         protected virtual float ScaleFactor => 1;
 
-        /// <summary>
-        /// Whether this hit object should stay on the catcher plate when the object is caught by the catcher.
-        /// </summary>
-        public virtual bool StaysOnPlate => true;
-
         public float DisplayRadius => CatchHitObject.OBJECT_RADIUS * HitObject.Scale * ScaleFactor;
 
         protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)
@@ -43,7 +38,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
             XBindable.BindValueChanged(x =>
             {
-                if (!IsOnPlate) X = x.NewValue;
+                X = x.NewValue;
             }, true);
 
             ScaleBindable.BindValueChanged(scale =>

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -11,7 +11,7 @@ using osuTK.Graphics;
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     [Cached(typeof(IHasCatchObjectState))]
-    public abstract class DrawablePalpableHasCatchHitObject : DrawableCatchHitObject, IHasCatchObjectState
+    public abstract class DrawablePalpableCatchHitObject : DrawableCatchHitObject, IHasCatchObjectState
     {
         public new PalpableCatchHitObject HitObject => (PalpableCatchHitObject)base.HitObject;
 
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         public float DisplayRadius => CatchHitObject.OBJECT_RADIUS * HitObject.Scale * ScaleFactor;
 
-        protected DrawablePalpableHasCatchHitObject([CanBeNull] CatchHitObject h)
+        protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)
             : base(h)
         {
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -29,16 +29,14 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         /// </summary>
         protected virtual float ScaleFactor => 1;
 
-        public float DisplayRadius => CatchHitObject.OBJECT_RADIUS * HitObject.Scale * ScaleFactor;
-
         /// <summary>
         /// The container internal transforms (such as scaling based on the circle size) are applied to.
         /// </summary>
         protected readonly Container ScalingContainer;
 
-        float IHasCatchObjectState.Scale => HitObject.Scale * ScaleFactor;
+        public Vector2 DisplaySize => ScalingContainer.Size * ScalingContainer.Scale;
 
-        float IHasCatchObjectState.Rotation => ScalingContainer.Rotation;
+        public float DisplayRotation => ScalingContainer.Rotation;
 
         protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)
             : base(h)
@@ -65,7 +63,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             ScaleBindable.BindValueChanged(scale =>
             {
                 ScalingContainer.Scale = new Vector2(scale.NewValue * ScaleFactor);
-                Size = ScalingContainer.Size * ScalingContainer.Scale;
+                Size = DisplaySize;
             }, true);
 
             IndexInBeatmap.BindValueChanged(_ => UpdateComboColour());

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableHasCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableHasCatchHitObject.cs
@@ -6,18 +6,22 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
-    public abstract class DrawablePalpableCatchHitObject : DrawableCatchHitObject
+    [Cached(typeof(IHasCatchObjectState))]
+    public abstract class DrawablePalpableHasCatchHitObject : DrawableCatchHitObject, IHasCatchObjectState
     {
         public new PalpableCatchHitObject HitObject => (PalpableCatchHitObject)base.HitObject;
 
-        public readonly Bindable<bool> HyperDash = new Bindable<bool>();
+        Bindable<Color4> IHasCatchObjectState.AccentColour => AccentColour;
 
-        public readonly Bindable<float> ScaleBindable = new Bindable<float>(1);
+        public Bindable<bool> HyperDash { get; } = new Bindable<bool>();
 
-        public readonly Bindable<int> IndexInBeatmap = new Bindable<int>();
+        public Bindable<float> ScaleBindable { get; } = new Bindable<float>(1);
+
+        public Bindable<int> IndexInBeatmap { get; } = new Bindable<int>();
 
         /// <summary>
         /// The multiplicative factor applied to <see cref="Drawable.Scale"/> relative to <see cref="HitObject"/> scale.
@@ -26,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         public float DisplayRadius => CatchHitObject.OBJECT_RADIUS * HitObject.Scale * ScaleFactor;
 
-        protected DrawablePalpableCatchHitObject([CanBeNull] CatchHitObject h)
+        protected DrawablePalpableHasCatchHitObject([CanBeNull] CatchHitObject h)
             : base(h)
         {
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -19,12 +19,4 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         float Rotation { get; }
         Vector2 Scale { get; }
     }
-
-    /// <summary>
-    /// Provides a visual state of a <see cref="Fruit"/>.
-    /// </summary>
-    public interface IHasFruitState : IHasCatchObjectState
-    {
-        Bindable<FruitVisualRepresentation> VisualRepresentation { get; }
-    }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         Bindable<Color4> AccentColour { get; }
         Bindable<bool> HyperDash { get; }
 
-        float Rotation { get; }
-        float Scale { get; }
+        Vector2 DisplaySize { get; }
+        float DisplayRotation { get; }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -7,6 +7,9 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
+    /// <summary>
+    /// Provides a visual state of a <see cref="PalpableCatchHitObject"/>.
+    /// </summary>
     public interface IHasCatchObjectState
     {
         PalpableCatchHitObject HitObject { get; }
@@ -17,6 +20,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         Vector2 Scale { get; }
     }
 
+    /// <summary>
+    /// Provides a visual state of a <see cref="Fruit"/>.
+    /// </summary>
     public interface IHasFruitState : IHasCatchObjectState
     {
         Bindable<FruitVisualRepresentation> VisualRepresentation { get; }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
@@ -17,6 +16,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         Bindable<bool> HyperDash { get; }
 
         float Rotation { get; }
-        Vector2 Scale { get; }
+        float Scale { get; }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
     public interface IHasCatchObjectState
     {
-        CatchHitObject HitObject { get; }
+        PalpableCatchHitObject HitObject { get; }
         Bindable<Color4> AccentColour { get; }
         Bindable<bool> HyperDash { get; }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -13,10 +13,13 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     public interface IHasCatchObjectState
     {
         PalpableCatchHitObject HitObject { get; }
+
         Bindable<Color4> AccentColour { get; }
+
         Bindable<bool> HyperDash { get; }
 
         Vector2 DisplaySize { get; }
+
         float DisplayRotation { get; }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    public interface IHasCatchObjectState
+    {
+        CatchHitObject HitObject { get; }
+        Bindable<Color4> AccentColour { get; }
+        Bindable<bool> HyperDash { get; }
+
+        float Rotation { get; }
+        Vector2 Scale { get; }
+    }
+
+    public interface IHasFruitState : IHasCatchObjectState
+    {
+        Bindable<FruitVisualRepresentation> VisualRepresentation { get; }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasFruitState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasFruitState.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    /// <summary>
+    /// Provides a visual state of a <see cref="Fruit"/>.
+    /// </summary>
+    public interface IHasFruitState : IHasCatchObjectState
+    {
+        Bindable<FruitVisualRepresentation> VisualRepresentation { get; }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Skinning/Default/CatchHitObjectPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Default/CatchHitObjectPiece.cs
@@ -21,6 +21,10 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
         [CanBeNull]
         protected DrawableHitObject DrawableHitObject { get; private set; }
 
+        [Resolved(canBeNull: true)]
+        [CanBeNull]
+        protected CaughtObject CaughtObject { get; private set; }
+
         /// <summary>
         /// A part of this piece that will be faded out while falling in the playfield.
         /// </summary>
@@ -45,6 +49,9 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
                 HyperDash.BindTo(hitObject.HyperDash);
             }
 
+            if (CaughtObject != null)
+                AccentColour.BindTo(CaughtObject.AccentColour);
+
             HyperDash.BindValueChanged(hyper =>
             {
                 if (HyperBorderPiece != null)
@@ -54,8 +61,13 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
 
         protected override void Update()
         {
-            if (BorderPiece != null && DrawableHitObject?.HitObject != null)
-                BorderPiece.Alpha = (float)Math.Clamp((DrawableHitObject.HitObject.StartTime - Time.Current) / 500, 0, 1);
+            if (BorderPiece != null)
+            {
+                if (DrawableHitObject?.HitObject != null)
+                    BorderPiece.Alpha = (float)Math.Clamp((DrawableHitObject.HitObject.StartTime - Time.Current) / 500, 0, 1);
+                else
+                    BorderPiece.Alpha = 0;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Skinning/Default/CatchHitObjectPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Default/CatchHitObjectPiece.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
-using osu.Game.Rulesets.Objects.Drawables;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.Skinning.Default
@@ -17,13 +16,8 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
         public readonly Bindable<Color4> AccentColour = new Bindable<Color4>();
         public readonly Bindable<bool> HyperDash = new Bindable<bool>();
 
-        [Resolved(canBeNull: true)]
-        [CanBeNull]
-        protected DrawableHitObject DrawableHitObject { get; private set; }
-
-        [Resolved(canBeNull: true)]
-        [CanBeNull]
-        protected CaughtObject CaughtObject { get; private set; }
+        [Resolved]
+        protected IHasCatchObjectState ObjectState { get; private set; }
 
         /// <summary>
         /// A part of this piece that will be faded out while falling in the playfield.
@@ -41,16 +35,8 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
         {
             base.LoadComplete();
 
-            var hitObject = (DrawablePalpableCatchHitObject)DrawableHitObject;
-
-            if (hitObject != null)
-            {
-                AccentColour.BindTo(hitObject.AccentColour);
-                HyperDash.BindTo(hitObject.HyperDash);
-            }
-
-            if (CaughtObject != null)
-                AccentColour.BindTo(CaughtObject.AccentColour);
+            AccentColour.BindTo(ObjectState.AccentColour);
+            HyperDash.BindTo(ObjectState.HyperDash);
 
             HyperDash.BindValueChanged(hyper =>
             {
@@ -61,13 +47,8 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
 
         protected override void Update()
         {
-            if (BorderPiece != null)
-            {
-                if (DrawableHitObject?.HitObject != null)
-                    BorderPiece.Alpha = (float)Math.Clamp((DrawableHitObject.HitObject.StartTime - Time.Current) / 500, 0, 1);
-                else
-                    BorderPiece.Alpha = 0;
-            }
+            if (BorderPiece != null && ObjectState?.HitObject != null)
+                BorderPiece.Alpha = (float)Math.Clamp((ObjectState.HitObject.StartTime - Time.Current) / 500, 0, 1);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Skinning/Default/CatchHitObjectPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Default/CatchHitObjectPiece.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
 
         protected override void Update()
         {
-            if (BorderPiece != null && ObjectState?.HitObject != null)
+            if (BorderPiece != null)
                 BorderPiece.Alpha = (float)Math.Clamp((ObjectState.HitObject.StartTime - Time.Current) / 500, 0, 1);
         }
     }

--- a/osu.Game.Rulesets.Catch/Skinning/Default/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Default/FruitPiece.cs
@@ -39,14 +39,8 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
         {
             base.LoadComplete();
 
-            var fruit = (DrawableFruit)DrawableHitObject;
-
-            if (fruit != null)
-                VisualRepresentation.BindTo(fruit.VisualRepresentation);
-
-            var caughtFruit = (CaughtFruit)CaughtObject;
-            if (caughtFruit != null)
-                VisualRepresentation.BindTo(caughtFruit.VisualRepresentation);
+            var fruitState = (IHasFruitState)ObjectState;
+            VisualRepresentation.BindTo(fruitState.VisualRepresentation);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Skinning/Default/FruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Default/FruitPiece.cs
@@ -43,6 +43,10 @@ namespace osu.Game.Rulesets.Catch.Skinning.Default
 
             if (fruit != null)
                 VisualRepresentation.BindTo(fruit.VisualRepresentation);
+
+            var caughtFruit = (CaughtFruit)CaughtObject;
+            if (caughtFruit != null)
+                VisualRepresentation.BindTo(caughtFruit.VisualRepresentation);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyFruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyFruitPiece.cs
@@ -14,14 +14,8 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
         {
             base.LoadComplete();
 
-            var fruit = (DrawableFruit)DrawableHitObject;
-
-            if (fruit != null)
-                VisualRepresentation.BindTo(fruit.VisualRepresentation);
-
-            var caughtFruit = (CaughtFruit)CaughtObject;
-            if (caughtFruit != null)
-                VisualRepresentation.BindTo(caughtFruit.VisualRepresentation);
+            var fruitState = (IHasFruitState)ObjectState;
+            VisualRepresentation.BindTo(fruitState.VisualRepresentation);
 
             VisualRepresentation.BindValueChanged(visual => setTexture(visual.NewValue), true);
         }

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyFruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyFruitPiece.cs
@@ -19,6 +19,10 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
             if (fruit != null)
                 VisualRepresentation.BindTo(fruit.VisualRepresentation);
 
+            var caughtFruit = (CaughtFruit)CaughtObject;
+            if (caughtFruit != null)
+                VisualRepresentation.BindTo(caughtFruit.VisualRepresentation);
+
             VisualRepresentation.BindValueChanged(visual => setTexture(visual.NewValue), true);
         }
 

--- a/osu.Game.Rulesets.Catch/Skinning/LegacyCatchHitObjectPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/LegacyCatchHitObjectPiece.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -10,7 +9,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.UI;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -29,13 +27,8 @@ namespace osu.Game.Rulesets.Catch.Skinning
         [Resolved]
         protected ISkinSource Skin { get; private set; }
 
-        [Resolved(canBeNull: true)]
-        [CanBeNull]
-        protected DrawableHitObject DrawableHitObject { get; private set; }
-
-        [Resolved(canBeNull: true)]
-        [CanBeNull]
-        protected CaughtObject CaughtObject { get; private set; }
+        [Resolved]
+        protected IHasCatchObjectState ObjectState { get; private set; }
 
         protected LegacyCatchHitObjectPiece()
         {
@@ -69,16 +62,8 @@ namespace osu.Game.Rulesets.Catch.Skinning
         {
             base.LoadComplete();
 
-            var hitObject = (DrawablePalpableCatchHitObject)DrawableHitObject;
-
-            if (hitObject != null)
-            {
-                AccentColour.BindTo(hitObject.AccentColour);
-                HyperDash.BindTo(hitObject.HyperDash);
-            }
-
-            if (CaughtObject != null)
-                AccentColour.BindTo(CaughtObject.AccentColour);
+            AccentColour.BindTo(ObjectState.AccentColour);
+            HyperDash.BindTo(ObjectState.HyperDash);
 
             hyperSprite.Colour = Skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashFruit)?.Value ??
                                  Skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value ??

--- a/osu.Game.Rulesets.Catch/Skinning/LegacyCatchHitObjectPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/LegacyCatchHitObjectPiece.cs
@@ -33,6 +33,10 @@ namespace osu.Game.Rulesets.Catch.Skinning
         [CanBeNull]
         protected DrawableHitObject DrawableHitObject { get; private set; }
 
+        [Resolved(canBeNull: true)]
+        [CanBeNull]
+        protected CaughtObject CaughtObject { get; private set; }
+
         protected LegacyCatchHitObjectPiece()
         {
             RelativeSizeAxes = Axes.Both;
@@ -72,6 +76,9 @@ namespace osu.Game.Rulesets.Catch.Skinning
                 AccentColour.BindTo(hitObject.AccentColour);
                 HyperDash.BindTo(hitObject.HyperDash);
             }
+
+            if (CaughtObject != null)
+                AccentColour.BindTo(CaughtObject.AccentColour);
 
             hyperSprite.Colour = Skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDashFruit)?.Value ??
                                  Skin.GetConfig<CatchSkinColour, Color4>(CatchSkinColour.HyperDash)?.Value ??

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         public CatchPlayfield(BeatmapDifficulty difficulty, Func<CatchHitObject, DrawableHitObject<CatchHitObject>> createDrawableRepresentation)
         {
-            var droppedObjectContainer = new Container
+            var droppedObjectContainer = new Container<CaughtObject>
             {
                 RelativeSizeAxes = Axes.Both,
             };

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -447,8 +447,10 @@ namespace osu.Game.Rulesets.Catch.UI
 
             if (caughtObject == null) return;
 
+            var positionInStack = computePositionInStack(new Vector2(source.X - X, 0), caughtObject.DisplayRadius);
+
             caughtObject.RelativePositionAxes = Axes.None;
-            caughtObject.X = source.X - X;
+            caughtObject.Position = positionInStack;
             caughtObject.IsOnPlate = true;
 
             caughtObject.Anchor = Anchor.TopCentre;
@@ -456,8 +458,6 @@ namespace osu.Game.Rulesets.Catch.UI
             caughtObject.Scale *= 0.5f;
             caughtObject.LifetimeStart = source.StartTime;
             caughtObject.LifetimeEnd = double.MaxValue;
-
-            adjustPositionInStack(caughtObject);
 
             caughtFruitContainer.Add(caughtObject);
 
@@ -467,22 +467,22 @@ namespace osu.Game.Rulesets.Catch.UI
                 removeFromPlate(caughtObject, DroppedObjectAnimation.Explode);
         }
 
-        private void adjustPositionInStack(DrawablePalpableCatchHitObject caughtObject)
+        private Vector2 computePositionInStack(Vector2 position, float displayRadius)
         {
             const float radius_div_2 = CatchHitObject.OBJECT_RADIUS / 2;
             const float allowance = 10;
 
-            float caughtObjectRadius = caughtObject.DisplayRadius;
-
-            while (caughtFruitContainer.Any(f => Vector2Extensions.Distance(f.Position, caughtObject.Position) < (caughtObjectRadius + radius_div_2) / (allowance / 2)))
+            while (caughtFruitContainer.Any(f => Vector2Extensions.Distance(f.Position, position) < (displayRadius + radius_div_2) / (allowance / 2)))
             {
-                float diff = (caughtObjectRadius + radius_div_2) / allowance;
+                float diff = (displayRadius + radius_div_2) / allowance;
 
-                caughtObject.X += (RNG.NextSingle() - 0.5f) * diff * 2;
-                caughtObject.Y -= RNG.NextSingle() * diff;
+                position.X += (RNG.NextSingle() - 0.5f) * diff * 2;
+                position.Y -= RNG.NextSingle() * diff;
             }
 
-            caughtObject.X = Math.Clamp(caughtObject.X, -CatcherArea.CATCHER_SIZE / 2, CatcherArea.CATCHER_SIZE / 2);
+            position.X = Math.Clamp(position.X, -CatcherArea.CATCHER_SIZE / 2, CatcherArea.CATCHER_SIZE / 2);
+
+            return position;
         }
 
         private void addLighting(DrawablePalpableCatchHitObject caughtObject)

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -215,7 +215,7 @@ namespace osu.Game.Rulesets.Catch.UI
             catchResult.CatcherAnimationState = CurrentState;
             catchResult.CatcherHyperDash = HyperDashing;
 
-            if (!(drawableObject is DrawablePalpableCatchHitObject palpableObject)) return;
+            if (!(drawableObject is DrawablePalpableHasCatchHitObject palpableObject)) return;
 
             var hitObject = palpableObject.HitObject;
 
@@ -450,7 +450,7 @@ namespace osu.Game.Rulesets.Catch.UI
             updateCatcher();
         }
 
-        private void placeCaughtObject(DrawablePalpableCatchHitObject drawableObject, Vector2 position)
+        private void placeCaughtObject(DrawablePalpableHasCatchHitObject drawableObject, Vector2 position)
         {
             var caughtObject = createCaughtObject(drawableObject.HitObject);
 
@@ -458,6 +458,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             caughtObject.CopyFrom(drawableObject);
             caughtObject.Position = position;
+            caughtObject.Scale /= 2;
 
             caughtFruitContainer.Add(caughtObject);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -274,7 +274,7 @@ namespace osu.Game.Rulesets.Catch.UI
             }
 
             caughtFruitContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
-            droppedObjectTarget.RemoveAll(d => (d as DrawableCatchHitObject)?.HitObject == drawableObject.HitObject);
+            droppedObjectTarget.RemoveAll(d => (d as CaughtObject)?.HitObject == drawableObject.HitObject);
             hitExplosionContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
         }
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -554,8 +554,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             var droppedObject = getDroppedObject(caughtObject);
 
-            if (!caughtObjectContainer.Remove(caughtObject))
-                throw new InvalidOperationException("Can only drop objects that were previously caught on the plate");
+            caughtObjectContainer.Remove(caughtObject);
 
             droppedObjectTarget.Add(droppedObject);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Contains caught objects on the plate.
         /// </summary>
-        private readonly Container<CaughtObject> caughtFruitContainer;
+        private readonly Container<CaughtObject> caughtObjectContainer;
 
         /// <summary>
         /// Contains objects dropped from the plate.
@@ -138,7 +138,7 @@ namespace osu.Game.Rulesets.Catch.UI
                 caughtBananaPool = new DrawablePool<CaughtBanana>(100),
                 // less capacity is needed compared to fruit because droplet is not stacked
                 caughtDropletPool = new DrawablePool<CaughtDroplet>(25),
-                caughtFruitContainer = new Container<CaughtObject>
+                caughtObjectContainer = new Container<CaughtObject>
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.BottomCentre,
@@ -186,7 +186,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Creates proxied content to be displayed beneath hitobjects.
         /// </summary>
-        public Drawable CreateProxiedContent() => caughtFruitContainer.CreateProxy();
+        public Drawable CreateProxiedContent() => caughtObjectContainer.CreateProxy();
 
         /// <summary>
         /// Calculates the scale of the catcher based off the provided beatmap difficulty.
@@ -279,7 +279,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     SetHyperDashState();
             }
 
-            caughtFruitContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
+            caughtObjectContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
             droppedObjectTarget.RemoveAll(d => d.HitObject == drawableObject.HitObject);
             hitExplosionContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
         }
@@ -475,7 +475,7 @@ namespace osu.Game.Rulesets.Catch.UI
             caughtObject.Position = position;
             caughtObject.Scale /= 2;
 
-            caughtFruitContainer.Add(caughtObject);
+            caughtObjectContainer.Add(caughtObject);
 
             if (!caughtObject.StaysOnPlate)
                 removeFromPlate(caughtObject, DroppedObjectAnimation.Explode);
@@ -486,7 +486,7 @@ namespace osu.Game.Rulesets.Catch.UI
             const float radius_div_2 = CatchHitObject.OBJECT_RADIUS / 2;
             const float allowance = 10;
 
-            while (caughtFruitContainer.Any(f => Vector2Extensions.Distance(f.Position, position) < (displayRadius + radius_div_2) / (allowance / 2)))
+            while (caughtObjectContainer.Any(f => Vector2Extensions.Distance(f.Position, position) < (displayRadius + radius_div_2) / (allowance / 2)))
             {
                 float diff = (displayRadius + radius_div_2) / allowance;
 
@@ -533,17 +533,17 @@ namespace osu.Game.Rulesets.Catch.UI
 
             droppedObject.CopyStateFrom(caughtObject);
             droppedObject.Anchor = Anchor.TopLeft;
-            droppedObject.Position = caughtFruitContainer.ToSpaceOfOtherDrawable(caughtObject.DrawPosition, droppedObjectTarget);
+            droppedObject.Position = caughtObjectContainer.ToSpaceOfOtherDrawable(caughtObject.DrawPosition, droppedObjectTarget);
 
             return droppedObject;
         }
 
         private void clearPlate(DroppedObjectAnimation animation)
         {
-            var caughtObjects = caughtFruitContainer.Children.ToArray();
+            var caughtObjects = caughtObjectContainer.Children.ToArray();
             var droppedObjects = caughtObjects.Select(getDroppedObject).ToArray();
 
-            caughtFruitContainer.Clear(false);
+            caughtObjectContainer.Clear(false);
 
             droppedObjectTarget.AddRange(droppedObjects);
 
@@ -555,7 +555,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             var droppedObject = getDroppedObject(caughtObject);
 
-            if (!caughtFruitContainer.Remove(caughtObject))
+            if (!caughtObjectContainer.Remove(caughtObject))
                 throw new InvalidOperationException("Can only drop a caught object on the plate");
 
             droppedObjectTarget.Add(droppedObject);
@@ -573,7 +573,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     break;
 
                 case DroppedObjectAnimation.Explode:
-                    var originalX = droppedObjectTarget.ToSpaceOfOtherDrawable(d.DrawPosition, caughtFruitContainer).X * Scale.X;
+                    var originalX = droppedObjectTarget.ToSpaceOfOtherDrawable(d.DrawPosition, caughtObjectContainer).X * Scale.X;
                     d.MoveToY(d.Y - 50, 250, Easing.OutSine).Then().MoveToY(d.Y + 50, 500, Easing.InSine);
                     d.MoveToX(d.X + originalX * 6, 1000);
                     d.FadeOut(750);

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Rulesets.Catch.UI
             catchResult.CatcherAnimationState = CurrentState;
             catchResult.CatcherHyperDash = HyperDashing;
 
-            if (!(drawableObject is DrawablePalpableHasCatchHitObject palpableObject)) return;
+            if (!(drawableObject is DrawablePalpableCatchHitObject palpableObject)) return;
 
             var hitObject = palpableObject.HitObject;
 
@@ -458,7 +458,7 @@ namespace osu.Game.Rulesets.Catch.UI
             updateCatcher();
         }
 
-        private void placeCaughtObject(DrawablePalpableHasCatchHitObject drawableObject, Vector2 position)
+        private void placeCaughtObject(DrawablePalpableCatchHitObject drawableObject, Vector2 position)
         {
             var caughtObject = getCaughtObject(drawableObject.HitObject);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -464,7 +464,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             if (caughtObject == null) return;
 
-            caughtObject.CopyFrom(drawableObject);
+            caughtObject.CopyStateFrom(drawableObject);
             caughtObject.Anchor = Anchor.TopCentre;
             caughtObject.Position = position;
             caughtObject.Scale /= 2;
@@ -525,7 +525,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             var droppedObject = getCaughtObject(caughtObject.HitObject);
 
-            droppedObject.CopyFrom(caughtObject);
+            droppedObject.CopyStateFrom(caughtObject);
             droppedObject.Anchor = Anchor.TopLeft;
             droppedObject.Position = caughtFruitContainer.ToSpaceOfOtherDrawable(caughtObject.DrawPosition, droppedObjectTarget);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -235,7 +235,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             if (result.IsHit)
             {
-                var positionInStack = computePositionInStack(new Vector2(palpableObject.X - X, 0), palpableObject.DisplayRadius);
+                var positionInStack = computePositionInStack(new Vector2(palpableObject.X - X, 0), palpableObject.DisplaySize.X / 2);
 
                 placeCaughtObject(palpableObject, positionInStack);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -555,7 +555,7 @@ namespace osu.Game.Rulesets.Catch.UI
             var droppedObject = getDroppedObject(caughtObject);
 
             if (!caughtObjectContainer.Remove(caughtObject))
-                throw new InvalidOperationException("Can only drop a caught object on the plate");
+                throw new InvalidOperationException("Can only drop objects that were previously caught on the plate");
 
             droppedObjectTarget.Add(droppedObject);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -540,8 +540,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private void clearPlate(DroppedObjectAnimation animation)
         {
-            var caughtObjects = caughtObjectContainer.Children.ToArray();
-            var droppedObjects = caughtObjects.Select(getDroppedObject).ToArray();
+            var droppedObjects = caughtObjectContainer.Children.Select(getDroppedObject).ToArray();
 
             caughtObjectContainer.Clear(false);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -53,9 +53,15 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private CatcherTrailDisplay trails;
 
-        private readonly Container droppedObjectTarget;
-
+        /// <summary>
+        /// Contains caught objects on the plate.
+        /// </summary>
         private readonly Container<CaughtObject> caughtFruitContainer;
+
+        /// <summary>
+        /// Contains objects dropped from the plate.
+        /// </summary>
+        private readonly Container<CaughtObject> droppedObjectTarget;
 
         public CatcherAnimationState CurrentState { get; private set; }
 
@@ -112,7 +118,7 @@ namespace osu.Game.Rulesets.Catch.UI
         private readonly DrawablePool<CaughtBanana> caughtBananaPool;
         private readonly DrawablePool<CaughtDroplet> caughtDropletPool;
 
-        public Catcher([NotNull] Container trailsTarget, [NotNull] Container droppedObjectTarget, BeatmapDifficulty difficulty = null)
+        public Catcher([NotNull] Container trailsTarget, [NotNull] Container<CaughtObject> droppedObjectTarget, BeatmapDifficulty difficulty = null)
         {
             this.trailsTarget = trailsTarget;
             this.droppedObjectTarget = droppedObjectTarget;
@@ -274,7 +280,7 @@ namespace osu.Game.Rulesets.Catch.UI
             }
 
             caughtFruitContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
-            droppedObjectTarget.RemoveAll(d => (d as CaughtObject)?.HitObject == drawableObject.HitObject);
+            droppedObjectTarget.RemoveAll(d => d.HitObject == drawableObject.HitObject);
             hitExplosionContainer.RemoveAll(d => d.HitObject == drawableObject.HitObject);
         }
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Catch.UI
         public readonly Catcher MovableCatcher;
         private readonly CatchComboDisplay comboDisplay;
 
-        public CatcherArea(Container droppedObjectContainer, BeatmapDifficulty difficulty = null)
+        public CatcherArea(Container<CaughtObject> droppedObjectContainer, BeatmapDifficulty difficulty = null)
         {
             Size = new Vector2(CatchPlayfield.WIDTH, CATCHER_SIZE);
             Children = new Drawable[]


### PR DESCRIPTION
Addressing the second homework mentioned in my previous PR #11011.

Before this PR, when a hit object is caught by the catcher, a DHO was created and placed on the catcher plate. Caught objects are constantly created and destroyed, and the allocation overhead is significant. Pooling caught objects is desired to reduce stuttering during the gameplay.

However, several DHO logics that are unneeded for a static caught object interfere with the desired pooling logic. For example, we had to use `ApplyCustomState` to workaround an issue of transforms cleared by DHO.

Thus, I decided to create a new class `CaughtObject` for a caught object, not a derived class of DHO.
To reduce code duplication, I extracted common properties of `DrawablePalpableCatchHitObject` and `CaughtObject` to `IHasCatchObjectState` interface.

Visual properties such as `AccentColour` are copied from the DHO to `CaughtObject`, not bound.
A known issue is if the skin is changed then caught objects will keep old skin's combo colors.
 The issue is properties such as `AccentColour` are only present in DHO, not in HOs. I'm currently not sure how to solve this issue. We cannot bind to a DHO because the DHO will be reused for another hit object while the `CaughtObject` is still alive.

I refactored some of the object catching logic of the catcher.
<s>I removed `ScaleContainer` from catch DHO to make the implementation simpler.</s>
Edit: I added it back.