### PR TITLE
Change PlayingUsers population logic to match expectations

### DIFF
--- a/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
+++ b/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using Humanizer;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Tests.Visual.Multiplayer;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.NonVisual.Multiplayer
+{
+    [HeadlessTest]
+    public class StatefulMultiplayerClientTest : MultiplayerTestScene
+    {
+        [Test]
+        public void TestPlayingUserTracking()
+        {
+            int id = 2000;
+
+            AddRepeatStep("add some users", () => Client.AddUser(new User { Id = id++ }), 5);
+            checkPlayingUserCount(0);
+
+            changeState(3, MultiplayerUserState.WaitingForLoad);
+            checkPlayingUserCount(3);
+
+            changeState(3, MultiplayerUserState.Playing);
+            checkPlayingUserCount(3);
+
+            changeState(3, MultiplayerUserState.Results);
+            checkPlayingUserCount(0);
+
+            changeState(6, MultiplayerUserState.WaitingForLoad);
+            checkPlayingUserCount(6);
+
+            AddStep("another user left", () => Client.RemoveUser(Client.Room?.Users.Last().User));
+            checkPlayingUserCount(5);
+
+            AddStep("leave room", () => Client.LeaveRoom());
+            checkPlayingUserCount(0);
+        }
+
+        private void checkPlayingUserCount(int expectedCount)
+            => AddAssert($"{"user".ToQuantity(expectedCount)} playing", () => Client.PlayingUsers.Count == expectedCount);
+
+        private void changeState(int userCount, MultiplayerUserState state)
+            => AddStep($"{"user".ToQuantity(userCount)} in {state}", () =>
+            {
+                for (int i = 0; i < userCount; ++i)
+                {
+                    var userId = Client.Room?.Users[i].UserID ?? throw new AssertionException("Room cannot be null!");
+                    Client.ChangeUserState(userId, state);
+                }
+            });
+    }
+}

--- a/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
+++ b/osu.Game.Tests/NonVisual/Multiplayer/StatefulMultiplayerClientTest.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.NonVisual.Multiplayer
         }
 
         private void checkPlayingUserCount(int expectedCount)
-            => AddAssert($"{"user".ToQuantity(expectedCount)} playing", () => Client.PlayingUsers.Count == expectedCount);
+            => AddAssert($"{"user".ToQuantity(expectedCount)} playing", () => Client.CurrentMatchPlayingUserIds.Count == expectedCount);
 
         private void changeState(int userCount, MultiplayerUserState state)
             => AddStep($"{"user".ToQuantity(userCount)} in {state}", () =>

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -62,8 +62,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 streamingClient.Start(Beatmap.Value.BeatmapInfo.OnlineBeatmapID ?? 0);
 
-                Client.PlayingUsers.Clear();
-                Client.PlayingUsers.AddRange(streamingClient.PlayingUsers);
+                Client.CurrentMatchPlayingUserIds.Clear();
+                Client.CurrentMatchPlayingUserIds.AddRange(streamingClient.PlayingUsers);
 
                 Children = new Drawable[]
                 {
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestUserQuit()
         {
-            AddRepeatStep("mark user quit", () => Client.PlayingUsers.RemoveAt(0), users);
+            AddRepeatStep("mark user quit", () => Client.CurrentMatchPlayingUserIds.RemoveAt(0), users);
         }
 
         public class TestMultiplayerStreaming : SpectatorStreamingClient

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -61,9 +61,9 @@ namespace osu.Game.Online.Multiplayer
         public MultiplayerRoom? Room { get; private set; }
 
         /// <summary>
-        /// The users currently in gameplay.
+        /// The users in the joined <see cref="Room"/> which are currently in gameplay.
         /// </summary>
-        public readonly BindableList<int> PlayingUsers = new BindableList<int>();
+        public readonly BindableList<int> CurrentMatchPlayingUserIds = new BindableList<int>();
 
         [Resolved]
         private UserLookupCache userLookupCache { get; set; } = null!;
@@ -133,7 +133,7 @@ namespace osu.Game.Online.Multiplayer
 
                 apiRoom = null;
                 Room = null;
-                PlayingUsers.Clear();
+                CurrentMatchPlayingUserIds.Clear();
 
                 RoomUpdated?.Invoke();
             }, false);
@@ -254,7 +254,7 @@ namespace osu.Game.Online.Multiplayer
                     return;
 
                 Room.Users.Remove(user);
-                PlayingUsers.Remove(user.UserID);
+                CurrentMatchPlayingUserIds.Remove(user.UserID);
 
                 RoomUpdated?.Invoke();
             }, false);
@@ -454,22 +454,22 @@ namespace osu.Game.Online.Multiplayer
         }
 
         /// <summary>
-        /// For the provided user ID, update whether the user is included in <see cref="PlayingUsers"/>.
+        /// For the provided user ID, update whether the user is included in <see cref="CurrentMatchPlayingUserIds"/>.
         /// </summary>
         /// <param name="userId">The user's ID.</param>
         /// <param name="state">The new state of the user.</param>
         private void updateUserPlayingState(int userId, MultiplayerUserState state)
         {
-            bool wasPlaying = PlayingUsers.Contains(userId);
+            bool wasPlaying = CurrentMatchPlayingUserIds.Contains(userId);
             bool isPlaying = state >= MultiplayerUserState.WaitingForLoad && state <= MultiplayerUserState.FinishedPlay;
 
             if (isPlaying == wasPlaying)
                 return;
 
             if (isPlaying)
-                PlayingUsers.Add(userId);
+                CurrentMatchPlayingUserIds.Add(userId);
             else
-                PlayingUsers.Remove(userId);
+                CurrentMatchPlayingUserIds.Remove(userId);
         }
     }
 }

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Online.Multiplayer
         public MultiplayerRoom? Room { get; private set; }
 
         /// <summary>
