### PR TITLE
Bump InspectCode tool to 2020.3.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "jetbrains.resharper.globaltools": {
-      "version": "2020.2.4",
+      "version": "2020.3.2",
       "commands": [
         "jb"
       ]

--- a/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
+++ b/osu.Game.Tests/Visual/Components/TestScenePreviewTrackManager.cs
@@ -8,7 +8,6 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
-using static osu.Game.Tests.Visual.Components.TestScenePreviewTrackManager.TestPreviewTrackManager;
 
 namespace osu.Game.Tests.Visual.Components
 {
@@ -100,7 +99,7 @@ namespace osu.Game.Tests.Visual.Components
         [Test]
         public void TestNonPresentTrack()
         {
-            TestPreviewTrack track = null;
+            TestPreviewTrackManager.TestPreviewTrack track = null;
 
             AddStep("get non-present track", () =>
             {
@@ -182,9 +181,9 @@ namespace osu.Game.Tests.Visual.Components
             AddAssert("track stopped", () => !track.IsRunning);
         }
 
-        private TestPreviewTrack getTrack() => (TestPreviewTrack)trackManager.Get(null);
+        private TestPreviewTrackManager.TestPreviewTrack getTrack() => (TestPreviewTrackManager.TestPreviewTrack)trackManager.Get(null);
 
-        private TestPreviewTrack getOwnedTrack()
+        private TestPreviewTrackManager.TestPreviewTrack getOwnedTrack()
         {
             var track = getTrack();
 

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -106,6 +106,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeCastWithTypeCheck/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeConditionalExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeSequentialChecks/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MergeSequentialPatterns/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MethodHasAsyncOverload/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MethodHasAsyncOverloadWithCancellation/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MethodSupportsCancellation/@EntryIndexedValue">WARNING</s:String>


### PR DESCRIPTION
Unblocks #11401.

* Works around an inspectcode issue with a `using static` to a nested class we had. Issue has actually been reported to JetBrains by @frenzibyte at: https://youtrack.jetbrains.com/issue/RSRP-482664
* Disables the new "merge sequential patterns" suggestions due to being bad wrt readability. Example of one from our code:

```diff
-    protected void ConfirmAtMainMenu() => AddUntilStep("Wait for main menu",
-        () => Game.ScreenStack.CurrentScreen is MainMenu menu && menu.IsLoaded);
+    protected void ConfirmAtMainMenu() => AddUntilStep("Wait for main menu",
+        () => Game.ScreenStack.CurrentScreen is MainMenu { IsLoaded: true });
```