### PR TITLE
Revert overlooked AR<8 speed buff

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (Attributes.ApproachRate > 10.33)
                 approachRateFactor += 0.4 * (Attributes.ApproachRate - 10.33);
             else if (Attributes.ApproachRate < 8.0)
-                approachRateFactor += 0.1 * (8.0 - Attributes.ApproachRate);
+                approachRateFactor += 0.01 * (8.0 - Attributes.ApproachRate);
 
             aimValue *= 1.0 + Math.Min(approachRateFactor, approachRateFactor * (totalHits / 1000.0));
 


### PR DESCRIPTION
Pull request #11107 introduced changes in osu! performance calculation, related to a scaling coefficient applied to the speed and aim skills. The coefficient in question was dependent on the approach rate of a map.

During a post-merge review of the contents of that PR, I spotted that the scaling coefficient for speed also had a 10x buff applied for AR<8 (see commit cf3fbe0b0b832ef2476e46eb600f086b385005b9 and the bump from `0.01` to `0.1` in line 106), which could reach magnitudes as large as 80% on AR0, which seems quite exorbitant. This change was not discussed or mentioned anywhere in the review process.

Revert back to the old multiplier of 0.01 rather than 0.1 for AR<8. The negative slope through AR0 to 8 is retained in its previous form.

The following graphs aim to show how the speed coefficient looked at various points and how it looks with this change:

| pre-#11107 | post-#11107 | this PR |
| :-: | :-: | :-: |
| ![ar_multiplier_before](https://user-images.githubusercontent.com/20418176/104485450-ca41d980-55ca-11eb-8a28-3f467636ff20.png) | ![ar_multiplier_after](https://user-images.githubusercontent.com/20418176/104485466-d168e780-55ca-11eb-98e8-fcb14f16979b.png) | ![ar_multiplier_revert](https://user-images.githubusercontent.com/20418176/104485488-d6c63200-55ca-11eb-9c25-25841e14d8ac.png) |

---

From what I know from various unofficial sources, there are also opinions that the AR coefficient:

* should not scale with object count,
* should be reverted to its original version,
* should not exist at all, ever.

Unless someone is willing to step up and PR a counter-proposal to the current state of affairs, this will probably be the best chance in a while to express an opinion on the matter (and there's been a little bit of chatter on discord today already) - that said, just in case this blows up, **I would ask to:**

* **think twice** before commenting in this thread and **try to optimise for uniqueness of information and brevity**,
* as a corollary of the above - **not add "+1" comments** and **use reactions** instead,
* and that **any real-time discussion ideally take place in `#osu-performance` on discord**, as it's a more conducive platform for that purpose.

The above requests aim to prevent unnecessary flame-wars and introducing noise due to prolonged discussion. Also note, that **even if this PR does not revert the original AR adjustment wholesale, it does not mean it is forever set in stone.** The eventual goal is to [decrease turnaround time on game balance changes so that they can be deployed on a less rigid schedule](https://github.com/ppy/osu/pull/11107#issuecomment-739721834).