### PR TITLE
Add support for hitobject application to taiko DHOs

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/HitObjectApplicationTestScene.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/HitObjectApplicationTestScene.cs
@@ -25,16 +25,22 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         private ScrollingHitObjectContainer hitObjectContainer;
 
-        [SetUpSteps]
-        public void SetUp()
-            => AddStep("create SHOC", () => Child = hitObjectContainer = new ScrollingHitObjectContainer
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = hitObjectContainer = new ScrollingHitObjectContainer
             {
                 RelativeSizeAxes = Axes.X,
                 Height = 200,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Clock = new FramedClock(new StopwatchClock())
-            });
+            };
+        }
+
+        [SetUpSteps]
+        public void SetUp()
+            => AddStep("clear SHOC", () => hitObjectContainer.Clear(false));
 
         protected void AddHitObject(DrawableHitObject hitObject)
             => AddStep("add to SHOC", () => hitObjectContainer.Add(hitObject));

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineApplication.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineApplication.cs
@@ -12,12 +12,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
         [Test]
         public void TestApplyNewBarLine()
         {
-            DrawableBarLine barLine = new DrawableBarLine(PrepareObject(new BarLine
+            DrawableBarLine barLine = new DrawableBarLine();
+
+            AddStep("apply new bar line", () => barLine.Apply(PrepareObject(new BarLine
             {
                 StartTime = 400,
                 Major = true
-            }));
-
+            }), null));
             AddHitObject(barLine);
             RemoveHitObject(barLine);
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumRollApplication.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumRollApplication.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TestSceneDrumRollApplication : HitObjectApplicationTestScene
+    {
+        [Test]
+        public void TestApplyNewDrumRoll()
+        {
+            var drumRoll = new DrawableDrumRoll();
+
+            AddStep("apply new drum roll", () => drumRoll.Apply(PrepareObject(new DrumRoll
+            {
+                StartTime = 300,
+                Duration = 500,
+                IsStrong = false,
+                TickRate = 2
+            }), null));
+
+            AddHitObject(drumRoll);
+            RemoveHitObject(drumRoll);
+
+            AddStep("apply new drum roll", () => drumRoll.Apply(PrepareObject(new DrumRoll
+            {
+                StartTime = 150,
+                Duration = 400,
+                IsStrong = true,
+                TickRate = 16
+            }), null));
+
+            AddHitObject(drumRoll);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHitApplication.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHitApplication.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TestSceneHitApplication : HitObjectApplicationTestScene
+    {
+        [Test]
+        public void TestApplyNewHit()
+        {
+            var hit = new DrawableHit();
+
+            AddStep("apply new hit", () => hit.Apply(PrepareObject(new Hit
+            {
+                Type = HitType.Rim,
+                IsStrong = false,
+                StartTime = 300
+            }), null));
+
+            AddHitObject(hit);
+            RemoveHitObject(hit);
+
+            AddStep("apply new hit", () => hit.Apply(PrepareObject(new Hit
+            {
+                Type = HitType.Centre,
+                IsStrong = true,
+                StartTime = 500
+            }), null));
+
+            AddHitObject(hit);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             Content.X = DrawHeight / 2;
         }
 
-        protected override DrawableStrongNestedHit CreateStrongNestedHit(DrumRoll.StrongNestedHit hitObject) => new StrongNestedHit(hitObject, this);
+        protected override DrawableStrongNestedHit CreateStrongNestedHit(DrumRoll.StrongNestedHit hitObject) => new StrongNestedHit(hitObject);
 
         private void updateColour(double fadeDuration = 0)
         {
@@ -176,17 +176,24 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         private class StrongNestedHit : DrawableStrongNestedHit
         {
-            public StrongNestedHit(DrumRoll.StrongNestedHit nestedHit, DrawableDrumRoll drumRoll)
-                : base(nestedHit, drumRoll)
+            public new DrawableDrumRoll ParentHitObject => (DrawableDrumRoll)base.ParentHitObject;
+
+            public StrongNestedHit()
+                : this(null)
+            {
+            }
+
+            public StrongNestedHit([CanBeNull] DrumRoll.StrongNestedHit nestedHit)
+                : base(nestedHit)
             {
             }
 
             protected override void CheckForResult(bool userTriggered, double timeOffset)
             {
-                if (!MainObject.Judged)
+                if (!ParentHitObject.Judged)
                     return;
 
-                ApplyResult(r => r.Type = MainObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                ApplyResult(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
 
             public override bool OnPressed(TaikoAction action) => false;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
@@ -31,15 +32,26 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// </summary>
         private int rollingHits;
 
-        private Container tickContainer;
+        private readonly Container tickContainer;
 
         private Color4 colourIdle;
         private Color4 colourEngaged;
 
-        public DrawableDrumRoll(DrumRoll drumRoll)
+        public DrawableDrumRoll()
+            : this(null)
+        {
+        }
+
+        public DrawableDrumRoll([CanBeNull] DrumRoll drumRoll)
             : base(drumRoll)
         {
             RelativeSizeAxes = Axes.Y;
+
+            Content.Add(tickContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Depth = float.MinValue
+            });
         }
 
         [BackgroundDependencyLoader]
@@ -47,12 +59,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             colourIdle = colours.YellowDark;
             colourEngaged = colours.YellowDarker;
-
-            Content.Add(tickContainer = new Container
-            {
-                RelativeSizeAxes = Axes.Both,
-                Depth = float.MinValue
-            });
         }
 
         protected override void LoadComplete()
@@ -66,6 +72,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             base.RecreatePieces();
             updateColour();
+        }
+
+        protected override void OnFree()
+        {
+            base.OnFree();
+            rollingHits = 0;
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
@@ -114,7 +126,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             rollingHits = Math.Clamp(rollingHits, 0, rolling_hits_for_engaged_colour);
 
-            updateColour();
+            updateColour(100);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
@@ -156,10 +168,10 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override DrawableStrongNestedHit CreateStrongNestedHit(DrumRoll.StrongNestedHit hitObject) => new StrongNestedHit(hitObject, this);
 
-        private void updateColour()
+        private void updateColour(double fadeDuration = 0)
         {
             Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
-            (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, 100);
+            (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, fadeDuration);
         }
 
         private class StrongNestedHit : DrawableStrongNestedHit

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
@@ -16,7 +17,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// </summary>
         public HitType JudgementType;
 
-        public DrawableDrumRollTick(DrumRollTick tick)
+        public DrawableDrumRollTick()
+            : this(null)
+        {
+        }
+
+        public DrawableDrumRollTick([CanBeNull] DrumRollTick tick)
             : base(tick)
         {
             FillMode = FillMode.Fit;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -67,21 +67,28 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             return UpdateResult(true);
         }
 
-        protected override DrawableStrongNestedHit CreateStrongNestedHit(DrumRollTick.StrongNestedHit hitObject) => new StrongNestedHit(hitObject, this);
+        protected override DrawableStrongNestedHit CreateStrongNestedHit(DrumRollTick.StrongNestedHit hitObject) => new StrongNestedHit(hitObject);
 
         private class StrongNestedHit : DrawableStrongNestedHit
         {
-            public StrongNestedHit(DrumRollTick.StrongNestedHit nestedHit, DrawableDrumRollTick tick)
-                : base(nestedHit, tick)
+            public new DrawableDrumRollTick ParentHitObject => (DrawableDrumRollTick)base.ParentHitObject;
+
+            public StrongNestedHit()
+                : this(null)
+            {
+            }
+
+            public StrongNestedHit([CanBeNull] DrumRollTick.StrongNestedHit nestedHit)
+                : base(nestedHit)
             {
             }
 
             protected override void CheckForResult(bool userTriggered, double timeOffset)
             {
-                if (!MainObject.Judged)
+                if (!ParentHitObject.Judged)
                     return;
 
-                ApplyResult(r => r.Type = MainObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                ApplyResult(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
 
             public override bool OnPressed(TaikoAction action) => false;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableStrongNestedHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableStrongNestedHit.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Objects.Drawables;
+using JetBrains.Annotations;
 using osu.Game.Rulesets.Taiko.Judgements;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
@@ -11,12 +11,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
     /// </summary>
     public abstract class DrawableStrongNestedHit : DrawableTaikoHitObject
     {
-        public readonly DrawableHitObject MainObject;
+        public new DrawableTaikoHitObject ParentHitObject => (DrawableTaikoHitObject)base.ParentHitObject;
 
-        protected DrawableStrongNestedHit(StrongNestedHitObject nestedHit, DrawableHitObject mainObject)
+        protected DrawableStrongNestedHit([CanBeNull] StrongNestedHitObject nestedHit)
             : base(nestedHit)
         {
-            MainObject = mainObject;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -35,7 +36,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private readonly CircularContainer targetRing;
         private readonly CircularContainer expandingRing;
 
-        public DrawableSwell(Swell swell)
+        public DrawableSwell()
+            : this(null)
+        {
+        }
+
+        public DrawableSwell([CanBeNull] Swell swell)
             : base(swell)
         {
             FillMode = FillMode.Fit;
@@ -123,12 +129,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 Origin = Anchor.Centre,
             });
 
-        protected override void LoadComplete()
+        protected override void OnFree()
         {
-            base.LoadComplete();
+            base.OnFree();
 
-            // We need to set this here because RelativeSizeAxes won't/can't set our size by default with a different RelativeChildSize
-            Width *= Parent.RelativeChildSize.X;
+            UnproxyContent();
+
+            lastWasCentre = null;
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
@@ -11,7 +12,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
     {
         public override bool DisplayResult => false;
 
-        public DrawableSwellTick(SwellTick hitObject)
+        public DrawableSwellTick()
+            : this(null)
+        {
+        }
+
+        public DrawableSwellTick([CanBeNull] SwellTick hitObject)
             : base(hitObject)
         {
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Allocation;
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         private readonly Container nonProxiedContent;
 
-        protected DrawableTaikoHitObject(TaikoHitObject hitObject)
+        protected DrawableTaikoHitObject([CanBeNull] TaikoHitObject hitObject)
             : base(hitObject)
         {
             AddRangeInternal(new[]
@@ -113,25 +113,23 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
     {
         public override Vector2 OriginPosition => new Vector2(DrawHeight / 2);
 
-        public new TObject HitObject;
+        public new TObject HitObject => (TObject)base.HitObject;
 
         protected Vector2 BaseSize;
         protected SkinnableDrawable MainPiece;
 
-        protected DrawableTaikoHitObject(TObject hitObject)
+        protected DrawableTaikoHitObject([CanBeNull] TObject hitObject)
             : base(hitObject)
         {
-            HitObject = hitObject;
-
             Anchor = Anchor.CentreLeft;
             Origin = Anchor.Custom;
 
             RelativeSizeAxes = Axes.Both;
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override void OnApply()
         {
+            base.OnApply();
             RecreatePieces();
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Allocation;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
@@ -16,28 +16,38 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         where TObject : TaikoStrongableHitObject
         where TStrongNestedObject : StrongNestedHitObject
     {
-        private readonly Bindable<bool> isStrong;
+        private readonly Bindable<bool> isStrong = new BindableBool();
 
         private readonly Container<DrawableStrongNestedHit> strongHitContainer;
 
-        protected DrawableTaikoStrongableHitObject(TObject hitObject)
+        protected DrawableTaikoStrongableHitObject([CanBeNull] TObject hitObject)
             : base(hitObject)
         {
-            isStrong = HitObject.IsStrongBindable.GetBoundCopy();
-
             AddInternal(strongHitContainer = new Container<DrawableStrongNestedHit>());
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override void OnApply()
         {
+            isStrong.BindTo(HitObject.IsStrongBindable);
             isStrong.BindValueChanged(_ =>
             {
-                // will overwrite samples, should only be called on change.
+                // will overwrite samples, should only be called on subsequent changes
+                // after the initial application.
                 updateSamplesFromStrong();
 
                 RecreatePieces();
             });
+
+            base.OnApply();
+        }
+
+        protected override void OnFree()
+        {
+            base.OnFree();
+
+            isStrong.UnbindFrom(HitObject.IsStrongBindable);
+            // ensure the next application does not accidentally overwrite samples.
+            isStrong.UnbindEvents();
         }
 
         private HitSampleInfo[] getStrongSamples() => HitObject.Samples.Where(s => s.Name == HitSampleInfo.HIT_FINISH).ToArray();

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -248,7 +248,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             {
                 case TaikoStrongJudgement _:
                     if (result.IsHit)
-                        hitExplosionContainer.Children.FirstOrDefault(e => e.JudgedObject == ((DrawableStrongNestedHit)judgedObject).MainObject)?.VisualiseSecondHit();
+                        hitExplosionContainer.Children.FirstOrDefault(e => e.JudgedObject == ((DrawableStrongNestedHit)judgedObject).ParentHitObject)?.VisualiseSecondHit();
                     break;
 
                 case TaikoDrumRollTickJudgement _:

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -303,7 +303,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             samplesBindable.CollectionChanged -= onSamplesChanged;
 
             // Release the samples for other hitobjects to use.
-            Samples.Samples = null;
+            if (Samples != null)
+                Samples.Samples = null;
 
             if (nestedHitObjects.IsValueCreated)
             {


### PR DESCRIPTION
Resumption of the taiko pooling series. This is a preparatory pull for actual DHO pooling (both main and nested), which will probably also come out today.

This is probably best reviewed by reading source and not the diff, to look through all the bits of state in each DHO and checking whether any were forgotten in `OnApply()`/`OnFree()`. This is my third-ish iteration of this change, and I don't believe I missed any, but that might still be the case.

Has a few weird changes along the way:

* a31e8d1 came up in tests; calling `free()` on a DHO that hadn't had any HO applied to it yet would trigger this.
* 232c020 fixes the hitobject application test scenes breaking when ran multiple times in succession.
* e3b6eaa removes a weird sizing vestige that has been removed from other DHO types before at various points in time (check commit message for references to those removals).
* The sample/colour/strong state synchronisation code was weird and gets perhaps a little weirder, but as previously stated, I'm not looking to fix this quite yet.

Nothing funny seemed to come up in testing, but I'm not expecting this pull to be the primary one causing regressions, if any. Since I'll have plenty of time off in the near future I'm thinking this might be the best occasion in a while to get this out so I can deal with any potential fallout easier.