### PR TITLE
Remove selection polling from multiplayer

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerRoomManager.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerRoomManager.cs
@@ -143,7 +143,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 RoomManager =
                 {
                     TimeBetweenListingPolls = { Value = 1 },
-                    TimeBetweenSelectionPolls = { Value = 1 }
                 }
             };
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!this.IsCurrentScreen())
             {
                 multiplayerRoomManager.TimeBetweenListingPolls.Value = 0;
-                multiplayerRoomManager.TimeBetweenSelectionPolls.Value = 0;
             }
             else
             {
@@ -41,18 +40,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 {
                     case LoungeSubScreen _:
                         multiplayerRoomManager.TimeBetweenListingPolls.Value = isIdle ? 120000 : 15000;
-                        multiplayerRoomManager.TimeBetweenSelectionPolls.Value = isIdle ? 120000 : 15000;
                         break;
 
                     // Don't poll inside the match or anywhere else.
                     default:
                         multiplayerRoomManager.TimeBetweenListingPolls.Value = 0;
-                        multiplayerRoomManager.TimeBetweenSelectionPolls.Value = 0;
                         break;
                 }
             }
 
-            Logger.Log($"Polling adjusted (listing: {multiplayerRoomManager.TimeBetweenListingPolls.Value}, selection: {multiplayerRoomManager.TimeBetweenSelectionPolls.Value})");
+            Logger.Log($"Polling adjusted (listing: {multiplayerRoomManager.TimeBetweenListingPolls.Value})");
         }
 
         protected override Room CreateNewRoom()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomManager.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private StatefulMultiplayerClient multiplayerClient { get; set; }
 
         public readonly Bindable<double> TimeBetweenListingPolls = new Bindable<double>();
-        public readonly Bindable<double> TimeBetweenSelectionPolls = new Bindable<double>();
+
         private readonly IBindable<bool> isConnected = new Bindable<bool>();
         private readonly Bindable<bool> allowPolling = new Bindable<bool>();
 
@@ -119,35 +119,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 TimeBetweenPolls = { BindTarget = TimeBetweenListingPolls },
                 AllowPolling = { BindTarget = allowPolling }
             },
-            new MultiplayerSelectionPollingComponent
-            {
-                TimeBetweenPolls = { BindTarget = TimeBetweenSelectionPolls },
-                AllowPolling = { BindTarget = allowPolling }
-            }
         };
 
         private class MultiplayerListingPollingComponent : ListingPollingComponent
-        {
-            public readonly IBindable<bool> AllowPolling = new Bindable<bool>();
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                AllowPolling.BindValueChanged(allowPolling =>
-                {
-                    if (!allowPolling.NewValue)
-                        return;
-
-                    if (IsLoaded)
-                        PollImmediately();
-                });
-            }
-
-            protected override Task Poll() => !AllowPolling.Value ? Task.CompletedTask : base.Poll();
-        }
-
-        private class MultiplayerSelectionPollingComponent : SelectionPollingComponent
         {
             public readonly IBindable<bool> AllowPolling = new Bindable<bool>();
 


### PR DESCRIPTION
Looks like this was just copy-paste without any thought into whether it should exist. It really shouldn't exist.

This is a thing for the playlists system because the *whole system* there relies on polling the web API to get updated information. In the case of mutliplayer, we hand off all communications to the realtime server at the point of joining the rooms.

The argument that this was there to do faster polling on the selection isn't valid since the polling times were the same for both cases.

Closes #11348.