### PR TITLE
Fix PerformFromMenuRunner failing if CurrentScreen is null

### DIFF
--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -73,13 +73,16 @@ namespace osu.Game
             // find closest valid target
             IScreen current = getCurrentScreen();
 
+            if (current == null)
+                return;
+
             // a dialog may be blocking the execution for now.
             if (checkForDialog(current)) return;
 
             game?.CloseAllOverlays(false);
 
             // we may already be at the target screen type.
-            if (validScreens.Contains(getCurrentScreen().GetType()) && !beatmap.Disabled)
+            if (validScreens.Contains(current.GetType()) && !beatmap.Disabled)
             {
                 complete();
                 return;

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -84,7 +84,8 @@ namespace osu.Game
             // we may already be at the target screen type.
             if (validScreens.Contains(current.GetType()) && !beatmap.Disabled)
             {
-                complete();
+                finalAction(current);
+                Cancel();
                 return;
             }
 
@@ -137,12 +138,6 @@ namespace osu.Game
             lastEncounteredDialog = currentDialog;
             lastEncounteredDialogScreen = current;
             return true;
-        }
-
-        private void complete()
-        {
-            finalAction(getCurrentScreen());
-            Cancel();
         }
     }
 }


### PR DESCRIPTION
Found this while testing. If the window decoration close button is used to exit the game, there's a potential that a `PerformFromMenu` operation is started which can never resolve the menu (due to the screen already being switched to `IntroTriangles` to play the outro). This means the scheduled operations will continue to run while the game shuts down. During this process, the screen stack may be empty for one (or more?) frames, which causes the nullref.