### PR TITLE
Change combo scaling curve for aim and speed pp in the osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)
-                aimValue *= Math.Min(Math.Pow(scoreMaxCombo, 0.8) / Math.Pow(Attributes.MaxCombo, 0.8), 1.0);
+                aimValue *= (Math.Exp(-Math.Exp((930.58 - scoreMaxCombo) / 969.16)) - 0.073373) / (Math.Exp(-Math.Exp((930.58 - Attributes.MaxCombo) / 969.16)) - 0.073373);
 
             double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             // Combo scaling
             if (Attributes.MaxCombo > 0)
-                speedValue *= Math.Min(Math.Pow(scoreMaxCombo, 0.8) / Math.Pow(Attributes.MaxCombo, 0.8), 1.0);
+                speedValue *= (Math.Exp(-Math.Exp((930.58 - scoreMaxCombo) / 969.16)) - 0.073373) / (Math.Exp(-Math.Exp((930.58 - Attributes.MaxCombo) / 969.16)) - 0.073373);
 
             double approachRateFactor = 0.0;
             if (Attributes.ApproachRate > 10.33)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double truncateMax = Math.Exp(-Math.Exp((combo_distribution_location - beatmapMaxCombo) / combo_distribution_scale));
 
-            // Truncate distribution support to [0, maxCombo].
+            // Truncate distribution support to [0, beatmapMaxCombo].
             cumulativeProbability -= combo_truncate_min;
             cumulativeProbability /= truncateMax - combo_truncate_min;
 

--- a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+++ b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
@@ -12,6 +12,10 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+  </PropertyGroup>
+
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>

--- a/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
+++ b/osu.Game.Rulesets.Osu/osu.Game.Rulesets.Osu.csproj
@@ -12,10 +12,6 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-  </PropertyGroup>
-
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Hello everyone! Inspired by the recent changes to performance calculation by Xexxar (particularly to the miss penalty curve), I decided to make an attempt at improving the combo scaling curve. This proposal only targets scores on which a full combo is not achieved, and otherwise leaves everything else unchanged.

Discussion and feedback are much appreciated.

### The problem

Currently, combo is considered by scaling `aimValue` and `speedValue` by a multiplicative factor

```
(scoreMaxCombo / MaxCombo) ^ 0.8
```

This curve gives the same values for combos considered as a fraction of the total combo achievable on maps, regardless of the lengths of the maps. For example, a score with combo 350/400 is treated identically to one with combo 7000/8000, as these are both the same fractional combo. However, all other factors considered equal, one would intuitively expect the fractional combo achieved on a map of length 8000 to be much lower than one of length 400. Furthermore, the reasoning behind the fractional-exponent form of the current curve is quite unclear (at least to me). I will present a new curve addressing the former of these two issues, followed by more detailed mathematical justification as to its form.

### My solution

My proposed curve (defined for combo *x* lying between 0 and the maximum possible combo *M*) has the form

<p align="center">
    <img src="https://user-images.githubusercontent.com/22407662/107047003-3923e400-67bf-11eb-8218-52680c7f24d4.gif">
</p>

where I have chosen suitable values for parameters `μ = 930.58` and `β = 969.16` in this PR. This leads to the proposed code

```C#
(Math.Exp(-Math.Exp((930.58 - scoreMaxCombo) / 969.16)) - 0.073373) / (Math.Exp(-Math.Exp((930.58 - Attributes.MaxCombo) / 969.16)) - 0.073373)
```

An **interactive plot** of this (and the current curve) can be found at https://www.desmos.com/calculator/csnjbbt7os. Notice in particular how the shape of the proposed curve (in green) changes when the map length *M* is adjusted. The curve is more forgiving of near-full (fractional) combo scores the longer the map. Compared with the current curve, such scores are buffed for very long maps, slightly nerfed for short maps, and treated similarly to present for maps of length approximately 2000.

#### Mathematical justification

The following justification is based on the underlying assumptions that hitting notes remains uniformly difficult throughout a map and that hitting a note is independent of hitting any other. While these assumptions are clearly false for real maps, they are probably necessary for a model of combo which is robust enough to be applied to every map and yet simple enough to be implemented here. We then hope to extract a somewhat reasonable model of combo from these simplifications.

We wish to derive the probability that the length of the longest run of successful hits (the combo) is *x* out of the total of *M* notes. The cumulative distribution (CDF) of this (giving the probability that the longest run is of at most length *x*) will then be our combo scaling curve. Unfortunately for us, the exact solution to the longest run problem is highly nontrivial, so we must attempt to approximate it using only simple functions.

In short, the trick is to consider the lengths of runs of hits comprising a score as a sequence of geometrically distributed random variables (modelled by the probability of a number of consecutive hits before a miss occurs), the maximum of which is then the longest run. One can apply the [Fisher–Tippett–Gnedenko theorem](https://en.wikipedia.org/wiki/Fisher%E2%80%93Tippett%E2%80%93Gnedenko_theorem) to see that the longest run is modelled by a [Gumbel distribution](https://en.wikipedia.org/wiki/Gumbel_distribution) in the asymptotic limit of large *M* (long maps). It also happens to be very well-approximated by this distribution for relatively small *M* (of the order of short maps). For more information on the approximation, see the article [[1][ref1]]. The CDF for the Gumbel distribution (truncated for combos between 0 and *M*) has exactly the form proposed, with location and scale parameters *μ* and *β* respectively.

The values for *μ* and *β* I chose to use for this PR were estimated from the mean and standard deviation (*m* and *s* sliders on the interactive plot) of combos achieved on maps at least 3000 objects in length, using the data available at https://data.ppy.sh/. I believe this choice of parameters indeed gives pleasing results, as shown by example player profiles.

### Example results

Here are some example profiles of notable players showing the proposed changes (generated using [`osu-tools`](https://github.com/ppy/osu-tools)):

[aetrna.txt](https://github.com/ppy/osu/files/5933106/aetrna.txt)
[Andros.txt](https://github.com/ppy/osu/files/5933122/Andros.txt)
[ASecretBox.txt](https://github.com/ppy/osu/files/5933123/ASecretBox.txt)
[BTMC.txt](https://github.com/ppy/osu/files/5933125/BTMC.txt)
[chocomint.txt](https://github.com/ppy/osu/files/5933126/chocomint.txt)
[Karthy.txt](https://github.com/ppy/osu/files/5933112/Karthy.txt)
[Mathi.txt](https://github.com/ppy/osu/files/5933111/Mathi.txt)
[mrekk.txt](https://github.com/ppy/osu/files/5933103/mrekk.txt)
[RyuK.txt](https://github.com/ppy/osu/files/5933110/RyuK.txt)
[Spare.txt](https://github.com/ppy/osu/files/5933115/Spare.txt)
[Vaxei.txt](https://github.com/ppy/osu/files/5933108/Vaxei.txt)
[WhiteCat.txt](https://github.com/ppy/osu/files/5933100/WhiteCat.txt)

### References

[1] Schilling, M.F., 2012. The surprising predictability of long runs. [Mathematics Magazine, 85(2), pp.141-149][ref1].

[ref1]: https://doi.org/10.4169/math.mag.85.2.141