### PR TITLE
Adjust osu! autoplay generation to ensure constant SPM with rate-changing mods

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModAutoplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Replays;
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModAutoplay : ModAutoplay<CatchHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "osu!salad!" } },
             Replay = new CatchAutoGenerator(beatmap).Generate(),

--- a/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModCinema.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Replays;
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModCinema : ModCinema<CatchHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "osu!salad!" } },
             Replay = new CatchAutoGenerator(beatmap).Generate(),

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModAutoplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModAutoplay : ModAutoplay<ManiaHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "osu!topus!" } },
             Replay = new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(),

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCinema.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
@@ -13,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModCinema : ModCinema<ManiaHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "osu!topus!" } },
             Replay = new ManiaAutoGenerator((ManiaBeatmap)beatmap).Generate(),

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Skinning.Default;
+using osu.Game.Rulesets.Osu.UI;
+
+namespace osu.Game.Rulesets.Osu.Tests.Mods
+{
+    public class TestSceneOsuModAutoplay : OsuModTestScene
+    {
+        [Test]
+        public void TestSpmUnaffectedByRateAdjust()
+            => runSpmTest(new OsuModDaycore
+            {
+                SpeedChange = { Value = 0.88 }
+            });
+
+        [Test]
+        public void TestSpmUnaffectedByTimeRamp()
+            => runSpmTest(new ModWindUp
+            {
+                InitialRate = { Value = 0.7 },
+                FinalRate = { Value = 1.3 }
+            });
+
+        private void runSpmTest(Mod mod)
+        {
+            SpinnerSpmCounter spmCounter = null;
+
+            CreateModTest(new ModTestData
+            {
+                Autoplay = true,
+                Mod = mod,
+                Beatmap = new Beatmap
+                {
+                    HitObjects =
+                    {
+                        new Spinner
+                        {
+                            Duration = 2000,
+                            Position = OsuPlayfield.BASE_SIZE / 2
+                        }
+                    }
+                },
+                PassCondition = () => Player.ScoreProcessor.JudgedHits >= 1
+            });
+
+            AddUntilStep("fetch SPM counter", () =>
+            {
+                spmCounter = this.ChildrenOfType<SpinnerSpmCounter>().SingleOrDefault();
+                return spmCounter != null;
+            });
+
+            AddUntilStep("SPM is correct", () => Precision.AlmostEquals(spmCounter.SpinsPerMinute, 477, 5));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Replays;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
@@ -65,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private class TestAutoMod : OsuModAutoplay
         {
-            public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+            public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
             {
                 ScoreInfo = new ScoreInfo { User = new User { Username = "Autoplay" } },
                 Replay = new MissingAutoGenerator(beatmap).Generate()

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
             {
                 ScoreInfo = new ScoreInfo { User = new User { Username = "Autoplay" } },
-                Replay = new MissingAutoGenerator(beatmap).Generate()
+                Replay = new MissingAutoGenerator(beatmap, mods).Generate()
             };
         }
 
@@ -78,8 +78,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             public new OsuBeatmap Beatmap => (OsuBeatmap)base.Beatmap;
 
-            public MissingAutoGenerator(IBeatmap beatmap)
-                : base(beatmap)
+            public MissingAutoGenerator(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+                : base(beatmap, mods)
             {
             }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -62,8 +62,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             inputManager.AllowUserCursorMovement = false;
 
             // Generate the replay frames the cursor should follow
-            var mods = (IReadOnlyList<Mod>)drawableRuleset.Dependencies.Get(typeof(IReadOnlyList<Mod>));
-            replayFrames = new OsuAutoGenerator(drawableRuleset.Beatmap, mods).Generate().Frames.Cast<OsuReplayFrame>().ToList();
+            replayFrames = new OsuAutoGenerator(drawableRuleset.Beatmap, drawableRuleset.Mods).Generate().Frames.Cast<OsuReplayFrame>().ToList();
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -62,7 +62,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             inputManager.AllowUserCursorMovement = false;
 
             // Generate the replay frames the cursor should follow
-            replayFrames = new OsuAutoGenerator(drawableRuleset.Beatmap).Generate().Frames.Cast<OsuReplayFrame>().ToList();
+            var mods = (IReadOnlyList<Mod>)drawableRuleset.Dependencies.Get(typeof(IReadOnlyList<Mod>));
+            replayFrames = new OsuAutoGenerator(drawableRuleset.Beatmap, mods).Generate().Frames.Cast<OsuReplayFrame>().ToList();
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "Autoplay" } },
-            Replay = new OsuAutoGenerator(beatmap).Generate()
+            Replay = new OsuAutoGenerator(beatmap, mods).Generate()
         };
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutoplay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModAutopilot)).Append(typeof(OsuModSpunOut)).ToArray();
 
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "Autoplay" } },
             Replay = new OsuAutoGenerator(beatmap).Generate()

