### PR TITLE
Fix invalid mod combinations potentially being selectable at a game level

### DIFF
--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -103,20 +103,43 @@ namespace osu.Game.Tests.Mods
             Assert.That(ModUtils.CheckAllowed(new[] { mod.Object }, new[] { typeof(Mod) }), Is.False);
         }
 
-        // test incompatible pair.
-        [TestCase(new[] { typeof(OsuModDoubleTime), typeof(OsuModHalfTime) }, new[] { typeof(OsuModDoubleTime), typeof(OsuModHalfTime) })]
-        // test incompatible pair with derived class.
-        [TestCase(new[] { typeof(OsuModNightcore), typeof(OsuModHalfTime) }, new[] { typeof(OsuModNightcore), typeof(OsuModHalfTime) })]
-        // test system mod.
-        [TestCase(new[] { typeof(OsuModDoubleTime), typeof(OsuModTouchDevice) }, new[] { typeof(OsuModTouchDevice) })]
-        // test valid.
-        [TestCase(new[] { typeof(OsuModDoubleTime), typeof(OsuModHardRock) }, null)]
-        public void TestInvalidModScenarios(Type[] input, Type[] expectedInvalid)
+        private static readonly object[] invalid_mod_test_scenarios =
         {
-            List<Mod> inputMods = new List<Mod>();
-            foreach (var t in input)
-                inputMods.Add((Mod)Activator.CreateInstance(t));
+            // incompatible pair.
+            new object[]
+            {
+                new Mod[] { new OsuModDoubleTime(), new OsuModHalfTime() },
+                new[] { typeof(OsuModDoubleTime), typeof(OsuModHalfTime) }
+            },
+            // incompatible pair with derived class.
+            new object[]
+            {
+                new Mod[] { new OsuModNightcore(), new OsuModHalfTime() },
+                new[] { typeof(OsuModNightcore), typeof(OsuModHalfTime) }
+            },
+            // system mod.
+            new object[]
+            {
+                new Mod[] { new OsuModDoubleTime(), new OsuModTouchDevice() },
+                new[] { typeof(OsuModTouchDevice) }
+            },
+            // multi mod.
+            new object[]
+            {
+                new Mod[] { new MultiMod(new OsuModHalfTime()), new OsuModHalfTime() },
+                new[] { typeof(MultiMod) }
+            },
+            // valid pair.
+            new object[]
+            {
+                new Mod[] { new OsuModDoubleTime(), new OsuModHardRock() },
+                null
+            }
+        };
 
+        [TestCaseSource(nameof(invalid_mod_test_scenarios))]
+        public void TestInvalidModScenarios(Mod[] inputMods, Type[] expectedInvalid)
+        {
             bool isValid = ModUtils.CheckValidForGameplay(inputMods, out var invalid);
 
             Assert.That(isValid, Is.EqualTo(expectedInvalid == null));

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using NUnit.Framework;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -468,6 +468,12 @@ namespace osu.Game
         private void modsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
             updateModDefaults();
+
+            if (!ModUtils.CheckValidForGameplay(mods.NewValue, out var invalid))
+            {
+                // ensure we always have a valid set of mods.
+                SelectedMods.Value = mods.NewValue.Except(invalid).ToArray();
+            }
         }
 
         private void updateModDefaults()

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -88,40 +88,22 @@ namespace osu.Game.Utils
         /// <param name="mods">The mods to check.</param>
         /// <param name="invalidMods">Invalid mods, if any were found. Can be null if all mods were valid.</param>
         /// <returns>Whether the input mods were all valid. If false, <paramref name="invalidMods"/> will contain all invalid entries.</returns>
-        public static bool CheckValidForGameplay(IEnumerable<Mod> mods, out Mod[]? invalidMods)
+        public static bool CheckValidForGameplay(IEnumerable<Mod> mods, out List<Mod>? invalidMods)
         {
             mods = mods.ToArray();
 
-            List<Mod>? foundInvalid = null;
-
-            void addInvalid(Mod mod)
-            {
-                foundInvalid ??= new List<Mod>();
-                foundInvalid.Add(mod);
-            }
+            CheckCompatibleSet(mods, out invalidMods);
 
             foreach (var mod in mods)
             {
-                bool valid = mod.Type != ModType.System
-                             && mod.HasImplementation
-                             && !(mod is MultiMod);
-
-                if (!valid)
+                if (mod.Type == ModType.System || !mod.HasImplementation || mod is MultiMod)
                 {
-                    // if this mod was found as invalid, we can exclude it before potentially excluding more incompatible types.
-                    addInvalid(mod);
-                    continue;
-                }
-
-                foreach (var type in mod.IncompatibleMods)
-                {
-                    foreach (var invalid in mods.Where(m => type.IsInstanceOfType(m)))
-                        addInvalid(invalid);
+                    invalidMods ??= new List<Mod>();
+                    invalidMods.Add(mod);
                 }
             }
 
-            invalidMods = foundInvalid?.ToArray();
-            return foundInvalid == null;
+            return invalidMods == null;
         }
 
         /// <summary>

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Utils
         /// Check the provided combination of mods are valid for a local gameplay session.
         /// </summary>
         /// <param name="mods">The mods to check.</param>
-        /// <param name="invalidMods">Invalid mods, if any where found. Can be null if all mods were valid.</param>
+        /// <param name="invalidMods">Invalid mods, if any were found. Can be null if all mods were valid.</param>
         /// <returns>Whether the input mods were all valid. If false, <paramref name="invalidMods"/> will contain all invalid entries.</returns>
         public static bool CheckValidForGameplay(IEnumerable<Mod> mods, out Mod[]? invalidMods)
         {


### PR DESCRIPTION
- [x] Depends on #11640 (to coexist in the new util class).
- [x] Needs tests.
- Closes https://github.com/ppy/osu/issues/9890.

I also used this in `ModSelectOverlay` (as a replacement for its current logic) but it seems to be pointless. Just PRing in an initial state to make sure this is the intende direction; will add some tests in line with the tests at #11640 in the coming hours/days.