### PR TITLE
Fix invalid numeric values for storyboard animation type parsing incorrectly

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -129,5 +129,25 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual(3456, ((StoryboardSprite)background.Elements.Single()).InitialPosition.X);
             }
         }
+
+        [Test]
+        public void TestDecodeOutOfRangeLoopAnimationType()
+        {
+            var decoder = new LegacyStoryboardDecoder();
+
+            using (var resStream = TestResources.OpenResource("animation-types.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var storyboard = decoder.Decode(stream);
+
+                StoryboardLayer foreground = storyboard.Layers.Single(l => l.Depth == 0);
+                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[0]).LoopType);
+                Assert.AreEqual(AnimationLoopType.LoopOnce, ((StoryboardAnimation)foreground.Elements[1]).LoopType);
+                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[2]).LoopType);
+                Assert.AreEqual(AnimationLoopType.LoopOnce, ((StoryboardAnimation)foreground.Elements[3]).LoopType);
+                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[4]).LoopType);
+                Assert.AreEqual(AnimationLoopType.LoopForever, ((StoryboardAnimation)foreground.Elements[5]).LoopType);
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Resources/animation-types.osb
+++ b/osu.Game.Tests/Resources/animation-types.osb
@@ -1,0 +1,9 @@
+osu file format v14
+
+[Events]
+Animation,Foreground,Centre,"forever-string.png",330,240,10,108,LoopForever
+Animation,Foreground,Centre,"once-string.png",330,240,10,108,LoopOnce
+Animation,Foreground,Centre,"forever-number.png",330,240,10,108,0
+Animation,Foreground,Centre,"once-number.png",330,240,10,108,1
+Animation,Foreground,Centre,"undefined-number.png",330,240,10,108,16
+Animation,Foreground,Centre,"omitted.png",330,240,10,108

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Beatmaps.Formats
                             // this is random as hell but taken straight from osu-stable.
                             frameDelay = Math.Round(0.015 * frameDelay) * 1.186 * (1000 / 60f);
 
-                        var loopType = split.Length > 8 ? (AnimationLoopType)Enum.Parse(typeof(AnimationLoopType), split[8]) : AnimationLoopType.LoopForever;
+                        var loopType = split.Length > 8 ? parseAnimationLoopType(split[8]) : AnimationLoopType.LoopForever;
                         storyboardSprite = new StoryboardAnimation(path, origin, new Vector2(x, y), frameCount, frameDelay, loopType);
                         storyboard.GetLayer(layer).Add(storyboardSprite);
                         break;
@@ -339,6 +339,12 @@ namespace osu.Game.Beatmaps.Formats
                 default:
                     return Anchor.TopLeft;
             }
+        }
+
+        private AnimationLoopType parseAnimationLoopType(string value)
+        {
+            var parsed = (AnimationLoopType)Enum.Parse(typeof(AnimationLoopType), value);
+            return Enum.IsDefined(typeof(AnimationLoopType), parsed) ? parsed : AnimationLoopType.LoopForever;
         }
 
         private void handleVariables(string line)


### PR DESCRIPTION
Closes #11098.

Fix is low-effort and issue is milestoned for January, so I figure I might as well.