### PR TITLE
Fix potential cross-thread operation during chat channel load

### DIFF
--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Overlays.Chat
             Colour = colours.ChatBlue.Lighten(0.7f),
         };
 
-        private void newMessagesArrived(IEnumerable<Message> newMessages)
+        private void newMessagesArrived(IEnumerable<Message> newMessages) => Schedule(() =>
         {
             if (newMessages.Min(m => m.Id) < chatLines.Max(c => c.Message.Id))
             {
@@ -155,9 +155,9 @@ namespace osu.Game.Overlays.Chat
 
             if (shouldScrollToEnd)
                 scrollToEnd();
-        }
+        });
 
-        private void pendingMessageResolved(Message existing, Message updated)
+        private void pendingMessageResolved(Message existing, Message updated) => Schedule(() =>
         {
             var found = chatLines.LastOrDefault(c => c.Message == existing);
 
@@ -169,12 +169,12 @@ namespace osu.Game.Overlays.Chat
                 found.Message = updated;
                 ChatLineFlow.Add(found);
             }
-        }
+        });
 
-        private void messageRemoved(Message removed)
+        private void messageRemoved(Message removed) => Schedule(() =>
         {
             chatLines.FirstOrDefault(c => c.Message == removed)?.FadeColour(Color4.Red, 400).FadeOut(600).Expire();
-        }
+        });
 
         private IEnumerable<ChatLine> chatLines => ChatLineFlow.Children.OfType<ChatLine>();
 


### PR DESCRIPTION
The callbacks are scheduled to the API thread, but hooked up in BDL load. This causes a potential case of cross-thread collection enumeration.

I've tested and it seems like the schedule logic should be fine for short term. Longer term, we probably want to re-think how this works so background operations aren't performed on the `DrawableChannel` in the first place (chat shouldn't have an overhead like this when not visible).

Closes #11231.