### PR TITLE
Fix "difficulty adjust" mod overridden settings getting discarded in multiplayer

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
@@ -12,23 +11,19 @@ namespace osu.Game.Rulesets.Catch.Mods
     public class CatchModDifficultyAdjust : ModDifficultyAdjust
     {
         [SettingSource("Circle Size", "Override a beatmap's set CS.", FIRST_SETTING_ORDER - 1)]
-        public BindableNumber<float> CircleSize { get; } = new BindableFloat
+        public DifficultyTrackingBindable<float> CircleSize { get; } = new DifficultyTrackingBindable<float>
         {
             Precision = 0.1f,
             MinValue = 1,
             MaxValue = 10,
-            Default = 5,
-            Value = 5,
         };
 
         [SettingSource("Approach Rate", "Override a beatmap's set AR.", LAST_SETTING_ORDER + 1)]
-        public BindableNumber<float> ApproachRate { get; } = new BindableFloat
+        public DifficultyTrackingBindable<float> ApproachRate { get; } = new DifficultyTrackingBindable<float>
         {
             Precision = 0.1f,
             MinValue = 1,
             MaxValue = 10,
-            Default = 5,
-            Value = 5,
         };
 
         public override string SettingDescription
@@ -51,8 +46,8 @@ namespace osu.Game.Rulesets.Catch.Mods
         {
             base.TransferSettings(difficulty);
 
-            TransferSetting(CircleSize, difficulty.CircleSize);
-            TransferSetting(ApproachRate, difficulty.ApproachRate);
+            CircleSize.ChangeBase(difficulty.CircleSize);
+            ApproachRate.ChangeBase(difficulty.ApproachRate);
         }
 
         protected override void ApplySettings(BeatmapDifficulty difficulty)

--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -30,8 +30,8 @@ namespace osu.Game.Rulesets.Catch.Mods
         {
             get
             {
-                string circleSize = CircleSize.IsDefault ? string.Empty : $"CS {CircleSize.Value:N1}";
-                string approachRate = ApproachRate.IsDefault ? string.Empty : $"AR {ApproachRate.Value:N1}";
+                string circleSize = !CircleSize.Overriden ? string.Empty : $"CS {CircleSize.Value:N1}";
+                string approachRate = !ApproachRate.Overriden ? string.Empty : $"AR {ApproachRate.Value:N1}";
 
                 return string.Join(", ", new[]
                 {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -30,8 +30,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             get
             {
-                string circleSize = CircleSize.IsDefault ? string.Empty : $"CS {CircleSize.Value:N1}";
-                string approachRate = ApproachRate.IsDefault ? string.Empty : $"AR {ApproachRate.Value:N1}";
+                string circleSize = !CircleSize.Overriden ? string.Empty : $"CS {CircleSize.Value:N1}";
+                string approachRate = !ApproachRate.Overriden ? string.Empty : $"AR {ApproachRate.Value:N1}";
 
                 return string.Join(", ", new[]
                 {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
@@ -12,23 +11,19 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModDifficultyAdjust : ModDifficultyAdjust
     {
         [SettingSource("Circle Size", "Override a beatmap's set CS.", FIRST_SETTING_ORDER - 1)]
-        public BindableNumber<float> CircleSize { get; } = new BindableFloat
+        public DifficultyTrackingBindable<float> CircleSize { get; } = new DifficultyTrackingBindable<float>
         {
             Precision = 0.1f,
             MinValue = 0,
             MaxValue = 10,
-            Default = 5,
-            Value = 5,
         };
 
         [SettingSource("Approach Rate", "Override a beatmap's set AR.", LAST_SETTING_ORDER + 1)]
-        public BindableNumber<float> ApproachRate { get; } = new BindableFloat
+        public DifficultyTrackingBindable<float> ApproachRate { get; } = new DifficultyTrackingBindable<float>
         {
             Precision = 0.1f,
             MinValue = 0,
             MaxValue = 10,
-            Default = 5,
-            Value = 5,
         };
 
         public override string SettingDescription
@@ -51,8 +46,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             base.TransferSettings(difficulty);
 
-            TransferSetting(CircleSize, difficulty.CircleSize);
-            TransferSetting(ApproachRate, difficulty.ApproachRate);
+            CircleSize.ChangeBase(difficulty.CircleSize);
+            ApproachRate.ChangeBase(difficulty.ApproachRate);
         }
 
         protected override void ApplySettings(BeatmapDifficulty difficulty)

--- a/osu.Game.Tests/NonVisual/ModDifficultyAdjustOverridingTest.cs
+++ b/osu.Game.Tests/NonVisual/ModDifficultyAdjustOverridingTest.cs
@@ -1,0 +1,129 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Osu.Mods;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class ModDifficultyAdjustOverridingTest
+    {
+        private OsuModDifficultyAdjust mod;
+        private int difficultyID;
+
+        [SetUp]
+        public void SetUp()
+        {
+            mod = new OsuModDifficultyAdjust();
+            difficultyID = 0;
+        }
+
+        [Test]
+        public void TestOverridenStopTrackingBase()
+        {
+            var baseDifficulty = createDifficulty(5);
+            mod.ReadFromDifficulty(baseDifficulty);
+
+            mod.ApproachRate.Value = 10;
+            mod.CircleSize.Value = 10;
+
+            Assert.AreEqual(10, mod.ApproachRate.Value);
+            Assert.AreEqual(10, mod.CircleSize.Value);
+            Assert.AreEqual(baseDifficulty.DrainRate, mod.DrainRate.Value);
+            Assert.AreEqual(baseDifficulty.OverallDifficulty, mod.OverallDifficulty.Value);
+
+            baseDifficulty = createDifficulty(3);
+            mod.ReadFromDifficulty(baseDifficulty);
+
+            Assert.AreEqual(10, mod.ApproachRate.Value);
+            Assert.AreEqual(10, mod.CircleSize.Value);
+            Assert.AreEqual(baseDifficulty.DrainRate, mod.DrainRate.Value);
+            Assert.AreEqual(baseDifficulty.OverallDifficulty, mod.OverallDifficulty.Value);
+        }
+
+        [Test]
+        public void TestOverridenAfterBaseTrackOnRevert()
+        {
+            var baseDifficulty = createDifficulty(5);
+            mod.ReadFromDifficulty(baseDifficulty);
+
+            mod.ApproachRate.Value = 10;
+            Assert.AreEqual(10, mod.ApproachRate.Value);
+            Assert.AreEqual(baseDifficulty.ApproachRate, mod.ApproachRate.Default);
+
+            mod.ApproachRate.SetDefault();
+            Assert.AreEqual(baseDifficulty.ApproachRate, mod.ApproachRate.Value);
+
+            baseDifficulty = createDifficulty(3);
+            mod.ReadFromDifficulty(baseDifficulty);
+
+            Assert.AreEqual(baseDifficulty.ApproachRate, mod.ApproachRate.Value);
+        }
+
+        [Test]
+        public void TestOverridenAfterBaseDontTrackWithoutChange()
+        {
+            mod.ReadFromDifficulty(createDifficulty(6));
+
+            mod.ApproachRate.Value = 3;
+            mod.CircleSize.Value = 3;
+
+            Assert.AreEqual(3, mod.ApproachRate.Value);
+            Assert.AreEqual(3, mod.CircleSize.Value);
+
+            mod.ReadFromDifficulty(createDifficulty(3));
+
+            Assert.AreEqual(3, mod.ApproachRate.Value);
+            Assert.AreEqual(3, mod.CircleSize.Value);
+
+            mod.ReadFromDifficulty(createDifficulty(4));
+
+            Assert.AreEqual(3, mod.ApproachRate.Value);
+            Assert.AreEqual(3, mod.CircleSize.Value);
+        }
+
+        [Test]
+        public void TestOverrideBeforeBase()
+        {
+            mod.ApproachRate.Value = 10;
+            mod.CircleSize.Value = 10;
+            mod.DrainRate.Value = 10;
+            mod.OverallDifficulty.Value = 10;
+
+            mod.ReadFromDifficulty(createDifficulty(3));
+
+            Assert.AreEqual(10, mod.ApproachRate.Value);
+            Assert.AreEqual(10, mod.CircleSize.Value);
+            Assert.AreEqual(10, mod.DrainRate.Value);
+            Assert.AreEqual(10, mod.OverallDifficulty.Value);
+        }
+
+        [Test]
+        public void TestOverridenBeforeBaseTracksBack()
+        {
+            mod.ApproachRate.Value = 6;
+            mod.CircleSize.Value = 6;
+
+            mod.ReadFromDifficulty(createDifficulty(6));
+
+            Assert.AreEqual(6, mod.ApproachRate.Value);
+            Assert.AreEqual(6, mod.CircleSize.Value);
+
+            mod.ReadFromDifficulty(createDifficulty(3));
+
+            Assert.AreEqual(3, mod.ApproachRate.Value);
+            Assert.AreEqual(3, mod.CircleSize.Value);
+        }
+
+        private BeatmapDifficulty createDifficulty(float value) => new BeatmapDifficulty
+        {
+            ApproachRate = value,
+            CircleSize = value,
+            DrainRate = value,
+            OverallDifficulty = value,
+            ID = difficultyID++,
+        };
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -52,8 +52,8 @@ namespace osu.Game.Rulesets.Mods
         {
             get
             {
-                string drainRate = DrainRate.IsDefault ? string.Empty : $"HP {DrainRate.Value:N1}";
-                string overallDifficulty = OverallDifficulty.IsDefault ? string.Empty : $"OD {OverallDifficulty.Value:N1}";
+                string drainRate = !DrainRate.Overriden ? string.Empty : $"HP {DrainRate.Value:N1}";
+                string overallDifficulty = !OverallDifficulty.Overriden ? string.Empty : $"OD {OverallDifficulty.Value:N1}";
 
                 return string.Join(", ", new[]
                 {


### PR DESCRIPTION
Closes #11305 

## What the issue is

The issue was occurring because of the mod getting reinstantiated twice during the room creation process:
https://github.com/ppy/osu/blob/6849eabf2ce56db434d9a68829f63207659b78a1/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs#L51 https://github.com/ppy/osu/blob/6849eabf2ce56db434d9a68829f63207659b78a1/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs#L443

when it gets reinstantiated, the settings are copied from the previous instance to the new one, and that is happening before `ReadFromDifficulty` is called, which means `userTrackedSettings` wouldn't be tracking the copying, therefore when `ReadFromDifficulty` gets called (by `OsuGame.updateModDefaults()`) the settings would be discarded and the base values would be used instead.

## The solution

I've tried a couple of solutions but none of them worked properly, involving:
 - copying `userTrackedSettings` over, which wouldn't work for `APIMod.ToMod()`.
 - applying difficulty before copying settings, which doesn't really sound sane to do + you would have to track exactly any instantiation of the mod and read difficulty there.
 - forcing difficulty in the `Mod` constructor, which I'm not really sure about, and I don't think will be possible with the current flow.

but I came up with a solution that I am satisfied with:

And what it does is extracting the logic into a `DifficultyTrackingBindable` class, and make it so that it can handle "changing difficulty settings without a base difficulty" cases properly, by tracking any touches to the bindable, until a base difficulty is received.

I've added test coverage for the new mod's settings overriding behaviour, which matches [as it was previously](https://github.com/ppy/osu/blob/3f85fcf0c94da5da35fb3bcad5ef8a4e57493362/osu.Game.Tests/NonVisual/ModDifficultyAdjustOverridingTest.cs#L23-L85) + handles [changing settings before base](https://github.com/ppy/osu/blob/3f85fcf0c94da5da35fb3bcad5ef8a4e57493362/osu.Game.Tests/NonVisual/ModDifficultyAdjustOverridingTest.cs#L87-L118) properly.