### PR TITLE
Fix difficulty adjust mod treating default values as user overrides

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -59,8 +59,8 @@ namespace osu.Game.Rulesets.Catch.Mods
         {
             base.ApplySettings(difficulty);
 
-            difficulty.CircleSize = CircleSize.Value;
-            difficulty.ApproachRate = ApproachRate.Value;
+            ApplySetting(CircleSize, cs => difficulty.CircleSize = cs);
+            ApplySetting(ApproachRate, ar => difficulty.ApproachRate = ar);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Tests.Mods
@@ -18,8 +22,23 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         public void TestNoAdjustment() => CreateModTest(new ModTestData
         {
             Mod = new OsuModDifficultyAdjust(),
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    BaseDifficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 }
+                }
+            },
             Autoplay = true,
-            PassCondition = checkSomeHit
+            PassCondition = () => checkSomeHit() && checkObjectsScale(0.29f)
         });
 
         [Test]

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -59,8 +59,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             base.ApplySettings(difficulty);
 
-            difficulty.CircleSize = CircleSize.Value;
-            difficulty.ApproachRate = ApproachRate.Value;
+            ApplySetting(CircleSize, cs => difficulty.CircleSize = cs);
+            ApplySetting(ApproachRate, ar => difficulty.ApproachRate = ar);
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Select.Details;
 using osuTK.Graphics;
 
@@ -141,16 +142,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select changed Difficulty Adjust mod", () =>
             {
                 var ruleset = advancedStats.Beatmap.Ruleset.CreateInstance();
-                var difficultyAdjustMod = ruleset.GetAllMods().OfType<ModDifficultyAdjust>().Single();
+                var difficultyAdjustMod = ruleset.GetAllMods().OfType<OsuModDifficultyAdjust>().Single();
                 var originalDifficulty = advancedStats.Beatmap.BaseDifficulty;
-                var adjustedDifficulty = new BeatmapDifficulty
-                {
-                    CircleSize = originalDifficulty.CircleSize,
-                    DrainRate = originalDifficulty.DrainRate - 0.5f,
-                    OverallDifficulty = originalDifficulty.OverallDifficulty,
-                    ApproachRate = originalDifficulty.ApproachRate + 2.2f,
-                };
-                difficultyAdjustMod.ReadFromDifficulty(adjustedDifficulty);
+
+                difficultyAdjustMod.ReadFromDifficulty(originalDifficulty);
+                difficultyAdjustMod.DrainRate.Value = originalDifficulty.DrainRate - 0.5f;
+                difficultyAdjustMod.ApproachRate.Value = originalDifficulty.ApproachRate + 2.2f;
                 SelectedMods.Value = new[] { difficultyAdjustMod };
             });
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/11437

Fix is ugly, and not entirely confident it is correct, but it seems to work and passes the previously-useless adjusted test. PRing so that it's out there. I still very much don't like how difficulty adjust is written and find it very hard to reason about due to state being kept in multiple different places and moved around like crazy (`IsDefault`? `userChangedSetting`? which one is correct to use at any given time?), which is why I suggested the insane rewrite in the first place.