--- a/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "Autoplay" } },
-            Replay = new OsuAutoGenerator(beatmap).Generate()
+            Replay = new OsuAutoGenerator(beatmap, mods).Generate()
         };
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModCinema.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModAutopilot)).Append(typeof(OsuModSpunOut)).ToArray();
 
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "Autoplay" } },
             Replay = new OsuAutoGenerator(beatmap).Generate()

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -35,11 +35,6 @@ namespace osu.Game.Rulesets.Osu.Replays
 
         #region Constants
 
-        /// <summary>
-        /// The "reaction time" in ms between "seeing" a new hit object and moving to "react" to it.
-        /// </summary>
-        private readonly double reactionTime;
-
         private readonly HitWindows defaultHitWindows;
 
         /// <summary>
@@ -54,9 +49,6 @@ namespace osu.Game.Rulesets.Osu.Replays
         public OsuAutoGenerator(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(beatmap, mods)
         {
-            // Already superhuman, but still somewhat realistic
-            reactionTime = ApplyModsToRate(100);
-
             defaultHitWindows = new OsuHitWindows();
             defaultHitWindows.SetDifficulty(Beatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty);
         }
@@ -242,7 +234,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             OsuReplayFrame lastFrame = (OsuReplayFrame)Frames[^1];
 
             // Wait until Auto could "see and react" to the next note.
-            double waitTime = h.StartTime - Math.Max(0.0, h.TimePreempt - reactionTime);
+            double waitTime = h.StartTime - Math.Max(0.0, h.TimePreempt - getReactionTime(h.StartTime - h.TimePreempt));
 
             if (waitTime > lastFrame.Time)
             {
@@ -252,7 +244,7 @@ namespace osu.Game.Rulesets.Osu.Replays
 
             Vector2 lastPosition = lastFrame.Position;
 
-            double timeDifference = ApplyModsToTime(h.StartTime - lastFrame.Time);
+            double timeDifference = ApplyModsToTimeDelta(lastFrame.Time, h.StartTime);
 
             // Only "snap" to hitcircles if they are far enough apart. As the time between hitcircles gets shorter the snapping threshold goes up.
             if (timeDifference > 0 && // Sanity checks
@@ -260,7 +252,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                  timeDifference >= 266)) // ... or the beats are slow enough to tap anyway.
             {
                 // Perform eased movement
-                for (double time = lastFrame.Time + FrameDelay; time < h.StartTime; time += FrameDelay)
+                for (double time = lastFrame.Time + GetFrameDelay(lastFrame.Time); time < h.StartTime; time += GetFrameDelay(time))
                 {
                     Vector2 currentPosition = Interpolation.ValueAt(time, lastPosition, targetPos, lastFrame.Time, h.StartTime, easing);
                     AddFrameToReplay(new OsuReplayFrame((int)time, new Vector2(currentPosition.X, currentPosition.Y)) { Actions = lastFrame.Actions });
@@ -273,6 +265,14 @@ namespace osu.Game.Rulesets.Osu.Replays
                 buttonIndex++;
             }
         }
+
+        /// <summary>
+        /// Calculates the "reaction time" in ms between "seeing" a new hit object and moving to "react" to it.
+        /// </summary>
+        /// <remarks>
+        /// Already superhuman, but still somewhat realistic.
+        /// </remarks>
+        private double getReactionTime(double timeInstant) => ApplyModsToRate(timeInstant, 100);
 
         // Add frames to click the hitobject
         private void addHitObjectClickFrames(OsuHitObject h, Vector2 startPosition, float spinnerDirection)
@@ -343,17 +343,23 @@ namespace osu.Game.Rulesets.Osu.Replays
                     float angle = radius == 0 ? 0 : MathF.Atan2(difference.Y, difference.X);
 
                     double t;
+                    double previousFrame = h.StartTime;
 
-                    for (double j = h.StartTime + FrameDelay; j < spinner.EndTime; j += FrameDelay)
+                    for (double nextFrame = h.StartTime + GetFrameDelay(h.StartTime); nextFrame < spinner.EndTime; nextFrame += GetFrameDelay(nextFrame))
                     {
-                        t = ApplyModsToTime(j - h.StartTime) * spinnerDirection;
+                        t = ApplyModsToTimeDelta(previousFrame, nextFrame) * spinnerDirection;
+                        angle += (float)t / 20;
 
-                        Vector2 pos = SPINNER_CENTRE + CirclePosition(t / 20 + angle, SPIN_RADIUS);
-                        AddFrameToReplay(new OsuReplayFrame((int)j, new Vector2(pos.X, pos.Y), action));
+                        Vector2 pos = SPINNER_CENTRE + CirclePosition(angle, SPIN_RADIUS);
+                        AddFrameToReplay(new OsuReplayFrame((int)nextFrame, new Vector2(pos.X, pos.Y), action));
+
+                        previousFrame = nextFrame;
                     }
 
-                    t = ApplyModsToTime(spinner.EndTime - h.StartTime) * spinnerDirection;
-                    Vector2 endPosition = SPINNER_CENTRE + CirclePosition(t / 20 + angle, SPIN_RADIUS);
+                    t = ApplyModsToTimeDelta(previousFrame, spinner.EndTime) * spinnerDirection;
+                    angle += (float)t / 20;
+
+                    Vector2 endPosition = SPINNER_CENTRE + CirclePosition(angle, SPIN_RADIUS);
 
                     AddFrameToReplay(new OsuReplayFrame(spinner.EndTime, new Vector2(endPosition.X, endPosition.Y), action));
 
@@ -361,7 +367,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                     break;
 
                 case Slider slider:
-                    for (double j = FrameDelay; j < slider.Duration; j += FrameDelay)
+                    for (double j = GetFrameDelay(slider.StartTime); j < slider.Duration; j += GetFrameDelay(slider.StartTime + j))
                     {
                         Vector2 pos = slider.StackedPositionAt(j / slider.Duration);
                         AddFrameToReplay(new OsuReplayFrame(h.StartTime + j, new Vector2(pos.X, pos.Y), action));

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -6,10 +6,12 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Osu.Objects;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Game.Replays;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Scoring;
@@ -49,8 +51,8 @@ namespace osu.Game.Rulesets.Osu.Replays
 
         #region Construction / Initialisation
 
-        public OsuAutoGenerator(IBeatmap beatmap)
-            : base(beatmap)
+        public OsuAutoGenerator(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            : base(beatmap, mods)
         {
             // Already superhuman, but still somewhat realistic
             reactionTime = ApplyModsToRate(100);

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
@@ -5,6 +5,7 @@ using osuTK;
 using osu.Game.Beatmaps;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.UI;
@@ -23,33 +24,61 @@ namespace osu.Game.Rulesets.Osu.Replays
 
         public const float SPIN_RADIUS = 50;
 
-        /// <summary>
-        /// The time in ms between each ReplayFrame.
-        /// </summary>
-        protected readonly double FrameDelay;
-
         #endregion
 
         #region Construction / Initialisation
 
         protected Replay Replay;
         protected List<ReplayFrame> Frames => Replay.Frames;
+        private readonly IReadOnlyList<IApplicableToRate> timeAffectingMods;
 
         protected OsuAutoGeneratorBase(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(beatmap)
         {
             Replay = new Replay();
 
-            // We are using ApplyModsToRate and not ApplyModsToTime to counteract the speed up / slow down from HalfTime / DoubleTime so that we remain at a constant framerate of 60 fps.
-            FrameDelay = ApplyModsToRate(1000.0 / 60.0);
+            timeAffectingMods = mods.OfType<IApplicableToRate>().ToList();
         }
 
         #endregion
 
         #region Utilities
 
-        protected double ApplyModsToTime(double v) => v;
-        protected double ApplyModsToRate(double v) => v;
+        /// <summary>
+        /// Returns the real duration of time between <paramref name="startTime"/> and <paramref name="endTime"/>
+        /// after applying rate-affecting mods.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be used when <paramref name="startTime"/> and <paramref name="endTime"/> are very close.
+        /// That is because the track rate might be changing with time,
+        /// and the method used here is a rough instantaneous approximation.
+        /// </remarks>
+        /// <param name="startTime">The start time of the time delta, in original track time.</param>
+        /// <param name="endTime">The end time of the time delta, in original track time.</param>
+        protected double ApplyModsToTimeDelta(double startTime, double endTime)
+        {
+            double delta = endTime - startTime;
+
+            foreach (var mod in timeAffectingMods)
+                delta /= mod.ApplyToRate(startTime);
+
+            return delta;
+        }
+
+        protected double ApplyModsToRate(double time, double rate)
+        {
+            foreach (var mod in timeAffectingMods)
+                rate = mod.ApplyToRate(time, rate);
+            return rate;
+        }
+
+        /// <summary>
+        /// Calculates the interval after which the next <see cref="ReplayFrame"/> should be generated,
+        /// in milliseconds.
+        /// </summary>
+        /// <param name="time">The time of the previous frame.</param>
+        protected double GetFrameDelay(double time)
+            => ApplyModsToRate(time, 1000.0 / 60);
 
         private class ReplayFrameComparer : IComparer<ReplayFrame>
         {

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
@@ -6,6 +6,7 @@ using osu.Game.Beatmaps;
 using System;
 using System.Collections.Generic;
 using osu.Game.Replays;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Replays;
 
@@ -34,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Replays
         protected Replay Replay;
         protected List<ReplayFrame> Frames => Replay.Frames;
 
-        protected OsuAutoGeneratorBase(IBeatmap beatmap)
+        protected OsuAutoGeneratorBase(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(beatmap)
         {
             Replay = new Replay();

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModAutoplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModAutoplay : ModAutoplay<TaikoHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "mekkadosu!" } },
             Replay = new TaikoAutoGenerator(beatmap).Generate(),

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModCinema.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModCinema : ModCinema<TaikoHitObject>
     {
-        public override Score CreateReplayScore(IBeatmap beatmap) => new Score
+        public override Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => new Score
         {
             ScoreInfo = new ScoreInfo { User = new User { Username = "mekkadosu!" } },
             Replay = new TaikoAutoGenerator(beatmap).Generate(),

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = Beatmap.Value.GetPlayableBeatmap(ruleset.RulesetInfo, Array.Empty<Mod>());
 
-            return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod()?.CreateReplayScore(beatmap));
+            return new ScoreAccessibleReplayPlayer(ruleset.GetAutoplayMod()?.CreateReplayScore(beatmap, Array.Empty<Mod>()));
         }
 
         protected override void AddCheckSteps()

--- a/osu.Game/Rulesets/Mods/IApplicableToRate.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToRate.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Mods
+{
+    /// <summary>
+    /// Interface that should be implemented by mods that affect the track playback speed,
+    /// and in turn, values of the track rate.
+    /// </summary>
+    public interface IApplicableToRate : IApplicableToAudio
+    {
+        /// <summary>
+        /// Returns the playback rate at <paramref name="time"/> after this mod is applied.
+        /// </summary>
+        /// <param name="time">The time instant at which the playback rate is queried.</param>
+        /// <param name="rate">The playback rate before applying this mod.</param>
+        /// <returns>The playback rate after applying this mod.</returns>
+        double ApplyToRate(double time, double rate = 1);
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -15,7 +16,11 @@ namespace osu.Game.Rulesets.Mods
     public abstract class ModAutoplay<T> : ModAutoplay, IApplicableToDrawableRuleset<T>
         where T : HitObject
     {
-        public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset) => drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap));
+        public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
+        {
+            var mods = (IReadOnlyList<Mod>)drawableRuleset.Dependencies.Get(typeof(IReadOnlyList<Mod>));
+            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, mods));
+        }
     }
 
     public abstract class ModAutoplay : Mod, IApplicableFailOverride
@@ -35,6 +40,11 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool HasImplementation => GetType().GenericTypeArguments.Length == 0;
 
+        [Obsolete("Use the mod-supporting override")] // can be removed 20210731
         public virtual Score CreateReplayScore(IBeatmap beatmap) => new Score { Replay = new Replay() };
+
+#pragma warning disable 618
+        public virtual Score CreateReplayScore(IBeatmap beatmap, IReadOnlyList<Mod> mods) => CreateReplayScore(beatmap);
+#pragma warning restore 618
     }
 }

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -18,8 +18,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {
-            var mods = (IReadOnlyList<Mod>)drawableRuleset.Dependencies.Get(typeof(IReadOnlyList<Mod>));
-            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, mods));
+            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, drawableRuleset.Mods));
         }
     }
 

