### PR TITLE
Fix taiko bpm multiplier losing too much precision

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TaikoBeatmapConversionTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoBeatmapConversionTest.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         [TestCase("sample-to-type-conversions")]
         [TestCase("slider-conversion-v6")]
         [TestCase("slider-conversion-v14")]
+        [TestCase("slider-generating-drumroll-2")]
         public void Test(string name) => base.Test(name);
 
         protected override IEnumerable<ConvertValue> CreateConvertValue(HitObject hitObject)

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             }
         }
 
-        private bool shouldConvertSliderToHits(HitObject obj, IBeatmap beatmap, IHasDistance distanceData, out double taikoDuration, out double tickSpacing)
+        private bool shouldConvertSliderToHits(HitObject obj, IBeatmap beatmap, IHasDistance distanceData, out int taikoDuration, out double tickSpacing)
         {
             // DO NOT CHANGE OR REFACTOR ANYTHING IN HERE WITHOUT TESTING AGAINST _ALL_ BEATMAPS.
             // Some of these calculations look redundant, but they are not - extremely small floating point errors are introduced to maintain 1:1 compatibility with stable.
@@ -185,7 +185,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
 
             // The velocity and duration of the taiko hit object - calculated as the velocity of a drum roll.
             double taikoVelocity = sliderScoringPointDistance * beatmap.BeatmapInfo.BaseDifficulty.SliderTickRate;
-            taikoDuration = distance / taikoVelocity * beatLength;
+            taikoDuration = (int)(distance / taikoVelocity * beatLength);
 
             if (isForCurrentRuleset)
             {
@@ -200,7 +200,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 beatLength = timingPoint.BeatLength;
 
             // If the drum roll is to be split into hit circles, assume the ticks are 1/8 spaced within the duration of one beat
-            tickSpacing = Math.Min(beatLength / beatmap.BeatmapInfo.BaseDifficulty.SliderTickRate, taikoDuration / spans);
+            tickSpacing = Math.Min(beatLength / beatmap.BeatmapInfo.BaseDifficulty.SliderTickRate, (double)taikoDuration / spans);
 
             return tickSpacing > 0
                    && distance / osuVelocity * 1000 < 2 * beatLength;

--- a/osu.Game.Rulesets.Taiko/Resources/Testing/Beatmaps/slider-conversion-v14-expected-conversion.json
+++ b/osu.Game.Rulesets.Taiko/Resources/Testing/Beatmaps/slider-conversion-v14-expected-conversion.json
@@ -1,7 +1,9 @@
 {
-    "Mappings": [{
+    "Mappings": [
+        {
             "StartTime": 2000,
-            "Objects": [{
+            "Objects": [
+                {
                     "StartTime": 2000,
                     "EndTime": 2000,
                     "IsRim": false,
@@ -23,7 +25,8 @@
         },
         {
             "StartTime": 4000,
-            "Objects": [{
+            "Objects": [
+                {
                     "StartTime": 4000,
                     "EndTime": 4000,
                     "IsRim": false,
@@ -45,7 +48,8 @@
         },
         {
             "StartTime": 6000,
-            "Objects": [{
+            "Objects": [
+                {
                     "StartTime": 6000,
                     "EndTime": 6000,
                     "IsRim": true,
@@ -76,300 +80,13 @@
         },
         {
             "StartTime": 8000,
-            "Objects": [{
+            "Objects": [
+                {
                     "StartTime": 8000,
-                    "EndTime": 8000,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8026,
-                    "EndTime": 8026,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8053,
-                    "EndTime": 8053,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8080,
-                    "EndTime": 8080,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8107,
-                    "EndTime": 8107,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8133,
-                    "EndTime": 8133,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8160,
-                    "EndTime": 8160,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8187,
-                    "EndTime": 8187,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8214,
-                    "EndTime": 8214,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8241,
-                    "EndTime": 8241,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8267,
-                    "EndTime": 8267,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8294,
-                    "EndTime": 8294,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8321,
-                    "EndTime": 8321,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8348,
-                    "EndTime": 8348,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8374,
-                    "EndTime": 8374,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8401,
-                    "EndTime": 8401,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8428,
-                    "EndTime": 8428,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8455,
-                    "EndTime": 8455,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8482,
-                    "EndTime": 8482,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8508,
-                    "EndTime": 8508,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8535,
-                    "EndTime": 8535,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8562,
-                    "EndTime": 8562,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8589,
-                    "EndTime": 8589,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8615,
-                    "EndTime": 8615,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8642,
-                    "EndTime": 8642,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8669,
-                    "EndTime": 8669,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8696,
-                    "EndTime": 8696,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8723,
-                    "EndTime": 8723,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8749,
-                    "EndTime": 8749,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8776,
-                    "EndTime": 8776,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8803,
-                    "EndTime": 8803,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8830,
-                    "EndTime": 8830,
-                    "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
-                    "IsSwell": false,
-                    "IsStrong": false
-                },
-                {
-                    "StartTime": 8857,
                     "EndTime": 8857,
                     "IsRim": false,
-                    "IsCentre": true,
-                    "IsDrumRoll": false,
+                    "IsCentre": false,
+                    "IsDrumRoll": true,
                     "IsSwell": false,
                     "IsStrong": false
                 }

--- a/osu.Game.Rulesets.Taiko/Resources/Testing/Beatmaps/slider-generating-drumroll-2-expected-conversion.json
+++ b/osu.Game.Rulesets.Taiko/Resources/Testing/Beatmaps/slider-generating-drumroll-2-expected-conversion.json
@@ -1,0 +1,18 @@
+{
+  "Mappings": [
+    {
+      "StartTime": 51532,
+      "Objects": [
+        {
+          "StartTime": 51532,
+          "EndTime": 52301,
+          "IsRim": false,
+          "IsCentre": false,
+          "IsDrumRoll": true,
+          "IsSwell": false,
+          "IsStrong": false
+        }
+      ]
+    }
+  ]
+}

--- a/osu.Game.Rulesets.Taiko/Resources/Testing/Beatmaps/slider-generating-drumroll-2.osu
+++ b/osu.Game.Rulesets.Taiko/Resources/Testing/Beatmaps/slider-generating-drumroll-2.osu
@@ -1,0 +1,19 @@
+osu file format v14
+
+[General]
+Mode: 0
+
+[Difficulty]
+HPDrainRate:2
+CircleSize:3.2
+OverallDifficulty:2
+ApproachRate:3
+SliderMultiplier:0.999999999999999
+SliderTickRate:1
+
+[TimingPoints]
+763,384.615384615385,4,2,0,70,1,0
+49993,-90.9090909090909,4,2,0,75,0,1
+
+[HitObjects]
+51,245,51532,2,0,P|18:150|17:122,2,110.000003356934,0|8|0,0:0|0:0|0:0,0:0:0:0:

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -164,12 +164,13 @@ namespace osu.Game.Beatmaps.Formats
             /// Legacy BPM multiplier that introduces floating-point errors for rulesets that depend on it.
             /// DO NOT USE THIS UNLESS 100% SURE.
             /// </summary>
-            public float BpmMultiplier { get; private set; }
+            public double BpmMultiplier { get; private set; }
 
             public LegacyDifficultyControlPoint(double beatLength)
                 : this()
             {
-                BpmMultiplier = beatLength < 0 ? Math.Clamp((float)-beatLength, 10, 10000) / 100f : 1;
+                // Note: In stable, the division occurs on floats, but with compiler optimisations turned on actually seems to occur on doubles via some .NET black magic (possibly inlining?).
+                BpmMultiplier = beatLength < 0 ? Math.Clamp((float)-beatLength, 10, 10000) / 100.0 : 1;
             }
 
             public LegacyDifficultyControlPoint()


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-stable-issues/issues/636 (the taiko beatmap).

I went pretty deep in the .NET stack here, and I'm just as confused as to why this is happening as anyone else, but it looks like the .NET Framework JIT has some funky execution ordering around floating point casts when targeting x86 with code optimisations turned on (i.e. Release mode).

The following code produces different results as described below:
```csharp
static void Main(string[] args)
{
    double mult = floatProp;
    Console.WriteLine(mult);
    Console.ReadKey();
}

// Everything works fine if this is a const.
private static readonly double double_val = -90.909090909090907;

private static float floatProp => (float)-double_val / 100f;
```

| platform | value |
| ----------- | ------- |
| .NET 4.7.2 / AnyCPU / Debug | 0.909090876579285 |
| .NET 4.7.2 / AnyCPU / Release | 0.909090876579285 |
| .NET 4.7.2 / x86 / Debug | 0.909090876579285 |
| .NET 4.7.2 / x86 / Release | 0.909090881347656* |
| .NET 4.7.2 / Mono / Debug | 0.909090876579285 |
| .NET 4.7.2 / Mono / Release | 0.909090876579285 |
| .NET 5.0 / Debug | 0.9090908765792847 |
| .NET 5.0 / Release | 0.9090908765792847 |

The extra precision in the .NET 5.0 results are due to different printing precisions, but internal data is the same in all except the highlighted case.

This can be seen in a few beatmaps:
- https://osu.ppy.sh/beatmapsets/383785#taiko/846143 (before: 2.04, after: 1.9)
- https://osu.ppy.sh/beatmapsets/811914#taiko/1726725 (before: 2.29, after: 0.96)
- https://osu.ppy.sh/beatmapsets/633693#osu/1344918 (before: 2.23, after: 1.16)

All now match the release mode build of osu-stable.