### PR TITLE
improve selection box rotation UX

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -191,7 +191,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 {
                     Anchor = Anchor.TopCentre,
                     Y = -separation,
-                    HandleDrag = e => OnRotation?.Invoke(e.Delta.X),
+                    HandleDrag = e => OnRotation?.Invoke(convertDragEventToAngleOfRotation(e)),
                     OperationStarted = operationStarted,
                     OperationEnded = operationEnded
                 }
@@ -241,6 +241,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
         });
 
         private int activeOperations;
+
+        private float convertDragEventToAngleOfRotation(DragEvent e)
+        {
+            // Adjust coordinate system to the center of SelectionBox
+            float startAngle = MathF.Atan2(e.LastMousePosition.Y - DrawHeight / 2, e.LastMousePosition.X - DrawWidth / 2);
+            float endAngle = MathF.Atan2(e.MousePosition.Y - DrawHeight / 2, e.MousePosition.X - DrawWidth / 2);
+
+            return (endAngle - startAngle) * 180 / MathF.PI;
+        }
 
         private void operationEnded()
         {


### PR DESCRIPTION
When I try to rotate a selection from the selection box, the rotation will spazz out if I rotate too much. It's not a great UX, so I made a better one that will always follow the mouse as you rotate.

The problem seemed a bit small to create an issue on github, especially when the fix is straightforward.

Not sure how to make and submit a gif that would demonstrate the before and after behavior, so if someone could show me how that would be much appreciated!