### PR TITLE
Make ongoing operation tracker disposals idempotent

### DIFF
--- a/osu.Game.Tests/NonVisual/OngoingOperationTrackerTest.cs
+++ b/osu.Game.Tests/NonVisual/OngoingOperationTrackerTest.cs
@@ -30,22 +30,22 @@ namespace osu.Game.Tests.NonVisual
             IDisposable secondOperation = null;
 
             AddStep("begin first operation", () => firstOperation = tracker.BeginOperation());
-            AddAssert("operation in progress", () => operationInProgress.Value);
+            AddAssert("first operation in progress", () => operationInProgress.Value);
 
             AddStep("cannot start another operation",
                 () => Assert.Throws<InvalidOperationException>(() => tracker.BeginOperation()));
 
             AddStep("end first operation", () => firstOperation.Dispose());
-            AddAssert("operation is ended", () => !operationInProgress.Value);
+            AddAssert("first operation is ended", () => !operationInProgress.Value);
 
             AddStep("start second operation", () => secondOperation = tracker.BeginOperation());
-            AddAssert("operation in progress", () => operationInProgress.Value);
+            AddAssert("second operation in progress", () => operationInProgress.Value);
 
             AddStep("dispose first operation again", () => firstOperation.Dispose());
-            AddAssert("operation in progress", () => operationInProgress.Value);
+            AddAssert("second operation still in progress", () => operationInProgress.Value);
 
             AddStep("dispose second operation", () => secondOperation.Dispose());
-            AddAssert("operation is ended", () => !operationInProgress.Value);
+            AddAssert("second operation is ended", () => !operationInProgress.Value);
         }
 
         [Test]

--- a/osu.Game.Tests/NonVisual/OngoingOperationTrackerTest.cs
+++ b/osu.Game.Tests/NonVisual/OngoingOperationTrackerTest.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Testing;
+using osu.Game.Screens.OnlinePlay;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [HeadlessTest]
+    public class OngoingOperationTrackerTest : OsuTestScene
+    {
+        private OngoingOperationTracker tracker;
+        private IBindable<bool> operationInProgress;
+
+        [SetUpSteps]
+        public void SetUp()
+        {
+            AddStep("create tracker", () => Child = tracker = new OngoingOperationTracker());
+            AddStep("bind to operation status", () => operationInProgress = tracker.InProgress.GetBoundCopy());
+        }
+
+        [Test]
+        public void TestOperationTracking()
+        {
+            IDisposable firstOperation = null;
+            IDisposable secondOperation = null;
+
+            AddStep("begin first operation", () => firstOperation = tracker.BeginOperation());
+            AddAssert("operation in progress", () => operationInProgress.Value);
+
+            AddStep("cannot start another operation",
+                () => Assert.Throws<InvalidOperationException>(() => tracker.BeginOperation()));
+
+            AddStep("end first operation", () => firstOperation.Dispose());
+            AddAssert("operation is ended", () => !operationInProgress.Value);
+
+            AddStep("start second operation", () => secondOperation = tracker.BeginOperation());
+            AddAssert("operation in progress", () => operationInProgress.Value);
+
+            AddStep("dispose first operation again", () => firstOperation.Dispose());
+            AddAssert("operation in progress", () => operationInProgress.Value);
+
+            AddStep("dispose second operation", () => secondOperation.Dispose());
+            AddAssert("operation is ended", () => !operationInProgress.Value);
+        }
+
+        [Test]
+        public void TestOperationDisposalAfterTracker()
+        {
+            IDisposable operation = null;
+
+            AddStep("begin operation", () => operation = tracker.BeginOperation());
+            AddStep("dispose tracker", () => tracker.Expire());
+            AddStep("end operation", () => operation.Dispose());
+            AddAssert("operation is ended", () => !operationInProgress.Value);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/OngoingOperationTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/OngoingOperationTracker.cs
@@ -52,5 +52,13 @@ namespace osu.Game.Screens.OnlinePlay
             leasedInProgress?.Return();
             leasedInProgress = null;
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            // base call does an UnbindAllBindables().
+            // clean up the leased reference here so that it doesn't get returned twice.
+            leasedInProgress = null;
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OngoingOperationTracker.cs
+++ b/osu.Game/Screens/OnlinePlay/OngoingOperationTracker.cs
@@ -49,10 +49,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         private void endOperation()
         {
-            if (leasedInProgress == null)
-                throw new InvalidOperationException("Cannot end operation multiple times.");
-
-            leasedInProgress.Return();
+            leasedInProgress?.Return();
             leasedInProgress = null;
         }
     }


### PR DESCRIPTION
Closes #11543.

PR does a little more than nulling out the reference as suggested, because I noticed that a potential double-disposal will potentially interfere with other consumers. Test coverage for both cases included.

I think this is better than scheduling. Have developed somewhat of an internal reluctance of relying on schedules unless absolutely required I guess.