### PR TITLE
Fix gameplay leaderboard avatars being clickable

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Online.Leaderboards
 
             statisticsLabels = GetStatistics(score).Select(s => new ScoreComponentLabel(s)).ToList();
 
-            DrawableAvatar innerAvatar;
+            ClickableAvatar innerAvatar;
 
             Children = new Drawable[]
             {
@@ -115,7 +115,7 @@ namespace osu.Game.Online.Leaderboards
                             Children = new[]
                             {
                                 avatar = new DelayedLoadWrapper(
-                                    innerAvatar = new DrawableAvatar(user)
+                                    innerAvatar = new ClickableAvatar(user)
                                     {
                                         RelativeSizeAxes = Axes.Both,
                                         CornerRadius = corner_radius,

--- a/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
+++ b/osu.Game/Overlays/Chat/Tabs/PrivateChannelTabItem.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.Chat.Tabs
             if (value.Type != ChannelType.PM)
                 throw new ArgumentException("Argument value needs to have the targettype user!");
 
-            DrawableAvatar avatar;
+            ClickableAvatar avatar;
 
             AddRange(new Drawable[]
             {
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.Chat.Tabs
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Masking = true,
-                            Child = new DelayedLoadWrapper(avatar = new DrawableAvatar(value.Users.First())
+                            Child = new DelayedLoadWrapper(avatar = new ClickableAvatar(value.Users.First())
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 OpenOnClick = { Value = false },

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -78,6 +78,8 @@ namespace osu.Game.Screens.Play.HUD
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
+            Container avatarContainer;
+
             InternalChildren = new Drawable[]
             {
                 mainFillContainer = new Container
@@ -152,7 +154,7 @@ namespace osu.Game.Screens.Play.HUD
                                         Spacing = new Vector2(4f, 0f),
                                         Children = new Drawable[]
                                         {
-                                            new CircularContainer
+                                            avatarContainer = new CircularContainer
                                             {
                                                 Masking = true,
                                                 Anchor = Anchor.CentreLeft,
@@ -166,11 +168,7 @@ namespace osu.Game.Screens.Play.HUD
                                                         Alpha = 0.3f,
                                                         RelativeSizeAxes = Axes.Both,
                                                         Colour = colours.Gray4,
-                                                    },
-                                                    new UpdateableAvatar(User)
-                                                    {
-                                                        RelativeSizeAxes = Axes.Both,
-                                                    },
+                                                    }
                                                 }
                                             },
                                             usernameText = new OsuSpriteText
@@ -226,6 +224,8 @@ namespace osu.Game.Screens.Play.HUD
                     }
                 }
             };
+
+            LoadComponentAsync(new DrawableAvatar(User), avatarContainer.Add);
 
             TotalScore.BindValueChanged(v => scoreText.Text = v.NewValue.ToString("N0"), true);
             Accuracy.BindValueChanged(v => accuracyText.Text = v.NewValue.FormatAccuracy(), true);

--- a/osu.Game/Users/Drawables/ClickableAvatar.cs
+++ b/osu.Game/Users/Drawables/ClickableAvatar.cs
@@ -14,7 +14,7 @@ using osu.Game.Graphics.Containers;
 namespace osu.Game.Users.Drawables
 {
     [LongRunningLoad]
-    public class DrawableAvatar : Container
+    public class ClickableAvatar : Container
     {
         /// <summary>
         /// Whether to open the user's profile when clicked.
@@ -27,10 +27,11 @@ namespace osu.Game.Users.Drawables
         private OsuGame game { get; set; }
 
         /// <summary>
-        /// An avatar for specified user.
+        /// A clickable avatar for specified user, with UI sounds included.
+        /// If <see cref="OpenOnClick"/> is <c>true</c>, clicking will open the user's profile.
         /// </summary>
         /// <param name="user">The user. A null value will get a placeholder avatar.</param>
-        public DrawableAvatar(User user = null)
+        public ClickableAvatar(User user = null)
         {
             this.user = user;
         }

--- a/osu.Game/Users/Drawables/ClickableAvatar.cs
+++ b/osu.Game/Users/Drawables/ClickableAvatar.cs
@@ -1,19 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Users.Drawables
 {
-    [LongRunningLoad]
     public class ClickableAvatar : Container
     {
         /// <summary>
@@ -27,7 +24,7 @@ namespace osu.Game.Users.Drawables
         private OsuGame game { get; set; }
 
         /// <summary>
-        /// A clickable avatar for specified user, with UI sounds included.
+        /// A clickable avatar for the specified user, with UI sounds included.
         /// If <see cref="OpenOnClick"/> is <c>true</c>, clicking will open the user's profile.
         /// </summary>
         /// <param name="user">The user. A null value will get a placeholder avatar.</param>
@@ -39,27 +36,14 @@ namespace osu.Game.Users.Drawables
         [BackgroundDependencyLoader]
         private void load(LargeTextureStore textures)
         {
-            if (textures == null)
-                throw new ArgumentNullException(nameof(textures));
-
-            Texture texture = null;
-            if (user != null && user.Id > 1) texture = textures.Get($@"https://a.ppy.sh/{user.Id}");
-            texture ??= textures.Get(@"Online/avatar-guest");
-
             ClickableArea clickableArea;
             Add(clickableArea = new ClickableArea
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = new Sprite
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Texture = texture,
-                    FillMode = FillMode.Fit,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
-                },
                 Action = openProfile
             });
+
+            LoadComponentAsync(new DrawableAvatar(user), clickableArea.Add);
 
             clickableArea.Enabled.BindTo(OpenOnClick);
         }

--- a/osu.Game/Users/Drawables/DrawableAvatar.cs
+++ b/osu.Game/Users/Drawables/DrawableAvatar.cs
@@ -35,5 +35,11 @@ namespace osu.Game.Users.Drawables
 
             Texture ??= textures.Get(@"Online/avatar-guest");
         }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            this.FadeInFromZero(300, Easing.OutQuint);
+        }
     }
 }

--- a/osu.Game/Users/Drawables/DrawableAvatar.cs
+++ b/osu.Game/Users/Drawables/DrawableAvatar.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Game.Users.Drawables
+{
+    [LongRunningLoad]
+    public class DrawableAvatar : Sprite
+    {
+        private readonly User user;
+
+        /// <summary>
+        /// A simple, non-interactable avatar sprite for the specified user.
+        /// </summary>
+        /// <param name="user">The user. A null value will get a placeholder avatar.</param>
+        public DrawableAvatar(User user = null)
+        {
+            this.user = user;
+
+            RelativeSizeAxes = Axes.Both;
+            FillMode = FillMode.Fit;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(LargeTextureStore textures)
+        {
+            if (user != null && user.Id > 1)
+                Texture = textures.Get($@"https://a.ppy.sh/{user.Id}");
+
+            Texture ??= textures.Get(@"Online/avatar-guest");
+        }
+    }
+}

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -70,7 +70,6 @@ namespace osu.Game.Users.Drawables
                 RelativeSizeAxes = Axes.Both,
             };
 
-            avatar.OnLoadComplete += d => d.FadeInFromZero(300, Easing.OutQuint);
             avatar.OpenOnClick.BindTo(OpenOnClick);
 
             return avatar;

--- a/osu.Game/Users/Drawables/UpdateableAvatar.cs
+++ b/osu.Game/Users/Drawables/UpdateableAvatar.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Users.Drawables
             if (user == null && !ShowGuestOnNull)
                 return null;
 
-            var avatar = new DrawableAvatar(user)
+            var avatar = new ClickableAvatar(user)
             {
                 RelativeSizeAxes = Axes.Both,
             };


### PR DESCRIPTION
Resolves #11295.

I initially thought that this pull was going to be a one-liner by doing

```csharp
new DrawableAvatar { OpenOnClick = { Value = false } };
```

but `DrawableAvatar` had `HoverClickSounds` tacked on within it and disabling it would be super wonky, so I just split the actual avatar-only part to a separate component and renamed things.

Intended direction to allow clicks while viewing replays would probably be to supply another implementation of the leaderboard. I think that's going to be required anyhow.