### PR TITLE
Fix tense mismatch in tournament schedule view

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneScheduleScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneScheduleScreen.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Tournament.Components;
@@ -16,5 +18,23 @@ namespace osu.Game.Tournament.Tests.Screens
             Add(new TourneyVideo("main") { RelativeSizeAxes = Axes.Both });
             Add(new ScheduleScreen());
         }
+
+        [Test]
+        public void TestCurrentMatchTime()
+        {
+            setMatchDate(TimeSpan.FromDays(-1));
+            setMatchDate(TimeSpan.FromSeconds(5));
+            setMatchDate(TimeSpan.FromMinutes(4));
+            setMatchDate(TimeSpan.FromHours(3));
+        }
+
+        private void setMatchDate(TimeSpan relativeTime)
+            // Humanizer cannot handle negative timespans.
+            => AddStep($"start time is {relativeTime}", () =>
+            {
+                var match = CreateSampleMatch();
+                match.Date.Value = DateTimeOffset.Now + relativeTime;
+                Ladder.CurrentMatch.Value = match;
+            });
     }
 }

--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -192,12 +192,7 @@ namespace osu.Game.Tournament.Screens.Schedule
                                         Origin = Anchor.CentreLeft,
                                         Children = new Drawable[]
                                         {
-                                            new TournamentSpriteText
-                                            {
-                                                Text = match.NewValue.Date.Value.CompareTo(DateTimeOffset.Now) > 0 ? "Starting " : "Started ",
-                                                Font = OsuFont.Torus.With(size: 24, weight: FontWeight.Regular)
-                                            },
-                                            new DrawableDate(match.NewValue.Date.Value)
+                                            new ScheduleMatchDate(match.NewValue.Date.Value)
                                             {
                                                 Font = OsuFont.Torus.With(size: 24, weight: FontWeight.Regular)
                                             }
@@ -249,6 +244,18 @@ namespace osu.Game.Tournament.Screens.Schedule
                     });
                 }
             }
+        }
+
+        public class ScheduleMatchDate : DrawableDate
+        {
+            public ScheduleMatchDate(DateTimeOffset date, float textSize = OsuFont.DEFAULT_FONT_SIZE, bool italic = true)
+                : base(date, textSize, italic)
+            {
+            }
+
+            protected override string Format() => Date < DateTimeOffset.Now
+                ? $"Started {base.Format()}"
+                : $"Starting {base.Format()}";
         }
 
         public class ScheduleContainer : Container

--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Tournament.Screens.Schedule
                                         {
                                             new TournamentSpriteText
                                             {
-                                                Text = "Starting ",
+                                                Text = match.NewValue.Date.Value.CompareTo(DateTimeOffset.Now) > 0 ? "Starting " : "Started ",
                                                 Font = OsuFont.Torus.With(size: 24, weight: FontWeight.Regular)
                                             },
                                             new DrawableDate(match.NewValue.Date.Value)


### PR DESCRIPTION
fixes grammar error at 'coming up next' section in schedule screen which displays schedule like "starting an hour ago" for past matches

![image](https://user-images.githubusercontent.com/31556924/105606204-5201c200-5ddb-11eb-9c5c-debb2c7e84ff.png)
