### PR TITLE
Fix incorrect joinedroom null checks

### DIFF
--- a/osu.Game/Screens/Multi/Components/RoomManager.cs
+++ b/osu.Game/Screens/Multi/Components/RoomManager.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Screens.Multi.Components
         {
             currentJoinRoomRequest?.Cancel();
 
-            if (JoinedRoom == null)
+            if (JoinedRoom.Value == null)
                 return;
 
             api.Queue(new PartRoomRequest(joinedRoom.Value));

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
         public override void PartRoom()
         {
-            if (JoinedRoom == null)
+            if (JoinedRoom.Value == null)
                 return;
 
             var joinedRoom = JoinedRoom.Value;


### PR DESCRIPTION
Would never fail because it's nullchecking the bindable rather than the bindable's value.