### PR TITLE
Add "Constant" osu!mania mod

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -238,6 +238,7 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModMirror(),
                         new ManiaModDifficultyAdjust(),
                         new ManiaModInvert(),
+                        new ManiaModConstant(),
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -238,7 +238,7 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModMirror(),
                         new ManiaModDifficultyAdjust(),
                         new ManiaModInvert(),
-                        new ManiaModConstant(),
+                        new ManiaModFixedScroll(),
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Mods;
@@ -39,9 +40,9 @@ namespace osu.Game.Rulesets.Mania.Mods
 
                     DifficultyControlPoint diffControlPoint = new DifficultyControlPoint();
 
-                    diffControlPoint.SpeedMultiplierBindable.MinValue = double.MinValue; // Uncapped minimum value
+                    diffControlPoint.SpeedMultiplierBindable.MinValue = Precision.DOUBLE_EPSILON; // Uncapped minimum value
                     diffControlPoint.SpeedMultiplierBindable.MaxValue = double.MaxValue; // Uncapped maximum value
-                    diffControlPoint.SpeedMultiplierBindable.Precision = 0.000000001d; // Arbitrary value, may need changing
+                    diffControlPoint.SpeedMultiplierBindable.Precision = Precision.DOUBLE_EPSILON;
                     diffControlPoint.SpeedMultiplier = initialBPM / timingControlPoint.BPM; // Counteract BPM velocity
 
                     group.Add(diffControlPoint);

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModConstant : Mod, IApplicableToBeatmap
+    {
+        public override string Name => "Constant";
+        public override string Acronym => "CT";
+        public override double ScoreMultiplier => 1;
+        public override string Description => "No more tricky note speed changes!";
+        public override IconUsage? Icon => FontAwesome.Solid.ArrowDown;
+        public override ModType Type => ModType.Conversion;
+        public override bool Ranked => false;
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            // Get all difficulty points
+            var difficultyPoints = beatmap.ControlPointInfo.DifficultyPoints;
+
+            foreach (var difficultyPoint in difficultyPoints)
+            {
+                // Set this difficulty point's speed multiplier to 1
+                difficultyPoint.SpeedMultiplier = 1;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModConstant : Mod, IApplicableToBeatmap
     {
-        public override string Name => "Constant";
-        public override string Acronym => "CT";
+        public override string Name => "Fixed Scroll";
+        public override string Acronym => "FS";
         public override double ScoreMultiplier => 1;
         public override string Description => "No more tricky note speed changes!";
         public override IconUsage? Icon => FontAwesome.Solid.BalanceScale;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
@@ -33,7 +33,15 @@ namespace osu.Game.Rulesets.Mania.Mods
                 // Get the difficulty control point of this group, if any
                 var difficultyControlPoints = group.ControlPoints.OfType<DifficultyControlPoint>().ToArray();
 
-                // If there is a timing control point
+                // If this group has a difficulty point, remove it
+                if (difficultyControlPoints.Any())
+                {
+                    var diffControlPoint = difficultyControlPoints[0];
+
+                    group.Remove(diffControlPoint);
+                }
+
+                // If this group has a timing point, add counteracting difficulty point
                 if (timingControlPoints.Any())
                 {
                     var timingControlPoint = timingControlPoints[0];
@@ -45,14 +53,8 @@ namespace osu.Game.Rulesets.Mania.Mods
                     diffControlPoint.SpeedMultiplierBindable.Precision = Precision.DOUBLE_EPSILON;
                     diffControlPoint.SpeedMultiplier = initialBPM / timingControlPoint.BPM; // Counteract BPM velocity
 
+                    // Add the new difficulty point to this group
                     group.Add(diffControlPoint);
-                }
-                // Else, there is no timing control point, but a difficulty control point
-                else if (difficultyControlPoints.Any())
-                {
-                    var diffControlPoint = difficultyControlPoints[0];
-
-                    group.Remove(diffControlPoint);
                 }
             }
         }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModConstant.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => "CT";
         public override double ScoreMultiplier => 1;
         public override string Description => "No more tricky note speed changes!";
-        public override IconUsage? Icon => FontAwesome.Solid.ArrowDown;
+        public override IconUsage? Icon => FontAwesome.Solid.BalanceScale;
         public override ModType Type => ModType.Conversion;
         public override bool Ranked => false;
 
@@ -21,11 +22,28 @@ namespace osu.Game.Rulesets.Mania.Mods
         {
             // Get all difficulty points
             var difficultyPoints = beatmap.ControlPointInfo.DifficultyPoints;
+            // Get all timing points
+            var timingPoints = beatmap.ControlPointInfo.TimingPoints;
+            // Get the initial BPM
+            var initialBPM = timingPoints[0].BPM;
 
             foreach (var difficultyPoint in difficultyPoints)
             {
                 // Set this difficulty point's speed multiplier to 1
                 difficultyPoint.SpeedMultiplier = 1;
+            }
+
+            // Correct changes in speed caused by timing points by adding an associated difficulty point
+            foreach (var timingPoint in timingPoints)
+            {
+                // Create a new difficulty point to counteract timing point
+                DifficultyControlPoint diffControlPoint = new DifficultyControlPoint
+                {
+                    SpeedMultiplier = initialBPM / timingPoint.BPM
+                };
+
+                // Add the new control point to the beatmap
+                beatmap.ControlPointInfo.Add(timingPoint.Time, diffControlPoint);
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFixedScroll.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFixedScroll.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModConstant : Mod, IApplicableToBeatmap
+    public class ManiaModFixedScroll : Mod, IApplicableToBeatmap
     {
         public override string Name => "Fixed Scroll";
         public override string Acronym => "FS";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFixedScroll.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFixedScroll.cs
@@ -6,11 +6,14 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModFixedScroll : Mod, IApplicableToBeatmap
+    public class ManiaModFixedScroll : Mod, IApplicableToBeatmap, IApplicableToDrawableRuleset<ManiaHitObject>
     {
         public override string Name => "Fixed Scroll";
         public override string Acronym => "FS";
@@ -57,6 +60,12 @@ namespace osu.Game.Rulesets.Mania.Mods
                     group.Add(diffControlPoint);
                 }
             }
+        }
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)
+        {
+            var maniaRuleset = (DrawableManiaRuleset)drawableRuleset;
+            maniaRuleset.PreserveDifficultyPoints = true;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Rulesets.Mania.UI
         // Stores the current speed adjustment active in gameplay.
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
 
+        /// <summary>
+        /// Whether difficulty points should be taken into account, even on convert maps.
+        /// </summary>
+        public bool PreserveDifficultyPoints { get; set; }
+
         public DrawableManiaRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
             : base(ruleset, beatmap, mods)
         {
@@ -76,7 +81,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 p.BaseBeatLength *= Beatmap.BeatmapInfo.BaseDifficulty.SliderMultiplier;
 
                 // For non-mania beatmap, speed changes should only happen through timing points
-                if (!isForCurrentRuleset)
+                if (!isForCurrentRuleset && !PreserveDifficultyPoints)
                     p.DifficultyPoint = new DifficultyControlPoint();
             }
 


### PR DESCRIPTION
Resolves #9802 
This adds a new mod to osu!mania that makes all the slider velocities/speed changes the default value (1).
It only affects difficulty points' speed multiplier as of now. BPM timing points are left unchanged, which may cause issues stated in #10267 (speeding up BPM, and slowing down scroll velocity).
The mod is set to unranked.