-        /// The users in the joined <see cref="Room"/> which are currently in gameplay.
+        /// The users in the joined <see cref="Room"/> which are participating in the current gameplay loop.
         /// </summary>
         public readonly BindableList<int> CurrentMatchPlayingUserIds = new BindableList<int>();
 

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -133,6 +133,7 @@ namespace osu.Game.Online.Multiplayer
 
                 apiRoom = null;
                 Room = null;
+                PlayingUsers.Clear();
 
                 RoomUpdated?.Invoke();
             }, false);
@@ -302,8 +303,7 @@ namespace osu.Game.Online.Multiplayer
 
                 Room.Users.Single(u => u.UserID == userId).State = state;
 
-                if (state != MultiplayerUserState.Playing)
-                    PlayingUsers.Remove(userId);
+                updatePlayingUsers(userId, state);
 
                 RoomUpdated?.Invoke();
             }, false);
@@ -336,8 +336,6 @@ namespace osu.Game.Online.Multiplayer
             {
                 if (Room == null)
                     return;
-
-                PlayingUsers.AddRange(Room.Users.Where(u => u.State == MultiplayerUserState.Playing).Select(u => u.UserID));
 
                 MatchStarted?.Invoke();
             }, false);
@@ -453,6 +451,18 @@ namespace osu.Game.Online.Multiplayer
 
             apiRoom.Playlist.Clear(); // Clearing should be unnecessary, but here for sanity.
             apiRoom.Playlist.Add(playlistItem);
+        }
+
+        private void updatePlayingUsers(int userId, MultiplayerUserState state)
+        {
+            bool isPlaying = state >= MultiplayerUserState.WaitingForLoad && state <= MultiplayerUserState.FinishedPlay;
+            bool wasPlaying = PlayingUsers.Contains(userId);
+
+            if (!wasPlaying && isPlaying)
+                PlayingUsers.Add(userId);
+
+            if (wasPlaying && !isPlaying)
+                PlayingUsers.Remove(userId);
         }
     }
 }

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -303,7 +303,7 @@ namespace osu.Game.Online.Multiplayer
 
                 Room.Users.Single(u => u.UserID == userId).State = state;
 
-                updatePlayingUsers(userId, state);
+                updateUserPlayingState(userId, state);
 
                 RoomUpdated?.Invoke();
             }, false);
@@ -453,15 +453,22 @@ namespace osu.Game.Online.Multiplayer
             apiRoom.Playlist.Add(playlistItem);
         }
 
-        private void updatePlayingUsers(int userId, MultiplayerUserState state)
+        /// <summary>
+        /// For the provided user ID, update whether the user is included in <see cref="PlayingUsers"/>.
+        /// </summary>
+        /// <param name="userId">The user's ID.</param>
+        /// <param name="state">The new state of the user.</param>
+        private void updateUserPlayingState(int userId, MultiplayerUserState state)
         {
-            bool isPlaying = state >= MultiplayerUserState.WaitingForLoad && state <= MultiplayerUserState.FinishedPlay;
             bool wasPlaying = PlayingUsers.Contains(userId);
+            bool isPlaying = state >= MultiplayerUserState.WaitingForLoad && state <= MultiplayerUserState.FinishedPlay;
 
-            if (!wasPlaying && isPlaying)
+            if (isPlaying == wasPlaying)
+                return;
+
+            if (isPlaying)
                 PlayingUsers.Add(userId);
-
-            if (wasPlaying && !isPlaying)
+            else
                 PlayingUsers.Remove(userId);
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             Debug.Assert(client.Room != null);
 
-            int[] userIds = client.PlayingUsers.ToArray();
+            int[] userIds = client.CurrentMatchPlayingUserIds.ToArray();
 
             StartPlay(() => new MultiplayerPlayer(SelectedItem.Value, userIds));
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             Debug.Assert(client.Room != null);
 
-            int[] userIds = client.Room.Users.Where(u => u.State >= MultiplayerUserState.WaitingForLoad).Select(u => u.UserID).ToArray();
+            int[] userIds = client.PlayingUsers.ToArray();
 
             StartPlay(() => new MultiplayerPlayer(SelectedItem.Value, userIds));
         }

--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -84,11 +84,11 @@ namespace osu.Game.Screens.Play.HUD
             // BindableList handles binding in a really bad way (Clear then AddRange) so we need to do this manually..
             foreach (int userId in playingUsers)
             {
-                if (!multiplayerClient.PlayingUsers.Contains(userId))
+                if (!multiplayerClient.CurrentMatchPlayingUserIds.Contains(userId))
                     usersChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, new[] { userId }));
             }
 
-            playingUsers.BindTo(multiplayerClient.PlayingUsers);
+            playingUsers.BindTo(multiplayerClient.CurrentMatchPlayingUserIds);
             playingUsers.BindCollectionChanged(usersChanged);
         }
 


### PR DESCRIPTION
Hopefully better fix for https://github.com/ppy/osu/issues/11345.

I know [we discussed not tracking](https://discord.com/channels/188630481301012481/188630652340404224/793157785478103080), but after looking at what would need to happen for the leaderboard to track quit if `PlayingUsers` got changed to a dumb LINQ/removed, I was no longer sure it was worth it anymore.

* Dumb LINQ means that each consumer of `PlayingUsers` has to do the differential check themselves if they want to get differential updates.
* Removing is even worse as each consumer has to remember and check every possible method of playing users changing (quitting out early, the local user leaving room entirely, the remote user leaving room entirely).

Half the issue was having the self-rolled logic in `MultiplayerMatchSubScreen`, I think. Now that they read from the same source this should not be an issue anymore.

Tested in a MP lobby on dev with @frenzibyte. Seemed to work OK.