### PR TITLE
Handle beatmap import from a stable installation with a custom Songs directory

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -33,7 +33,7 @@ namespace osu.Desktop
             noVersionOverlay = args?.Any(a => a == "--no-version-overlay") ?? false;
         }
 
-        public override Storage GetStorageForStableInstall()
+        public override StableStorage GetStorageForStableInstall()
         {
             try
             {

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -18,6 +18,7 @@ using osu.Framework.Screens;
 using osu.Game.Screens.Menu;
 using osu.Game.Updater;
 using osu.Desktop.Windows;
+using osu.Game.IO;
 
 namespace osu.Desktop
 {
@@ -40,7 +41,7 @@ namespace osu.Desktop
                 {
                     string stablePath = getStableInstallPath();
                     if (!string.IsNullOrEmpty(stablePath))
-                        return new DesktopStorage(stablePath, desktopHost);
+                        return new StableStorage(stablePath, desktopHost);
                 }
             }
             catch (Exception)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -64,7 +64,13 @@ namespace osu.Game.Beatmaps
 
         protected override string[] HashableFileTypes => new[] { ".osu" };
 
-        protected override string ImportFromStablePath => "Songs";
+        protected override bool CheckStableDirectoryExists(StableStorage stableStorage) => stableStorage.GetSongStorage().ExistsDirectory(".");
+
+        protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStoage)
+        {
+            var songStorage = stableStoage.GetSongStorage();
+            return songStorage.GetDirectories(".").Select(path => songStorage.GetFullPath(path));
+        }
 
         private readonly RulesetStore rulesets;
         private readonly BeatmapStore beatmaps;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -64,13 +64,9 @@ namespace osu.Game.Beatmaps
 
         protected override string[] HashableFileTypes => new[] { ".osu" };
 
-        protected override bool StableDirectoryExists(StableStorage stableStorage) => stableStorage.GetSongStorage().ExistsDirectory(".");
+        protected override string ImportFromStablePath => ".";
 
-        protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStorage)
-        {
-            var songStorage = stableStorage.GetSongStorage();
-            return songStorage.GetDirectories(".").Select(path => songStorage.GetFullPath(path));
-        }
+        protected override Storage PrepareStableStorage(StableStorage stableStorage) => stableStorage.GetSongStorage();
 
         private readonly RulesetStore rulesets;
         private readonly BeatmapStore beatmaps;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Beatmaps
 
         protected override string[] HashableFileTypes => new[] { ".osu" };
 
-        protected override bool CheckStableDirectoryExists(StableStorage stableStorage) => stableStorage.GetSongStorage().ExistsDirectory(".");
+        protected override bool StableDirectoryExists(StableStorage stableStorage) => stableStorage.GetSongStorage().ExistsDirectory(".");
 
         protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStorage)
         {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -66,9 +66,9 @@ namespace osu.Game.Beatmaps
 
         protected override bool CheckStableDirectoryExists(StableStorage stableStorage) => stableStorage.GetSongStorage().ExistsDirectory(".");
 
-        protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStoage)
+        protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStorage)
         {
-            var songStorage = stableStoage.GetSongStorage();
+            var songStorage = stableStorage.GetSongStorage();
             return songStorage.GetDirectories(".").Select(path => songStorage.GetFullPath(path));
         }
 

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -640,10 +640,10 @@ namespace osu.Game.Database
         /// <summary>
         /// Checks for the existence of an osu-stable directory.
         /// </summary>
-        protected virtual bool CheckStableDirectoryExists(StableStorage stableStorage) => stableStorage.ExistsDirectory(ImportFromStablePath);
+        protected virtual bool StableDirectoryExists(StableStorage stableStorage) => stableStorage.ExistsDirectory(ImportFromStablePath);
 
         /// <summary>
-        /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
+        /// Select paths to import from stable where all paths should be absolute. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
         protected virtual IEnumerable<string> GetStableImportPaths(StableStorage stableStorage) => stableStorage.GetDirectories(ImportFromStablePath)
                                                                                                                 .Select(path => stableStorage.GetFullPath(path));
@@ -668,7 +668,7 @@ namespace osu.Game.Database
                 return Task.CompletedTask;
             }
 
