### PR TITLE
Revert polling changes to fix participant list display

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerRoomManager.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerRoomManager.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 RoomManager =
                 {
                     TimeBetweenListingPolls = { Value = 1 },
+                    TimeBetweenSelectionPolls = { Value = 1 }
                 }
             };
 

--- a/osu.Game/Screens/OnlinePlay/Components/SelectionPollingComponent.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/SelectionPollingComponent.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -47,9 +48,11 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             pollReq.Success += result =>
             {
-                var rooms = new List<Room>(roomManager.Rooms);
+                // existing rooms need to be ordered by their position because the received of NotifyRoomsReceives expects to be able to sort them based on this order.
+                var rooms = new List<Room>(roomManager.Rooms.OrderBy(r => r.Position.Value));
 
                 int index = rooms.FindIndex(r => r.RoomID.Value == result.RoomID.Value);
+
                 if (index < 0)
                     return;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!this.IsCurrentScreen())
             {
                 multiplayerRoomManager.TimeBetweenListingPolls.Value = 0;
+                multiplayerRoomManager.TimeBetweenSelectionPolls.Value = 0;
             }
             else
             {
@@ -40,16 +41,18 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 {
                     case LoungeSubScreen _:
                         multiplayerRoomManager.TimeBetweenListingPolls.Value = isIdle ? 120000 : 15000;
+                        multiplayerRoomManager.TimeBetweenSelectionPolls.Value = isIdle ? 120000 : 15000;
                         break;
 
                     // Don't poll inside the match or anywhere else.
                     default:
                         multiplayerRoomManager.TimeBetweenListingPolls.Value = 0;
+                        multiplayerRoomManager.TimeBetweenSelectionPolls.Value = 0;
                         break;
                 }
             }
 
-            Logger.Log($"Polling adjusted (listing: {multiplayerRoomManager.TimeBetweenListingPolls.Value})");
+            Logger.Log($"Polling adjusted (listing: {multiplayerRoomManager.TimeBetweenListingPolls.Value}, selection: {multiplayerRoomManager.TimeBetweenSelectionPolls.Value})");
         }
 
         protected override Room CreateNewRoom()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomManager.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private StatefulMultiplayerClient multiplayerClient { get; set; }
 
         public readonly Bindable<double> TimeBetweenListingPolls = new Bindable<double>();
-
+        public readonly Bindable<double> TimeBetweenSelectionPolls = new Bindable<double>();
         private readonly IBindable<bool> isConnected = new Bindable<bool>();
         private readonly Bindable<bool> allowPolling = new Bindable<bool>();
 
@@ -119,9 +119,35 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 TimeBetweenPolls = { BindTarget = TimeBetweenListingPolls },
                 AllowPolling = { BindTarget = allowPolling }
             },
+            new MultiplayerSelectionPollingComponent
+            {
+                TimeBetweenPolls = { BindTarget = TimeBetweenSelectionPolls },
+                AllowPolling = { BindTarget = allowPolling }
+            }
         };
 
         private class MultiplayerListingPollingComponent : ListingPollingComponent
+        {
+            public readonly IBindable<bool> AllowPolling = new Bindable<bool>();
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                AllowPolling.BindValueChanged(allowPolling =>
+                {
+                    if (!allowPolling.NewValue)
+                        return;
+
+                    if (IsLoaded)
+                        PollImmediately();
+                });
+            }
+
+            protected override Task Poll() => !AllowPolling.Value ? Task.CompletedTask : base.Poll();
+        }
+
+        private class MultiplayerSelectionPollingComponent : SelectionPollingComponent
         {
             public readonly IBindable<bool> AllowPolling = new Bindable<bool>();
 


### PR DESCRIPTION
It turns out this polling was necessary to get extra data that isn't included in the main listing request. It was removed deemed useless, and in order to fix the order of rooms changing when selecting a room.  Weirdly, I can't reproduce this happening any more, and on close inspection of the code can't see how it could happen in the first place.

For now, let's revert this change and iterate from there, if/when the same issue arises again.

I've discussed avoiding this second poll by potentially including more data (just `user_id`s?) in the main listing request, but not 100% sure on this - even if the returned data is minimal it's an extra join server-side, which could cause performance issues for large numbers of rooms.

Reverts changes from https://github.com/ppy/osu/pull/11358.