### PR TITLE
Fix SQLite exception thrown if a beatmap lookup is attempted without an OnlineBeatmapID present

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
+++ b/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Beatmaps
                             cmd.CommandText = "SELECT beatmapset_id, beatmap_id, approved FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineBeatmapID OR filename = @Path";
 
                             cmd.Parameters.Add(new SqliteParameter("@MD5Hash", beatmap.MD5Hash));
-                            cmd.Parameters.Add(new SqliteParameter("@OnlineBeatmapID", beatmap.OnlineBeatmapID));
+                            cmd.Parameters.Add(new SqliteParameter("@OnlineBeatmapID", beatmap.OnlineBeatmapID ?? (object)DBNull.Value));
                             cmd.Parameters.Add(new SqliteParameter("@Path", beatmap.Path));
 
                             using (var reader = cmd.ExecuteReader())


### PR DESCRIPTION
It turns out the SQLite API isn't smart enough to handle nullables
directly, so we need to help it out a bit.

Stops the following from being thrown:

```
System.InvalidOperationException: Value must be set.
   at Microsoft.Data.Sqlite.SqliteParameter.Bind(sqlite3_stmt stmt) = 3
at
   at Microsoft.Data.Sqlite.SqliteParameterCollection.Bind(sqlite3_stmt
stmt) = 3 at
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior
behavior)
   at Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader()
   at
osu.Game.Beatmaps.BeatmapManager.BeatmapOnlineLookupQueue.checkLocalCache(BeatmapSetInfo
set, BeatmapInfo beatmap) in
/Users/dean/Projects/osu/osu.Game/Beatmaps/BeatmapManager_BeatmapOnlineLookupQueue.cs:line
166 = 166
```

Reference: https://stackoverflow.com/questions/51751290/system-invalidoperationexception-value-must-be-set-setting-null-parameters-for / https://stackoverflow.com/a/10853351