### PR TITLE
Fix client potentially not leaving a room on exiting multiplayer

### DIFF
--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -144,17 +144,14 @@ namespace osu.Game.Online.Multiplayer
 
         public virtual Task LeaveRoom()
         {
-            Scheduler.Add(() =>
+            if (Room != null)
             {
-                if (Room == null)
-                    return;
-
                 apiRoom = null;
                 Room = null;
                 CurrentMatchPlayingUserIds.Clear();
 
-                RoomUpdated?.Invoke();
-            }, false);
+                Scheduler.Add(() => RoomUpdated?.Invoke(), false);
+            }
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Aims to fix the main issue pointed out in https://github.com/ppy/osu/issues/11315. If a join completed after the local user has already exited the multiplayer screen stack, the `MultiplayerClient` would remain in a joined state.

Not sure this is testable, but for manual testing you can add an `await Task.Delay(5000)` to `MultiplayerClient.JoinRoom` then follow the instructions in the referenced issue.

Closes #11315.