### PR TITLE
Fix mod select footer not animating correctly on first reveal

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -216,9 +216,9 @@ namespace osu.Game.Overlays.Mods
                         },
                         new Drawable[]
                         {
-                            // Footer
                             new Container
                             {
+                                Name = "Footer content",
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
                                 Origin = Anchor.TopCentre,
@@ -237,10 +237,9 @@ namespace osu.Game.Overlays.Mods
                                         Anchor = Anchor.BottomCentre,
                                         AutoSizeAxes = Axes.Y,
                                         RelativeSizeAxes = Axes.X,
+                                        RelativePositionAxes = Axes.X,
                                         Width = content_width,
                                         Spacing = new Vector2(footer_button_spacing, footer_button_spacing / 2),
-                                        LayoutDuration = 100,
-                                        LayoutEasing = Easing.OutQuint,
                                         Padding = new MarginPadding
                                         {
                                             Vertical = 15,
@@ -354,7 +353,7 @@ namespace osu.Game.Overlays.Mods
         {
             base.PopOut();
 
-            footerContainer.MoveToX(footerContainer.DrawSize.X, WaveContainer.DISAPPEAR_DURATION, Easing.InSine);
+            footerContainer.MoveToX(content_width, WaveContainer.DISAPPEAR_DURATION, Easing.InSine);
             footerContainer.FadeOut(WaveContainer.DISAPPEAR_DURATION, Easing.InSine);
 
             foreach (var section in ModSectionsContainer.Children)


### PR DESCRIPTION
The LayoutEasing was not working well with the overall movement (likely due to the footer not arriving in a present state until some way into the animation). Removing completely doesn't detract from the overall animation so this is the easiest solution.

Relative position was switched to not rely on `DrawSize` (for the same reason as above). Maybe not required but seems sane.

Before:
![2021-01-25 14 51 49](https://user-images.githubusercontent.com/191335/105666562-e293eb80-5f1c-11eb-8363-7edeec759c18.gif)


After:
![image](https://user-images.githubusercontent.com/191335/105666512-c7c17700-5f1c-11eb-998b-fbe9345ae97b.gif)
