### PR TITLE
Fix sliders with an even number of repeats not allowing rotation/scale transforms

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -239,12 +239,14 @@ namespace osu.Game.Rulesets.Osu.Edit
             getSurroundingQuad(hitObjects.SelectMany(h =>
             {
                 if (h is IHasPath path)
+                {
                     return new[]
                     {
                         h.Position,
                         // can't use EndPosition for reverse slider cases.
                         h.Position + path.Path.PositionAt(1)
                     };
+                }
 
                 return new[] { h.Position };
             }));

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -236,7 +236,18 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// </summary>
         /// <param name="hitObjects">The hit objects to calculate a quad for.</param>
         private Quad getSurroundingQuad(OsuHitObject[] hitObjects) =>
-            getSurroundingQuad(hitObjects.SelectMany(h => new[] { h.Position, h.EndPosition }));
+            getSurroundingQuad(hitObjects.SelectMany(h =>
+            {
+                if (h is IHasPath path)
+                    return new[]
+                    {
+                        h.Position,
+                        // can't use EndPosition for reverse slider cases.
+                        h.Position + path.Path.PositionAt(1)
+                    };
+
+                return new[] { h.Position };
+            }));
 
         /// <summary>
         /// Returns a gamefield-space quad surrounding the provided points.


### PR DESCRIPTION
`EndPosition` was not the correct secondary position for use with sliders here. Accessing the path directly to query its end position seems like the best solution.