-            if (!CheckStableDirectoryExists(stable))
+            if (!StableDirectoryExists(stable))
             {
                 // This handles situations like when the user does not have a Skins folder
                 Logger.Log($"No {ImportFromStablePath} folder available in osu!stable installation", LoggingTarget.Information, LogLevel.Error);

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -625,7 +625,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Set a storage with access to an osu-stable install for import purposes.
         /// </summary>
-        public Func<Storage> GetStableStorage { private get; set; }
+        public Func<StableStorage> GetStableStorage { private get; set; }
 
         /// <summary>
         /// Denotes whether an osu-stable installation is present to perform automated imports from.
@@ -640,7 +640,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
-        protected virtual IEnumerable<string> GetStableImportPaths(Storage stableStoage) => stableStoage.GetDirectories(ImportFromStablePath);
+        protected virtual IEnumerable<string> GetStableImportPaths(StableStorage stableStoage) => stableStoage.GetDirectories(ImportFromStablePath);
 
         /// <summary>
         /// Whether this specified path should be removed after successful import.

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -645,8 +645,8 @@ namespace osu.Game.Database
         /// <summary>
         /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
-        protected virtual IEnumerable<string> GetStableImportPaths(StableStorage stableStoage) => stableStoage.GetDirectories(ImportFromStablePath)
-                                                                                                              .Select(path => stableStoage.GetFullPath(path));
+        protected virtual IEnumerable<string> GetStableImportPaths(StableStorage stableStorage) => stableStorage.GetDirectories(ImportFromStablePath)
+                                                                                                              .Select(path => stableStorage.GetFullPath(path));
 
         /// <summary>
         /// Whether this specified path should be removed after successful import.

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -646,7 +646,7 @@ namespace osu.Game.Database
         /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
         protected virtual IEnumerable<string> GetStableImportPaths(StableStorage stableStorage) => stableStorage.GetDirectories(ImportFromStablePath)
-                                                                                                              .Select(path => stableStorage.GetFullPath(path));
+                                                                                                                .Select(path => stableStorage.GetFullPath(path));
 
         /// <summary>
         /// Whether this specified path should be removed after successful import.

--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -638,9 +638,15 @@ namespace osu.Game.Database
         protected virtual string ImportFromStablePath => null;
 
         /// <summary>
+        /// Checks for the existence of an osu-stable directory.
+        /// </summary>
+        protected virtual bool CheckStableDirectoryExists(StableStorage stableStorage) => stableStorage.ExistsDirectory(ImportFromStablePath);
+
+        /// <summary>
         /// Select paths to import from stable. Default implementation iterates all directories in <see cref="ImportFromStablePath"/>.
         /// </summary>
-        protected virtual IEnumerable<string> GetStableImportPaths(StableStorage stableStoage) => stableStoage.GetDirectories(ImportFromStablePath);
+        protected virtual IEnumerable<string> GetStableImportPaths(StableStorage stableStoage) => stableStoage.GetDirectories(ImportFromStablePath)
+                                                                                                              .Select(path => stableStoage.GetFullPath(path));
 
         /// <summary>
         /// Whether this specified path should be removed after successful import.
@@ -662,14 +668,14 @@ namespace osu.Game.Database
                 return Task.CompletedTask;
             }
 
-            if (!stable.ExistsDirectory(ImportFromStablePath))
+            if (!CheckStableDirectoryExists(stable))
             {
                 // This handles situations like when the user does not have a Skins folder
                 Logger.Log($"No {ImportFromStablePath} folder available in osu!stable installation", LoggingTarget.Information, LogLevel.Error);
                 return Task.CompletedTask;
             }
 
-            return Task.Run(async () => await Import(GetStableImportPaths(GetStableStorage()).Select(f => stable.GetFullPath(f)).ToArray()));
+            return Task.Run(async () => await Import(GetStableImportPaths(stable).ToArray()));
         }
 
         #endregion

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -17,26 +17,26 @@ namespace osu.Game.IO
         private const string stable_songs_path = "Songs";
 
         private readonly DesktopGameHost host;
-        private string songs_path;
+        private readonly string songsPath;
 
         public StableStorage(string path, DesktopGameHost host)
             : base(path, host)
         {
             this.host = host;
-            songs_path = locateSongsDirectory();
+            songsPath = locateSongsDirectory();
         }
 
         /// <summary>
         /// Returns a <see cref="Storage"/> pointing to the osu-stable Songs directory.
         /// </summary>