--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
@@ -15,8 +14,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {
-            var mods = (IReadOnlyList<Mod>)drawableRuleset.Dependencies.Get(typeof(IReadOnlyList<Mod>));
-            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, mods));
+            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, drawableRuleset.Mods));
 
             // AlwaysPresent required for hitsounds
             drawableRuleset.Playfield.AlwaysPresent = true;

--- a/osu.Game/Rulesets/Mods/ModCinema.cs
+++ b/osu.Game/Rulesets/Mods/ModCinema.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
@@ -14,7 +15,8 @@ namespace osu.Game.Rulesets.Mods
     {
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<T> drawableRuleset)
         {
-            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap));
+            var mods = (IReadOnlyList<Mod>)drawableRuleset.Dependencies.Get(typeof(IReadOnlyList<Mod>));
+            drawableRuleset.SetReplayScore(CreateReplayScore(drawableRuleset.Beatmap, mods));
 
             // AlwaysPresent required for hitsounds
             drawableRuleset.Playfield.AlwaysPresent = true;

--- a/osu.Game/Rulesets/Mods/ModRateAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModRateAdjust.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.Audio;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModRateAdjust : Mod, IApplicableToAudio
+    public abstract class ModRateAdjust : Mod, IApplicableToRate
     {
         public abstract BindableNumber<double> SpeedChange { get; }
 
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Mods
         {
             sample.AddAdjustment(AdjustableProperty.Frequency, SpeedChange);
         }
+
+        public double ApplyToRate(double time, double rate) => rate * SpeedChange.Value;
 
         public override string SettingDescription => SpeedChange.IsDefault ? string.Empty : $"{SpeedChange.Value:N2}x";
     }

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -79,7 +79,9 @@ namespace osu.Game.Rulesets.Mods
         {
             double amount = (time - beginRampTime) / Math.Max(1, finalRateTime - beginRampTime);
             double ramp = InitialRate.Value + (FinalRate.Value - InitialRate.Value) * Math.Clamp(amount, 0, 1);
-            return rate * ramp;
+
+            // round the end result to match the bindable SpeedChange's precision, in case this is called externally.
+            return rate * Math.Round(ramp, 2);
         }
 
         public virtual void Update(Playfield playfield)

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -14,7 +14,7 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModTimeRamp : Mod, IUpdatableByPlayfield, IApplicableToBeatmap, IApplicableToAudio
+    public abstract class ModTimeRamp : Mod, IUpdatableByPlayfield, IApplicableToBeatmap, IApplicableToRate
     {
         /// <summary>
         /// The point in the beatmap at which the final ramping rate should be reached.
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Mods
         protected ModTimeRamp()
         {
             // for preview purpose at song select. eventually we'll want to be able to update every frame.
-            FinalRate.BindValueChanged(val => applyRateAdjustment(1), true);
+            FinalRate.BindValueChanged(val => applyRateAdjustment(double.PositiveInfinity), true);
             AdjustPitch.BindValueChanged(applyPitchAdjustment);
         }
 
@@ -75,17 +75,22 @@ namespace osu.Game.Rulesets.Mods
             finalRateTime = firstObjectStart + FINAL_RATE_PROGRESS * (lastObjectEnd - firstObjectStart);
         }
 
