### PR TITLE
Refactor and restore taiko hits test scene to a working state

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTaikoRulesetTestScene.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTaikoRulesetTestScene.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
 {
     public abstract class DrawableTaikoRulesetTestScene : OsuTestScene
     {
+        protected const int DEFAULT_PLAYFIELD_CONTAINER_HEIGHT = 768;
+
         protected DrawableTaikoRuleset DrawableRuleset { get; private set; }
         protected Container PlayfieldContainer { get; private set; }
 
@@ -44,10 +46,10 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
             Add(PlayfieldContainer = new Container
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
                 RelativeSizeAxes = Axes.X,
-                Height = 768,
+                Height = DEFAULT_PLAYFIELD_CONTAINER_HEIGHT,
                 Children = new[] { DrawableRuleset = new DrawableTaikoRuleset(new TaikoRuleset(), beatmap.GetPlayableBeatmap(new TaikoRuleset().RulesetInfo)) }
             });
         }

--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTestHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTestHit.cs
@@ -13,12 +13,15 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         public readonly HitResult Type;
 
-        public DrawableTestHit(Hit hit, HitResult type = HitResult.Great)
+        public DrawableTestHit(Hit hit, HitResult type = HitResult.Great, bool kiai = false)
             : base(hit)
         {
             Type = type;
 
-            HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new EffectControlPoint { KiaiMode = kiai });
+
+            HitObject.ApplyDefaults(controlPoints, new BeatmapDifficulty());
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Judgements;
@@ -118,7 +120,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             HitResult hitResult = RNG.Next(2) == 0 ? HitResult.Ok : HitResult.Great;
 
-            Hit hit = new Hit { IsStrong = true };
+            Hit hit = new Hit
+            {
+                IsStrong = true,
+                Samples = createSamples(strong: true)
+            };
             var h = new DrawableTestHit(hit, kiai: kiai) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
 
             DrawableRuleset.Playfield.Add(h);
@@ -166,6 +172,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 StartTime = DrawableRuleset.Playfield.Time.Current + scroll_time,
                 IsStrong = strong,
+                Samples = createSamples(strong: strong),
                 Duration = duration,
                 TickRate = 8,
             };
@@ -183,7 +190,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
             Hit h = new Hit
             {
                 StartTime = DrawableRuleset.Playfield.Time.Current + scroll_time,
-                IsStrong = strong
+                IsStrong = strong,
+                Samples = createSamples(HitType.Centre, strong)
             };
 
             h.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
@@ -196,12 +204,27 @@ namespace osu.Game.Rulesets.Taiko.Tests
             Hit h = new Hit
             {
                 StartTime = DrawableRuleset.Playfield.Time.Current + scroll_time,
-                IsStrong = strong
+                IsStrong = strong,
+                Samples = createSamples(HitType.Rim, strong)
             };
 
             h.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
             DrawableRuleset.Playfield.Add(new DrawableHit(h));
