### PR TITLE
Make pausing on window focus loss instantaneous

### DIFF
--- a/osu.Game/Screens/Play/BreakTracker.cs
+++ b/osu.Game/Screens/Play/BreakTracker.cs
@@ -23,16 +23,16 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public IBindable<bool> IsBreakTime => isBreakTime;
 
-        private readonly BindableBool isBreakTime = new BindableBool();
+        private readonly BindableBool isBreakTime = new BindableBool(true);
 
         public IReadOnlyList<BreakPeriod> Breaks
         {
             set
             {
-                isBreakTime.Value = false;
-
                 breaks = new PeriodTracker(value.Where(b => b.HasEffect)
                                                 .Select(b => new Period(b.StartTime, b.EndTime - BreakOverlay.BREAK_FADE_DURATION)));
+
+                updateBreakTime();
             }
         }
 
@@ -45,8 +45,12 @@ namespace osu.Game.Screens.Play
         protected override void Update()
         {
             base.Update();
+            updateBreakTime();
+        }
 
-            var time = Clock.CurrentTime;
+        private void updateBreakTime()
+        {
+            var time = Clock?.CurrentTime ?? 0;
 
             isBreakTime.Value = breaks?.IsInAny(time) == true
                                 || time < gameplayStartTime

--- a/osu.Game/Screens/Play/BreakTracker.cs
+++ b/osu.Game/Screens/Play/BreakTracker.cs
@@ -32,7 +32,8 @@ namespace osu.Game.Screens.Play
                 breaks = new PeriodTracker(value.Where(b => b.HasEffect)
                                                 .Select(b => new Period(b.StartTime, b.EndTime - BreakOverlay.BREAK_FADE_DURATION)));
 
-                updateBreakTime();
+                if (IsLoaded)
+                    updateBreakTime();
             }
         }
 
@@ -50,7 +51,7 @@ namespace osu.Game.Screens.Play
 
         private void updateBreakTime()
         {
-            var time = Clock?.CurrentTime ?? 0;
+            var time = Clock.CurrentTime;
 
             isBreakTime.Value = breaks?.IsInAny(time) == true
                                 || time < gameplayStartTime

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -88,11 +88,6 @@ namespace osu.Game.Screens.Play.HUD
             return base.OnMouseMove(e);
         }
 
-        public bool PauseOnFocusLost
-        {
-            set => button.PauseOnFocusLost = value;
-        }
-
         protected override void Update()
         {
             base.Update();
@@ -119,8 +114,6 @@ namespace osu.Game.Screens.Play.HUD
 
             public Action HoverGained;
             public Action HoverLost;
-
-            private readonly IBindable<bool> gameActive = new Bindable<bool>(true);
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colours, Framework.Game game)
@@ -164,14 +157,6 @@ namespace osu.Game.Screens.Play.HUD
                 };
 
                 bind();
-
-                gameActive.BindTo(game.IsActive);
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-                gameActive.BindValueChanged(_ => updateActive(), true);
             }
 
             private void bind()
@@ -219,31 +204,6 @@ namespace osu.Game.Screens.Play.HUD
             {
                 HoverLost?.Invoke();
                 base.OnHoverLost(e);
-            }
-
-            private bool pauseOnFocusLost = true;
-
-            public bool PauseOnFocusLost
-            {
-                set
-                {
-                    if (pauseOnFocusLost == value)
-                        return;
-
-                    pauseOnFocusLost = value;
-                    if (IsLoaded)
-                        updateActive();
-                }
-            }
-
-            private void updateActive()
-            {
-                if (!pauseOnFocusLost || IsPaused.Value) return;
-
-                if (gameActive.Value)
-                    AbortConfirm();
-                else
-                    BeginConfirm();
             }
 
             public bool OnPressed(GlobalAction action)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(AudioManager audio, OsuConfigManager config, OsuGame game, OsuGameBase gameBase)
+        private void load(AudioManager audio, OsuConfigManager config, OsuGame game)
         {
             Mods.Value = base.Mods.Value.Select(m => m.CreateCopy()).ToArray();
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -433,7 +433,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             if (gameActive.Value == false)
-                performUserRequestedExit();
+                Pause();
         }
 
         private IBeatmap loadPlayableBeatmap()

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -81,6 +81,9 @@ namespace osu.Game.Screens.Play
         public int RestartCount;
 
         [Resolved]
