### PR TITLE
Add classic mod for the osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
@@ -1,0 +1,491 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Screens;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public class TestSceneObjectOrderedHitPolicy : RateAdjustedBeatmapTestScene
+    {
+        private const double early_miss_window = 1000; // time after -1000 to -500 is considered a miss
+        private const double late_miss_window = 500; // time after +500 is considered a miss
+
+        /// <summary>
+        /// Tests clicking a future circle before the first circle's start time, while the first circle HAS NOT been judged.
+        /// </summary>
+        [Test]
+        public void TestClickSecondCircleBeforeFirstCircleTime()
+        {
+            const double time_first_circle = 1500;
+            const double time_second_circle = 1600;
+            Vector2 positionFirstCircle = Vector2.Zero;
+            Vector2 positionSecondCircle = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_first_circle,
+                    Position = positionFirstCircle
+                },
+                new TestHitCircle
+                {
+                    StartTime = time_second_circle,
+                    Position = positionSecondCircle
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_circle - 100, Position = positionSecondCircle, Actions = { OsuAction.LeftButton } }
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Miss);
+            addJudgementAssert(hitObjects[1], HitResult.Miss);
+            addJudgementOffsetAssert(hitObjects[0], late_miss_window);
+        }
+
+        /// <summary>
+        /// Tests clicking a future circle at the first circle's start time, while the first circle HAS NOT been judged.
+        /// </summary>
+        [Test]
+        public void TestClickSecondCircleAtFirstCircleTime()
+        {
+            const double time_first_circle = 1500;
+            const double time_second_circle = 1600;
+            Vector2 positionFirstCircle = Vector2.Zero;
+            Vector2 positionSecondCircle = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_first_circle,
+                    Position = positionFirstCircle
+                },
+                new TestHitCircle
+                {
+                    StartTime = time_second_circle,
+                    Position = positionSecondCircle
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_circle, Position = positionSecondCircle, Actions = { OsuAction.LeftButton } }
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Miss);
+            addJudgementAssert(hitObjects[1], HitResult.Miss);
+            addJudgementOffsetAssert(hitObjects[0], late_miss_window);
+        }
+
+        /// <summary>
+        /// Tests clicking a future circle after the first circle's start time, while the first circle HAS NOT been judged.
+        /// </summary>
+        [Test]
+        public void TestClickSecondCircleAfterFirstCircleTime()
+        {
+            const double time_first_circle = 1500;
+            const double time_second_circle = 1600;
+            Vector2 positionFirstCircle = Vector2.Zero;
+            Vector2 positionSecondCircle = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_first_circle,
+                    Position = positionFirstCircle
+                },
+                new TestHitCircle
+                {
+                    StartTime = time_second_circle,
+                    Position = positionSecondCircle
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_circle + 100, Position = positionSecondCircle, Actions = { OsuAction.LeftButton } }
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Miss);
+            addJudgementAssert(hitObjects[1], HitResult.Miss);
+            addJudgementOffsetAssert(hitObjects[0], late_miss_window);
+        }
+
+        /// <summary>
+        /// Tests clicking a future circle before the first circle's start time, while the first circle HAS been judged.
+        /// </summary>
+        [Test]
+        public void TestClickSecondCircleBeforeFirstCircleTimeWithFirstCircleJudged()
+        {
+            const double time_first_circle = 1500;
+            const double time_second_circle = 1600;
+            Vector2 positionFirstCircle = Vector2.Zero;
+            Vector2 positionSecondCircle = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_first_circle,
+                    Position = positionFirstCircle
+                },
+                new TestHitCircle
+                {
+                    StartTime = time_second_circle,
+                    Position = positionSecondCircle
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_circle - 200, Position = positionFirstCircle, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_first_circle - 100, Position = positionSecondCircle, Actions = { OsuAction.RightButton } }
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementOffsetAssert(hitObjects[0], -200); // time_first_circle - 200
+            addJudgementOffsetAssert(hitObjects[0], -200); // time_second_circle - first_circle_time - 100
+        }
+
+        /// <summary>
+        /// Tests clicking a future circle after the first circle's start time, while the first circle HAS been judged.
+        /// </summary>
+        [Test]
+        public void TestClickSecondCircleAfterFirstCircleTimeWithFirstCircleJudged()
+        {
+            const double time_first_circle = 1500;
+            const double time_second_circle = 1600;
+            Vector2 positionFirstCircle = Vector2.Zero;
+            Vector2 positionSecondCircle = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_first_circle,
+                    Position = positionFirstCircle
+                },
+                new TestHitCircle
+                {
+                    StartTime = time_second_circle,
+                    Position = positionSecondCircle
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_circle - 200, Position = positionFirstCircle, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_first_circle, Position = positionSecondCircle, Actions = { OsuAction.RightButton } }
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementOffsetAssert(hitObjects[0], -200); // time_first_circle - 200
+            addJudgementOffsetAssert(hitObjects[1], -100); // time_second_circle - first_circle_time
+        }
+
+        /// <summary>
+        /// Tests clicking a future circle after a slider's start time, but hitting all slider ticks.
+        /// </summary>
+        [Test]
+        public void TestMissSliderHeadAndHitAllSliderTicks()
+        {
+            const double time_slider = 1500;
+            const double time_circle = 1510;
+            Vector2 positionCircle = Vector2.Zero;
+            Vector2 positionSlider = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_circle,
+                    Position = positionCircle
+                },
+                new TestSlider
+                {
+                    StartTime = time_slider,
+                    Position = positionSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_slider, Position = positionCircle, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_slider + 10, Position = positionSlider, Actions = { OsuAction.RightButton } }
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Miss);
+            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.IgnoreHit);
+            addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
+        }
+
+        /// <summary>
+        /// Tests clicking hitting future slider ticks before a circle.
+        /// </summary>
+        [Test]
+        public void TestHitSliderTicksBeforeCircle()
+        {
+            const double time_slider = 1500;
+            const double time_circle = 1510;
+            Vector2 positionCircle = Vector2.Zero;
+            Vector2 positionSlider = new Vector2(30);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_circle,
+                    Position = positionCircle
+                },
+                new TestSlider
+                {
+                    StartTime = time_slider,
+                    Position = positionSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_slider, Position = positionSlider, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_circle + late_miss_window - 100, Position = positionCircle, Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_circle + late_miss_window - 90, Position = positionSlider, Actions = { OsuAction.LeftButton } },
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.IgnoreHit);
+            addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
+        }
+
+        /// <summary>
+        /// Tests clicking a future circle before a spinner.
+        /// </summary>
+        [Test]
+        public void TestHitCircleBeforeSpinner()
+        {
+            const double time_spinner = 1500;
+            const double time_circle = 1800;
+            Vector2 positionCircle = Vector2.Zero;
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestSpinner
+                {
+                    StartTime = time_spinner,
+                    Position = new Vector2(256, 192),
+                    EndTime = time_spinner + 1000,
+                },
+                new TestHitCircle
+                {
+                    StartTime = time_circle,
+                    Position = positionCircle
+                },
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_spinner - 100, Position = positionCircle, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_spinner + 10, Position = new Vector2(236, 192), Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_spinner + 20, Position = new Vector2(256, 172), Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_spinner + 30, Position = new Vector2(276, 192), Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_spinner + 40, Position = new Vector2(256, 212), Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_spinner + 50, Position = new Vector2(236, 192), Actions = { OsuAction.RightButton } },
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.Great);
+        }
+
+        [Test]
+        public void TestHitSliderHeadBeforeHitCircle()
+        {
+            const double time_circle = 1000;
+            const double time_slider = 1200;
+            Vector2 positionCircle = Vector2.Zero;
+            Vector2 positionSlider = new Vector2(80);
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_circle,
+                    Position = positionCircle
+                },
+                new TestSlider
+                {
+                    StartTime = time_slider,
+                    Position = positionSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_circle - 100, Position = positionSlider, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_circle, Position = positionCircle, Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_slider, Position = positionSlider, Actions = { OsuAction.LeftButton } },
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.Great);
+        }
+
+        private void addJudgementAssert(OsuHitObject hitObject, HitResult result)
+        {
+            AddAssert($"({hitObject.GetType().ReadableName()} @ {hitObject.StartTime}) judgement is {result}",
+                () => judgementResults.Single(r => r.HitObject == hitObject).Type == result);
+        }
+
+        private void addJudgementAssert(string name, Func<OsuHitObject> hitObject, HitResult result)
+        {
+            AddAssert($"{name} judgement is {result}",
+                () => judgementResults.Single(r => r.HitObject == hitObject()).Type == result);
+        }
+
+        private void addJudgementOffsetAssert(OsuHitObject hitObject, double offset)
+        {
+            AddAssert($"({hitObject.GetType().ReadableName()} @ {hitObject.StartTime}) judged at {offset}",
+                () => Precision.AlmostEquals(judgementResults.Single(r => r.HitObject == hitObject).TimeOffset, offset, 100));
+        }
+
+        private ScoreAccessibleReplayPlayer currentPlayer;
+        private List<JudgementResult> judgementResults;
+
+        private void performTest(List<OsuHitObject> hitObjects, List<ReplayFrame> frames)
+        {
+            AddStep("load player", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(new Beatmap<OsuHitObject>
+                {
+                    HitObjects = hitObjects,
+                    BeatmapInfo =
+                    {
+                        BaseDifficulty = new BeatmapDifficulty { SliderTickRate = 3 },
+                        Ruleset = new OsuRuleset().RulesetInfo
+                    },
+                });
+
+                Beatmap.Value.Beatmap.ControlPointInfo.Add(0, new DifficultyControlPoint { SpeedMultiplier = 0.1f });
+
+                SelectedMods.Value = new[] { new OsuModClassic() };
+
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+
+                p.OnLoadComplete += _ =>
+                {
+                    p.ScoreProcessor.NewJudgement += result =>
+                    {
+                        if (currentPlayer == p) judgementResults.Add(result);
+                    };
+                };
+
+                LoadScreen(currentPlayer = p);
+                judgementResults = new List<JudgementResult>();
+            });
+
+            AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
+            AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
+        }
+
+        private class TestHitCircle : HitCircle
+        {
+            protected override HitWindows CreateHitWindows() => new TestHitWindows();
+        }
+
+        private class TestSlider : Slider
+        {
+            public TestSlider()
+            {
+                DefaultsApplied += _ =>
+                {
+                    HeadCircle.HitWindows = new TestHitWindows();
+                    TailCircle.HitWindows = new TestHitWindows();
+
+                    HeadCircle.HitWindows.SetDifficulty(0);
+                    TailCircle.HitWindows.SetDifficulty(0);
+                };
+            }
+        }
+
+        private class TestSpinner : Spinner
+        {
+            protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, BeatmapDifficulty difficulty)
+            {
+                base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
+                SpinsRequired = 1;
+            }
+        }
+
+        private class TestHitWindows : HitWindows
+        {
+            private static readonly DifficultyRange[] ranges =
+            {
+                new DifficultyRange(HitResult.Great, 500, 500, 500),
+                new DifficultyRange(HitResult.Miss, early_miss_window, early_miss_window, early_miss_window),
+            };
+
+            public override bool IsHitResultAllowed(HitResult result) => result == HitResult.Great || result == HitResult.Miss;
+
+            protected override DifficultyRange[] GetRanges() => ranges;
+        }
+
+        private class ScoreAccessibleReplayPlayer : ReplayPlayer
+        {
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            protected override bool PauseOnFocusLost => false;
+
+            public ScoreAccessibleReplayPlayer(Score score)
+                : base(score, new PlayerConfiguration
+                {
+                    AllowPause = false,
+                    ShowResults = false,
+                })
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
@@ -248,7 +248,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             addJudgementAssert(hitObjects[0], HitResult.Miss);
             addJudgementAssert(hitObjects[1], HitResult.Great);
-            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.IgnoreHit);
+            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.LargeTickHit);
             addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
         }
 
