### PR TITLE
Fix crash on local user not being present when updating the ready button display

### DIFF
--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// Invoked when any change occurs to the multiplayer room.
         /// </summary>
-        public event Action? RoomChanged;
+        public event Action? RoomUpdated;
 
         /// <summary>
         /// Invoked when the multiplayer server requests the current beatmap to be loaded into play.
@@ -134,7 +134,7 @@ namespace osu.Game.Online.Multiplayer
                 apiRoom = null;
                 Room = null;
 
-                RoomChanged?.Invoke();
+                RoomUpdated?.Invoke();
             });
 
             return Task.CompletedTask;
@@ -214,7 +214,7 @@ namespace osu.Game.Online.Multiplayer
                         break;
                 }
 
-                RoomChanged?.Invoke();
+                RoomUpdated?.Invoke();
             });
 
             return Task.CompletedTask;
@@ -238,7 +238,7 @@ namespace osu.Game.Online.Multiplayer
 
                 Room.Users.Add(user);
 
-                RoomChanged?.Invoke();
+                RoomUpdated?.Invoke();
             });
         }
 
@@ -255,7 +255,7 @@ namespace osu.Game.Online.Multiplayer
                 Room.Users.Remove(user);
                 PlayingUsers.Remove(user.UserID);
 
-                RoomChanged?.Invoke();
+                RoomUpdated?.Invoke();
             });
 
             return Task.CompletedTask;
@@ -278,7 +278,7 @@ namespace osu.Game.Online.Multiplayer
                 Room.Host = user;
                 apiRoom.Host.Value = user?.User;
 
-                RoomChanged?.Invoke();
+                RoomUpdated?.Invoke();
             });
 
             return Task.CompletedTask;
@@ -305,7 +305,7 @@ namespace osu.Game.Online.Multiplayer
                 if (state != MultiplayerUserState.Playing)
                     PlayingUsers.Remove(userId);
 
-                RoomChanged?.Invoke();
+                RoomUpdated?.Invoke();
             });
 
             return Task.CompletedTask;
@@ -419,7 +419,7 @@ namespace osu.Game.Online.Multiplayer
                 // In-order for the client to not display an outdated beatmap, the playlist is forcefully cleared here.
                 apiRoom.Playlist.Clear();
 
-                RoomChanged?.Invoke();
+                RoomUpdated?.Invoke();
 
                 var req = new GetBeatmapSetRequest(settings.BeatmapID, BeatmapSetLookupType.BeatmapId);
                 req.Success += res => updatePlaylist(settings, res);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -60,7 +60,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         {
             base.OnRoomUpdated();
 
-            localUser = Room?.Users.Single(u => u.User?.Id == api.LocalUser.Value.Id);
+            // this method is called on leaving the room, so the local user may not exist in the room any more.
+            localUser = Room?.Users.SingleOrDefault(u => u.User?.Id == api.LocalUser.Value.Id);
+
             button.Enabled.Value = Client.Room?.State == MultiplayerRoomState.Open;
             updateState();
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -56,9 +56,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             sampleReadyCount = audio.Samples.Get(@"SongSelect/select-difficulty");
         }
 
-        protected override void OnRoomChanged()
+        protected override void OnRoomUpdated()
         {
-            base.OnRoomChanged();
+            base.OnRoomUpdated();
 
             localUser = Room?.Users.Single(u => u.User?.Id == api.LocalUser.Value.Id);
             button.Enabled.Value = Client.Room?.State == MultiplayerRoomState.Open;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomComposite.cs
@@ -19,18 +19,21 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
-            Client.RoomChanged += OnRoomChanged;
-            OnRoomChanged();
+            Client.RoomUpdated += OnRoomUpdated;
+            OnRoomUpdated();
         }
 
-        protected virtual void OnRoomChanged()
+        /// <summary>
+        /// Invoked when any change occurs to the multiplayer room.
+        /// </summary>
+        protected virtual void OnRoomUpdated()
         {
         }
 
         protected override void Dispose(bool isDisposing)
         {
             if (Client != null)
-                Client.RoomChanged -= OnRoomChanged;
+                Client.RoomUpdated -= OnRoomUpdated;
 
             base.Dispose(isDisposing);
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -135,9 +135,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             };
         }
 
-        protected override void OnRoomChanged()
+        protected override void OnRoomUpdated()
         {
-            base.OnRoomChanged();
+            base.OnRoomUpdated();
 
             if (Room == null)
                 return;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantsList.cs
@@ -36,9 +36,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             };
         }
 
-        protected override void OnRoomChanged()
+        protected override void OnRoomUpdated()
         {
-            base.OnRoomChanged();
+            base.OnRoomUpdated();
 
             if (Room == null)
                 panels.Clear();


### PR DESCRIPTION
Also renames a confusing event (wasn't sure if it was fired when the room instance changed.. hopefully renaming from Changed to Updated helps with understanding this).

- [x] Depends on #11316
- Closes #11292.