### PR TITLE
Improve reliability of handling user joined messages

### DIFF
--- a/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeMultiplayer.cs
+++ b/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeMultiplayer.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Game.Screens.Multi.Components;
+using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.RealtimeMultiplayer
 {
@@ -13,6 +15,28 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
 
             AddStep("show", () => LoadScreen(multi));
             AddUntilStep("wait for loaded", () => multi.IsLoaded);
+        }
+
+        [Test]
+        public void TestOneUserJoinedMultipleTimes()
+        {
+            var user = new User { Id = 33 };
+
+            AddRepeatStep("add user multiple times", () => Client.AddUser(user), 3);
+
+            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
+        }
+
+        [Test]
+        public void TestOneUserLeftMultipleTimes()
+        {
+            var user = new User { Id = 44 };
+
+            AddStep("add user", () => Client.AddUser(user));
+            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
+
+            AddRepeatStep("remove user multiple times", () => Client.RemoveUser(user), 3);
+            AddAssert("room has 1 user", () => Client.Room?.Users.Count == 1);
         }
 
         private class TestRealtimeMultiplayer : Screens.Multi.RealtimeMultiplayer.RealtimeMultiplayer

--- a/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeReadyButton.cs
+++ b/osu.Game.Tests/Visual/RealtimeMultiplayer/TestSceneRealtimeReadyButton.cs
@@ -55,8 +55,6 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
                     }
                 }
             };
-
-            Client.AddUser(API.LocalUser.Value);
         });
 
         [Test]

--- a/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/RealtimeMultiplayer/StatefulMultiplayerClient.cs
@@ -226,6 +226,10 @@ namespace osu.Game.Online.RealtimeMultiplayer
                 if (Room == null)
                     return;
 
+                // for sanity, ensure that there can be no duplicate users in the room user list.
+                if (Room.Users.Any(existing => existing.UserID == user.UserID))
+                    return;
+
                 Room.Users.Add(user);
 
                 RoomChanged?.Invoke();

--- a/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/RealtimeMultiplayer/TestRealtimeMultiplayerClient.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.RealtimeMultiplayer
         public void RemoveUser(User user)
         {
             Debug.Assert(Room != null);
-            ((IMultiplayerClient)this).UserLeft(Room.Users.Single(u => u.User == user));
+            ((IMultiplayerClient)this).UserLeft(new MultiplayerRoomUser(user.Id));
 
             Schedule(() =>
             {


### PR DESCRIPTION
Fixes intermittent test failures as seen in https://ci.appveyor.com/project/peppy/osu/builds/36971822/tests (one instance of many).

`TestSceneRealtimeReadyButton` was manually adding `API.LocalUser`, which wasn't actually needed. The base `RealtimeMultiplayerTestScene` by default creates a new room as `API.LocalUser`, therefore automatically adding that user to the room - and as such there is no need to add them manually unless the `joinRoom` ctor param is specified as `false`.

While those test failures were a shortcoming of the test (which is fixed with the first commit here), they exposed a potential vulnerable point of the multiplayer client logic. In case of unreliable message delivery it is not unreasonable that duplicate messages might arrive, in which case the same scenario that failed in the tests could crash the game.

To ensure that is not the case, explicitly screen each new joined user against the room user list, to ensure that duplicates do not show up. `UserLeft` is already tolerant in that respect (if a user is requested to be removed twice by the server, the second removal just won't do anything).

I've also added test coverage for such edge-case scenarios, mostly for posterity.