@@ -291,7 +291,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
             addJudgementAssert(hitObjects[1], HitResult.Great);
-            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.IgnoreHit);
+            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.LargeTickHit);
             addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderCircleSelectionBlueprint.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         {
             base.Update();
 
-            CirclePiece.UpdateFrom(position == SliderPosition.Start ? HitObject.HeadCircle : HitObject.TailCircle);
+            CirclePiece.UpdateFrom(position == SliderPosition.Start ? (HitCircle)HitObject.HeadCircle : HitObject.TailCircle);
         }
 
         // Todo: This is temporary, since the slider circle masks don't do anything special yet. In the future they will handle input.

--- a/osu.Game.Rulesets.Osu/Judgements/SliderTickJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/SliderTickJudgement.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Judgements
+{
+    public class SliderTickJudgement : OsuJudgement
+    {
+        public override HitResult MaxResult => HitResult.LargeTickHit;
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             switch (hitObject)
             {
                 case Slider slider:
-                    slider.IgnoreJudgement = !NoSliderHeadAccuracy.Value;
+                    slider.OnlyJudgeNestedObjects = !NoSliderHeadAccuracy.Value;
 
                     foreach (var head in slider.NestedHitObjects.OfType<SliderHeadCircle>())
                         head.JudgeAsNormalHitCircle = !NoSliderHeadAccuracy.Value;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -50,10 +50,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                     slider.IgnoreJudgement = !DisableSliderHeadJudgement.Value;
 
                     foreach (var head in slider.NestedHitObjects.OfType<SliderHeadCircle>())
-                    {
-                        head.TrackFollowCircle = !DisableSliderHeadTracking.Value;
                         head.JudgeAsNormalHitCircle = !DisableSliderHeadJudgement.Value;
-                    }
 
                     break;
             }
@@ -71,8 +68,16 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             foreach (var obj in drawables)
             {
-                if (obj is DrawableSlider slider)
-                    slider.Ball.TrackVisualSize = !DisableExactFollowCircleTracking.Value;
+                switch (obj)
+                {
+                    case DrawableSlider slider:
+                        slider.Ball.TrackVisualSize = !DisableExactFollowCircleTracking.Value;
+                        break;
+
+                    case DrawableSliderHead head:
+                        head.TrackFollowCircle = !DisableSliderHeadTracking.Value;
+                        break;
+                }
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -32,27 +32,27 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override ModType Type => ModType.Conversion;
 
-        [SettingSource("Disable slider head judgement", "Scores sliders proportionally to the number of ticks hit.")]
-        public Bindable<bool> DisableSliderHeadJudgement { get; } = new BindableBool(true);
+        [SettingSource("No slider head accuracy requirement", "Scores sliders proportionally to the number of ticks hit.")]
+        public Bindable<bool> NoSliderHeadAccuracy { get; } = new BindableBool(true);
 
-        [SettingSource("Disable slider head tracking", "Pins slider heads at their starting position, regardless of time.")]
-        public Bindable<bool> DisableSliderHeadTracking { get; } = new BindableBool(true);
+        [SettingSource("No slider head movement", "Pins slider heads at their starting position, regardless of time.")]
+        public Bindable<bool> NoSliderHeadMovement { get; } = new BindableBool(true);
 
-        [SettingSource("Disable note lock lenience", "Applies note lock to the full hit window.")]
-        public Bindable<bool> DisableLenientNoteLock { get; } = new BindableBool(true);
+        [SettingSource("Apply classic note lock", "Applies note lock to the full hit window.")]
+        public Bindable<bool> ClassicNoteLock { get; } = new BindableBool(true);
 
-        [SettingSource("Disable exact slider follow circle tracking", "Makes the slider follow circle track its final size at all times.")]
-        public Bindable<bool> DisableExactFollowCircleTracking { get; } = new BindableBool(true);
+        [SettingSource("Use fixed slider follow circle hit area", "Makes the slider follow circle track its final size at all times.")]
+        public Bindable<bool> FixedFollowCircleHitArea { get; } = new BindableBool(true);
 
         public void ApplyToHitObject(HitObject hitObject)
         {
             switch (hitObject)
             {
                 case Slider slider:
-                    slider.IgnoreJudgement = !DisableSliderHeadJudgement.Value;
+                    slider.IgnoreJudgement = !NoSliderHeadAccuracy.Value;
 
                     foreach (var head in slider.NestedHitObjects.OfType<SliderHeadCircle>())
-                        head.JudgeAsNormalHitCircle = !DisableSliderHeadJudgement.Value;
+                        head.JudgeAsNormalHitCircle = !NoSliderHeadAccuracy.Value;
 
                     break;
             }
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var osuRuleset = (DrawableOsuRuleset)drawableRuleset;
 
-            if (!DisableLenientNoteLock.Value)
+            if (!ClassicNoteLock.Value)
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
         }
 
@@ -73,11 +73,11 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (obj)
                 {
                     case DrawableSlider slider:
-                        slider.Ball.TrackVisualSize = !DisableExactFollowCircleTracking.Value;
+                        slider.Ball.TrackVisualSize = !FixedFollowCircleHitArea.Value;
                         break;
 
                     case DrawableSliderHead head:
-                        head.TrackFollowCircle = !DisableSliderHeadTracking.Value;
+                        head.TrackFollowCircle = !NoSliderHeadMovement.Value;
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModClassic : Mod, IApplicableToHitObject
+    {
+        public override string Name => "Classic";
+
+        public override string Acronym => "CL";
+
+        public override double ScoreMultiplier => 1;
+
+        public override IconUsage? Icon => FontAwesome.Solid.History;
+
+        public override string Description => "Feeling nostalgic?";
+
+        public override bool Ranked => false;
+
+        public void ApplyToHitObject(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case Slider slider:
+                    slider.IgnoreJudgement = false;
+
+                    foreach (var head in slider.NestedHitObjects.OfType<SliderHeadCircle>())
+                    {
+                        head.TrackFollowCircle = false;
+                        head.JudgeAsNormalHitCircle = false;
+                    }
+
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (obj)
                 {
                     case DrawableSlider slider:
-                        slider.Ball.TrackVisualSize = !FixedFollowCircleHitArea.Value;
+                        slider.Ball.InputTracksVisualSize = !FixedFollowCircleHitArea.Value;
                         break;
 
                     case DrawableSliderHead head:

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var osuRuleset = (DrawableOsuRuleset)drawableRuleset;
 
-            if (!ClassicNoteLock.Value)
+            if (ClassicNoteLock.Value)
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
         }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -1,19 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModClassic : Mod, IApplicableToHitObject, IApplicableToDrawableRuleset<OsuHitObject>
+    public class OsuModClassic : Mod, IApplicableToHitObject, IApplicableToDrawableHitObjects, IApplicableToDrawableRuleset<OsuHitObject>
     {
         public override string Name => "Classic";
 
@@ -35,6 +38,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         [SettingSource("Disable note lock lenience", "Applies note lock to the full hit window.")]
         public Bindable<bool> DisableLenientNoteLock { get; } = new BindableBool(true);
+
+        [SettingSource("Disable exact slider follow circle tracking", "Makes the slider follow circle track its final size at all times.")]
+        public Bindable<bool> DisableExactFollowCircleTracking { get; } = new BindableBool(true);
 
         public void ApplyToHitObject(HitObject hitObject)
         {
@@ -59,6 +65,15 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             if (!DisableLenientNoteLock.Value)
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
+        }
+
+        public void ApplyToDrawableHitObjects(IEnumerable<DrawableHitObject> drawables)
+        {
+            foreach (var obj in drawables)
+            {
+                if (obj is DrawableSlider slider)
+                    slider.Ball.TrackVisualSize = !DisableExactFollowCircleTracking.Value;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override bool Ranked => false;
 
+        public override ModType Type => ModType.Conversion;
+
         [SettingSource("Disable slider head judgement", "Scores sliders proportionally to the number of ticks hit.")]
         public Bindable<bool> DisableSliderHeadJudgement { get; } = new BindableBool(true);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 return;
             }
 
-            var result = HitObject.HitWindows.ResultFor(timeOffset);
+            var result = ResultFor(timeOffset);
 
             if (result == HitResult.None || CheckHittable?.Invoke(this, Time.Current) == false)
             {
@@ -145,6 +145,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 circleResult.Type = result;
             });
         }
+
+        /// <summary>
+        /// Retrieves the <see cref="HitResult"/> for a time offset.
+        /// </summary>
+        /// <param name="timeOffset">The time offset.</param>
+        /// <returns>The hit result, or <see cref="HitResult.None"/> if <paramref name="timeOffset"/> doesn't result in a judgement.</returns>
+        protected virtual HitResult ResultFor(double timeOffset) => HitObject.HitWindows.ResultFor(timeOffset);
 
         protected override void UpdateInitialTransforms()
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (JudgedObject?.HitObject is OsuHitObject osuObject)
             {
-                Position = osuObject.StackedPosition;
+                Position = osuObject.StackedEndPosition;
                 Scale = new Vector2(osuObject.Scale);
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -271,11 +271,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 else
                 {
                     double hitFraction = (double)totalTicks / hitTicks;
-
-                    if (hitFraction >= 0.5)
-                        r.Type = HitResult.Ok;
-                    else if (hitFraction > 0)
-                        r.Type = HitResult.Meh;
+                    r.Type = hitFraction >= 0.5 ? HitResult.Ok : HitResult.Meh;
                 }
             });
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -250,13 +250,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (userTriggered || Time.Current < HitObject.EndTime)
                 return;
 
+            // If only the nested hitobjects are judged, then the slider's own judgement is ignored for scoring purposes.
+            // But the slider needs to still be judged with a reasonable hit/miss result for visual purposes (hit/miss transforms, etc).
             if (HitObject.OnlyJudgeNestedObjects)
             {
                 ApplyResult(r => r.Type = NestedHitObjects.Any(h => h.Result.IsHit) ? r.Judgement.MaxResult : r.Judgement.MinResult);
                 return;
             }
 
-            // If not ignoring judgement, score proportionally based on the number of ticks hit, counting the head circle as a tick.
+            // Otherwise, if this slider is also needs to be judged, apply judgement proportionally to the number of nested hitobjects hit. This is the classic osu!stable scoring.
             ApplyResult(r =>
             {
                 int totalTicks = NestedHitObjects.Count;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -263,16 +263,20 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 int totalTicks = NestedHitObjects.Count;
                 int hitTicks = NestedHitObjects.Count(h => h.IsHit);
-                double hitFraction = (double)totalTicks / hitTicks;
 
                 if (hitTicks == totalTicks)
                     r.Type = HitResult.Great;
-                else if (hitFraction >= 0.5)
-                    r.Type = HitResult.Ok;
-                else if (hitFraction > 0)
-                    r.Type = HitResult.Meh;
-                else
+                else if (hitTicks == 0)
                     r.Type = HitResult.Miss;
+                else
+                {
+                    double hitFraction = (double)totalTicks / hitTicks;
+
+                    if (hitFraction >= 0.5)
+                        r.Type = HitResult.Ok;
+                    else if (hitFraction > 0)
+                        r.Type = HitResult.Meh;
+                }
             });
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -270,7 +270,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     r.Type = HitResult.Miss;
                 else
                 {
-                    double hitFraction = (double)totalTicks / hitTicks;
+                    double hitFraction = (double)hitTicks / totalTicks;
                     r.Type = hitFraction >= 0.5 ? HitResult.Ok : HitResult.Meh;
                 }
             });

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public SliderBall Ball { get; private set; }
         public SkinnableDrawable Body { get; private set; }
 
-        public override bool DisplayResult => !HitObject.IgnoreJudgement;
+        public override bool DisplayResult => !HitObject.OnlyJudgeNestedObjects;
 
         private PlaySliderBody sliderBody => Body.Drawable as PlaySliderBody;
 
@@ -250,7 +250,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (userTriggered || Time.Current < HitObject.EndTime)
                 return;
 
-            if (HitObject.IgnoreJudgement)
+            if (HitObject.OnlyJudgeNestedObjects)
             {
                 ApplyResult(r => r.Type = NestedHitObjects.Any(h => h.Result.IsHit) ? r.Judgement.MaxResult : r.Judgement.MinResult);
                 return;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public SliderBall Ball { get; private set; }
         public SkinnableDrawable Body { get; private set; }
 
-        public override bool DisplayResult => false;
+        public override bool DisplayResult => !HitObject.IgnoreJudgement;
 
         private PlaySliderBody sliderBody => Body.Drawable as PlaySliderBody;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -258,7 +258,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 return;
             }
 
-            // Otherwise, if this slider is also needs to be judged, apply judgement proportionally to the number of nested hitobjects hit. This is the classic osu!stable scoring.
+            // Otherwise, if this slider also needs to be judged, apply judgement proportionally to the number of nested hitobjects hit. This is the classic osu!stable scoring.
             ApplyResult(r =>
             {
                 int totalTicks = NestedHitObjects.Count;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (HitObject.JudgeAsNormalHitCircle)
                 return base.ResultFor(timeOffset);
 
-            // If not judged as a normal hitcircle, only track whether a hit has occurred (via IgnoreHit) rather than a scorable hit result.
+            // If not judged as a normal hitcircle, judge as a slider tick instead. This is the classic osu!stable scoring.
             var result = base.ResultFor(timeOffset);
             return result.IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss;
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -22,6 +22,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public override bool DisplayResult => HitObject?.JudgeAsNormalHitCircle ?? base.DisplayResult;
 
+        /// <summary>
+        /// Makes this <see cref="DrawableSliderHead"/> track the follow circle when the start time is reached.
+        /// If <c>false</c>, this <see cref="DrawableSliderHead"/> will be pinned to its initial position in the slider.
+        /// </summary>
+        public bool TrackFollowCircle = true;
+
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 
         protected override OsuSkinComponents CirclePieceComponent => OsuSkinComponents.SliderHeadHitCircle;
@@ -66,7 +72,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Debug.Assert(Slider != null);
             Debug.Assert(HitObject != null);
 
-            if (HitObject.TrackFollowCircle)
+            if (TrackFollowCircle)
             {
                 double completionProgress = Math.Clamp((Time.Current - Slider.StartTime) / Slider.Duration, 0, 1);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -18,6 +19,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public Slider Slider => DrawableSlider?.HitObject;
 
         protected DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
+
+        public override bool DisplayResult => HitObject?.JudgeAsNormalHitCircle ?? base.DisplayResult;
 
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 
@@ -71,6 +74,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 if (!IsHit)
                     Position = Slider.CurvePositionAt(completionProgress);
             }
+        }
+
+        protected override HitResult ResultFor(double timeOffset)
+        {
+            Debug.Assert(HitObject != null);
+
+            if (HitObject.JudgeAsNormalHitCircle)
+                return base.ResultFor(timeOffset);
+
+            // If not judged as a normal hitcircle, only track whether a hit has occurred (via IgnoreHit) rather than a scorable hit result.
+            var result = base.ResultFor(timeOffset);
+            return result.IsHit() ? HitResult.IgnoreHit : result;
         }
 
         public Action<double> OnShake;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
     public class DrawableSliderHead : DrawableHitCircle
     {
+        public new SliderHeadCircle HitObject => (SliderHeadCircle)base.HitObject;
+
         [CanBeNull]
         public Slider Slider => DrawableSlider?.HitObject;
 
@@ -59,12 +61,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.Update();
 
             Debug.Assert(Slider != null);
+            Debug.Assert(HitObject != null);
 
-            double completionProgress = Math.Clamp((Time.Current - Slider.StartTime) / Slider.Duration, 0, 1);
+            if (HitObject.TrackFollowCircle)
+            {
+                double completionProgress = Math.Clamp((Time.Current - Slider.StartTime) / Slider.Duration, 0, 1);
 
-            //todo: we probably want to reconsider this before adding scoring, but it looks and feels nice.
-            if (!IsHit)
-                Position = Slider.CurvePositionAt(completionProgress);
+                //todo: we probably want to reconsider this before adding scoring, but it looks and feels nice.
+                if (!IsHit)
+                    Position = Slider.CurvePositionAt(completionProgress);
+            }
         }
 
         public Action<double> OnShake;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             // If not judged as a normal hitcircle, only track whether a hit has occurred (via IgnoreHit) rather than a scorable hit result.
             var result = base.ResultFor(timeOffset);
-            return result.IsHit() ? HitResult.IgnoreHit : HitResult.IgnoreMiss;
+            return result.IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss;
         }
 
         public Action<double> OnShake;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             // If not judged as a normal hitcircle, only track whether a hit has occurred (via IgnoreHit) rather than a scorable hit result.
             var result = base.ResultFor(timeOffset);
-            return result.IsHit() ? HitResult.IgnoreHit : result;
+            return result.IsHit() ? HitResult.IgnoreHit : HitResult.IgnoreMiss;
         }
 
         public Action<double> OnShake;

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public bool IgnoreJudgement = true;
 
         [JsonIgnore]
-        public HitCircle HeadCircle { get; protected set; }
+        public SliderHeadCircle HeadCircle { get; protected set; }
 
         [JsonIgnore]
         public SliderTailCircle TailCircle { get; protected set; }

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -115,10 +115,10 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double TickDistanceMultiplier = 1;
 
         /// <summary>
-        /// Whether this <see cref="Slider"/>'s judgement should be ignored.
-        /// If <c>false</c>, this <see cref="Slider"/> will be judged proportionally to the number of ticks hit.
+        /// Whether this <see cref="Slider"/>'s judgement is fully handled by its nested <see cref="HitObject"/>s.
+        /// If <c>false</c>, this <see cref="Slider"/> will be judged proportionally to the number of nested <see cref="HitObject"/>s hit.
         /// </summary>
-        public bool IgnoreJudgement = true;
+        public bool OnlyJudgeNestedObjects = true;
 
         [JsonIgnore]
         public SliderHeadCircle HeadCircle { get; protected set; }
@@ -239,7 +239,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                 HeadCircle.Samples = this.GetNodeSamples(0);
         }
 
-        public override Judgement CreateJudgement() => IgnoreJudgement ? new OsuIgnoreJudgement() : new OsuJudgement();
+        public override Judgement CreateJudgement() => OnlyJudgeNestedObjects ? new OsuIgnoreJudgement() : new OsuJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
     }

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -114,6 +114,12 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// </summary>
         public double TickDistanceMultiplier = 1;
 
