### PR TITLE
Allow tournament client to use default mod icons if custom icons are not present

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -43,24 +42,19 @@ namespace osu.Game.Tournament.Tests.Components
             });
         }
 
-        [Test]
-        public void TestModDisplay()
+        private void success(APIBeatmap apiBeatmap)
         {
-            AddUntilStep("beatmap is available", () => beatmap != null);
-            AddStep("add maps with available mods for ruleset", () => displayForRuleset(Ladder.Ruleset.Value.ID ?? 0));
-        }
-
-        private void displayForRuleset(int rulesetId)
-        {
-            fillFlow.Clear();
-            var mods = rulesets.GetRuleset(rulesetId).CreateInstance().GetAllMods();
+            beatmap = apiBeatmap.ToBeatmap(rulesets);
+            var mods = rulesets.GetRuleset(Ladder.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods();
 
             foreach (var mod in mods)
             {
-                fillFlow.Add(new TournamentBeatmapPanel(beatmap, mod.Acronym));
+                fillFlow.Add(new TournamentBeatmapPanel(beatmap, mod.Acronym)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                });
             }
         }
-
-        private void success(APIBeatmap apiBeatmap) => beatmap = apiBeatmap.ToBeatmap(rulesets);
     }
 }

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets;
+using osu.Game.Tournament.Components;
+
+namespace osu.Game.Tournament.Tests.Components
+{
+    public class TestSceneTournamentModDisplay : TournamentTestScene
+    {
+        [Resolved]
+        private IAPIProvider api { get; set; }
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        private FillFlowContainer<TournamentBeatmapPanel> fillFlow;
+
+        private BeatmapInfo beatmap;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var req = new GetBeatmapRequest(new BeatmapInfo { OnlineBeatmapID = 490154 });
+            req.Success += success;
+            api.Queue(req);
+
+            Add(fillFlow = new FillFlowContainer<TournamentBeatmapPanel>
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Direction = FillDirection.Full,
+                Spacing = new osuTK.Vector2(10)
+            });
+        }
+
+        [Test]
+        public void TestModDisplay()
+        {
+            AddUntilStep("beatmap is available", () => beatmap != null);
+            AddStep("add maps with available mods for ruleset", () => displayForRuleset(Ladder.Ruleset.Value.ID ?? 0));
+        }
+
+        private void displayForRuleset(int rulesetId)
+        {
+            fillFlow.Clear();
+            var mods = rulesets.GetRuleset(rulesetId).CreateInstance().GetAllMods();
+
+            foreach (var mod in mods)
+            {
+                fillFlow.Add(new TournamentBeatmapPanel(beatmap, mod.Acronym));
+            }
+        }
+
+        private void success(APIBeatmap apiBeatmap) => beatmap = apiBeatmap.ToBeatmap(rulesets);
+    }
+}

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -203,7 +203,7 @@ namespace osu.Game.Tournament.Components
             }
 
             [BackgroundDependencyLoader]
-            private void load(TextureStore textures, IBindable<RulesetInfo> ruleset)
+            private void load(TextureStore textures)
             {
                 var texture = textures.Get($"mods/{Mod}");
 

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -123,14 +123,13 @@ namespace osu.Game.Tournament.Components
 
             if (!string.IsNullOrEmpty(mod))
             {
-                AddInternal(new TournamentModDisplay
+                AddInternal(new TournamentModDisplay(mod)
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
                     Margin = new MarginPadding(10),
                     Width = 60,
                     RelativeSizeAxes = Axes.Y,
-                    ModAcronym = mod
                 });
             }
         }

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -16,6 +16,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Tournament.Models;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Play.HUD;
 using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Components
@@ -124,21 +127,11 @@ namespace osu.Game.Tournament.Components
 
             if (!string.IsNullOrEmpty(mods))
             {
-                AddInternal(new Container
+                AddInternal(new ModSprite
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    Width = 60,
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Margin = new MarginPadding(10),
-                    Child = new Sprite
-                    {
-                        FillMode = FillMode.Fit,
-                        RelativeSizeAxes = Axes.Both,
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Texture = textures.Get($"mods/{mods}"),
-                    }
+                    Mod = mods
                 });
             }
         }
