### PR TITLE
Clamp osu!mania's HitPosition offset to match osu-stable implementation

### DIFF
--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Skinning
                         break;
 
                     case "HitPosition":
-                        currentConfig.HitPosition = (480 - float.Parse(pair.Value, CultureInfo.InvariantCulture)) * LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
+                        currentConfig.HitPosition = (480 - Math.Clamp(float.Parse(pair.Value, CultureInfo.InvariantCulture), 240, 480)) * LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
                         break;
 
                     case "LightPosition":


### PR DESCRIPTION
Closes #11184.

Note that this still isn't perfect with the provided skin, likely due to the hit judgement area still being incorrectly vertically positioned in lazer?

![2020-12-16 18 09 00](https://user-images.githubusercontent.com/191335/102328000-d76aa900-3fc9-11eb-9a34-9e37094c1275.gif)
