### PR TITLE
Include accuracy value in spectator frame header

### DIFF
--- a/osu.Game/Online/Spectator/FrameHeader.cs
+++ b/osu.Game/Online/Spectator/FrameHeader.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Online.Spectator
     public class FrameHeader
     {
         /// <summary>
+        /// The current accuracy of the score.
+        /// </summary>
+        public double Accuracy { get; set; }
+
+        /// <summary>
         /// The current combo of the score.
         /// </summary>
         public int Combo { get; set; }
@@ -42,16 +47,18 @@ namespace osu.Game.Online.Spectator
         {
             Combo = score.Combo;
             MaxCombo = score.MaxCombo;
+            Accuracy = score.Accuracy;
 
             // copy for safety
             Statistics = new Dictionary<HitResult, int>(score.Statistics);
         }
 
         [JsonConstructor]
-        public FrameHeader(int combo, int maxCombo, Dictionary<HitResult, int> statistics, DateTimeOffset receivedTime)
+        public FrameHeader(int combo, int maxCombo, double accuracy, Dictionary<HitResult, int> statistics, DateTimeOffset receivedTime)
         {
             Combo = combo;
             MaxCombo = maxCombo;
+            Accuracy = accuracy;
             Statistics = statistics;
             ReceivedTime = receivedTime;
         }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Rulesets.Scoring
         private void updateScore()
         {
             if (rollingMaxBaseScore != 0)
-                Accuracy.Value = baseScore / rollingMaxBaseScore;
+                Accuracy.Value = calculateAccuracyRatio(baseScore, true);
 
             TotalScore.Value = getScore(Mode.Value);
         }
@@ -233,13 +233,13 @@ namespace osu.Game.Rulesets.Scoring
         }
 
         /// <summary>
-        /// Given a minimal set of inputs, return the computed score and accuracy for the tracked beatmap / mods combination, at the current point in time.
+        /// Given a minimal set of inputs, return the computed score for the tracked beatmap / mods combination, at the current point in time.
         /// </summary>
         /// <param name="mode">The <see cref="ScoringMode"/> to compute the total score in.</param>
         /// <param name="maxCombo">The maximum combo achievable in the beatmap.</param>
         /// <param name="statistics">Statistics to be used for calculating accuracy, bonus score, etc.</param>
-        /// <returns>The computed score and accuracy for provided inputs.</returns>
-        public (double score, double accuracy) GetScoreAndAccuracy(ScoringMode mode, int maxCombo, Dictionary<HitResult, int> statistics)
+        /// <returns>The computed score for provided inputs.</returns>
+        public double GetImmediateScore(ScoringMode mode, int maxCombo, Dictionary<HitResult, int> statistics)
         {
             // calculate base score from statistics pairs
             int computedBaseScore = 0;
@@ -252,12 +252,7 @@ namespace osu.Game.Rulesets.Scoring
                 computedBaseScore += Judgement.ToNumericResult(pair.Key) * pair.Value;
             }
 
-            double pointInTimeAccuracy = calculateAccuracyRatio(computedBaseScore, true);
-            double comboRatio = calculateComboRatio(maxCombo);
-
-            double score = GetScore(mode, maxAchievableCombo, calculateAccuracyRatio(computedBaseScore), comboRatio, scoreResultCounts);
-
-            return (score, pointInTimeAccuracy);
+            return GetScore(mode, maxAchievableCombo, calculateAccuracyRatio(computedBaseScore), calculateComboRatio(maxCombo), scoreResultCounts);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -122,8 +122,8 @@ namespace osu.Game.Screens.Play.HUD
                 if (LastHeader == null)
                     return;
 
-                (score.Value, accuracy.Value) = processor.GetScoreAndAccuracy(mode, LastHeader.MaxCombo, LastHeader.Statistics);
-
+                score.Value = processor.GetImmediateScore(mode, LastHeader.MaxCombo, LastHeader.Statistics);
+                accuracy.Value = LastHeader.Accuracy;
                 currentCombo.Value = LastHeader.Combo;
             }
         }


### PR DESCRIPTION
Until now, we were relying on a "mostly correct" method of determining other users' display accuracy in multiplayer games. This would cause issues when latency is involves, as it was using the local value for `maxBaseScore` rather than remote (resulting in incorrect accuracy display, sometimes above 100%).

This solves the issue in the simplest way: sending the accuracy as seen by the remote client in the header data. Another option would be sending the `maxBaseScore` instead, and this was actually my preference, but it is a bit more complicated to implement as the value is not available in `ScoreInfo` (which is what we currently source all header information from).

Requires a server deploy to correctly serialize/deserialize the new header data.