### PR TITLE
Fix incorrect speed change calculation in time ramp mods

### DIFF
--- a/osu.Game.Tests/Rulesets/Mods/ModTimeRampTest.cs
+++ b/osu.Game.Tests/Rulesets/Mods/ModTimeRampTest.cs
@@ -16,23 +16,11 @@ namespace osu.Game.Tests.Rulesets.Mods
         private const double duration = 9000;
 
         private TrackVirtual track;
-        private IBeatmap beatmap;
 
         [SetUp]
         public void SetUp()
         {
             track = new TrackVirtual(20_000);
-            beatmap = new Beatmap
-            {
-                HitObjects =
-                {
-                    new Spinner
-                    {
-                        StartTime = start_time,
-                        Duration = duration
-                    }
-                }
-            };
         }
 
         [TestCase(0, 1)]
@@ -43,6 +31,7 @@ namespace osu.Game.Tests.Rulesets.Mods
         [TestCase(15000, 1.5)]
         public void TestModWindUp(double time, double expectedRate)
         {
+            var beatmap = createSingleSpinnerBeatmap();
             var mod = new ModWindUp();
             mod.ApplyToBeatmap(beatmap);
             mod.ApplyToTrack(track);
@@ -60,10 +49,26 @@ namespace osu.Game.Tests.Rulesets.Mods
         [TestCase(15000, 0.5)]
         public void TestModWindDown(double time, double expectedRate)
         {
+            var beatmap = createSingleSpinnerBeatmap();
             var mod = new ModWindDown
             {
                 FinalRate = { Value = 0.5 }
             };
+            mod.ApplyToBeatmap(beatmap);
+            mod.ApplyToTrack(track);
+
+            seekTrackAndUpdateMod(mod, time);
+
+            Assert.That(mod.SpeedChange.Value, Is.EqualTo(expectedRate));
+        }
+
+        [TestCase(0, 1)]
+        [TestCase(start_time, 1)]
+        [TestCase(2 * start_time, 1.5)]
+        public void TestZeroDurationMap(double time, double expectedRate)
+        {
+            var beatmap = createSingleObjectBeatmap();
+            var mod = new ModWindUp();
             mod.ApplyToBeatmap(beatmap);
             mod.ApplyToTrack(track);
 
@@ -77,6 +82,32 @@ namespace osu.Game.Tests.Rulesets.Mods
             track.Seek(time);
             // update the mod via a fake playfield to re-calculate the current rate.
             mod.Update(null);
+        }
+
+        private static Beatmap createSingleSpinnerBeatmap()
+        {
+            return new Beatmap
+            {
+                HitObjects =
+                {
+                    new Spinner
+                    {
+                        StartTime = start_time,
+                        Duration = duration
+                    }
+                }
+            };
+        }
+
+        private static Beatmap createSingleObjectBeatmap()
+        {
+            return new Beatmap
+            {
+                HitObjects =
+                {
+                    new HitCircle { StartTime = start_time }
+                }
+            };
         }
     }
 }

