### PR TITLE
Refactor LoadingLayer to avoid applying effects to external drawables

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLoadingLayer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLoadingLayer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,10 +15,11 @@ namespace osu.Game.Tests.Visual.UserInterface
 {
     public class TestSceneLoadingLayer : OsuTestScene
     {
-        private Drawable dimContent;
         private LoadingLayer overlay;
 
         private Container content;
+
+        private Drawable dimContent => overlay.Children.OfType<Box>().First();
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -29,14 +31,14 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Size = new Vector2(300),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Children = new[]
+                    Children = new Drawable[]
                     {
                         new Box
                         {
                             Colour = Color4.SlateGray,
                             RelativeSizeAxes = Axes.Both,
                         },
-                        dimContent = new FillFlowContainer
+                        new FillFlowContainer
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
@@ -51,7 +53,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                                 new TriangleButton { Text = "puush me", Width = 200, Action = () => { } },
                             }
                         },
-                        overlay = new LoadingLayer(dimContent),
+                        overlay = new LoadingLayer(true),
                     }
                 },
             };

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLoadingLayer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLoadingLayer.cs
@@ -1,11 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osuTK;
@@ -15,11 +15,9 @@ namespace osu.Game.Tests.Visual.UserInterface
 {
     public class TestSceneLoadingLayer : OsuTestScene
     {
-        private LoadingLayer overlay;
+        private TestLoadingLayer overlay;
 
         private Container content;
-
-        private Drawable dimContent => overlay.Children.OfType<Box>().First();
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -53,7 +51,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                                 new TriangleButton { Text = "puush me", Width = 200, Action = () => { } },
                             }
                         },
-                        overlay = new LoadingLayer(true),
+                        overlay = new TestLoadingLayer(true),
                     }
                 },
             };
@@ -66,25 +64,11 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("show", () => overlay.Show());
 
-            AddUntilStep("wait for content dim", () => dimContent.Colour != Color4.White);
+            AddUntilStep("wait for content dim", () => overlay.BackgroundDimLayer.Alpha > 0);
 
             AddStep("hide", () => overlay.Hide());
 
-            AddUntilStep("wait for content restore", () => dimContent.Colour == Color4.White);
-        }
-
-        [Test]
-        public void TestContentRestoreOnDispose()
-        {
-            AddAssert("not visible", () => !overlay.IsPresent);
-
-            AddStep("show", () => overlay.Show());
-
-            AddUntilStep("wait for content dim", () => dimContent.Colour != Color4.White);
-
-            AddStep("expire", () => overlay.Expire());
-
-            AddUntilStep("wait for content restore", () => dimContent.Colour == Color4.White);
+            AddUntilStep("wait for content restore", () => Precision.AlmostEquals(overlay.BackgroundDimLayer.Alpha, 0));
         }
 
         [Test]
@@ -99,6 +83,16 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
 
             AddStep("hide", () => overlay.Hide());
