### PR TITLE
Fix multiple cases of unobserved async errors being thrown in fire-and-forget usages

### DIFF
--- a/osu.Game/Extensions/TaskExtensions.cs
+++ b/osu.Game/Extensions/TaskExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using osu.Framework.Logging;
+
+namespace osu.Game.Extensions
+{
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// Denote a task which is to be run without local error handling logic, where failure is not catastrophic.
+        /// Avoids unobserved exceptions from being fired.
+        /// </summary>
+        /// <param name="task">The task.</param>
+        /// <param name="logOnError">Whether errors should be logged as important, or silently ignored.</param>
+        public static void FireAndForget(this Task task, bool logOnError = false)
+        {
+            task.ContinueWith(t =>
+            {
+                if (logOnError)
+                    Logger.Log($"Error running task: {t.Exception?.Message ?? "unknown"}", LoggingTarget.Runtime, LogLevel.Important);
+            }, TaskContinuationOptions.NotOnRanToCompletion);
+        }
+    }
+}

--- a/osu.Game/Extensions/TaskExtensions.cs
+++ b/osu.Game/Extensions/TaskExtensions.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Extensions
         /// </summary>
         /// <param name="task">The task.</param>
         /// <param name="logOnError">Whether errors should be logged as important, or silently ignored.</param>
-        public static void FireAndForget(this Task task, bool logOnError = false)
+        public static void CatchUnobservedExceptions(this Task task, bool logOnError = false)
         {
             task.ContinueWith(t =>
             {

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable enable
@@ -14,6 +14,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -84,7 +85,7 @@ namespace osu.Game.Online.RealtimeMultiplayer
                 if (!connected.NewValue)
                 {
                     Logger.Log("Connection to multiplayer server was lost.", LoggingTarget.Runtime, LogLevel.Important);
-                    LeaveRoom();
+                    LeaveRoom().FireAndForget();
                 }
             });
         }

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -1,4 +1,4 @@
-
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable enable

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Online.RealtimeMultiplayer
                 if (!connected.NewValue)
                 {
                     Logger.Log("Connection to multiplayer server was lost.", LoggingTarget.Runtime, LogLevel.Important);
-                    LeaveRoom().FireAndForget();
+                    LeaveRoom().CatchUnobservedExceptions();
                 }
             });
         }

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/Match/RealtimeReadyButton.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/Match/RealtimeReadyButton.cs
@@ -106,13 +106,13 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer.Match
                 return;
 
             if (localUser.State == MultiplayerUserState.Idle)
-                Client.ChangeState(MultiplayerUserState.Ready).FireAndForget(true);
+                Client.ChangeState(MultiplayerUserState.Ready).CatchUnobservedExceptions(true);
             else
             {
                 if (Room?.Host?.Equals(localUser) == true)
-                    Client.StartMatch().FireAndForget(true);
+                    Client.StartMatch().CatchUnobservedExceptions(true);
                 else
-                    Client.ChangeState(MultiplayerUserState.Idle).FireAndForget(true);
+                    Client.ChangeState(MultiplayerUserState.Idle).CatchUnobservedExceptions(true);
             }
         }
 

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/Match/RealtimeReadyButton.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/Match/RealtimeReadyButton.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Online.API;
@@ -105,13 +106,13 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer.Match
                 return;
 
             if (localUser.State == MultiplayerUserState.Idle)
-                Client.ChangeState(MultiplayerUserState.Ready);
+                Client.ChangeState(MultiplayerUserState.Ready).FireAndForget(true);
             else
             {
                 if (Room?.Host?.Equals(localUser) == true)
-                    Client.StartMatch();
+                    Client.StartMatch().FireAndForget(true);
                 else
-                    Client.ChangeState(MultiplayerUserState.Idle);
+                    Client.ChangeState(MultiplayerUserState.Idle).FireAndForget(true);
             }
         }
 

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/Participants/ParticipantPanel.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -176,7 +177,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer.Participants
                         if (Room.Host?.UserID != api.LocalUser.Value.Id)
                             return;
 
-                        Client.TransferHost(targetUser);
+                        Client.TransferHost(targetUser).FireAndForget(true);
                     })
                 };
             }

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/Participants/ParticipantPanel.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer.Participants
                         if (Room.Host?.UserID != api.LocalUser.Value.Id)
                             return;
 
-                        Client.TransferHost(targetUser).FireAndForget(true);
+                        Client.TransferHost(targetUser).CatchUnobservedExceptions(true);
                     })
                 };
             }

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSongSelect.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSongSelect.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
                 client.ChangeSettings(item: item).ContinueWith(t =>
                 {
-                    return Schedule(() =>
+                    Schedule(() =>
                     {
                         loadingLayer.Hide();
 

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
+using osu.Game.Extensions;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.RealtimeMultiplayer;
 using osu.Game.Screens.Multi.Components;
@@ -21,7 +22,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             base.OnResuming(last);
 
             if (client.Room != null)
-                client.ChangeState(MultiplayerUserState.Idle);
+                client.ChangeState(MultiplayerUserState.Idle).FireAndForget(true);
         }
 
         protected override void UpdatePollingRate(bool isIdle)

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             base.OnResuming(last);
 
             if (client.Room != null)
-                client.ChangeState(MultiplayerUserState.Idle).FireAndForget(true);
+                client.ChangeState(MultiplayerUserState.Idle).CatchUnobservedExceptions(true);
         }
 
         protected override void UpdatePollingRate(bool isIdle)

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
                 }
             }, true);
 
-            client.ChangeState(MultiplayerUserState.Loaded).ContinueWith(task =>
-                failAndBail(task.Exception?.Message ?? "Server error"), TaskContinuationOptions.NotOnRanToCompletion);
+            client.ChangeState(MultiplayerUserState.Loaded)
+                  .ContinueWith(task => failAndBail(task.Exception?.Message ?? "Server error"), TaskContinuationOptions.NotOnRanToCompletion);
 
             if (!startedEvent.Wait(TimeSpan.FromSeconds(30)))
                 failAndBail("Failed to start the multiplayer match in time.");

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
             base.PartRoom();
 
-            multiplayerClient.LeaveRoom().FireAndForget();
+            multiplayerClient.LeaveRoom().CatchUnobservedExceptions();
 
             // Todo: This is not the way to do this. Basically when we're the only participant and the room closes, there's no way to know if this is actually the case.
             // This is delayed one frame because upon exiting the match subscreen, multiplayer updates the polling rate and messes with polling.

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Game.Extensions;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.RoomStatuses;
 using osu.Game.Online.RealtimeMultiplayer;
@@ -68,7 +69,8 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             var joinedRoom = JoinedRoom.Value;
 
             base.PartRoom();
-            multiplayerClient.LeaveRoom();
+
+            multiplayerClient.LeaveRoom().FireAndForget();
 
             // Todo: This is not the way to do this. Basically when we're the only participant and the room closes, there's no way to know if this is actually the case.
             // This is delayed one frame because upon exiting the match subscreen, multiplayer updates the polling rate and messes with polling.


### PR DESCRIPTION
This should (hopefully) cover all the cases where a SignalR exception could arrive as an unobserved exception due to there being no `await` or `ContinueWith` on an async call.

- [x] Depends on #11265 for ease of merging.