### PR TITLE
Ensure correct initial state of taiko bar lines

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableBarLine.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            major.BindValueChanged(updateMajor);
+            major.BindValueChanged(updateMajor, true);
         }
 
         private void updateMajor(ValueChangedEvent<bool> major)


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/commit/704150306324135bbb6ba4957627619fa294548c (dropped `true` param).

Worse thing is I was actually watching that being typed out and didn't notice... In a semblance of a defense, it *was* 7 AM.

Mostly affected tests.