### PR TITLE
Fix non-hosts crashing on load requested

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -241,8 +241,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             void endOperation()
             {
-                Debug.Assert(readyClickOperation != null);
-                readyClickOperation.Dispose();
+                readyClickOperation?.Dispose();
                 readyClickOperation = null;
             }
         }
@@ -255,9 +254,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             StartPlay(() => new MultiplayerPlayer(SelectedItem.Value, userIds));
 
-            Debug.Assert(readyClickOperation != null);
-
-            readyClickOperation.Dispose();
+            readyClickOperation?.Dispose();
             readyClickOperation = null;
         }
 


### PR DESCRIPTION
`onLoadRequested()` always released the `readyClickOperation` ongoing operation, without checking whether it actually needs to/should (it should only do so if the action initiating the operation was starting the game by the host). This would crash all other players, who already released the operation when their ready-up operation completed server side.

To resolve, relax the constraint such that the operation can be ended multiple times in any order. At the end of the day the thing that matters is that the operation is done and the ready button is unblocked.

---

I wanted to add a test for this but failed to get one done in time tonight (super finicky to get through all of the hoops like importing beatmap, setting up another user, having to hack past [the implementation of the stateful client](https://github.com/ppy/osu/blob/becd52b5d2c508d06467e32a48c61a289ac7f282/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs#L459-L461) to make work). Will revisit and add one on request tomorrow, mostly just wanted to get this out so that it doesn't look like I forgot about this. Have tested this empirically on two instances.

In theory having `endOperation()` be null-tolerant is not required but again - I don't really think it matters this much if it doesn't do anything, as long as someone releases the buttons. This way at least all places are treating the thing consistently.