### PR TITLE
Handle osu! URIs on Android

### DIFF
--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -14,7 +14,7 @@ using osu.Framework.Android;
 
 namespace osu.Android
 {
-    [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
+    [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false, LaunchMode = LaunchMode.SingleInstance)]
     [IntentFilter(new[] { Intent.ActionDefault, Intent.ActionSend }, Categories = new[] { Intent.CategoryDefault }, DataPathPatterns = new[] { ".*\\.osz", ".*\\.osk" }, DataMimeType = "application/*")]
     [IntentFilter(new[] { Intent.ActionView }, Categories = new[] { Intent.CategoryBrowsable, Intent.CategoryDefault }, DataScheme = osu_url_scheme)]
     public class OsuGameActivity : AndroidGameActivity

--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -16,8 +16,11 @@ namespace osu.Android
 {
     [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false)]
     [IntentFilter(new[] { Intent.ActionDefault, Intent.ActionSend }, Categories = new[] { Intent.CategoryDefault }, DataPathPatterns = new[] { ".*\\.osz", ".*\\.osk" }, DataMimeType = "application/*")]
+    [IntentFilter(new[] { Intent.ActionView }, Categories = new[] { Intent.CategoryBrowsable, Intent.CategoryDefault }, DataScheme = osu_url_scheme)]
     public class OsuGameActivity : AndroidGameActivity
     {
+        private const string osu_url_scheme = "osu";
+
         private OsuGameAndroid game;
 
         protected override Framework.Game CreateGame() => game = new OsuGameAndroid(this);
@@ -49,6 +52,8 @@ namespace osu.Android
                 case Intent.ActionDefault:
                     if (intent.Scheme == ContentResolver.SchemeContent)
                         handleImportFromUri(intent.Data);
+                    else if (intent.Scheme == osu_url_scheme)
+                        Task.Run(() => game.HandleLink(intent.DataString));
                     break;
 
                 case Intent.ActionSend:

--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
@@ -16,10 +17,10 @@ namespace osu.Android
 {
     [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.FullUser, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = false, LaunchMode = LaunchMode.SingleInstance)]
     [IntentFilter(new[] { Intent.ActionDefault, Intent.ActionSend }, Categories = new[] { Intent.CategoryDefault }, DataPathPatterns = new[] { ".*\\.osz", ".*\\.osk" }, DataMimeType = "application/*")]
-    [IntentFilter(new[] { Intent.ActionView }, Categories = new[] { Intent.CategoryBrowsable, Intent.CategoryDefault }, DataScheme = osu_url_scheme)]
+    [IntentFilter(new[] { Intent.ActionView }, Categories = new[] { Intent.CategoryBrowsable, Intent.CategoryDefault }, DataSchemes = new[] { "osu", "osump" })]
     public class OsuGameActivity : AndroidGameActivity
     {
-        private const string osu_url_scheme = "osu";
+        private static readonly string[] osu_url_schemes = { "osu", "osump" };
 
         private OsuGameAndroid game;
 
@@ -52,8 +53,8 @@ namespace osu.Android
                 case Intent.ActionDefault:
                     if (intent.Scheme == ContentResolver.SchemeContent)
                         handleImportFromUri(intent.Data);
-                    else if (intent.Scheme == osu_url_scheme)
-                        Task.Run(() => game.HandleLink(intent.DataString));
+                    else if (osu_url_schemes.Contains(intent.Scheme))
+                        game.HandleLink(intent.DataString);
                     break;
 
                 case Intent.ActionSend:


### PR DESCRIPTION
This should resolve the Android part of #10423 and should put Android on par with iOS in terms of integration.

# Summary
This PR adds the ability to handle URI links with the `osu://` scheme on Android. This also sets the `LaunchMode` of the osu! game activity to `SingleInstance` to spawn the activity in a separate task.

# Testing
Done on two devices running android  > 9.0, shouldn't have any problems with versions <= 7.0.
Can easily be tested by pasting some `<a>` tags to an html file with `href` set to an osu! URI.

I've put two links to test behaviour in a html file to be copied directly to the device, zipped under this line because github doesn't accept directly HTML files.
[testing_osu_links.zip](https://github.com/ppy/osu/files/5735689/testing_osu_links.zip)



