### PR TITLE
Fix default judgement text mispositioned for one frame

### DIFF
--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Rulesets.Judgements
             {
                 JudgementText = new OsuSpriteText
                 {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
                     Text = Result.GetDescription().ToUpperInvariant(),
                     Colour = colours.ForHitResult(Result),
                     Font = OsuFont.Numeric.With(size: 20),


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/11463

The underlying issue here is https://github.com/ppy/osu-framework/issues/3369