### PR TITLE
Fix incorrect null handling in GameplayLeaderboard

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             public bool CheckPositionByUsername(string username, int? expectedPosition)
             {
-                var scoreItem = this.FirstOrDefault(i => i.User.Username == username);
+                var scoreItem = this.FirstOrDefault(i => i.User?.Username == username);
 
                 return scoreItem != null && scoreItem.ScorePosition == expectedPosition;
             }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -20,10 +20,9 @@ using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
-using osu.Game.Tests.Visual.Multiplayer;
 using osu.Game.Tests.Visual.Online;
 
-namespace osu.Game.Tests.Visual.Gameplay
+namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayerGameplayLeaderboard : MultiplayerTestScene
     {

--- a/osu.Game.Tests/Visual/Online/TestSceneCurrentlyPlayingDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneCurrentlyPlayingDisplay.cs
@@ -90,11 +90,17 @@ namespace osu.Game.Tests.Visual.Online
             };
 
             protected override Task<User> ComputeValueAsync(int lookup, CancellationToken token = default)
-                => Task.FromResult(new User
+            {
+                // tests against failed lookups
+                if (lookup == 13)
+                    return Task.FromResult<User>(null);
+
+                return Task.FromResult(new User
                 {
                     Id = lookup,
                     Username = usernames[lookup % usernames.Length],
                 });
+            }
         }
     }
 }

--- a/osu.Game/Database/UserLookupCache.cs
+++ b/osu.Game/Database/UserLookupCache.cs
@@ -17,6 +17,12 @@ namespace osu.Game.Database
         [Resolved]
         private IAPIProvider api { get; set; }
 
+        /// <summary>
+        /// Perform an API lookup on the specified user, populating a <see cref="User"/> model.
+        /// </summary>
+        /// <param name="userId">The user to lookup.</param>
+        /// <param name="token">An optional cancellation token.</param>
+        /// <returns>The populated user, or null if the user does not exist or the request could not be satisfied.</returns>
         public Task<User> GetUserAsync(int userId, CancellationToken token = default) => GetAsync(userId, token);
 
         protected override async Task<User> ComputeValueAsync(int lookup, CancellationToken token = default)

--- a/osu.Game/Database/UserLookupCache.cs
+++ b/osu.Game/Database/UserLookupCache.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -23,6 +24,7 @@ namespace osu.Game.Database
         /// <param name="userId">The user to lookup.</param>
         /// <param name="token">An optional cancellation token.</param>
         /// <returns>The populated user, or null if the user does not exist or the request could not be satisfied.</returns>
+        [ItemCanBeNull]
         public Task<User> GetUserAsync(int userId, CancellationToken token = default) => GetAsync(userId, token);
 
         protected override async Task<User> ComputeValueAsync(int lookup, CancellationToken token = default)

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -42,7 +43,7 @@ namespace osu.Game.Screens.Play.HUD
         /// Whether the player should be tracked on the leaderboard.
         /// Set to <c>true</c> for the local player or a player whose replay is currently being played.
         /// </param>
-        public ILeaderboardScore AddPlayer(User user, bool isTracked)
+        public ILeaderboardScore AddPlayer([CanBeNull] User user, bool isTracked)
         {
             var drawable = new GameplayLeaderboardScore(user, isTracked)
             {

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -56,6 +57,7 @@ namespace osu.Game.Screens.Play.HUD
             }
         }
 
+        [CanBeNull]
         public User User { get; }
 
         private readonly bool trackedPlayer;
@@ -68,7 +70,7 @@ namespace osu.Game.Screens.Play.HUD
         /// </summary>
         /// <param name="user">The score's player.</param>
         /// <param name="trackedPlayer">Whether the player is the local user or a replay player.</param>
-        public GameplayLeaderboardScore(User user, bool trackedPlayer)
+        public GameplayLeaderboardScore([CanBeNull] User user, bool trackedPlayer)
         {
             User = user;
             this.trackedPlayer = trackedPlayer;
@@ -180,7 +182,7 @@ namespace osu.Game.Screens.Play.HUD
                                                 Origin = Anchor.CentreLeft,
                                                 Colour = Color4.White,
                                                 Font = OsuFont.Torus.With(size: 14, weight: FontWeight.SemiBold),
-                                                Text = User.Username,
+                                                Text = User?.Username,
                                                 Truncate = true,
                                                 Shadow = false,
                                             }

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Play.HUD
                 var trackedUser = new TrackedUserData();
 
                 userScores[userId] = trackedUser;
-                var leaderboardScore = AddPlayer(resolvedUser, resolvedUser.Id == api.LocalUser.Value.Id);
+                var leaderboardScore = AddPlayer(resolvedUser, resolvedUser?.Id == api.LocalUser.Value.Id);
 
                 ((IBindable<double>)leaderboardScore.Accuracy).BindTo(trackedUser.Accuracy);
                 ((IBindable<double>)leaderboardScore.TotalScore).BindTo(trackedUser.Score);


### PR DESCRIPTION
This fixes another oversight of `UserLookupCache` potentially returning null on failure. It also adds annotations and xmldoc to avoid such issues at an earlier stage of development going forward.

We may decide in a future refactor to create an "unknown user" instance which is returned in these scenarios, avoiding the null return situation. This is already done for guest users at the `APIAccess` level.