### PR TITLE
Update squirrel to fix incorrect desktop icon creation on install

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
-    <PackageReference Include="ppy.squirrel.windows" Version="1.9.0.4" />
+    <PackageReference Include="ppy.squirrel.windows" Version="1.9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
Fixes a shortcut is pointing to `createdump.exe` being created on install, due to it now being bundled with published releases. It looks like this may change in net60 (https://github.com/dotnet/runtime/issues/43716), but for now I've added a fix to our Squirrel fork to ignore this file.

It is safe to delete the shortcut yourself if it was made. Future releases will not create it any more.

Closes #11554.