+        }
+
+        private class TestLoadingLayer : LoadingLayer
+        {
+            public new Box BackgroundDimLayer => base.BackgroundDimLayer;
+
+            public TestLoadingLayer(bool dimBackground = false, bool withBox = true)
+                : base(dimBackground, withBox)
+            {
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osuTK;
@@ -81,17 +80,6 @@ namespace osu.Game.Graphics.UserInterface
             base.Update();
 
             MainContents.Size = new Vector2(Math.Clamp(Math.Min(DrawWidth, DrawHeight) * 0.25f, 30, 100));
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (State.Value == Visibility.Visible)
-            {
-                // ensure we don't leave the target in a bad state.
-                // dimTarget?.FadeColour(Color4.White, TRANSITION_DURATION, Easing.OutQuint);
-            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public class LoadingLayer : LoadingSpinner
     {
-        private readonly Box backgroundDimLayer;
+        protected Box BackgroundDimLayer { get; private set; }
 
         /// <summary>
         /// Construct a new loading spinner.
@@ -34,7 +34,7 @@ namespace osu.Game.Graphics.UserInterface
 
             if (dimBackground)
             {
-                AddInternal(backgroundDimLayer = new Box
+                AddInternal(BackgroundDimLayer = new Box
                 {
                     Depth = float.MaxValue,
                     Colour = Color4.Black,
@@ -65,13 +65,13 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void PopIn()
         {
-            backgroundDimLayer?.FadeTo(0.5f, TRANSITION_DURATION * 2, Easing.OutQuint);
+            BackgroundDimLayer?.FadeTo(0.5f, TRANSITION_DURATION * 2, Easing.OutQuint);
             base.PopIn();
         }
 
         protected override void PopOut()
         {
-            backgroundDimLayer?.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
+            BackgroundDimLayer?.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
             base.PopOut();
         }
 

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public class LoadingLayer : LoadingSpinner
     {
-        protected Box BackgroundDimLayer { get; private set; }
+        protected Box BackgroundDimLayer { get; }
 
         /// <summary>
         /// Construct a new loading spinner.

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
@@ -17,6 +18,7 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public class LoadingLayer : LoadingSpinner
     {
+        [CanBeNull]
         protected Box BackgroundDimLayer { get; }
 
         /// <summary>

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osuTK;
 using osuTK.Graphics;
@@ -17,22 +18,31 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public class LoadingLayer : LoadingSpinner
     {
-        private readonly Drawable dimTarget;
+        private readonly Box backgroundDimLayer;
 
         /// <summary>
-        /// Constuct a new loading spinner.
+        /// Construct a new loading spinner.
         /// </summary>
-        /// <param name="dimTarget">An optional target to dim when displayed.</param>
+        /// <param name="dimBackground">Whether the full background area should be dimmed while loading.</param>
         /// <param name="withBox">Whether the spinner should have a surrounding black box for visibility.</param>
-        public LoadingLayer(Drawable dimTarget = null, bool withBox = true)
+        public LoadingLayer(bool dimBackground = false, bool withBox = true)
             : base(withBox)
         {
             RelativeSizeAxes = Axes.Both;
             Size = new Vector2(1);
 
-            this.dimTarget = dimTarget;
-
             MainContents.RelativeSizeAxes = Axes.None;
+
+            if (dimBackground)
+            {
+                AddInternal(backgroundDimLayer = new Box
+                {
+                    Depth = float.MaxValue,
+                    Colour = Color4.Black,
+                    Alpha = 0,
+                    RelativeSizeAxes = Axes.Both,
+                });
+            }
         }
 
         public override bool HandleNonPositionalInput => false;
@@ -56,19 +66,20 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override void PopIn()
         {
-            dimTarget?.FadeColour(OsuColour.Gray(0.5f), TRANSITION_DURATION, Easing.OutQuint);
+            backgroundDimLayer?.FadeTo(0.5f, TRANSITION_DURATION * 2, Easing.OutQuint);
             base.PopIn();
         }
 
         protected override void PopOut()
         {
-            dimTarget?.FadeColour(Color4.White, TRANSITION_DURATION, Easing.OutQuint);
+            backgroundDimLayer?.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
             base.PopOut();
         }
 
         protected override void Update()
         {
             base.Update();
+
             MainContents.Size = new Vector2(Math.Clamp(Math.Min(DrawWidth, DrawHeight) * 0.25f, 30, 100));
         }
 
@@ -79,7 +90,7 @@ namespace osu.Game.Graphics.UserInterface
             if (State.Value == Visibility.Visible)
             {
                 // ensure we don't leave the target in a bad state.
-                dimTarget?.FadeColour(Color4.White, TRANSITION_DURATION, Easing.OutQuint);
+                // dimTarget?.FadeColour(Color4.White, TRANSITION_DURATION, Easing.OutQuint);
             }
         }
     }

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Overlays.AccountCreation
                         },
                     },
                 },
-                loadingLayer = new LoadingLayer(mainContent)
+                loadingLayer = new LoadingLayer(true)
             };
 
             textboxes = new[] { usernameTextBox, emailTextBox, passwordTextBox };

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -48,11 +48,9 @@ namespace osu.Game.Overlays.AccountCreation
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            FillFlowContainer mainContent;
-
             InternalChildren = new Drawable[]
             {
-                mainContent = new FillFlowContainer
+                new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Direction = FillDirection.Vertical,

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -92,14 +92,14 @@ namespace osu.Game.Overlays
                                         {
                                             foundContent = new FillFlowContainer<BeatmapPanel>(),
                                             notFoundContent = new NotFoundDrawable(),
-                                            loadingLayer = new LoadingLayer(panelTarget)
                                         }
                                     }
-                                }
+                                },
                             },
                         }
-                    }
-                }
+                    },
+                },
+                loadingLayer = new LoadingLayer(true)
             };
         }
 

--- a/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/FavouriteButton.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
                     Size = new Vector2(18),
                     Shadow = false,
                 },
-                loading = new LoadingLayer(icon, false),
+                loading = new LoadingLayer(true, false),
             });
 
             Action = () =>

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -157,11 +157,11 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                                         }
                                     }
                                 },
-                                loading = new LoadingLayer()
                             }
                         }
-                    }
-                }
+                    },
+                },
+                loading = new LoadingLayer()
             });
         }
 
@@ -228,7 +228,9 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             {
                 Scores = null;
                 notSupporterPlaceholder.Show();
+
                 loading.Hide();
+                loading.FinishTransforms();
                 return;
             }
 
@@ -241,6 +243,8 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             getScoresRequest.Success += scores =>
             {
                 loading.Hide();
+                loading.FinishTransforms();
+
                 Scores = scores;
 
                 if (!scores.Scores.Any())

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                                                 AutoSizeAxes = Axes.Y,
                                                 Padding = new MarginPadding { Horizontal = 50 }
                                             },
-                                            loading = new LoadingLayer(itemsPlaceholder)
+                                            loading = new LoadingLayer(true)
                                         }
                                     }
                                 }

--- a/osu.Game/Overlays/DashboardOverlay.cs
+++ b/osu.Game/Overlays/DashboardOverlay.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Overlays
                         }
                     }
                 },
