### PR TITLE
Fix track previews crashing on completion

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanel.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         private Container content;
 
         public PreviewTrack Preview => PlayButton.Preview;
-        public Bindable<bool> PreviewPlaying => PlayButton?.Playing;
+        public IBindable<bool> PreviewPlaying => PlayButton?.Playing;
 
         protected abstract PlayButton PlayButton { get; }
         protected abstract Box PreviewBar { get; }

--- a/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
@@ -18,7 +18,10 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
 {
     public class PlayButton : Container
     {
-        public readonly BindableBool Playing = new BindableBool();
+        public IBindable<bool> Playing => playing;
+
+        private readonly BindableBool playing = new BindableBool();
+
         public PreviewTrack Preview { get; private set; }
 
         private BeatmapSetInfo beatmapSet;
@@ -36,7 +39,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                 Preview?.Expire();
                 Preview = null;
 
-                Playing.Value = false;
+                playing.Value = false;
             }
         }
 
@@ -82,7 +85,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                 },
             });
 
-            Playing.ValueChanged += playingStateChanged;
+            playing.ValueChanged += playingStateChanged;
         }
 
         [Resolved]
@@ -96,7 +99,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
 
         protected override bool OnClick(ClickEvent e)
         {
-            Playing.Toggle();
+            playing.Toggle();
             return true;
         }
 
@@ -108,7 +111,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            if (!Playing.Value)
+            if (!playing.Value)
                 icon.FadeColour(Color4.White, 120, Easing.InOutQuint);
             base.OnHoverLost(e);
         }
@@ -122,7 +125,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
             {
                 if (BeatmapSet == null)
                 {
-                    Playing.Value = false;
+                    playing.Value = false;
                     return;
                 }
 
@@ -144,10 +147,10 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                     loading = false;
                     // make sure that the update of value of Playing (and the ensuing value change callbacks)
                     // are marshaled back to the update thread.
-                    preview.Stopped += () => Schedule(() => Playing.Value = false);
+                    preview.Stopped += () => Schedule(() => playing.Value = false);
 
                     // user may have changed their mind.
-                    if (Playing.Value)
+                    if (playing.Value)
                         attemptStart();
                 });
             }
@@ -161,7 +164,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         private void attemptStart()
         {
             if (Preview?.Start() != true)
-                Playing.Value = false;
+                playing.Value = false;
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
@@ -163,11 +163,5 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
             if (Preview?.Start() != true)
                 Playing.Value = false;
         }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-            Playing.Value = false;
-        }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
@@ -142,7 +142,9 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
 
                     AddInternal(preview);
                     loading = false;
-                    preview.Stopped += () => Playing.Value = false;
+                    // make sure that the update of value of Playing (and the ensuing value change callbacks)
+                    // are marshaled back to the update thread.
+                    preview.Stopped += () => Schedule(() => Playing.Value = false);
 
                     // user may have changed their mind.
                     if (Playing.Value)

--- a/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
@@ -24,7 +24,8 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
         private readonly PlayButton playButton;
 
         private PreviewTrack preview => playButton.Preview;
-        public Bindable<bool> Playing => playButton.Playing;
+
+        public IBindable<bool> Playing => playButton.Playing;
 
         public BeatmapSetInfo BeatmapSet
         {

--- a/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
 {
     public class PreviewButton : OsuClickableContainer
     {
-        private const float transition_duration = 500;
-
         private readonly Box background, progress;
         private readonly PlayButton playButton;
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/11445. Minimal possible set of changes I could come up with.

`PlayButton` was playing very fast and loose with threading. There were two unsafe accesses.

First one is via `Stopped`, which is executed on an audio callback; it is even annotated as not being thread-safe (but was annotated as such long after the button's nascence). Scheduled the value update locally inside of the button, because the bindable has many consumers (all beatmap panels, and also play button on the beatmap overlay), so I believe internally fixing up is better than spreading schedules everywhere.

Second potential one was via disposal; it seems to be a weird vestige from an earlier revision of the old "direct" panel, which relied on `DisposeOnDeathRemoval` to finish track playback (and then was removed in 6c150c9). The play button is no longer responsible for managing preview track lifetime anyway; `PreviewTrackManager`'s method are intended for that, so I just nuked that entirely. I checked when the disposals were executing - they ran at game exit, which is definitely too late to clean up any track.

I was also somewhat worried about the set to `false` in `attemptStart()`, but both call sites in `playingStateChanged` are safe, as long as that callback always executes on update thread (which it will do now). The usage inside of the `LoadComponentAsync()` call is safe by definition.