### PR TITLE
Reduce final fill alpha of main menu confirm-to-exit

### DIFF
--- a/osu.Game/Overlays/HoldToConfirmOverlay.cs
+++ b/osu.Game/Overlays/HoldToConfirmOverlay.cs
@@ -24,6 +24,13 @@ namespace osu.Game.Overlays
         [Resolved]
         private AudioManager audio { get; set; }
 
+        private readonly float finalFillAlpha;
+
+        protected HoldToConfirmOverlay(float finalFillAlpha = 1)
+        {
+            this.finalFillAlpha = finalFillAlpha;
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -42,8 +49,10 @@ namespace osu.Game.Overlays
 
             Progress.ValueChanged += p =>
             {
-                audioVolume.Value = 1 - p.NewValue;
-                overlay.Alpha = (float)p.NewValue;
+                var target = p.NewValue * finalFillAlpha;
+
+                audioVolume.Value = 1 - target;
+                overlay.Alpha = (float)target;
             };
 
             audio.Tracks.AddAdjustment(AdjustableProperty.Volume, audioVolume);

--- a/osu.Game/Screens/Menu/ExitConfirmOverlay.cs
+++ b/osu.Game/Screens/Menu/ExitConfirmOverlay.cs
@@ -13,6 +13,11 @@ namespace osu.Game.Screens.Menu
 
         public void Abort() => AbortConfirm();
 
+        public ExitConfirmOverlay()
+            : base(0.7f)
+        {
+        }
+
         public bool OnPressed(GlobalAction action)
         {
             if (action == GlobalAction.Back)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11095. I tried interpolation first but having it lag behind the confirm-to-exit value (when not set to 0ms) feels not so nice, especially in other usages (retry/quick exit in gameplay, where hitting black signifies the point of confirmation).