### PR TITLE
Fix being able to enter online screens while API is in a failing mode

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Screens.Menu
 
         private void onMultiplayer()
         {
-            if (!api.IsLoggedIn || api.State.Value != APIState.Online)
+            if (api.State.Value != APIState.Online)
             {
                 notifications?.Post(new SimpleNotification
                 {
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.Menu
 
         private void onPlaylists()
         {
-            if (!api.IsLoggedIn || api.State.Value != APIState.Online)
+            if (api.State.Value != APIState.Online)
             {
                 notifications?.Post(new SimpleNotification
                 {

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Screens.Menu
             {
                 notifications?.Post(new SimpleNotification
                 {
-                    Text = "You gotta be logged in to multi 'yo!",
+                    Text = "You gotta be online to multi 'yo!",
                     Icon = FontAwesome.Solid.Globe,
                     Activated = () =>
                     {
@@ -181,7 +181,7 @@ namespace osu.Game.Screens.Menu
             {
                 notifications?.Post(new SimpleNotification
                 {
-                    Text = "You gotta be logged in to view playlists 'yo!",
+                    Text = "You gotta be online to view playlists 'yo!",
                     Icon = FontAwesome.Solid.Globe,
                     Activated = () =>
                     {

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Screens.Menu
 
         private void onMultiplayer()
         {
-            if (!api.IsLoggedIn)
+            if (!api.IsLoggedIn || api.State.Value != APIState.Online)
             {
                 notifications?.Post(new SimpleNotification
                 {
@@ -177,11 +177,11 @@ namespace osu.Game.Screens.Menu
 
         private void onPlaylists()
         {
-            if (!api.IsLoggedIn)
+            if (!api.IsLoggedIn || api.State.Value != APIState.Online)
             {
                 notifications?.Post(new SimpleNotification
                 {
-                    Text = "You gotta be logged in to multi 'yo!",
+                    Text = "You gotta be logged in to view playlists 'yo!",
                     Icon = FontAwesome.Solid.Globe,
                     Activated = () =>
                     {

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics.Containers;
@@ -165,7 +166,10 @@ namespace osu.Game.Screens.OnlinePlay
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>
         {
             if (state.NewValue != APIState.Online)
+            {
+                Logger.Log("API connection was lost, can't continue with online play", LoggingTarget.Network, LogLevel.Important);
                 Schedule(forcefullyExit);
+            }
         });
 
         protected override void LoadComplete()


### PR DESCRIPTION
Without this change, the user could enter the screens from the main menu in APIState.Failing, only to be returned back to the menu in milliseconds. This changes the state check to include all non-online states for the time being.

Also provides better messaging when an online screen needs to be exited due to a connection loss.