### PR TITLE
Fix editor effect attribute tooltip having unnecessary whitespace when only one is enabled

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -151,11 +151,10 @@ namespace osu.Game.Screens.Edit.Timing
                         return new RowAttribute("difficulty", () => $"{difficulty.SpeedMultiplier:n2}x", colour);
 
                     case EffectControlPoint effect:
-                        return new RowAttribute("effect", () => string.Join(" ", new[]
-                        {
+                        return new RowAttribute("effect", () => string.Join(" ",
                             effect.KiaiMode ? "Kiai" : string.Empty,
                             effect.OmitFirstBarLine ? "NoBarLine" : string.Empty
-                        }.Where(s => !string.IsNullOrEmpty(s))), colour);
+                        ).Trim(), colour);
 
                     case SampleControlPoint sample:
                         return new RowAttribute("sample", () => $"{sample.SampleBank} {sample.SampleVolume}%", colour);

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -151,7 +151,11 @@ namespace osu.Game.Screens.Edit.Timing
                         return new RowAttribute("difficulty", () => $"{difficulty.SpeedMultiplier:n2}x", colour);
 
                     case EffectControlPoint effect:
-                        return new RowAttribute("effect", () => $"{(effect.KiaiMode ? "Kiai " : "")}{(effect.OmitFirstBarLine ? "NoBarLine " : "")}", colour);
+                        return new RowAttribute("effect", () => string.Join(" ", new[]
+                        {
+                            effect.KiaiMode ? "Kiai" : string.Empty,
+                            effect.OmitFirstBarLine ? "NoBarLine" : string.Empty
+                        }.Where(s => !string.IsNullOrEmpty(s))), colour);
 
                     case SampleControlPoint sample:
                         return new RowAttribute("sample", () => $"{sample.SampleBank} {sample.SampleVolume}%", colour);


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![osu!_2IlaAXWRjs](https://user-images.githubusercontent.com/35318437/107264220-91ddc180-69f7-11eb-8d22-f718111d9ca8.jpg) | ![dotnet_bJNF7q4s4V](https://user-images.githubusercontent.com/35318437/107264335-b33ead80-69f7-11eb-8739-063530d1d8f0.jpg) |