### PR TITLE
Add explicit content markers to beatmap panels and overlay

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -222,6 +222,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("download buttons shown", () => playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().All(d => d.IsPresent));
         }
 
+        [Test]
+        public void TestExplicitBeatmapItem()
+        {
+            var beatmap = new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo;
+            beatmap.BeatmapSet.OnlineInfo.HasExplicitContent = true;
+
+            createPlaylist(beatmap);
+        }
+
         private void moveToItem(int index, Vector2? offset = null)
             => AddStep($"move mouse to item {index}", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<OsuRearrangeableListItem<PlaylistItem>>().ElementAt(index), offset));
 

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -236,6 +236,17 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
+        public void TestExplicitBeatmap()
+        {
+            AddStep("show explicit map", () =>
+            {
+                var beatmapSet = CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet;
+                beatmapSet.OnlineInfo.HasExplicitContent = true;
+                overlay.ShowBeatmapSet(beatmapSet);
+            });
+        }
+
+        [Test]
         public void TestHide()
         {
             AddStep(@"hide", overlay.Hide);

--- a/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDirectPanel.cs
@@ -99,12 +99,15 @@ namespace osu.Game.Tests.Visual.Online
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
         {
-            var normal = CreateWorkingBeatmap(Ruleset.Value).BeatmapSetInfo;
+            var normal = CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet;
             normal.OnlineInfo.HasVideo = true;
             normal.OnlineInfo.HasStoryboard = true;
 
             var undownloadable = getUndownloadableBeatmapSet();
             var manyDifficulties = getManyDifficultiesBeatmapSet(rulesets);
+
+            var explicitMap = CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet;
+            explicitMap.OnlineInfo.HasExplicitContent = true;
 
             Child = new BasicScrollContainer
             {
@@ -121,9 +124,11 @@ namespace osu.Game.Tests.Visual.Online
                         new GridBeatmapPanel(normal),
                         new GridBeatmapPanel(undownloadable),
                         new GridBeatmapPanel(manyDifficulties),
+                        new GridBeatmapPanel(explicitMap),
                         new ListBeatmapPanel(normal),
                         new ListBeatmapPanel(undownloadable),
                         new ListBeatmapPanel(manyDifficulties),
+                        new ListBeatmapPanel(explicitMap)
                     },
                 },
             };

--- a/osu.Game/Beatmaps/BeatmapSetOnlineInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapSetOnlineInfo.cs
@@ -32,6 +32,11 @@ namespace osu.Game.Beatmaps
         public BeatmapSetOnlineStatus Status { get; set; }
 
         /// <summary>
+        /// Whether or not this beatmap set has explicit content.
+        /// </summary>
+        public bool HasExplicitContent { get; set; }
+
+        /// <summary>
         /// Whether or not this beatmap set has a background video.
         /// </summary>
         public bool HasVideo { get; set; }

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -42,6 +42,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"bpm")]
         private double bpm { get; set; }
 
+        [JsonProperty(@"nsfw")]
+        private bool hasExplicitContent { get; set; }
+
         [JsonProperty(@"video")]
         private bool hasVideo { get; set; }
 
@@ -94,6 +97,7 @@ namespace osu.Game.Online.API.Requests.Responses
                     FavouriteCount = favouriteCount,
                     BPM = bpm,
                     Status = Status,
+                    HasExplicitContent = hasExplicitContent,
                     HasVideo = hasVideo,
                     HasStoryboard = hasStoryboard,
                     Submitted = submitted,

--- a/osu.Game/Overlays/BeatmapListing/Panels/GridBeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/GridBeatmapPanel.cs
@@ -14,6 +14,7 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays.BeatmapSet;
 using osuTK;
 using osuTK.Graphics;
 
@@ -24,7 +25,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         private const float horizontal_padding = 10;
         private const float vertical_padding = 5;
 
-        private FillFlowContainer bottomPanel, statusContainer;
+        private FillFlowContainer bottomPanel, statusContainer, titleContainer;
         private PlayButton playButton;
         private Box progressBar;
 
@@ -73,12 +74,20 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                             AutoSizeAxes = Axes.Both,
                             Padding = new MarginPadding { Left = horizontal_padding, Right = horizontal_padding },
                             Direction = FillDirection.Vertical,
-                            Children = new[]
+                            Children = new Drawable[]
                             {
-                                new OsuSpriteText
+                                titleContainer = new FillFlowContainer
                                 {
-                                    Text = new LocalisedString((SetInfo.Metadata.TitleUnicode, SetInfo.Metadata.Title)),
-                                    Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold, italics: true)
+                                    AutoSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Horizontal,
+                                    Children = new Drawable[]
+                                    {
+                                        new OsuSpriteText
+                                        {
+                                            Text = new LocalisedString((SetInfo.Metadata.TitleUnicode, SetInfo.Metadata.Title)),
+                                            Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold, italics: true)
+                                        },
+                                    }
                                 },
                                 new OsuSpriteText
                                 {
@@ -193,6 +202,16 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                     Alpha = 0,
                 },
             });