@@ -190,6 +183,87 @@ namespace osu.Game.Tournament.Components
                 Colour = Color4.White;
                 BorderThickness = 0;
                 Alpha = 1;
+            }
+        }
+
+        private class ModSprite : Container
+        {
+            public string Mod;
+
+            public ModSprite()
+            {
+                Margin = new MarginPadding(10);
+                Width = 60;
+                RelativeSizeAxes = Axes.Y;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(TextureStore textures)
+            {
+                var texture = textures.Get($"mods/{Mod}");
+
+                if (texture != null)
+                {
+                    Child = new Sprite
+                    {
+                        FillMode = FillMode.Fit,
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                        Texture = texture
+                    };
+                }
+                else
+                {
+                    Mod selectedMod = null;
+
+                    switch (Mod)
+                    {
+                        case "DT":
+                            selectedMod = new OsuModDoubleTime();
+                            break;
+
+                        case "FL":
+                            selectedMod = new OsuModFlashlight();
+                            break;
+
+                        case "HT":
+                            selectedMod = new OsuModHalfTime();
+                            break;
+
+                        case "HD":
+                            selectedMod = new OsuModHidden();
+                            break;
+
+                        case "HR":
+                            selectedMod = new OsuModHardRock();
+                            break;
+
+                        case "NF":
+                            selectedMod = new OsuModNoFail();
+                            break;
+
+                        case "EZ":
+                            selectedMod = new OsuModEasy();
+                            break;
+                    }
+
+                    if (selectedMod != null)
+                    {
+                        Child = new ModDisplay
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Current =
+                            {
+                                Value = new[]
+                                {
+                                    selectedMod
+                                }
+                            }
+                        };
+                    }
+                }
             }
         }
     }

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -32,12 +32,12 @@ namespace osu.Game.Tournament.Components
         private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
         private Box flash;
 
-        public TournamentBeatmapPanel(BeatmapInfo beatmap, string mods = null)
+        public TournamentBeatmapPanel(BeatmapInfo beatmap, string mod = null)
         {
             if (beatmap == null) throw new ArgumentNullException(nameof(beatmap));
 
             Beatmap = beatmap;
-            this.mod = mods;
+            this.mod = mod;
             Width = 400;
             Height = HEIGHT;
         }

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Tournament.Components
 
             if (!string.IsNullOrEmpty(mod))
             {
-                AddInternal(new TournamentModDisplay(mod)
+                AddInternal(new TournamentModIcon(mod)
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -9,14 +9,11 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
-using osu.Game.Rulesets;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Tournament.Models;
 using osuTK.Graphics;
 
@@ -25,7 +22,7 @@ namespace osu.Game.Tournament.Components
     public class TournamentBeatmapPanel : CompositeDrawable
     {
         public readonly BeatmapInfo Beatmap;
-        private readonly string mods;
+        private readonly string mod;
 
         private const float horizontal_padding = 10;
         private const float vertical_padding = 10;
@@ -40,7 +37,7 @@ namespace osu.Game.Tournament.Components
             if (beatmap == null) throw new ArgumentNullException(nameof(beatmap));
 
             Beatmap = beatmap;
-            this.mods = mods;
+            this.mod = mods;
             Width = 400;
             Height = HEIGHT;
         }
@@ -124,13 +121,16 @@ namespace osu.Game.Tournament.Components
                 },
             });
 
-            if (!string.IsNullOrEmpty(mods))
+            if (!string.IsNullOrEmpty(mod))
             {
-                AddInternal(new ModSprite
+                AddInternal(new TournamentModDisplay
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Mod = mods
+                    Margin = new MarginPadding(10),
+                    Width = 60,
+                    RelativeSizeAxes = Axes.Y,
+                    ModAcronym = mod
                 });
             }
         }
@@ -182,54 +182,6 @@ namespace osu.Game.Tournament.Components
                 Colour = Color4.White;
                 BorderThickness = 0;
                 Alpha = 1;