--- a/osu.Game.Tests/Rulesets/Mods/ModTimeRampTest.cs
+++ b/osu.Game.Tests/Rulesets/Mods/ModTimeRampTest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Audio.Track;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Tests.Rulesets.Mods
+{
+    [TestFixture]
+    public class ModTimeRampTest
+    {
+        private const double start_time = 1000;
+        private const double duration = 9000;
+
+        private TrackVirtual track;
+        private IBeatmap beatmap;
+
+        [SetUp]
+        public void SetUp()
+        {
+            track = new TrackVirtual(20_000);
+            beatmap = new Beatmap
+            {
+                HitObjects =
+                {
+                    new Spinner
+                    {
+                        StartTime = start_time,
+                        Duration = duration
+                    }
+                }
+            };
+        }
+
+        [TestCase(0, 1)]
+        [TestCase(start_time, 1)]
+        [TestCase(start_time + duration * ModTimeRamp.FINAL_RATE_PROGRESS / 2, 1.25)]
+        [TestCase(start_time + duration * ModTimeRamp.FINAL_RATE_PROGRESS, 1.5)]
+        [TestCase(start_time + duration, 1.5)]
+        [TestCase(15000, 1.5)]
+        public void TestModWindUp(double time, double expectedRate)
+        {
+            var mod = new ModWindUp();
+            mod.ApplyToBeatmap(beatmap);
+            mod.ApplyToTrack(track);
+
+            seekTrackAndUpdateMod(mod, time);
+
+            Assert.That(mod.SpeedChange.Value, Is.EqualTo(expectedRate));
+        }
+
+        [TestCase(0, 1)]
+        [TestCase(start_time, 1)]
+        [TestCase(start_time + duration * ModTimeRamp.FINAL_RATE_PROGRESS / 2, 0.75)]
+        [TestCase(start_time + duration * ModTimeRamp.FINAL_RATE_PROGRESS, 0.5)]
+        [TestCase(start_time + duration, 0.5)]
+        [TestCase(15000, 0.5)]
+        public void TestModWindDown(double time, double expectedRate)
+        {
+            var mod = new ModWindDown
+            {
+                FinalRate = { Value = 0.5 }
+            };
+            mod.ApplyToBeatmap(beatmap);
+            mod.ApplyToTrack(track);
+
+            seekTrackAndUpdateMod(mod, time);
+
+            Assert.That(mod.SpeedChange.Value, Is.EqualTo(expectedRate));
+        }
+
+        private void seekTrackAndUpdateMod(ModTimeRamp mod, double time)
+        {
+            track.Seek(time);
+            // update the mod via a fake playfield to re-calculate the current rate.
+            mod.Update(null);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -66,17 +66,18 @@ namespace osu.Game.Rulesets.Mods
 
         public virtual void ApplyToBeatmap(IBeatmap beatmap)
         {
-            HitObject lastObject = beatmap.HitObjects.LastOrDefault();
-
             SpeedChange.SetDefault();
 
-            beginRampTime = beatmap.HitObjects.FirstOrDefault()?.StartTime ?? 0;
-            finalRateTime = FINAL_RATE_PROGRESS * (lastObject?.GetEndTime() ?? 0);
+            double firstObjectStart = beatmap.HitObjects.FirstOrDefault()?.StartTime ?? 0;
+            double lastObjectEnd = beatmap.HitObjects.LastOrDefault()?.GetEndTime() ?? 0;
+
+            beginRampTime = firstObjectStart;
+            finalRateTime = firstObjectStart + FINAL_RATE_PROGRESS * (lastObjectEnd - firstObjectStart);
         }
 
         public virtual void Update(Playfield playfield)
         {
-            applyRateAdjustment((track.CurrentTime - beginRampTime) / finalRateTime);
+            applyRateAdjustment((track.CurrentTime - beginRampTime) / (finalRateTime - beginRampTime));
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Mods
 
         public virtual void Update(Playfield playfield)
         {
-            applyRateAdjustment((track.CurrentTime - beginRampTime) / (finalRateTime - beginRampTime));
+            applyRateAdjustment((track.CurrentTime - beginRampTime) / Math.Max(1, finalRateTime - beginRampTime));
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// The point in the beatmap at which the final ramping rate should be reached.
         /// </summary>
-        private const double final_rate_progress = 0.75f;
+        public const double FINAL_RATE_PROGRESS = 0.75f;
 
         [SettingSource("Initial rate", "The starting speed of the track")]
         public abstract BindableNumber<double> InitialRate { get; }
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Mods
             SpeedChange.SetDefault();
 
             beginRampTime = beatmap.HitObjects.FirstOrDefault()?.StartTime ?? 0;
-            finalRateTime = final_rate_progress * (lastObject?.GetEndTime() ?? 0);
+            finalRateTime = FINAL_RATE_PROGRESS * (lastObject?.GetEndTime() ?? 0);
         }
 
         public virtual void Update(Playfield playfield)


### PR DESCRIPTION
This fell out during looking into resolving #10283.

It seems to me that the implementation of `ModTimeRamp` had at least two bugs that seem to run counter to what I think the original implementation intention was, namely:

* The mod was supposed to ramp up/down to its final speed upon reaching 75% of gameplay. This was not exactly the case, because the calculation of `finalRateTime` - by what seems like an accident - took 75% of the *absolute time value* of the last object's end time. This is slightly wrong in the case of maps on which the first object does not start at time 0.
* Additionally, the ramp factor itself was applied wrongly. The previous ramp factor of:

  ```csharp
  (track.CurrentTime - beginRampTime) / finalRateTime
  ```

  does not reach 1 at `finalRateTime`, but at `beginRampTime + finalRateTime` instead, which also seems to run counter to intention.

The new behaviour with this pull is described by the attached test case. Which is a little weird, but I hope it's permissible... The next pull I'm preparing on top of this would have made it possibly nicer, but that one is a bit out there and I'm not confident of it, so I don't want this fix to rely on it.