+        public double ApplyToRate(double time, double rate = 1)
+        {
+            double amount = (time - beginRampTime) / Math.Max(1, finalRateTime - beginRampTime);
+            double ramp = InitialRate.Value + (FinalRate.Value - InitialRate.Value) * Math.Clamp(amount, 0, 1);
+            return rate * ramp;
+        }
+
         public virtual void Update(Playfield playfield)
         {
-            applyRateAdjustment((track.CurrentTime - beginRampTime) / Math.Max(1, finalRateTime - beginRampTime));
+            applyRateAdjustment(track.CurrentTime);
         }
 
         /// <summary>
-        /// Adjust the rate along the specified ramp
+        /// Adjust the rate along the specified ramp.
         /// </summary>
-        /// <param name="amount">The amount of adjustment to apply (from 0..1).</param>
-        private void applyRateAdjustment(double amount) =>
-            SpeedChange.Value = InitialRate.Value + (FinalRate.Value - InitialRate.Value) * Math.Clamp(amount, 0, 1);
+        private void applyRateAdjustment(double time) => SpeedChange.Value = ApplyToRate(time);
 
         private void applyPitchAdjustment(ValueChangedEvent<bool> adjustPitchSetting)
         {

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.UI
         protected IRulesetConfigManager Config { get; private set; }
 
         [Cached(typeof(IReadOnlyList<Mod>))]
-        protected override IReadOnlyList<Mod> Mods { get; }
+        public sealed override IReadOnlyList<Mod> Mods { get; }
 
         private FrameStabilityContainer frameStabilityContainer;
 
@@ -434,7 +434,7 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// The mods which are to be applied.
         /// </summary>
-        protected abstract IReadOnlyList<Mod> Mods { get; }
+        public abstract IReadOnlyList<Mod> Mods { get; }
 
         /// <summary>~
         /// The associated ruleset.


### PR DESCRIPTION
Closes #10283.

A few notes to explain things:

The first thing that this PR does to achieve its end result is allow autoplay implementations to access the list of mods used to generate the autoplay replay for. I've gone ahead and marked the old `CreateReplayScore()` method as obsolete in favour of the one that accepts mods - consumers can always ignore the mods. Curious if you agree with this choice, and I'll split this part of the PR (essentially the first commit) on request.

Secondly, most of the pieces in place to achieve this (the same way that stable seems to do) were in place already in `OsuAutoGeneratorBase`, in the way of two methods: `ApplyModsToRate(double)` and `ApplyModsToTime(double)`. Unfortunately, `ModTimeRamp` - which was not in stable - is a major complication to these methods, as the track rate in it depends on track time, which kills the simple calculations.

I've managed to somewhat salvage that structure by moving stuff around. All call sites of `ApplyModsToRate()` now need to accept a track time instant to be able to transform time correctly - in particular some things that were constants previously, now can't be for exactly that reason, and are usually replaced with private/protected methods that calculate these constants for a given time instant (see `FrameDelay` and `reactionTime`).

The worse part was `ApplyModsToTime()`. The transformation of track time to real time for `ModTimeRamp` is - I'm pretty sure - non-linear. [I thought I had the formula for it right](https://github.com/ppy/osu/issues/10283#issuecomment-771241482), but it was just slightly off, and it was inscrutable anyway. Thankfully today I realised there is an alternative - because all usages of that method were usually called on time *deltas*, not actual time instants, then I can perform a local approximation for that delta by just dividing by the track rate at a given time instant. It's not perfectly correct, but seems to work well enough in practice.

I've both tested this manually [on this map](https://osu.ppy.sh/beatmapsets/679738) and added automated test cases. Note that scrubbing the replay will break this because it's presumably playing back past frames with a future rate, but that's a separate issue and this pull is too large as-is to meaningfully address that anyway.