### PR TITLE
Fix spectator client sending no data if there is no local user input

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
         }
 
-        private double latency = SpectatorStreamingClient.TIME_BETWEEN_SENDS;
+        private double latency = SpectatorStreamingClient.MIN_TIME_BETWEEN_SENDS;
 
         protected override void Update()
         {

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -29,9 +29,15 @@ namespace osu.Game.Online.Spectator
     public class SpectatorStreamingClient : Component, ISpectatorClient
     {
         /// <summary>
-        /// The maximum milliseconds between frame bundle sends.
+        /// The minimum milliseconds between frame bundle sends.
         /// </summary>
-        public const double TIME_BETWEEN_SENDS = 200;
+        public const double MIN_TIME_BETWEEN_SENDS = 200;
+
+        /// <summary>
+        /// The maximum milliseconds between frame bundle sends.
+        /// A frame bundle will always be sent at least once after this duration elapsees.
+        /// </summary>
+        public const double MAX_TIME_BETWEEN_SENDS = 1000;
 
         private HubConnection connection;
 
@@ -292,7 +298,10 @@ namespace osu.Game.Online.Spectator
         {
             base.Update();
 
-            if (pendingFrames.Count > 0 && Time.Current - lastSendTime > TIME_BETWEEN_SENDS)
+            double timeSinceLastSend = Time.Current - lastSendTime;
+
+            if ((pendingFrames.Count > 0 && timeSinceLastSend > MIN_TIME_BETWEEN_SENDS)
+                || (currentScore != null && timeSinceLastSend > MAX_TIME_BETWEEN_SENDS))
                 purgePendingFrames();
         }
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -268,6 +268,12 @@ namespace osu.Game.Rulesets.UI
             return false;
         }
 
+        public override void EndRecording()
+        {
+            if ((KeyBindingInputManager is IHasRecordingHandler recordingInputManager))
+                recordingInputManager.Recorder = null;
+        }
+
         public sealed override void SetRecordTarget(Score score)
         {
             if (!(KeyBindingInputManager is IHasRecordingHandler recordingInputManager))
@@ -518,6 +524,11 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         /// <param name="score">The target to be recorded to.</param>
         public abstract void SetRecordTarget(Score score);
+
+        /// <summary>
+        /// End recording of gameplay, if any recording is active.
+        /// </summary>
+        public abstract void EndRecording();
 
         /// <summary>
         /// Invoked when the interactive user requests resuming from a paused state.

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -55,7 +55,9 @@ namespace osu.Game.Rulesets.UI
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
             spectatorStreaming?.EndPlaying();
+            spectatorStreaming = null;
         }
 
         protected override bool OnMouseMove(MouseMoveEvent e)

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -30,12 +30,21 @@ namespace osu.Game.Rulesets.UI
         {
             set
             {
-                if (recorder != null)
-                    throw new InvalidOperationException("Cannot attach more than one recorder");
+                if (value == null)
+                {
+                    if (recorder == null) return;
 
-                recorder = value;
+                    KeyBindingContainer.Remove(recorder);
+                    recorder.Dispose();
+                }
+                else
+                {
+                    if (recorder != null)
+                        throw new InvalidOperationException("Cannot attach more than one recorder");
 
-                KeyBindingContainer.Add(recorder);
+                    recorder = value;
+                    KeyBindingContainer.Add(recorder);
+                }
             }
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -539,6 +539,8 @@ namespace osu.Game.Screens.Play
 
             ValidForResume = false;
 
+            DrawableRuleset.EndRecording();
+
             if (!showResults) return;
 
             scoreSubmissionTask ??= Task.Run(async () =>


### PR DESCRIPTION
This half fixes the issue of idle input looking the same as the user being paused to someone spectating a user. It is mainly intended to fix the multiplayer scoreboard, as this fix only covers the cases where `FrameBundleHeader` data is user, not where time / frame information is required.

A further fix will be required to keep player moving forward during such periods, likely by sending the last input frame with an updated timestamp. This requires the `SpectatorStreamingClient` to know about game time which adds further complexity, so I've left it as a follow up task.

Note that this continues to send updates while paused or at a retry screen. These scenarios should also be handled better in the future.