### PR TITLE
Fix dotnet run/publish with runtime specified not working again

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -24,16 +24,13 @@
     <ProjectReference Include="..\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="5.0.0" />
     <PackageReference Include="ppy.squirrel.windows" Version="1.9.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="DiscordRichPresence" Version="1.0.169" />
-    <!-- .NET 3.1 SDK seems to cause issues with a runtime specification. This will likely be resolved in .NET 5. -->
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Label="Resources">
     <EmbeddedResource Include="lazer.ico" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ppy.osu.Framework" Version="2021.127.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2020.1202.0" />


### PR DESCRIPTION
This fixes issues where executing `dotnet run -r osx-x64` (or other runtimes as well) fails with package downgrades like:
```
/Users/salman/Desktop/osu/osu.Game/osu.Game.csproj : error NU1605: Detected package downgrade: System.Diagnostics.Debug from 4.3.0 to 4.0.11. Reference the package directly from the project to select a different version.  [/Users/salman/Desktop/osu/osu.Desktop/osu.Desktop.csproj]
/Users/salman/Desktop/osu/osu.Game/osu.Game.csproj : error NU1605:  ppy.osu.Game -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.6 -> Microsoft.Extensions.DependencyModel 2.1.0 -> Microsoft.DotNet.PlatformAbstractions 2.1.0 -> System.IO.FileSystem 4.0.1 -> runtime.unix.System.IO.FileSystem 4.3.0 -> System.Diagnostics.Debug (>= 4.3.0)  [/Users/salman/Desktop/osu/osu.Desktop/osu.Desktop.csproj]
/Users/salman/Desktop/osu/osu.Game/osu.Game.csproj : error NU1605:  ppy.osu.Game -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.6 -> Microsoft.Extensions.DependencyModel 2.1.0 -> System.Diagnostics.Debug (>= 4.0.11) [/Users/salman/Desktop/osu/osu.Desktop/osu.Desktop.csproj]
/Users/salman/Desktop/osu/osu.Game.Tournament/osu.Game.Tournament.csproj : error NU1605: Detected package downgrade: System.IO.FileSystem.Primitives from 4.3.0 to 4.0.1. Reference the package directly from the project to select a different version.  [/Users/salman/Desktop/osu/osu.Desktop/osu.Desktop.csproj]
/Users/salman/Desktop/osu/osu.Game.Tournament/osu.Game.Tournament.csproj : error NU1605:  osu.Game.Tournament -> ppy.osu.Game -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.6 -> Microsoft.Extensions.DependencyModel 2.1.0 -> Microsoft.DotNet.PlatformAbstractions 2.1.0 -> System.IO.FileSystem 4.0.1 -> runtime.unix.System.IO.FileSystem 4.3.0 -> System.IO.FileSystem.Primitives (>= 4.3.0)  [/Users/salman/Desktop/osu/osu.Desktop/osu.Desktop.csproj]
/Users/salman/Desktop/osu/osu.Game.Tournament/osu.Game.Tournament.csproj : error NU1605:  osu.Game.Tournament -> ppy.osu.Game -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.2.6 -> Microsoft.Extensions.DependencyModel 2.1.0 -> Microsoft.DotNet.PlatformAbstractions 2.1.0 -> System.IO.FileSystem 4.0.1 -> System.IO.FileSystem.Primitives (>= 4.0.1) [/Users/salman/Desktop/osu/osu.Desktop/osu.Desktop.csproj]
```

After googling and searching thoroughly, I found [this in the docs](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1605#example-2), which is nearly identical to what's been encountered above, I applied the workaround suggested in there and it's working properly now (also rendering the references added from https://github.com/ppy/osu/pull/9260 null and void)

Since `Microsoft.EntityFrameworkCore.Sqlite.Core` is the package causing these issues, I've applied the workaround on the projects referencing it.

@peppy check if this fixes the issue you have!