### PR TITLE
Fix mods on participant panels flashing when changed

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -162,15 +162,20 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             const double fade_time = 50;
 
-            var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID).CreateInstance();
-
             userStateDisplay.Status = User.State;
-            userModsDisplay.Current.Value = User.Mods.Select(m => m.ToMod(ruleset)).ToList();
 
             if (Room.Host?.Equals(User) == true)
                 crown.FadeIn(fade_time);
             else
                 crown.FadeOut(fade_time);
+
+            // If the mods are updated at the end of the frame, the flow container will skip a reflow cycle: https://github.com/ppy/osu-framework/issues/4187
+            // This looks particularly jarring here, so re-schedule the update to that start of our frame as a fix.
+            Schedule(() =>
+            {
+                var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID).CreateInstance();
+                userModsDisplay.Current.Value = User.Mods.Select(m => m.ToMod(ruleset)).ToList();
+            });
         }
 
         public MenuItem[] ContextMenuItems


### PR DESCRIPTION
The core issue here is that `MultiplayerClient` is updated at the very end of the frame, long after the mods display has processed its layout. This runs into https://github.com/ppy/osu-framework/issues/4187 which causes a flicker.

![image](https://user-images.githubusercontent.com/1329837/107017480-85345000-67e2-11eb-87c5-63420203c3f7.png)

These elements should quite possibly be updated before the rest of the game, but that's a much larger change that I'm unwilling to take on at this time - it's quite a big restructuring. Regardless, the o!f issue should be fixed eventually rendering this moot.