### PR TITLE
Fix beatmap track not looping on multiplayer song selects

### DIFF
--- a/osu.Game/Screens/Multi/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/Multi/Match/RoomSubScreen.cs
@@ -41,27 +41,24 @@ namespace osu.Game.Screens.Multi.Match
 
             managerUpdated = beatmapManager.ItemUpdated.GetBoundCopy();
             managerUpdated.BindValueChanged(beatmapUpdated);
-
-            if (music != null)
-                music.TrackChanged += applyToTrack;
         }
 
         public override void OnEntering(IScreen last)
         {
             base.OnEntering(last);
-            applyToTrack();
+            beginHandlingTrack();
         }
 
         public override void OnSuspending(IScreen next)
         {
-            resetTrack();
+            endHandlingTrack();
             base.OnSuspending(next);
         }
 
         public override void OnResuming(IScreen last)
         {
             base.OnResuming(last);
-            applyToTrack();
+            beginHandlingTrack();
         }
 
         public override bool OnExiting(IScreen next)
@@ -69,7 +66,7 @@ namespace osu.Game.Screens.Multi.Match
             RoomManager?.PartRoom();
             Mods.Value = Array.Empty<Mod>();
 
-            resetTrack();
+            endHandlingTrack();
 
             return base.OnExiting(next);
         }
@@ -98,7 +95,18 @@ namespace osu.Game.Screens.Multi.Match
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
         }
 
-        private void applyToTrack(WorkingBeatmap _ = default, TrackChangeDirection __ = default)
+        private void beginHandlingTrack()
+        {
+            Beatmap.BindValueChanged(applyLoopingToTrack, true);
+        }
+
+        private void endHandlingTrack()
+        {
+            Beatmap.ValueChanged -= applyLoopingToTrack;
+            cancelTrackLooping();
+        }
+
+        private void applyLoopingToTrack(ValueChangedEvent<WorkingBeatmap> _ = null)
         {
             if (!this.IsCurrentScreen())
                 return;
@@ -114,7 +122,7 @@ namespace osu.Game.Screens.Multi.Match
             }
         }
 
-        private void resetTrack()
+        private void cancelTrackLooping()
         {
             var track = Beatmap?.Value?.Track;
 

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -198,8 +197,6 @@ namespace osu.Game.Screens.Multi
         {
             this.FadeIn();
             waves.Show();
-
-            beginHandlingTrack();
         }
 
         public override void OnResuming(IScreen last)
@@ -209,8 +206,6 @@ namespace osu.Game.Screens.Multi
 
             base.OnResuming(last);
 
-            beginHandlingTrack();
-
             UpdatePollingRate(isIdle.Value);
         }
 
@@ -218,8 +213,6 @@ namespace osu.Game.Screens.Multi
         {
             this.ScaleTo(1.1f, 250, Easing.InSine);
             this.FadeOut(250);
-
-            endHandlingTrack();
 
             UpdatePollingRate(isIdle.Value);
         }
@@ -234,8 +227,6 @@ namespace osu.Game.Screens.Multi
 
             if (screenStack.CurrentScreen != null)
                 loungeSubScreen.MakeCurrent();
-
-            endHandlingTrack();
 
             base.OnExiting(next);
             return false;
@@ -275,17 +266,6 @@ namespace osu.Game.Screens.Multi
         /// <returns>The created <see cref="Room"/>.</returns>
         protected virtual Room CreateNewRoom() => new Room { Name = { Value = $"{api.LocalUser}'s awesome room" } };
 
-        private void beginHandlingTrack()
-        {
-            Beatmap.BindValueChanged(updateTrack, true);
-        }
-
-        private void endHandlingTrack()
-        {
-            cancelLooping();
-            Beatmap.ValueChanged -= updateTrack;
-        }
-
         private void screenPushed(IScreen lastScreen, IScreen newScreen)
         {
             subScreenChanged(lastScreen, newScreen);
@@ -322,42 +302,9 @@ namespace osu.Game.Screens.Multi
 
             UpdatePollingRate(isIdle.Value);
             createButton.FadeTo(newScreen is LoungeSubScreen ? 1 : 0, 200);
-
-            updateTrack();
         }
 
         protected IScreen CurrentSubScreen => screenStack.CurrentScreen;
-
-        private void updateTrack(ValueChangedEvent<WorkingBeatmap> _ = null)
-        {
-            if (screenStack.CurrentScreen is RoomSubScreen)
-            {
-                var track = Beatmap.Value?.Track;
-
-                if (track != null)
-                {
-                    track.RestartPoint = Beatmap.Value.Metadata.PreviewTime;
-                    track.Looping = true;
-
-                    music?.EnsurePlayingSomething();
-                }
-            }
-            else
-            {
-                cancelLooping();
-            }
-        }
-
-        private void cancelLooping()
-        {
-            var track = Beatmap?.Value?.Track;
-
-            if (track != null)
-            {
-                track.Looping = false;
-                track.RestartPoint = 0;
-            }
-        }
 
         protected abstract RoomManager CreateRoomManager();
 


### PR DESCRIPTION
This was occurring due to `Multiplayer.updateTrack()`'s looping logic overriding any other one (`SongSelect`'s looping logic in this case) and assuming it should always be set to `false`.

Fixed it by moving the looping logic inside `MatchSubScreen` such that when it's not the current screen, looping can be changed freely.