### PR TITLE
Add ability to toggle discord rich presence

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -31,7 +31,8 @@ namespace osu.Desktop
 
         private readonly IBindable<UserStatus> status = new Bindable<UserStatus>();
         private readonly IBindable<UserActivity> activity = new Bindable<UserActivity>();
-        private readonly Bindable<DiscordRichPresenceMode> mode = new Bindable<DiscordRichPresenceMode>();
+
+        private readonly Bindable<DiscordRichPresenceMode> privacyMode = new Bindable<DiscordRichPresenceMode>();
 
         private readonly RichPresence presence = new RichPresence
         {
@@ -53,7 +54,8 @@ namespace osu.Desktop
 
             client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Code} {e.Message}", LoggingTarget.Network);
 
-            config.BindWith(OsuSetting.DiscordRichPresence, mode);
+            config.BindWith(OsuSetting.DiscordRichPresence, privacyMode);
+
             (user = provider.LocalUser.GetBoundCopy()).BindValueChanged(u =>
             {
                 status.UnbindBindings();
@@ -66,7 +68,7 @@ namespace osu.Desktop
             ruleset.BindValueChanged(_ => updateStatus());
             status.BindValueChanged(_ => updateStatus());
             activity.BindValueChanged(_ => updateStatus());
-            mode.BindValueChanged(_ => updateStatus());
+            privacyMode.BindValueChanged(_ => updateStatus());
 
             client.Initialize();
         }
@@ -82,7 +84,7 @@ namespace osu.Desktop
             if (!client.IsInitialized)
                 return;
 
-            if (status.Value is UserStatusOffline || mode.Value == DiscordRichPresenceMode.Off)
+            if (status.Value is UserStatusOffline || privacyMode.Value == DiscordRichPresenceMode.Off)
             {
                 client.ClearPresence();
                 return;
@@ -100,7 +102,7 @@ namespace osu.Desktop
             }
 
             // update user information
-            if (mode.Value == DiscordRichPresenceMode.Limited)
+            if (privacyMode.Value == DiscordRichPresenceMode.Limited)
                 presence.Assets.LargeImageText = string.Empty;
             else
                 presence.Assets.LargeImageText = $"{user.Value.Username}" + (user.Value.Statistics?.Ranks.Global > 0 ? $" (rank #{user.Value.Statistics.Ranks.Global:N0})" : string.Empty);
@@ -144,7 +146,7 @@ namespace osu.Desktop
                     return edit.Beatmap.ToString();
 
                 case UserActivity.InLobby lobby:
-                    return mode.Value == DiscordRichPresenceMode.Limited ? string.Empty : lobby.Room.Name.Value;
+                    return privacyMode.Value == DiscordRichPresenceMode.Limited ? string.Empty : lobby.Room.Name.Value;
             }
 
             return string.Empty;

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -82,7 +82,7 @@ namespace osu.Desktop
             if (!client.IsInitialized)
                 return;
 
-            if (status.Value is UserStatusOffline || mode.Value == DiscordRichPresenceMode.Disabled)
+            if (status.Value is UserStatusOffline || mode.Value == DiscordRichPresenceMode.Off)
             {
                 client.ClearPresence();
                 return;

--- a/osu.Game/Configuration/DiscordRichPresenceMode.cs
+++ b/osu.Game/Configuration/DiscordRichPresenceMode.cs
@@ -7,11 +7,11 @@ namespace osu.Game.Configuration
 {
     public enum DiscordRichPresenceMode
     {
-        Disabled,
+        Off,
 
         [Description("Hide identifiable information")]
         Limited,
 
-        Enabled
+        Full
     }
 }

--- a/osu.Game/Configuration/DiscordRichPresenceMode.cs
+++ b/osu.Game/Configuration/DiscordRichPresenceMode.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.Configuration
+{
+    public enum DiscordRichPresenceMode
+    {
+        Disabled,
+
+        [Description("Hide identifiable information")]
+        Limited,
+
+        Enabled
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -138,6 +138,8 @@ namespace osu.Game.Configuration
             Set(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin);
             Set(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Sometimes);
 
+            Set(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Enabled);
+
             Set(OsuSetting.EditorWaveformOpacity, 1f);
         }
 
@@ -266,6 +268,7 @@ namespace osu.Game.Configuration
         GameplayDisableWinKey,
         SeasonalBackgroundMode,
         EditorWaveformOpacity,
+        DiscordRichPresence,
         AutomaticallyDownloadWhenSpectating,
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Configuration
             Set(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin);
             Set(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Sometimes);
 
-            Set(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Enabled);
+            Set(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Full);
 
             Set(OsuSetting.EditorWaveformOpacity, 1f);
         }

--- a/osu.Game/Overlays/Settings/Sections/Online/IntegrationSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/IntegrationSettings.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Configuration;
+
+namespace osu.Game.Overlays.Settings.Sections.Online
+{
+    public class IntegrationSettings : SettingsSubsection
+    {
+        protected override string Header => "Integrations";
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            Children = new Drawable[]
+            {
+                new SettingsEnumDropdown<DiscordRichPresenceMode>
+                {
+                    LabelText = "Discord Rich Presence",
+                    Current = config.GetBindable<DiscordRichPresenceMode>(OsuSetting.DiscordRichPresence)
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
@@ -20,7 +20,8 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             Children = new Drawable[]
             {
-                new WebSettings()
+                new WebSettings(),
+                new IntegrationSettings()
             };
         }
     }


### PR DESCRIPTION
There are 3 modes: enabled, limited, and disabled.

The limited mode hides identifiable information such as username, rank, and (if participating in one) multiplayer lobby name.

Closes #5090
Supersedes / closes #8258

