### PR TITLE
Leave the multiplayer channel when leaving multiplayer

### DIFF
--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -339,7 +339,7 @@ namespace osu.Game.Online.Chat
         }
 
         /// <summary>
-        /// Joins a channel if it has not already been joined.
+        /// Joins a channel if it has not already been joined. Must be called from the update thread.
         /// </summary>
         /// <param name="channel">The channel to join.</param>
         /// <returns>The joined channel. Note that this may not match the parameter channel as it is a backed object.</returns>
@@ -399,7 +399,11 @@ namespace osu.Game.Online.Chat
             return channel;
         }
 
-        public void LeaveChannel(Channel channel)
+        /// <summary>
+        /// Leave the specified channel. Can be called from any thread.
+        /// </summary>
+        /// <param name="channel">The channel to leave.</param>
+        public void LeaveChannel(Channel channel) => Schedule(() =>
         {
             if (channel == null) return;
 
@@ -413,7 +417,7 @@ namespace osu.Game.Online.Chat
                 api.Queue(new LeaveChannelRequest(channel));
                 channel.Joined.Value = false;
             }
-        }
+        });
 
         private long lastMessageId;
 

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
@@ -38,5 +38,11 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
             Channel.Value = channelManager?.JoinChannel(new Channel { Id = channelId.Value, Type = ChannelType.Multiplayer, Name = $"#lazermp_{roomId.Value}" });
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            channelManager?.LeaveChannel(Channel.Value);
+        }
     }
 }


### PR DESCRIPTION
We may want to do this server-side eventually (to catch cases like the client crashing, where we probably still want to remove the user from the channel), but this seems like a good thing to have in the mean time.

Closes https://github.com/ppy/osu/issues/11299.