### PR TITLE
Make playlist settings area taller to better match screen aspect ratio

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsMatchSettingsOverlay.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                                             Child = new GridContainer
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
-                                                                Height = 300,
+                                                                Height = 500,
                                                                 Content = new[]
                                                                 {
                                                                     new Drawable[]


### PR DESCRIPTION
Before:

![20210202 163234 (dotnet)](https://user-images.githubusercontent.com/191335/106566874-426d4080-6574-11eb-9944-43c9854f79eb.png)

After:

![20210202 163107 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/106566754-1356cf00-6574-11eb-9d54-fc3ad93146a2.png)

Especially noticeable when running in a portrait aspect ratio (where this now takes up a good portion of the screen.

