### PR TITLE
Fix mod test failing intermittently

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
+            SelectedMods.Value = Array.Empty<Mod>();
             Children = new Drawable[]
             {
                 modSelect = new TestModSelectOverlay

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -134,6 +134,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestExternallySetCustomizedMod()
         {
+            changeRuleset(0);
+
             AddStep("set customized mod externally", () => SelectedMods.Value = new[] { new OsuModDoubleTime { SpeedChange = { Value = 1.01 } } });
 
             AddAssert("ensure button is selected and customized accordingly", () =>


### PR DESCRIPTION
As seen in https://ci.appveyor.com/project/peppy/osu/builds/37369319/tests & https://ci.appveyor.com/project/peppy/osu/builds/37367027/tests

Just depends on test ordering, which can be altered manually via `[Order(...)]`.