### PR TITLE
Fix CurrentTime is not always between CurrentFrame.Time and NextFrame.Time

### DIFF
--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -123,9 +123,7 @@ namespace osu.Game.Rulesets.Replays
             // if we have a next frame, check if it is before or at the current time in playback, and advance time to it if so.
             if (next != null)
             {
-                int compare = time.CompareTo(next.Time);
-
-                if (compare == 0 || compare == currentDirection)
+                if (currentDirection == 1 ? next.Time <= time : time <= next.Time)
                 {
                     currentFrameIndex = clampedNextFrameIndex;
                     return CurrentTime = CurrentFrame.Time;
@@ -164,12 +162,15 @@ namespace osu.Game.Rulesets.Replays
             if (!CurrentTime.HasValue)
             {
                 currentDirection = 1;
+                return;
             }
-            else
-            {
-                currentDirection = time.CompareTo(CurrentTime);
-                if (currentDirection == 0) currentDirection = 1;
-            }
+
+            var newDirection = CurrentTime <= time ? 1 : -1;
+
+            if (currentDirection == newDirection) return;
+
+            currentFrameIndex = clampedNextFrameIndex;
+            currentDirection = newDirection;
         }
     }
 }


### PR DESCRIPTION
It should be always:
- `CurrentFrame.Time <= CurrentTime <= NextFrame.Time` when direction == 1
- `CurrentFrame.Time >= CurrentTime >= NextFrame.Time` when direction == -1
but the invariant was broken when the direction changed (a replay is rewound).

The issue is most visible in osu!catch ruleset, and it can be seen as the catcher goes outside of the playfield when an autoplay is rewound, due to the low number of autoplay frames, but the issue is present on all rulesets.

Also, removed assumption of `CompareTo` always returns {-1,0,1}. The document says only sign matters, and it can be any integer.

- <s>Fixes/ #3530</s> (There are multiple issues reported there, but the main issue "acc is not 100%" is solved here).
  - It seems like there are more ways a replay misses hit objects.