-                loading = new LoadingLayer(content),
+                loading = new LoadingLayer(true),
             };
         }
 

--- a/osu.Game/Overlays/NewsOverlay.cs
+++ b/osu.Game/Overlays/NewsOverlay.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays
                         },
                     },
                 },
-                loading = new LoadingLayer(content),
+                loading = new LoadingLayer(true),
             };
         }
 

--- a/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightsLayout.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Overlays.Rankings
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
+
             InternalChild = new ReverseChildIDFillFlowContainer<Drawable>
             {
                 RelativeSizeAxes = Axes.X,
@@ -68,7 +69,7 @@ namespace osu.Game.Overlays.Rankings
                                 AutoSizeAxes = Axes.Y,
                                 Margin = new MarginPadding { Vertical = 10 }
                             },
-                            loading = new LoadingLayer(content)
+                            loading = new LoadingLayer(true)
                         }
                     }
                 }

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Overlays
                 Depth = -float.MaxValue
             })
         {
+            loading = new LoadingLayer(true);
+
             Children = new Drawable[]
             {
                 background = new Box
@@ -74,12 +76,12 @@ namespace osu.Game.Overlays
                                         RelativeSizeAxes = Axes.X,
                                         Margin = new MarginPadding { Bottom = 10 }
                                     },
-                                    loading = new LoadingLayer(contentContainer),
                                 }
                             }
                         }
                     }
-                }
+                },
+                loading
             };
         }
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                                     Padding = new MarginPadding(10),
                                     Child = roomsContainer = new RoomsContainer { JoinRequested = joinRequested }
                                 },
