### PR TITLE
Fix attributes header not being aligned with content in editor timing mode

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -74,7 +74,8 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 new TableColumn(string.Empty, Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
                 new TableColumn("Time", Anchor.Centre, new Dimension(GridSizeMode.AutoSize)),
-                new TableColumn("Attributes", Anchor.Centre),
+                new TableColumn(),
+                new TableColumn("Attributes", Anchor.CentreLeft),
             };
 
             return columns.ToArray();
@@ -93,6 +94,7 @@ namespace osu.Game.Screens.Edit.Timing
                 Text = group.Time.ToEditorFormattedString(),
                 Font = OsuFont.GetFont(size: text_size, weight: FontWeight.Bold)
             },
+            null,
             new ControlGroupAttributes(group),
         };
 
@@ -108,7 +110,6 @@ namespace osu.Game.Screens.Edit.Timing
                 {
                     RelativeSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
-                    Padding = new MarginPadding(10),
                     Spacing = new Vector2(2)
                 };
 

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             public ControlGroupAttributes(ControlPointGroup group)
             {
+                RelativeSizeAxes = Axes.Both;
                 InternalChild = fill = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Instead of centering a column and hacking content alignment with zero size, just have two columns distribute (one being blank) and the other one anchored to the left.

| Before | After (aligned and last attribute on-screen is visible) |
| --- | --- |
| ![osu_2021-02-08_01-40-10](https://user-images.githubusercontent.com/35318437/107202610-3daeef00-69af-11eb-85fe-b800254408f1.png) | ![osu_2021-02-08_01-41-30](https://user-images.githubusercontent.com/35318437/107202650-47d0ed80-69af-11eb-81bb-8595f2ed537d.jpg) |