### PR TITLE
Silence network errors that don't need to be shown to the user

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.1202.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.1228.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2020.1229.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -293,8 +294,21 @@ namespace osu.Game.Online.API
                 failureCount = 0;
                 return true;
             }
+            catch (HttpRequestException re)
+            {
+                log.Add($"{nameof(HttpRequestException)} while performing request {req}: {re.Message}");
+                handleFailure();
+                return false;
+            }
+            catch (SocketException se)
+            {
+                log.Add($"{nameof(SocketException)} while performing request {req}: {se.Message}");
+                handleFailure();
+                return false;
+            }
             catch (WebException we)
             {
+                log.Add($"{nameof(WebException)} while performing request {req}: {we.Message}");
                 handleWebException(we);
                 return false;
             }
@@ -312,7 +326,7 @@ namespace osu.Game.Online.API
         /// </summary>
         public IBindable<APIState> State => state;
 
-        private bool handleWebException(WebException we)
+        private void handleWebException(WebException we)
         {
             HttpStatusCode statusCode = (we.Response as HttpWebResponse)?.StatusCode
                                         ?? (we.Status == WebExceptionStatus.UnknownError ? HttpStatusCode.NotAcceptable : HttpStatusCode.RequestTimeout);
@@ -330,26 +344,24 @@ namespace osu.Game.Online.API
             {
                 case HttpStatusCode.Unauthorized:
                     Logout();
-                    return true;
+                    break;
 
                 case HttpStatusCode.RequestTimeout:
-                    failureCount++;
-                    log.Add($@"API failure count is now {failureCount}");
-
-                    if (failureCount < 3)
-                        // we might try again at an api level.
-                        return false;
-
-                    if (State.Value == APIState.Online)
-                    {
-                        state.Value = APIState.Failing;
-                        flushQueue();
-                    }
-
-                    return true;
+                    handleFailure();
+                    break;
             }
+        }
 
-            return true;
+        private void handleFailure()
+        {
+            failureCount++;
+            log.Add($@"API failure count is now {failureCount}");
+
+            if (failureCount >= 3 && State.Value == APIState.Online)
+            {
+                state.Value = APIState.Failing;
+                flushQueue();
+            }
         }
 
         public bool IsLoggedIn => localUser.Value.Id > 1;

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Online.Multiplayer
             IsConnected.BindValueChanged(connected =>
             {
                 // clean up local room state on server disconnect.
-                if (!connected.NewValue)
+                if (!connected.NewValue && Room != null)
                 {
                     Logger.Log("Connection to multiplayer server was lost.", LoggingTarget.Runtime, LogLevel.Important);
                     LeaveRoom().CatchUnobservedExceptions();

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.1228.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.1229.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.1202.0" />
     <PackageReference Include="Sentry" Version="2.1.8" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.1228.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2020.1229.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.1202.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -88,7 +88,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2020.1228.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2020.1229.0" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- Fix error message being surfaced to user on multiplayer disconnection when not in room
- Handle SocketExceptions and HttpRequestExceptions more silently

These can occur when a network connection is completely unavailable (ie.  host resolution failures are occurring). Currently these would appear as important errors which spammed the notification overlay every retry forever, while no network connection is available.

I also took this opportunity to remove a lot of `bool` passing which was no longer in use (previously the fail count / retry process was different to what we have today).

- [x] Depends on https://github.com/ppy/osu-framework/pull/4115
- Closes #11347

2cb84c5111 (Dean Herbert, 63 minutes ago)