+
+            if (SetInfo.OnlineInfo?.HasExplicitContent ?? false)
+            {
+                titleContainer.Add(new ExplicitBeatmapPill
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding { Left = 10f, Top = 2f },
+                });
+            }
 
             if (SetInfo.OnlineInfo?.HasVideo ?? false)
             {

--- a/osu.Game/Overlays/BeatmapListing/Panels/ListBeatmapPanel.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/ListBeatmapPanel.cs
@@ -14,6 +14,7 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays.BeatmapSet;
 using osuTK;
 using osuTK.Graphics;
 
@@ -26,7 +27,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         private const float vertical_padding = 5;
         private const float height = 70;
 
-        private FillFlowContainer statusContainer;
+        private FillFlowContainer statusContainer, titleContainer;
         protected BeatmapPanelDownloadButton DownloadButton;
         private PlayButton playButton;
         private Box progressBar;
@@ -98,10 +99,18 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                                                     Direction = FillDirection.Vertical,
                                                     Children = new Drawable[]
                                                     {
-                                                        new OsuSpriteText
+                                                        titleContainer = new FillFlowContainer
                                                         {
-                                                            Text = new LocalisedString((SetInfo.Metadata.TitleUnicode, SetInfo.Metadata.Title)),
-                                                            Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold, italics: true)
+                                                            AutoSizeAxes = Axes.Both,
+                                                            Direction = FillDirection.Horizontal,
+                                                            Children = new[]
+                                                            {
+                                                                new OsuSpriteText
+                                                                {
+                                                                    Text = new LocalisedString((SetInfo.Metadata.TitleUnicode, SetInfo.Metadata.Title)),
+                                                                    Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold, italics: true)
+                                                                },
+                                                            }
                                                         },
                                                         new OsuSpriteText
                                                         {
@@ -207,6 +216,16 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                     Colour = colours.Yellow,
                 },
             });
+
+            if (SetInfo.OnlineInfo?.HasExplicitContent ?? false)
+            {
+                titleContainer.Add(new ExplicitBeatmapPill
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Margin = new MarginPadding { Left = 10f, Top = 2f },
+                });
+            }
 
             if (SetInfo.OnlineInfo?.HasVideo ?? false)
             {

--- a/osu.Game/Overlays/BeatmapSet/ExplicitBeatmapPill.cs
+++ b/osu.Game/Overlays/BeatmapSet/ExplicitBeatmapPill.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Overlays.BeatmapSet
+{
+    public class ExplicitBeatmapPill : CompositeDrawable
+    {
+        public ExplicitBeatmapPill()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuColour colours, OverlayColourProvider colourProvider)
+        {
+            InternalChild = new CircularContainer
+            {
+                Masking = true,
+                AutoSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider?.Background5 ?? colours.Gray2,
+                    },
+                    new OsuSpriteText
+                    {
+                        Margin = new MarginPadding { Horizontal = 10f, Vertical = 2f },
+                        Text = "EXPLICIT",
+                        Font = OsuFont.GetFont(size: 10, weight: FontWeight.Bold),
+                        // todo: this is --hsl-orange-2 from the new palette in https://github.com/ppy/osu-web/blob/8ceb46f/resources/assets/less/colors.less#L128-L151,
+                        // should probably take the whole palette from there onto OsuColour for a nicer look in code.
+                        Colour = Color4.FromHsl(new Vector4(45f / 360, 0.8f, 0.6f, 1f)),
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/BeatmapSet/ExplicitBeatmapPill.cs
+++ b/osu.Game/Overlays/BeatmapSet/ExplicitBeatmapPill.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.BeatmapSet
                     {
                         Margin = new MarginPadding { Horizontal = 10f, Vertical = 2f },
                         Text = "EXPLICIT",
-                        Font = OsuFont.GetFont(size: 10, weight: FontWeight.Bold),
+                        Font = OsuFont.GetFont(size: 10, weight: FontWeight.SemiBold),
                         Colour = OverlayColourProvider.Orange.Colour2,
                     }
                 }

--- a/osu.Game/Overlays/BeatmapSet/ExplicitBeatmapPill.cs
+++ b/osu.Game/Overlays/BeatmapSet/ExplicitBeatmapPill.cs
@@ -7,8 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Overlays.BeatmapSet
 {
@@ -38,9 +36,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         Margin = new MarginPadding { Horizontal = 10f, Vertical = 2f },
                         Text = "EXPLICIT",
                         Font = OsuFont.GetFont(size: 10, weight: FontWeight.Bold),
-                        // todo: this is --hsl-orange-2 from the new palette in https://github.com/ppy/osu-web/blob/8ceb46f/resources/assets/less/colors.less#L128-L151,
-                        // should probably take the whole palette from there onto OsuColour for a nicer look in code.
-                        Colour = Color4.FromHsl(new Vector4(45f / 360, 0.8f, 0.6f, 1f)),
+                        Colour = OverlayColourProvider.Orange.Colour2,
                     }
                 }
             };

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -145,14 +145,14 @@ namespace osu.Game.Overlays.BeatmapSet
                                                     {
                                                         Anchor = Anchor.BottomLeft,
                                                         Origin = Anchor.BottomLeft,
-                                                        Margin = new MarginPadding { Left = 3, Bottom = 4 }, // To better lineup with the font
+                                                        Margin = new MarginPadding { Left = 5, Bottom = 4 }, // To better lineup with the font
                                                     },
                                                     explicitPill = new ExplicitBeatmapPill
                                                     {
                                                         Alpha = 0f,
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft,
-                                                        Margin = new MarginPadding { Left = 15f, Top = 4 },
+                                                        Anchor = Anchor.BottomLeft,
+                                                        Origin = Anchor.BottomLeft,
+                                                        Margin = new MarginPadding { Left = 10, Bottom = 4 },
                                                     }
                                                 }
                                             },

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -34,6 +34,7 @@ namespace osu.Game.Overlays.BeatmapSet
         private readonly Box coverGradient;
         private readonly OsuSpriteText title, artist;
         private readonly AuthorInfo author;
