### PR TITLE
Fix beatmap listing placeholder disappearing on second time display

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -1,0 +1,81 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.BeatmapListing;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    public class TestSceneBeatmapListingOverlay : OsuTestScene
+    {
+        private readonly List<APIBeatmapSet> setsForResponse = new List<APIBeatmapSet>();
+
+        private BeatmapListingOverlay overlay;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = overlay = new BeatmapListingOverlay { State = { Value = Visibility.Visible } };
+
+            ((DummyAPIAccess)API).HandleRequest = req =>
+            {
+                if (req is SearchBeatmapSetsRequest searchBeatmapSetsRequest)
+                {
+                    searchBeatmapSetsRequest.TriggerSuccess(new SearchBeatmapSetsResponse
+                    {
+                        BeatmapSets = setsForResponse,
+                    });
+                }
+            };
+        }
+
+        [Test]
+        public void TestNoBeatmapsPlaceholder()
+        {
+            AddStep("fetch for 0 beatmaps", () => fetchFor());
+            AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
+
+            AddStep("fetch for 1 beatmap", () => fetchFor(CreateBeatmap(Ruleset.Value).BeatmapInfo.BeatmapSet));
+            AddUntilStep("placeholder hidden", () => !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any());
+
+            AddStep("fetch for 0 beatmaps", () => fetchFor());
+            AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
+
+            // fetch once more to ensure nothing happens in displaying placeholder again when it already is present.
+            AddStep("fetch for 0 beatmaps again", () => fetchFor());
+            AddUntilStep("placeholder shown", () => overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().SingleOrDefault()?.IsPresent == true);
+        }
+
+        private void fetchFor(params BeatmapSetInfo[] beatmaps)
+        {
+            setsForResponse.Clear();
+            setsForResponse.AddRange(beatmaps.Select(b => new TestAPIBeatmapSet(b)));
+
+            // trigger arbitrary change for fetching.
+            overlay.ChildrenOfType<BeatmapListingSearchControl>().Single().Query.TriggerChange();
+        }
+
+        private class TestAPIBeatmapSet : APIBeatmapSet
+        {
+            private readonly BeatmapSetInfo beatmapSet;
+
+            public TestAPIBeatmapSet(BeatmapSetInfo beatmapSet)
+            {
+                this.beatmapSet = beatmapSet;
+            }
+
+            public override BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets) => beatmapSet;
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Online/TestSceneOnlineBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneOnlineBeatmapListingOverlay.cs
@@ -6,13 +6,14 @@ using NUnit.Framework;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    public class TestSceneBeatmapListingOverlay : OsuTestScene
+    [Description("uses online API")]
+    public class TestSceneOnlineBeatmapListingOverlay : OsuTestScene
     {
         protected override bool UseOnlineAPI => true;
 
         private readonly BeatmapListingOverlay overlay;
 
-        public TestSceneBeatmapListingOverlay()
+        public TestSceneOnlineBeatmapListingOverlay()
         {
             Add(overlay = new BeatmapListingOverlay());
         }

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"beatmaps")]
         private IEnumerable<APIBeatmap> beatmaps { get; set; }
 
-        public BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets)
+        public virtual BeatmapSetInfo ToBeatmapSet(RulesetStore rulesets)
         {
             var beatmapSet = new BeatmapSetInfo
             {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -176,6 +176,9 @@ namespace osu.Game.Overlays
             loadingLayer.Hide();
             lastFetchDisplayedTime = Time.Current;
 
+            if (content == currentContent)
+                return;
+
             var lastContent = currentContent;
 
             if (lastContent != null)

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Overlays
             base.Dispose(isDisposing);
         }
 
-        private class NotFoundDrawable : CompositeDrawable
+        public class NotFoundDrawable : CompositeDrawable
         {
             public NotFoundDrawable()
             {


### PR DESCRIPTION
Closes #11601 
- [x] Depends on #11604 (for fixing tests failing by same issue that's fixing)

This is happening because of the content displaying logic in beatmap listing overlay removing the previous content few frames later after adding the new content for transition reasons, which wouldn't work well if both "previous content" and "new content" refer to the same drawable, which is the case for `notFoundContent`. (one single instance used for the overlay's whole life)

I've fixed this by basically adding an early check to guard against `content == currentContent`, as there isn't really anything needed to perform on the content if its the same instance.