### PR TITLE
Fix a potential crash when exiting the editor before a new beatmap is added to the database

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -109,7 +110,16 @@ namespace osu.Game.Screens.Edit
             if (Beatmap.Value is DummyWorkingBeatmap)
             {
                 isNewBeatmap = true;
-                Beatmap.Value = beatmapManager.CreateNew(Ruleset.Value, api.LocalUser.Value);
+
+                var newBeatmap = beatmapManager.CreateNew(Ruleset.Value, api.LocalUser.Value);
+
+                // this is a bit haphazard, but guards against setting the lease Beatmap bindable if
+                // the editor has already been exited.
+                if (!ValidForPush)
+                    return;
+
+                // this probably shouldn't be set in the asynchronous load method, but everything following relies on it.
+                Beatmap.Value = newBeatmap;
             }
 
             beatDivisor.Value = Beatmap.Value.BeatmapInfo.BeatDivisor;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;


### PR DESCRIPTION
Obviously not a great solution. Further work will need to be done to move this into LoadComplete (potentially moving the rest of the asynchronous load content to a sub component or task).

Resolves the exception part of https://github.com/ppy/osu/issues/11198#issuecomment-749328053.