### PR TITLE
Ensure spinners only handle input during their hittable time

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Ranking;
 using osu.Game.Skinning;
 
@@ -242,6 +243,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.Update();
 
+            HandleUserInput = Time.Current >= HitObject.StartTime && Time.Current <= HitObject.EndTime;
+
             if (HandleUserInput)
                 RotationTracker.Tracking = !Result.HasResult && (OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
 
@@ -255,6 +258,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (!SpmCounter.IsPresent && RotationTracker.Tracking)
                 SpmCounter.FadeIn(HitObject.TimeFadeIn);
+
             SpmCounter.SetRotation(Result.RateAdjustedRotation);
 
             updateBonusScore();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -18,7 +18,6 @@ using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Ranking;
 using osu.Game.Skinning;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -242,10 +242,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.Update();
 
-            HandleUserInput = Time.Current >= HitObject.StartTime && Time.Current <= HitObject.EndTime;
-
             if (HandleUserInput)
-                RotationTracker.Tracking = !Result.HasResult && (OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
+            {
+                bool isValidSpinningTime = Time.Current >= HitObject.StartTime && Time.Current <= HitObject.EndTime;
+                bool correctButtonPressed = (OsuActionInputManager?.PressedActions.Any(x => x == OsuAction.LeftButton || x == OsuAction.RightButton) ?? false);
+
+                RotationTracker.Tracking = !Result.HasResult
+                                           && correctButtonPressed
+                                           && isValidSpinningTime;
+            }
 
             if (spinningSample != null && spinnerFrequencyModulate)
                 spinningSample.Frequency.Value = spinning_sample_modulated_base_frequency + Progress;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCounter.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCounter.cs
@@ -4,16 +4,21 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
     public class SpinnerSpmCounter : Container
     {
+        [Resolved]
+        private DrawableHitObject drawableSpinner { get; set; }
+
         private readonly OsuSpriteText spmText;
 
         public SpinnerSpmCounter()
@@ -36,6 +41,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                     Y = 30
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            drawableSpinner.HitObjectApplied += resetState;
         }
 
         private double spm;
@@ -81,6 +92,20 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             }
 
             records.Enqueue(new RotationRecord { Rotation = currentRotation, Time = Time.Current });
+        }
+
+        private void resetState(DrawableHitObject hitObject)
+        {
+            SpinsPerMinute = 0;
+            records.Clear();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (drawableSpinner != null)
+                drawableSpinner.HitObjectApplied -= resetState;
         }
     }
 }


### PR DESCRIPTION
While this was already being enforced inside of `CheckForResult`, the internal tracking values of rotation were still being incremented as long as the `DrawableSpinner` was present. This resulted in incorrect SPM values being displayed if a user was to start spinning before the object's `StartTime`.

Kind of annoying to write a test for (there's no setup for spinners yet) but am willing to do so if that is deemed necessary.

Closes https://github.com/ppy/osu/issues/11600.