### PR TITLE
Fix editor crashing on enter if login overlay was previously opened

### DIFF
--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -143,7 +143,11 @@ namespace osu.Game.Screens
         private void load(OsuGame osu, AudioManager audio)
         {
             sampleExit = audio.Samples.Get(@"UI/screen-back");
+        }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
             Activity.Value ??= InitialActivity;
         }
 


### PR DESCRIPTION
Resolves #11449.

[As reported on discord](https://discord.com/channels/188630481301012481/188630652340404224/797170511435399218). Reproduction scenario is simple (see [video](https://discord.com/channels/188630481301012481/188630652340404224/797190619733688370) by @Gabixel):

1. Open game
2. Open and close login overlay
3. Open editor - will crash.

Obviously the cause is `OsuScreen` mutating bindables bound to transform additions in an unsafe context. Resolved in the simplest way I could think of, which is by moving the set to `LoadComplete()`, which runs on the update thread. Semantically moving also makes sense to me, as the user activity should change once the screen they're moving to has actually loaded and displayed to the user.

Two asides:

---

While the fix is general, the editor is the only screen with this problem. This is due to a combination of circumstances. `OsuGame.ScreenChanged()` {binds to,unbinds from} individual screens' `Activity` bindables on `ScreenPushed`, which happens *before* the screens begin loading, which was a necessary precondition to be able to hit this, but requires particular conditions which other screens don't meet, namely:

* Song select is pre-loaded in `MainMenu`, so the activity set in BDL was actually firing much earlier than `ScreenPushed`, preventing it from causing the problem.
* Multiplayer screens were "safe", because they had child screen stacks, and the root screen did not override `InitialActivity`. It was still risky to have the set in `load()`, but as it happens, due to a separate screen stack, those screens ran through a different path in `Push()`, which had a lucky schedule:

![2021-01-08-214407_1565x324_scrot](https://user-images.githubusercontent.com/20418176/104062384-ae20ef80-51fa-11eb-9a67-f025bd23fdb3.png)

---

Investigating this made me aware of a potential blind spot memory-wise that we might be hitting. If bindable callbacks add transforms to drawables that aren't alive, they'll be accumulating said transforms until they become alive, which will get immediately removed when it comes back up. I don't think it'll amount to much in the very end, but this is something that we might want to eye as a future means of optimisation.

![osu_2021-01-08_21-23-53](https://user-images.githubusercontent.com/20418176/104062452-d0b30880-51fa-11eb-9b3e-9a31624fa6aa.jpg)