### PR TITLE
Implement a stateful multiplayer client + test realtime room manager

### DIFF
--- a/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeRoomManager.cs
+++ b/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeRoomManager.cs
@@ -90,6 +90,52 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
             AddAssert("initial rooms not received", () => !roomManager.InitialRoomsReceived.Value);
         }
 
+        [Test]
+        public void TestMultiplayerRoomJoinedWhenCreated()
+        {
+            AddStep("create room manager with a room", () =>
+            {
+                createRoomManager().With(d => d.OnLoadComplete += _ =>
+                {
+                    roomManager.CreateRoom(new Room());
+                });
+            });
+
+            AddAssert("multiplayer room joined", () => roomContainer.Client.Room != null);
+        }
+
+        [Test]
+        public void TestMultiplayerRoomPartedWhenAPIRoomParted()
+        {
+            AddStep("create room manager with a room", () =>
+            {
+                createRoomManager().With(d => d.OnLoadComplete += _ =>
+                {
+                    roomManager.CreateRoom(new Room());
+                    roomManager.PartRoom();
+                });
+            });
+
+            AddAssert("multiplayer room parted", () => roomContainer.Client.Room == null);
+        }
+
+        [Test]
+        public void TestMultiplayerRoomPartedWhenAPIRoomJoined()
+        {
+            AddStep("create room manager with a room", () =>
+            {
+                createRoomManager().With(d => d.OnLoadComplete += _ =>
+                {
+                    var r = new Room();
+                    roomManager.CreateRoom(r);
+                    roomManager.PartRoom();
+                    roomManager.JoinRoom(r);
+                });
+            });
+
+            AddAssert("multiplayer room parted", () => roomContainer.Client.Room != null);
+        }
+
         private TestRealtimeRoomManager createRoomManager()
         {
             Child = roomContainer = new TestRealtimeRoomContainer

--- a/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeRoomManager.cs
+++ b/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeRoomManager.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
         }
 
         [Test]
-        public void TestMultiplayerRoomPartedWhenAPIRoomJoined()
+        public void TestMultiplayerRoomJoinedWhenAPIRoomJoined()
         {
             AddStep("create room manager with a room", () =>
             {
@@ -133,7 +133,7 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
                 });
             });
 
-            AddAssert("multiplayer room parted", () => roomContainer.Client.Room != null);
+            AddAssert("multiplayer room joined", () => roomContainer.Client.Room != null);
         }
 
         private TestRealtimeRoomManager createRoomManager()