+        /// <summary>
+        /// Whether this <see cref="Slider"/>'s judgement should be ignored.
+        /// If <c>false</c>, this <see cref="Slider"/> will be judged proportionally to the number of ticks hit.
+        /// </summary>
+        public bool IgnoreJudgement = true;
+
         [JsonIgnore]
         public HitCircle HeadCircle { get; protected set; }
 
@@ -233,7 +239,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                 HeadCircle.Samples = this.GetNodeSamples(0);
         }
 
-        public override Judgement CreateJudgement() => new OsuIgnoreJudgement();
+        public override Judgement CreateJudgement() => IgnoreJudgement ? new OsuIgnoreJudgement() : new OsuJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
     }

--- a/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
@@ -1,13 +1,25 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Judgements;
+
 namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SliderHeadCircle : HitCircle
     {
         /// <summary>
-        /// Makes the head circle track the follow circle when the start time is reached.
+        /// Makes this <see cref="SliderHeadCircle"/> track the follow circle when the start time is reached.
+        /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be pinned to its initial position in the slider.
         /// </summary>
         public bool TrackFollowCircle = true;
+
+        /// <summary>
+        /// Whether to treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
+        /// If <c>false</c>, judgement will be ignored.
+        /// </summary>
+        public bool JudgeAsNormalHitCircle = true;
+
+        public override Judgement CreateJudgement() => JudgeAsNormalHitCircle ? base.CreateJudgement() : new OsuIgnoreJudgement();
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
@@ -5,5 +5,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SliderHeadCircle : HitCircle
     {
+        /// <summary>
+        /// Makes the head circle track the follow circle when the start time is reached.
+        /// </summary>
+        public bool TrackFollowCircle = true;
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
@@ -10,10 +10,10 @@ namespace osu.Game.Rulesets.Osu.Objects
     {
         /// <summary>
         /// Whether to treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
-        /// If <c>false</c>, judgement will be ignored.
+        /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
         /// </summary>
         public bool JudgeAsNormalHitCircle = true;
 
-        public override Judgement CreateJudgement() => JudgeAsNormalHitCircle ? base.CreateJudgement() : new OsuIgnoreJudgement();
+        public override Judgement CreateJudgement() => JudgeAsNormalHitCircle ? base.CreateJudgement() : new SliderTickJudgement();
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
@@ -9,12 +9,6 @@ namespace osu.Game.Rulesets.Osu.Objects
     public class SliderHeadCircle : HitCircle
     {
         /// <summary>
-        /// Makes this <see cref="SliderHeadCircle"/> track the follow circle when the start time is reached.
-        /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be pinned to its initial position in the slider.
-        /// </summary>
-        public bool TrackFollowCircle = true;
-
-        /// <summary>
         /// Whether to treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
         /// If <c>false</c>, judgement will be ignored.
         /// </summary>

--- a/osu.Game.Rulesets.Osu/Objects/SliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTick.cs
@@ -33,10 +33,5 @@ namespace osu.Game.Rulesets.Osu.Objects
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
 
         public override Judgement CreateJudgement() => new SliderTickJudgement();
-
-        public class SliderTickJudgement : OsuJudgement
-        {
-            public override HitResult MaxResult => HitResult.LargeTickHit;
-        }
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -163,6 +163,7 @@ namespace osu.Game.Rulesets.Osu
                     {
                         new OsuModTarget(),
                         new OsuModDifficultyAdjust(),
+                        new OsuModClassic()
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         [Resolved(CanBeNull = true)]
         private OsuRulesetConfigManager config { get; set; }
 
-        private readonly Bindable<bool> snakingOut = new Bindable<bool>();
+        private readonly Bindable<bool> configSnakingOut = new Bindable<bool>();
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin, DrawableHitObject drawableObject)
@@ -37,9 +37,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             accentColour = drawableObject.AccentColour.GetBoundCopy();
             accentColour.BindValueChanged(accent => updateAccentColour(skin, accent.NewValue), true);
 
-            SnakingOut.BindTo(snakingOut);
             config?.BindWith(OsuRulesetSetting.SnakingInSliders, SnakingIn);
-            config?.BindWith(OsuRulesetSetting.SnakingOutSliders, snakingOut);
+            config?.BindWith(OsuRulesetSetting.SnakingOutSliders, configSnakingOut);
+
+            SnakingOut.BindTo(configSnakingOut);
 
             BorderSize = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderBorderSize)?.Value ?? 1;
             BorderColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value ?? Color4.White;
@@ -56,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             if (!drawableSlider.HeadCircle.TrackFollowCircle)
             {
                 // When not tracking the follow circle, force the path to not snake out as it looks better that way.
-                SnakingOut.UnbindFrom(snakingOut);
+                SnakingOut.UnbindFrom(configSnakingOut);
                 SnakingOut.Value = false;
             }
         }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -45,7 +45,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             BorderColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value ?? Color4.White;
 
             drawableObject.HitObjectApplied += onHitObjectApplied;
-            onHitObjectApplied(drawableObject);
         }
 
         private void onHitObjectApplied(DrawableHitObject obj)

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             if (drawableSlider.HitObject == null)
                 return;
 
-            if (!drawableSlider.HitObject.HeadCircle.TrackFollowCircle)
+            if (!drawableSlider.HeadCircle.TrackFollowCircle)
             {
                 // When not tracking the follow circle, force the path to not snake out as it looks better that way.
                 SnakingOut.UnbindFrom(snakingOut);

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -54,9 +54,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             if (drawableSlider.HitObject == null)
                 return;
 
+            // When not tracking the follow circle, unbind from the config and forcefully disable snaking out - it looks better that way.
             if (!drawableSlider.HeadCircle.TrackFollowCircle)
             {
-                // When not tracking the follow circle, force the path to not snake out as it looks better that way.
                 SnakingOut.UnbindFrom(configSnakingOut);
                 SnakingOut.Value = false;
             }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         /// Whether to track accurately to the visual size of this <see cref="SliderBall"/>.
         /// If <c>false</c>, tracking will be performed at the final scale at all times.
         /// </summary>
-        public bool TrackVisualSize = true;
+        public bool InputTracksVisualSize = true;
 
         private readonly Drawable followCircle;
         private readonly DrawableSlider drawableSlider;
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
                 tracking = value;
 
-                if (TrackVisualSize)
+                if (InputTracksVisualSize)
                     followCircle.ScaleTo(tracking ? 2.4f : 1f, 300, Easing.OutQuint);
                 else
                 {

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
@@ -31,6 +31,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             set => ball.Colour = value;
         }
 
+        /// <summary>
+        /// Whether to track accurately to the visual size of this <see cref="SliderBall"/>.
+        /// If <c>false</c>, tracking will be performed at the final scale at all times.
+        /// </summary>
+        public bool TrackVisualSize = true;
+
         private readonly Drawable followCircle;
         private readonly DrawableSlider drawableSlider;
         private readonly Drawable ball;
@@ -94,7 +100,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
                 tracking = value;
 
-                followCircle.ScaleTo(tracking ? 2.4f : 1f, 300, Easing.OutQuint);
+                if (TrackVisualSize)
+                    followCircle.ScaleTo(tracking ? 2.4f : 1f, 300, Easing.OutQuint);
+                else
+                {
+                    // We need to always be tracking the final size, at both endpoints. For now, this is achieved by removing the scale duration.
+                    followCircle.ScaleTo(tracking ? 2.4f : 1f);
+                }
+
                 followCircle.FadeTo(tracking ? 1f : 0, 300, Easing.OutQuint);
             }
         }

