### PR TITLE
Fix non-threadsafe usage of MultiplayerClient.IsConnected

### DIFF
--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -52,6 +52,7 @@ namespace osu.Game.Online.Multiplayer
 
         /// <summary>
         /// Whether the <see cref="StatefulMultiplayerClient"/> is currently connected.
+        /// This is NOT thread safe and usage should be scheduled.
         /// </summary>
         public abstract IBindable<bool> IsConnected { get; }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/CreateMultiplayerMatchButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/CreateMultiplayerMatchButton.cs
@@ -34,8 +34,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
-            isConnected.BindValueChanged(_ => updateState());
-            operationInProgress.BindValueChanged(_ => updateState(), true);
+            isConnected.BindValueChanged(_ => Scheduler.AddOnce(updateState));
+            operationInProgress.BindValueChanged(_ => Scheduler.AddOnce(updateState), true);
         }
 
         private void updateState() => Enabled.Value = isConnected.Value && !operationInProgress.Value;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -77,14 +77,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             });
 
             isConnected = client.IsConnected.GetBoundCopy();
-            isConnected.BindValueChanged(connected =>
+            isConnected.BindValueChanged(connected => Schedule(() =>
             {
                 if (!connected.NewValue)
                 {
                     // messaging to the user about this disconnect will be provided by the MultiplayerMatchSubScreen.
                     failAndBail();
                 }
-            }, true);
+            }), true);
 
             Debug.Assert(client.Room != null);
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomManager.cs
@@ -34,10 +34,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             base.LoadComplete();
 
             isConnected.BindTo(multiplayerClient.IsConnected);
-            isConnected.BindValueChanged(_ => Schedule(updatePolling));
-            JoinedRoom.BindValueChanged(_ => updatePolling());
-
-            updatePolling();
+            isConnected.BindValueChanged(_ => Scheduler.AddOnce(updatePolling));
+            JoinedRoom.BindValueChanged(_ => Scheduler.AddOnce(updatePolling), true);
         }
 
         public override void CreateRoom(Room room, Action<Room> onSuccess = null, Action<string> onError = null)


### PR DESCRIPTION
Resolves hard crashes due to cross-thread transform manipulation:

![](https://cdn.discordapp.com/attachments/188630652340404224/798476030183997450/unknown.png)
