### PR TITLE
Improve error handling at realtime room settings screen

### DIFF
--- a/osu.Game/Online/RealtimeMultiplayer/RealtimeMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/RealtimeMultiplayerClient.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Online.RealtimeMultiplayer
         protected override Task<MultiplayerRoom> JoinRoom(long roomId)
         {
             if (!isConnected.Value)
-                return Task.FromCanceled<MultiplayerRoom>(CancellationToken.None);
+                return Task.FromCanceled<MultiplayerRoom>(new CancellationToken(true));
 
             return connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoom), roomId);
         }

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/Match/RealtimeMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/Match/RealtimeMatchSettingsOverlay.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -299,7 +300,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer.Match
                         if (t.IsCompletedSuccessfully)
                             onSuccess(currentRoom.Value);
                         else
-                            onError(t.Exception?.Message ?? "Error changing settings.");
+                            onError(t.Exception?.AsSingular().Message ?? "Error changing settings.");
                     }));
                 }
                 else

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeRoomManager.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Logging;
 using osu.Game.Extensions;
 using osu.Game.Online.Multiplayer;
@@ -91,11 +92,13 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
                     Schedule(() => onSuccess?.Invoke(room));
                 else
                 {
+                    const string message = "Failed to join multiplayer room.";
+
                     if (t.Exception != null)
-                        Logger.Error(t.Exception, "Failed to join multiplayer room.");
+                        Logger.Error(t.Exception, message);
 
                     PartRoom();
-                    Schedule(() => onError?.Invoke(t.Exception?.ToString() ?? string.Empty));
+                    Schedule(() => onError?.Invoke(t.Exception?.AsSingular().Message ?? message));
                 }
             });
         }


### PR DESCRIPTION
- [x] Depends on #11266 for mergeability.

---

- 3b0bf11 resolves apparent misuse of `FromCanceled` reported [on discord here](https://discord.com/channels/188630481301012481/188630652340404224/791327998569218069).
- e495948 makes errors less ugly in multiple respects:
	* Originally `AggregateException`s were logged directly, and those have ugly exception messages due to including inner exception text in them
	* After fixing the issue in the first commit, hitting the not-connected branch resulted in no error message, but a disabled "create match" button - a saner default than `string.Empty` is chosen here
	* Generally we should probably not be printing exceptions raw like this but this is just to restore a semblance of sanity for now.