### PR TITLE
Fix multiplayer gameplay potentially looping audio after reaching end

### DIFF
--- a/osu.Game/Screens/Multi/Multiplayer.cs
+++ b/osu.Game/Screens/Multi/Multiplayer.cs
@@ -202,6 +202,11 @@ namespace osu.Game.Screens.Multi
         {
             this.FadeIn();
             waves.Show();
+
+            if (loungeSubScreen.IsCurrentScreen())
+                loungeSubScreen.OnEntering(last);
+            else
+                loungeSubScreen.MakeCurrent();
         }
 
         public override void OnResuming(IScreen last)
@@ -209,6 +214,7 @@ namespace osu.Game.Screens.Multi
             this.FadeIn(250);
             this.ScaleTo(1, 250, Easing.OutSine);
 
+            screenStack.CurrentScreen?.OnResuming(last);
             base.OnResuming(last);
 
             UpdatePollingRate(isIdle.Value);
@@ -218,6 +224,8 @@ namespace osu.Game.Screens.Multi
         {
             this.ScaleTo(1.1f, 250, Easing.InSine);
             this.FadeOut(250);
+
+            screenStack.CurrentScreen?.OnSuspending(next);
 
             UpdatePollingRate(isIdle.Value);
         }
@@ -230,9 +238,7 @@ namespace osu.Game.Screens.Multi
 
             this.Delay(WaveContainer.DISAPPEAR_DURATION).FadeOut();
 
-            if (screenStack.CurrentScreen != null)
-                loungeSubScreen.MakeCurrent();
-
+            screenStack.CurrentScreen?.OnExiting(next);
             base.OnExiting(next);
             return false;
         }


### PR DESCRIPTION
Fixes the track potentially looping in player, therefore preventing users from progressing to results. For 100% reproduction of that issue, comment out the body of `onResultsReady()` in `RealtimePlayer`.

Must have been an issue all along, but probably masked by the fact that player exited too fast to begin looping.

Not a 100% sure this is proper but it seems to behave properly, pass multiplayer tests and makes sense to me code-wise.