### PR TITLE
Fix editor timeline not snapping on non-precise wheel scroll

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -138,6 +138,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 scrollToTrackTime();
         }
 
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            // if this is not a precision scroll event, let the editor handle the seek itself (for snapping support)
+            if (!e.AltPressed && !e.IsPrecise)
+                return false;
+
+            return base.OnScroll(e);
+        }
+
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();


### PR DESCRIPTION
For wheel input with precision, we still prefer exact tracking for now. May change this in the future based on feedback from mappers, but it makes little sense to do non-snapped scrolling when input is coming from a non-precise source.

Closes (most of) https://github.com/ppy/osu/issues/11497.