-                                loadingLayer = new LoadingLayer(roomsContainer),
+                                loadingLayer = new LoadingLayer(true),
                             }
                         },
                         new RoomInspector

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -71,201 +71,192 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                Container dimContent;
-
                 InternalChildren = new Drawable[]
                 {
-                    dimContent = new Container
+                    new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Children = new Drawable[]
+                        Colour = Color4Extensions.FromHex(@"28242d"),
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        RowDimensions = new[]
                         {
-                            new Box
+                            new Dimension(GridSizeMode.Distributed),
+                            new Dimension(GridSizeMode.AutoSize),
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = Color4Extensions.FromHex(@"28242d"),
-                            },
-                            new GridContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                RowDimensions = new[]
+                                new OsuScrollContainer
                                 {
-                                    new Dimension(GridSizeMode.Distributed),
-                                    new Dimension(GridSizeMode.AutoSize),
-                                },
-                                Content = new[]
-                                {
-                                    new Drawable[]
+                                    Padding = new MarginPadding
                                     {
-                                        new OsuScrollContainer
+                                        Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING,
+                                        Vertical = 10
+                                    },
+                                    RelativeSizeAxes = Axes.Both,
+                                    Children = new[]
+                                    {
+                                        new FillFlowContainer
                                         {
-                                            Padding = new MarginPadding
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Vertical,
+                                            Spacing = new Vector2(0, 10),
+                                            Children = new Drawable[]
                                             {
-                                                Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING,
-                                                Vertical = 10
-                                            },
-                                            RelativeSizeAxes = Axes.Both,
-                                            Children = new[]
-                                            {
-                                                new FillFlowContainer
+                                                new Container
                                                 {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.WIDTH_PADDING },
                                                     RelativeSizeAxes = Axes.X,
                                                     AutoSizeAxes = Axes.Y,
-                                                    Direction = FillDirection.Vertical,
-                                                    Spacing = new Vector2(0, 10),
                                                     Children = new Drawable[]
                                                     {
-                                                        new Container
+                                                        new SectionContainer
                                                         {
-                                                            Anchor = Anchor.TopCentre,
-                                                            Origin = Anchor.TopCentre,
-                                                            Padding = new MarginPadding { Horizontal = WaveOverlayContainer.WIDTH_PADDING },
-                                                            RelativeSizeAxes = Axes.X,
-                                                            AutoSizeAxes = Axes.Y,
-                                                            Children = new Drawable[]
+                                                            Padding = new MarginPadding { Right = FIELD_PADDING / 2 },
+                                                            Children = new[]
                                                             {
-                                                                new SectionContainer
+                                                                new Section("Room name")
                                                                 {
-                                                                    Padding = new MarginPadding { Right = FIELD_PADDING / 2 },
-                                                                    Children = new[]
+                                                                    Child = NameField = new SettingsTextBox
                                                                     {
-                                                                        new Section("Room name")
+                                                                        RelativeSizeAxes = Axes.X,
+                                                                        TabbableContentContainer = this,
+                                                                    },
+                                                                },
+                                                                new Section("Room visibility")
+                                                                {
+                                                                    Alpha = disabled_alpha,
+                                                                    Child = AvailabilityPicker = new RoomAvailabilityPicker
+                                                                    {
+                                                                        Enabled = { Value = false }
+                                                                    },
+                                                                },
+                                                                new Section("Game type")
+                                                                {
+                                                                    Alpha = disabled_alpha,
+                                                                    Child = new FillFlowContainer
+                                                                    {
+                                                                        AutoSizeAxes = Axes.Y,
+                                                                        RelativeSizeAxes = Axes.X,
+                                                                        Direction = FillDirection.Vertical,
+                                                                        Spacing = new Vector2(7),
+                                                                        Children = new Drawable[]
                                                                         {
-                                                                            Child = NameField = new SettingsTextBox
+                                                                            TypePicker = new GameTypePicker
                                                                             {
                                                                                 RelativeSizeAxes = Axes.X,
-                                                                                TabbableContentContainer = this,
-                                                                            },
-                                                                        },
-                                                                        new Section("Room visibility")
-                                                                        {
-                                                                            Alpha = disabled_alpha,
-                                                                            Child = AvailabilityPicker = new RoomAvailabilityPicker
-                                                                            {
                                                                                 Enabled = { Value = false }
                                                                             },
-                                                                        },
-                                                                        new Section("Game type")
-                                                                        {
-                                                                            Alpha = disabled_alpha,
-                                                                            Child = new FillFlowContainer
+                                                                            typeLabel = new OsuSpriteText
                                                                             {
-                                                                                AutoSizeAxes = Axes.Y,
-                                                                                RelativeSizeAxes = Axes.X,
-                                                                                Direction = FillDirection.Vertical,
-                                                                                Spacing = new Vector2(7),
-                                                                                Children = new Drawable[]
-                                                                                {
-                                                                                    TypePicker = new GameTypePicker
-                                                                                    {
-                                                                                        RelativeSizeAxes = Axes.X,
-                                                                                        Enabled = { Value = false }
-                                                                                    },
-                                                                                    typeLabel = new OsuSpriteText
-                                                                                    {
-                                                                                        Font = OsuFont.GetFont(size: 14),
-                                                                                        Colour = colours.Yellow
-                                                                                    },
-                                                                                },
+                                                                                Font = OsuFont.GetFont(size: 14),
+                                                                                Colour = colours.Yellow
                                                                             },
                                                                         },
                                                                     },
                                                                 },
-                                                                new SectionContainer
-                                                                {
-                                                                    Anchor = Anchor.TopRight,
-                                                                    Origin = Anchor.TopRight,
-                                                                    Padding = new MarginPadding { Left = FIELD_PADDING / 2 },
-                                                                    Children = new[]
-                                                                    {
-                                                                        new Section("Max participants")
-                                                                        {
-                                                                            Alpha = disabled_alpha,
-                                                                            Child = MaxParticipantsField = new SettingsNumberTextBox
-                                                                            {
-                                                                                RelativeSizeAxes = Axes.X,
-                                                                                TabbableContentContainer = this,
-                                                                                ReadOnly = true,
-                                                                            },
-                                                                        },
-                                                                        new Section("Password (optional)")
-                                                                        {
-                                                                            Alpha = disabled_alpha,
-                                                                            Child = new SettingsPasswordTextBox
-                                                                            {
-                                                                                RelativeSizeAxes = Axes.X,
-                                                                                TabbableContentContainer = this,
-                                                                                ReadOnly = true,
-                                                                            },
-                                                                        },
-                                                                    }
-                                                                }
                                                             },
                                                         },
-                                                        initialBeatmapControl = new BeatmapSelectionControl
+                                                        new SectionContainer
                                                         {
-                                                            Anchor = Anchor.TopCentre,
-                                                            Origin = Anchor.TopCentre,
-                                                            RelativeSizeAxes = Axes.X,
-                                                            Width = 0.5f
+                                                            Anchor = Anchor.TopRight,
+                                                            Origin = Anchor.TopRight,
+                                                            Padding = new MarginPadding { Left = FIELD_PADDING / 2 },
+                                                            Children = new[]
+                                                            {
+                                                                new Section("Max participants")
+                                                                {
+                                                                    Alpha = disabled_alpha,
+                                                                    Child = MaxParticipantsField = new SettingsNumberTextBox
+                                                                    {
+                                                                        RelativeSizeAxes = Axes.X,
+                                                                        TabbableContentContainer = this,
+                                                                        ReadOnly = true,
+                                                                    },
+                                                                },
+                                                                new Section("Password (optional)")
+                                                                {
+                                                                    Alpha = disabled_alpha,
+                                                                    Child = new SettingsPasswordTextBox
+                                                                    {
+                                                                        RelativeSizeAxes = Axes.X,
+                                                                        TabbableContentContainer = this,
+                                                                        ReadOnly = true,
+                                                                    },
+                                                                },
+                                                            }
                                                         }
-                                                    }
+                                                    },
+                                                },
+                                                initialBeatmapControl = new BeatmapSelectionControl
+                                                {
+                                                    Anchor = Anchor.TopCentre,
+                                                    Origin = Anchor.TopCentre,
+                                                    RelativeSizeAxes = Axes.X,
+                                                    Width = 0.5f
                                                 }
-                                            },
-                                        },
+                                            }
+                                        }
                                     },
