### PR TITLE
Fix display settings binding to configuration bindables in async load

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -133,6 +133,15 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 },
             };
 
+            scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            windowModeDropdown.Current.ValueChanged += _ => updateResolutionDropdown();
+
             windowModes.BindCollectionChanged((sender, args) =>
             {
                 if (windowModes.Count > 1)
@@ -140,8 +149,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 else
                     windowModeDropdown.Hide();
             }, true);
-
-            windowModeDropdown.Current.ValueChanged += _ => updateResolutionDropdown();
 
             currentDisplay.BindValueChanged(display => Schedule(() =>
             {
@@ -158,8 +165,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
                 updateResolutionDropdown();
             }), true);
-
-            scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
 
             scalingMode.BindValueChanged(mode =>
             {

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -132,13 +132,13 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                     }
                 },
             };
-
-            scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
 
             windowModeDropdown.Current.ValueChanged += _ => updateResolutionDropdown();
 
@@ -186,11 +186,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             }
         }
 
-        /// <summary>
-        /// Create a delayed bindable which only updates when a condition is met.
-        /// </summary>
-        /// <param name="bindable">The config bindable.</param>
-        /// <returns>A bindable which will propagate updates with a delay.</returns>
         private void bindPreviewEvent(Bindable<float> bindable)
         {
             bindable.ValueChanged += _ =>


### PR DESCRIPTION
This was potentially causing drawables to be mutated before they finished loading.