### PR TITLE
Don't begin gameplay until all users are in a completely prepared state

### DIFF
--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.RealtimeMultiplayer;
 using osu.Game.Scoring;
@@ -33,12 +33,13 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
         private IBindable<bool> isConnected;
 
         private readonly TaskCompletionSource<bool> resultsReady = new TaskCompletionSource<bool>();
-        private readonly ManualResetEventSlim startedEvent = new ManualResetEventSlim();
 
         [CanBeNull]
         private MultiplayerGameplayLeaderboard leaderboard;
 
         private readonly int[] userIds;
+
+        private LoadingLayer loadingDisplay;
 
         /// <summary>
         /// Construct a multiplayer player.
@@ -60,6 +61,12 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             client.MatchStarted += onMatchStarted;
             client.ResultsReady += onResultsReady;
 
+            ScoreProcessor.HasCompleted.BindValueChanged(completed =>
+            {
+                // wait for server to tell us that results are ready (see SubmitScore implementation)
+                loadingDisplay.Show();
+            });
+
             isConnected = client.IsConnected.GetBoundCopy();
             isConnected.BindValueChanged(connected =>
             {
@@ -70,19 +77,20 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
                 }
             }, true);
 
-            client.ChangeState(MultiplayerUserState.Loaded)
-                  .ContinueWith(task => failAndBail(task.Exception?.Message ?? "Server error"), TaskContinuationOptions.NotOnRanToCompletion);
-
-            if (!startedEvent.Wait(TimeSpan.FromSeconds(30)))
-            {
-                failAndBail("Failed to start the multiplayer match in time.");
-                return;
-            }
-
             Debug.Assert(client.Room != null);
 
             // todo: this should be implemented via a custom HUD implementation, and correctly masked to the main content area.
             LoadComponentAsync(leaderboard = new MultiplayerGameplayLeaderboard(ScoreProcessor, userIds), HUDOverlay.Add);
+
+            HUDOverlay.Add(loadingDisplay = new LoadingLayer(DrawableRuleset) { Depth = float.MaxValue });
+        }
+
+        protected override void StartGameplay()
+        {
+            // block base call, but let the server know we are ready to start.
+            loadingDisplay.Show();
+
+            client.ChangeState(MultiplayerUserState.Loaded).ContinueWith(task => failAndBail(task.Exception?.Message ?? "Server error"), TaskContinuationOptions.NotOnRanToCompletion);
         }
 
         private void failAndBail(string message = null)
@@ -90,7 +98,6 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             if (!string.IsNullOrEmpty(message))
                 Logger.Log(message, LoggingTarget.Runtime, LogLevel.Important);
 
-            startedEvent.Set();
             Schedule(() => PerformExit(false));
         }
 
@@ -112,7 +119,11 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
                 padding + HUDOverlay.TopScoringElementsHeight);
         }
 
-        private void onMatchStarted() => startedEvent.Set();
+        private void onMatchStarted() => Scheduler.Add(() =>
+        {
+            loadingDisplay.Hide();
+            base.StartGameplay();
+        });
 
         private void onResultsReady() => resultsReady.SetResult(true);
 
@@ -124,7 +135,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
             // Await up to 30 seconds for results to become available (3 api request timeouts).
             // This is arbitrary just to not leave the player in an essentially deadlocked state if any connection issues occur.
-            await Task.WhenAny(resultsReady.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+            await Task.WhenAny(resultsReady.Task, Task.Delay(TimeSpan.FromSeconds(60)));
         }
 
         protected override ResultsScreen CreateResults(ScoreInfo score)

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimePlayer.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
             await client.ChangeState(MultiplayerUserState.FinishedPlay);
 
-            // Await up to 30 seconds for results to become available (3 api request timeouts).
+            // Await up to 60 seconds for results to become available (6 api request timeouts).
             // This is arbitrary just to not leave the player in an essentially deadlocked state if any connection issues occur.
             await Task.WhenAny(resultsReady.Task, Task.Delay(TimeSpan.FromSeconds(60)));
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -723,9 +723,6 @@ namespace osu.Game.Screens.Play
 
             storyboardReplacesBackground.Value = Beatmap.Value.Storyboard.ReplacesBackground && Beatmap.Value.Storyboard.HasDrawable;
 
-            GameplayClockContainer.Restart();
-            GameplayClockContainer.FadeInFromZero(750, Easing.OutQuint);
-
             foreach (var mod in Mods.Value.OfType<IApplicableToPlayer>())
                 mod.ApplyToPlayer(this);
 
@@ -740,6 +737,21 @@ namespace osu.Game.Screens.Play
                 mod.ApplyToTrack(musicController.CurrentTrack);
 
             updateGameplayState();
+
+            GameplayClockContainer.FadeInFromZero(750, Easing.OutQuint);
+            StartGameplay();
+        }
+
+        /// <summary>
+        /// Called to trigger the starting of the gameplay clock and underlying gameplay.
+        /// This will be called on entering the player screen once. A derived class may block the first call to this to delay the start of gameplay.
+        /// </summary>
+        protected virtual void StartGameplay()
+        {
+            if (GameplayClockContainer.GameplayClock.IsRunning)
+                throw new InvalidOperationException($"{nameof(StartGameplay)} should not be called when the gameplay clock is already running");
+
+            GameplayClockContainer.Restart();
         }
 
         public override void OnSuspending(IScreen next)


### PR DESCRIPTION
Before this change, players' clients would signal ready when the bulk of the beatmap processing completed, but while the user still had the ability to interrupt the gameplay start process (by, for instance, hovering the settings on the `PlayerLoader` screen). A client may also show a notification during this period indefinitely blocking gameplay start.

To ensure that all players start in sync, I've moved the "is loaded" state change to now be when the gameplay clock is ready to start. This is at a point where the user has no ability to interrupt the start of gameplay.

This also adds a loading overlay which signifies that the game is waiting on other players. Note that this does not have any explanatory text, but I intend to show status updates on the leaderboard as to which players we are waiting on, which should give enough visual cues for the time being.