### PR TITLE
Fix carousel beatmap set panels applying transforms to difficulties while they are loading

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -178,6 +178,9 @@ namespace osu.Game.Screens.Select.Carousel
 
         private void updateBeatmapYPositions()
         {
+            if (beatmapContainer == null)
+                return;
+
             if (beatmapsLoadTask == null || !beatmapsLoadTask.IsCompleted)
                 return;
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -37,10 +38,12 @@ namespace osu.Game.Screens.Select.Carousel
 
         public IEnumerable<DrawableCarouselItem> DrawableBeatmaps => beatmapContainer?.Children ?? Enumerable.Empty<DrawableCarouselItem>();
 
+        [CanBeNull]
         private Container<DrawableCarouselItem> beatmapContainer;
 
         private BeatmapSetInfo beatmapSet;
 
+        [CanBeNull]
         private Task beatmapsLoadTask;
 
         [Resolved]


### PR DESCRIPTION
This resolves exceptions being rightly thrown after the introduction of ppy/osu-framework#4135.