+        private OsuGameBase gameBase { get; set; }
+
+        [Resolved]
         private ScoreManager scoreManager { get; set; }
 
         private RulesetInfo rulesetInfo;
@@ -157,7 +160,8 @@ namespace osu.Game.Screens.Play
             if (!Mods.Value.Any(m => m is ModAutoplay))
                 PrepareReplay();
 
-            // needs to be bound here as the last binding, otherwise starting a replay while not focused causes player to exit.
+            // needs to be bound here as the last binding, otherwise cases like starting a replay while not focused causes player to exit, if activity is bound before checks.
+            gameActive.BindTo(gameBase.IsActive);
             gameActive.BindValueChanged(_ => updatePauseOnFocusLostState(), true);
         }
 
@@ -190,8 +194,6 @@ namespace osu.Game.Screens.Play
             sampleRestart = audio.Samples.Get(@"Gameplay/restart");
 
             mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
-
-            gameActive.BindTo(gameBase.IsActive);
 
             if (game != null)
                 LocalUserPlaying.BindTo(game.LocalUserPlaying);
@@ -429,7 +431,7 @@ namespace osu.Game.Screens.Play
 
         private void updatePauseOnFocusLostState()
         {
-            if (!IsLoaded || !PauseOnFocusLost || DrawableRuleset.HasReplayLoaded.Value || breakTracker.IsBreakTime.Value)
+            if (!PauseOnFocusLost || DrawableRuleset.HasReplayLoaded.Value || breakTracker.IsBreakTime.Value)
                 return;
 
             if (gameActive.Value == false)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -81,9 +81,6 @@ namespace osu.Game.Screens.Play
         public int RestartCount;
 
         [Resolved]
-        private OsuGameBase gameBase { get; set; }
-
-        [Resolved]
         private ScoreManager scoreManager { get; set; }
 
         private RulesetInfo rulesetInfo;
@@ -160,7 +157,6 @@ namespace osu.Game.Screens.Play
             if (!Mods.Value.Any(m => m is ModAutoplay))
                 PrepareReplay();
 
-            gameActive.BindTo(gameBase.IsActive);
             gameActive.BindValueChanged(_ => updatePauseOnFocusLostState(), true);
         }
 
@@ -195,7 +191,10 @@ namespace osu.Game.Screens.Play
             mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
 
             if (game != null)
+            {
                 LocalUserPlaying.BindTo(game.LocalUserPlaying);
+                gameActive.BindTo(game.IsActive);
+            }
 
             DrawableRuleset = ruleset.CreateDrawableRulesetWith(playableBeatmap, Mods.Value);
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -160,7 +160,6 @@ namespace osu.Game.Screens.Play
             if (!Mods.Value.Any(m => m is ModAutoplay))
                 PrepareReplay();
 
-            // needs to be bound here as the last binding, otherwise cases like starting a replay while not focused causes player to exit, if activity is bound before checks.
             gameActive.BindTo(gameBase.IsActive);
             gameActive.BindValueChanged(_ => updatePauseOnFocusLostState(), true);
         }
@@ -266,8 +265,6 @@ namespace osu.Game.Screens.Play
             DrawableRuleset.FrameStableClock.IsCatchingUp.BindValueChanged(_ => updateSampleDisabledState());
 
             DrawableRuleset.HasReplayLoaded.BindValueChanged(_ => updateGameplayState());
-
-            DrawableRuleset.HasReplayLoaded.BindValueChanged(_ => updatePauseOnFocusLostState(), true);
 
             // bind clock into components that require it
             DrawableRuleset.IsPaused.BindTo(GameplayClockContainer.IsPaused);
@@ -431,7 +428,7 @@ namespace osu.Game.Screens.Play
 
         private void updatePauseOnFocusLostState()
         {
-            if (!PauseOnFocusLost || DrawableRuleset.HasReplayLoaded.Value || breakTracker.IsBreakTime.Value)
+            if (!PauseOnFocusLost || breakTracker.IsBreakTime.Value)
                 return;
 
             if (gameActive.Value == false)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11624 as per https://github.com/ppy/osu/issues/11624#issuecomment-770118396

I've moved the "pause on focus lost" logic outside of the button and into `Player` while at it, given that the button is no longer relevant in pausing for this case.

I've also corrected `IsBreakTime` to become `true` by default, and calculate its value directly in the property to avoid incorrectly setting it to `false` there.

Cannot add a test case (unfortunately) for the above issue as there's no window in a headless host.