### PR TITLE
Fix editor background not being correctly cleaned up on forced exit

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -461,7 +461,7 @@ namespace osu.Game.Screens.Edit
                 if (dialogOverlay == null || dialogOverlay.CurrentDialog is PromptForSaveDialog)
                 {
                     confirmExit();
-                    return false;
+                    return base.OnExiting(next);
                 }
 
                 if (isNewBeatmap || HasUnsavedChanges)


### PR DESCRIPTION
Closes #11214. Should be pretty obvious why.