### PR TITLE
Improve drag and selection UX on editor timeline

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            Height = 0.4f;
+            Height = 0.6f;
 
             AddInternal(new Box
             {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
@@ -25,9 +26,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
 
+        [Resolved]
+        private OsuColour colours { get; set; }
+
         private DragEvent lastDragEvent;
         private Bindable<HitObject> placement;
         private SelectionBlueprint placementBlueprint;
+
+        private readonly Box backgroundBox;
 
         public TimelineBlueprintContainer(HitObjectComposer composer)
             : base(composer)
@@ -38,7 +44,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             Height = 0.6f;
 
-            AddInternal(new Box
+            AddInternal(backgroundBox = new Box
             {
                 Colour = Color4.Black,
                 RelativeSizeAxes = Axes.Both,
@@ -76,6 +82,18 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         }
 
         protected override Container<SelectionBlueprint> CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            backgroundBox.FadeColour(colours.BlueLighter, 120, Easing.OutQuint);
+            return base.OnHover(e);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            backgroundBox.FadeColour(Color4.Black, 600, Easing.OutQuint);
+            base.OnHoverLost(e);
+        }
 
         protected override void OnDrag(DragEvent e)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     {
         private const float thickness = 5;
         private const float shadow_radius = 5;
-        private const float circle_size = 24;
+        private const float circle_size = 34;
 
         public Action<DragEvent> OnDragHandled;
 


### PR DESCRIPTION
Closes #10486 (and potentially #10487?) by increasing the drag area, the blueprint circle size, and also highlighting the draggable area when hovering for better visibility.

before:

![2020-12-21 18 17 45](https://user-images.githubusercontent.com/191335/102760456-dc0fd280-43b8-11eb-90b0-d17b275d0716.gif)

after:

![2020-12-21 18 16 09](https://user-images.githubusercontent.com/191335/102760286-a4088f80-43b8-11eb-926a-1e2429163d04.gif)
