### PR TITLE
Fix setting copying ignored for customized target mods

### DIFF
--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -147,15 +147,16 @@ namespace osu.Game.Rulesets.Mods
                 var targetBindable = (IBindable)prop.GetValue(this);
                 var sourceBindable = (IBindable)prop.GetValue(source);
 
-                // we only care about changes that have been made away from defaults.
-                if (!sourceBindable.IsDefault)
+                // we only care about changes that have been made away from defaults, or if source is default but target is not.
+                if (!sourceBindable.IsDefault || !targetBindable.IsDefault)
                     CopyAdjustedSetting(targetBindable, sourceBindable);
             }
         }
 
         /// <summary>
-        /// When creating copies or clones of a Mod, this method will be called
-        /// to copy explicitly adjusted user settings from <paramref name="target"/>.
+        /// When creating copies or clones of or copying from a Mod, this method will be called
+        /// to copy explicitly adjusted user settings from <paramref name="source"/>,
+        /// or to reset already adjusted setting back to default.
         /// The base implementation will transfer the value via <see cref="Bindable{T}.Parse"/>
         /// or by binding and unbinding (if <paramref name="source"/> is an <see cref="IBindable"/>)
         /// and should be called unless replaced with custom logic.

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -147,9 +147,7 @@ namespace osu.Game.Rulesets.Mods
                 var targetBindable = (IBindable)prop.GetValue(this);
                 var sourceBindable = (IBindable)prop.GetValue(source);
 
-                // we only care about changes that have been made away from defaults, or if source is default but target is not.
-                if (!sourceBindable.IsDefault || !targetBindable.IsDefault)
-                    CopyAdjustedSetting(targetBindable, sourceBindable);
+                CopyAdjustedSetting(targetBindable, sourceBindable);
             }
         }
 

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -147,7 +147,9 @@ namespace osu.Game.Rulesets.Mods
                 var targetBindable = (IBindable)prop.GetValue(this);
                 var sourceBindable = (IBindable)prop.GetValue(source);
 
-                CopyAdjustedSetting(targetBindable, sourceBindable);
+                // we only care about changes that have been made away from defaults, or if source is default but target is not.
+                if (!sourceBindable.IsDefault || !targetBindable.IsDefault)
+                    CopyAdjustedSetting(targetBindable, sourceBindable);
             }
         }
 

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -154,9 +154,9 @@ namespace osu.Game.Rulesets.Mods
         }
 
         /// <summary>
-        /// When creating copies or clones of or copying from a Mod, this method will be called
+        /// When copying from or creating copies/clones of a Mod, this method will be called
         /// to copy explicitly adjusted user settings from <paramref name="source"/>,
-        /// or to reset already adjusted setting back to default.
+        /// or to reset already adjusted setting here back to default.
         /// The base implementation will transfer the value via <see cref="Bindable{T}.Parse"/>
         /// or by binding and unbinding (if <paramref name="source"/> is an <see cref="IBindable"/>)
         /// and should be called unless replaced with custom logic.


### PR DESCRIPTION
Oversight from introduction of `CopyFrom(Mod)` in https://github.com/ppy/osu/pull/11386.
Fixes [test failure](https://ci.appveyor.com/project/peppy/osu/builds/37612080) encountered in https://github.com/ppy/osu/pull/11641 (reason of failure explained in https://github.com/ppy/osu/pull/11641#issuecomment-773424800).

Previously when this code was in `CreateCopy()`, the target mod is instantiated locally and is expected to always be in a default state (`targetBindable.IsDefault` always true), but now after moving logic into `CopyFrom`, the target mod could've been customized already, rendering the below check insufficient:
https://github.com/ppy/osu/blob/4b4adc927cb49a166f9f13c093c318afbbe18f2b/osu.Game/Rulesets/Mods/Mod.cs#L150-L152

Therefore I fixed it by appending `|| !targetBindable.IsDefault` to the check, such that `CopyAdjustedSetting` will also be called to reset an already customized target setting back to default, if source is. Hopefully all of this will go away with the alternative `OverridableBindable` path.