### PR TITLE
Switch spectator and multiplayer to use more efficient MessagePack protocol

### DIFF
--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
+using MessagePack;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
@@ -13,16 +14,20 @@ using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Online.API
 {
+    [MessagePackObject]
     public class APIMod : IMod
     {
         [JsonProperty("acronym")]
+        [Key(0)]
         public string Acronym { get; set; }
 
         [JsonProperty("settings")]
+        [Key(1)]
         public Dictionary<string, object> Settings { get; set; } = new Dictionary<string, object>();
 
         [JsonConstructor]
-        private APIMod()
+        [SerializationConstructor]
+        public APIMod()
         {
         }
 

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Online.Multiplayer
                          {
                              options.Headers.Add("Authorization", $"Bearer {api.AccessToken}");
                          })
-                         .AddNewtonsoftJsonProtocol(options => { options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; })
+                         .AddMessagePackProtocol()
                          .Build();
 
             // this is kind of SILLY

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;

--- a/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoom.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using MessagePack;
 using Newtonsoft.Json;
 
 namespace osu.Game.Online.Multiplayer
@@ -13,35 +14,42 @@ namespace osu.Game.Online.Multiplayer
     /// A multiplayer room.
     /// </summary>
     [Serializable]
+    [MessagePackObject]
     public class MultiplayerRoom
     {
         /// <summary>
         /// The ID of the room, used for database persistence.
         /// </summary>
+        [Key(0)]
         public readonly long RoomID;
 
         /// <summary>
         /// The current state of the room (ie. whether it is in progress or otherwise).
         /// </summary>
+        [Key(1)]
         public MultiplayerRoomState State { get; set; }
 
         /// <summary>
         /// All currently enforced game settings for this room.
         /// </summary>
+        [Key(2)]
         public MultiplayerRoomSettings Settings { get; set; } = new MultiplayerRoomSettings();
 
         /// <summary>
         /// All users currently in this room.
         /// </summary>
+        [Key(3)]
         public List<MultiplayerRoomUser> Users { get; set; } = new List<MultiplayerRoomUser>();
 
         /// <summary>
         /// The host of this room, in control of changing room settings.
         /// </summary>
+        [Key(4)]
         public MultiplayerRoomUser? Host { get; set; }
 
         [JsonConstructor]
-        public MultiplayerRoom(in long roomId)
+        [SerializationConstructor]
+        public MultiplayerRoom(long roomId)
         {
             RoomID = roomId;
         }

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -7,22 +7,29 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using MessagePack;
 using osu.Game.Online.API;
 
 namespace osu.Game.Online.Multiplayer
 {
     [Serializable]
+    [MessagePackObject]
     public class MultiplayerRoomSettings : IEquatable<MultiplayerRoomSettings>
     {
+        [Key(0)]
         public int BeatmapID { get; set; }
 
+        [Key(1)]
         public int RulesetID { get; set; }
 
+        [Key(2)]
         public string BeatmapChecksum { get; set; } = string.Empty;
 
+        [Key(3)]
         public string Name { get; set; } = "Unnamed room";
 
         [NotNull]
+        [Key(4)]
         public IEnumerable<APIMod> Mods { get; set; } = Enumerable.Empty<APIMod>();
 
         public bool Equals(MultiplayerRoomSettings other)

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using MessagePack;
 using Newtonsoft.Json;
 using osu.Game.Online.Rooms;
 using osu.Game.Users;
@@ -11,21 +12,26 @@ using osu.Game.Users;
 namespace osu.Game.Online.Multiplayer
 {
     [Serializable]
+    [MessagePackObject]
     public class MultiplayerRoomUser : IEquatable<MultiplayerRoomUser>
     {
+        [Key(0)]
         public readonly int UserID;
 
+        [Key(1)]
         public MultiplayerUserState State { get; set; } = MultiplayerUserState.Idle;
 
         /// <summary>
         /// The availability state of the current beatmap.
         /// </summary>
+        [Key(2)]
         public BeatmapAvailability BeatmapAvailability { get; set; } = BeatmapAvailability.LocallyAvailable();
 
+        [IgnoreMember]
         public User? User { get; set; }
 
         [JsonConstructor]
-        public MultiplayerRoomUser(in int userId)
+        public MultiplayerRoomUser(int userId)
         {
             UserID = userId;
         }

--- a/osu.Game/Online/Rooms/BeatmapAvailability.cs
+++ b/osu.Game/Online/Rooms/BeatmapAvailability.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using MessagePack;
 using Newtonsoft.Json;
 
 namespace osu.Game.Online.Rooms
@@ -9,20 +10,23 @@ namespace osu.Game.Online.Rooms
     /// <summary>
     /// The local availability information about a certain beatmap for the client.
     /// </summary>
+    [MessagePackObject]
     public class BeatmapAvailability : IEquatable<BeatmapAvailability>
     {
         /// <summary>
         /// The beatmap's availability state.
         /// </summary>
+        [Key(0)]
         public readonly DownloadState State;
 
         /// <summary>
         /// The beatmap's downloading progress, null when not in <see cref="DownloadState.Downloading"/> state.
         /// </summary>
+        [Key(1)]
         public readonly double? DownloadProgress;
 
         [JsonConstructor]
-        private BeatmapAvailability(DownloadState state, double? downloadProgress = null)
+        public BeatmapAvailability(DownloadState state, double? downloadProgress = null)
         {
             State = state;
             DownloadProgress = downloadProgress;

--- a/osu.Game/Online/Spectator/FrameDataBundle.cs
+++ b/osu.Game/Online/Spectator/FrameDataBundle.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using MessagePack;
 using Newtonsoft.Json;
 using osu.Game.Replays.Legacy;
 using osu.Game.Scoring;
@@ -12,10 +13,13 @@ using osu.Game.Scoring;
 namespace osu.Game.Online.Spectator
 {
     [Serializable]
+    [MessagePackObject]
     public class FrameDataBundle
     {
+        [Key(0)]
         public FrameHeader Header { get; set; }
 
+        [Key(1)]
         public IEnumerable<LegacyReplayFrame> Frames { get; set; }
 
         public FrameDataBundle(ScoreInfo score, IEnumerable<LegacyReplayFrame> frames)

--- a/osu.Game/Online/Spectator/FrameHeader.cs
+++ b/osu.Game/Online/Spectator/FrameHeader.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using MessagePack;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -12,31 +13,37 @@ using osu.Game.Scoring;
 namespace osu.Game.Online.Spectator
 {
     [Serializable]
+    [MessagePackObject]
     public class FrameHeader
     {
         /// <summary>
         /// The current accuracy of the score.
         /// </summary>
+        [Key(0)]
         public double Accuracy { get; set; }
 
         /// <summary>
         /// The current combo of the score.
         /// </summary>
+        [Key(1)]
         public int Combo { get; set; }
 
         /// <summary>
         /// The maximum combo achieved up to the current point in time.
         /// </summary>
+        [Key(2)]
         public int MaxCombo { get; set; }
 
         /// <summary>
         /// Cumulative hit statistics.
         /// </summary>
+        [Key(3)]
         public Dictionary<HitResult, int> Statistics { get; set; }
 
         /// <summary>
         /// The time at which this frame was received by the server.
         /// </summary>
+        [Key(4)]
         public DateTimeOffset ReceivedTime { get; set; }
 
         /// <summary>
@@ -54,7 +61,8 @@ namespace osu.Game.Online.Spectator
         }
 
         [JsonConstructor]
-        public FrameHeader(int combo, int maxCombo, double accuracy, Dictionary<HitResult, int> statistics, DateTimeOffset receivedTime)
+        [SerializationConstructor]
+        public FrameHeader(double accuracy, int combo, int maxCombo, Dictionary<HitResult, int> statistics, DateTimeOffset receivedTime)
         {
             Combo = combo;
             MaxCombo = maxCombo;

--- a/osu.Game/Online/Spectator/SpectatorState.cs
+++ b/osu.Game/Online/Spectator/SpectatorState.cs
@@ -5,18 +5,23 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using MessagePack;
 using osu.Game.Online.API;
 
 namespace osu.Game.Online.Spectator
 {
     [Serializable]
+    [MessagePackObject]
     public class SpectatorState : IEquatable<SpectatorState>
     {
+        [Key(0)]
         public int? BeatmapID { get; set; }
 
+        [Key(1)]
         public int? RulesetID { get; set; }
 
         [NotNull]
+        [Key(2)]
         public IEnumerable<APIMod> Mods { get; set; } = Enumerable.Empty<APIMod>();
 
         public bool Equals(SpectatorState other) => BeatmapID == other?.BeatmapID && Mods.SequenceEqual(other?.Mods) && RulesetID == other?.RulesetID;

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Online.Spectator
                          {
                              options.Headers.Add("Authorization", $"Bearer {api.AccessToken}");
                          })
-                         .AddNewtonsoftJsonProtocol(options => { options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; })
+                         .AddMessagePackProtocol()
                          .Build();
 
             // until strong typed client support is added, each method must be manually bound (see https://github.com/dotnet/aspnetcore/issues/15198)

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game/Replays/Legacy/LegacyReplayFrame.cs
+++ b/osu.Game/Replays/Legacy/LegacyReplayFrame.cs
@@ -1,38 +1,51 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using MessagePack;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Replays;
 using osuTK;
 
 namespace osu.Game.Replays.Legacy
 {
+    [MessagePackObject]
     public class LegacyReplayFrame : ReplayFrame
     {
         [JsonIgnore]
+        [IgnoreMember]
         public Vector2 Position => new Vector2(MouseX ?? 0, MouseY ?? 0);
 
+        [Key(1)]
         public float? MouseX;
+
+        [Key(2)]
         public float? MouseY;
 
         [JsonIgnore]
+        [IgnoreMember]
         public bool MouseLeft => MouseLeft1 || MouseLeft2;
 
         [JsonIgnore]
+        [IgnoreMember]
         public bool MouseRight => MouseRight1 || MouseRight2;
 
         [JsonIgnore]
+        [IgnoreMember]
         public bool MouseLeft1 => ButtonState.HasFlag(ReplayButtonState.Left1);
 
         [JsonIgnore]
+        [IgnoreMember]
         public bool MouseRight1 => ButtonState.HasFlag(ReplayButtonState.Right1);
 
         [JsonIgnore]
+        [IgnoreMember]
         public bool MouseLeft2 => ButtonState.HasFlag(ReplayButtonState.Left2);
 
         [JsonIgnore]
+        [IgnoreMember]
         public bool MouseRight2 => ButtonState.HasFlag(ReplayButtonState.Right2);
 
+        [Key(3)]
         public ReplayButtonState ButtonState;
 
         public LegacyReplayFrame(double time, float? mouseX, float? mouseY, ReplayButtonState buttonState)

--- a/osu.Game/Rulesets/Replays/ReplayFrame.cs
+++ b/osu.Game/Rulesets/Replays/ReplayFrame.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using MessagePack;
+
 namespace osu.Game.Rulesets.Replays
 {
+    [MessagePackObject]
     public class ReplayFrame
     {
+        [Key(0)]
         public double Time;
 
         public ReplayFrame()

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="DiffPlex" Version="1.6.3" />
     <PackageReference Include="Humanizer" Version="2.8.26" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.11" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />


### PR DESCRIPTION
Something I wanted to do from day one, but ran into some issues with serialization. It would seem that things worked as expected this time around.

For a `FrameBundleData` with 10 frames:

Newtonsoft.Json: 1091 bytes
MessagePack: 433 bytes

Further optimisation may be feasible by examining individual data types and reducing precision where possible. For reference, here is the above message in its JSON (legible) format.

```json

{
    "type": 1,
    "target": "SendFrameData",
    "arguments": [
        {
            "header": {
                "accuracy": 0.0077,
                "combo": 0,
                "maxCombo": 1,
                "statistics": {
                    "miss": 119,
                    "meh": 0,
                    "ok": 0,
                    "good": 0,
                    "great": 1,
                    "perfect": 0,
                    "smallTickMiss": 61,
                    "smallTickHit": 0,
                    "largeTickMiss": 71,
                    "largeTickHit": 0,
                    "smallBonus": 0,
                    "largeBonus": 0
                },
                "receivedTime": "0001-01-01T00:00:00+00:00"
            },
            "frames": [
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                },
                {
                    "mouseX": 256.9375,
                    "mouseY": 299.0,
                    "buttonState": 0,
                    "time": -482.59630000000004
                }
            ]
        }
    ]
}

```

For debugging and compatibility purposes, I recommend we leave the server supporting both protocols for the foreseeable future. At a protocol level, trying to understand webpack is not easy, so switching back may be desired in such debug scenarios.

One thing we will need to test (before this is merged) is mobile support. Special consideration is required for AOT compilation environments (ie. iOS). See https://github.com/neuecc/MessagePack-CSharp#aot-code-generation-support-for-unityxamarin for the general process. If this is required for android then it should be considered blocking for merge of this PR; if it's only required for iOS it may be okay to defer until we have a working iOS build toolchain.

This change is already deployed to the *production* spectator and multiplayer servers, but *not development*. Please test against production (or your own test setup) for now.

- [x] Test on android