### PR TITLE
Fix storyboard samples continuing to play when the beatmap is paused or intro is skipped

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Storyboards;
+using osu.Game.Storyboards.Drawables;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public class TestSceneStoryboardSamplePlayback : PlayerTestScene
+    {
+        private Storyboard storyboard;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            config.Set(OsuSetting.ShowStoryboard, true);
+
+            storyboard = new Storyboard();
+            var backgroundLayer = storyboard.GetLayer("Background");
+            backgroundLayer.Add(new StoryboardSampleInfo("Intro/welcome.mp3", time: -7000, volume: 20));
+            backgroundLayer.Add(new StoryboardSampleInfo("Intro/welcome.mp3", time: -5000, volume: 20));
+            backgroundLayer.Add(new StoryboardSampleInfo("Intro/welcome.mp3", time: 0, volume: 20));
+        }
+
+        [Test]
+        public void TestStoryboardSamplesStopDuringPause()
+        {
+            checkForFirstSamplePlayback();
+
+            AddStep("player paused", () => Player.Pause());
+            AddAssert("player is currently paused", () => Player.GameplayClockContainer.IsPaused.Value);
+            AddAssert("all storyboard samples stopped immediately", () => allStoryboardSamples.All(sound => !sound.IsPlaying));
+
+            AddStep("player resume", () => Player.Resume());
+            AddUntilStep("any storyboard samples playing after resume", () => allStoryboardSamples.Any(sound => sound.IsPlaying));
+        }
+
+        [Test]
+        public void TestStoryboardSamplesStopOnSkip()
+        {
+            checkForFirstSamplePlayback();
+
+            AddStep("skip intro", () => InputManager.Key(osuTK.Input.Key.Space));
+            AddAssert("all storyboard samples stopped immediately", () => allStoryboardSamples.All(sound => !sound.IsPlaying));
+
+            AddUntilStep("any storyboard samples playing after skip", () => allStoryboardSamples.Any(sound => sound.IsPlaying));
+        }
+
+        private void checkForFirstSamplePlayback()
+        {
+            AddUntilStep("storyboard loaded", () => Player.Beatmap.Value.StoryboardLoaded);
+            AddUntilStep("any storyboard samples playing", () => allStoryboardSamples.Any(sound => sound.IsPlaying));
+        }
+
+        private IEnumerable<DrawableStoryboardSample> allStoryboardSamples => Player.ChildrenOfType<DrawableStoryboardSample>();
+
+        protected override bool AllowFail => false;
+
+        protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
+        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new TestPlayer(true, false);
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null) =>
+            new ClockBackedTestWorkingBeatmap(beatmap, storyboard ?? this.storyboard, Clock, Audio);
+    }
+}

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -353,7 +353,7 @@ namespace osu.Game.Screens.Play
                     },
                     skipOverlay = new SkipOverlay(DrawableRuleset.GameplayStartTime)
                     {
-                        RequestSkip = GameplayClockContainer.Skip
+                        RequestSkip = performUserRequestedSkip
                     },
                     FailOverlay = new FailOverlay
                     {
@@ -486,6 +486,17 @@ namespace osu.Game.Screens.Play
                 performUserRequestedExit();
             else
                 this.Exit();
+        }
+
+        private void performUserRequestedSkip()
+        {
+            // user requested skip
+            // disable sample playback to stop currently playing samples and perform skip
+            samplePlaybackDisabled.Value = true;
+            GameplayClockContainer.Skip();
+
+            // return samplePlaybackDisabled.Value to what is defined by the beatmap's current state
+            updateSampleDisabledState();
         }
 
         private void performUserRequestedExit()

--- a/osu.Game/Skinning/PausableSkinnableSound.cs
+++ b/osu.Game/Skinning/PausableSkinnableSound.cs
@@ -18,7 +18,13 @@ namespace osu.Game.Skinning
 
         protected bool RequestedPlaying { get; private set; }
 
