### PR TITLE
Change conditional used to decide legacy judgement animation to match stable

### DIFF
--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -381,9 +381,7 @@ namespace osu.Game.Skinning
                         var particle = getParticleTexture(resultComponent.Component);
 
                         if (particle != null)
-                        {
                             return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, particle);
-                        }
                         else
                             return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
                     }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -378,8 +378,12 @@ namespace osu.Game.Skinning
                     // kind of wasteful that we throw this away, but should do for now.
                     if (createDrawable() != null)
                     {
-                        if (Configuration.LegacyVersion > 1)
-                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, getParticleTexture(resultComponent.Component));
+                        var particle = getParticleTexture(resultComponent.Component);
+
+                        if (particle != null)
+                        {
+                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, particle);
+                        }
                         else
                             return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
                     }


### PR DESCRIPTION
In stable, the type of legacy judgement to show is based on the presence of particle textures in the skin. We were using the skin version instead, which turns out to be incorrect and not what some user skins expect.

in `osu-stable`:

![image](https://user-images.githubusercontent.com/191335/104686816-5b3ac100-5741-11eb-8cbd-9bb65d169ae8.png)

![image](https://user-images.githubusercontent.com/191335/104686839-6392fc00-5741-11eb-9245-f30f31a0f625.png)

Closes #11078.