### PR TITLE
Improve auto-scrolling logic for drawable channels

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -217,6 +217,33 @@ namespace osu.Game.Tests.Visual.Online
             checkScrolledToBottom();
         }
 
+        [Test]
+        public void TestLocalEchoMessageResetsScroll()
+        {
+            fillChat();
+
+            sendMessage();
+            checkScrolledToBottom();
+
+            AddStep("User scroll up", () =>
+            {
+                InputManager.MoveMouseTo(chatDisplay.ScreenSpaceDrawQuad.Centre);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.MoveMouseTo(chatDisplay.ScreenSpaceDrawQuad.Centre + new Vector2(0, chatDisplay.ScreenSpaceDrawQuad.Height));
+                InputManager.ReleaseButton(MouseButton.Left);
+            });
+
+            checkNotScrolledToBottom();
+            sendMessage();
+            checkNotScrolledToBottom();
+
+            sendLocalMessage();
+            checkScrolledToBottom();
+
+            sendMessage();
+            checkScrolledToBottom();
+        }
+
         private void fillChat()
         {
             AddStep("fill chat", () =>
@@ -240,6 +267,15 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Sender = longUsernameUser,
                 Content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce et bibendum velit.",
+            }));
+        }
+
+        private void sendLocalMessage()
+        {
+            AddStep("send local echo", () => testChannel.AddLocalEcho(new LocalEchoMessage()
+            {
+                Sender = longUsernameUser,
+                Content = "This is a local echo message.",
             }));
         }
 