-        public Storage GetSongStorage() => new DesktopStorage(songs_path, host);
+        public Storage GetSongStorage() => new DesktopStorage(songsPath, host);
 
         private string locateSongsDirectory()
         {
             var configFile = GetStream(GetFiles(".", "osu!.*.cfg").First());
             var textReader = new StreamReader(configFile);
 
-            var songs_directory_path = Path.Combine(BasePath, stable_songs_path);
+            var songsDirectoryPath = Path.Combine(BasePath, stable_songs_path);
 
             while (!textReader.EndOfStream)
             {
@@ -46,13 +46,13 @@ namespace osu.Game.IO
                 {
                     var directory = line.Split('=')[1].TrimStart();
                     if (Path.IsPathFullyQualified(directory))
-                        songs_directory_path = directory;
+                        songsDirectoryPath = directory;
 
                     break;
                 }
             }
 
-            return songs_directory_path;
+            return songsDirectoryPath;
         }
     }
 }

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -35,7 +35,11 @@ namespace osu.Game.IO
         {
             var songsDirectoryPath = Path.Combine(BasePath, stable_default_songs_path);
 
-            var configFile = GetFiles(".", "osu!.*.cfg").SingleOrDefault();
+            // enumerate the user config files available in case the user migrated their files from another pc / operating system.
+            var foundConfigFiles = GetFiles(".", "osu!.*.cfg");
+
+            // if more than one config file is found, let's use the oldest one (where the username in the filename doesn't match the local username).
+            var configFile = foundConfigFiles.Count() > 1 ? foundConfigFiles.FirstOrDefault(filename => !filename[5..^4].Contains(Environment.UserName, StringComparison.Ordinal)) : foundConfigFiles.FirstOrDefault();
 
             if (configFile == null)
                 return songsDirectoryPath;

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -29,20 +29,14 @@ namespace osu.Game.IO
         /// <summary>
         /// Returns a <see cref="Storage"/> pointing to the osu-stable Songs directory.
         /// </summary>
-        public Storage GetSongStorage()
-        {
-            if (songs_path.Equals(stable_songs_path, StringComparison.OrdinalIgnoreCase))
-                return GetStorageForDirectory(stable_songs_path);
-            else
-                return new DesktopStorage(songs_path, host);
-        }
+        public Storage GetSongStorage() => new DesktopStorage(songs_path, host);
 
         private string locateSongsDirectory()
         {
             var configFile = GetStream(GetFiles(".", "osu!.*.cfg").First());
             var textReader = new StreamReader(configFile);
 
-            var songs_directory_path = stable_songs_path;
+            var songs_directory_path = Path.Combine(BasePath, stable_songs_path);
 
             while (!textReader.EndOfStream)
             {
@@ -51,7 +45,7 @@ namespace osu.Game.IO
                 if (line?.StartsWith("BeatmapDirectory", StringComparison.OrdinalIgnoreCase) == true)
                 {
                     var directory = line.Split('=')[1].TrimStart();
-                    if (Path.IsPathFullyQualified(directory) && !directory.Equals(stable_songs_path, StringComparison.OrdinalIgnoreCase))
+                    if (Path.IsPathFullyQualified(directory))
                         songs_directory_path = directory;
 
                     break;

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Linq;
+using osu.Framework.Platform;
+
+namespace osu.Game.IO
+{
+    /// <summary>
+    /// A storage pointing to an osu-stable installation.
+    /// Provides methods for handling installations with a custom Song folder location.
+    /// </summary>
+    public class StableStorage : DesktopStorage
+    {
+        private const string stable_songs_path = "Songs";
+
+        private readonly DesktopGameHost host;
+        private string songs_path;
+
+        public StableStorage(string path, DesktopGameHost host)
+            : base(path, host)
+        {
+            this.host = host;
+            songs_path = locateSongsDirectory();
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Storage"/> pointing to the osu-stable Songs directory.
+        /// </summary>
+        public Storage GetSongStorage()
+        {
+            if (songs_path.Equals(stable_songs_path, StringComparison.OrdinalIgnoreCase))
+                return GetStorageForDirectory(stable_songs_path);
+            else
+                return new DesktopStorage(songs_path, host);
+        }
+
+        private string locateSongsDirectory()
+        {
+            var configFile = GetStream(GetFiles(".", "osu!.*.cfg").First());
+            var textReader = new StreamReader(configFile);
+
+            var songs_directory_path = stable_songs_path;
+
+            while (!textReader.EndOfStream)
+            {
+                var line = textReader.ReadLine();
+
+                if (line?.StartsWith("BeatmapDirectory", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    var directory = line.Split('=')[1].TrimStart();
+                    if (Path.IsPathFullyQualified(directory) && !directory.Equals(stable_songs_path, StringComparison.OrdinalIgnoreCase))
+                        songs_directory_path = directory;
+
+                    break;
+                }
+            }
+
+            return songs_directory_path;
+        }
+    }
+}

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -35,12 +35,13 @@ namespace osu.Game.IO
         {
             var songsDirectoryPath = Path.Combine(BasePath, stable_default_songs_path);
 
-            var configFile = GetFiles(".", "osu!.*.cfg").FirstOrDefault();
+            var configFile = GetFiles(".", "osu!.*.cfg").SingleOrDefault();
 
             if (configFile == null)
                 return songsDirectoryPath;
 
-            using (var textReader = new StreamReader(GetStream(configFile)))
+            using (var stream = GetStream(configFile))
+            using (var textReader = new StreamReader(stream))
             {
                 string line;
 

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -35,11 +35,7 @@ namespace osu.Game.IO
         {
             var songsDirectoryPath = Path.Combine(BasePath, stable_default_songs_path);
 
-            // enumerate the user config files available in case the user migrated their files from another pc / operating system.
-            var foundConfigFiles = GetFiles(".", "osu!.*.cfg");
-
-            // if more than one config file is found, let's use the oldest one (where the username in the filename doesn't match the local username).
-            var configFile = foundConfigFiles.Count() > 1 ? foundConfigFiles.FirstOrDefault(filename => !filename[5..^4].Contains(Environment.UserName, StringComparison.Ordinal)) : foundConfigFiles.FirstOrDefault();
+            var configFile = GetFiles(".", $"osu!.{Environment.UserName}.cfg").SingleOrDefault();
 
             if (configFile == null)
                 return songsDirectoryPath;

--- a/osu.Game/IO/StableStorage.cs
+++ b/osu.Game/IO/StableStorage.cs
@@ -14,7 +14,7 @@ namespace osu.Game.IO
     /// </summary>
     public class StableStorage : DesktopStorage
     {
-        private const string stable_songs_path = "Songs";
+        private const string stable_default_songs_path = "Songs";
 
         private readonly DesktopGameHost host;
         private readonly string songsPath;
@@ -36,7 +36,7 @@ namespace osu.Game.IO
             var configFile = GetStream(GetFiles(".", "osu!.*.cfg").First());
             var textReader = new StreamReader(configFile);
 
-            var songsDirectoryPath = Path.Combine(BasePath, stable_songs_path);
+            var songsDirectoryPath = Path.Combine(BasePath, stable_default_songs_path);
 
             while (!textReader.EndOfStream)
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -28,7 +28,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -52,6 +52,7 @@ using osu.Game.Updater;
 using osu.Game.Utils;
 using LogLevel = osu.Framework.Logging.LogLevel;
 using osu.Game.Database;
+using osu.Game.IO;
 
 namespace osu.Game
 {
@@ -88,7 +89,7 @@ namespace osu.Game
 
         protected SentryLogger SentryLogger;
 
-        public virtual Storage GetStorageForStableInstall() => null;
+        public virtual StableStorage GetStorageForStableInstall() => null;
 
         public float ToolbarOffset => (Toolbar?.Position.Y ?? 0) + (Toolbar?.DrawHeight ?? 0);
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -16,7 +16,6 @@ using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
-using osu.Game.IO;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -72,9 +71,9 @@ namespace osu.Game.Scoring
             }
         }
 
-        protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStorage)
-            => stableStorage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false))
-                            .Select(path => stableStorage.GetFullPath(path));
+        protected override IEnumerable<string> GetStableImportPaths(Storage storage)
+            => storage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false))
+                      .Select(path => storage.GetFullPath(path));
 
         public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -73,7 +73,8 @@ namespace osu.Game.Scoring
         }
 
         protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStorage)
-            => stableStorage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false));
+            => stableStorage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false))
+                            .Select(path => stableStorage.GetFullPath(path));
 
         public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -16,6 +16,7 @@ using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.IO;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
@@ -71,7 +72,7 @@ namespace osu.Game.Scoring
             }
         }
 
-        protected override IEnumerable<string> GetStableImportPaths(Storage stableStorage)
+        protected override IEnumerable<string> GetStableImportPaths(StableStorage stableStorage)
             => stableStorage.GetFiles(ImportFromStablePath).Where(p => HandledExtensions.Any(ext => Path.GetExtension(p)?.Equals(ext, StringComparison.OrdinalIgnoreCase) ?? false));
 
         public Score GetScore(ScoreInfo score) => new LegacyDatabasedScore(score, rulesets, beatmaps(), Files.Store);


### PR DESCRIPTION
Taking another crack at this one.

 # Summary

This adds the ability to import beatmaps from a stable installation with a custom Songs directory, which is defined in the osu! user configuration file.

This implements a `StableStorage` class containing logic to locate the songs directory of the local osu! stable installation, and a `GetSongStorage()` method to get a storage pointing to the songs directory.

## Testing status

 Haven't implemented automated tests for this (not sure this is doable) so manual testing is required. I did test that on my own machine and it works