### PR TITLE
Rename "timeshift" to "playlists"

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiHeader.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiHeader.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Children = new Drawable[]
             {
                 screenStack,
-                new Header(screenStack)
+                new Header("Multiplayer", screenStack)
             };
 
             AddStep("push multi screen", () => screenStack.CurrentScreen.Push(new TestMultiplayerSubScreen(++index)));

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Screens.Menu
         {
             buttonsPlay.Add(new Button(@"solo", @"button-solo-select", FontAwesome.Solid.User, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
             buttonsPlay.Add(new Button(@"multi", @"button-generic-select", FontAwesome.Solid.Users, new Color4(94, 63, 186, 255), onMultiplayer, 0, Key.M));
-            buttonsPlay.Add(new Button(@"timeshift", @"button-generic-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onTimeshift, 0, Key.L));
+            buttonsPlay.Add(new Button(@"playlists", @"button-generic-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onTimeshift, 0, Key.L));
             buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
 
             buttonsTopLevel.Add(new Button(@"play", @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH, Key.P));

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Screens.Menu
                 "Most of the web content (profiles, rankings, etc.) are available natively in-game from the icons on the toolbar!",
                 "Get more details, hide or delete a beatmap by right-clicking on its panel at song select!",
                 "All delete operations are temporary until exiting. Restore accidentally deleted content from the maintenance settings!",
-                "Check out the \"timeshift\" multiplayer system, which has local permanent leaderboards and playlist support!",
+                "Check out the \"playlist\" system, which lets users create their own custom and permanent leaderboards!",
                 "Toggle advanced frame / thread statistics with Ctrl-F11!",
                 "Take a look under the hood at performance counters and enable verbose performance logging with Ctrl-F2!",
             };

--- a/osu.Game/Screens/Menu/Disclaimer.cs
+++ b/osu.Game/Screens/Menu/Disclaimer.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Screens.Menu
                 "Most of the web content (profiles, rankings, etc.) are available natively in-game from the icons on the toolbar!",
                 "Get more details, hide or delete a beatmap by right-clicking on its panel at song select!",
                 "All delete operations are temporary until exiting. Restore accidentally deleted content from the maintenance settings!",
-                "Check out the \"playlist\" system, which lets users create their own custom and permanent leaderboards!",
+                "Check out the \"playlists\" system, which lets users create their own custom and permanent leaderboards!",
                 "Toggle advanced frame / thread statistics with Ctrl-F11!",
                 "Take a look under the hood at performance counters and enable verbose performance logging with Ctrl-F2!",
             };

--- a/osu.Game/Screens/Multi/Header.cs
+++ b/osu.Game/Screens/Multi/Header.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Multi
     {
         public const float HEIGHT = 80;
 
-        public Header(ScreenStack stack)
+        public Header(string mainTitle, ScreenStack stack)
         {
             RelativeSizeAxes = Axes.X;
             Height = HEIGHT;
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Multi
                     Padding = new MarginPadding { Left = WaveOverlayContainer.WIDTH_PADDING + OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
                     Children = new Drawable[]
                     {
-                        title = new MultiHeaderTitle
+                        title = new MultiHeaderTitle(mainTitle)
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.BottomLeft,
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Multi
                 set => pageTitle.Text = value.ShortTitle.Titleize();
             }
 
-            public MultiHeaderTitle()
+            public MultiHeaderTitle(string mainTitle)
             {
                 AutoSizeAxes = Axes.Both;
 
@@ -98,7 +98,7 @@ namespace osu.Game.Screens.Multi
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                                 Font = OsuFont.GetFont(size: 24),
-                                Text = "Multiplayer"
+                                Text = mainTitle
                             },
                             dot = new OsuSpriteText
                             {

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.Multi
                             screenStack = new MultiplayerSubScreenStack { RelativeSizeAxes = Axes.Both }
                         }
                     },
-                    new Header(screenStack),
+                    new Header(ScreenTitle, screenStack),
                     createButton = CreateNewMultiplayerGameButton().With(button =>
                     {
                         button.Anchor = Anchor.TopRight;
@@ -310,6 +310,8 @@ namespace osu.Game.Screens.Multi
         }
 
         protected IScreen CurrentSubScreen => screenStack.CurrentScreen;
+
+        protected abstract string ScreenTitle { get; }
 
         protected abstract RoomManager CreateRoomManager();
 

--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Multi
         private OsuGameBase game { get; set; }
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        protected IAPIProvider API { get; private set; }
 
         [Resolved(CanBeNull = true)]
         private OsuLogo logo { get; set; }
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.Multi
         [BackgroundDependencyLoader(true)]
         private void load(IdleTracker idleTracker)
         {
-            apiState.BindTo(api.State);
+            apiState.BindTo(API.State);
             apiState.BindValueChanged(onlineStateChanged, true);
 
             if (idleTracker != null)
@@ -269,7 +269,7 @@ namespace osu.Game.Screens.Multi
         /// Creates a new room.
         /// </summary>
         /// <returns>The created <see cref="Room"/>.</returns>
-        protected virtual Room CreateNewRoom() => new Room { Name = { Value = $"{api.LocalUser}'s awesome room" } };
+        protected abstract Room CreateNewRoom();
 
         private void screenPushed(IScreen lastScreen, IScreen newScreen)
         {

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/CreateRealtimeMatchButton.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/CreateRealtimeMatchButton.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
         {
             Triangles.TriangleScale = 1.5f;
 
-            Text = "Create match";
+            Text = "Create room";
 
             ((IBindable<bool>)Enabled).BindTo(multiplayerClient.IsConnected);
         }

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSubScreen.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMatchSubScreen.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
     {
         public override string Title { get; }
 
-        public override string ShortTitle => "match";
+        public override string ShortTitle => "room";
 
         [Resolved]
         private StatefulMultiplayerClient client { get; set; }
@@ -37,7 +37,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
         public RealtimeMatchSubScreen(Room room)
         {
-            Title = room.RoomID.Value == null ? "New match" : room.Name.Value;
+            Title = room.RoomID.Value == null ? "New room" : room.Name.Value;
             Activity.Value = new UserActivity.InLobby(room);
         }
 

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
             return room;
         }
 
+        protected override string ScreenTitle => "Multiplayer";
+
         protected override RoomManager CreateRoomManager() => new RealtimeRoomManager();
 
         protected override LoungeSubScreen CreateLounge() => new RealtimeLoungeSubScreen();

--- a/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
+++ b/osu.Game/Screens/Multi/RealtimeMultiplayer/RealtimeMultiplayer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.Multi.RealtimeMultiplayer
 
         protected override Room CreateNewRoom()
         {
-            var room = base.CreateNewRoom();
+            var room = new Room { Name = { Value = $"{API.LocalUser}'s awesome room" } };
             room.Category.Value = RoomCategory.Realtime;
             return room;
         }

--- a/osu.Game/Screens/Multi/Timeshift/CreateTimeshiftRoomButton.cs
+++ b/osu.Game/Screens/Multi/Timeshift/CreateTimeshiftRoomButton.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.Multi.Timeshift
         {
             Triangles.TriangleScale = 1.5f;
 
-            Text = "Create room";
+            Text = "Create playlist";
         }
     }
 }

--- a/osu.Game/Screens/Multi/Timeshift/TimeshiftMultiplayer.cs
+++ b/osu.Game/Screens/Multi/Timeshift/TimeshiftMultiplayer.cs
@@ -51,6 +51,8 @@ namespace osu.Game.Screens.Multi.Timeshift
             return new Room { Name = { Value = $"{API.LocalUser}'s awesome playlist" } };
         }
 
+        protected override string ScreenTitle => "Playlists";
+
         protected override RoomManager CreateRoomManager() => new TimeshiftRoomManager();
 
         protected override LoungeSubScreen CreateLounge() => new TimeshiftLoungeSubScreen();

--- a/osu.Game/Screens/Multi/Timeshift/TimeshiftMultiplayer.cs
+++ b/osu.Game/Screens/Multi/Timeshift/TimeshiftMultiplayer.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.Multi.Components;
 using osu.Game.Screens.Multi.Lounge;
 using osu.Game.Screens.Multi.Match;
@@ -43,6 +44,11 @@ namespace osu.Game.Screens.Multi.Timeshift
             }
 
             Logger.Log($"Polling adjusted (listing: {timeshiftManager.TimeBetweenListingPolls.Value}, selection: {timeshiftManager.TimeBetweenSelectionPolls.Value})");
+        }
+
+        protected override Room CreateNewRoom()
+        {
+            return new Room { Name = { Value = $"{API.LocalUser}'s awesome playlist" } };
         }
 
         protected override RoomManager CreateRoomManager() => new TimeshiftRoomManager();

--- a/osu.Game/Screens/Multi/Timeshift/TimeshiftRoomSubScreen.cs
+++ b/osu.Game/Screens/Multi/Timeshift/TimeshiftRoomSubScreen.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Multi.Timeshift
     {
         public override string Title { get; }
 
-        public override string ShortTitle => "room";
+        public override string ShortTitle => "playlist";
 
         [Resolved(typeof(Room), nameof(Room.RoomID))]
         private Bindable<int?> roomId { get; set; }
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Multi.Timeshift
 
         public TimeshiftRoomSubScreen(Room room)
         {
-            Title = room.RoomID.Value == null ? "New room" : room.Name.Value;
+            Title = room.RoomID.Value == null ? "New playlist" : room.Name.Value;
             Activity.Value = new UserActivity.InLobby(room);
         }
 


### PR DESCRIPTION
This only covers the user-facing instances. Code and class name changes will happen once things have calmed down. Note that there's still quite a few references (especially in the `Multiplayer` class) to "room" where it should really say "playlist". These will take a bit more work an abstraction.

This is just important to set the branding apart of "realtime" multiplayer and "timeshift" multiplayer, so we stop referring to multiplayer with the silly "realtime" prefix. Multiplayer *is* real-time.