### PR TITLE
Enable pooling for taiko DHOs

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneSampleOutput.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneSampleOutput.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Testing;
 using osu.Game.Audio;
@@ -18,24 +19,33 @@ namespace osu.Game.Rulesets.Taiko.Tests
         public override void SetUpSteps()
         {
             base.SetUpSteps();
-            AddAssert("has correct samples", () =>
+
+            var expectedSampleNames = new[]
             {
-                var names = Player.DrawableRuleset.Playfield.AllHitObjects.OfType<DrawableHit>().Select(h => string.Join(',', h.GetSamples().Select(s => s.Name)));
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                HitSampleInfo.HIT_FINISH,
+                HitSampleInfo.HIT_WHISTLE,
+                HitSampleInfo.HIT_WHISTLE,
+                HitSampleInfo.HIT_WHISTLE,
+            };
+            var actualSampleNames = new List<string>();
 
-                var expected = new[]
-                {
-                    string.Empty,
-                    string.Empty,
-                    string.Empty,
-                    string.Empty,
-                    HitSampleInfo.HIT_FINISH,
-                    HitSampleInfo.HIT_WHISTLE,
-                    HitSampleInfo.HIT_WHISTLE,
-                    HitSampleInfo.HIT_WHISTLE,
-                };
+            // due to pooling we can't access all samples right away due to object re-use,
+            // so we need to collect as we go.
+            AddStep("collect sample names", () => Player.DrawableRuleset.Playfield.NewResult += (dho, _) =>
+            {
+                if (!(dho is DrawableHit h))
+                    return;
 
-                return names.SequenceEqual(expected);
+                actualSampleNames.Add(string.Join(',', h.GetSamples().Select(s => s.Name)));
             });
+
+            AddUntilStep("all samples collected", () => actualSampleNames.Count == expectedSampleNames.Length);
+
+            AddAssert("samples are correct", () => actualSampleNames.SequenceEqual(expectedSampleNames));
         }
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TaikoBeatmapConversionTest().GetBeatmap("sample-to-type-conversions");

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -174,7 +174,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, fadeDuration);
         }
 
