### PR TITLE
Hide beatmap set covers and preview button on explicit beatmaps

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneExplicitContentPermission.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneExplicitContentPermission.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Configuration;
+using osu.Game.Online;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays.BeatmapListing.Panels;
+using osu.Game.Screens.OnlinePlay;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public class TestSceneExplicitContentPermission : OsuManualInputManagerTestScene
+    {
+        [Resolved]
+        private IExplicitContentPermission gameExplicitPermission { get; set; }
+
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            var explicitBeatmap = new TestBeatmap(Ruleset.Value).BeatmapInfo;
+            explicitBeatmap.BeatmapSet.OnlineInfo.HasExplicitContent = true;
+
+            Children = new Drawable[]
+            {
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(10f),
+                    Children = new Drawable[]
+                    {
+                        new GridBeatmapPanel(explicitBeatmap.BeatmapSet)
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        new DrawableRoomPlaylistItem(new PlaylistItem
+                        {
+                            Beatmap = { Value = explicitBeatmap },
+                            Ruleset = { Value = explicitBeatmap.Ruleset },
+                        }, false, false)
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                    }
+                }
+            };
+
+            config.Set(OsuSetting.ShowOnlineExplicitContent, false);
+
+            InputManager.MoveMouseTo(this.ChildrenOfType<GridBeatmapPanel>().Single());
+        });
+
+        [Test]
+        public void TestGlobalPermissionRespectsConfig()
+        {
+            AddStep("enable explicit content setting", () => config.Set(OsuSetting.ShowOnlineExplicitContent, true));
+            AddAssert("global permission set to allowed", () => gameExplicitPermission.UserAllowed.Value);
+            AddStep("disable explicit content setting", () => config.Set(OsuSetting.ShowOnlineExplicitContent, false));
+            AddAssert("global permission set to denied", () => !gameExplicitPermission.UserAllowed.Value);
+        }
+    }
+}

--- a/osu.Game/Online/ConfigExplicitContentPermission.cs
+++ b/osu.Game/Online/ConfigExplicitContentPermission.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+
+namespace osu.Game.Online
+{
+    /// <summary>
+    /// A type of <see cref="IExplicitContentPermission"/> that binds <see cref="UserAllowed"/> to <see cref="OsuSetting.ShowOnlineExplicitContent"/>'s value directly.
+    /// </summary>
+    internal class ConfigExplicitContentPermission : IExplicitContentPermission
+    {
+        public IBindable<bool> UserAllowed => userAllowed;
+
+        private readonly Bindable<bool> userAllowed = new Bindable<bool>();
+
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable (hold reference)
+        private readonly IBindable<bool> showExplicitContentSetting;
+
+        public ConfigExplicitContentPermission(OsuConfigManager config)
+        {
+            showExplicitContentSetting = config.GetBindable<bool>(OsuSetting.ShowOnlineExplicitContent);
+            showExplicitContentSetting.BindValueChanged(e => userAllowed.Value = e.NewValue, true);
+        }
+    }
+}

--- a/osu.Game/Online/IExplicitContentPermission.cs
+++ b/osu.Game/Online/IExplicitContentPermission.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps.Drawables;
+using osu.Game.Overlays.BeatmapListing.Panels;
+
+namespace osu.Game.Online
+{
+    /// <summary>
+    /// An interface used for components that may be backed with a beatmap containing explicit content.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="BeatmapSetCover"/> and <see cref="PlayButton"/> for an example of usage.
+    /// </remarks>
+    public interface IExplicitContentPermission
+    {
+        /// <summary>
+        /// Whether user allowed displaying explicit content on screen.
+        /// </summary>
+        IBindable<bool> UserAllowed { get; }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -81,6 +81,8 @@ namespace osu.Game
 
         protected IAPIProvider API;
 
+        private IExplicitContentPermission configExplicitPermission;
+
         private SpectatorStreamingClient spectatorStreaming;
         private StatefulMultiplayerClient multiplayerClient;
 
@@ -217,6 +219,8 @@ namespace osu.Game
             EndpointConfiguration endpoints = UseDevelopmentServer ? (EndpointConfiguration)new DevelopmentEndpointConfiguration() : new ProductionEndpointConfiguration();
 
             dependencies.CacheAs(API ??= new APIAccess(LocalConfig, endpoints));
+
+            dependencies.CacheAs(configExplicitPermission ??= new ConfigExplicitContentPermission(LocalConfig));
 
             dependencies.CacheAs(spectatorStreaming = new SpectatorStreamingClient(endpoints));
             dependencies.CacheAs(multiplayerClient = new MultiplayerClient(endpoints));

--- a/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
@@ -47,6 +47,9 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                 Preview = null;
 
                 playing.Value = false;
+
+                if (IsLoaded)
+                    updateEnabledState();
             }
         }
 
