### PR TITLE
Fix beatmapset panel difficulty icon order

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
             }
             else
             {
-                foreach (var b in SetInfo.Beatmaps.OrderBy(beatmap => beatmap.StarDifficulty))
+                foreach (var b in SetInfo.Beatmaps.OrderBy(beatmap => beatmap.Ruleset.ID).ThenBy(beatmap => beatmap.StarDifficulty))
                     icons.Add(new DifficultyIcon(b));
             }
 


### PR DESCRIPTION
In website the difficulty icon is sort by game mode then by the star rating, while in lazer it just sort by the star rating.

**Website**

![Screenshot from 2020-12-15 11-11-41](https://user-images.githubusercontent.com/4964985/102170732-9db17980-3ec7-11eb-9add-3a71f892b27b.png)

**Lazer**

![Screenshot from 2020-12-15 11-14-39](https://user-images.githubusercontent.com/4964985/102170774-b02bb300-3ec7-11eb-9fe6-93d01fc56497.png)

**Lazer (this PR)**

![Screenshot from 2020-12-15 11-12-03](https://user-images.githubusercontent.com/4964985/102170812-c89bcd80-3ec7-11eb-99e9-1ffb39497b71.png)


**Website**

![Screenshot from 2020-12-15 11-13-16](https://user-images.githubusercontent.com/4964985/102170837-d94c4380-3ec7-11eb-9cb7-db15eb163dc6.png)

**Lazer**

![Screenshot from 2020-12-15 11-15-23](https://user-images.githubusercontent.com/4964985/102170858-e5380580-3ec7-11eb-9c3b-6d7172517e39.png)

**Lazer (this PR)**

![Screenshot from 2020-12-15 11-13-25](https://user-images.githubusercontent.com/4964985/102170885-eec16d80-3ec7-11eb-83f7-f44bb5cf1b20.png)
