### PR TITLE
Schedule UpdateFilter calls to avoid operations occuring while at a sub screen

### DIFF
--- a/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
+++ b/osu.Game/Screens/Multi/Lounge/Components/FilterControl.cs
@@ -98,7 +98,9 @@ namespace osu.Game.Screens.Multi.Lounge.Components
             scheduledFilterUpdate = Scheduler.AddDelayed(UpdateFilter, 200);
         }
 
-        protected void UpdateFilter()
+        protected void UpdateFilter() => Scheduler.AddOnce(updateFilter);
+
+        private void updateFilter()
         {
             scheduledFilterUpdate?.Cancel();
 


### PR DESCRIPTION
Without this, filter operations can occur when at a multiplayer subscreen. This means that changing the ruleset at `MatchSongSelect` can run a filter, which (for whatever reason) completely breaks the playlist item of the room a user is currently joined to. It's probably worth finding the root cause if this, but I can imagine what it is (reference to the room is the same, and being altered from outside).

I changed all calls to flow through an `AddOnce` path because we definitely don't want to be running this more than once if we can avoid it. The important part is that they are always scheduled though (and therefore will not run when at a sub screen).

Reproduction on master:

- create a room
- post creation, change the beatmap and change your ruleset at the song select screen.
- beatmap will no longer display; ready button will be disabled.