@@ -64,6 +67,17 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
             };
 
             playing.ValueChanged += playingStateChanged;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateEnabledState();
+        }
+
+        private void updateEnabledState()
+        {
+            button.Enabled.Value = BeatmapSet != null;
         }
 
         public void ToggleButton()

--- a/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
@@ -10,14 +10,19 @@ using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.BeatmapListing.Panels
 {
-    public class PlayButton : Container
+    public class PlayButton : CompositeDrawable
     {
+        private const float transition_duration = 500;
+
+        private readonly Button button;
+
         public IBindable<bool> Playing => playing;
 
         private readonly BindableBool playing = new BindableBool();
@@ -43,84 +48,30 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
             }
         }
 
-        private Color4 hoverColour;
-        private readonly SpriteIcon icon;
-        private readonly LoadingSpinner loadingSpinner;
-
-        private const float transition_duration = 500;
-
-        private bool loading
-        {
-            set
-            {
-                if (value)
-                {
-                    icon.FadeTo(0.5f, transition_duration, Easing.OutQuint);
-                    loadingSpinner.Show();
-                }
-                else
-                {
-                    icon.FadeTo(1, transition_duration, Easing.OutQuint);
-                    loadingSpinner.Hide();
-                }
-            }
-        }
+        [Resolved]
+        private PreviewTrackManager previewTrackManager { get; set; }
 
         public PlayButton(BeatmapSetInfo setInfo = null)
         {
             BeatmapSet = setInfo;
-            AddRange(new Drawable[]
+
+            InternalChild = button = new Button(this)
             {
-                icon = new SpriteIcon
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    FillMode = FillMode.Fit,
-                    RelativeSizeAxes = Axes.Both,
-                    Icon = FontAwesome.Solid.Play,
-                },
-                loadingSpinner = new LoadingSpinner
-                {
-                    Size = new Vector2(15),
-                },
-            });
+                RelativeSizeAxes = Axes.Both,
+                Action = ToggleButton,
+            };
 
             playing.ValueChanged += playingStateChanged;
         }
 
