### PR TITLE
Fix TimelineParts not using correct beatmap

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSummaryTimeline.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSummaryTimeline.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Timelines.Summary;
 using osuTK;
 
@@ -13,6 +15,9 @@ namespace osu.Game.Tests.Visual.Editing
     [TestFixture]
     public class TestSceneEditorSummaryTimeline : EditorClockTestScene
     {
+        [Cached(typeof(EditorBeatmap))]
+        private readonly EditorBeatmap editorBeatmap = new EditorBeatmap(new OsuBeatmap());
+
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BookmarkPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BookmarkPart.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations;
 
@@ -13,7 +12,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// </summary>
     public class BookmarkPart : TimelinePart
     {
-        protected override void LoadBeatmap(WorkingBeatmap beatmap)
+        protected override void LoadBeatmap(EditorBeatmap beatmap)
         {
             base.LoadBeatmap(beatmap);
             foreach (int bookmark in beatmap.BeatmapInfo.Bookmarks)

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations;
@@ -14,10 +13,10 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// </summary>
     public class BreakPart : TimelinePart
     {
-        protected override void LoadBeatmap(WorkingBeatmap beatmap)
+        protected override void LoadBeatmap(EditorBeatmap beatmap)
         {
             base.LoadBeatmap(beatmap);
-            foreach (var breakPeriod in beatmap.Beatmap.Breaks)
+            foreach (var breakPeriod in beatmap.Breaks)
                 Add(new BreakVisualisation(breakPeriod));
         }
 

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointPart.cs
@@ -4,7 +4,6 @@
 using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Bindables;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 
 namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
@@ -16,12 +15,12 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     {
         private readonly IBindableList<ControlPointGroup> controlPointGroups = new BindableList<ControlPointGroup>();
 
-        protected override void LoadBeatmap(WorkingBeatmap beatmap)
+        protected override void LoadBeatmap(EditorBeatmap beatmap)
         {
             base.LoadBeatmap(beatmap);
 
             controlPointGroups.UnbindAll();
-            controlPointGroups.BindTo(beatmap.Beatmap.ControlPointInfo.Groups);
+            controlPointGroups.BindTo(beatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((sender, args) =>
             {
                 switch (args.Action)

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/MarkerPart.cs
@@ -2,15 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics;
+using osuTK;
 
 namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 {
@@ -54,9 +53,6 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             scheduledSeek?.Cancel();
             scheduledSeek = Schedule(() =>
             {
-                if (Beatmap.Value == null)
-                    return;
-
                 float markerPos = Math.Clamp(ToLocalSpace(screenPosition).X, 0, DrawWidth);
                 editorClock.SeekSmoothlyTo(markerPos / DrawWidth * editorClock.TrackLength);
             });
@@ -68,7 +64,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             marker.X = (float)editorClock.CurrentTime;
         }
 
-        protected override void LoadBeatmap(WorkingBeatmap beatmap)
+        protected override void LoadBeatmap(EditorBeatmap beatmap)
         {
             // block base call so we don't clear our marker (can be reused on beatmap change).
         }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
@@ -21,7 +21,10 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
     /// </summary>
     public class TimelinePart<T> : Container<T> where T : Drawable
     {
-        protected readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
+        private readonly IBindable<WorkingBeatmap> beatmap = new Bindable<WorkingBeatmap>();
+
+        [Resolved]
+        protected EditorBeatmap EditorBeatmap { get; private set; }
 
         protected readonly IBindable<Track> Track = new Bindable<Track>();
 
@@ -33,10 +36,9 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
         {
             AddInternal(this.content = content ?? new Container<T> { RelativeSizeAxes = Axes.Both });
 
-            Beatmap.ValueChanged += b =>
+            beatmap.ValueChanged += b =>
             {
                 updateRelativeChildSize();
-                LoadBeatmap(b.NewValue);
             };
 
             Track.ValueChanged += _ => updateRelativeChildSize();
@@ -45,24 +47,26 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
         [BackgroundDependencyLoader]
         private void load(IBindable<WorkingBeatmap> beatmap, EditorClock clock)
         {
-            Beatmap.BindTo(beatmap);
+            this.beatmap.BindTo(beatmap);
+            LoadBeatmap(EditorBeatmap);
+
             Track.BindTo(clock.Track);
         }
 
         private void updateRelativeChildSize()
         {
             // the track may not be loaded completely (only has a length once it is).
-            if (!Beatmap.Value.Track.IsLoaded)
+            if (!beatmap.Value.Track.IsLoaded)
             {
                 content.RelativeChildSize = Vector2.One;
                 Schedule(updateRelativeChildSize);
                 return;
             }
 
-            content.RelativeChildSize = new Vector2((float)Math.Max(1, Beatmap.Value.Track.Length), 1);
+            content.RelativeChildSize = new Vector2((float)Math.Max(1, beatmap.Value.Track.Length), 1);
         }
 
-        protected virtual void LoadBeatmap(WorkingBeatmap beatmap)
+        protected virtual void LoadBeatmap(EditorBeatmap beatmap)
         {
             content.Clear();
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineControlPointDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineControlPointDisplay.cs
@@ -5,7 +5,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 
@@ -23,12 +22,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             RelativeSizeAxes = Axes.Both;
         }
 
-        protected override void LoadBeatmap(WorkingBeatmap beatmap)
+        protected override void LoadBeatmap(EditorBeatmap beatmap)
         {
             base.LoadBeatmap(beatmap);
 
             controlPointGroups.UnbindAll();
-            controlPointGroups.BindTo(beatmap.Beatmap.ControlPointInfo.Groups);
+            controlPointGroups.BindTo(beatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((sender, args) =>
             {
                 switch (args.Action)


### PR DESCRIPTION
Turns out I missed these ones. Causes deficiencies such as the BPM/volume displays in the editor timeline not updating with changes from the timing screen.