### PR TITLE
Add multiplayer server disconnection flow

### DIFF
--- a/osu.Game/Online/RealtimeMultiplayer/RealtimeMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/RealtimeMultiplayerClient.cs
@@ -130,7 +130,11 @@ namespace osu.Game.Online.RealtimeMultiplayer
         public override async Task LeaveRoom()
         {
             if (!isConnected.Value)
+            {
+                // even if not connected, make sure the local room state can be cleaned up.
+                await base.LeaveRoom();
                 return;
+            }
 
             if (Room == null)
                 return;

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -75,6 +75,16 @@ namespace osu.Game.Online.RealtimeMultiplayer
         // Todo: This is temporary, until the multiplayer server returns the item id on match start or otherwise.
         private int playlistItemId;
 
+        protected StatefulMultiplayerClient()
+        {
+            IsConnected.BindValueChanged(connected =>
+            {
+                // clean up local room state on server disconnect.
+                if (!connected.NewValue)
+                    LeaveRoom();
+            });
+        }
+
         /// <summary>
         /// Joins the <see cref="MultiplayerRoom"/> for a given API <see cref="Room"/>.
         /// </summary>

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API;
@@ -81,7 +82,10 @@ namespace osu.Game.Online.RealtimeMultiplayer
             {
                 // clean up local room state on server disconnect.
                 if (!connected.NewValue)
+                {
+                    Logger.Log("Connection to multiplayer server was lost.", LoggingTarget.Runtime, LogLevel.Important);
                     LeaveRoom();
+                }
             });
         }
 

--- a/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/Multi/Lounge/LoungeSubScreen.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Screens.Multi.Lounge
         /// <summary>
         /// Push a room as a new subscreen.
         /// </summary>
-        public void Open(Room room)
+        public virtual void Open(Room room)
         {
             // Handles the case where a room is clicked 3 times in quick succession
             if (!this.IsCurrentScreen())

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeLoungeSubScreen.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeLoungeSubScreen.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.RealtimeMultiplayer;
 using osu.Game.Screens.Multi.Lounge;
 using osu.Game.Screens.Multi.Lounge.Components;
 using osu.Game.Screens.Multi.Match;
@@ -13,5 +16,19 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
         protected override FilterControl CreateFilterControl() => new RealtimeFilterControl();
 
         protected override RoomSubScreen CreateRoomSubScreen(Room room) => new RealtimeMatchSubScreen(room);
+
+        [Resolved]
+        private StatefulMultiplayerClient client { get; set; }
+
+        public override void Open(Room room)
+        {
+            if (!client.IsConnected.Value)
+            {
+                Logger.Log("Not currently connected to the multiplayer server.", LoggingTarget.Runtime, LogLevel.Important);
+                return;
+            }
+
+            base.Open(room);
+        }
     }
 }

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSubScreen.cs
@@ -4,8 +4,10 @@
 using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.RealtimeMultiplayer;
@@ -33,6 +35,8 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
         private StatefulMultiplayerClient client { get; set; }
 
         private RealtimeMatchSettingsOverlay settingsOverlay;
+
+        private IBindable<bool> isConnected;
 
         public RealtimeMatchSubScreen(Room room)
         {
@@ -173,6 +177,16 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             Playlist.BindCollectionChanged(onPlaylistChanged, true);
 
             client.LoadRequested += onLoadRequested;
+
+            isConnected = client.IsConnected.GetBoundCopy();
+            isConnected.BindValueChanged(connected =>
+            {
+                if (!connected.NewValue)
+                {
+                    Logger.Log("Connection to multiplayer server was lost.", LoggingTarget.Runtime, LogLevel.Important);
+                    Schedule(this.Exit);
+                }
+            }, true);
         }
 
         public override bool OnBackButton()

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSubScreen.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.RealtimeMultiplayer;
@@ -18,6 +17,7 @@ using osu.Game.Screens.Multi.RealtimeMultiplayer.Match;
 using osu.Game.Screens.Multi.RealtimeMultiplayer.Participants;
 using osu.Game.Screens.Play;
 using osu.Game.Users;
