### PR TITLE
Use `IParseable` interface for mod parsing/copying logic

### DIFF
--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Online.API
                 if (!Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
                     continue;
 
-                ((IBindable)property.GetValue(resultMod)).Parse(settingValue);
+                ((IParseable)property.GetValue(resultMod)).Parse(settingValue);
             }
 
             return resultMod;

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -135,16 +134,7 @@ namespace osu.Game.Rulesets.Mods
 
             // Copy bindable values across
             foreach (var (_, prop) in this.GetSettingsSourceProperties())
-            {
-                var origBindable = prop.GetValue(this);
-                var copyBindable = prop.GetValue(copy);
-
-                // The bindables themselves are readonly, so the value must be transferred through the Bindable<T>.Value property.
-                var valueProperty = origBindable.GetType().GetProperty(nameof(Bindable<object>.Value), BindingFlags.Public | BindingFlags.Instance);
-                Debug.Assert(valueProperty != null);
-
-                valueProperty.SetValue(copyBindable, valueProperty.GetValue(origBindable));
-            }
+                ((IParseable)prop.GetValue(this)).Parse(prop.GetValue(copy));
 
             return copy;
         }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Mods
 
             // Copy bindable values across
             foreach (var (_, prop) in this.GetSettingsSourceProperties())
-                ((IParseable)prop.GetValue(this)).Parse(prop.GetValue(copy));
+                ((IParseable)prop.GetValue(copy)).Parse(prop.GetValue(this));
 
             return copy;
         }


### PR DESCRIPTION
Required for the proposed `OverridableBindable` class to be allowed for use as mod property.

Not sure about the `Mod.CreateCopy()` changes part though, going through `IParseable` seems the best way currently, no more reflection hacks with that, but feedbacks would be appreciated.