### PR TITLE
Fix RemoveBlockingOverlay causing transform mutation from disposal threads

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -151,11 +151,11 @@ namespace osu.Game
             updateBlockingOverlayFade();
         }
 
-        public void RemoveBlockingOverlay(OverlayContainer overlay)
+        public void RemoveBlockingOverlay(OverlayContainer overlay) => Schedule(() =>
         {
             visibleBlockingOverlays.Remove(overlay);
             updateBlockingOverlayFade();
-        }
+        });
 
         /// <summary>
         /// Close all game-wide overlays.


### PR DESCRIPTION
This is just one of multiple cases of transform mutation from incorrect threads that I unearthed (causing enumeration-on-modified-collection exceptions).