### PR TITLE
Fix swells crashing on rapid seeks in editor

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                 foreach (var t in ticks)
                 {
-                    if (!t.IsHit)
+                    if (!t.Result.HasResult)
                     {
                         nextTick = t;
                         break;
@@ -208,7 +208,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                         continue;
                     }
 
-                    tick.TriggerResult(false);
+                    if (!tick.Result.HasResult)
+                        tick.TriggerResult(false);
                 }
 
                 ApplyResult(r => r.Type = numHits > HitObject.RequiredHits / 2 ? HitResult.Ok : r.Judgement.MinResult);


### PR DESCRIPTION
Fell out when testing pooling changes. Can be reproduced by seeking back and forth in editor using the bottom timeline around a swell (can crash in either of the two fixed cases).

Cause (and applied fix) is pretty much the same as was the case for osu! spinners in https://github.com/ppy/osu/pull/10352.