### PR TITLE
Add scroll speed adjustment to taiko's DifficultyAdjust mod

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -11,8 +11,8 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModDifficultyAdjust : ModDifficultyAdjust
     {
-        [SettingSource("Slider Velocity", "Adjust a beatmap's set SV", LAST_SETTING_ORDER + 1)]
-        public BindableNumber<float> SliderVelocity { get; } = new BindableFloat
+        [SettingSource("Scroll Speed", "Adjust a beatmap's set scroll speed", LAST_SETTING_ORDER + 1)]
+        public BindableNumber<float> ScrollSpeed { get; } = new BindableFloat
         {
             Precision = 0.05f,
             MinValue = 0.25f,
@@ -25,12 +25,12 @@ namespace osu.Game.Rulesets.Taiko.Mods
         {
             get
             {
-                string sliderVelocity = SliderVelocity.IsDefault ? string.Empty : $"SV {SliderVelocity.Value:N1}";
+                string scrollSpeed = ScrollSpeed.IsDefault ? string.Empty : $"Scroll x{ScrollSpeed.Value:N1}";
 
                 return string.Join(", ", new[]
                 {
                     base.SettingDescription,
-                    sliderVelocity
+                    scrollSpeed
                 }.Where(s => !string.IsNullOrEmpty(s)));
             }
         }
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         {
             base.ApplySettings(difficulty);
 
-            ApplySetting(SliderVelocity, sv => difficulty.SliderMultiplier *= sv);
+            ApplySetting(ScrollSpeed, scroll => difficulty.SliderMultiplier *= scroll);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -1,11 +1,45 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModDifficultyAdjust : ModDifficultyAdjust
     {
+        [SettingSource("Slider Velocity", "Adjust a beatmap's set SV", LAST_SETTING_ORDER + 1)]
+        public BindableNumber<float> SliderVelocity { get; } = new BindableFloat
+        {
+            Precision = 0.05f,
+            MinValue = 0.25f,
+            MaxValue = 4,
+            Default = 1,
+            Value = 1,
+        };
+
+        public override string SettingDescription
+        {
+            get
+            {
+                string sliderVelocity = SliderVelocity.IsDefault ? string.Empty : $"SV {SliderVelocity.Value:N1}";
+
+                return string.Join(", ", new[]
+                {
+                    base.SettingDescription,
+                    sliderVelocity
+                }.Where(s => !string.IsNullOrEmpty(s)));
+            }
+        }
+
+        protected override void ApplySettings(BeatmapDifficulty difficulty)
+        {
+            base.ApplySettings(difficulty);
+
+            ApplySetting(SliderVelocity, sv => difficulty.SliderMultiplier *= sv);
+        }
     }
 }


### PR DESCRIPTION
Implements #7513 - an extra slider on taiko's DA mod that applies a multiplier to all scroll speeds on a map.
Requires web-side implementation.

Current defined adjustment range of .25x to 4x should cover most wanted sane scenarios, based on Stable editor's Scroll multiplier range, but extended down a bit so it's the same in both directions.

![image](https://user-images.githubusercontent.com/12499153/106255324-197f3f80-6244-11eb-877b-d1070853e3cb.png)
![image](https://user-images.githubusercontent.com/12499153/106255353-2308a780-6244-11eb-9fe7-2345183dfd96.png)

unadjusted:
![image](https://user-images.githubusercontent.com/12499153/106244483-26486700-6235-11eb-8ee5-7dc808e55c72.png)
Scroll x2.4:
![image](https://user-images.githubusercontent.com/12499153/106244525-382a0a00-6235-11eb-8c2f-27c0e5c26bb8.png)
Scroll x0.4:
![image](https://user-images.githubusercontent.com/12499153/106244546-44ae6280-6235-11eb-8458-a487046051ec.png)