### PR TITLE
Asyncify player score creation and submission

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneCompletionCancellation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneCompletionCancellation.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Scoring;
+using osu.Game.Screens.Ranking;
 using osu.Game.Storyboards;
 using osuTK;
 
@@ -51,7 +52,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             cancel();
             complete();
 
-            AddUntilStep("attempted to push ranking", () => ((FakeRankingPushPlayer)Player).GotoRankingInvoked);
+            AddUntilStep("attempted to push ranking", () => ((FakeRankingPushPlayer)Player).ResultsCreated);
         }
 
         /// <summary>
@@ -85,7 +86,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             // wait to ensure there was no attempt of pushing the results screen.
             AddWaitStep("wait", resultsDisplayWaitCount);
-            AddAssert("no attempt to push ranking", () => !((FakeRankingPushPlayer)Player).GotoRankingInvoked);
+            AddAssert("no attempt to push ranking", () => !((FakeRankingPushPlayer)Player).ResultsCreated);
         }
 
         protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
@@ -111,16 +112,18 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         public class FakeRankingPushPlayer : TestPlayer
         {
-            public bool GotoRankingInvoked;
+            public bool ResultsCreated { get; private set; }
 
             public FakeRankingPushPlayer()
                 : base(true, true)
             {
             }
 
-            protected override void GotoRanking(ScoreInfo score)
+            protected override ResultsScreen CreateResults(ScoreInfo score)
             {
-                GotoRankingInvoked = true;
+                var results = base.CreateResults(score);
+                ResultsCreated = true;
+                return results;
             }
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneCompletionCancellation.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneCompletionCancellation.cs
@@ -10,6 +10,7 @@ using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Scoring;
 using osu.Game.Storyboards;
 using osuTK;
 
@@ -117,7 +118,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
             }
 
-            protected override void GotoRanking()
+            protected override void GotoRanking(ScoreInfo score)
             {
                 GotoRankingInvoked = true;
             }

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -107,25 +107,23 @@ namespace osu.Game.Screens.Multi.Play
         {
             Debug.Assert(token != null);
 
-            bool completed = false;
+            var tcs = new TaskCompletionSource<bool>();
             var request = new SubmitRoomScoreRequest(token.Value, roomId.Value ?? 0, playlistItem.ID, score.ScoreInfo);
 
             request.Success += s =>
             {
                 score.ScoreInfo.OnlineScoreID = s.ID;
-                completed = true;
+                tcs.SetResult(true);
             };
 
             request.Failure += e =>
             {
                 Logger.Error(e, "Failed to submit score");
-                completed = true;
+                tcs.SetResult(false);
             };
 
             api.Queue(request);
-
-            while (!completed)
-                await Task.Delay(100);
+            await tcs.Task;
 
             return await base.SubmitScore(score);
         }

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -103,8 +103,10 @@ namespace osu.Game.Screens.Multi.Play
             return score;
         }
 
-        protected override async Task<ScoreInfo> SubmitScore(Score score)
+        protected override async Task SubmitScore(Score score)
         {
+            await base.SubmitScore(score);
+
             Debug.Assert(token != null);
 
             var tcs = new TaskCompletionSource<bool>();
@@ -124,8 +126,6 @@ namespace osu.Game.Screens.Multi.Play
 
             api.Queue(request);
             await tcs.Task;
-
-            return await base.SubmitScore(score);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
+++ b/osu.Game/Screens/Multi/Play/TimeshiftPlayer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
@@ -95,19 +96,25 @@ namespace osu.Game.Screens.Multi.Play
             return new TimeshiftResultsScreen(score, roomId.Value.Value, playlistItem, true);
         }
 