--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -272,7 +272,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private void sendLocalMessage()
         {
-            AddStep("send local echo", () => testChannel.AddLocalEcho(new LocalEchoMessage()
+            AddStep("send local echo", () => testChannel.AddLocalEcho(new LocalEchoMessage
             {
                 Sender = longUsernameUser,
                 Content = "This is a local echo message.",

--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Tests.Visual.Online
 
             protected DrawableChannel DrawableChannel => InternalChildren.OfType<DrawableChannel>().First();
 
-            protected OsuScrollContainer ScrollContainer => (OsuScrollContainer)((Container)DrawableChannel.Child).Child;
+            protected UserTrackingScrollContainer ScrollContainer => (UserTrackingScrollContainer)((Container)DrawableChannel.Child).Child;
 
             public FillFlowContainer FillFlow => (FillFlowContainer)ScrollContainer.Child;
 

--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -46,7 +46,6 @@ namespace osu.Game.Tests.Visual.Online
         private ChannelManager channelManager = new ChannelManager();
 
         private TestStandAloneChatDisplay chatDisplay;
-        private TestStandAloneChatDisplay chatDisplay2;
         private int messageIdSequence;
 
         private Channel testChannel;
@@ -72,7 +71,7 @@ namespace osu.Game.Tests.Visual.Online
                     Size = new Vector2(400, 80),
                     Channel = { Value = testChannel },
                 },
-                chatDisplay2 = new TestStandAloneChatDisplay(true)
+                new TestStandAloneChatDisplay(true)
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -45,5 +45,11 @@ namespace osu.Game.Graphics.Containers
             UserScrolling = false;
             base.ScrollTo(value, animated, distanceDecay);
         }
+
+        public new void ScrollToEnd(bool animated = true, bool allowDuringDrag = false)
+        {
+            UserScrolling = false;
+            base.ScrollToEnd(animated, allowDuringDrag);
+        }
     }
 }

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         public bool UserScrolling { get; private set; }
 
+        public void CancelUserScroll() => UserScrolling = false;
+
         public UserTrackingScrollContainer()
         {
         }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -241,6 +241,11 @@ namespace osu.Game.Overlays.Chat
         /// </summary>
         private class ChannelScrollContainer : OsuScrollContainer
         {
+            /// <summary>
+            /// The chat will be automatically scrolled to end if and only if
+            /// the distance between the current scroll position and the end of the scroll
+            /// is less than this value.
+            /// </summary>
             private const float auto_scroll_leniency = 10f;
 
             private float? lastExtent;

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -257,9 +257,9 @@ namespace osu.Game.Overlays.Chat
                 lastExtent = null;
             }
 
-            protected override void UpdateAfterChildren()
+            protected override void Update()
             {
-                base.UpdateAfterChildren();
+                base.Update();
 
                 // If the user has scrolled to the bottom of the container, we should resume tracking new content.
                 if (UserScrolling && IsScrolledToEnd(auto_scroll_leniency))
@@ -270,7 +270,8 @@ namespace osu.Game.Overlays.Chat
 
                 if (requiresScrollUpdate)
                 {
-                    ScheduleAfterChildren(() =>
+                    // Schedule required to allow FillFlow to be the correct size.
+                    Schedule(() =>
                     {
                         if (!UserScrolling)
                         {

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -261,8 +261,8 @@ namespace osu.Game.Overlays.Chat
 
                 if ((lastExtent == null || ScrollableExtent > lastExtent) && ShouldAutoScroll)
                     ScrollToEnd();
-                else
-                    ShouldAutoScroll = IsScrolledToEnd(auto_scroll_leniency);
+
+                ShouldAutoScroll = IsScrolledToEnd(auto_scroll_leniency);
 
                 lastExtent = ScrollableExtent;
             }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -262,17 +262,21 @@ namespace osu.Game.Overlays.Chat
                 base.UpdateAfterChildren();
 
                 // If the user has scrolled to the bottom of the container, we should resume tracking new content.
-                bool cancelUserScroll = UserScrolling && IsScrolledToEnd(auto_scroll_leniency);
+                if (UserScrolling && IsScrolledToEnd(auto_scroll_leniency))
+                    CancelUserScroll();
 
                 // If the user hasn't overridden our behaviour and there has been new content added to the container, we should update our scroll position to track it.
                 bool requiresScrollUpdate = !UserScrolling && (lastExtent == null || Precision.AlmostBigger(ScrollableExtent, lastExtent.Value));
 
-                if (cancelUserScroll || requiresScrollUpdate)
+                if (requiresScrollUpdate)
                 {
                     ScheduleAfterChildren(() =>
                     {
-                        ScrollToEnd();
-                        lastExtent = ScrollableExtent;
+                        if (!UserScrolling)
+                        {
+                            ScrollToEnd();
+                            lastExtent = ScrollableExtent;
+                        }
                     });
                 }
             }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Overlays.Chat
         }
 
         /// <summary>
-        /// An <see cref="OsuScrollContainer"/> with functionality to automatically scrolls whenever the maximum scrollable distance increases.
+        /// An <see cref="OsuScrollContainer"/> with functionality to automatically scroll whenever the maximum scrollable distance increases.
         /// </summary>
         private class ChannelScrollContainer : OsuScrollContainer
         {
@@ -246,7 +246,7 @@ namespace osu.Game.Overlays.Chat
             private float? lastExtent;
 
             /// <summary>
-            /// Whether this should automatically scroll to end on the next call to <see cref="UpdateAfterChildren"/>.
+            /// Whether this container should automatically scroll to end on the next call to <see cref="UpdateAfterChildren"/>.
             /// </summary>
             public bool ShouldAutoScroll { get; private set; } = true;
 


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/11588

Previously, auto-scrolling-to-bottom logic in chats will only happen when new messages are added, which means on cases like https://github.com/ppy/osu/issues/11588 where the channel content's height changes but not because of new messages added (message text wrapping down in that case), auto-scrolling will not be accounted for them.

Therefore I improved this into handling such cases by creating a custom scroll container that will auto scroll automatically on new changes to the scroll content if the user did not manually scroll back up. Not sure whether it's worth making it a public class and move it to its own file, though.

Before, on the aforementioned issue case:

https://user-images.githubusercontent.com/22781491/106400060-42aef400-642d-11eb-80b2-7a0486e15900.mov

After (notice scrolling forward while contracting as messages wrap down):

https://user-images.githubusercontent.com/22781491/106400073-55292d80-642d-11eb-93bf-f6840a158979.mov