### PR TITLE
Improve hover sounds playback (to reduce volume saturation and delay)

### DIFF
--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Configuration
         {
             Set(Static.LoginOverlayDisplayed, false);
             Set(Static.MutedAudioNotificationShownOnce, false);
-            Set(Static.LastHoverSoundPlaybackTime, 0.0);
+            Set(Static.LastHoverSoundPlaybackTime, (double?)0.0);
             Set<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
     }

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
 
 namespace osu.Game.Configuration
 {
@@ -14,6 +16,7 @@ namespace osu.Game.Configuration
         {
             Set(Static.LoginOverlayDisplayed, false);
             Set(Static.MutedAudioNotificationShownOnce, false);
+            Set(Static.LastHoverSoundPlaybackTime, 0.0);
             Set<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
     }
@@ -28,5 +31,11 @@ namespace osu.Game.Configuration
         /// Value under this lookup can be <c>null</c> if there are no backgrounds available (or API is not reachable).
         /// </summary>
         SeasonalBackgrounds,
+
+        /// <summary>
+        /// The last playback time in milliseconds of a hover sample (from <see cref="HoverSounds"/>).
+        /// Used to debounce hover sounds game-wide to avoid volume saturation, especially in scrolling views with many UI controls like <see cref="SettingsOverlay"/>.
+        /// </summary>
+        LastHoverSoundPlaybackTime
     }
 }

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Configuration
         {
             Set(Static.LoginOverlayDisplayed, false);
             Set(Static.MutedAudioNotificationShownOnce, false);
-            Set(Static.LastHoverSoundPlaybackTime, (double?)0.0);
+            Set(Static.LastHoverSoundPlaybackTime, (double?)null);
             Set<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
     }

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -5,11 +5,12 @@ using System.ComponentModel;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
-using osu.Framework.Threading;
+using osu.Game.Configuration;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -28,30 +29,34 @@ namespace osu.Game.Graphics.UserInterface
 
         protected readonly HoverSampleSet SampleSet;
 
+        private Bindable<double> lastPlaybackTime;
+
         public HoverSounds(HoverSampleSet sampleSet = HoverSampleSet.Normal)
         {
             SampleSet = sampleSet;
             RelativeSizeAxes = Axes.Both;
         }
 
-        private ScheduledDelegate playDelegate;
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio, SessionStatics statics)
+        {
+            lastPlaybackTime = statics.GetBindable<double>(Static.LastHoverSoundPlaybackTime);
+
+            sampleHover = audio.Samples.Get($@"UI/generic-hover{SampleSet.GetDescription()}");
+        }
 
         protected override bool OnHover(HoverEvent e)
         {
-            playDelegate?.Cancel();
+            bool requiresDebounce = HoverDebounceTime <= 0;
+            bool enoughTimePassedSinceLastPlayback = lastPlaybackTime.Value == 0 || Time.Current - lastPlaybackTime.Value > HoverDebounceTime;
 
-            if (HoverDebounceTime <= 0)
+            if (!requiresDebounce || enoughTimePassedSinceLastPlayback)
+            {
                 sampleHover?.Play();
-            else
-                playDelegate = Scheduler.AddDelayed(() => sampleHover?.Play(), HoverDebounceTime);
+                lastPlaybackTime.Value = Time.Current;
+            }
 
             return base.OnHover(e);
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
-        {
-            sampleHover = audio.Samples.Get($@"UI/generic-hover{SampleSet.GetDescription()}");
         }
     }
 

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -47,10 +47,9 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnHover(HoverEvent e)
         {
-            bool requiresDebounce = HoverDebounceTime <= 0;
             bool enoughTimePassedSinceLastPlayback = !lastPlaybackTime.Value.HasValue || Time.Current - lastPlaybackTime.Value >= HoverDebounceTime;
 
-            if (!requiresDebounce || enoughTimePassedSinceLastPlayback)
+            if (enoughTimePassedSinceLastPlayback)
             {
                 sampleHover?.Play();
                 lastPlaybackTime.Value = Time.Current;

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Graphics.UserInterface
         private SampleChannel sampleHover;
 
         /// <summary>
-        /// Length of debounce for hover sound playback, in milliseconds. Default is 50ms.
+        /// Length of debounce for hover sound playback, in milliseconds.
         /// </summary>
         public double HoverDebounceTime { get; } = 20;
 

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected readonly HoverSampleSet SampleSet;
 
-        private Bindable<double> lastPlaybackTime;
+        private Bindable<double?> lastPlaybackTime;
 
         public HoverSounds(HoverSampleSet sampleSet = HoverSampleSet.Normal)
         {
@@ -40,7 +40,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio, SessionStatics statics)
         {
-            lastPlaybackTime = statics.GetBindable<double>(Static.LastHoverSoundPlaybackTime);
+            lastPlaybackTime = statics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime);
 
             sampleHover = audio.Samples.Get($@"UI/generic-hover{SampleSet.GetDescription()}");
         }
@@ -48,7 +48,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnHover(HoverEvent e)
         {
             bool requiresDebounce = HoverDebounceTime <= 0;
-            bool enoughTimePassedSinceLastPlayback = lastPlaybackTime.Value == 0 || Time.Current - lastPlaybackTime.Value > HoverDebounceTime;
+            bool enoughTimePassedSinceLastPlayback = !lastPlaybackTime.Value.HasValue || Time.Current - lastPlaybackTime.Value >= HoverDebounceTime;
 
             if (!requiresDebounce || enoughTimePassedSinceLastPlayback)
             {

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <summary>
         /// Length of debounce for hover sound playback, in milliseconds. Default is 50ms.
         /// </summary>
-        public double HoverDebounceTime { get; } = 50;
+        public double HoverDebounceTime { get; } = 20;
 
         protected readonly HoverSampleSet SampleSet;
 


### PR DESCRIPTION
This aims to fix two issues:

- Hover sound playback until now was arbitrarily delayed by 50ms, giving them less responsiveness than they should have.
- The debounce interval was per-instance, which basically had zero effect.

The previous 50ms was likely never hit due to being for since instances. Upon making this change, I've readjusted it to 20ms as this seems to feel better to me (50ms feels a bit too... structured? like you can predict when the next sample is going to play).

Considered using a local static dictionary rather than `SessionStatics` but on checking, it would seem such static usage is nowhere in this project and I can guarantee there will be heated discussion if I went in this direction. For now I've just made it shared across all hover sounds types. Still feels fine.