-        protected override ScoreInfo CreateScore()
+        protected override Score CreateScore()
         {
             var score = base.CreateScore();
-            score.TotalScore = (int)Math.Round(ScoreProcessor.GetStandardisedScore());
+            score.ScoreInfo.TotalScore = (int)Math.Round(ScoreProcessor.GetStandardisedScore());
+            return score;
+        }
+
+        protected override async Task<ScoreInfo> SubmitScore(Score score)
+        {
+            await base.SubmitScore(score);
 
             Debug.Assert(token != null);
 
-            var request = new SubmitRoomScoreRequest(token.Value, roomId.Value ?? 0, playlistItem.ID, score);
-            request.Success += s => score.OnlineScoreID = s.ID;
+            var request = new SubmitRoomScoreRequest(token.Value, roomId.Value ?? 0, playlistItem.ID, score.ScoreInfo);
+            request.Success += s => score.ScoreInfo.OnlineScoreID = s.ID;
             request.Failure += e => Logger.Error(e, "Failed to submit score");
             api.Queue(request);
 
-            return score;
+            return score.ScoreInfo;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -502,6 +502,7 @@ namespace osu.Game.Screens.Play
         }
 
         private ScheduledDelegate completionProgressDelegate;
+        private Task<ScoreInfo> scoreSubmissionTask;
 
         private void updateCompletionState(ValueChangedEvent<bool> completionState)
         {
@@ -528,7 +529,8 @@ namespace osu.Game.Screens.Play
 
             if (!showResults) return;
 
-            SubmitScore(CreateScore()).ContinueWith(t => Schedule(() =>
+            scoreSubmissionTask ??= SubmitScore(CreateScore());
+            scoreSubmissionTask.ContinueWith(t => Schedule(() =>
             {
                 using (BeginDelayedSequence(RESULTS_DISPLAY_DELAY))
                 {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -527,8 +528,18 @@ namespace osu.Game.Screens.Play
 
             if (!showResults) return;
 
-            using (BeginDelayedSequence(RESULTS_DISPLAY_DELAY))
-                completionProgressDelegate = Schedule(GotoRanking);
+            SubmitScore(CreateScore()).ContinueWith(t => Schedule(() =>
+            {
+                using (BeginDelayedSequence(RESULTS_DISPLAY_DELAY))
+                {
+                    completionProgressDelegate = Schedule(() =>
+                    {
+                        // screen may be in the exiting transition phase.
+                        if (this.IsCurrentScreen())
+                            GotoRanking(t.Result);
+                    });
+                }
+            }));
         }
 
         protected override bool OnScroll(ScrollEvent e) => mouseWheelDisabled.Value && !GameplayClockContainer.IsPaused.Value;
@@ -727,59 +738,55 @@ namespace osu.Game.Screens.Play
             return base.OnExiting(next);
         }
 
-        protected virtual ScoreInfo CreateScore()
+        protected virtual Score CreateScore()
         {
-            var score = new ScoreInfo
+            var score = new Score
             {
-                Beatmap = Beatmap.Value.BeatmapInfo,
-                Ruleset = rulesetInfo,
-                Mods = Mods.Value.ToArray(),
+                ScoreInfo = new ScoreInfo
+                {
+                    Beatmap = Beatmap.Value.BeatmapInfo,
+                    Ruleset = rulesetInfo,
+                    Mods = Mods.Value.ToArray(),
+                }
             };
 
             if (DrawableRuleset.ReplayScore != null)
-                score.User = DrawableRuleset.ReplayScore.ScoreInfo?.User ?? new GuestUser();
+            {
+                score.ScoreInfo.User = DrawableRuleset.ReplayScore.ScoreInfo?.User ?? new GuestUser();
+                score.Replay = DrawableRuleset.ReplayScore.Replay;
+            }
             else
-                score.User = api.LocalUser.Value;
+            {
+                score.ScoreInfo.User = api.LocalUser.Value;
+                if (recordingScore?.Replay.Frames.Count > 0)
+                    score.Replay = recordingScore.Replay;
+            }
 
-            ScoreProcessor.PopulateScore(score);
+            ScoreProcessor.PopulateScore(score.ScoreInfo);
 
             return score;
         }
 
-        protected virtual void GotoRanking()
+        protected virtual async Task<ScoreInfo> SubmitScore(Score score)
         {
+            // Replays are already populated and present in the game's database, so should not be re-imported.
             if (DrawableRuleset.ReplayScore != null)
+                return score.ScoreInfo;
+
+            LegacyByteArrayReader replayReader;
+
+            using (var stream = new MemoryStream())
             {
-                // if a replay is present, we likely don't want to import into the local database.
-                this.Push(CreateResults(CreateScore()));
-                return;
+                new LegacyScoreEncoder(score, gameplayBeatmap.PlayableBeatmap).Encode(stream);
+                replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
             }
 
-            LegacyByteArrayReader replayReader = null;
-
-            var score = new Score { ScoreInfo = CreateScore() };
-
-            if (recordingScore?.Replay.Frames.Count > 0)
-            {
-                score.Replay = recordingScore.Replay;
-
-                using (var stream = new MemoryStream())
-                {
-                    new LegacyScoreEncoder(score, gameplayBeatmap.PlayableBeatmap).Encode(stream);
-                    replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
-                }
-            }
-
-            scoreManager.Import(score.ScoreInfo, replayReader)
-                        .ContinueWith(imported => Schedule(() =>
-                        {
-                            // screen may be in the exiting transition phase.
-                            if (this.IsCurrentScreen())
-                                this.Push(CreateResults(imported.Result));
-                        }));
+            return await scoreManager.Import(score.ScoreInfo, replayReader);
         }
 
         protected virtual ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, true);
+
+        protected virtual void GotoRanking(ScoreInfo score) => this.Push(CreateResults(score));
 
         private void fadeOut(bool instant = false)
         {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -536,7 +536,7 @@ namespace osu.Game.Screens.Play
                     {
                         // screen may be in the exiting transition phase.
                         if (this.IsCurrentScreen())
-                            GotoRanking(t.Result);
+                            this.Push(CreateResults(t.Result));
                     });
                 }
             }));
