### PR TITLE
Fix metadata lost in beatmapset deserialisation

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Online.API.Requests.Responses
 
         public BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets)
         {
-            return new BeatmapSetInfo
+            var beatmapSet = new BeatmapSetInfo
             {
                 OnlineBeatmapSetID = OnlineBeatmapSetID,
                 Metadata = this,
@@ -104,8 +104,17 @@ namespace osu.Game.Online.API.Requests.Responses
                     Genre = genre,
                     Language = language
                 },
-                Beatmaps = beatmaps?.Select(b => b.ToBeatmap(rulesets)).ToList(),
             };
+
+            beatmapSet.Beatmaps = beatmaps?.Select(b =>
+            {
+                var beatmap = b.ToBeatmap(rulesets);
+                beatmap.BeatmapSet = beatmapSet;
+                beatmap.Metadata = beatmapSet.Metadata;
+                return beatmap;
+            }).ToList();
+
+            return beatmapSet;
         }
     }
 }


### PR DESCRIPTION
When deserialising `APIBeatmap` by itself (i.e. via `GetBeatmapRequest`), the `APIBeatmap` contains the beatmap set and then it sets the resultant `BeatmapInfo`'s `Metadata` and `BeatmapSet` properties accordingly:
https://github.com/ppy/osu/blob/d5644c7f862bfe7c9f600cbf783b5b4868438b55/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs#L71-L83
Note how it takes the metadata from the set.

This PR basically does the same thing for when deserialising an `APIBeatmapSet` (i.e. via `GetBeatmapSetRequest`), because in this case the `APIBeatmap`s _don't_ contain the set - it's in the parent `APIBeatmapSet` object.