### PR TITLE
Restore nuget packages per project to avoid toolchain incompatibilities

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,9 +48,8 @@ desc 'Deploy to play store'
 
   desc 'Compile the project'
   lane :build do |options|
-    nuget_restore(
-      project_path: 'osu.sln'
-    )
+    nuget_restore(project_path: 'osu.Android/osu.Android.csproj')
+    nuget_restore(project_path: 'osu.Game/osu.Game.csproj')
 
     souyuz(
       build_configuration: 'Release',
@@ -107,9 +106,8 @@ platform :ios do
 
   desc 'Compile the project'
   lane :build do
-    nuget_restore(
-      project_path: 'osu.sln'
-    )
+    nuget_restore(project_path: 'osu.iOS/osu.iOS.csproj')
+    nuget_restore(project_path: 'osu.Game/osu.Game.csproj')
 
     souyuz(
       platform: "ios",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,6 +48,10 @@ desc 'Deploy to play store'
 
   desc 'Compile the project'
   lane :build do |options|
+    nuget_restore(
+      project_path: 'osu.sln'
+    )
+
     souyuz(
       build_configuration: 'Release',
       solution_path: 'osu.sln',
@@ -103,6 +107,10 @@ platform :ios do
 
   desc 'Compile the project'
   lane :build do
+    nuget_restore(
+      project_path: 'osu.sln'
+    )
+
     souyuz(
       platform: "ios",
       plist_path: "osu.iOS/Info.plist"


### PR DESCRIPTION
Have tested this on the build server and it seems to work as expected. Not the pretties way to do things, but oh well.