-                                    new Drawable[]
+                                },
+                            },
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Y = 2,
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = new Drawable[]
                                     {
-                                        new Container
+                                        new Box
                                         {
-                                            Anchor = Anchor.BottomLeft,
-                                            Origin = Anchor.BottomLeft,
-                                            Y = 2,
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = Color4Extensions.FromHex(@"28242d").Darken(0.5f).Opacity(1f),
+                                        },
+                                        new FillFlowContainer
+                                        {
                                             RelativeSizeAxes = Axes.X,
                                             AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Vertical,
+                                            Spacing = new Vector2(0, 20),
+                                            Margin = new MarginPadding { Vertical = 20 },
+                                            Padding = new MarginPadding { Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
                                             Children = new Drawable[]
                                             {
-                                                new Box
+                                                ApplyButton = new CreateOrUpdateButton
                                                 {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4Extensions.FromHex(@"28242d").Darken(0.5f).Opacity(1f),
+                                                    Anchor = Anchor.BottomCentre,
+                                                    Origin = Anchor.BottomCentre,
+                                                    Size = new Vector2(230, 55),
+                                                    Enabled = { Value = false },
+                                                    Action = apply,
                                                 },
-                                                new FillFlowContainer
+                                                ErrorText = new OsuSpriteText
                                                 {
-                                                    RelativeSizeAxes = Axes.X,
-                                                    AutoSizeAxes = Axes.Y,
-                                                    Direction = FillDirection.Vertical,
-                                                    Spacing = new Vector2(0, 20),
-                                                    Margin = new MarginPadding { Vertical = 20 },
-                                                    Padding = new MarginPadding { Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
-                                                    Children = new Drawable[]
-                                                    {
-                                                        ApplyButton = new CreateOrUpdateButton
-                                                        {
-                                                            Anchor = Anchor.BottomCentre,
-                                                            Origin = Anchor.BottomCentre,
-                                                            Size = new Vector2(230, 55),
-                                                            Enabled = { Value = false },
-                                                            Action = apply,
-                                                        },
-                                                        ErrorText = new OsuSpriteText
-                                                        {
-                                                            Anchor = Anchor.BottomCentre,
-                                                            Origin = Anchor.BottomCentre,
-                                                            Alpha = 0,
-                                                            Depth = 1,
-                                                            Colour = colours.RedDark
-                                                        }
-                                                    }
+                                                    Anchor = Anchor.BottomCentre,
+                                                    Origin = Anchor.BottomCentre,
+                                                    Alpha = 0,
+                                                    Depth = 1,
+                                                    Colour = colours.RedDark
                                                 }
                                             }
                                         }
                                     }
                                 }
-                            },
+                            }
                         }
                     },
-                    loadingLayer = new LoadingLayer(dimContent)
+                    loadingLayer = new LoadingLayer(true)
                 };
 
                 TypePicker.Current.BindValueChanged(type => typeLabel.Text = type.NewValue?.Name ?? string.Empty, true);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(loadingLayer = new LoadingLayer(Carousel));
+            AddInternal(loadingLayer = new LoadingLayer(true));
             initialBeatmap = Beatmap.Value;
             initialRuleset = Ruleset.Value;
             initialMods = Mods.Value.ToList();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             // todo: this should be implemented via a custom HUD implementation, and correctly masked to the main content area.
             LoadComponentAsync(leaderboard = new MultiplayerGameplayLeaderboard(ScoreProcessor, userIds), HUDOverlay.Add);
 
