### PR TITLE
Fix selection box not updating with hitcircles/sliders far in the future or past

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCircleSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCircleSelectionBlueprint.cs
@@ -30,6 +30,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => DrawableObject.HitArea.ReceivePositionalInputAt(screenSpacePos);
 
-        public override Quad SelectionQuad => DrawableObject.HitArea.ScreenSpaceDrawQuad;
+        public override Quad SelectionQuad => CirclePiece.ScreenSpaceDrawQuad;
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         [Resolved(CanBeNull = true)]
         private IEditorChangeHandler changeHandler { get; set; }
 
+        public override Quad SelectionQuad => BodyPiece.ScreenSpaceDrawQuad;
+
         private readonly BindableList<PathControlPoint> controlPoints = new BindableList<PathControlPoint>();
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 


### PR DESCRIPTION
Reduces dependence on `DrawableHitObject`s, which may not be updated. We should be using blueprint components for the `SelectionQuad` specification wherever possible.

Closes #11203.