### PR TITLE
Change cursor trail blending mode based on cursor trail type to match stable behaviour

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
@@ -20,16 +20,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private double lastTrailTime;
         private IBindable<float> cursorSize;
 
-        public LegacyCursorTrail()
-        {
-            Blending = BlendingParameters.Additive;
-        }
-
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin, OsuConfigManager config)
         {
             Texture = skin.GetTexture("cursortrail");
             disjointTrail = skin.GetTexture("cursormiddle") == null;
+
+            Blending = !disjointTrail ? BlendingParameters.Additive : BlendingParameters.Inherit;
 
             if (Texture != null)
             {


### PR DESCRIPTION
Lazer currently uses additive blending for both cursor trail types (both with and without cursormiddle.png).

This PR changes the blending mode based on the type of cursor trail (additive with cursormiddle.png, otherwise inherit) to match stable behaviour.

Stable:
![stable-snippet](https://user-images.githubusercontent.com/10572146/103253683-3f5fbd00-49d6-11eb-89af-71fc6190f7ca.png)

Lazer (current):
![lazer-additive-snippet](https://user-images.githubusercontent.com/10572146/103253688-42f34400-49d6-11eb-97b7-6c9f92bbcc33.png)

Lazer (new):
![lazer-inherit-snippet](https://user-images.githubusercontent.com/10572146/103253689-44247100-49d6-11eb-998b-f3901fbedb2e.png)