### PR TITLE
Fix all users showing up as quit in multiplayer

### DIFF
--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -80,7 +80,11 @@ namespace osu.Game.Screens.Play.HUD
         protected override void LoadComplete()
         {
             base.LoadComplete();
+            multiplayerClient.MatchStarted += onMatchStarted;
+        }
 
+        private void onMatchStarted()
+        {
             // BindableList handles binding in a really bad way (Clear then AddRange) so we need to do this manually..
             foreach (int userId in playingUsers)
             {
@@ -137,6 +141,9 @@ namespace osu.Game.Screens.Play.HUD
 
                 streamingClient.OnNewFrames -= handleIncomingFrames;
             }
+
+            if (multiplayerClient != null)
+                multiplayerClient.MatchStarted -= onMatchStarted;
         }
 
         private class TrackedUserData


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/11345.

`MultiplayerGameplayLeaderboard` was possibly reading `PlayingUsers` from the multiplayer client too early - they are not populated until a `MatchStarted` call from the server.

Delay hooking up mark-as-quit logic until the `MatchStarted` event has actually fired.