### PR TITLE
Add custom MessagePack resolver for mod settings dictionary

### DIFF
--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -1,0 +1,139 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Online.API;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Tests.Online
+{
+    [TestFixture]
+    public class TestAPIModJsonSerialization
+    {
+        [Test]
+        public void TestAcronymIsPreserved()
+        {
+            var apiMod = new APIMod(new TestMod());
+
+            var deserialized = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+
+            Assert.That(deserialized.Acronym, Is.EqualTo(apiMod.Acronym));
+        }
+
+        [Test]
+        public void TestRawSettingIsPreserved()
+        {
+            var apiMod = new APIMod(new TestMod { TestSetting = { Value = 2 } });
+
+            var deserialized = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+
+            Assert.That(deserialized.Settings, Contains.Key("test_setting").With.ContainValue(2.0));
+        }
+
+        [Test]
+        public void TestConvertedModHasCorrectSetting()
+        {
+            var apiMod = new APIMod(new TestMod { TestSetting = { Value = 2 } });
+
+            var deserialized = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+            var converted = (TestMod)deserialized.ToMod(new TestRuleset());
+
+            Assert.That(converted.TestSetting.Value, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TestDeserialiseTimeRampMod()
+        {
+            // Create the mod with values different from default.
+            var apiMod = new APIMod(new TestModTimeRamp
+            {
+                AdjustPitch = { Value = false },
+                InitialRate = { Value = 1.25 },
+                FinalRate = { Value = 0.25 }
+            });
+
+            var deserialised = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+            var converted = (TestModTimeRamp)deserialised.ToMod(new TestRuleset());
+
+            Assert.That(converted.AdjustPitch.Value, Is.EqualTo(false));
+            Assert.That(converted.InitialRate.Value, Is.EqualTo(1.25));
+            Assert.That(converted.FinalRate.Value, Is.EqualTo(0.25));
+        }
+
+        private class TestRuleset : Ruleset
+        {
+            public override IEnumerable<Mod> GetModsFor(ModType type) => new Mod[]
+            {
+                new TestMod(),
+                new TestModTimeRamp(),
+            };
+
+            public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod> mods = null) => throw new System.NotImplementedException();
+
+            public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => throw new System.NotImplementedException();
+
+            public override DifficultyCalculator CreateDifficultyCalculator(WorkingBeatmap beatmap) => throw new System.NotImplementedException();
+
+            public override string Description { get; } = string.Empty;
+            public override string ShortName { get; } = string.Empty;
+        }
+
+        private class TestMod : Mod
+        {
+            public override string Name => "Test Mod";
+            public override string Acronym => "TM";
+            public override double ScoreMultiplier => 1;
+
+            [SettingSource("Test")]
+            public BindableNumber<double> TestSetting { get; } = new BindableDouble
+            {
+                MinValue = 0,
+                MaxValue = 10,
+                Default = 5,
+                Precision = 0.01,
+            };
+        }
+
+        private class TestModTimeRamp : ModTimeRamp
+        {
+            public override string Name => "Test Mod";
+            public override string Acronym => "TMTR";
+            public override double ScoreMultiplier => 1;
+
+            [SettingSource("Initial rate", "The starting speed of the track")]
+            public override BindableNumber<double> InitialRate { get; } = new BindableDouble
+            {
+                MinValue = 1,
+                MaxValue = 2,
+                Default = 1.5,
+                Value = 1.5,
+                Precision = 0.01,
+            };
+
+            [SettingSource("Final rate", "The speed increase to ramp towards")]
+            public override BindableNumber<double> FinalRate { get; } = new BindableDouble
+            {
+                MinValue = 0,
+                MaxValue = 1,
+                Default = 0.5,
+                Value = 0.5,
+                Precision = 0.01,
+            };
+
+            [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
+            public override BindableBool AdjustPitch { get; } = new BindableBool
+            {
+                Default = true,
+                Value = true
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using MessagePack;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
@@ -16,14 +16,14 @@ using osu.Game.Rulesets.UI;
 namespace osu.Game.Tests.Online
 {
     [TestFixture]
-    public class TestAPIModSerialization
+    public class TestAPIModMessagePackSerialization
     {
         [Test]
         public void TestAcronymIsPreserved()
         {
             var apiMod = new APIMod(new TestMod());
 
-            var deserialized = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+            var deserialized = MessagePackSerializer.Deserialize<APIMod>(MessagePackSerializer.Serialize(apiMod));
 
             Assert.That(deserialized.Acronym, Is.EqualTo(apiMod.Acronym));
         }
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Online
         {
             var apiMod = new APIMod(new TestMod { TestSetting = { Value = 2 } });
 
-            var deserialized = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+            var deserialized = MessagePackSerializer.Deserialize<APIMod>(MessagePackSerializer.Serialize(apiMod));
 
             Assert.That(deserialized.Settings, Contains.Key("test_setting").With.ContainValue(2.0));
         }
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Online
         {
             var apiMod = new APIMod(new TestMod { TestSetting = { Value = 2 } });
 
-            var deserialized = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+            var deserialized = MessagePackSerializer.Deserialize<APIMod>(MessagePackSerializer.Serialize(apiMod));
             var converted = (TestMod)deserialized.ToMod(new TestRuleset());
 
             Assert.That(converted.TestSetting.Value, Is.EqualTo(2));
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Online
                 FinalRate = { Value = 0.25 }
             });
 
-            var deserialised = JsonConvert.DeserializeObject<APIMod>(JsonConvert.SerializeObject(apiMod));
+            var deserialised = MessagePackSerializer.Deserialize<APIMod>(MessagePackSerializer.Serialize(apiMod));
             var converted = (TestModTimeRamp)deserialised.ToMod(new TestRuleset());
 
             Assert.That(converted.AdjustPitch.Value, Is.EqualTo(false));

--- a/osu.Game/Online/API/APIMod.cs
+++ b/osu.Game/Online/API/APIMod.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Online.API
 
         [JsonProperty("settings")]
         [Key(1)]
+        [MessagePackFormatter(typeof(ModSettingsDictionaryFormatter))]
         public Dictionary<string, object> Settings { get; set; } = new Dictionary<string, object>();
 
         [JsonConstructor]

--- a/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
+++ b/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using MessagePack;
 using MessagePack.Formatters;

--- a/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
+++ b/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using System;
 using System.Collections.Generic;
 using MessagePack;

--- a/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
+++ b/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
@@ -38,7 +38,9 @@ namespace osu.Game.Online.API
                         break;
 
                     default:
-                        throw new ArgumentException("A setting was of a type not supported by the messagepack serialiser", nameof(bytes));
+                        // fall back for non-bindable cases.
+                        offset += primitiveFormatter.Serialize(ref bytes, offset, kvp.Value, formatterResolver);
+                        break;
                 }
             }
 

--- a/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
+++ b/osu.Game/Online/API/ModSettingsDictionaryFormatter.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using MessagePack;
+using MessagePack.Formatters;
+using osu.Framework.Bindables;
+
+namespace osu.Game.Online.API
+{
+    public class ModSettingsDictionaryFormatter : IMessagePackFormatter<Dictionary<string, object>>
+    {
+        public int Serialize(ref byte[] bytes, int offset, Dictionary<string, object> value, IFormatterResolver formatterResolver)
+        {
+            int startOffset = offset;
+
+            offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, value.Count);
+
+            foreach (var kvp in value)
+            {
+                offset += MessagePackBinary.WriteString(ref bytes, offset, kvp.Key);
+
+                switch (kvp.Value)
+                {
+                    case Bindable<double> d:
+                        offset += MessagePackBinary.WriteDouble(ref bytes, offset, d.Value);
+                        break;
+
+                    case Bindable<float> f:
+                        offset += MessagePackBinary.WriteSingle(ref bytes, offset, f.Value);
+                        break;
+
+                    case Bindable<bool> b:
+                        offset += MessagePackBinary.WriteBoolean(ref bytes, offset, b.Value);
+                        break;
+
+                    default:
+                        throw new ArgumentException("A setting was of a type not supported by the messagepack serialiser", nameof(bytes));
+                }
+            }
+
+            return offset - startOffset;
+        }
+
+        public Dictionary<string, object> Deserialize(byte[] bytes, int offset, IFormatterResolver formatterResolver, out int readSize)
+        {
+            int startOffset = offset;
+
+            var output = new Dictionary<string, object>();
+
+            int itemCount = MessagePackBinary.ReadArrayHeader(bytes, offset, out readSize);
+            offset += readSize;
+
+            for (int i = 0; i < itemCount; i++)
+            {
+                var key = MessagePackBinary.ReadString(bytes, offset, out readSize);
+                offset += readSize;
+
+                switch (MessagePackBinary.GetMessagePackType(bytes, offset))
+                {
+                    case MessagePackType.Float:
+                    {
+                        // could be either float or double...
+                        // see https://github.com/msgpack/msgpack/blob/master/spec.md#serialization-type-to-format-conversion
+                        switch (MessagePackCode.ToFormatName(bytes[offset]))
+                        {
+                            case "float 32":
+                                output[key] = MessagePackBinary.ReadSingle(bytes, offset, out readSize);
+                                offset += readSize;
+                                break;
+
+                            case "float 64":
+                                output[key] = MessagePackBinary.ReadDouble(bytes, offset, out readSize);
+                                offset += readSize;
+                                break;
+
+                            default:
+                                throw new ArgumentException("A setting was of a type not supported by the messagepack deserialiser", nameof(bytes));
+                        }
+
+                        break;
+                    }
+
+                    case MessagePackType.Boolean:
+                        output[key] = MessagePackBinary.ReadBoolean(bytes, offset, out readSize);
+                        offset += readSize;
+                        break;
+
+                    default:
+                        throw new ArgumentException("A setting was of a type not supported by the messagepack deserialiser", nameof(bytes));
+                }
+            }
+
+            readSize = offset - startOffset;
+            return output;
+        }
+    }
+}


### PR DESCRIPTION
This was failing until now (causing potential runtime crashes) when attempting to play with a mod that had adjusted settings (due to MessagePack now knowing how to serialises bindables).

Note that this is not in a working state. While the tests pass, it causes disconnections/errors at a server-side level which I am still investigating. I'm PRing this because I spent the good part of an hour investigating and I'm 99.99% sure there are no issues with my code.

```
dbug: Microsoft.AspNetCore.SignalR.HubConnectionHandler[2]
      Error when processing requests.
      System.IO.InvalidDataException: Reading array length for 'streamIds' failed.
       ---> System.InvalidOperationException: code is invalid. code:202 format:float 32
         at MessagePack.Decoders.InvalidArrayHeader.Read(Byte[] bytes, Int32 offset, Int32& readSize)
         at Microsoft.AspNetCore.SignalR.Protocol.MessagePackHubProtocol.ReadArrayLength(Byte[] input, Int32& offset, String field)
         --- End of inner exception stack trace ---
         at Microsoft.AspNetCore.SignalR.Protocol.MessagePackHubProtocol.ReadArrayLength(Byte[] input, Int32& offset, String field)
         at Microsoft.AspNetCore.SignalR.Protocol.MessagePackHubProtocol.ReadStreamIds(Byte[] input, Int32& offset)
         at Microsoft.AspNetCore.SignalR.Protocol.MessagePackHubProtocol.CreateInvocationMessage(Byte[] input, Int32& offset, IInvocationBinder binder, IFormatterResolver resolver, Int32 itemCount)
         at Microsoft.AspNetCore.SignalR.Protocol.MessagePackHubProtocol.ParseMessage(Byte[] input, Int32 startOffset, IInvocationBinder binder, IFormatterResolver resolver)
         at Microsoft.AspNetCore.SignalR.Protocol.MessagePackHubProtocol.TryParseMessage(ReadOnlySequence`1& input, IInvocationBinder binder, HubMessage& message)
         at Microsoft.AspNetCore.SignalR.HubConnectionHandler`1.DispatchMessagesAsync(HubConnectionContext connection)
         at Microsoft.AspNetCore.SignalR.HubConnectionHandler`1.RunHubAsync(HubConnectionContext connection)
2021-02-03 10:46:19 [3504]: Disconnected
```

The exception points at the offset not being incremented correctly for the next read (`streamIds` is part of the parent object in signalr's messagepack message protocol), but I have confirmed that the returned `readSize` matches on serialisation and deserialisation of the same message, both at a client-client level and also client-server.

My next step will be to test after updating SignalR to see if it is actually a SignalR (or [Microsoft.AspNetCore.SignalR.Protocol.MessagePackHubProtocol](https://github.com/dotnet/aspnetcore/blob/c3acdcac86dad91c3d3fbc3b93ecc6b7ba494bdc/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs#L679)) bug.

- Closes #11660