-        protected virtual bool AllowNonLoopingCutOff => false;
+        /// <summary>
+        /// Whether this <see cref="PausableSkinnableSound"/> is affected by
+        /// a higher-level <see cref="ISamplePlaybackDisabler"/>'s state changes.
+        /// By default only looping samples are started/stopped on sample disable
+        /// to prevent one-time samples from cutting off abruptly.
+        /// </summary>
+        protected virtual bool AffectedBySamplePlaybackDisable => Looping;
 
         public PausableSkinnableSound()
         {
@@ -48,10 +54,7 @@ namespace osu.Game.Skinning
                 samplePlaybackDisabled.BindValueChanged(disabled =>
                 {
                     if (!RequestedPlaying) return;
-
-                    // if the sample is non-looping, and non-looping cut off is not allowed,
-                    // let the sample play out to completion (sounds better than abruptly cutting off).
-                    if (!Looping && !AllowNonLoopingCutOff) return;
+                    if (!AffectedBySamplePlaybackDisable) return;
 
                     cancelPendingStart();
 

--- a/osu.Game/Skinning/PausableSkinnableSound.cs
+++ b/osu.Game/Skinning/PausableSkinnableSound.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Skinning
         {
         }
 
-        private readonly IBindable<bool> samplePlaybackDisabled = new Bindable<bool>();
+        protected readonly IBindable<bool> SamplePlaybackDisabled = new Bindable<bool>();
 
         private ScheduledDelegate scheduledStart;
 
@@ -42,8 +42,8 @@ namespace osu.Game.Skinning
             // if in a gameplay context, pause sample playback when gameplay is paused.
             if (samplePlaybackDisabler != null)
             {
-                samplePlaybackDisabled.BindTo(samplePlaybackDisabler.SamplePlaybackDisabled);
-                samplePlaybackDisabled.BindValueChanged(disabled =>
+                SamplePlaybackDisabled.BindTo(samplePlaybackDisabler.SamplePlaybackDisabled);
+                SamplePlaybackDisabled.BindValueChanged(disabled =>
                 {
                     if (!RequestedPlaying) return;
 
@@ -72,7 +72,7 @@ namespace osu.Game.Skinning
             cancelPendingStart();
             RequestedPlaying = true;
 
-            if (samplePlaybackDisabled.Value)
+            if (SamplePlaybackDisabled.Value)
                 return;
 
             base.Play(restart);

--- a/osu.Game/Skinning/PausableSkinnableSound.cs
+++ b/osu.Game/Skinning/PausableSkinnableSound.cs
@@ -18,6 +18,10 @@ namespace osu.Game.Skinning
 
         protected bool RequestedPlaying { get; private set; }
 
+        protected IBindable<bool> SamplePlaybackDisabled => samplePlaybackDisabled;
+
+        private readonly Bindable<bool> samplePlaybackDisabled = new Bindable<bool>();
+
         public PausableSkinnableSound()
         {
         }
@@ -31,8 +35,6 @@ namespace osu.Game.Skinning
             : base(sample)
         {
         }
-
-        protected readonly IBindable<bool> SamplePlaybackDisabled = new Bindable<bool>();
 
         private ScheduledDelegate scheduledStart;
 

--- a/osu.Game/Skinning/PausableSkinnableSound.cs
+++ b/osu.Game/Skinning/PausableSkinnableSound.cs
@@ -18,9 +18,7 @@ namespace osu.Game.Skinning
 
         protected bool RequestedPlaying { get; private set; }
 
-        protected IBindable<bool> SamplePlaybackDisabled => samplePlaybackDisabled;
-
-        private readonly Bindable<bool> samplePlaybackDisabled = new Bindable<bool>();
+        protected readonly IBindable<bool> SamplePlaybackDisabled = new Bindable<bool>();
 
         public PausableSkinnableSound()
         {

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -54,7 +54,6 @@ namespace osu.Game.Storyboards.Drawables
             }
             else
                 base.SamplePlaybackDisabledChanged(disabled);
-
         }
 
         protected override void Update()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool RemoveWhenNotAlive => false;
 
+        protected override bool AllowNonLoopingCutOff => true;
+
         public DrawableStoryboardSample(StoryboardSampleInfo sampleInfo)
             : base(sampleInfo)
         {
@@ -30,19 +32,6 @@ namespace osu.Game.Storyboards.Drawables
 
         [Resolved]
         private IBindable<IReadOnlyList<Mod>> mods { get; set; }
-
-        protected override void SamplePlaybackDisabledChanged(ValueChangedEvent<bool> disabled)
-        {
-            if (!RequestedPlaying) return;
-
-            if (disabled.NewValue)
-                Stop();
-            else
-            {
-                CancelPendingStart();
-                ScheduleStart();
-            }
-        }
 
         protected override void SkinChanged(ISkinSource skin, bool allowFallback)
         {

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -21,12 +21,6 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool RemoveWhenNotAlive => false;
 
-        /// <remarks>
-        /// Contrary to <see cref="PausableSkinnableSound"/>, all <see cref="DrawableStoryboardSample"/>s are affected
-        /// by sample disables, as they are oftentimes longer-running sound effects. This also matches stable behaviour.
-        /// </remarks>
-        protected override bool AffectedBySamplePlaybackDisable => true;
-
         public DrawableStoryboardSample(StoryboardSampleInfo sampleInfo)
             : base(sampleInfo)
         {
@@ -46,6 +40,14 @@ namespace osu.Game.Storyboards.Drawables
                 foreach (var sample in DrawableSamples)
                     mod.ApplyToSample(sample);
             }
+        }
+
+        protected override void SamplePlaybackDisabledChanged(ValueChangedEvent<bool> disabled)
+        {
+            if (!RequestedPlaying) return;
+
+            if (disabled.NewValue)
+                Stop();
         }
 
         protected override void Update()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -21,33 +21,28 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool RemoveWhenNotAlive => false;
 
-        private readonly IBindable<bool> samplePlaybackDisabled;
-
         public DrawableStoryboardSample(StoryboardSampleInfo sampleInfo)
             : base(sampleInfo)
         {
             this.sampleInfo = sampleInfo;
             LifetimeStart = sampleInfo.StartTime;
-
-            samplePlaybackDisabled = SamplePlaybackDisabled.GetBoundCopy();
-        }
-
-        [BackgroundDependencyLoader(true)]
-        private void load()
-        {
-            samplePlaybackDisabled.BindValueChanged(disabled =>
-            {
-                if (!RequestedPlaying) return;
-
-                // Since storyboard samples can be very long we want to stop the playback regardless of
-                // whether or not the sample is looping or not
-                if (disabled.NewValue)
-                    Stop();
-            });
         }
 
         [Resolved]
         private IBindable<IReadOnlyList<Mod>> mods { get; set; }
+
+        protected override void SamplePlaybackDisabledChanged(ValueChangedEvent<bool> disabled)
+        {
+            if (!RequestedPlaying) return;
+
+            if (disabled.NewValue)
+                Stop();
+            else
+            {
+                CancelPendingStart();
+                ScheduleStart();
+            }
+        }
 
         protected override void SkinChanged(ISkinSource skin, bool allowFallback)
         {

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -46,8 +46,15 @@ namespace osu.Game.Storyboards.Drawables
         {
             if (!RequestedPlaying) return;
 
-            if (disabled.NewValue)
-                Stop();
+            // non-looping storyboard samples should be stopped immediately when sample playback is disabled
+            if (!Looping)
+            {
+                if (disabled.NewValue)
+                    Stop();
+            }
+            else
+                base.SamplePlaybackDisabledChanged(disabled);
+
         }
 
         protected override void Update()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -46,14 +46,15 @@ namespace osu.Game.Storyboards.Drawables
         {
             if (!RequestedPlaying) return;
 
-            // non-looping storyboard samples should be stopped immediately when sample playback is disabled
-            if (!Looping)
+            if (!Looping && disabled.NewValue)
             {
-                if (disabled.NewValue)
-                    Stop();
+                // the default behaviour for sample disabling is to allow one-shot samples to play out.
+                // storyboards regularly have long running samples that can cause this behaviour to lead to unintended results.
+                // for this reason, we immediately stop such samples.
+                Stop();
             }
-            else
-                base.SamplePlaybackDisabledChanged(disabled);
+
+            base.SamplePlaybackDisabledChanged(disabled);
         }
 
         protected override void Update()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -40,6 +40,16 @@ namespace osu.Game.Storyboards.Drawables
                 foreach (var sample in DrawableSamples)
                     mod.ApplyToSample(sample);
             }
+
+            SamplePlaybackDisabled.BindValueChanged(disabled =>
+            {
+                if (!RequestedPlaying) return;
+
+                // Since storyboard samples can be very long we want to stop the playback regardless of
+                // whether or not the sample is looping or not
+                if (disabled.NewValue)
+                    Stop();
+            });
         }
 
         protected override void Update()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -21,7 +21,11 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool RemoveWhenNotAlive => false;
 
-        protected override bool AllowNonLoopingCutOff => true;
+        /// <remarks>
+        /// Contrary to <see cref="PausableSkinnableSound"/>, all <see cref="DrawableStoryboardSample"/>s are affected
+        /// by sample disables, as they are oftentimes longer-running sound effects. This also matches stable behaviour.
+        /// </remarks>
+        protected override bool AffectedBySamplePlaybackDisable => true;
 
         public DrawableStoryboardSample(StoryboardSampleInfo sampleInfo)
             : base(sampleInfo)

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -21,11 +21,29 @@ namespace osu.Game.Storyboards.Drawables
 
         public override bool RemoveWhenNotAlive => false;
 
+        private readonly IBindable<bool> samplePlaybackDisabled;
+
         public DrawableStoryboardSample(StoryboardSampleInfo sampleInfo)
             : base(sampleInfo)
         {
             this.sampleInfo = sampleInfo;
             LifetimeStart = sampleInfo.StartTime;
+
+            samplePlaybackDisabled = SamplePlaybackDisabled.GetBoundCopy();
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load()
+        {
+            samplePlaybackDisabled.BindValueChanged(disabled =>
+            {
+                if (!RequestedPlaying) return;
+
+                // Since storyboard samples can be very long we want to stop the playback regardless of
+                // whether or not the sample is looping or not
+                if (disabled.NewValue)
+                    Stop();
+            });
         }
 
         [Resolved]
@@ -40,16 +58,6 @@ namespace osu.Game.Storyboards.Drawables
                 foreach (var sample in DrawableSamples)
                     mod.ApplyToSample(sample);
             }
-
-            SamplePlaybackDisabled.BindValueChanged(disabled =>
-            {
-                if (!RequestedPlaying) return;
-
-                // Since storyboard samples can be very long we want to stop the playback regardless of
-                // whether or not the sample is looping or not
-                if (disabled.NewValue)
-                    Stop();
-            });
         }
 
         protected override void Update()


### PR DESCRIPTION
Fixes #11421 by allowing storyboard samples to be stopped even if they are not looping, bypassing the check here
https://github.com/ppy/osu/blob/82848a7d70e8bb1dbd7bed2b4a178dfe2ce94bcc/osu.Game/Skinning/PausableSkinnableSound.cs#L50-L51

Since some storyboard samples can be ~20-30 seconds long, allowing them to play out is undesirable when skipping or pausing a beatmap.

Note: This still has the same issue as #10285 where the samples don't resume once stopped.