### PR TITLE
Fix resolution dropdown not respecting current display changes

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Drawing;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -150,8 +151,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 {
                     resolutions.AddRange(display.NewValue.DisplayModes
                                                 .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
-                                                .OrderByDescending(m => m.Size.Width)
-                                                .ThenByDescending(m => m.Size.Height)
+                                                .OrderByDescending(m => Math.Max(m.Size.Height, m.Size.Width))
                                                 .Select(m => m.Size)
                                                 .Distinct());
                 }

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -25,9 +24,13 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private FillFlowContainer<SettingsSlider<float>> scalingSettings;
 
+        private readonly IBindable<Display> currentDisplay = new Bindable<Display>();
+        private readonly IBindableList<WindowMode> windowModes = new BindableList<WindowMode>();
+
         private Bindable<ScalingMode> scalingMode;
         private Bindable<Size> sizeFullscreen;
-        private readonly IBindableList<WindowMode> windowModes = new BindableList<WindowMode>();
+
+        private readonly BindableList<Size> resolutions = new BindableList<Size>(new[] { new Size(9999, 9999) });
 
         [Resolved]
         private OsuGameBase game { get; set; }
@@ -53,9 +56,10 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             scalingPositionY = osuConfig.GetBindable<float>(OsuSetting.ScalingPositionY);
 
             if (host.Window != null)
+            {
+                currentDisplay.BindTo(host.Window.CurrentDisplayBindable);
                 windowModes.BindTo(host.Window.SupportedWindowModes);
-
-            Container resolutionSettingsContainer;
+            }
 
             Children = new Drawable[]
             {
@@ -65,10 +69,12 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                     Current = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode),
                     ItemSource = windowModes,
                 },
-                resolutionSettingsContainer = new Container
+                resolutionDropdown = new ResolutionSettingsDropdown
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y
+                    LabelText = "Resolution",
+                    ShowsDefaultIndicator = false,
+                    ItemSource = resolutions,
+                    Current = sizeFullscreen
                 },
                 new SettingsSlider<float, UIScaleSlider>
                 {
@@ -126,31 +132,34 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 },
             };
 
-            scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
-
-            var resolutions = getResolutions();
-
-            if (resolutions.Count > 1)
+            windowModes.BindCollectionChanged((sender, args) =>
             {
-                resolutionSettingsContainer.Child = resolutionDropdown = new ResolutionSettingsDropdown
-                {
-                    LabelText = "Resolution",
-                    ShowsDefaultIndicator = false,
-                    Items = resolutions,
-                    Current = sizeFullscreen
-                };
+                if (windowModes.Count > 1)
+                    windowModeDropdown.Show();
+                else
+                    windowModeDropdown.Hide();
+            }, true);
 
-                windowModeDropdown.Current.BindValueChanged(mode =>
+            windowModeDropdown.Current.ValueChanged += v => updateResolutionDropdown();
+
+            currentDisplay.BindValueChanged(v => Schedule(() =>
+            {
+                resolutions.RemoveRange(1, resolutions.Count - 1);
+
+                if (v.NewValue != null)
                 {
-                    if (mode.NewValue == WindowMode.Fullscreen)
-                    {
-                        resolutionDropdown.Show();
-                        sizeFullscreen.TriggerChange();
-                    }
-                    else
-                        resolutionDropdown.Hide();
-                }, true);
-            }
+                    resolutions.AddRange(v.NewValue.DisplayModes
+                                          .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
+                                          .OrderByDescending(m => m.Size.Width)
+                                          .ThenByDescending(m => m.Size.Height)
+                                          .Select(m => m.Size)
+                                          .Distinct());
+                }
+
+                updateResolutionDropdown();
+            }), true);
+
+            scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
 
             scalingMode.BindValueChanged(mode =>
             {
@@ -163,17 +172,13 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 scalingSettings.ForEach(s => s.TransferValueOnCommit = mode.NewValue == ScalingMode.Everything);
             }, true);
 
-            windowModes.CollectionChanged += (sender, args) => windowModesChanged();
-
-            windowModesChanged();
-        }
-
-        private void windowModesChanged()
-        {
-            if (windowModes.Count > 1)
-                windowModeDropdown.Show();
-            else
-                windowModeDropdown.Hide();
+            void updateResolutionDropdown()
+            {
+                if (resolutions.Count > 1 && windowModeDropdown.Current.Value == WindowMode.Fullscreen)
+                    resolutionDropdown.Show();
+                else
+                    resolutionDropdown.Hide();
+            }
         }
 
         /// <summary>
@@ -203,24 +208,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
             preview.FadeOutFromOne(1500);
             preview.Expire();
-        }
-
-        private IReadOnlyList<Size> getResolutions()
-        {
-            var resolutions = new List<Size> { new Size(9999, 9999) };
-            var currentDisplay = game.Window?.CurrentDisplayBindable.Value;
-
-            if (currentDisplay != null)
-            {
-                resolutions.AddRange(currentDisplay.DisplayModes
-                                                   .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
-                                                   .OrderByDescending(m => m.Size.Width)
-                                                   .ThenByDescending(m => m.Size.Height)
-                                                   .Select(m => m.Size)
-                                                   .Distinct());
-            }
-
-            return resolutions;
         }
 
         private class ScalingPreview : ScalingContainer

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -140,20 +140,20 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                     windowModeDropdown.Hide();
             }, true);
 
-            windowModeDropdown.Current.ValueChanged += v => updateResolutionDropdown();
+            windowModeDropdown.Current.ValueChanged += _ => updateResolutionDropdown();
 
-            currentDisplay.BindValueChanged(v => Schedule(() =>
+            currentDisplay.BindValueChanged(display => Schedule(() =>
             {
                 resolutions.RemoveRange(1, resolutions.Count - 1);
 
-                if (v.NewValue != null)
+                if (display.NewValue != null)
                 {
-                    resolutions.AddRange(v.NewValue.DisplayModes
-                                          .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
-                                          .OrderByDescending(m => m.Size.Width)
-                                          .ThenByDescending(m => m.Size.Height)
-                                          .Select(m => m.Size)
-                                          .Distinct());
+                    resolutions.AddRange(display.NewValue.DisplayModes
+                                                .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
+                                                .OrderByDescending(m => m.Size.Width)
+                                                .ThenByDescending(m => m.Size.Height)
+                                                .Select(m => m.Size)
+                                                .Distinct());
                 }
 
                 updateResolutionDropdown();


### PR DESCRIPTION
Not entirely sure about whether scheduling `currentDisplay.BindValueChanged` is the right way:

https://github.com/frenzibyte/osu/blob/dab5924a63c869dc0ce74b3c22e8c797a6485169/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs#L145

`currentDisplay` is changed in the main thread by `SDL2DesktopWindow`, therefore any changes to the items of resolution dropdown would result in "invalid thread for child mutation", so I guess scheduling is fine for now.