### PR TITLE
Fix difficulty adjust settings not being transferred correctly in multiplayer/playlists

### DIFF
--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -31,7 +31,12 @@ namespace osu.Game.Online.API
             Acronym = mod.Acronym;
 
             foreach (var (_, property) in mod.GetSettingsSourceProperties())
-                Settings.Add(property.Name.Underscore(), property.GetValue(mod));
+            {
+                var bindable = (IBindable)property.GetValue(mod);
+
+                if (!bindable.IsDefault)
+                    Settings.Add(property.Name.Underscore(), property.GetValue(mod));
+            }
         }
 
         public Mod ToMod(Ruleset ruleset)

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Online.API
                 var bindable = (IBindable)property.GetValue(mod);
 
                 if (!bindable.IsDefault)
-                    Settings.Add(property.Name.Underscore(), property.GetValue(mod));
+                    Settings.Add(property.Name.Underscore(), bindable);
             }
         }
 

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Online.API
                 if (!Settings.TryGetValue(property.Name.Underscore(), out object settingValue))
                     continue;
 
-                ((IBindable)property.GetValue(resultMod)).Parse(settingValue);
+                resultMod.CopyAdjustedSetting((IBindable)property.GetValue(resultMod), settingValue);
             }
 
             return resultMod;

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Online.API
 
         public Mod ToMod(Ruleset ruleset)
         {
-            Mod resultMod = ruleset.GetAllMods().FirstOrDefault(m => m.Acronym == Acronym);
+            Mod resultMod = ruleset.GetAllMods().SingleOrDefault(m => m.Acronym == Acronym);
 
             if (resultMod == null)
                 throw new InvalidOperationException($"There is no mod in the ruleset ({ruleset.ShortName}) matching the acronym {Acronym}.");

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Online.API
 
         public Mod ToMod(Ruleset ruleset)
         {
-            Mod resultMod = ruleset.GetAllMods().SingleOrDefault(m => m.Acronym == Acronym);
+            Mod resultMod = ruleset.GetAllMods().FirstOrDefault(m => m.Acronym == Acronym);
 
             if (resultMod == null)
                 throw new InvalidOperationException($"There is no mod in the ruleset ({ruleset.ShortName}) matching the acronym {Acronym}.");

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -150,7 +150,17 @@ namespace osu.Game.Rulesets.Mods
         /// </summary>
         /// <param name="bindable">The target bindable to apply the adjustment.</param>
         /// <param name="value">The adjustment to apply.</param>
-        internal virtual void CopyAdjustedSetting(IBindable bindable, object value) => bindable.Parse(value);
+        internal virtual void CopyAdjustedSetting(IBindable bindable, object value)
+        {
+            if (value is IBindable incoming)
+            {
+                //copy including transfer of default values.
+                bindable.BindTo(incoming);
+                bindable.UnbindFrom(incoming);
+            }
+            else
+                bindable.Parse(value);
+        }
 
         public bool Equals(IMod other) => GetType() == other?.GetType();
     }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -145,16 +145,19 @@ namespace osu.Game.Rulesets.Mods
         }
 
         /// <summary>
-        /// When creating copies or clones of a Mod, this method will be called to copy explicitly adjusted user settings.
-        /// The base implementation will transfer the value via <see cref="Bindable{T}.Parse"/> and should be called unless replaced with custom logic.
+        /// When creating copies or clones of a Mod, this method will be called
+        /// to copy explicitly adjusted user settings from <paramref name="target"/>.
+        /// The base implementation will transfer the value via <see cref="Bindable{T}.Parse"/>
+        /// or by binding and unbinding (if <paramref name="source"/> is an <see cref="IBindable"/>)
+        /// and should be called unless replaced with custom logic.
         /// </summary>
