### PR TITLE
Add global friends list to API providers

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -26,7 +26,7 @@ namespace osu.Desktop
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; }
 
-        private Bindable<User> user;
+        private IBindable<User> user;
 
         private readonly IBindable<UserStatus> status = new Bindable<UserStatus>();
         private readonly IBindable<UserActivity> activity = new Bindable<UserActivity>();

--- a/osu.Game.Tests/Visual/Menus/TestSceneDisclaimer.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneDisclaimer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Game.Online.API;
 using osu.Game.Screens.Menu;
 using osu.Game.Users;
 
@@ -16,7 +17,7 @@ namespace osu.Game.Tests.Visual.Menus
 
             AddStep("toggle support", () =>
             {
-                API.LocalUser.Value = new User
+                ((DummyAPIAccess)API).LocalUser.Value = new User
                 {
                     Username = API.LocalUser.Value.Username,
                     Id = API.LocalUser.Value.Id + 1,

--- a/osu.Game.Tests/Visual/Online/TestSceneAccountCreationOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneAccountCreationOverlay.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tests.Visual.Online
     {
         private readonly Container userPanelArea;
 
-        private Bindable<User> localUser;
+        private IBindable<User> localUser;
 
         public TestSceneAccountCreationOverlay()
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.Online
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
-        private TestFriendDisplay display;
+        private FriendDisplay display;
 
         [SetUp]
         public void Setup() => Schedule(() =>
@@ -28,7 +28,7 @@ namespace osu.Game.Tests.Visual.Online
             Child = new BasicScrollContainer
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = display = new TestFriendDisplay()
+                Child = display = new FriendDisplay()
             };
         });
 
@@ -41,7 +41,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestOnline()
         {
-            AddStep("Fetch online", () => display?.Fetch());
+            // No need to do anything, fetch is performed automatically.
         }
 
         private List<User> getUsers() => new List<User>
@@ -76,10 +76,5 @@ namespace osu.Game.Tests.Visual.Online
                 LastVisit = DateTimeOffset.Now
             }
         };
-
-        private class TestFriendDisplay : FriendDisplay
-        {
-            public void Fetch() => PerformFetch();
-        }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Online.API;
 using osu.Game.Online.Chat;
 using osu.Game.Rulesets;
 using osu.Game.Users;
@@ -18,6 +19,8 @@ namespace osu.Game.Tests.Visual.Online
         [Cached(typeof(IChannelPostTarget))]
         private PostTarget postTarget { get; set; }
 