--- a/osu.Game.Rulesets.Osu/UI/ObjectOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/ObjectOrderedHitPolicy.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Osu.UI
+{
+    /// <summary>
+    /// Ensures that <see cref="HitObject"/>s are hit in order of appearance. The classic note lock.
+    /// <remarks>
+    /// Hits will be blocked until the previous <see cref="HitObject"/>s have been judged.
+    /// </remarks>
+    /// </summary>
+    public class ObjectOrderedHitPolicy : IHitPolicy
+    {
+        private IEnumerable<DrawableHitObject> hitObjects;
+
+        public void SetHitObjects(IEnumerable<DrawableHitObject> hitObjects) => this.hitObjects = hitObjects;
+
+        public bool IsHittable(DrawableHitObject hitObject, double time) => enumerateHitObjectsUpTo(hitObject.HitObject.StartTime).All(obj => obj.AllJudged);
+
+        public void HandleHit(DrawableHitObject hitObject)
+        {
+        }
+
+        private IEnumerable<DrawableHitObject> enumerateHitObjectsUpTo(double targetTime)
+        {
+            foreach (var obj in hitObjects)
+            {
+                if (obj.HitObject.StartTime >= targetTime)
+                    yield break;
+
+                switch (obj)
+                {
+                    case DrawableSpinner _:
+                        continue;
+
+                    case DrawableSlider slider:
+                        yield return slider.HeadCircle;
+
+                        break;
+
+                    default:
+                        yield return obj;
+
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.UI
         private readonly ProxyContainer spinnerProxies;
         private readonly JudgementContainer<DrawableOsuJudgement> judgementLayer;
         private readonly FollowPointRenderer followPoints;
-        private readonly StartTimeOrderedHitPolicy hitPolicy;
+        private readonly IHitPolicy hitPolicy;
 
         public static readonly Vector2 BASE_SIZE = new Vector2(512, 384);
 
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.UI
                 approachCircles = new ProxyContainer { RelativeSizeAxes = Axes.Both },
             };
 
-            hitPolicy = new StartTimeOrderedHitPolicy();
+            hitPolicy = new ObjectOrderedHitPolicy();
             hitPolicy.SetHitObjects(HitObjectContainer.AliveObjects);
 
             var hitWindows = new OsuHitWindows();

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -31,7 +31,6 @@ namespace osu.Game.Rulesets.Osu.UI
         private readonly ProxyContainer spinnerProxies;
         private readonly JudgementContainer<DrawableOsuJudgement> judgementLayer;
         private readonly FollowPointRenderer followPoints;
-        private readonly IHitPolicy hitPolicy;
 
         public static readonly Vector2 BASE_SIZE = new Vector2(512, 384);
 
@@ -54,17 +53,27 @@ namespace osu.Game.Rulesets.Osu.UI
                 approachCircles = new ProxyContainer { RelativeSizeAxes = Axes.Both },
             };
 
-            hitPolicy = new ObjectOrderedHitPolicy();
-            hitPolicy.SetHitObjects(HitObjectContainer.AliveObjects);
+            HitPolicy = new ObjectOrderedHitPolicy();
 
             var hitWindows = new OsuHitWindows();
-
             foreach (var result in Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r > HitResult.None && hitWindows.IsHitResultAllowed(r)))
                 poolDictionary.Add(result, new DrawableJudgementPool(result, onJudgmentLoaded));
 
             AddRangeInternal(poolDictionary.Values);
 
             NewResult += onNewResult;
+        }
+
+        private IHitPolicy hitPolicy;
+
+        public IHitPolicy HitPolicy
+        {
+            get => hitPolicy;
+            set
+            {
+                hitPolicy = value ?? throw new ArgumentNullException(nameof(value));
+                hitPolicy.SetHitObjects(HitObjectContainer.AliveObjects);
+            }
         }
 
         protected override void OnNewDrawableHitObject(DrawableHitObject drawable)

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.UI
                 approachCircles = new ProxyContainer { RelativeSizeAxes = Axes.Both },
             };
 
-            HitPolicy = new ObjectOrderedHitPolicy();
+            HitPolicy = new StartTimeOrderedHitPolicy();
 
             var hitWindows = new OsuHitWindows();
             foreach (var result in Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => r > HitResult.None && hitWindows.IsHitResultAllowed(r)))


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/11679

Closes https://github.com/ppy/osu/issues/7521.

Tested with both ThePooN and FGSky's replays on https://osu.ppy.sh/beatmapsets/743239#osu/1567435. Both combo break on master and don't with this PR.
To test, you can just `yield return new OsuModClassic()` from `OsuRuleset.ConvertFromLegacyMods()` and re-import the score.

Unsure how we want to apply this just yet, so I've only added it as a mod without forcing it upon replay/beatmaps.