-            HUDOverlay.Add(loadingDisplay = new LoadingLayer(DrawableRuleset) { Depth = float.MaxValue });
+            HUDOverlay.Add(loadingDisplay = new LoadingLayer(true) { Depth = float.MaxValue });
 
             if (Token == null)
                 return; // Todo: Somehow handle token retrieval failure.

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsMatchSettingsOverlay.cs
@@ -64,243 +64,234 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                Container dimContent;
-
                 InternalChildren = new Drawable[]
                 {
-                    dimContent = new Container
+                    new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Children = new Drawable[]
+                        Colour = Color4Extensions.FromHex(@"28242d"),
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        RowDimensions = new[]
                         {
-                            new Box
+                            new Dimension(GridSizeMode.Distributed),
+                            new Dimension(GridSizeMode.AutoSize),
+                        },
+                        Content = new[]
+                        {
+                            new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = Color4Extensions.FromHex(@"28242d"),
-                            },
-                            new GridContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                RowDimensions = new[]
+                                new OsuScrollContainer
                                 {
-                                    new Dimension(GridSizeMode.Distributed),
-                                    new Dimension(GridSizeMode.AutoSize),
-                                },
-                                Content = new[]
-                                {
-                                    new Drawable[]
+                                    Padding = new MarginPadding
                                     {
-                                        new OsuScrollContainer
-                                        {
-                                            Padding = new MarginPadding
-                                            {
-                                                Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING,
-                                                Vertical = 10
-                                            },
-                                            RelativeSizeAxes = Axes.Both,
-                                            Children = new[]
-                                            {
-                                                new Container
-                                                {
-                                                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.WIDTH_PADDING },
-                                                    RelativeSizeAxes = Axes.X,
-                                                    AutoSizeAxes = Axes.Y,
-                                                    Children = new Drawable[]
-                                                    {
-                                                        new SectionContainer
-                                                        {
-                                                            Padding = new MarginPadding { Right = FIELD_PADDING / 2 },
-                                                            Children = new[]
-                                                            {
-                                                                new Section("Room name")
-                                                                {
-                                                                    Child = NameField = new SettingsTextBox
-                                                                    {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        TabbableContentContainer = this,
-                                                                        LengthLimit = 100
-                                                                    },
-                                                                },
-                                                                new Section("Duration")
-                                                                {
-                                                                    Child = DurationField = new DurationDropdown
-                                                                    {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        Items = new[]
-                                                                        {
-                                                                            TimeSpan.FromMinutes(30),
-                                                                            TimeSpan.FromHours(1),
-                                                                            TimeSpan.FromHours(2),
-                                                                            TimeSpan.FromHours(4),
-                                                                            TimeSpan.FromHours(8),
-                                                                            TimeSpan.FromHours(12),
-                                                                            //TimeSpan.FromHours(16),
-                                                                            TimeSpan.FromHours(24),
-                                                                            TimeSpan.FromDays(3),
-                                                                            TimeSpan.FromDays(7)
-                                                                        }
-                                                                    }
-                                                                },
-                                                                new Section("Room visibility")
-                                                                {
-                                                                    Alpha = disabled_alpha,
-                                                                    Child = AvailabilityPicker = new RoomAvailabilityPicker
-                                                                    {
-                                                                        Enabled = { Value = false }
-                                                                    },
-                                                                },
-                                                                new Section("Game type")
-                                                                {
-                                                                    Alpha = disabled_alpha,
-                                                                    Child = new FillFlowContainer
-                                                                    {
-                                                                        AutoSizeAxes = Axes.Y,
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        Direction = FillDirection.Vertical,
-                                                                        Spacing = new Vector2(7),
-                                                                        Children = new Drawable[]
-                                                                        {
-                                                                            TypePicker = new GameTypePicker
-                                                                            {
-                                                                                RelativeSizeAxes = Axes.X,
-                                                                                Enabled = { Value = false }
-                                                                            },
-                                                                            typeLabel = new OsuSpriteText
-                                                                            {
-                                                                                Font = OsuFont.GetFont(size: 14),
-                                                                                Colour = colours.Yellow
-                                                                            },
-                                                                        },
-                                                                    },
-                                                                },
-                                                                new Section("Max participants")
-                                                                {
-                                                                    Alpha = disabled_alpha,
-                                                                    Child = MaxParticipantsField = new SettingsNumberTextBox
-                                                                    {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        TabbableContentContainer = this,
-                                                                        ReadOnly = true,
-                                                                    },
-                                                                },
-                                                                new Section("Password (optional)")
-                                                                {
-                                                                    Alpha = disabled_alpha,
-                                                                    Child = new SettingsPasswordTextBox
-                                                                    {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        TabbableContentContainer = this,
-                                                                        ReadOnly = true,
-                                                                    },
-                                                                },
-                                                            },
-                                                        },
-                                                        new SectionContainer
-                                                        {
-                                                            Anchor = Anchor.TopRight,
-                                                            Origin = Anchor.TopRight,
-                                                            Padding = new MarginPadding { Left = FIELD_PADDING / 2 },
-                                                            Children = new[]
-                                                            {
-                                                                new Section("Playlist")
-                                                                {
-                                                                    Child = new GridContainer
-                                                                    {
-                                                                        RelativeSizeAxes = Axes.X,
-                                                                        Height = 300,
-                                                                        Content = new[]
-                                                                        {
-                                                                            new Drawable[]
-                                                                            {
-                                                                                playlist = new DrawableRoomPlaylist(true, true) { RelativeSizeAxes = Axes.Both }
-                                                                            },
-                                                                            new Drawable[]
-                                                                            {
-                                                                                playlistLength = new OsuSpriteText
-                                                                                {
-                                                                                    Margin = new MarginPadding { Vertical = 5 },
-                                                                                    Colour = colours.Yellow,
-                                                                                    Font = OsuFont.GetFont(size: 12),
-                                                                                }
-                                                                            },
-                                                                            new Drawable[]
-                                                                            {
-                                                                                new PurpleTriangleButton
-                                                                                {
-                                                                                    RelativeSizeAxes = Axes.X,
-                                                                                    Height = 40,
-                                                                                    Text = "Edit playlist",
-                                                                                    Action = () => EditPlaylist?.Invoke()
-                                                                                }
-                                                                            }
-                                                                        },
-                                                                        RowDimensions = new[]
-                                                                        {
-                                                                            new Dimension(),
-                                                                            new Dimension(GridSizeMode.AutoSize),
-                                                                            new Dimension(GridSizeMode.AutoSize),
-                                                                        }
-                                                                    }
-                                                                },
-                                                            },
-                                                        },
-                                                    },
-                                                }
-                                            },
-                                        },
+                                        Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING,
+                                        Vertical = 10
                                     },
-                                    new Drawable[]
+                                    RelativeSizeAxes = Axes.Both,
+                                    Children = new[]
                                     {
                                         new Container
                                         {
-                                            Anchor = Anchor.BottomLeft,
-                                            Origin = Anchor.BottomLeft,
-                                            Y = 2,
+                                            Padding = new MarginPadding { Horizontal = WaveOverlayContainer.WIDTH_PADDING },
                                             RelativeSizeAxes = Axes.X,
                                             AutoSizeAxes = Axes.Y,
                                             Children = new Drawable[]
                                             {
-                                                new Box
+                                                new SectionContainer
                                                 {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4Extensions.FromHex(@"28242d").Darken(0.5f).Opacity(1f),
-                                                },
-                                                new FillFlowContainer
-                                                {
-                                                    RelativeSizeAxes = Axes.X,
-                                                    AutoSizeAxes = Axes.Y,
-                                                    Direction = FillDirection.Vertical,
-                                                    Spacing = new Vector2(0, 20),
-                                                    Margin = new MarginPadding { Vertical = 20 },
-                                                    Padding = new MarginPadding { Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
-                                                    Children = new Drawable[]
+                                                    Padding = new MarginPadding { Right = FIELD_PADDING / 2 },
+                                                    Children = new[]
                                                     {
-                                                        ApplyButton = new CreateRoomButton
+                                                        new Section("Room name")
                                                         {
-                                                            Anchor = Anchor.BottomCentre,
-                                                            Origin = Anchor.BottomCentre,
-                                                            Size = new Vector2(230, 55),
-                                                            Enabled = { Value = false },
-                                                            Action = apply,
+                                                            Child = NameField = new SettingsTextBox
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                TabbableContentContainer = this,
+                                                                LengthLimit = 100
+                                                            },
                                                         },
-                                                        ErrorText = new OsuSpriteText
+                                                        new Section("Duration")
                                                         {
-                                                            Anchor = Anchor.BottomCentre,
-                                                            Origin = Anchor.BottomCentre,
-                                                            Alpha = 0,
-                                                            Depth = 1,
-                                                            Colour = colours.RedDark
-                                                        }
-                                                    }
+                                                            Child = DurationField = new DurationDropdown
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                Items = new[]
+                                                                {
+                                                                    TimeSpan.FromMinutes(30),
+                                                                    TimeSpan.FromHours(1),
+                                                                    TimeSpan.FromHours(2),
+                                                                    TimeSpan.FromHours(4),
+                                                                    TimeSpan.FromHours(8),
+                                                                    TimeSpan.FromHours(12),
+                                                                    //TimeSpan.FromHours(16),
+                                                                    TimeSpan.FromHours(24),
+                                                                    TimeSpan.FromDays(3),
+                                                                    TimeSpan.FromDays(7)
+                                                                }
+                                                            }
+                                                        },
+                                                        new Section("Room visibility")
+                                                        {
+                                                            Alpha = disabled_alpha,
+                                                            Child = AvailabilityPicker = new RoomAvailabilityPicker
+                                                            {
+                                                                Enabled = { Value = false }
+                                                            },
+                                                        },
+                                                        new Section("Game type")
+                                                        {
+                                                            Alpha = disabled_alpha,
+                                                            Child = new FillFlowContainer
+                                                            {
+                                                                AutoSizeAxes = Axes.Y,
+                                                                RelativeSizeAxes = Axes.X,
+                                                                Direction = FillDirection.Vertical,
+                                                                Spacing = new Vector2(7),
+                                                                Children = new Drawable[]
+                                                                {
+                                                                    TypePicker = new GameTypePicker
+                                                                    {
+                                                                        RelativeSizeAxes = Axes.X,
+                                                                        Enabled = { Value = false }
+                                                                    },
+                                                                    typeLabel = new OsuSpriteText
+                                                                    {
+                                                                        Font = OsuFont.GetFont(size: 14),
+                                                                        Colour = colours.Yellow
+                                                                    },
+                                                                },
+                                                            },
+                                                        },
+                                                        new Section("Max participants")
+                                                        {
+                                                            Alpha = disabled_alpha,
+                                                            Child = MaxParticipantsField = new SettingsNumberTextBox
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                TabbableContentContainer = this,
+                                                                ReadOnly = true,
+                                                            },
+                                                        },
+                                                        new Section("Password (optional)")
+                                                        {
+                                                            Alpha = disabled_alpha,
+                                                            Child = new SettingsPasswordTextBox
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                TabbableContentContainer = this,
+                                                                ReadOnly = true,
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                                new SectionContainer
+                                                {
+                                                    Anchor = Anchor.TopRight,
+                                                    Origin = Anchor.TopRight,
+                                                    Padding = new MarginPadding { Left = FIELD_PADDING / 2 },
+                                                    Children = new[]
+                                                    {
+                                                        new Section("Playlist")
+                                                        {
+                                                            Child = new GridContainer
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                Height = 300,
+                                                                Content = new[]
+                                                                {
+                                                                    new Drawable[]
+                                                                    {
+                                                                        playlist = new DrawableRoomPlaylist(true, true) { RelativeSizeAxes = Axes.Both }
+                                                                    },
+                                                                    new Drawable[]
+                                                                    {
+                                                                        playlistLength = new OsuSpriteText
+                                                                        {
+                                                                            Margin = new MarginPadding { Vertical = 5 },
+                                                                            Colour = colours.Yellow,
+                                                                            Font = OsuFont.GetFont(size: 12),
+                                                                        }
+                                                                    },
+                                                                    new Drawable[]
+                                                                    {
+                                                                        new PurpleTriangleButton
+                                                                        {
+                                                                            RelativeSizeAxes = Axes.X,
+                                                                            Height = 40,
+                                                                            Text = "Edit playlist",
+                                                                            Action = () => EditPlaylist?.Invoke()
+                                                                        }
+                                                                    }
+                                                                },
+                                                                RowDimensions = new[]
+                                                                {
+                                                                    new Dimension(),
+                                                                    new Dimension(GridSizeMode.AutoSize),
+                                                                    new Dimension(GridSizeMode.AutoSize),
+                                                                }
+                                                            }
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        }
+                                    },
+                                },
+                            },
+                            new Drawable[]
+                            {
+                                new Container
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    Y = 2,
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = Color4Extensions.FromHex(@"28242d").Darken(0.5f).Opacity(1f),
+                                        },
+                                        new FillFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
+                                            Direction = FillDirection.Vertical,
+                                            Spacing = new Vector2(0, 20),
+                                            Margin = new MarginPadding { Vertical = 20 },
+                                            Padding = new MarginPadding { Horizontal = OsuScreen.HORIZONTAL_OVERFLOW_PADDING },
+                                            Children = new Drawable[]
+                                            {
+                                                ApplyButton = new CreateRoomButton
+                                                {
+                                                    Anchor = Anchor.BottomCentre,
+                                                    Origin = Anchor.BottomCentre,
+                                                    Size = new Vector2(230, 55),
+                                                    Enabled = { Value = false },
+                                                    Action = apply,
+                                                },
+                                                ErrorText = new OsuSpriteText
+                                                {
+                                                    Anchor = Anchor.BottomCentre,
+                                                    Origin = Anchor.BottomCentre,
+                                                    Alpha = 0,
+                                                    Depth = 1,
+                                                    Colour = colours.RedDark
                                                 }
                                             }
                                         }
                                     }
                                 }
