### PR TITLE
Add a base class for all realtime multiplayer composites

### DIFF
--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomComposite.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomComposite.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Game.Online.RealtimeMultiplayer;
+
+namespace osu.Game.Screens.Multi.RealtimeMultiplayer
+{
+    public abstract class RealtimeRoomComposite : MultiplayerComposite
+    {
+        [CanBeNull]
+        protected MultiplayerRoom Room => Client.Room;
+
+        [Resolved]
+        protected StatefulMultiplayerClient Client { get; private set; }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Client.RoomChanged += OnRoomChanged;
+            OnRoomChanged();
+        }
+
+        protected virtual void OnRoomChanged()
+        {
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (Client != null)
+                Client.RoomChanged -= OnRoomChanged;
+
+            base.Dispose(isDisposing);
+        }
+    }
+}


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/11205

Extends `MultiplayerComposite` by also providing the client and a `OnRoomChanged()` method.