### PR TITLE
Fix Storyboard's FirstEventTime not finding the true earliest event

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual(1500, background.Elements[0].StartTime);
                 Assert.AreEqual(1000, background.Elements[1].StartTime);
 
-                Assert.AreEqual(1000, storyboard.FirstEventTime);
+                Assert.AreEqual(1000, storyboard.EarliestEventTime);
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -96,6 +96,26 @@ namespace osu.Game.Tests.Beatmaps.Formats
         }
 
         [Test]
+        public void TestOutOfOrderStartTimes()
+        {
+            var decoder = new LegacyStoryboardDecoder();
+
+            using (var resStream = TestResources.OpenResource("out-of-order-starttimes.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var storyboard = decoder.Decode(stream);
+
+                StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
+                Assert.AreEqual(2, background.Elements.Count);
+
+                Assert.AreEqual(1500, background.Elements[0].StartTime);
+                Assert.AreEqual(1000, background.Elements[1].StartTime);
+
+                Assert.AreEqual(1000, storyboard.FirstEventTime);
+            }
+        }
+
+        [Test]
         public void TestDecodeVariableWithSuffix()
         {
             var decoder = new LegacyStoryboardDecoder();

--- a/osu.Game.Tests/Resources/out-of-order-starttimes.osb
+++ b/osu.Game.Tests/Resources/out-of-order-starttimes.osb
@@ -1,0 +1,6 @@
+[Events]
+//Storyboard Layer 0 (Background)
+Sprite,Background,TopCentre,"img.jpg",320,240
+ F,0,1500,1600,0,1
+Sprite,Background,TopCentre,"img.jpg",320,240
+ F,0,1000,1100,0,1

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -131,7 +131,9 @@ namespace osu.Game.Screens.Play
 
                 // if a storyboard is present, it may dictate the appropriate start time by having events in negative time space.
                 // this is commonly used to display an intro before the audio track start.
-                startTime = Math.Min(startTime, beatmap.Storyboard.FirstEventTime);
+                double? firstStoryboardEvent = beatmap.Storyboard.EarliestEventTime;
+                if (firstStoryboardEvent != null)
+                    startTime = Math.Min(startTime, firstStoryboardEvent.Value);
 
                 // some beatmaps specify a current lead-in time which should be used instead of the ruleset-provided value when available.
                 // this is not available as an option in the live editor but can still be applied via .osu editing.

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
@@ -27,7 +28,14 @@ namespace osu.Game.Storyboards
 
         public bool HasDrawable => Layers.Any(l => l.Elements.Any(e => e.IsDrawable));
 
-        public double FirstEventTime => Layers.Min(l => l.Elements.FirstOrDefault()?.StartTime ?? 0);
+        /// <summary>
+        /// Across all layers, find the earliest point in time that a storyboard element exists at.
+        /// Will return null if there are no elements.
+        /// </summary>
+        /// <remarks>
+        /// This iterates all elements and as such should be used sparingly or stored locally.
+        /// </remarks>
+        public double? EarliestEventTime => Layers.SelectMany(l => l.Elements).OrderBy(e => e.StartTime).FirstOrDefault()?.StartTime;
 
         /// <summary>
         /// Depth of the currently front-most storyboard layer, excluding the overlay layer.

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Internal;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;


### PR DESCRIPTION
This regressed due to the change to storyboard element order parsing (correct for other usages) in https://github.com/ppy/osu/pull/7302. The resolution here is to re-check the minimum `StartTime` rather than rely on the previously-correct element ordering.

Closes #6840 (regressed).