### PR TITLE
Fix account creation overlay not showing up the first time after a log-out

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneAccountCreationOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneAccountCreationOverlay.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -13,13 +14,12 @@ namespace osu.Game.Tests.Visual.Online
     public class TestSceneAccountCreationOverlay : OsuTestScene
     {
         private readonly Container userPanelArea;
+        private readonly AccountCreationOverlay accountCreation;
 
         private IBindable<User> localUser;
 
         public TestSceneAccountCreationOverlay()
         {
-            AccountCreationOverlay accountCreation;
-
             Children = new Drawable[]
             {
                 accountCreation = new AccountCreationOverlay(),
@@ -31,8 +31,6 @@ namespace osu.Game.Tests.Visual.Online
                     Origin = Anchor.TopRight,
                 },
             };
-
-            AddStep("show", () => accountCreation.Show());
         }
 
         [BackgroundDependencyLoader]
@@ -42,8 +40,19 @@ namespace osu.Game.Tests.Visual.Online
 
             localUser = API.LocalUser.GetBoundCopy();
             localUser.BindValueChanged(user => { userPanelArea.Child = new UserGridPanel(user.NewValue) { Width = 200 }; }, true);
+        }
 
-            AddStep("logout", API.Logout);
+        [Test]
+        public void TestOverlayVisibility()
+        {
+            AddStep("start hidden", () => accountCreation.Hide());
+            AddStep("log out", API.Logout);
+
+            AddStep("show manually", () => accountCreation.Show());
+            AddUntilStep("overlay is visible", () => accountCreation.State.Value == Visibility.Visible);
+
+            AddStep("log back in", () => API.Login("dummy", "password"));
+            AddUntilStep("overlay is hidden", () => accountCreation.State.Value == Visibility.Hidden);
         }
     }
 }


### PR DESCRIPTION
Resolves #11303.

Regressed in #10579. Scheduling the entire API state change callback caused the scheduled hide to fire the first time the user attempted to display the account creation overlay after a logout, because the drawable wasn't present before that (so its scheduler wasn't running).

It is not theoretically safe to run `Hide()` unscheduled at its present call site (as the value change callbacks are fired on the background API thread). This could also be fixed by setting `AlwaysPresent = true`, but that's a pretty ugly and unperformant change to make in general.