### PR TITLE
Fix the beatmap carousel playing the difficulty change sample on beatmap change

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -500,7 +500,7 @@ namespace osu.Game.Screens.Select
 
                     if (beatmap != null)
                     {
-                        if (beatmap.BeatmapSetInfoID == beatmapNoDebounce?.BeatmapSetInfoID)
+                        if (beatmap.BeatmapSetInfoID == previous?.BeatmapInfo.BeatmapSetInfoID)
                             sampleChangeDifficulty.Play();
                         else
                             sampleChangeBeatmap.Play();


### PR DESCRIPTION
This regressed at some point - was checking the new beatmap against itself, resulting in always playing the difficulty change sample.