-                            },
+                            }
                         }
                     },
-                    loadingLayer = new LoadingLayer(dimContent)
+                    loadingLayer = new LoadingLayer(true)
                 };
 
                 TypePicker.Current.BindValueChanged(type => typeLabel.Text = type.NewValue?.Name ?? string.Empty, true);

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -53,7 +53,6 @@ namespace osu.Game.Screens.Play
         private readonly Bindable<IReadOnlyList<Mod>> mods;
         private readonly Drawable facade;
         private LoadingSpinner loading;
-        private Sprite backgroundSprite;
 
         public IBindable<IReadOnlyList<Mod>> Mods => mods;
 
@@ -123,7 +122,7 @@ namespace osu.Game.Screens.Play
                             Masking = true,
                             Children = new Drawable[]
                             {
-                                backgroundSprite = new Sprite
+                                new Sprite
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Texture = beatmap?.Background,

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Screens.Play
                                     Anchor = Anchor.Centre,
                                     FillMode = FillMode.Fill,
                                 },
-                                loading = new LoadingLayer(backgroundSprite)
+                                loading = new LoadingLayer(true)
                             }
                         },
                         new OsuSpriteText

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -63,8 +63,6 @@ namespace osu.Game.Screens.Select
 
         public BeatmapDetails()
         {
-            Container content;
-
             Children = new Drawable[]
             {
                 new Box
@@ -72,7 +70,7 @@ namespace osu.Game.Screens.Select
                     RelativeSizeAxes = Axes.Both,
                     Colour = Color4.Black.Opacity(0.5f),
                 },
-                content = new Container
+                new Container
                 {
                     RelativeSizeAxes = Axes.Both,
                     Padding = new MarginPadding { Horizontal = spacing },
@@ -159,7 +157,7 @@ namespace osu.Game.Screens.Select
                         },
                     },
                 },
-                loading = new LoadingLayer(content),
+                loading = new LoadingLayer(true),
             };
         }
 


### PR DESCRIPTION
In theory this seemed like a good idea (and an optimisation in some cases, due to lower fill rate), but in practice this leads to weird edge cases.

This aims to do away with the operations on external drawables by applying a dim to the area behind the `LoadingLayer` when required.  I went over each usage and ensured they look as good or better than previously.

The specific bad usage here was the restoration of the colour on dispose (if the `LoadingLayer` was disposed in a still-visible state).

I'm aware that the `BeatmapListingOverlay` will now dim completely during load. I think this is fine for the time being.

I've touched on some remaining pain points (both master and on this PR) in https://github.com/ppy/osu/issues/11427.