### PR TITLE
Add nuget deploys for all rulesets

### DIFF
--- a/appveyor_deploy.yml
+++ b/appveyor_deploy.yml
@@ -1,21 +1,68 @@
 clone_depth: 1
 version: '{build}'
 image: Visual Studio 2019
-dotnet_csproj:
-  patch: true
-  file: 'osu.Game\osu.Game.csproj' # Use wildcard when it's able to exclude Xamarin projects
-  version: $(APPVEYOR_REPO_TAG_NAME)
-before_build:
-  - ps: dotnet --info # Useful when version mismatch between CI and local
-  - ps: nuget restore -verbosity quiet # Only nuget.exe knows both new (.NET Core) and old (Xamarin) projects
 test: off
 skip_non_tags: true
 configuration: Release
-build:
-  project: build\Desktop.proj # Skipping Xamarin Release that's slow and covered by fastlane
-  parallel: true
-  verbosity: minimal
-  publish_nuget: true
+
+environment:
+  matrix:
+    - job_name: osu-game
+    - job_name: osu-ruleset
+      job_depends_on: osu-game
+    - job_name: taiko-ruleset
+      job_depends_on: osu-game
+    - job_name: catch-ruleset
+      job_depends_on: osu-game
+    - job_name: mania-ruleset
+      job_depends_on: osu-game
+
+nuget:
+  project_feed: true
+
+for:
+  -
+    matrix:
+      only:
+        - job_name: osu-game
+    build_script:
+      - cmd: dotnet pack osu.Game\osu.Game.csproj /p:Version=%APPVEYOR_REPO_TAG_NAME%
+  -
+    matrix:
+      only:
+        - job_name: osu-ruleset
+    build_script:
+      - cmd: dotnet remove osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj reference osu.Game\osu.Game.csproj
+      - cmd: dotnet add osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj package ppy.osu.Game -v %APPVEYOR_REPO_TAG_NAME%
+      - cmd: dotnet pack osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj /p:Version=%APPVEYOR_REPO_TAG_NAME%
+  -
+    matrix:
+      only:
+        - job_name: taiko-ruleset
+    build_script:
+      - cmd: dotnet remove osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj reference osu.Game\osu.Game.csproj
+      - cmd: dotnet add osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj package ppy.osu.Game -v %APPVEYOR_REPO_TAG_NAME%
+      - cmd: dotnet pack osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj /p:Version=%APPVEYOR_REPO_TAG_NAME%
+  -
+    matrix:
+      only:
+        - job_name: catch-ruleset
+    build_script:
+      - cmd: dotnet remove osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj reference osu.Game\osu.Game.csproj
+      - cmd: dotnet add osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj package ppy.osu.Game -v %APPVEYOR_REPO_TAG_NAME%
+      - cmd: dotnet pack osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj /p:Version=%APPVEYOR_REPO_TAG_NAME%
+  -
+    matrix:
+      only:
+        - job_name: mania-ruleset
+    build_script:
+      - cmd: dotnet remove osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj reference osu.Game\osu.Game.csproj
+      - cmd: dotnet add osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj package ppy.osu.Game -v %APPVEYOR_REPO_TAG_NAME%
+      - cmd: dotnet pack osu.Game.Rulesets.Mania\osu.Game.Rulesets.Mania.csproj /p:Version=%APPVEYOR_REPO_TAG_NAME%
+
+artifacts:
+  - path: '**\*.nupkg'
+
 deploy:
   - provider: Environment
     name: nuget

--- a/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
+++ b/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
@@ -5,6 +5,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>catch the fruit. to the beat.</Description>
   </PropertyGroup>
+
+  <PropertyGroup Label="Nuget">
+    <Title>osu!catch</Title>
+    <PackageId>ppy.osu.Game.Rulesets.Catch</PackageId>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>

--- a/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
+++ b/osu.Game.Rulesets.Catch/osu.Game.Rulesets.Catch.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">
-    <Title>osu!catch</Title>
+    <Title>osu!catch (ruleset)</Title>
     <PackageId>ppy.osu.Game.Rulesets.Catch</PackageId>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+++ b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">
-    <Title>osu!mania</Title>
+    <Title>osu!mania (ruleset)</Title>
     <PackageId>ppy.osu.Game.Rulesets.Mania</PackageId>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
+++ b/osu.Game.Rulesets.Mania/osu.Game.Rulesets.Mania.csproj
@@ -5,6 +5,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>smash the keys. to the beat.</Description>
   </PropertyGroup>
+
+  <PropertyGroup Label="Nuget">
+    <Title>osu!mania</Title>
+    <PackageId>ppy.osu.Game.Rulesets.Mania</PackageId>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>

--- a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+++ b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">
-    <Title>osu!standard</Title>
+    <Title>osu! (ruleset)</Title>
     <PackageId>ppy.osu.Game.Rulesets.Osu</PackageId>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+++ b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
@@ -5,6 +5,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>click the circles. to the beat.</Description>
   </PropertyGroup>
+
+  <PropertyGroup Label="Nuget">
+    <Title>osu!standard</Title>
+    <PackageId>ppy.osu.Game.Rulesets.Osu</PackageId>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>

--- a/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
+++ b/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
@@ -5,6 +5,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>bash the drum. to the beat.</Description>
   </PropertyGroup>
+
+  <PropertyGroup Label="Nuget">
+    <Title>osu!taiko</Title>
+    <PackageId>ppy.osu.Game.Rulesets.Taiko</PackageId>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>

--- a/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
+++ b/osu.Game.Rulesets.Taiko/osu.Game.Rulesets.Taiko.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Nuget">
-    <Title>osu!taiko</Title>
+    <Title>osu!taiko (ruleset)</Title>
     <PackageId>ppy.osu.Game.Rulesets.Taiko</PackageId>
     <IsPackable>true</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This adds nuget packaging and deployment for all ruleset projects, by replacing the `osu.Game` project reference with a package reference during deploy using appveyor's project nuget feed.

I hope that the process here is generalised enough that this can also be done for the templates and framework-side stuff too - currently framework templates are always one version behind as they rely on dependabot to discover the nuget.org package post-deploy.

Sample of successful run (minus failure on deploy): https://ci.appveyor.com/project/smoogipoo/osu-bdjcw/builds/37310556

For @peppy : The current `osu (nuget deploy)` project doesn't use the `appveyor_deploy.yml` file.