### PR TITLE
Move thread safety / locking logic from MultiplayerRoom

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
@@ -5,9 +5,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Newtonsoft.Json;
-using osu.Framework.Allocation;
 
 namespace osu.Game.Online.Multiplayer
 {
@@ -46,27 +44,6 @@ namespace osu.Game.Online.Multiplayer
         public MultiplayerRoom(in long roomId)
         {
             RoomID = roomId;
-        }
-
-        private object updateLock = new object();
-
-        private ManualResetEventSlim freeForWrite = new ManualResetEventSlim(true);
-
-        /// <summary>
-        /// Request a lock on this room to perform a thread-safe update.
-        /// </summary>
-        public IDisposable LockForUpdate()
-        {
-            // ReSharper disable once InconsistentlySynchronizedField
-            freeForWrite.Wait();
-
-            lock (updateLock)
-            {
-                freeForWrite.Wait();
-                freeForWrite.Reset();
-
-                return new ValueInvokeOnDisposal<MultiplayerRoom>(this, r => freeForWrite.Set());
-            }
         }
 
         public override string ToString() => $"RoomID:{RoomID} Host:{Host?.UserID} Users:{Users.Count} State:{State} Settings: [{Settings}]";


### PR DESCRIPTION
This was only used server-side and is now in the process of being replaced by a more reliable mechanism.