-        /// <param name="target">The target bindable to apply the adjustment.</param>
+        /// <param name="target">The target bindable to apply the adjustment to.</param>
         /// <param name="source">The adjustment to apply.</param>
         internal virtual void CopyAdjustedSetting(IBindable target, object source)
         {
             if (source is IBindable sourceBindable)
             {
-                //copy including transfer of default values.
+                // copy including transfer of default values.
                 target.BindTo(sourceBindable);
                 target.UnbindFrom(sourceBindable);
             }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -148,18 +148,18 @@ namespace osu.Game.Rulesets.Mods
         /// When creating copies or clones of a Mod, this method will be called to copy explicitly adjusted user settings.
         /// The base implementation will transfer the value via <see cref="Bindable{T}.Parse"/> and should be called unless replaced with custom logic.
         /// </summary>
-        /// <param name="bindable">The target bindable to apply the adjustment.</param>
-        /// <param name="value">The adjustment to apply.</param>
-        internal virtual void CopyAdjustedSetting(IBindable bindable, object value)
+        /// <param name="target">The target bindable to apply the adjustment.</param>
+        /// <param name="source">The adjustment to apply.</param>
+        internal virtual void CopyAdjustedSetting(IBindable target, object source)
         {
-            if (value is IBindable incoming)
+            if (source is IBindable sourceBindable)
             {
                 //copy including transfer of default values.
-                bindable.BindTo(incoming);
-                bindable.UnbindFrom(incoming);
+                target.BindTo(sourceBindable);
+                target.UnbindFrom(sourceBindable);
             }
             else
-                bindable.Parse(value);
+                target.Parse(source);
         }
 
         public bool Equals(IMod other) => GetType() == other?.GetType();

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -84,12 +84,10 @@ namespace osu.Game.Rulesets.Mods
 
                 foreach ((SettingSourceAttribute attr, PropertyInfo property) in this.GetOrderedSettingsSourceProperties())
                 {
-                    object bindableObj = property.GetValue(this);
+                    var bindable = (IBindable)property.GetValue(this);
 
-                    if ((bindableObj as IHasDefaultValue)?.IsDefault == true)
-                        continue;
-
-                    tooltipTexts.Add($"{attr.Label} {bindableObj}");
+                    if (!bindable.IsDefault)
+                        tooltipTexts.Add($"{attr.Label} {bindable}");
                 }
 
                 return string.Join(", ", tooltipTexts.Where(s => !string.IsNullOrEmpty(s)));

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -114,6 +114,12 @@ namespace osu.Game.Rulesets.Mods
             bindable.ValueChanged += _ => userChangedSettings[bindable] = !bindable.IsDefault;
         }
 
+        internal override void CopyAdjustedSetting(IBindable bindable, object value)
+        {
+            userChangedSettings[bindable] = true;
+            base.CopyAdjustedSetting(bindable, value);
+        }
+
         /// <summary>
         /// Apply all custom settings to the provided beatmap.
         /// </summary>

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -114,10 +114,10 @@ namespace osu.Game.Rulesets.Mods
             bindable.ValueChanged += _ => userChangedSettings[bindable] = !bindable.IsDefault;
         }
 
-        internal override void CopyAdjustedSetting(IBindable bindable, object value)
+        internal override void CopyAdjustedSetting(IBindable target, object source)
         {
-            userChangedSettings[bindable] = true;
-            base.CopyAdjustedSetting(bindable, value);
+            userChangedSettings[target] = true;
+            base.CopyAdjustedSetting(target, source);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11305

This fixes a number of issues with serialisation and deserialisation of `Mod`/`APIMod` when `ModDifficultyAdjust` is involved. I've aimed to make the minimum number of changes possible to fix mutliplayer/playlists usage. The main issues were:

- Depends on application order of difficulty settings (from the beatmap) and user difficulty settings (from the serialisation), user adjustments could be overwritten by beatmap values as they are not considered tracked. This provides a pathway to forcefully apply and track user adjustments when we are sure they are non-defaults.
- To ensure they are non-defaults, only adjusted values are serialised. Previously the client was sending all values to the server, including map defaults (which was very wrong). Now, only adjusted values are sent.
- Tidied up usage of `GetOrderedSettingsSourceProperties` where it was not assumed that the retrieved properties were `IBindable` (the whole underlying system relies on them being such).

Alternative to the other pathway being explored by @frenzibyte. We may still want to go down that road to better solidify the API (and provide a questionably better user experience via the checkbox model?), but I'm hoping to get this in as a hotfix solution in the mean time.