+        private DummyAPIAccess api => (DummyAPIAccess)API;
+
         public TestSceneNowPlayingCommand()
         {
             Add(postTarget = new PostTarget());
@@ -26,7 +29,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestGenericActivity()
         {
-            AddStep("Set activity", () => API.Activity.Value = new UserActivity.InLobby(null));
+            AddStep("Set activity", () => api.Activity.Value = new UserActivity.InLobby(null));
 
             AddStep("Run command", () => Add(new NowPlayingCommand()));
 
@@ -36,7 +39,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestEditActivity()
         {
-            AddStep("Set activity", () => API.Activity.Value = new UserActivity.Editing(new BeatmapInfo()));
+            AddStep("Set activity", () => api.Activity.Value = new UserActivity.Editing(new BeatmapInfo()));
 
             AddStep("Run command", () => Add(new NowPlayingCommand()));
 
@@ -46,7 +49,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestPlayActivity()
         {
-            AddStep("Set activity", () => API.Activity.Value = new UserActivity.SoloGame(new BeatmapInfo(), new RulesetInfo()));
+            AddStep("Set activity", () => api.Activity.Value = new UserActivity.SoloGame(new BeatmapInfo(), new RulesetInfo()));
 
             AddStep("Run command", () => Add(new NowPlayingCommand()));
 
@@ -57,7 +60,7 @@ namespace osu.Game.Tests.Visual.Online
         [TestCase(false)]
         public void TestLinkPresence(bool hasOnlineId)
         {
-            AddStep("Set activity", () => API.Activity.Value = new UserActivity.InLobby(null));
+            AddStep("Set activity", () => api.Activity.Value = new UserActivity.InLobby(null));
 
             AddStep("Set beatmap", () => Beatmap.Value = new DummyWorkingBeatmap(Audio, null)
             {

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -153,8 +153,7 @@ namespace osu.Game.Online.API
 
                         if (!handleRequest(userReq))
                         {
-                            if (State.Value == APIState.Connecting)
-                                state.Value = APIState.Failing;
+                            failConnectionProcess();
                             continue;
                         }
 
@@ -170,7 +169,11 @@ namespace osu.Game.Online.API
                         };
 
                         if (!handleRequest(friendsReq))
-                            state.Value = APIState.Failing;
+                        {
+                            failConnectionProcess();
+                            continue;
+                        }
+
                         // The Success callback event is fired on the main thread, so we should wait for that to run before proceeding.
                         // Without this, we will end up circulating this Connecting loop multiple times and queueing up many web requests
                         // before actually going online.
@@ -202,6 +205,13 @@ namespace osu.Game.Online.API
                 }
 
                 Thread.Sleep(50);
+            }
+
+            void failConnectionProcess()
+            {
+                // if something went wrong during the connection process, we want to reset the state (but only if still connecting).
+                if (State.Value == APIState.Connecting)
+                    state.Value = APIState.Failing;
             }
         }
 

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -146,11 +146,15 @@ namespace osu.Game.Online.API
                             failureCount = 0;
 
                             var friendsReq = new GetFriendsRequest();
-                            friendsReq.Success += f => Friends.AddRange(f);
-                            handleRequest(friendsReq);
+                            friendsReq.Success += f =>
+                            {
+                                Friends.AddRange(f);
 
-                            //we're connected!
-                            state.Value = APIState.Online;
+                                //we're connected!
+                                state.Value = APIState.Online;
+                            };
+
+                            handleRequest(friendsReq);
                         };
 
                         if (!handleRequest(userReq))

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -39,11 +39,15 @@ namespace osu.Game.Online.API
 
         private string password;
 
-        public Bindable<User> LocalUser { get; } = new Bindable<User>(createGuestUser());
+        public IBindable<User> LocalUser => localUser;
+        public IBindableList<User> Friends => friends;
+        public IBindable<UserActivity> Activity => activity;
 
-        public BindableList<User> Friends { get; } = new BindableList<User>();
+        private Bindable<User> localUser { get; } = new Bindable<User>(createGuestUser());
 
-        public Bindable<UserActivity> Activity { get; } = new Bindable<UserActivity>();
+        private BindableList<User> friends { get; } = new BindableList<User>();
+
+        private Bindable<UserActivity> activity { get; } = new Bindable<UserActivity>();
 
         protected bool HasLogin => authentication.Token.Value != null || (!string.IsNullOrEmpty(ProvidedUsername) && !string.IsNullOrEmpty(password));
 
@@ -63,10 +67,10 @@ namespace osu.Game.Online.API
             authentication.TokenString = config.Get<string>(OsuSetting.Token);
             authentication.Token.ValueChanged += onTokenChanged;
 
-            LocalUser.BindValueChanged(u =>
+            localUser.BindValueChanged(u =>
             {
-                u.OldValue?.Activity.UnbindFrom(Activity);
-                u.NewValue.Activity.BindTo(Activity);
+                u.OldValue?.Activity.UnbindFrom(activity);
+                u.NewValue.Activity.BindTo(activity);
             }, true);
 
             var thread = new Thread(run)
@@ -138,10 +142,10 @@ namespace osu.Game.Online.API
                         var userReq = new GetUserRequest();
                         userReq.Success += u =>
                         {
-                            LocalUser.Value = u;
+                            localUser.Value = u;
 
                             // todo: save/pull from settings
-                            LocalUser.Value.Status.Value = new UserStatusOnline();
+                            localUser.Value.Status.Value = new UserStatusOnline();
 
                             failureCount = 0;
 
@@ -343,7 +347,7 @@ namespace osu.Game.Online.API
             return true;
         }
 
-        public bool IsLoggedIn => LocalUser.Value.Id > 1;
+        public bool IsLoggedIn => localUser.Value.Id > 1;
 
         public void Queue(APIRequest request)
         {
@@ -376,8 +380,8 @@ namespace osu.Game.Online.API
             // Scheduled prior to state change such that the state changed event is invoked with the correct user and their friends present
             Schedule(() =>
             {
-                LocalUser.Value = createGuestUser();
-                Friends.Clear();
+                localUser.Value = createGuestUser();
+                friends.Clear();
             });
 
             state.Value = APIState.Offline;

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -145,16 +145,14 @@ namespace osu.Game.Online.API
 
                             failureCount = 0;
 
-                            var friendsReq = new GetFriendsRequest();
-                            friendsReq.Success += f =>
+                            fetchFriends(() =>
                             {
-                                Friends.AddRange(f);
-
                                 //we're connected!
                                 state.Value = APIState.Online;
-                            };
-
-                            handleRequest(friendsReq);
+                            }, () =>
+                            {
+                                state.Value = APIState.Failing;
+                            });
                         };
 
                         if (!handleRequest(userReq))
@@ -253,6 +251,19 @@ namespace osu.Game.Online.API
             }
 
             return null;
+        }
+
+        private void fetchFriends(Action onSuccess, Action onFail)
+        {
+            var friendsReq = new GetFriendsRequest();
+            friendsReq.Success += res =>
+            {
+                Friends.AddRange(res);
+                onSuccess?.Invoke();
+            };
+
+            if (!handleRequest(friendsReq))
+                onFail?.Invoke();
         }
 
         /// <summary>

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -19,11 +19,7 @@ namespace osu.Game.Online.API
             Id = 1001,
         });
 
