### PR TITLE
Mark legacy beatmap skin colour test as abstract

### DIFF
--- a/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
@@ -17,7 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Tests.Beatmaps
 {
-    public class LegacyBeatmapSkinColourTest : ScreenTestScene
+    public abstract class LegacyBeatmapSkinColourTest : ScreenTestScene
     {
         protected readonly Bindable<bool> BeatmapSkins = new Bindable<bool>();
         protected readonly Bindable<bool> BeatmapColours = new Bindable<bool>();


### PR DESCRIPTION
Shows up weirdly in test browsers for osu! and catch rulesets otherwise:

![2021-01-19-231132_1920x1138_scrot](https://user-images.githubusercontent.com/20418176/105099305-c1aa4100-5aab-11eb-9db3-ed95824a2823.png)