### PR TITLE
Refactor to encapsulate strain logic into Skill class

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchDifficultyCalculator.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty
     {
         private const double star_scaling_factor = 0.153;
 
-        protected override int SectionLength => 750;
-
         private float halfCatcherWidth;
 
         public CatchDifficultyCalculator(Ruleset ruleset, WorkingBeatmap beatmap)

--- a/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
 
         protected override double DecayWeight => 0.94;
 
+        protected override int SectionLength => 750;
+
         protected readonly float HalfCatcherWidth;
 
         private float? lastPlayerPosition;

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -7,7 +7,6 @@ using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Mania.Difficulty.Skills
 {
@@ -36,7 +35,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
         protected override double StrainValueOf(DifficultyHitObject current)
         {
             var maniaCurrent = (ManiaDifficultyHitObject)current;
-            var endTime = maniaCurrent.BaseObject.GetEndTime();
+            var endTime = maniaCurrent.EndTime;
             var column = maniaCurrent.BaseObject.Column;
 
             double holdFactor = 1.0; // Factor to all additional strains in case something else is held
@@ -46,7 +45,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             for (int i = 0; i < holdEndTimes.Length; ++i)
             {
                 // If there is at least one other overlapping end or note, then we get an addition, buuuuuut...
-                if (Precision.DefinitelyBigger(holdEndTimes[i], maniaCurrent.BaseObject.StartTime, 1) && Precision.DefinitelyBigger(endTime, holdEndTimes[i], 1))
+                if (Precision.DefinitelyBigger(holdEndTimes[i], maniaCurrent.StartTime, 1) && Precision.DefinitelyBigger(endTime, holdEndTimes[i], 1))
                     holdAddition = 1.0;
 
                 // ... this addition only is valid if there is _no_ other note with the same ending. Releasing multiple notes at the same time is just as easy as releasing 1

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -133,11 +133,16 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         {
             List<double> peaks = new List<double>();
 
-            for (int i = 0; i < colour.StrainPeaks.Count; i++)
+            var colourPeaks = colour.GetCurrentStrainPeaks().ToList();
+            var rhythmPeaks = rhythm.GetCurrentStrainPeaks().ToList();
+            var staminaRightPeaks = staminaRight.GetCurrentStrainPeaks().ToList();
+            var staminaLeftPeaks = staminaLeft.GetCurrentStrainPeaks().ToList();
+
+            for (int i = 0; i < colourPeaks.Count; i++)
             {
-                double colourPeak = colour.StrainPeaks[i] * colour_skill_multiplier;
-                double rhythmPeak = rhythm.StrainPeaks[i] * rhythm_skill_multiplier;
-                double staminaPeak = (staminaRight.StrainPeaks[i] + staminaLeft.StrainPeaks[i]) * stamina_skill_multiplier * staminaPenalty;
+                double colourPeak = colourPeaks[i] * colour_skill_multiplier;
+                double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier;
+                double staminaPeak = (staminaRightPeaks[i] + staminaLeftPeaks[i]) * stamina_skill_multiplier * staminaPenalty;
                 peaks.Add(norm(2, colourPeak, rhythmPeak, staminaPeak));
             }
 

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -16,11 +16,6 @@ namespace osu.Game.Rulesets.Difficulty
 {
     public abstract class DifficultyCalculator
     {
-        /// <summary>
-        /// The length of each strain section.
-        /// </summary>
-        protected virtual int SectionLength => 400;
-
         private readonly Ruleset ruleset;
         private readonly WorkingBeatmap beatmap;
 
@@ -71,31 +66,13 @@ namespace osu.Game.Rulesets.Difficulty
 
             var difficultyHitObjects = SortObjects(CreateDifficultyHitObjects(beatmap, clockRate)).ToList();
 
-            double sectionLength = SectionLength * clockRate;
-
-            // The first object doesn't generate a strain, so we begin with an incremented section end
-            double currentSectionEnd = Math.Ceiling(beatmap.HitObjects.First().StartTime / sectionLength) * sectionLength;
-
-            foreach (DifficultyHitObject h in difficultyHitObjects)
+            foreach (var hitObject in difficultyHitObjects)
             {
-                while (h.BaseObject.StartTime > currentSectionEnd)
+                foreach (var skill in skills)
                 {
-                    foreach (Skill s in skills)
-                    {
-                        s.SaveCurrentPeak();
-                        s.StartNewSectionFrom(currentSectionEnd / clockRate);
-                    }
-
-                    currentSectionEnd += sectionLength;
+                    skill.Process(hitObject);
                 }
-
-                foreach (Skill s in skills)
-                    s.Process(h);
             }
-
-            // The peak strain will not be saved for the last section in the above loop
-            foreach (Skill s in skills)
-                s.SaveCurrentPeak();
 
             return CreateDifficultyAttributes(beatmap, mods, skills, clockRate);
         }

--- a/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
+++ b/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Difficulty.Preprocessing
         public readonly HitObject LastObject;
 
         /// <summary>
-        /// Amount of time elapsed between <see cref="BaseObject"/> and <see cref="LastObject"/>.
+        /// Amount of time elapsed between <see cref="BaseObject"/> and <see cref="LastObject"/>, adjusted by clockrate.
         /// </summary>
         public readonly double DeltaTime;
 


### PR DESCRIPTION
This PR is part of #11407 which I have split into 4 smaller PRs for the sake of backporting to osu-stable in smaller chunks.
- Add a list of mods to `Skill` class (#11687)
- Implement dynamic previous hitobject retention for `Skill` class (#11688)
- Refactor to encapsulate strain logic into `Skill` class (#11689)
    - Refactor to abstract out strain logic into `StrainSkill` class (#11690, branched from #11689)

# Changes

- Refactors to encapsulate the strain logic into the `Skill` class rather than at the `DifficultyCalculator` level

# Reason

As strains are an implementation detail of the current skill calculations, it makes sense that strain related logic should be encapsulated within the `Skill` class.

Depends on #11849