### PR TITLE
Allow signalr to retry connecting when connection is closed without an exception

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -88,11 +88,12 @@ namespace osu.Game.Online.Multiplayer
             {
                 isConnected.Value = false;
 
-                if (ex != null)
-                {
-                    Logger.Log($"Multiplayer client lost connection: {ex}", LoggingTarget.Network);
+                Logger.Log(ex != null
+                    ? $"Multiplayer client lost connection: {ex}"
+                    : "Multiplayer client disconnected", LoggingTarget.Network);
+
+                if (connection != null)
                     await tryUntilConnected();
-                }
             };
 
             await tryUntilConnected();


### PR DESCRIPTION
Even though the documentation says that the exception on the `OnDisconnectedAsync` call will be populated on a non-intentional disconnection, there seems to be instances where it isn't. One such isntance is graceful server shutdown, where the server intends for the connection to be closed, but the client doesn't

This is an initial step towards fixing #11280. It is not a final fix, for the following reasons:

- I would still prefer we use the reconnect logic provided by SignalR, as mentioned in the linked issue.
- When switching to their econnect logic, we need to fix the thread-safety of the `connection` variable. Right now it has the potential of going null (from the API scheduler) while in use (on the reconnect loop). This could lead to an exception being thrown, or worse, a connection being established and having its reference lost when it was intended to be closed. the `connection` variable likely needs to be `readonly` or only set / cleared from the API scheduler, and only after a successful connection has finished being established.

I want to get this one in as the above may take a bit more time to realise. It should fix a lot of cases where the client gets stuck in a state of thinking it doesn't need to reconnect.