-        private class StrongNestedHit : DrawableStrongNestedHit
+        public class StrongNestedHit : DrawableStrongNestedHit
         {
             public new DrawableDrumRoll ParentHitObject => (DrawableDrumRoll)base.ParentHitObject;
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            tickContainer.Clear();
+            tickContainer.Clear(false);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override DrawableStrongNestedHit CreateStrongNestedHit(DrumRollTick.StrongNestedHit hitObject) => new StrongNestedHit(hitObject);
 
-        private class StrongNestedHit : DrawableStrongNestedHit
+        public class StrongNestedHit : DrawableStrongNestedHit
         {
             public new DrawableDrumRollTick ParentHitObject => (DrawableDrumRollTick)base.ParentHitObject;
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override DrawableStrongNestedHit CreateStrongNestedHit(Hit.StrongNestedHit hitObject) => new StrongNestedHit(hitObject);
 
-        private class StrongNestedHit : DrawableStrongNestedHit
+        public class StrongNestedHit : DrawableStrongNestedHit
         {
             public new DrawableHit ParentHitObject => (DrawableHit)base.ParentHitObject;
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            ticks.Clear();
+            ticks.Clear(false);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override void ClearNestedHitObjects()
         {
             base.ClearNestedHitObjects();
-            strongHitContainer.Clear();
+            strongHitContainer.Clear(false);
         }
 
         protected override DrawableHitObject CreateNestedHitObject(HitObject hitObject)

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
-using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.Taiko.Replays;
 using osu.Framework.Input;
@@ -64,22 +63,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         protected override Playfield CreatePlayfield() => new TaikoPlayfield(Beatmap.ControlPointInfo);
 
-        public override DrawableHitObject<TaikoHitObject> CreateDrawableRepresentation(TaikoHitObject h)
-        {
-            switch (h)
-            {
-                case Hit hit:
-                    return new DrawableHit(hit);
-
-                case DrumRoll drumRoll:
-                    return new DrawableDrumRoll(drumRoll);
-
-                case Swell swell:
-                    return new DrawableSwell(swell);
-            }
-
-            return null;
-        }
+        public override DrawableHitObject<TaikoHitObject> CreateDrawableRepresentation(TaikoHitObject h) => null;
 
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new TaikoFramedReplayInputHandler(replay);
 

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -149,6 +149,12 @@ namespace osu.Game.Rulesets.Taiko.UI
             };
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            NewResult += OnNewResult;
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -208,7 +214,6 @@ namespace osu.Game.Rulesets.Taiko.UI
                     break;
 
                 case DrawableTaikoHitObject taikoObject:
-                    h.OnNewResult += OnNewResult;
                     topLevelHitContainer.Add(taikoObject.CreateProxiedContent());
                     base.Add(h);
                     break;
@@ -226,7 +231,6 @@ namespace osu.Game.Rulesets.Taiko.UI
                     return barLinePlayfield.Remove(barLine);
 
                 case DrawableTaikoHitObject _:
-                    h.OnNewResult -= OnNewResult;
                     // todo: consider tidying of proxied content if required.
                     return base.Remove(h);
 

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -155,6 +155,14 @@ namespace osu.Game.Rulesets.Taiko.UI
             NewResult += OnNewResult;
         }
 
+        protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
+        {
+            base.OnNewDrawableHitObject(drawableHitObject);
+
+            var taikoObject = (DrawableTaikoHitObject)drawableHitObject;
+            topLevelHitContainer.Add(taikoObject.CreateProxiedContent());
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -213,8 +221,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                     barLinePlayfield.Add(barLine);
                     break;
 
-                case DrawableTaikoHitObject taikoObject:
-                    topLevelHitContainer.Add(taikoObject.CreateProxiedContent());
+                case DrawableTaikoHitObject _:
                     base.Add(h);
                     break;
 
@@ -231,7 +238,6 @@ namespace osu.Game.Rulesets.Taiko.UI
                     return barLinePlayfield.Remove(barLine);
 
                 case DrawableTaikoHitObject _:
-                    // todo: consider tidying of proxied content if required.
                     return base.Remove(h);
 
                 default:

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -147,6 +147,18 @@ namespace osu.Game.Rulesets.Taiko.UI
                 },
                 drumRollHitContainer.CreateProxy(),
             };
+
+            RegisterPool<Hit, DrawableHit>(50);
+            RegisterPool<Hit.StrongNestedHit, DrawableHit.StrongNestedHit>(50);
+
+            RegisterPool<DrumRoll, DrawableDrumRoll>(5);
+            RegisterPool<DrumRoll.StrongNestedHit, DrawableDrumRoll.StrongNestedHit>(5);
+
+            RegisterPool<DrumRollTick, DrawableDrumRollTick>(100);
+            RegisterPool<DrumRollTick.StrongNestedHit, DrawableDrumRollTick.StrongNestedHit>(100);
+
+            RegisterPool<Swell, DrawableSwell>(5);
+            RegisterPool<SwellTick, DrawableSwellTick>(100);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
- (Mostly) closes #6123.
- [x] Depends on #11221.

In terms of pooling, this will be most likely the single biggest noticeable change memory-usage-wise. It's especially visible on long maps; for a data point, I ran a rough single-run test on [this marathon map](https://osu.ppy.sh/beatmapsets/447342#taiko/960444) and the results are as follows:

| | load time | memory usage at song select | memory usage at ~1:00 |
| :-: | -: | -: | -: |
| `master` | 1min 6s | 847k | 1.450G |
| this PR | 3s | 960k | 1.059G |

Allocations are not entirely gone, mind you - there's still work to be done in that respect. Individual DHOs will still recreate their child drawables on application and cause GC churn, and flying hits and explosions are yet to be pooled.

Pool counts are ballpark and based on the densest maps I had locally imported; hits rarely go above high 20s/low 30s and the rest is for safety, and drum rolls and swells get on average 20 nested objects per main object instance.

In my testing I couldn't see any breakage in gameplay, but editor seemed to have some issues, perhaps predictably so, given that this is the first scrolling ruleset with both pooling and editor. For instance, frame-stable seeks, as usual, break stuff and take out too many drawables from the pool, but I'm not yet sure what's the cause of that (and they do get returned when playback resumes). Let me know if you want me to address that before merging this, or if we'll proceed with this and fix up editor later as was the case with osu! efforts.