-        public BindableList<User> Friends { get; } = new BindableList<User>(new User
-        {
-            Username = @"Dummy's friend",
-            Id = 2002,
-        }.Yield());
+        public BindableList<User> Friends { get; } = new BindableList<User>();
 
         public Bindable<UserActivity> Activity { get; } = new Bindable<UserActivity>();
 

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Users;
 

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Users;
 
@@ -17,6 +18,12 @@ namespace osu.Game.Online.API
             Username = @"Dummy",
             Id = 1001,
         });
+
+        public BindableList<User> Friends { get; } = new BindableList<User>(new User
+        {
+            Username = @"Dummy's friend",
+            Id = 2002,
+        }.Yield());
 
         public Bindable<UserActivity> Activity { get; } = new Bindable<UserActivity>();
 

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -93,5 +93,9 @@ namespace osu.Game.Online.API
         }
 
         public void SetState(APIState newState) => state.Value = newState;
+
+        IBindable<User> IAPIProvider.LocalUser => LocalUser;
+        IBindableList<User> IAPIProvider.Friends => Friends;
+        IBindable<UserActivity> IAPIProvider.Activity => Activity;
     }
 }

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -16,6 +16,12 @@ namespace osu.Game.Online.API
         Bindable<User> LocalUser { get; }
 
         /// <summary>
+        /// The user's friends.
+        /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
+        /// </summary>
+        BindableList<User> Friends { get; }
+
+        /// <summary>
         /// The current user's activity.
         /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
         /// </summary>

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -13,19 +13,19 @@ namespace osu.Game.Online.API
         /// The local user.
         /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
         /// </summary>
-        Bindable<User> LocalUser { get; }
+        IBindable<User> LocalUser { get; }
 
         /// <summary>
         /// The user's friends.
         /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
         /// </summary>
-        BindableList<User> Friends { get; }
+        IBindableList<User> Friends { get; }
 
         /// <summary>
         /// The current user's activity.
         /// This is not thread-safe and should be scheduled locally if consumed from a drawable component.
         /// </summary>
