### PR TITLE
Fix leaderboard showing score updates for quit users

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -20,11 +20,12 @@ using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Tests.Visual.Multiplayer;
 using osu.Game.Tests.Visual.Online;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
-    public class TestSceneMultiplayerGameplayLeaderboard : OsuTestScene
+    public class TestSceneMultiplayerGameplayLeaderboard : MultiplayerTestScene
     {
         [Cached(typeof(SpectatorStreamingClient))]
         private TestMultiplayerStreaming streamingClient = new TestMultiplayerStreaming(16);
@@ -47,7 +48,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [SetUpSteps]
-        public void SetUpSteps()
+        public override void SetUpSteps()
         {
             AddStep("create leaderboard", () =>
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -54,6 +54,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep("create leaderboard", () =>
             {
+                leaderboard?.Expire();
+
                 OsuScoreProcessor scoreProcessor;
                 Beatmap.Value = CreateWorkingBeatmap(Ruleset.Value);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -27,8 +27,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public class TestSceneMultiplayerGameplayLeaderboard : MultiplayerTestScene
     {
+        private const int users = 16;
+
         [Cached(typeof(SpectatorStreamingClient))]
-        private TestMultiplayerStreaming streamingClient = new TestMultiplayerStreaming(16);
+        private TestMultiplayerStreaming streamingClient = new TestMultiplayerStreaming(users);
 
         [Cached(typeof(UserLookupCache))]
         private UserLookupCache lookupCache = new TestSceneCurrentlyPlayingDisplay.TestUserLookupCache();
@@ -59,6 +61,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 streamingClient.Start(Beatmap.Value.BeatmapInfo.OnlineBeatmapID ?? 0);
 
+                Client.PlayingUsers.Clear();
+                Client.PlayingUsers.AddRange(streamingClient.PlayingUsers);
+
                 Children = new Drawable[]
                 {
                     scoreProcessor = new OsuScoreProcessor(),
@@ -80,6 +85,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestScoreUpdates()
         {
             AddRepeatStep("update state", () => streamingClient.RandomlyUpdateState(), 100);
+        }
+
+        [Test]
+        public void TestUserQuit()
+        {
+            AddRepeatStep("mark user quit", () => Client.PlayingUsers.RemoveAt(0), users);
         }
 
         public class TestMultiplayerStreaming : SpectatorStreamingClient

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Play.HUD
                     positionText.Text = $"#{scorePosition.Value.FormatRank()}";
 
                 positionText.FadeTo(scorePosition.HasValue ? 1 : 0);
-                updateColour();
+                updateState();
             }
         }
 
@@ -231,20 +231,20 @@ namespace osu.Game.Screens.Play.HUD
             TotalScore.BindValueChanged(v => scoreText.Text = v.NewValue.ToString("N0"), true);
             Accuracy.BindValueChanged(v => accuracyText.Text = v.NewValue.FormatAccuracy(), true);
             Combo.BindValueChanged(v => comboText.Text = $"{v.NewValue}x", true);
-            HasQuit.BindValueChanged(v => updateColour());
+            HasQuit.BindValueChanged(v => updateState());
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            updateColour();
+            updateState();
             FinishTransforms(true);
         }
 
         private const double panel_transition_duration = 500;
 
-        private void updateColour()
+        private void updateState()
         {
             if (HasQuit.Value)
             {

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -231,7 +231,7 @@ namespace osu.Game.Screens.Play.HUD
             TotalScore.BindValueChanged(v => scoreText.Text = v.NewValue.ToString("N0"), true);
             Accuracy.BindValueChanged(v => accuracyText.Text = v.NewValue.FormatAccuracy(), true);
             Combo.BindValueChanged(v => comboText.Text = $"{v.NewValue}x", true);
-            HasQuit.BindValueChanged(v => updateState());
+            HasQuit.BindValueChanged(_ => updateState());
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -34,6 +34,7 @@ namespace osu.Game.Screens.Play.HUD
         public BindableDouble TotalScore { get; } = new BindableDouble();
         public BindableDouble Accuracy { get; } = new BindableDouble(1);
         public BindableInt Combo { get; } = new BindableInt();
+        public BindableBool HasQuit { get; } = new BindableBool();
 
         private int? scorePosition;
 
@@ -230,6 +231,15 @@ namespace osu.Game.Screens.Play.HUD
             TotalScore.BindValueChanged(v => scoreText.Text = v.NewValue.ToString("N0"), true);
             Accuracy.BindValueChanged(v => accuracyText.Text = v.NewValue.FormatAccuracy(), true);
             Combo.BindValueChanged(v => comboText.Text = $"{v.NewValue}x", true);
+            HasQuit.BindValueChanged(v =>
+            {
+                if (v.NewValue)
+                {
+                    // we will probably want to display this in a better way once we have a design.
+                    // and also show states other than quit.
+                    panelColour = Color4.Gray;
+                }
+            }, true);
         }
 
         protected override void LoadComplete()
@@ -244,6 +254,9 @@ namespace osu.Game.Screens.Play.HUD
 
         private void updateColour()
         {
+            if (HasQuit.Value)
+                return;
+
             if (scorePosition == 1)
             {
                 mainFillContainer.ResizeWidthTo(EXTENDED_WIDTH, panel_transition_duration, Easing.OutElastic);

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -231,15 +231,7 @@ namespace osu.Game.Screens.Play.HUD
             TotalScore.BindValueChanged(v => scoreText.Text = v.NewValue.ToString("N0"), true);
             Accuracy.BindValueChanged(v => accuracyText.Text = v.NewValue.FormatAccuracy(), true);
             Combo.BindValueChanged(v => comboText.Text = $"{v.NewValue}x", true);
-            HasQuit.BindValueChanged(v =>
-            {
-                if (v.NewValue)
-                {
-                    // we will probably want to display this in a better way once we have a design.
-                    // and also show states other than quit.
-                    panelColour = Color4.Gray;
-                }
-            }, true);
+            HasQuit.BindValueChanged(v => updateColour());
         }
 
         protected override void LoadComplete()
@@ -255,7 +247,14 @@ namespace osu.Game.Screens.Play.HUD
         private void updateColour()
         {
             if (HasQuit.Value)
+            {
+                // we will probably want to display this in a better way once we have a design.
+                // and also show states other than quit.
+                mainFillContainer.ResizeWidthTo(regular_width, panel_transition_duration, Easing.OutElastic);
+                panelColour = Color4.Gray;
+                textColour = Color4.White;
                 return;
+            }
 
             if (scorePosition == 1)
             {

--- a/osu.Game/Screens/Play/HUD/ILeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/ILeaderboardScore.cs
@@ -10,5 +10,7 @@ namespace osu.Game.Screens.Play.HUD
         BindableDouble TotalScore { get; }
         BindableDouble Accuracy { get; }
         BindableInt Combo { get; }
+
+        BindableBool HasQuit { get; }
     }
 }

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -165,8 +165,6 @@ namespace osu.Game.Screens.Play.HUD
 
             public void UpdateScore(ScoreProcessor processor, ScoringMode mode)
             {
-                Debug.Assert(!UserQuit.Value);
-
                 if (LastHeader == null)
                     return;
 

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -93,6 +93,9 @@ namespace osu.Game.Screens.Play.HUD
                     foreach (var userId in e.OldItems.OfType<int>())
                     {
                         streamingClient.StopWatchingUser(userId);
+
+                        if (userScores.TryGetValue(userId, out var trackedData))
+                            trackedData.MarkUserQuit();
                     }
 
                     break;
@@ -143,11 +146,19 @@ namespace osu.Game.Screens.Play.HUD
 
             private readonly BindableInt currentCombo = new BindableInt();
 
+            public IBindable<bool> UserQuit => userQuit;
+
+            private readonly BindableBool userQuit = new BindableBool();
+
             [CanBeNull]
             public FrameHeader LastHeader;
 
+            public void MarkUserQuit() => userQuit.Value = true;
+
             public void UpdateScore(ScoreProcessor processor, ScoringMode mode)
             {
+                Debug.Assert(UserQuit.Value);
+
                 if (LastHeader == null)
                     return;
 


### PR DESCRIPTION
The spectator data feed was not unbound if a user quit the room, meaning if they continued to join another room (or play solo) their now incorrect score was still showing up on the leaderboard.

This change unsubscribes and also shows quit users visually (via a tint of their panel to gray).

Closes https://github.com/ppy/osu/issues/11308.