### PR TITLE
Bind MultiplayerGameplayLeaderboard to player updates later in load process

### DIFF
--- a/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/MultiplayerGameplayLeaderboard.cs
@@ -53,8 +53,6 @@ namespace osu.Game.Screens.Play.HUD
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, IAPIProvider api)
         {
-            streamingClient.OnNewFrames += handleIncomingFrames;
-
             foreach (var userId in playingUsers)
             {
                 streamingClient.WatchUser(userId);
@@ -90,6 +88,9 @@ namespace osu.Game.Screens.Play.HUD
 
             playingUsers.BindTo(multiplayerClient.CurrentMatchPlayingUserIds);
             playingUsers.BindCollectionChanged(usersChanged);
+
+            // this leaderboard should be guaranteed to be completely loaded before the gameplay starts (is a prerequisite in MultiplayerPlayer).
+            streamingClient.OnNewFrames += handleIncomingFrames;
         }
 
         private void usersChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
Noticed this while investigating https://github.com/ppy/osu/issues/11574. It's not necessarily going to fix anything, but binding to listen closer to gameplay start seems like the right thing to do.

Due to the flow of `MultiplayerPlayer` (only telling the server that the local client is ready after the full player stack is loaded), this should be very safe.