+        }
+
+        // TODO: can be removed if a better way of handling colour/strong type and samples is developed
+        private IList<HitSampleInfo> createSamples(HitType? hitType = null, bool strong = false)
+        {
+            var samples = new List<HitSampleInfo>();
+
+            if (hitType == HitType.Rim)
+                samples.Add(new HitSampleInfo(HitSampleInfo.HIT_CLAP));
+
+            if (strong)
+                samples.Add(new HitSampleInfo(HitSampleInfo.HIT_FINISH));
+
+            return samples;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -106,13 +106,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             HitResult hitResult = RNG.Next(2) == 0 ? HitResult.Ok : HitResult.Great;
 
-            var cpi = new ControlPointInfo();
-            cpi.Add(0, new EffectControlPoint { KiaiMode = kiai });
-
             Hit hit = new Hit();
-            hit.ApplyDefaults(cpi, new BeatmapDifficulty());
-
-            var h = new DrawableTestHit(hit) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
+            var h = new DrawableTestHit(hit, kiai: kiai) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
 
             DrawableRuleset.Playfield.Add(h);
 
@@ -123,13 +118,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             HitResult hitResult = RNG.Next(2) == 0 ? HitResult.Ok : HitResult.Great;
 
-            var cpi = new ControlPointInfo();
-            cpi.Add(0, new EffectControlPoint { KiaiMode = kiai });
-
             Hit hit = new Hit { IsStrong = true };
-            hit.ApplyDefaults(cpi, new BeatmapDifficulty());
-
-            var h = new DrawableTestHit(hit) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
+            var h = new DrawableTestHit(hit, kiai: kiai) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
 
             DrawableRuleset.Playfield.Add(h);
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                     break;
 
                 case 6:
-                    PlayfieldContainer.Delay(delay).ResizeTo(new Vector2(1, TaikoPlayfield.DEFAULT_HEIGHT), 500);
+                    PlayfieldContainer.Delay(delay).ResizeTo(new Vector2(1, DEFAULT_PLAYFIELD_CONTAINER_HEIGHT), 500);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -130,8 +130,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
         private void addMissJudgement()
         {
             DrawableTestHit h;
-            DrawableRuleset.Playfield.Add(h = new DrawableTestHit(new Hit(), HitResult.Miss));
-            ((TaikoPlayfield)DrawableRuleset.Playfield).OnNewResult(h, new JudgementResult(new HitObject(), new TaikoJudgement()) { Type = HitResult.Miss });
+            DrawableRuleset.Playfield.Add(h = new DrawableTestHit(new Hit { StartTime = DrawableRuleset.Playfield.Time.Current }, HitResult.Miss)
+            {
+                Alpha = 0
+            });
+            ((TaikoPlayfield)DrawableRuleset.Playfield).OnNewResult(h, new JudgementResult(h.HitObject, new TaikoJudgement()) { Type = HitResult.Miss });
         }
 
         private void addBarLine(bool major, double delay = scroll_time)

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
@@ -9,7 +10,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             var cpi = new ControlPointInfo();
             cpi.Add(0, new EffectControlPoint { KiaiMode = kiai });
 
-            Hit hit = new Hit();
+            Hit hit = new Hit { IsStrong = true };
             hit.ApplyDefaults(cpi, new BeatmapDifficulty());
 
             var h = new DrawableTestHit(hit) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             DrawableRuleset.Playfield.Add(h);
 
             ((TaikoPlayfield)DrawableRuleset.Playfield).OnNewResult(h, new JudgementResult(new HitObject(), new TaikoJudgement()) { Type = hitResult });
-            ((TaikoPlayfield)DrawableRuleset.Playfield).OnNewResult(new TestStrongNestedHit(h), new JudgementResult(new HitObject(), new TaikoStrongJudgement()) { Type = HitResult.Great });
+            ((TaikoPlayfield)DrawableRuleset.Playfield).OnNewResult(h.NestedHitObjects.Single(), new JudgementResult(new HitObject(), new TaikoStrongJudgement()) { Type = HitResult.Great });
         }
 
         private void addMissJudgement()
@@ -209,16 +209,6 @@ namespace osu.Game.Rulesets.Taiko.Tests
             h.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
             DrawableRuleset.Playfield.Add(new DrawableHit(h));
-        }
-
-        private class TestStrongNestedHit : DrawableStrongNestedHit
-        {
-            public TestStrongNestedHit(DrawableHitObject mainObject)
-                : base(new StrongHitObject { StartTime = mainObject.HitObject.StartTime }, mainObject)
-            {
-            }
-
-            public override bool OnPressed(TaikoAction action) => false;
         }
     }
 }


### PR DESCRIPTION
Currently on `master` taiko's `TestSceneHits` is in a pretty busted-up state from a collection of relatively recent mutually unrelated changes. This PR aims to restore things to a working state, without considering larger refactorings yet.

Taking it commit by commit:

* b56e932 - This wasn't actually broken; the commit is actually a preparatory change for pooling and sort of the pretext for this PR. Because at one point nested objects will be pooled, it gets appropriately harder to jam in the parent hitobject like the test scene does now (because with the pooling changes I'm replacing taiko drawables' `MainObject` with the now-existing `ParentHitObject`). Yields a net line decrease, too, so I think it's objectively a change for the better.
* d7551d9 - Broke with some test scene refactorings. Defaults were applied twice (once to the HO itself in the test scene, once in `DrawableTestHit`).
* f49d908 - Broke with judgement pooling/animation changes due to using an absolute sequence starting at `Result.TimeAbsolute`.
* 49768d4 - Broke with editor changes to support two-way sample and colour/strong state synchronisation. This is by far the wonkiest change and I dislike it right now, but I'm not necessarily aiming to address that just yet (and risk breaking all of taiko). I might address this at a later point after I'm done with the pooling series; my main thought for now is to move out the synchronisation logic from DHOs to HOs, although I haven't yet even looked towards checking if that is a viable direction wrt legacy decoding logic.
* e0ba5a4 - Not entirely sure where this broke, but I do recall it working as it does after the change.