### PR TITLE
Fix copying a multiplayer room attempting to create a playlist room instead

### DIFF
--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -130,6 +130,7 @@ namespace osu.Game.Online.Rooms
         {
             RoomID.Value = other.RoomID.Value;
             Name.Value = other.Name.Value;
+            Category.Value = other.Category.Value;
 
             if (other.Host.Value != null && Host.Value?.Id != other.Host.Value.Id)
                 Host.Value = other.Host.Value;

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -130,7 +130,9 @@ namespace osu.Game.Online.Rooms
         {
             RoomID.Value = other.RoomID.Value;
             Name.Value = other.Name.Value;
-            Category.Value = other.Category.Value;
+
+            if (other.Category.Value != RoomCategory.Spotlight)
+                Category.Value = other.Category.Value;
 
             if (other.Host.Value != null && Host.Value?.Id != other.Host.Value.Id)
                 Host.Value = other.Host.Value;


### PR DESCRIPTION
Fixes #11310 by properly copying the `Category` value, as described in the issue. 