+using ParticipantsList = osu.Game.Screens.Multi.RealtimeMultiplayer.Participants.ParticipantsList;
 
 namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 {
@@ -106,7 +106,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
                                                                     new Drawable[] { new ParticipantsListHeader() },
                                                                     new Drawable[]
                                                                     {
-                                                                        new Participants.ParticipantsList
+                                                                        new ParticipantsList
                                                                         {
                                                                             RelativeSizeAxes = Axes.Both
                                                                         },
@@ -182,10 +182,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             isConnected.BindValueChanged(connected =>
             {
                 if (!connected.NewValue)
-                {
-                    Logger.Log("Connection to multiplayer server was lost.", LoggingTarget.Runtime, LogLevel.Important);
                     Schedule(this.Exit);
-                }
             }, true);
         }
 

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
                     startedEvent.Set();
 
                     // messaging to the user about this disconnect will be provided by the RealtimeMatchSubScreen.
-                    Schedule(PerformImmediateExit);
+                    Schedule(() => PerformExit(false));
                 }
             }, true);
 
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             {
                 Logger.Log("Failed to start the multiplayer match in time.", LoggingTarget.Runtime, LogLevel.Important);
 
-                Schedule(PerformImmediateExit);
+                Schedule(() => PerformExit(false));
             }
 
             Debug.Assert(client.Room != null);

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
@@ -51,8 +51,12 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             isConnected.BindValueChanged(connected =>
             {
                 if (!connected.NewValue)
+                {
+                    startedEvent.Set();
+
                     // messaging to the user about this disconnect will be provided by the RealtimeMatchSubScreen.
-                    Schedule(this.Exit);
+                    Schedule(PerformImmediateExit);
+                }
             }, true);
 
             client.ChangeState(MultiplayerUserState.Loaded);
@@ -61,11 +65,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             {
                 Logger.Log("Failed to start the multiplayer match in time.", LoggingTarget.Runtime, LogLevel.Important);
 
-                Schedule(() =>
-                {
-                    ValidForResume = false;
-                    this.Exit();
-                });
+                Schedule(PerformImmediateExit);
             }
         }
 

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
-using osu.Framework.Screens;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.RealtimeMultiplayer;
 using osu.Game.Scoring;

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -43,6 +43,12 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
         public override void JoinRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)
         {
+            if (!multiplayerClient.IsConnected.Value)
+            {
+                onError?.Invoke("Not currently connected to the multiplayer server.");
+                return;
+            }
+
             // this is done here as a pre-check to avoid clicking on already closed rooms in the lounge from triggering a server join.
             // should probably be done at a higher level, but due to the current structure of things this is the easiest place for now.
             if (room.Status.Value is RoomStatusEnded)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -386,7 +386,7 @@ namespace osu.Game.Screens.Play
                         if (!this.IsCurrentScreen()) return;
 
                         fadeOut(true);
-                        PerformImmediateExit();
+                        PerformExit(true);
                     },
                 },
                 failAnimation = new FailAnimation(DrawableRuleset) { OnComplete = onFailComplete, },
@@ -458,20 +458,30 @@ namespace osu.Game.Screens.Play
             return playable;
         }
 
-        protected void PerformImmediateExit()
+        /// <summary>
+        /// Exits the <see cref="Player"/>.
+        /// </summary>
+        /// <param name="userRequested">
+        /// Whether the exit is requested by the user, or a higher-level game component.
+        /// Pausing is allowed only in the former case.
+        /// </param>
+        protected void PerformExit(bool userRequested)
         {
             // if a restart has been requested, cancel any pending completion (user has shown intent to restart).
             completionProgressDelegate?.Cancel();
 
             ValidForResume = false;
 
-            performUserRequestedExit();
+            if (!this.IsCurrentScreen()) return;
+
+            if (userRequested)
+                performUserRequestedExit();
+            else
+                this.Exit();
         }
 
         private void performUserRequestedExit()
         {
-            if (!this.IsCurrentScreen()) return;
-
             if (ValidForResume && HasFailed && !FailOverlay.IsPresent)
             {
                 failAnimation.FinishTransforms(true);
@@ -498,7 +508,7 @@ namespace osu.Game.Screens.Play
             RestartRequested?.Invoke();
 
             if (this.IsCurrentScreen())
-                PerformImmediateExit();
+                PerformExit(true);
             else
                 this.MakeCurrent();
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -386,7 +386,7 @@ namespace osu.Game.Screens.Play
                         if (!this.IsCurrentScreen()) return;
 
                         fadeOut(true);
-                        performImmediateExit();
+                        PerformImmediateExit();
                     },
                 },
                 failAnimation = new FailAnimation(DrawableRuleset) { OnComplete = onFailComplete, },
@@ -458,7 +458,7 @@ namespace osu.Game.Screens.Play
             return playable;
         }
 
-        private void performImmediateExit()
+        protected void PerformImmediateExit()
         {
             // if a restart has been requested, cancel any pending completion (user has shown intent to restart).
             completionProgressDelegate?.Cancel();
@@ -498,7 +498,7 @@ namespace osu.Game.Screens.Play
             RestartRequested?.Invoke();
 
             if (this.IsCurrentScreen())
-                performImmediateExit();
+                PerformImmediateExit();
             else
                 this.MakeCurrent();
         }


### PR DESCRIPTION
This handles multiple cases of the client getting stuck (or worse, crashing) when the multiplayer server connection is lost. It also provides better messaging and flow when attempting to create a room while the server is unavailable.