### PR TITLE
Make carousel scrolling drawable independent 

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -629,8 +629,11 @@ namespace osu.Game.Screens.Select
             }
 
             // Update Y positions for the non-drawable models
-            foreach (var set in beatmapSets)
-                set.UpdateYPosition(Time.Elapsed);
+            if (Clock != null)
+            {
+                foreach (var set in beatmapSets)
+                    set.UpdateYPosition(Time.Elapsed);
+            }
 
             // Update externally controlled state of currently visible items (e.g. x-offset and opacity).
             // This is a per-frame update on all drawable panels.

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -567,6 +567,9 @@ namespace osu.Game.Screens.Select
 
         #endregion
 
+        private double timeSinceLastModelUpdate;
+        private const int model_updates_per_second = 10;
+
         protected override void Update()
         {
             base.Update();
@@ -631,8 +634,23 @@ namespace osu.Game.Screens.Select
             // Update Y positions for the non-drawable models
             if (Clock != null)
             {
-                foreach (var set in beatmapSets)
-                    set.UpdateYPosition(Time.Elapsed);
+                if (timeSinceLastModelUpdate + Time.Elapsed > 1000.0 / model_updates_per_second)
+                {
+                    foreach (var set in beatmapSets)
+                        set.UpdateYPosition(timeSinceLastModelUpdate + Time.Elapsed, true);
+
+                    timeSinceLastModelUpdate = 0;
+                }
+                else
+                {
+                    foreach (var d in Scroll.Children)
+                    {
+                        var set = d.Item as CarouselBeatmapSet;
+                        set?.UpdateYPosition(Time.Elapsed, false);
+                    }
+
+                    timeSinceLastModelUpdate += Time.Elapsed;
+                }
             }
 
             // Update externally controlled state of currently visible items (e.g. x-offset and opacity).

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
 
@@ -41,6 +42,26 @@ namespace osu.Game.Screens.Select.Carousel
                       .Where(b => !b.Hidden)
                       .Select(b => new CarouselBeatmap(b))
                       .ForEach(AddChild);
+        }
+
+        public float YPosition;
+
+        public void UpdateYPosition(double elapsed)
+        {
+            if (YPosition == default)
+            {
+                YPosition = CarouselYPosition;
+                return;
+            }
+
+            float targetY = CarouselYPosition;
+
+            if (Precision.AlmostEquals(targetY, YPosition))
+                YPosition = targetY;
+            else
+                // algorithm for this is taken from ScrollContainer.
+                // while it doesn't necessarily need to match 1:1, as we are emulating scroll in some cases this feels most correct.
+                YPosition = (float)Interpolation.Lerp(targetY, YPosition, Math.Exp(-0.01 * elapsed));
         }
 
         protected override CarouselItem GetNextToSelect()

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -45,13 +45,24 @@ namespace osu.Game.Screens.Select.Carousel
         }
 
         public float YPosition;
+        private double durationNotBulkUpdated;
 
-        public void UpdateYPosition(double elapsed)
+        public void UpdateYPosition(double elapsed, bool isBulkUpdate)
         {
             if (YPosition == default)
             {
                 YPosition = CarouselYPosition;
                 return;
+            }
+
+            if (isBulkUpdate)
+            {
+                elapsed -= durationNotBulkUpdated;
+                durationNotBulkUpdated = 0;
+            }
+            else
+            {
+                durationNotBulkUpdated += elapsed;
             }
 
             float targetY = CarouselYPosition;

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Graphics.UserInterface;
@@ -61,23 +60,13 @@ namespace osu.Game.Screens.Select.Carousel
                 viewDetails = beatmapOverlay.FetchAndShowBeatmapSet;
         }
 
+        public void UpdateY() => Y = ((CarouselBeatmapSet)Item).YPosition;
+
         protected override void Update()
         {
             base.Update();
 
-            // position updates should not occur if the item is filtered away.
-            // this avoids panels flying across the screen only to be eventually off-screen or faded out.
-            if (!Item.Visible)
-                return;
-
-            float targetY = Item.CarouselYPosition;
-
-            if (Precision.AlmostEquals(targetY, Y))
-                Y = targetY;
-            else
-                // algorithm for this is taken from ScrollContainer.
-                // while it doesn't necessarily need to match 1:1, as we are emulating scroll in some cases this feels most correct.
-                Y = (float)Interpolation.Lerp(targetY, Y, Math.Exp(-0.01 * Time.Elapsed));
+            UpdateY();
         }
 
         protected override void UpdateItem()


### PR DESCRIPTION
* [x] Closes #11156
* [ ] Figure out why panels weren't updating their position while being filtered (I can't reproduce the behaviour mentioned in the comment)

## Summary
This PR would remove anything that changes drawable Y position from beatmap carousel, moving that logic to underlying models instead. This makes all scrolling look consistent as the underlying models are never unloaded.

## Changes
* Calculate Y position in ``CarouselBeatmapSet`` - Call that calculation from ``BeatmapCarousel``
* Use calculated Y position in ``DrawableCarouselBeatmapSet``
* Correctly initialize ``DrawableCarouselBeatmapSet`` Y position when it's gotten from pool
* Find target Y / ``CarouselYPosition`` even for filtered sets
  * This is to add more consistency when filtering items. Newly visible items get a good position right away.
* Fix bug in scrolling off extremes 
  * Squeezing it into this PR, is a 2 line change (``visibleHalfHeight - BleedTop/Bottom`` change)
* Update drawable Y when scrolling to avoid off-by-one frame issues
  * Issues like drawables appearing in wrong places because they didn't get unloaded correctly by some scrolling that would have placed them outside visible area