@@ -738,6 +738,10 @@ namespace osu.Game.Screens.Play
             return base.OnExiting(next);
         }
 
+        /// <summary>
+        /// Creates the player's <see cref="Score"/>.
+        /// </summary>
+        /// <returns>The <see cref="Score"/>.</returns>
         protected virtual Score CreateScore()
         {
             var score = new Score
@@ -767,6 +771,11 @@ namespace osu.Game.Screens.Play
             return score;
         }
 
+        /// <summary>
+        /// Submits the player's <see cref="Score"/>.
+        /// </summary>
+        /// <param name="score">The <see cref="Score"/> to submit.</param>
+        /// <returns>The submitted score.</returns>
         protected virtual async Task<ScoreInfo> SubmitScore(Score score)
         {
             // Replays are already populated and present in the game's database, so should not be re-imported.
@@ -784,9 +793,12 @@ namespace osu.Game.Screens.Play
             return await scoreManager.Import(score.ScoreInfo, replayReader);
         }
 
+        /// <summary>
+        /// Creates the <see cref="ResultsScreen"/> for a <see cref="ScoreInfo"/>.
+        /// </summary>
+        /// <param name="score">The <see cref="ScoreInfo"/> to be displayed in the results screen.</param>
+        /// <returns>The <see cref="ResultsScreen"/>.</returns>
         protected virtual ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, true);
-
-        protected virtual void GotoRanking(ScoreInfo score) => this.Push(CreateResults(score));
 
         private void fadeOut(bool instant = false)
         {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -23,8 +23,10 @@ using osu.Game.Graphics.Containers;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
+using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
@@ -781,8 +783,7 @@ namespace osu.Game.Screens.Play
             else
             {
                 score.ScoreInfo.User = api.LocalUser.Value;
-                if (recordingScore?.Replay.Frames.Count > 0)
-                    score.Replay = recordingScore.Replay;
+                score.Replay = new Replay { Frames = recordingScore?.Replay.Frames.ToList() ?? new List<ReplayFrame>() };
             }
 
             ScoreProcessor.PopulateScore(score.ScoreInfo);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -806,11 +806,11 @@ namespace osu.Game.Screens.Play
         /// </summary>
         /// <param name="score">The <see cref="Score"/> to import.</param>
         /// <returns>The imported score.</returns>
-        protected virtual async Task ImportScore(Score score)
+        protected virtual Task ImportScore(Score score)
         {
             // Replays are already populated and present in the game's database, so should not be re-imported.
             if (DrawableRuleset.ReplayScore != null)
-                return;
+                return Task.CompletedTask;
 
             LegacyByteArrayReader replayReader;
 
@@ -820,7 +820,7 @@ namespace osu.Game.Screens.Play
                 replayReader = new LegacyByteArrayReader(stream.ToArray(), "replay.osr");
             }
 
-            await scoreManager.Import(score.ScoreInfo, replayReader);
+            return scoreManager.Import(score.ScoreInfo, replayReader);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -531,28 +531,7 @@ namespace osu.Game.Screens.Play
                 completionProgressDelegate = Schedule(GotoRanking);
         }
 
