### PR TITLE
Rename download state `Downloaded` to `Importing`

### DIFF
--- a/osu.Game/Graphics/UserInterface/DownloadButton.cs
+++ b/osu.Game/Graphics/UserInterface/DownloadButton.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Graphics.UserInterface
                     TooltipText = "Downloading...";
                     break;
 
-                case DownloadState.Downloaded:
+                case DownloadState.Importing:
                     background.FadeColour(colours.Yellow, 500, Easing.InOutExpo);
                     TooltipText = "Importing";
                     break;

--- a/osu.Game/Online/DownloadState.cs
+++ b/osu.Game/Online/DownloadState.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Online
     {
         NotDownloaded,
         Downloading,
-        Downloaded,
+        Importing,
         LocallyAvailable
     }
 }

--- a/osu.Game/Online/DownloadTrackingComposite.cs
+++ b/osu.Game/Online/DownloadTrackingComposite.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Online
             {
                 if (attachedRequest.Progress == 1)
                 {
-                    State.Value = DownloadState.Downloaded;
+                    State.Value = DownloadState.Importing;
                     Progress.Value = 1;
                 }
                 else
@@ -125,7 +125,7 @@ namespace osu.Game.Online
             }
         }
 
-        private void onRequestSuccess(string _) => Schedule(() => State.Value = DownloadState.Downloaded);
+        private void onRequestSuccess(string _) => Schedule(() => State.Value = DownloadState.Importing);
 
         private void onRequestProgress(float progress) => Schedule(() => Progress.Value = progress);
 

--- a/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/BeatmapPanelDownloadButton.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                 switch (State.Value)
                 {
                     case DownloadState.Downloading:
-                    case DownloadState.Downloaded:
+                    case DownloadState.Importing:
                         shakeContainer.Shake();
                         break;
 

--- a/osu.Game/Overlays/BeatmapListing/Panels/DownloadProgressBar.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/DownloadProgressBar.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                         progressBar.ResizeHeightTo(4, 400, Easing.OutQuint);
                         break;
 
-                    case DownloadState.Downloaded:
+                    case DownloadState.Importing:
                         progressBar.FadeIn(400, Easing.OutQuint);
                         progressBar.ResizeHeightTo(4, 400, Easing.OutQuint);
 

--- a/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
                         };
                         break;
 
-                    case DownloadState.Downloaded:
+                    case DownloadState.Importing:
                         textSprites.Children = new Drawable[]
                         {
                             new OsuSpriteText

--- a/osu.Game/Overlays/BeatmapSet/Header.cs
+++ b/osu.Game/Overlays/BeatmapSet/Header.cs
@@ -287,7 +287,7 @@ namespace osu.Game.Overlays.BeatmapSet
                     break;
 
                 case DownloadState.Downloading:
-                case DownloadState.Downloaded:
+                case DownloadState.Importing:
                     // temporary to avoid showing two buttons for maps with novideo. will be fixed in new beatmap overlay design.
                     downloadButtonsContainer.Child = new HeaderDownloadButton(BeatmapSet.Value);
                     break;

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Ranking
                         scores.Download(Model.Value);
                         break;
 
-                    case DownloadState.Downloaded:
+                    case DownloadState.Importing:
                     case DownloadState.Downloading:
                         shakeContainer.Shake();
                         break;


### PR DESCRIPTION
As per https://github.com/ppy/osu/pull/11410#discussion_r554737638. This caused confusion over what the state actually means in an overall model availability context, renaming to `Importing` explains better.