-        [Resolved]
-        private PreviewTrackManager previewTrackManager { get; set; }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colour)
+        public void ToggleButton()
         {
-            hoverColour = colour.Yellow;
-        }
-
-        protected override bool OnClick(ClickEvent e)
-        {
-            playing.Toggle();
-            return true;
-        }
-
-        protected override bool OnHover(HoverEvent e)
-        {
-            icon.FadeColour(hoverColour, 120, Easing.InOutQuint);
-            return base.OnHover(e);
-        }
-
-        protected override void OnHoverLost(HoverLostEvent e)
-        {
-            if (!playing.Value)
-                icon.FadeColour(Color4.White, 120, Easing.InOutQuint);
-            base.OnHoverLost(e);
+            if (button.Enabled.Value)
+                playing.Toggle();
         }
 
         private void playingStateChanged(ValueChangedEvent<bool> e)
         {
-            icon.Icon = e.NewValue ? FontAwesome.Solid.Stop : FontAwesome.Solid.Play;
-            icon.FadeColour(e.NewValue || IsHovered ? hoverColour : Color4.White, 120, Easing.InOutQuint);
-
             if (e.NewValue)
             {
                 if (BeatmapSet == null)
@@ -135,7 +86,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                     return;
                 }
 
-                loading = true;
+                button.Loading = true;
 
                 LoadComponentAsync(Preview = previewTrackManager.Get(beatmapSet), preview =>
                 {
@@ -144,7 +95,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
                         return;
 
                     AddInternal(preview);
-                    loading = false;
+                    button.Loading = false;
                     // make sure that the update of value of Playing (and the ensuing value change callbacks)
                     // are marshaled back to the update thread.
                     preview.Stopped += () => Schedule(() => playing.Value = false);
@@ -157,7 +108,7 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
             else
             {
                 Preview?.Stop();
-                loading = false;
+                button.Loading = false;
             }
         }
 
@@ -165,6 +116,89 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
         {
             if (Preview?.Start() != true)
                 playing.Value = false;
+        }
+
+        private class Button : OsuClickableContainer
+        {
+            private readonly SpriteIcon icon;
+            private readonly LoadingSpinner loadingSpinner;
+
+            private readonly IBindable<bool> playing;
+
+            public bool Loading
+            {
+                set
+                {
+                    if (value)
+                    {
+                        icon.FadeTo(0.5f, transition_duration, Easing.OutQuint);
+                        loadingSpinner.Show();
+                    }
+                    else
+                    {
+                        icon.FadeTo(1, transition_duration, Easing.OutQuint);
+                        loadingSpinner.Hide();
+                    }
+                }
+            }
+
+            public Button(PlayButton player)
+            {
+                playing = player.Playing.GetBoundCopy();
+
+                Children = new Drawable[]
+                {
+                    icon = new SpriteIcon
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        FillMode = FillMode.Fit,
+                        RelativeSizeAxes = Axes.Both,
+                        Icon = FontAwesome.Solid.Play,
+                    },
+                    loadingSpinner = new LoadingSpinner
+                    {
+                        Size = new Vector2(15),
+                    },
+                };
+            }
+
+            private Color4 hoverColour;
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                hoverColour = colours.Yellow;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Enabled.BindValueChanged(e => this.FadeTo(e.NewValue ? 1 : 0), true);
+
+                playing.BindValueChanged(e =>
+                {
+                    icon.Icon = e.NewValue ? FontAwesome.Solid.Stop : FontAwesome.Solid.Play;
+                    icon.FadeColour(e.NewValue || IsHovered ? hoverColour : Color4.White, 120, Easing.InOutQuint);
+                }, true);
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                if (!Enabled.Value)
+                    return false;
+
+                icon.FadeColour(hoverColour, 120, Easing.InOutQuint);
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                if (!playing.Value)
+                    icon.FadeColour(Color4.White, 120, Easing.InOutQuint);
+                base.OnHoverLost(e);
+            }
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
+++ b/osu.Game/Overlays/BeatmapListing/Panels/PlayButton.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Overlays.BeatmapListing.Panels
 
         private readonly Button button;
 
+        public IBindable<bool> Enabled => button.Enabled;
+
         public IBindable<bool> Playing => playing;
 
         private readonly BindableBool playing = new BindableBool();

--- a/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
@@ -74,6 +74,13 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
             background.Colour = colourProvider.Background6;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            playButton.Enabled.BindValueChanged(e => Enabled.Value = e.NewValue, true);
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -89,6 +96,9 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
 
         protected override bool OnHover(HoverEvent e)
         {
+            if (!Enabled.Value)
+                return false;
+
             background.FadeTo(0.75f, 80);
             return base.OnHover(e);
         }

--- a/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
                 },
             };
 
-            Action = () => playButton.Click();
+            Action = () => playButton.ToggleButton();
             Playing.ValueChanged += playing => progress.FadeTo(playing.NewValue ? 1 : 0, 100);
         }
 


### PR DESCRIPTION
- [ ] Depends on #11583

Third step in fulfilling #11460 

https://user-images.githubusercontent.com/22781491/105618579-0a3e6300-5dfa-11eb-8ed5-3c20773607ab.mov

Worthy to note:
 - Beatmap set overlay will be affected by this change as well, an upcoming PR will make the overlay only enterable if the user chose to allow explicit content anyways (via popup dialog), so not worth changing anything there at the moment.
 - Currently replicating osu!web's behaviour on this 1:1, not sure about disabling/hiding the download button and how it would feel UX-wise so I decided not to touch it for now.