--- a/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeRoomManager.cs
+++ b/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeRoomManager.cs
@@ -3,10 +3,12 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Online.Multiplayer;
 
 namespace osu.Game.Tests.Visual.RealtimeMultiplayer
 {
+    [HeadlessTest]
     public class TestSceneRealtimeRoomManager : MultiplayerTestScene
     {
         private TestRealtimeRoomContainer roomContainer;

--- a/osu.Game/Online/API/Requests/GetBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapSetRequest.cs
@@ -7,16 +7,16 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetBeatmapSetRequest : APIRequest<APIBeatmapSet>
     {
-        private readonly int id;
-        private readonly BeatmapSetLookupType type;
+        public readonly int ID;
+        public readonly BeatmapSetLookupType Type;
 
         public GetBeatmapSetRequest(int id, BeatmapSetLookupType type = BeatmapSetLookupType.SetId)
         {
-            this.id = id;
-            this.type = type;
+            ID = id;
+            Type = type;
         }
 
-        protected override string Target => type == BeatmapSetLookupType.SetId ? $@"beatmapsets/{id}" : $@"beatmapsets/lookup?beatmap_id={id}";
+        protected override string Target => Type == BeatmapSetLookupType.SetId ? $@"beatmapsets/{ID}" : $@"beatmapsets/lookup?beatmap_id={ID}";
     }
 
     public enum BeatmapSetLookupType

--- a/osu.Game/Online/Multiplayer/CreateRoomRequest.cs
+++ b/osu.Game/Online/Multiplayer/CreateRoomRequest.cs
@@ -10,11 +10,11 @@ namespace osu.Game.Online.Multiplayer
 {
     public class CreateRoomRequest : APIRequest<APICreatedRoom>
     {
-        private readonly Room room;
+        public readonly Room Room;
 
         public CreateRoomRequest(Room room)
         {
-            this.room = room;
+            Room = room;
         }
 
         protected override WebRequest CreateWebRequest()
@@ -24,7 +24,7 @@ namespace osu.Game.Online.Multiplayer
             req.ContentType = "application/json";
             req.Method = HttpMethod.Post;
 
-            req.AddRaw(JsonConvert.SerializeObject(room));
+            req.AddRaw(JsonConvert.SerializeObject(Room));
 
             return req;
         }

--- a/osu.Game/Online/Multiplayer/GetRoomRequest.cs
+++ b/osu.Game/Online/Multiplayer/GetRoomRequest.cs
@@ -7,13 +7,13 @@ namespace osu.Game.Online.Multiplayer
 {
     public class GetRoomRequest : APIRequest<Room>
     {
-        private readonly int roomId;
+        public readonly int RoomId;
 
         public GetRoomRequest(int roomId)
         {
-            this.roomId = roomId;
+            RoomId = roomId;
         }
 
-        protected override string Target => $"rooms/{roomId}";
+        protected override string Target => $"rooms/{RoomId}";
     }
 }

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -354,14 +354,14 @@ namespace osu.Game.Online.RealtimeMultiplayer
                 var beatmap = beatmapSet.Beatmaps.Single(b => b.OnlineBeatmapID == settings.BeatmapID);
                 beatmap.MD5Hash = settings.BeatmapChecksum;
 
-                var ruleset = rulesets.GetRuleset(settings.RulesetID);
-                var mods = settings.Mods.Select(m => m.ToMod(ruleset.CreateInstance()));
+                var ruleset = rulesets.GetRuleset(settings.RulesetID).CreateInstance();
+                var mods = settings.Mods.Select(m => m.ToMod(ruleset));
 
                 PlaylistItem playlistItem = new PlaylistItem
                 {
                     ID = playlistItemId,
                     Beatmap = { Value = beatmap },
-                    Ruleset = { Value = ruleset },
+                    Ruleset = { Value = ruleset.RulesetInfo },
                 };
 
                 playlistItem.RequiredMods.AddRange(mods);

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -140,20 +141,14 @@ namespace osu.Game.Online.RealtimeMultiplayer
                 RulesetID = Room.Settings.RulesetID
             };
 
-            var newSettings = new MultiplayerRoomSettings
+            ChangeSettings(new MultiplayerRoomSettings
             {
                 Name = name.GetOr(Room.Settings.Name),
                 BeatmapID = item.GetOr(existingPlaylistItem).BeatmapID,
                 BeatmapChecksum = item.GetOr(existingPlaylistItem).Beatmap.Value.MD5Hash,
                 RulesetID = item.GetOr(existingPlaylistItem).RulesetID,
-                Mods = item.HasValue ? item.Value!.RequiredMods.Select(m => new APIMod(m)).ToList() : Room.Settings.Mods
-            };
-
-            // Make sure there would be a meaningful change in settings.
-            if (newSettings.Equals(Room.Settings))
-                return;
-
-            ChangeSettings(newSettings);
+                Mods = item.HasValue ? item.Value.AsNonNull().RequiredMods.Select(m => new APIMod(m)).ToList() : Room.Settings.Mods
+            });
         }
 
         public abstract Task TransferHost(int userId);

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -1,0 +1,389 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.RoomStatuses;
+using osu.Game.Rulesets;
+using osu.Game.Users;
+using osu.Game.Utils;
+
+namespace osu.Game.Online.RealtimeMultiplayer
+{
+    public abstract class StatefulMultiplayerClient : Component, IMultiplayerClient, IMultiplayerRoomServer
+    {
+        /// <summary>
+        /// Invoked when any change occurs to the multiplayer room.
+        /// </summary>
+        public event Action? RoomChanged;
+
+        /// <summary>
+        /// Invoked when the multiplayer server requests the current beatmap to be loaded into play.
+        /// </summary>
+        public event Action? LoadRequested;
+
+        /// <summary>
+        /// Invoked when the multiplayer server requests gameplay to be started.
+        /// </summary>
+        public event Action? MatchStarted;
+
+        /// <summary>
+        /// Invoked when the multiplayer server has finished collating results.
+        /// </summary>
+        public event Action? ResultsReady;
+
+        /// <summary>
+        /// Whether the <see cref="StatefulMultiplayerClient"/> is currently connected.
+        /// </summary>
+        public abstract IBindable<bool> IsConnected { get; }
+
+        /// <summary>
+        /// The joined <see cref="MultiplayerRoom"/>.
+        /// </summary>
+        public MultiplayerRoom? Room { get; private set; }
+
+        /// <summary>
+        /// The users currently in gameplay.
+        /// </summary>
+        public readonly BindableList<int> PlayingUsers = new BindableList<int>();
+
+        [Resolved]
+        private UserLookupCache userLookupCache { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        private Room? apiRoom;
+        private int playlistItemId; // Todo: THIS IS SUPER TEMPORARY!!
+
+        /// <summary>
+        /// Joins the <see cref="MultiplayerRoom"/> for a given API <see cref="Room"/>.
+        /// </summary>
+        /// <param name="room">The API <see cref="Room"/>.</param>
+        public async Task JoinRoom(Room room)
+        {
+            Debug.Assert(Room == null);
+            Debug.Assert(room.RoomID.Value != null);
+
+            apiRoom = room;
+            playlistItemId = room.Playlist.SingleOrDefault()?.ID ?? 0;
+
+            Room = await JoinRoom(room.RoomID.Value.Value);
+
+            Debug.Assert(Room != null);
+
+            foreach (var user in Room.Users)
+                await PopulateUser(user);
+
+            updateLocalRoomSettings(Room.Settings);
+        }
+
+        /// <summary>
+        /// Joins the <see cref="MultiplayerRoom"/> with a given ID.
+        /// </summary>
+        /// <param name="roomId">The room ID.</param>
+        /// <returns>The joined <see cref="MultiplayerRoom"/>.</returns>
+        protected abstract Task<MultiplayerRoom> JoinRoom(long roomId);
+
+        public virtual Task LeaveRoom()
+        {
+            if (Room == null)
+                return Task.CompletedTask;
+
+            apiRoom = null;
+            Room = null;
+
+            Schedule(() => RoomChanged?.Invoke());
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Change the current <see cref="MultiplayerRoom"/> settings.
+        /// </summary>
+        /// <remarks>
+        /// A room must have been joined via <see cref="JoinRoom"/> for this to have any effect.
+        /// </remarks>
+        /// <param name="name">The new room name, if any.</param>
+        /// <param name="item">The new room playlist item, if any.</param>
+        public void ChangeSettings(Optional<string> name = default, Optional<PlaylistItem> item = default)
+        {
+            if (Room == null)
+                return;
+
+            // A dummy playlist item filled with the current room settings (except mods).
+            var existingPlaylistItem = new PlaylistItem
+            {
+                Beatmap =
+                {
+                    Value = new BeatmapInfo
+                    {
+                        OnlineBeatmapID = Room.Settings.BeatmapID,
+                        MD5Hash = Room.Settings.BeatmapChecksum
+                    }
+                },
+                RulesetID = Room.Settings.RulesetID
+            };
+
+            var newSettings = new MultiplayerRoomSettings
+            {
+                Name = name.GetOr(Room.Settings.Name),
+                BeatmapID = item.GetOr(existingPlaylistItem).BeatmapID,
+                BeatmapChecksum = item.GetOr(existingPlaylistItem).Beatmap.Value.MD5Hash,
+                RulesetID = item.GetOr(existingPlaylistItem).RulesetID,
+                Mods = item.HasValue ? item.Value!.RequiredMods.Select(m => new APIMod(m)).ToList() : Room.Settings.Mods
+            };
+
+            // Make sure there would be a meaningful change in settings.
+            if (newSettings.Equals(Room.Settings))
+                return;
+
+            ChangeSettings(newSettings);
+        }
+
+        public abstract Task TransferHost(int userId);
+
+        public abstract Task ChangeSettings(MultiplayerRoomSettings settings);
+
+        public abstract Task ChangeState(MultiplayerUserState newState);
+
+        public abstract Task StartMatch();
+
+        Task IMultiplayerClient.RoomStateChanged(MultiplayerRoomState state)
+        {
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                Debug.Assert(apiRoom != null);
+
+                Room.State = state;
+
+                switch (state)
+                {
+                    case MultiplayerRoomState.Open:
+                        apiRoom.Status.Value = new RoomStatusOpen();
+                        break;
+
+                    case MultiplayerRoomState.Playing:
+                        apiRoom.Status.Value = new RoomStatusPlaying();
+                        break;
+
+                    case MultiplayerRoomState.Closed:
+                        apiRoom.Status.Value = new RoomStatusEnded();
+                        break;
+                }
+
+                RoomChanged?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        async Task IMultiplayerClient.UserJoined(MultiplayerRoomUser user)
+        {
+            await PopulateUser(user);
+
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                Room.Users.Add(user);
+
+                RoomChanged?.Invoke();
+            });
+        }
+
+        Task IMultiplayerClient.UserLeft(MultiplayerRoomUser user)
+        {
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                Room.Users.Remove(user);
+                PlayingUsers.Remove(user.UserID);
+
+                RoomChanged?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.HostChanged(int userId)
+        {
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                Debug.Assert(apiRoom != null);
+
+                var user = Room.Users.FirstOrDefault(u => u.UserID == userId);
+
+                Room.Host = user;
+                apiRoom.Host.Value = user?.User;
+
+                RoomChanged?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.SettingsChanged(MultiplayerRoomSettings newSettings)
+        {
+            updateLocalRoomSettings(newSettings);
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.UserStateChanged(int userId, MultiplayerUserState state)
+        {
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                Room.Users.Single(u => u.UserID == userId).State = state;
+
+                if (state != MultiplayerUserState.Playing)
+                    PlayingUsers.Remove(userId);
+
+                RoomChanged?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.LoadRequested()
+        {
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                LoadRequested?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.MatchStarted()
+        {
+            Debug.Assert(Room != null);
+            var players = Room.Users.Where(u => u.State == MultiplayerUserState.Playing).Select(u => u.UserID).ToList();
+
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                PlayingUsers.AddRange(players);
+
+                MatchStarted?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.ResultsReady()
+        {
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                ResultsReady?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Populates the <see cref="User"/> for a given <see cref="MultiplayerRoomUser"/>.
+        /// </summary>
+        /// <param name="multiplayerUser">The <see cref="MultiplayerRoomUser"/> to populate.</param>
+        protected async Task PopulateUser(MultiplayerRoomUser multiplayerUser) => multiplayerUser.User ??= await userLookupCache.GetUserAsync(multiplayerUser.UserID);
+
+        /// <summary>
+        /// Updates the local room settings with the given <see cref="MultiplayerRoomSettings"/>.
+        /// </summary>
+        /// <remarks>
+        /// This updates both the joined <see cref="MultiplayerRoom"/> and the respective API <see cref="Room"/>.
+        /// </remarks>
+        /// <param name="settings">The new <see cref="MultiplayerRoomSettings"/> to update from.</param>
+        private void updateLocalRoomSettings(MultiplayerRoomSettings settings)
+        {
+            if (Room == null)
+                return;
+
+            // Update a few instantaneously properties of the room.
+            Schedule(() =>
+            {
+                if (Room == null)
+                    return;
+
+                Debug.Assert(apiRoom != null);
+
+                Room.Settings = settings;
+                apiRoom.Name.Value = Room.Settings.Name;
+
+                // The playlist update is delayed until an online beatmap lookup (below) succeeds.
+                // In-order for the client to not display an outdated beatmap, the playlist is forcefully cleared here.
+                apiRoom.Playlist.Clear();
+
+                RoomChanged?.Invoke();
+            });
+
+            var req = new GetBeatmapSetRequest(settings.BeatmapID, BeatmapSetLookupType.BeatmapId);
+            req.Success += res =>
+            {
+                var beatmapSet = res.ToBeatmapSet(rulesets);
+
+                var beatmap = beatmapSet.Beatmaps.Single(b => b.OnlineBeatmapID == settings.BeatmapID);
+                beatmap.MD5Hash = settings.BeatmapChecksum;
+
+                var ruleset = rulesets.GetRuleset(settings.RulesetID);
+                var mods = settings.Mods.Select(m => m.ToMod(ruleset.CreateInstance()));
+
+                PlaylistItem playlistItem = new PlaylistItem
+                {
+                    ID = playlistItemId,
+                    Beatmap = { Value = beatmap },
+                    Ruleset = { Value = ruleset },
+                };
+
+                playlistItem.RequiredMods.AddRange(mods);
+
+                Schedule(() =>
+                {
+                    if (Room == null || !Room.Settings.Equals(settings))
+                        return;
+
+                    Debug.Assert(apiRoom != null);
+
+                    apiRoom.Playlist.Clear(); // Clearing should be unnecessary, but here for sanity.
+                    apiRoom.Playlist.Add(playlistItem);
+                });
+            };
+
+            api.Queue(req);
+        }
+    }
+}

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -328,7 +328,7 @@ namespace osu.Game.Online.RealtimeMultiplayer
             if (Room == null)
                 return;
 
-            // Update a few instantaneously properties of the room.
+            // Update a few properties of the room instantaneously.
             Schedule(() =>
             {
                 if (Room == null)

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -71,7 +71,9 @@ namespace osu.Game.Online.RealtimeMultiplayer
         private RulesetStore rulesets { get; set; } = null!;
 
         private Room? apiRoom;
-        private int playlistItemId; // Todo: THIS IS SUPER TEMPORARY!!
+
+        // Todo: This is temporary, until the multiplayer server returns the item id on match start or otherwise.
+        private int playlistItemId;
 
         /// <summary>
         /// Joins the <see cref="MultiplayerRoom"/> for a given API <see cref="Room"/>.

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Online.RealtimeMultiplayer
         /// Change the current <see cref="MultiplayerRoom"/> settings.
         /// </summary>
         /// <remarks>
-        /// A room must have been joined via <see cref="JoinRoom"/> for this to have any effect.
+        /// A room must be joined for this to have any effect.
         /// </remarks>
         /// <param name="name">The new room name, if any.</param>
         /// <param name="item">The new room playlist item, if any.</param>

--- a/osu.Game/Screens/Multi/Components/RoomManager.cs
+++ b/osu.Game/Screens/Multi/Components/RoomManager.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Screens.Multi.Components
             api.Queue(currentJoinRoomRequest);
         }
 
-        public void PartRoom()
+        public virtual void PartRoom()
         {
             currentJoinRoomRequest?.Cancel();
 
@@ -156,6 +156,8 @@ namespace osu.Game.Screens.Multi.Components
 
             RoomsUpdated?.Invoke();
         }
+
+        protected void RemoveRoom(Room room) => rooms.Remove(room);
 
         protected void ClearRooms()
         {

--- a/osu.Game/Screens/Multi/Components/RoomManager.cs
+++ b/osu.Game/Screens/Multi/Components/RoomManager.cs
@@ -157,6 +157,12 @@ namespace osu.Game.Screens.Multi.Components
             RoomsUpdated?.Invoke();
         }
 
+        protected void ClearRooms()
+        {
+            rooms.Clear();
+            InitialRoomsReceived.Value = false;
+        }
+
         /// <summary>
         /// Updates a local <see cref="Room"/> with a remote copy.
         /// </summary>

--- a/osu.Game/Screens/Multi/Components/RoomManager.cs
+++ b/osu.Game/Screens/Multi/Components/RoomManager.cs
@@ -27,7 +27,8 @@ namespace osu.Game.Screens.Multi.Components
 
         public IBindableList<Room> Rooms => rooms;
 
-        protected Room JoinedRoom { get; private set; }
+        protected IBindable<Room> JoinedRoom => joinedRoom;
+        private readonly Bindable<Room> joinedRoom = new Bindable<Room>();
 
         [Resolved]
         private RulesetStore rulesets { get; set; }
@@ -64,7 +65,7 @@ namespace osu.Game.Screens.Multi.Components
 
             req.Success += result =>
             {
-                JoinedRoom = room;
+                joinedRoom.Value = room;
 
                 update(room, result);
                 addRoom(room);
@@ -93,7 +94,7 @@ namespace osu.Game.Screens.Multi.Components
 
             currentJoinRoomRequest.Success += () =>
             {
-                JoinedRoom = room;
+                joinedRoom.Value = room;
                 onSuccess?.Invoke(room);
             };
 
@@ -114,8 +115,8 @@ namespace osu.Game.Screens.Multi.Components
             if (JoinedRoom == null)
                 return;
 
-            api.Queue(new PartRoomRequest(JoinedRoom));
-            JoinedRoom = null;
+            api.Queue(new PartRoomRequest(joinedRoom.Value));
+            joinedRoom.Value = null;
         }
 
         private readonly HashSet<int> ignoredRooms = new HashSet<int>();

--- a/osu.Game/Screens/Multi/Components/RoomManager.cs
+++ b/osu.Game/Screens/Multi/Components/RoomManager.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Screens.Multi.Components
 
         public IBindableList<Room> Rooms => rooms;
 
+        protected Room JoinedRoom { get; private set; }
+
         [Resolved]
         private RulesetStore rulesets { get; set; }
 
@@ -35,8 +37,6 @@ namespace osu.Game.Screens.Multi.Components
 
         [Resolved]
         private IAPIProvider api { get; set; }
-
-        private Room joinedRoom;
 
         protected RoomManager()
         {
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Multi.Components
 
             req.Success += result =>
             {
-                joinedRoom = room;
+                JoinedRoom = room;
 
                 update(room, result);
                 addRoom(room);
@@ -93,7 +93,7 @@ namespace osu.Game.Screens.Multi.Components
 
             currentJoinRoomRequest.Success += () =>
             {
-                joinedRoom = room;
+                JoinedRoom = room;
                 onSuccess?.Invoke(room);
             };
 
@@ -111,11 +111,11 @@ namespace osu.Game.Screens.Multi.Components
         {
             currentJoinRoomRequest?.Cancel();
 
-            if (joinedRoom == null)
+            if (JoinedRoom == null)
                 return;
 
-            api.Queue(new PartRoomRequest(joinedRoom));
-            joinedRoom = null;
+            api.Queue(new PartRoomRequest(JoinedRoom));
+            JoinedRoom = null;
         }
 
         private readonly HashSet<int> ignoredRooms = new HashSet<int>();

--- a/osu.Game/Screens/Multi/Components/RoomManager.cs
+++ b/osu.Game/Screens/Multi/Components/RoomManager.cs
@@ -125,8 +125,7 @@ namespace osu.Game.Screens.Multi.Components
         {
             if (received == null)
             {
-                rooms.Clear();
-                initialRoomsReceived.Value = false;
+                ClearRooms();
                 return;
             }
 
@@ -171,7 +170,7 @@ namespace osu.Game.Screens.Multi.Components
         protected void ClearRooms()
         {
             rooms.Clear();
-            InitialRoomsReceived.Value = false;
+            initialRoomsReceived.Value = false;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -30,7 +30,8 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             base.LoadComplete();
 
             isConnected.BindTo(multiplayerClient.IsConnected);
-            isConnected.BindValueChanged(_ => Schedule(updatePolling), true);
+            isConnected.BindValueChanged(_ => Schedule(updatePolling));
+            JoinedRoom.BindValueChanged(_ => updatePolling());
 
             updatePolling();
         }
@@ -46,7 +47,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             if (JoinedRoom == null)
                 return;
 
-            var joinedRoom = JoinedRoom;
+            var joinedRoom = JoinedRoom.Value;
 
             base.PartRoom();
             multiplayerClient.LeaveRoom().Wait();
@@ -77,7 +78,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
                 ClearRooms();
 
             // Don't poll when not connected or when a room has been joined.
-            allowPolling.Value = isConnected.Value && JoinedRoom == null;
+            allowPolling.Value = isConnected.Value && JoinedRoom.Value == null;
         }
 
         protected override RoomPollingComponent[] CreatePollingComponents() => new RoomPollingComponent[]
@@ -102,8 +103,11 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             {
                 base.LoadComplete();
 
-                AllowPolling.BindValueChanged(_ =>
+                AllowPolling.BindValueChanged(allowPolling =>
                 {
+                    if (!allowPolling.NewValue)
+                        return;
+
                     if (IsLoaded)
                         PollImmediately();
                 });
@@ -120,8 +124,11 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             {
                 base.LoadComplete();
 
-                AllowPolling.BindValueChanged(_ =>
+                AllowPolling.BindValueChanged(allowPolling =>
                 {
+                    if (!allowPolling.NewValue)
+                        return;
+
                     if (IsLoaded)
                         PollImmediately();
                 });

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.RealtimeMultiplayer;
+using osu.Game.Screens.Multi.Components;
+
+namespace osu.Game.Screens.Multi.RealtimeMultiplayer
+{
+    public class RealtimeRoomManager : RoomManager
+    {
+        [Resolved]
+        private StatefulMultiplayerClient multiplayerClient { get; set; }
+
+        public override void CreateRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)
+            => base.CreateRoom(room, r => joinMultiplayerRoom(r, onSuccess), onError);
+
+        public override void JoinRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)
+            => base.JoinRoom(room, r => joinMultiplayerRoom(r, onSuccess), onError);
+
+        private void joinMultiplayerRoom(Room room, Action<Room> onSuccess = null)
+        {
+            Debug.Assert(room.RoomID.Value != null);
+
+            var joinTask = multiplayerClient.JoinRoom(room);
+            joinTask.ContinueWith(_ => onSuccess?.Invoke(room));
+            joinTask.ContinueWith(t =>
+            {
+                PartRoom();
+                if (t.Exception != null)
+                    Logger.Error(t.Exception, "Failed to join multiplayer room.");
+            }, TaskContinuationOptions.NotOnRanToCompletion);
+        }
+
+        protected override RoomPollingComponent[] CreatePollingComponents() => new RoomPollingComponent[]
+        {
+            new ListingPollingComponent()
+        };
+    }
+}

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
@@ -81,7 +82,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             allowPolling.Value = isConnected.Value && JoinedRoom.Value == null;
         }
 
-        protected override RoomPollingComponent[] CreatePollingComponents() => new RoomPollingComponent[]
+        protected override IEnumerable<RoomPollingComponent> CreatePollingComponents() => new RoomPollingComponent[]
         {
             listingPollingComponent = new RealtimeListingPollingComponent
             {

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             Debug.Assert(room.RoomID.Value != null);
 
             var joinTask = multiplayerClient.JoinRoom(room);
-            joinTask.ContinueWith(_ => onSuccess?.Invoke(room));
+            joinTask.ContinueWith(_ => onSuccess?.Invoke(room), TaskContinuationOptions.OnlyOnRanToCompletion);
             joinTask.ContinueWith(t =>
             {
                 PartRoom();

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -54,9 +54,12 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             multiplayerClient.LeaveRoom().Wait();
 
             // Todo: This is not the way to do this. Basically when we're the only participant and the room closes, there's no way to know if this is actually the case.
-            RemoveRoom(joinedRoom);
             // This is delayed one frame because upon exiting the match subscreen, multiplayer updates the polling rate and messes with polling.
-            Schedule(() => listingPollingComponent.PollImmediately());
+            Schedule(() =>
+            {
+                RemoveRoom(joinedRoom);
+                listingPollingComponent.PollImmediately();
+            });
         }
 
         private void joinMultiplayerRoom(Room room, Action<Room> onSuccess = null)

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/RealtimeMultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/RealtimeMultiplayerTestScene.cs
@@ -44,10 +44,7 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
             RoomManager.Schedule(() => RoomManager.PartRoom());
 
             if (joinRoom)
-            {
-                Room.RoomID.Value = 1;
-                RoomManager.Schedule(() => RoomManager.JoinRoom(Room, null, null));
-            }
+                RoomManager.Schedule(() => RoomManager.CreateRoom(Room));
         });
     }
 }

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/RealtimeMultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/RealtimeMultiplayerTestScene.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Online.RealtimeMultiplayer;
+using osu.Game.Screens.Multi.Lounge.Components;
+using osu.Game.Screens.Multi.RealtimeMultiplayer;
+
+namespace osu.Game.Tests.Visual.RealtimeMultiplayer
+{
+    public class RealtimeMultiplayerTestScene : MultiplayerTestScene
+    {
+        [Cached(typeof(StatefulMultiplayerClient))]
+        public TestRealtimeMultiplayerClient Client { get; }
+
+        [Cached(typeof(RealtimeRoomManager))]
+        public TestRealtimeRoomManager RoomManager { get; }
+
+        [Cached]
+        public Bindable<FilterCriteria> Filter { get; }
+
+        protected override Container<Drawable> Content => content;
+        private readonly TestRealtimeRoomContainer content;
+
+        private readonly bool joinRoom;
+
+        public RealtimeMultiplayerTestScene(bool joinRoom = true)
+        {
+            this.joinRoom = joinRoom;
+            base.Content.Add(content = new TestRealtimeRoomContainer { RelativeSizeAxes = Axes.Both });
+
+            Client = content.Client;
+            RoomManager = content.RoomManager;
+            Filter = content.Filter;
+        }
+
+        [SetUp]
+        public new void Setup() => Schedule(() =>
+        {
+            RoomManager.Schedule(() => RoomManager.PartRoom());
+
+            if (joinRoom)
+            {
+                Room.RoomID.Value = 1;
+                RoomManager.Schedule(() => RoomManager.JoinRoom(Room, null, null));
+            }
+        });
+    }
+}

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
@@ -16,10 +16,15 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
 {
     public class TestRealtimeMultiplayerClient : StatefulMultiplayerClient
     {
-        public override IBindable<bool> IsConnected { get; } = new Bindable<bool>(true);
+        public override IBindable<bool> IsConnected => isConnected;
+        private readonly Bindable<bool> isConnected = new Bindable<bool>(true);
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
+
+        public void Connect() => isConnected.Value = true;
+
+        public void Disconnect() => isConnected.Value = false;
 
         public void AddUser(User user) => ((IMultiplayerClient)this).UserJoined(new MultiplayerRoomUser(user.Id) { User = user });
 

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Online.API;
+using osu.Game.Online.RealtimeMultiplayer;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.Visual.RealtimeMultiplayer
+{
+    public class TestRealtimeMultiplayerClient : StatefulMultiplayerClient
+    {
+        public override IBindable<bool> IsConnected { get; } = new Bindable<bool>(true);
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        public void AddUser(User user) => ((IMultiplayerClient)this).UserJoined(new MultiplayerRoomUser(user.Id) { User = user });
+
+        public void RemoveUser(User user)
+        {
+            Debug.Assert(Room != null);
+            ((IMultiplayerClient)this).UserLeft(Room.Users.Single(u => u.User == user));
+
+            Schedule(() =>
+            {
+                if (Room.Users.Any())
+                    TransferHost(Room.Users.First().UserID);
+            });
+        }
+
+        public void ChangeUserState(int userId, MultiplayerUserState newState)
+        {
+            Debug.Assert(Room != null);
+
+            ((IMultiplayerClient)this).UserStateChanged(userId, newState);
+
+            Schedule(() =>
+            {
+                switch (newState)
+                {
+                    case MultiplayerUserState.Loaded:
+                        if (Room.Users.All(u => u.State != MultiplayerUserState.WaitingForLoad))
+                        {
+                            foreach (var u in Room.Users.Where(u => u.State == MultiplayerUserState.Loaded))
+                                ChangeUserState(u.UserID, MultiplayerUserState.Playing);
+
+                            ((IMultiplayerClient)this).MatchStarted();
+                        }
+
+                        break;
+
+                    case MultiplayerUserState.FinishedPlay:
+                        if (Room.Users.All(u => u.State != MultiplayerUserState.Playing))
+                        {
+                            foreach (var u in Room.Users.Where(u => u.State == MultiplayerUserState.FinishedPlay))
+                                ChangeUserState(u.UserID, MultiplayerUserState.Results);
+
+                            ((IMultiplayerClient)this).ResultsReady();
+                        }
+
+                        break;
+                }
+            });
+        }
+
+        protected override Task<MultiplayerRoom> JoinRoom(long roomId)
+        {
+            var user = new MultiplayerRoomUser(api.LocalUser.Value.Id) { User = api.LocalUser.Value };
+
+            var room = new MultiplayerRoom(roomId);
+            room.Users.Add(user);
+
+            if (room.Users.Count == 1)
+                room.Host = user;
+
+            return Task.FromResult(room);
+        }
+
+        public override Task TransferHost(int userId) => ((IMultiplayerClient)this).HostChanged(userId);
+
+        public override async Task ChangeSettings(MultiplayerRoomSettings settings)
+        {
+            Debug.Assert(Room != null);
+
+            await ((IMultiplayerClient)this).SettingsChanged(settings);
+
+            foreach (var user in Room.Users.Where(u => u.State == MultiplayerUserState.Ready))
+                ChangeUserState(user.UserID, MultiplayerUserState.Idle);
+        }
+
+        public override Task ChangeState(MultiplayerUserState newState)
+        {
+            ChangeUserState(api.LocalUser.Value.Id, newState);
+            return Task.CompletedTask;
+        }
+
+        public override async Task StartMatch()
+        {
+            Debug.Assert(Room != null);
+
+            foreach (var user in Room.Users.Where(u => u.State == MultiplayerUserState.Ready))
+                ChangeUserState(user.UserID, MultiplayerUserState.WaitingForLoad);
+
+            await ((IMultiplayerClient)this).LoadRequested();
+        }
+    }
+}

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
@@ -106,14 +106,14 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
             return Task.CompletedTask;
         }
 
-        public override async Task StartMatch()
+        public override Task StartMatch()
         {
             Debug.Assert(Room != null);
 
             foreach (var user in Room.Users.Where(u => u.State == MultiplayerUserState.Ready))
                 ChangeUserState(user.UserID, MultiplayerUserState.WaitingForLoad);
 
-            await ((IMultiplayerClient)this).LoadRequested();
+            return ((IMultiplayerClient)this).LoadRequested();
         }
     }
 }

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomContainer.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomContainer.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Online.RealtimeMultiplayer;
+using osu.Game.Screens.Multi.Lounge.Components;
+using osu.Game.Screens.Multi.RealtimeMultiplayer;
+
+namespace osu.Game.Tests.Visual.RealtimeMultiplayer
+{
+    public class TestRealtimeRoomContainer : Container
+    {
+        protected override Container<Drawable> Content => content;
+        private readonly Container content;
+
+        [Cached(typeof(StatefulMultiplayerClient))]
+        public readonly TestRealtimeMultiplayerClient Client;
+
+        [Cached(typeof(RealtimeRoomManager))]
+        public readonly TestRealtimeRoomManager RoomManager;
+
+        [Cached]
+        public readonly Bindable<FilterCriteria> Filter = new Bindable<FilterCriteria>(new FilterCriteria());
+
+        public TestRealtimeRoomContainer()
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            AddRangeInternal(new Drawable[]
+            {
+                Client = new TestRealtimeMultiplayerClient(),
+                RoomManager = new TestRealtimeRoomManager(),
+                content = new Container { RelativeSizeAxes = Axes.Both }
+            });
+        }
+    }
+}

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomManager.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomManager.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Multi.RealtimeMultiplayer;
+
+namespace osu.Game.Tests.Visual.RealtimeMultiplayer
+{
+    public class TestRealtimeRoomManager : RealtimeRoomManager
+    {
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
+        [Resolved]
+        private OsuGameBase game { get; set; }
+
+        private readonly List<Room> rooms = new List<Room>();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            int currentScoreId = 0;
+
+            ((DummyAPIAccess)api).HandleRequest = req =>
+            {
+                switch (req)
+                {
+                    case CreateRoomRequest createRoomRequest:
+                        var createdRoom = new APICreatedRoom();
+
+                        createdRoom.CopyFrom(createRoomRequest.Room);
+                        createdRoom.RoomID.Value = 1;
+
+                        rooms.Add(createdRoom);
+                        createRoomRequest.TriggerSuccess(createdRoom);
+                        break;
+
+                    case JoinRoomRequest joinRoomRequest:
+                        joinRoomRequest.TriggerSuccess();
+                        break;
+
+                    case PartRoomRequest partRoomRequest:
+                        partRoomRequest.TriggerSuccess();
+                        break;
+
+                    case GetRoomsRequest getRoomsRequest:
+                        getRoomsRequest.TriggerSuccess(rooms);
+                        break;
+
+                    case GetBeatmapSetRequest getBeatmapSetRequest:
+                        var onlineReq = new GetBeatmapSetRequest(getBeatmapSetRequest.ID, getBeatmapSetRequest.Type);
+                        onlineReq.Success += res => getBeatmapSetRequest.TriggerSuccess(res);
+                        onlineReq.Failure += e => getBeatmapSetRequest.TriggerFailure(e);
+
+                        // Get the online API from the game's dependencies.
+                        game.Dependencies.Get<IAPIProvider>().Queue(onlineReq);
+                        break;
+
+                    case CreateRoomScoreRequest createRoomScoreRequest:
+                        createRoomScoreRequest.TriggerSuccess(new APIScoreToken { ID = 1 });
+                        break;
+
+                    case SubmitRoomScoreRequest submitRoomScoreRequest:
+                        submitRoomScoreRequest.TriggerSuccess(new MultiplayerScore
+                        {
+                            ID = currentScoreId++,
+                            Accuracy = 1,
+                            EndedAt = DateTimeOffset.Now,
+                            Passed = true,
+                            Rank = ScoreRank.S,
+                            MaxCombo = 1000,
+                            TotalScore = 1000000,
+                            User = api.LocalUser.Value,
+                            Statistics = new Dictionary<HitResult, int>()
+                        });
+                        break;
+                }
+            };
+        }
+
+        public new void Schedule(Action action) => base.Schedule(action);
+    }
+}

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomManager.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomManager.cs
@@ -5,11 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
+using osu.Game.Screens.Multi.Lounge.Components;
 using osu.Game.Screens.Multi.RealtimeMultiplayer;
 
 namespace osu.Game.Tests.Visual.RealtimeMultiplayer
@@ -22,6 +24,9 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
         [Resolved]
         private OsuGameBase game { get; set; }
 
+        [Cached]
+        public readonly Bindable<FilterCriteria> Filter = new Bindable<FilterCriteria>(new FilterCriteria());
+
         private readonly List<Room> rooms = new List<Room>();
 
         protected override void LoadComplete()
@@ -29,6 +34,7 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
             base.LoadComplete();
 
             int currentScoreId = 0;
+            int currentRoomId = 0;
 
             ((DummyAPIAccess)api).HandleRequest = req =>
             {
@@ -38,7 +44,7 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
                         var createdRoom = new APICreatedRoom();
 
                         createdRoom.CopyFrom(createRoomRequest.Room);
-                        createdRoom.RoomID.Value = 1;
+                        createdRoom.RoomID.Value ??= currentRoomId++;
 
                         rooms.Add(createdRoom);
                         createRoomRequest.TriggerSuccess(createdRoom);
@@ -102,6 +108,8 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
                 }
             };
         }
+
+        public new void ClearRooms() => base.ClearRooms();
 
         public new void Schedule(Action action) => base.Schedule(action);
     }

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomManager.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeRoomManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -52,7 +53,23 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
                         break;
 
                     case GetRoomsRequest getRoomsRequest:
-                        getRoomsRequest.TriggerSuccess(rooms);
+                        var roomsWithoutParticipants = new List<Room>();
+
+                        foreach (var r in rooms)
+                        {
+                            var newRoom = new Room();
+
+                            newRoom.CopyFrom(r);
+                            newRoom.RecentParticipants.Clear();
+
+                            roomsWithoutParticipants.Add(newRoom);
+                        }
+
+                        getRoomsRequest.TriggerSuccess(roomsWithoutParticipants);
+                        break;
+
+                    case GetRoomRequest getRoomRequest:
+                        getRoomRequest.TriggerSuccess(rooms.Single(r => r.RoomID.Value == getRoomRequest.RoomId));
                         break;
 
                     case GetBeatmapSetRequest getBeatmapSetRequest:


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/11204

`StatefulMultiplayerClient` has all the business logic of realtime multiplayer. It handles updates to the room based on responses from the server (both multiplayer room and api room).

In the future, there will be a `RealtimeMultiplayerClient : StatefulMultiplayerClient` that implements the connection logic (all the abstract methods).

`RealtimeRoomManager` is a component which has two purposes on top of the base `RoomManager`:
1. It doesn't poll for rooms when disconnected, and clears rooms when disconnected to disallow the user from joining rooms.
2. It forwards join/part messages to the `StatefulMultiplayerClient` to join the `MultiplayerRoom`.

The rest included in this PR are testing components and the testing of `RealtimeRoomManager`. In particular, `TestRealtimeRoomContainer` will come in handy when testing components with very specific flows like here, while `RealtimeMultiplayerTestScene` comes in handy for testing general components + the main screen test scene.