-        Bindable<UserActivity> Activity { get; }
+        IBindable<UserActivity> Activity { get; }
 
         /// <summary>
         /// Retrieve the OAuth access token.

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -51,7 +51,6 @@ using osu.Game.Screens.Select;
 using osu.Game.Updater;
 using osu.Game.Utils;
 using LogLevel = osu.Framework.Logging.LogLevel;
-using osu.Game.Users;
 using System.IO;
 
 namespace osu.Game
@@ -976,7 +975,7 @@ namespace osu.Game
             if (newScreen is IOsuScreen newOsuScreen)
             {
                 OverlayActivationMode.BindTo(newOsuScreen.OverlayActivationMode);
-                ((IBindable<UserActivity>)API.Activity).BindTo(newOsuScreen.Activity);
+                API.Activity.BindTo(newOsuScreen.Activity);
 
                 MusicController.AllowRateAdjustments = newOsuScreen.AllowRateAdjustments;
 

--- a/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
         private PostBeatmapFavouriteRequest request;
         private LoadingLayer loading;
 
-        private readonly Bindable<User> localUser = new Bindable<User>();
+        private readonly IBindable<User> localUser = new Bindable<User>();
 
         public string TooltipText
         {

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         public readonly Bindable<BeatmapInfo> Beatmap = new Bindable<BeatmapInfo>();
         private readonly Bindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
         private readonly Bindable<BeatmapLeaderboardScope> scope = new Bindable<BeatmapLeaderboardScope>(BeatmapLeaderboardScope.Global);
-        private readonly Bindable<User> user = new Bindable<User>();
+        private readonly IBindable<User> user = new Bindable<User>();
 
         private readonly Box background;
         private readonly ScoreTable scoreTable;

--- a/osu.Game/Overlays/Comments/CommentsContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentsContainer.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.Comments
         public readonly Bindable<CommentsSortCriteria> Sort = new Bindable<CommentsSortCriteria>();
         public readonly BindableBool ShowDeleted = new BindableBool();
 
-        protected readonly Bindable<User> User = new Bindable<User>();
+        protected readonly IBindable<User> User = new Bindable<User>();
 
         [Resolved]
         private IAPIProvider api { get; set; }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -5,16 +5,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Overlays.Dashboard.Friends
 {
-    public class FriendDisplay : OverlayView<List<User>>
+    public class FriendDisplay : CompositeDrawable
     {
         private List<User> users = new List<User>();
 
@@ -39,8 +41,16 @@ namespace osu.Game.Overlays.Dashboard.Friends
         private Container itemsPlaceholder;
         private LoadingLayer loading;
 
-        [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private readonly IBindableList<User> apiFriends = new BindableList<User>();
+
+        public FriendDisplay()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(OverlayColourProvider colourProvider, IAPIProvider api)
         {
             InternalChild = new FillFlowContainer
             {
@@ -130,6 +140,9 @@ namespace osu.Game.Overlays.Dashboard.Friends
 
             background.Colour = colourProvider.Background4;
             controlBackground.Colour = colourProvider.Background5;
+
+            apiFriends.BindTo(api.Friends);
+            apiFriends.BindCollectionChanged((_, __) => Schedule(() => Users = apiFriends.ToList()), true);
         }
 
         protected override void LoadComplete()
@@ -139,13 +152,6 @@ namespace osu.Game.Overlays.Dashboard.Friends
             onlineStreamControl.Current.BindValueChanged(_ => recreatePanels());
             userListToolbar.DisplayStyle.BindValueChanged(_ => recreatePanels());
             userListToolbar.SortCriteria.BindValueChanged(_ => recreatePanels());
-        }
-
-        protected override void PerformFetch()
-        {
-            base.PerformFetch();
-
-            Users = API.Friends.ToList();
         }
 
         private void recreatePanels()

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -9,8 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Users;
 using osuTK;
 
@@ -143,11 +141,11 @@ namespace osu.Game.Overlays.Dashboard.Friends
             userListToolbar.SortCriteria.BindValueChanged(_ => recreatePanels());
         }
 
-        protected override APIRequest<List<User>> CreateRequest() => new GetFriendsRequest();
-
-        protected override void OnSuccess(List<User> response)
+        protected override void PerformFetch()
         {
-            Users = response;
+            base.PerformFetch();
+
+            Users = API.Friends.ToList();
         }
 
         private void recreatePanels()

--- a/osu.Game/Overlays/OverlayView.cs
+++ b/osu.Game/Overlays/OverlayView.cs
@@ -42,29 +42,25 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Create the API request for fetching data.
         /// </summary>
-        protected virtual APIRequest<T> CreateRequest() => null;
+        protected abstract APIRequest<T> CreateRequest();
 
         /// <summary>
         /// Fired when results arrive from the main API request.
         /// </summary>
         /// <param name="response"></param>
-        protected virtual void OnSuccess(T response)
-        {
-        }
+        protected abstract void OnSuccess(T response);
 
         /// <summary>
         /// Force a re-request for data from the API.
         /// </summary>
-        protected virtual void PerformFetch()
+        protected void PerformFetch()
         {
             request?.Cancel();
-            request = CreateRequest();
 
-            if (request != null)
-            {
-                request.Success += response => Schedule(() => OnSuccess(response));
-                API.Queue(request);
-            }
+            request = CreateRequest();
+            request.Success += response => Schedule(() => OnSuccess(response));
+
+            API.Queue(request);
         }
 
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>

--- a/osu.Game/Overlays/OverlayView.cs
+++ b/osu.Game/Overlays/OverlayView.cs
@@ -42,25 +42,29 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Create the API request for fetching data.
         /// </summary>
-        protected abstract APIRequest<T> CreateRequest();
+        protected virtual APIRequest<T> CreateRequest() => null;
 
         /// <summary>
         /// Fired when results arrive from the main API request.
         /// </summary>
         /// <param name="response"></param>
-        protected abstract void OnSuccess(T response);
+        protected virtual void OnSuccess(T response)
+        {
+        }
 
         /// <summary>
         /// Force a re-request for data from the API.
         /// </summary>
-        protected void PerformFetch()
+        protected virtual void PerformFetch()
         {
             request?.Cancel();
-
             request = CreateRequest();
-            request.Success += response => Schedule(() => OnSuccess(response));
 
-            API.Queue(request);
+            if (request != null)
+            {
+                request.Success += response => Schedule(() => OnSuccess(response));
+                API.Queue(request);
+            }
         }
 
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>

--- a/osu.Game/Overlays/Profile/Header/Components/AddFriendButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/AddFriendButton.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 }
             };
 
+            // todo: when friending/unfriending is implemented, the APIAccess.Friends list should be updated accordingly.
+
             User.BindValueChanged(user => updateFollowers(user.NewValue), true);
         }
 

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Backgrounds
 
         private int currentDisplay;
         private const int background_count = 7;
-        private Bindable<User> user;
+        private IBindable<User> user;
         private Bindable<Skin> skin;
         private Bindable<BackgroundSource> mode;
         private Bindable<IntroSequence> introSequence;

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Screens.Menu
             if (nextScreen != null)
                 LoadComponentAsync(nextScreen);
 
-            currentUser.BindTo(api.LocalUser);
+            ((IBindable<User>)currentUser).BindTo(api.LocalUser);
         }
 
         public override void OnEntering(IScreen last)

--- a/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/MenuLogoVisualisation.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Screens.Menu
 {
     internal class MenuLogoVisualisation : LogoVisualisation
     {
-        private Bindable<User> user;
+        private IBindable<User> user;
         private Bindable<Skin> skin;
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Menu/MenuSideFlashes.cs
+++ b/osu.Game/Screens/Menu/MenuSideFlashes.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Menu
         private const double box_fade_in_time = 65;
         private const int box_width = 200;
 
-        private Bindable<User> user;
+        private IBindable<User> user;
         private Bindable<Skin> skin;
 
         [Resolved]


### PR DESCRIPTION
Exposes a `BindableList` of the current user's friends, this allows components to determine whether a certain user is followed by the local user.