+        private readonly ExplicitBeatmapPill explicitPill;
         private readonly FillFlowContainer downloadButtonsContainer;
         private readonly BeatmapAvailability beatmapAvailability;
         private readonly BeatmapSetOnlineStatusPill onlineStatusPill;
@@ -146,6 +147,13 @@ namespace osu.Game.Overlays.BeatmapSet
                                                         Origin = Anchor.BottomLeft,
                                                         Margin = new MarginPadding { Left = 3, Bottom = 4 }, // To better lineup with the font
                                                     },
+                                                    explicitPill = new ExplicitBeatmapPill
+                                                    {
+                                                        Alpha = 0f,
+                                                        Anchor = Anchor.CentreLeft,
+                                                        Origin = Anchor.CentreLeft,
+                                                        Margin = new MarginPadding { Left = 10f, Top = 4 },
+                                                    }
                                                 }
                                             },
                                             artist = new OsuSpriteText
@@ -252,6 +260,8 @@ namespace osu.Game.Overlays.BeatmapSet
 
                     title.Text = setInfo.NewValue.Metadata.Title ?? string.Empty;
                     artist.Text = setInfo.NewValue.Metadata.Artist ?? string.Empty;
+
+                    explicitPill.Alpha = setInfo.NewValue.OnlineInfo.HasExplicitContent ? 1 : 0;
 
                     onlineStatusPill.FadeIn(500, Easing.OutQuint);
                     onlineStatusPill.Status = setInfo.NewValue.OnlineInfo.Status;

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Overlays.BeatmapSet
                                                         Alpha = 0f,
                                                         Anchor = Anchor.CentreLeft,
                                                         Origin = Anchor.CentreLeft,
-                                                        Margin = new MarginPadding { Left = 10f, Top = 4 },
+                                                        Margin = new MarginPadding { Left = 15f, Top = 4 },
                                                     }
                                                 }
                                             },

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -16,6 +16,11 @@ namespace osu.Game.Overlays
             this.colourScheme = colourScheme;
         }
 