-            }
-        }
-
-        private class ModSprite : Container
-        {
-            public string Mod;
-
-            [Resolved]
-            private LadderInfo ladderInfo { get; set; }
-
-            [Resolved]
-            private RulesetStore rulesets { get; set; }
-
-            public ModSprite()
-            {
-                Margin = new MarginPadding(10);
-                Width = 60;
-                RelativeSizeAxes = Axes.Y;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
-            {
-                var texture = textures.Get($"mods/{Mod}");
-
-                if (texture != null)
-                {
-                    Child = new Sprite
-                    {
-                        FillMode = FillMode.Fit,
-                        RelativeSizeAxes = Axes.Both,
-                        Anchor = Anchor.CentreRight,
-                        Origin = Anchor.CentreRight,
-                        Texture = texture
-                    };
-                }
-                else
-                {
-                    Child = new ModDisplay
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Current =
-                        {
-                            Value = rulesets.GetRuleset(ladderInfo.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods().Where(mod => mod.Acronym == Mod).ToArray()
-                        }
-                    };
-                }
             }
         }
     }

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -15,10 +15,9 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
-using osu.Game.Tournament.Models;
-using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Tournament.Models;
 using osuTK.Graphics;
 
 namespace osu.Game.Tournament.Components
@@ -190,6 +189,12 @@ namespace osu.Game.Tournament.Components
         {
             public string Mod;
 
+            [Resolved]
+            private LadderInfo ladderInfo { get; set; }
+
+            [Resolved]
+            private RulesetStore rulesets { get; set; }
+
             public ModSprite()
             {
                 Margin = new MarginPadding(10);
@@ -198,7 +203,7 @@ namespace osu.Game.Tournament.Components
             }
 
             [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
+            private void load(TextureStore textures, IBindable<RulesetInfo> ruleset)
             {
                 var texture = textures.Get($"mods/{Mod}");
 
@@ -215,54 +220,15 @@ namespace osu.Game.Tournament.Components
                 }
                 else
                 {
-                    Mod selectedMod = null;
-
-                    switch (Mod)
+                    Child = new ModDisplay
                     {
-                        case "DT":
-                            selectedMod = new OsuModDoubleTime();
-                            break;
-
-                        case "FL":
-                            selectedMod = new OsuModFlashlight();
-                            break;
-
-                        case "HT":
-                            selectedMod = new OsuModHalfTime();
-                            break;
-
-                        case "HD":
-                            selectedMod = new OsuModHidden();
-                            break;
-
-                        case "HR":
-                            selectedMod = new OsuModHardRock();
-                            break;
-
-                        case "NF":
-                            selectedMod = new OsuModNoFail();
-                            break;
-
-                        case "EZ":
-                            selectedMod = new OsuModEasy();
-                            break;
-                    }
-
-                    if (selectedMod != null)
-                    {
-                        Child = new ModDisplay
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Current =
                         {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Current =
-                            {
-                                Value = new[]
-                                {
-                                    selectedMod
-                                }
-                            }
-                        };
-                    }
+                            Value = rulesets.GetRuleset(ladderInfo.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods().Where(mod => mod.Acronym == Mod).ToArray()
+                        }
+                    };
                 }
             }
         }

--- a/osu.Game.Tournament/Components/TournamentModDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentModDisplay.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.UI;
+using osu.Game.Tournament.Models;
+using osuTK;
+
+namespace osu.Game.Tournament.Components
+{
+    public class TournamentModDisplay : CompositeDrawable
+    {
+        public string ModAcronym;
+
+        [Resolved]
+        private LadderInfo ladderInfo { get; set; }
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
+        {
+            var texture = textures.Get($"mods/{ModAcronym}");
+
+            if (texture != null)
+            {
+                AddInternal(new Sprite
+                {
+                    FillMode = FillMode.Fit,
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    Texture = texture
+                });
+            }
+            else
+            {
+                var mod = rulesets.GetRuleset(ladderInfo.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
+
+                AddInternal(new ModIcon(mod)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(0.5f)
+                });
+            }
+        }
+    }
+}

--- a/osu.Game.Tournament/Components/TournamentModDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentModDisplay.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Tournament.Components
                 if (modIcon == null)
                     return;
 
