### PR TITLE
Fix changelog header staying dimmed after build show

### DIFF
--- a/osu.Game/Overlays/Changelog/ChangelogUpdateStreamControl.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogUpdateStreamControl.cs
@@ -7,12 +7,11 @@ namespace osu.Game.Overlays.Changelog
 {
     public class ChangelogUpdateStreamControl : OverlayStreamControl<APIUpdateStream>
     {
-        protected override OverlayStreamItem<APIUpdateStream> CreateStreamItem(APIUpdateStream value) => new ChangelogUpdateStreamItem(value);
-
-        protected override void LoadComplete()
+        public ChangelogUpdateStreamControl()
         {
-            // suppress base logic of immediately selecting first item if one exists
-            // (we always want to start with no stream selected).
+            SelectFirstTabByDefault = false;
         }
+
+        protected override OverlayStreamItem<APIUpdateStream> CreateStreamItem(APIUpdateStream value) => new ChangelogUpdateStreamItem(value);
     }
 }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/4114.

Fixes issue mentioned [in discord](https://discord.com/channels/188630481301012481/188630652340404224/793124272801054730).