### PR TITLE
Fix local echo messages remaining permanently dimmed when chatting via multiplayer

### DIFF
--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -190,13 +190,13 @@ namespace osu.Game.Overlays.Chat
                     }
                 }
             };
-
-            updateMessageContent();
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            updateMessageContent();
             FinishTransforms(true);
         }
 


### PR DESCRIPTION
Turns out everything was working correctly, except for how the animation was being applied.

Closes #9508.