### PR TITLE
Fix Catch autoplay rewinding on instantaneous hits

### DIFF
--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -45,6 +45,9 @@ namespace osu.Game.Rulesets.Catch.Replays
                 float positionChange = Math.Abs(lastPosition - h.EffectiveX);
                 double timeAvailable = h.StartTime - lastTime;
 
+                if (timeAvailable < 0)
+                    return;
+
                 // So we can either make it there without a dash or not.
                 // If positionChange is 0, we don't need to move, so speedRequired should also be 0 (could be NaN if timeAvailable is 0 too)
                 // The case where positionChange > 0 and timeAvailable == 0 results in PositiveInfinity which provides expected beheaviour.

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -46,7 +46,9 @@ namespace osu.Game.Rulesets.Catch.Replays
                 double timeAvailable = h.StartTime - lastTime;
 
                 if (timeAvailable < 0)
+                {
                     return;
+                }
 
                 // So we can either make it there without a dash or not.
                 // If positionChange is 0, we don't need to move, so speedRequired should also be 0 (could be NaN if timeAvailable is 0 too)


### PR DESCRIPTION
This PR fixes the speedup bug in rare occasions mentioned in #9304 

There should be a more elegant solution, but it patches both of the bugged maps mentioned in the issue.  
The auto generator doesn't give priority to fruits when there is multiple objects appearing at the same time, should I create a new issue for this ? I think it can be easily fixed too. 