-                AddInternal(new ModIcon(modIcon)
+                AddInternal(new ModIcon(modIcon, false)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game.Tournament/Components/TournamentModDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentModDisplay.cs
@@ -16,15 +16,20 @@ namespace osu.Game.Tournament.Components
 {
     public class TournamentModDisplay : CompositeDrawable
     {
-        public string ModAcronym;
+        private readonly string modAcronym;
 
         [Resolved]
         private RulesetStore rulesets { get; set; }
 
+        public TournamentModDisplay(string mod)
+        {
+            modAcronym = mod;
+        }
+
         [BackgroundDependencyLoader]
         private void load(TextureStore textures, LadderInfo ladderInfo)
         {
-            var texture = textures.Get($"mods/{ModAcronym}");
+            var texture = textures.Get($"mods/{modAcronym}");
 
             if (texture != null)
             {
@@ -40,7 +45,7 @@ namespace osu.Game.Tournament.Components
             else
             {
                 var ruleset = rulesets.GetRuleset(ladderInfo.Ruleset.Value?.ID ?? 0);
-                var modIcon = ruleset?.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
+                var modIcon = ruleset?.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == modAcronym);
 
                 if (modIcon == null)
                     return;

--- a/osu.Game.Tournament/Components/TournamentModDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentModDisplay.cs
@@ -42,9 +42,9 @@ namespace osu.Game.Tournament.Components
             }
             else
             {
-                var mod = rulesets.GetRuleset(ladderInfo.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
+                var modIcon = rulesets.GetRuleset(ladderInfo.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
 
-                AddInternal(new ModIcon(mod)
+                AddInternal(new ModIcon(modIcon)
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game.Tournament/Components/TournamentModDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentModDisplay.cs
@@ -42,7 +42,15 @@ namespace osu.Game.Tournament.Components
             }
             else
             {
-                var modIcon = rulesets.GetRuleset(ladderInfo.Ruleset.Value.ID ?? 0).CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
+                var ruleset = rulesets.AvailableRulesets.FirstOrDefault(r => r == ladderInfo.Ruleset.Value);
+
+                if (ruleset == null)
+                    return;
+
+                var modIcon = ruleset.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
+
+                if (modIcon == null)
+                    return;
 
                 AddInternal(new ModIcon(modIcon)
                 {

--- a/osu.Game.Tournament/Components/TournamentModDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentModDisplay.cs
@@ -19,13 +19,10 @@ namespace osu.Game.Tournament.Components
         public string ModAcronym;
 
         [Resolved]
-        private LadderInfo ladderInfo { get; set; }
-
-        [Resolved]
         private RulesetStore rulesets { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(TextureStore textures, LadderInfo ladderInfo)
         {
             var texture = textures.Get($"mods/{ModAcronym}");
 
@@ -42,12 +39,8 @@ namespace osu.Game.Tournament.Components
             }
             else
             {
-                var ruleset = rulesets.AvailableRulesets.FirstOrDefault(r => r == ladderInfo.Ruleset.Value);
-
-                if (ruleset == null)
-                    return;
-
-                var modIcon = ruleset.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
+                var ruleset = rulesets.GetRuleset(ladderInfo.Ruleset.Value?.ID ?? 0);
+                var modIcon = ruleset?.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == ModAcronym);
 
                 if (modIcon == null)
                     return;

--- a/osu.Game.Tournament/Components/TournamentModIcon.cs
+++ b/osu.Game.Tournament/Components/TournamentModIcon.cs
@@ -14,16 +14,19 @@ using osuTK;
 
 namespace osu.Game.Tournament.Components
 {
-    public class TournamentModDisplay : CompositeDrawable
+    /// <summary>
+    /// Mod icon displayed in tournament usages, allowing user overridden graphics.
+    /// </summary>
+    public class TournamentModIcon : CompositeDrawable
     {
         private readonly string modAcronym;
 
         [Resolved]
         private RulesetStore rulesets { get; set; }
 
-        public TournamentModDisplay(string mod)
+        public TournamentModIcon(string modAcronym)
         {
-            modAcronym = mod;
+            this.modAcronym = modAcronym;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Tournament/Components/TournamentModIcon.cs
+++ b/osu.Game.Tournament/Components/TournamentModIcon.cs
@@ -32,9 +32,9 @@ namespace osu.Game.Tournament.Components
         [BackgroundDependencyLoader]
         private void load(TextureStore textures, LadderInfo ladderInfo)
         {
-            var texture = textures.Get($"mods/{modAcronym}");
+            var customTexture = textures.Get($"mods/{modAcronym}");
 
-            if (texture != null)
+            if (customTexture != null)
             {
                 AddInternal(new Sprite
                 {
@@ -42,24 +42,24 @@ namespace osu.Game.Tournament.Components
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Texture = texture
+                    Texture = customTexture
                 });
+
+                return;
             }
-            else
+
+            var ruleset = rulesets.GetRuleset(ladderInfo.Ruleset.Value?.ID ?? 0);
+            var modIcon = ruleset?.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == modAcronym);
+
+            if (modIcon == null)
+                return;
+
+            AddInternal(new ModIcon(modIcon, false)
             {
-                var ruleset = rulesets.GetRuleset(ladderInfo.Ruleset.Value?.ID ?? 0);
-                var modIcon = ruleset?.CreateInstance().GetAllMods().FirstOrDefault(mod => mod.Acronym == modAcronym);
-
-                if (modIcon == null)
-                    return;
-
-                AddInternal(new ModIcon(modIcon, false)
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Scale = new Vector2(0.5f)
-                });
-            }
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(0.5f)
+            });
         }
     }
 }

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -236,13 +236,13 @@ namespace osu.Game.Overlays.Mods
             {
                 iconsContainer.AddRange(new[]
                 {
-                    backgroundIcon = new PassThroughTooltipModIcon(Mods[1])
+                    backgroundIcon = new ModIcon(Mods[1], false)
                     {
                         Origin = Anchor.BottomRight,
                         Anchor = Anchor.BottomRight,
                         Position = new Vector2(1.5f),
                     },
-                    foregroundIcon = new PassThroughTooltipModIcon(Mods[0])
+                    foregroundIcon = new ModIcon(Mods[0], false)
                     {
                         Origin = Anchor.BottomRight,
                         Anchor = Anchor.BottomRight,
@@ -252,7 +252,7 @@ namespace osu.Game.Overlays.Mods
             }
             else
             {
-                iconsContainer.Add(foregroundIcon = new PassThroughTooltipModIcon(Mod)
+                iconsContainer.Add(foregroundIcon = new ModIcon(Mod, false)
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
@@ -296,16 +296,6 @@ namespace osu.Game.Overlays.Mods
             };
 
             Mod = mod;
-        }
-
-        private class PassThroughTooltipModIcon : ModIcon
-        {
-            public override string TooltipText => null;
-
-            public PassThroughTooltipModIcon(Mod mod)
-                : base(mod)
-            {
-            }
         }
     }
 }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -16,6 +16,9 @@ using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.UI
 {
+    /// <summary>
+    /// Display the specified mod at a fixed size.
+    /// </summary>
     public class ModIcon : Container, IHasTooltip
     {
         public readonly BindableBool Selected = new BindableBool();
@@ -28,9 +31,10 @@ namespace osu.Game.Rulesets.UI
 
         private readonly ModType type;
 
-        public virtual string TooltipText => mod.IconTooltip;
+        public virtual string TooltipText => showTooltip ? mod.IconTooltip : null;
 
         private Mod mod;
+        private readonly bool showTooltip;
 
         public Mod Mod
         {
@@ -42,9 +46,15 @@ namespace osu.Game.Rulesets.UI
             }
         }
 
-        public ModIcon(Mod mod)
+        /// <summary>
+        /// Construct a new instance.
+        /// </summary>
+        /// <param name="mod">The mod to be displayed</param>
+        /// <param name="showTooltip">Whether a tooltip describing the mod should display on hover.</param>
+        public ModIcon(Mod mod, bool showTooltip = true)
         {
             this.mod = mod ?? throw new ArgumentNullException(nameof(mod));
+            this.showTooltip = showTooltip;
 
             type = mod.Type;
 


### PR DESCRIPTION
This implements game side's mod icons into the tournament client. Tournament managers can still choose to use their own assets to override but if they are not found it will fall back to the original mod icon.

As far as I know there's no native NoMod icon, so that will currently stay blank in the Mappool/Round Editor. 

Example of what it will look like in the panel for Hidden: 
![image](https://user-images.githubusercontent.com/803255/105638622-e61f6800-5e73-11eb-9edd-e6b345ab184b.png)