+        public Color4 Colour1 => getColour(1, 0.7f);
+        public Color4 Colour2 => getColour(0.8f, 0.6f);
+        public Color4 Colour3 => getColour(0.6f, 0.5f);
+        public Color4 Colour4 => getColour(0.4f, 0.3f);
+
         public Color4 Highlight1 => getColour(1, 0.7f);
         public Color4 Content1 => getColour(0.4f, 1);
         public Color4 Content2 => getColour(0.4f, 0.9f);

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -11,6 +11,13 @@ namespace osu.Game.Overlays
     {
         private readonly OverlayColourScheme colourScheme;
 
+        public static OverlayColourProvider Red { get; } = new OverlayColourProvider(OverlayColourScheme.Red);
+        public static OverlayColourProvider Pink { get; } = new OverlayColourProvider(OverlayColourScheme.Pink);
+        public static OverlayColourProvider Orange { get; } = new OverlayColourProvider(OverlayColourScheme.Orange);
+        public static OverlayColourProvider Green { get; } = new OverlayColourProvider(OverlayColourScheme.Green);
+        public static OverlayColourProvider Purple { get; } = new OverlayColourProvider(OverlayColourScheme.Purple);
+        public static OverlayColourProvider Blue { get; } = new OverlayColourProvider(OverlayColourScheme.Blue);
+
         public OverlayColourProvider(OverlayColourScheme colourScheme)
         {
             this.colourScheme = colourScheme;

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -23,6 +23,7 @@ using osu.Game.Online;
 using osu.Game.Online.Chat;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.BeatmapListing.Panels;
+using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Play.HUD;
@@ -41,6 +42,7 @@ namespace osu.Game.Screens.OnlinePlay
         private Container difficultyIconContainer;
         private LinkFlowContainer beatmapText;
         private LinkFlowContainer authorText;
+        private ExplicitBeatmapPill explicitPill;
         private ModDisplay modDisplay;
 
         private readonly Bindable<BeatmapInfo> beatmap = new Bindable<BeatmapInfo>();
@@ -116,6 +118,9 @@ namespace osu.Game.Screens.OnlinePlay
                 authorText.AddUserLink(Item.Beatmap.Value?.Metadata.Author);
             }
 
+            bool hasExplicitContent = Item.Beatmap.Value.BeatmapSet.OnlineInfo?.HasExplicitContent == true;
+            explicitPill.Alpha = hasExplicitContent ? 1 : 0;
+
             modDisplay.Current.Value = requiredMods.ToArray();
         }
 
@@ -165,18 +170,37 @@ namespace osu.Game.Screens.OnlinePlay
                                 {
                                     AutoSizeAxes = Axes.Both,
                                     Direction = FillDirection.Horizontal,
-                                    Spacing = new Vector2(15, 0),
+                                    Spacing = new Vector2(10f, 0),
                                     Children = new Drawable[]
                                     {
-                                        authorText = new LinkFlowContainer { AutoSizeAxes = Axes.Both },
-                                        modDisplay = new ModDisplay
+                                        new FillFlowContainer
+                                        {
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Horizontal,
+                                            Spacing = new Vector2(10f, 0),
+                                            Children = new Drawable[]
+                                            {
+                                                authorText = new LinkFlowContainer { AutoSizeAxes = Axes.Both },
+                                                explicitPill = new ExplicitBeatmapPill
+                                                {
+                                                    Alpha = 0f,
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Margin = new MarginPadding { Top = 3f },
+                                                }
+                                            },
+                                        },
+                                        new Container
                                         {
                                             Anchor = Anchor.CentreLeft,
                                             Origin = Anchor.CentreLeft,
                                             AutoSizeAxes = Axes.Both,
-                                            Scale = new Vector2(0.4f),
-                                            DisplayUnrankedText = false,
-                                            ExpansionMode = ExpansionMode.AlwaysExpanded
+                                            Child = modDisplay = new ModDisplay
+                                            {
+                                                Scale = new Vector2(0.4f),
+                                                DisplayUnrankedText = false,
+                                                ExpansionMode = ExpansionMode.AlwaysExpanded
+                                            }
                                         }
                                     }
                                 }

--- a/osu.Game/Tests/Beatmaps/TestBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestBeatmap.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Tests.Beatmaps
             BeatmapInfo.BeatmapSet.Files = new List<BeatmapSetFileInfo>();
             BeatmapInfo.BeatmapSet.Beatmaps = new List<BeatmapInfo> { BeatmapInfo };
             BeatmapInfo.Length = 75000;
+            BeatmapInfo.OnlineInfo = new BeatmapOnlineInfo();
             BeatmapInfo.BeatmapSet.OnlineInfo = new BeatmapSetOnlineInfo
             {
                 Status = BeatmapSetOnlineStatus.Ranked,


### PR DESCRIPTION
First step in fulfilling #11460 

![image](https://user-images.githubusercontent.com/22781491/104432004-9b5f3f80-5599-11eb-975f-474fe9b2674a.png)
![image](https://user-images.githubusercontent.com/22781491/104432122-bdf15880-5599-11eb-9091-1d0a0078cada.png)
![image](https://user-images.githubusercontent.com/22781491/104432622-4112ae80-559a-11eb-9522-7f21d8bcfc81.png)

Also about the orange colour thing in `ExplicitBeatmapPill`:
https://github.com/ppy/osu/blob/ee6baeb57e0d51e8d65a3c8c70e25701cc58ada8/osu.Game/Overlays/BeatmapSet/ExplicitBeatmapPill.cs#L36-L44

Can use `colours.Yellow` instead but felt like a bad thing to do, so I've used the exact colour used in osu!web, and added a todo comment to port the new colour palette into `OsuColours` later on, might do this myself if I get time.

Side note, the development server isn't updated with the explicit content changes yet, so you have to use the production server for testing this in-game.

I've added test cases to see this in the test browser, since that would be easier and more preferable anyways.