### PR TITLE
Fix crash when attempting to scale two hitobjects on the same axis

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -157,10 +157,16 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                 foreach (var h in hitObjects)
                 {
-                    h.Position = new Vector2(
-                        quad.TopLeft.X + (h.X - quad.TopLeft.X) / quad.Width * (quad.Width + scale.X),
-                        quad.TopLeft.Y + (h.Y - quad.TopLeft.Y) / quad.Height * (quad.Height + scale.Y)
-                    );
+                    var newPosition = h.Position;
+
+                    // guard against no-ops and NaN.
+                    if (scale.X != 0 && quad.Width > 0)
+                        newPosition.X = quad.TopLeft.X + (h.X - quad.TopLeft.X) / quad.Width * (quad.Width + scale.X);
+
+                    if (scale.Y != 0 && quad.Height > 0)
+                        newPosition.Y = quad.TopLeft.Y + (h.Y - quad.TopLeft.Y) / quad.Height * (quad.Height + scale.Y);
+
+                    h.Position = newPosition;
                 }
             }
 


### PR DESCRIPTION
Not sure how/when this regressed, but it's a pretty easy one to reproduce (try and adjust the scale of two hitcircles that are on the same X or Y coodinates):

![2020-12-22 12 54 38](https://user-images.githubusercontent.com/191335/102847013-e089c900-4454-11eb-8d86-41b1886f92b4.gif)

```

Unhandled exception. System.ArgumentException: Position must be finite, but is (257.98788, NaN).
   at osu.Framework.Graphics.Drawable.set_Position(Vector2 value)
   at osu.Game.Rulesets.Osu.Edit.Blueprints.BlueprintPiece`1.UpdateFrom(T hitObject) in /Users/dean/Projects/osu/osu.Game.Rulesets.Osu/Edit/Blueprints/BlueprintPiece.cs:line 22
   at osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components.HitCirclePiece.UpdateFrom(HitCircle hitObject) in /Users/dean/Projects/osu/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/Components/HitCirclePiece.cs:line 35
   at osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.HitCircleSelectionBlueprint.Update() in /Users/dean/Projects/osu/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCircleSelectionBlueprint.cs:line 28
   at osu.Framework.Graphics.Drawable.UpdateSubTree()

```

Closes https://github.com/ppy/osu/issues/11201.

Note that this does leave a remaining (potential?) issue when dragging a selection to the point where all objects are at the same point in time, where positional data is lost:

![2020-12-22 13 48 45](https://user-images.githubusercontent.com/191335/102850316-83921100-445c-11eb-9a8b-dd233a348544.gif)

This will probably need to be solved by limiting the minimum size of the resultant scale (or rather, the minimum distance between hitobjects in the selection).