### PR TITLE
Change miss penalty curve for speed and aim pp awarded in the osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
-                aimValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, 0.775), countMiss);
+                aimValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), countMiss);
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
-                speedValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, 0.775), countMiss);
+                speedValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), countMiss);
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
-                aimValue *= .97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, .775), Math.Pow(countMiss, .75));
+                aimValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, 0.775), countMiss);
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
-                speedValue *= .97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, .775), Math.Pow(countMiss, 1));
+                speedValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, 0.775), countMiss);
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             aimValue *= lengthBonus;
 
-            // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
+            // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
                 aimValue *= .97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, .775), Math.Pow(countMiss, .75));
 
@@ -139,7 +139,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                                  (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
             speedValue *= lengthBonus;
 
-            // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
+            // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
                 speedValue *= .97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, .775), Math.Pow(countMiss, 1));
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -93,7 +93,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             aimValue *= lengthBonus;
 
             // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
-            aimValue *= Math.Pow(0.97, countMiss);
+            if (countMiss > 0)
+                aimValue *= .97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, .775), Math.Pow(countMiss, .75));
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)
@@ -139,7 +140,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             speedValue *= lengthBonus;
 
             // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
-            speedValue *= Math.Pow(0.97, countMiss);
+            if (countMiss > 0)
+                speedValue *= .97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, .775), Math.Pow(countMiss, 1));
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
-                aimValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, 0.775), countMiss);
+                aimValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), countMiss);
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
-                speedValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / (double)totalHits, 0.775), countMiss);
+                speedValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), Math.Pow(countMiss, .75));
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Penalize misses by assessing # of misses relative to the total # of objects. Default a 3% reduction for any # of misses.
             if (countMiss > 0)
-                speedValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), Math.Pow(countMiss, .75));
+                speedValue *= 0.97 * Math.Pow(1 - Math.Pow((double)countMiss / totalHits, 0.775), Math.Pow(countMiss, .875));
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)


### PR DESCRIPTION
Hello! This change is part of my goal of revitalizing the existing pp system in an effort to keep the competitive scene alive. This is the third (and final) hotfix I plan to create a MR for. I have future plans to look at star rating, but for now, the sum of all three of my proposals will serve as a good refresh for the competitive scene.

**The Problem**
Currently in PP, there exists a curve for miss count and for combo. Though the combo curve is problematic too, the focus of this MR is on the penalty for misses. Currently, the implementation is:

```
            // Penalize misses exponentially. This mainly fixes tag4 maps and the likes until a per-hitobject solution is available
            aimValue *= Math.Pow(0.97, countMiss);
```

which I believe the comment speaks for itself as to how old this implementation is. The problem with this implementation is that it simply reduces pp by a function of missCount, completely ignoring the number of objects in the map. 3 misses on a 100 note map certainly deserve to be penalized harder than 3 misses on a 1000 note map.

**Proposal**
I have created a new curve that scales much more dynamically with object count. No matter how many objects, the curve will automatically reduce pp by 3% for having any number of misses, and from there scales depending on the number of total objects in the map. The curve can be viewed below. The `l` slider is the number of objects, and the X-axis is the number of misses. Visible is the existing curve in green and the new curve in purple.

Curves: https://www.desmos.com/calculator/rshij9757a

The goal of this change is to penalize misses on short maps more, while reducing the impact of having more than 1 misses on longer maps. This way, plays that are 3000 notes where someone accidently wiffed a stream do not lose  `1 - .97^5` pp. The purpose for defaulting a 3% penalty for missing is to encourage S-ranks and discourage players from accepting 1 miss plays.

**Results**
Below are profiles featuring all 3 of my MR's (AR11 Nerf, Speed Accuracy Change, and this). 

Aetrna: https://cdn.discordapp.com/attachments/105047038915256320/786695258650050590/aetrna.txt
Vaxei: https://cdn.discordapp.com/attachments/105047038915256320/786695327482642503/vaxei.txt
Whitecat: https://cdn.discordapp.com/attachments/105047038915256320/786695344078979083/whitecat.txt
Chocomint: https://cdn.discordapp.com/attachments/105047038915256320/786696195149266985/chocomint.txt
Badeu: https://cdn.discordapp.com/attachments/105047038915256320/786696339568197663/badeu.txt
idke: https://cdn.discordapp.com/attachments/105047038915256320/786696491929436200/idke.txt
mrekk: https://cdn.discordapp.com/attachments/105047038915256320/786697229695320075/mrekk.txt
ryuk: https://cdn.discordapp.com/attachments/105047038915256320/786697263274524713/ryuk.txt

This MR is a little shorter, if there are reqs for more information or details, please feel free to comment. Thanks for reading.