### PR TITLE
Fix playlist item download button never shown back after hiding

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -201,11 +201,17 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        public void TestDownloadButtonHiddenInitiallyWhenBeatmapExists()
+        public void TestDownloadButtonHiddenWhenBeatmapExists()
         {
             createPlaylist(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo);
 
             AddAssert("download button hidden", () => !playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().IsPresent);
+
+            AddStep("delete beatmap set", () => manager.Delete(manager.QueryBeatmapSets(_ => true).Single()));
+            AddUntilStep("download button shown", () => playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().IsPresent);
+
+            AddStep("undelete beatmap set", () => manager.Undelete(manager.QueryBeatmapSets(_ => true).Single()));
+            AddUntilStep("download button hidden", () => !playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().IsPresent);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -205,13 +205,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             createPlaylist(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo);
 
-            AddAssert("download button hidden", () => !playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().IsPresent);
+            assertDownloadButtonVisible(false);
 
             AddStep("delete beatmap set", () => manager.Delete(manager.QueryBeatmapSets(_ => true).Single()));
-            AddUntilStep("download button shown", () => playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().IsPresent);
+            assertDownloadButtonVisible(true);
 
             AddStep("undelete beatmap set", () => manager.Undelete(manager.QueryBeatmapSets(_ => true).Single()));
-            AddUntilStep("download button hidden", () => !playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().IsPresent);
+            assertDownloadButtonVisible(false);
+
+            void assertDownloadButtonVisible(bool visible) => AddUntilStep($"download button {(visible ? "shown" : "hidden")}",
+                () => playlist.ChildrenOfType<BeatmapDownloadTrackingComposite>().Single().Alpha == (visible ? 1 : 0));
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -249,6 +249,8 @@ namespace osu.Game.Screens.OnlinePlay
             [Resolved]
             private BeatmapManager beatmapManager { get; set; }
 
+            public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+
             public PlaylistDownloadButton(PlaylistItem playlistItem)
                 : base(playlistItem.Beatmap.Value.BeatmapSet)
             {


### PR DESCRIPTION
After the playlist item download button becomes hidden due to having the beatmap locally, it'll never be shown back even if you delete the beatmap. 

And that's because when the button gets hidden, `IsPresent` becomes false, therefore the schedules added by `DownloadTrackingComposite` will never be invoked back, so making `IsPresent` aware of pending scheduler tasks solve the problem.