-        protected virtual ScoreInfo CreateScore()
-        {
-            var score = new ScoreInfo
-            {
-                Beatmap = Beatmap.Value.BeatmapInfo,
-                Ruleset = rulesetInfo,
-                Mods = Mods.Value.ToArray(),
-            };
-
-            if (DrawableRuleset.ReplayScore != null)
-                score.User = DrawableRuleset.ReplayScore.ScoreInfo?.User ?? new GuestUser();
-            else
-                score.User = api.LocalUser.Value;
-
-            ScoreProcessor.PopulateScore(score);
-
-            return score;
-        }
-
         protected override bool OnScroll(ScrollEvent e) => mouseWheelDisabled.Value && !GameplayClockContainer.IsPaused.Value;
-
-        protected virtual ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, true);
 
         #region Fail Logic
 
@@ -748,6 +727,25 @@ namespace osu.Game.Screens.Play
             return base.OnExiting(next);
         }
 
+        protected virtual ScoreInfo CreateScore()
+        {
+            var score = new ScoreInfo
+            {
+                Beatmap = Beatmap.Value.BeatmapInfo,
+                Ruleset = rulesetInfo,
+                Mods = Mods.Value.ToArray(),
+            };
+
+            if (DrawableRuleset.ReplayScore != null)
+                score.User = DrawableRuleset.ReplayScore.ScoreInfo?.User ?? new GuestUser();
+            else
+                score.User = api.LocalUser.Value;
+
+            ScoreProcessor.PopulateScore(score);
+
+            return score;
+        }
+
         protected virtual void GotoRanking()
         {
             if (DrawableRuleset.ReplayScore != null)
@@ -780,6 +778,8 @@ namespace osu.Game.Screens.Play
                                 this.Push(CreateResults(imported.Result));
                         }));
         }
+
+        protected virtual ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, true);
 
         private void fadeOut(bool instant = false)
         {

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -37,7 +37,8 @@ namespace osu.Game.Screens.Play
             return Score;
         }
 
-        protected override Task<ScoreInfo> SubmitScore(Score score) => Task.FromResult(score.ScoreInfo);
+        // Don't re-import replay scores as they're already present in the database.
+        protected override Task ImportScore(Score score) => Task.CompletedTask;
 
         protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, false);
 

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading.Tasks;
 using osu.Framework.Input.Bindings;
 using osu.Game.Input.Bindings;
 using osu.Game.Scoring;
@@ -26,17 +27,19 @@ namespace osu.Game.Screens.Play
             DrawableRuleset?.SetReplayScore(Score);
         }
 
-        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, false);
-
-        protected override ScoreInfo CreateScore()
+        protected override Score CreateScore()
         {
             var baseScore = base.CreateScore();
 
             // Since the replay score doesn't contain statistics, we'll pass them through here.
-            Score.ScoreInfo.HitEvents = baseScore.HitEvents;
+            Score.ScoreInfo.HitEvents = baseScore.ScoreInfo.HitEvents;
 
-            return Score.ScoreInfo;
+            return Score;
         }
+
+        protected override Task<ScoreInfo> SubmitScore(Score score) => Task.FromResult(score.ScoreInfo);
+
+        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, false);
 
         public bool OnPressed(GlobalAction action)
         {


### PR DESCRIPTION
The main purpose of this PR is to asyncify the score submission process and have the completion progress delegate wait for submission to complete before continuing to the results screen.

In realtime multiplayer, score submission includes setting the `FinishedPlay` state and waiting for a `ResultsReady` event from the server.

I've added waiting for the timeshift request to complete in this PR.