### PR TITLE
Fix beatmap listing placeholder potentially getting disposed

### DIFF
--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -178,21 +178,18 @@ namespace osu.Game.Overlays
 
             var lastContent = currentContent;
 
-            if (lastContent != null)
+            // "not found" placeholder is reused, only remove without disposing through expire.
+            if (lastContent == notFoundContent)
+                lastContent.FadeOut(100, Easing.OutQuint).Schedule(() => panelTarget.Remove(lastContent));
+            else if (lastContent != null)
             {
-                lastContent.FadeOut(100, Easing.OutQuint);
+                lastContent.FadeOut(100, Easing.OutQuint).Expire();
 
                 // Consider the case when the new content is smaller than the last content.
                 // If the auto-size computation is delayed until fade out completes, the background remain high for too long making the resulting transition to the smaller height look weird.
                 // At the same time, if the last content's height is bypassed immediately, there is a period where the new content is at Alpha = 0 when the auto-sized height will be 0.
                 // To resolve both of these issues, the bypass is delayed until a point when the content transitions (fade-in and fade-out) overlap and it looks good to do so.
-                lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y).Then().Schedule(() =>
-                {
-                    panelTarget.Remove(lastContent);
-
-                    // the content may be reused again (e.g. notFoundContent), clear Y-axis bypass for displaying back properly.
-                    lastContent.BypassAutoSizeAxes = Axes.None;
-                });
+                lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y).Then().Schedule(() => panelTarget.Remove(lastContent));
             }
 
             if (!content.IsAlive)

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -178,24 +178,29 @@ namespace osu.Game.Overlays
 
             var lastContent = currentContent;
 
-            // "not found" placeholder is reused, only remove without disposing through expire.
-            if (lastContent == notFoundContent)
-                lastContent.FadeOut(100, Easing.OutQuint).Schedule(() => panelTarget.Remove(lastContent));
-            else if (lastContent != null)
+            if (lastContent != null)
             {
-                lastContent.FadeOut(100, Easing.OutQuint).Expire();
+                var transform = lastContent.FadeOut(100, Easing.OutQuint);
 
-                // Consider the case when the new content is smaller than the last content.
-                // If the auto-size computation is delayed until fade out completes, the background remain high for too long making the resulting transition to the smaller height look weird.
-                // At the same time, if the last content's height is bypassed immediately, there is a period where the new content is at Alpha = 0 when the auto-sized height will be 0.
-                // To resolve both of these issues, the bypass is delayed until a point when the content transitions (fade-in and fade-out) overlap and it looks good to do so.
-                lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y).Then().Schedule(() => panelTarget.Remove(lastContent));
+                if (lastContent == notFoundContent)
+                {
+                    // not found display may be used multiple times, so don't expire/dispose it.
+                    transform.Schedule(() => panelTarget.Remove(lastContent));
+                }
+                else
+                {
+                    // Consider the case when the new content is smaller than the last content.
+                    // If the auto-size computation is delayed until fade out completes, the background remain high for too long making the resulting transition to the smaller height look weird.
+                    // At the same time, if the last content's height is bypassed immediately, there is a period where the new content is at Alpha = 0 when the auto-sized height will be 0.
+                    // To resolve both of these issues, the bypass is delayed until a point when the content transitions (fade-in and fade-out) overlap and it looks good to do so.
+                    lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y).Then().Schedule(() => lastContent.Expire());
+                }
             }
 
             if (!content.IsAlive)
                 panelTarget.Add(content);
-            content.FadeInFromZero(200, Easing.OutQuint);
 
+            content.FadeInFromZero(200, Easing.OutQuint);
             currentContent = content;
         }
 

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -180,18 +180,24 @@ namespace osu.Game.Overlays
 
             if (lastContent != null)
             {
-                lastContent.FadeOut(100, Easing.OutQuint).Expire();
+                lastContent.FadeOut(100, Easing.OutQuint);
 
                 // Consider the case when the new content is smaller than the last content.
                 // If the auto-size computation is delayed until fade out completes, the background remain high for too long making the resulting transition to the smaller height look weird.
                 // At the same time, if the last content's height is bypassed immediately, there is a period where the new content is at Alpha = 0 when the auto-sized height will be 0.
                 // To resolve both of these issues, the bypass is delayed until a point when the content transitions (fade-in and fade-out) overlap and it looks good to do so.
-                lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y).Then().Schedule(() => panelTarget.Remove(lastContent));
+                lastContent.Delay(25).Schedule(() => lastContent.BypassAutoSizeAxes = Axes.Y).Then().Schedule(() =>
+                {
+                    panelTarget.Remove(lastContent);
+
+                    // the content may be reused again (e.g. notFoundContent), clear Y-axis bypass for displaying back properly.
+                    lastContent.BypassAutoSizeAxes = Axes.None;
+                });
             }
 
             if (!content.IsAlive)
                 panelTarget.Add(content);
-            content.FadeIn(200, Easing.OutQuint);
+            content.FadeInFromZero(200, Easing.OutQuint);
 
             currentContent = content;
         }


### PR DESCRIPTION
Closes #11602 

See https://github.com/ppy/osu/issues/11602#issuecomment-767132829 for reproduction steps.

This is happening because of the content displaying logic in beatmap listing overlay assuming that previous content will not be reused later on (which is not the case for `notFoundContent`), leading to expiring it which results in the drawable getting disposed and not able to be used again.

~~I've changed it into not expiring at all and leaving previous content to be finalized when no longer used, that would allow previous content to be usable again if needed, which would fix the aforementioned issue.~~

I've changed it into not expiring content if its `notFoundContent`, only remove, as suggested in https://github.com/ppy/osu/pull/11604#discussion_r564070121.

As for how all of this resulted in an indefinitely loading state, it's because when a disposed drawable is passed to `LoadComponentAsync`, it'll silently return with `onLoaded` never invoked, leading to loading layer never getting hidden. Kinda feels incorrect for the method to just silently return without any exception thrown or otherwise, but I assume it's done as-is for certain reasons.

Also:
  - Changed `FadeIn` to `FadeInFromZero` for transitions to look proper in case the new content is already visible.
  - Reverted `BypassAutoSizeAxes` state back to none after end of transition effect, for `notFoundContent` to be usable without any changes to it, if not obvious already.