### PR TITLE
Fix HOC not propagating DHO results applied on kill

### DIFF
--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -124,9 +124,11 @@ namespace osu.Game.Rulesets.UI
             Debug.Assert(drawableMap.ContainsKey(entry));
 
             var drawable = drawableMap[entry];
+
+            // OnKilled can potentially change the hitobject's result, so it needs to run first before unbinding.
+            drawable.OnKilled();
             drawable.OnNewResult -= onNewResult;
             drawable.OnRevertResult -= onRevertResult;
-            drawable.OnKilled();
 
             drawableMap.Remove(entry);
 


### PR DESCRIPTION
Closes #11545.

`DrawableHitObject.OnKilled()` calls `UpdateResult()` to clean up a hitobject's state definitively with regard to the judgement result before returning the DHO back to the pool.

As it turns out, if a consumer was relying on this code path (as taiko was in the case of nested strong hit objects), it would not work properly with pooling, due to `HitObjectContainer` unsubscribing from `On{New,Revert}Result` *before* calling the DHO's `OnKilled()`.

This in turn would lead to users potentially getting stuck in gameplay, due to `ScoreProcessor` not receiving all results via that event path.

To resolve, change the call ordering to allow hit result changes applied in `OnKilled()` to propagate normally.

---

The attached test fudges things a little bit and calls `ApplyResult()` in the override manually, but that is [functionally equivalent to normal operation](https://github.com/ppy/osu/blob/7da7079ef29d8f680549c8b82f224b95715641b8/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L709).