### PR TITLE
Display user global rank for multiplayer room participants

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -105,7 +105,7 @@ namespace osu.Desktop
             if (privacyMode.Value == DiscordRichPresenceMode.Limited)
                 presence.Assets.LargeImageText = string.Empty;
             else
-                presence.Assets.LargeImageText = $"{user.Value.Username}" + (user.Value.Statistics?.Ranks.Global > 0 ? $" (rank #{user.Value.Statistics.Ranks.Global:N0})" : string.Empty);
+                presence.Assets.LargeImageText = $"{user.Value.Username}" + (user.Value.Statistics?.GlobalRank > 0 ? $" (rank #{user.Value.Statistics.GlobalRank:N0})" : string.Empty);
 
             // update ruleset
             presence.Assets.SmallImageKey = ruleset.Value.ID <= 3 ? $"mode_{ruleset.Value.ID}" : "mode_custom";

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         Username = $"User {i}",
                         AllStatistics =
                         {
-                            { Ruleset.Value, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
+                            { Ruleset.Value.ShortName, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
                         },
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                     });
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Username = "User 0",
                     AllStatistics =
                     {
-                        { Ruleset.Value, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
+                        { Ruleset.Value.ShortName, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
                     },
                     CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -158,7 +158,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         Username = $"User {i}",
                         RulesetsStatistics = new Dictionary<string, UserStatistics>
                         {
-                            { Ruleset.Value.ShortName, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
+                            {
+                                Ruleset.Value.ShortName,
+                                new UserStatistics
+                                {
+                                    Ranks = new UserStatistics.UserRanks { Global = RNG.Next(1, 100000) }
+                                }
+                            }
                         },
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                     });
@@ -199,7 +205,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     Username = "User 0",
                     RulesetsStatistics = new Dictionary<string, UserStatistics>
                     {
-                        { Ruleset.Value.ShortName, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
+                        {
+                            Ruleset.Value.ShortName,
+                            new UserStatistics
+                            {
+                                Ranks = new UserStatistics.UserRanks { Global = RNG.Next(1, 100000) }
+                            }
+                        }
                     },
                     CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -155,7 +155,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     {
                         Id = i,
                         Username = $"User {i}",
-                        CurrentModeRank = RNG.Next(1, 100000),
+                        AllStatistics =
+                        {
+                            { Ruleset.Value, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
+                        },
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                     });
 
@@ -193,7 +196,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 {
                     Id = 0,
                     Username = "User 0",
-                    CurrentModeRank = RNG.Next(1, 100000),
+                    AllStatistics =
+                    {
+                        { Ruleset.Value, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
+                    },
                     CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -160,10 +160,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         {
                             {
                                 Ruleset.Value.ShortName,
-                                new UserStatistics
-                                {
-                                    Ranks = new UserStatistics.UserRanks { Global = RNG.Next(1, 100000) }
-                                }
+                                new UserStatistics { GlobalRank = RNG.Next(1, 100000), }
                             }
                         },
                         CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
@@ -207,10 +204,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     {
                         {
                             Ruleset.Value.ShortName,
-                            new UserStatistics
-                            {
-                                Ranks = new UserStatistics.UserRanks { Global = RNG.Next(1, 100000) }
-                            }
+                            new UserStatistics { GlobalRank = RNG.Next(1, 100000), }
                         }
                     },
                     CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -155,7 +156,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     {
                         Id = i,
                         Username = $"User {i}",
-                        AllStatistics =
+                        RulesetsStatistics = new Dictionary<string, UserStatistics>
                         {
                             { Ruleset.Value.ShortName, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
                         },
@@ -196,7 +197,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 {
                     Id = 0,
                     Username = "User 0",
-                    AllStatistics =
+                    RulesetsStatistics = new Dictionary<string, UserStatistics>
                     {
                         { Ruleset.Value.ShortName, new UserStatistics { GlobalRank = RNG.Next(1, 100000) } }
                     },

--- a/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
-                    Ranks = new UserStatistics.UserRanks { Global = 123456 },
+                    GlobalRank = 123456,
                     PP = 12345,
                 };
             });
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
-                    Ranks = new UserStatistics.UserRanks { Global = 89000 },
+                    GlobalRank = 89000,
                     PP = 12345,
                     RankHistory = new User.RankHistoryData
                     {
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
-                    Ranks = new UserStatistics.UserRanks { Global = 89000 },
+                    GlobalRank = 89000,
                     PP = 12345,
                     RankHistory = new User.RankHistoryData
                     {
@@ -105,7 +105,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
-                    Ranks = new UserStatistics.UserRanks { Global = 12000 },
+                    GlobalRank = 12000,
                     PP = 12345,
                     RankHistory = new User.RankHistoryData
                     {
@@ -118,7 +118,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
-                    Ranks = new UserStatistics.UserRanks { Global = 12000 },
+                    GlobalRank = 12000,
                     PP = 12345,
                     RankHistory = new User.RankHistoryData
                     {

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tests.Visual.Online
             Statistics = new UserStatistics
             {
                 GlobalRank = 2148,
-                Ranks = new UserStatistics.UserRanks { Country = 1, },
+                CountryRank = 1,
                 PP = 4567.89m,
                 Level = new UserStatistics.LevelInfo
                 {

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -33,7 +33,8 @@ namespace osu.Game.Tests.Visual.Online
             ProfileOrder = new[] { "me" },
             Statistics = new UserStatistics
             {
-                Ranks = new UserStatistics.UserRanks { Global = 2148, Country = 1 },
+                GlobalRank = 2148,
+                Ranks = new UserStatistics.UserRanks { Country = 1, },
                 PP = 4567.89m,
                 Level = new UserStatistics.LevelInfo
                 {

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -113,11 +113,11 @@ namespace osu.Game.Tournament.Tests
                     },
                     Players =
                     {
-                        new User { Username = "Hello", Statistics = new UserStatistics { Ranks = new UserStatistics.UserRanks { Global = 12 } } },
-                        new User { Username = "Hello", Statistics = new UserStatistics { Ranks = new UserStatistics.UserRanks { Global = 16 } } },
-                        new User { Username = "Hello", Statistics = new UserStatistics { Ranks = new UserStatistics.UserRanks { Global = 20 } } },
-                        new User { Username = "Hello", Statistics = new UserStatistics { Ranks = new UserStatistics.UserRanks { Global = 24 } } },
-                        new User { Username = "Hello", Statistics = new UserStatistics { Ranks = new UserStatistics.UserRanks { Global = 30 } } },
+                        new User { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 12 } },
+                        new User { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 16 } },
+                        new User { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 20 } },
+                        new User { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 24 } },
+                        new User { Username = "Hello", Statistics = new UserStatistics { GlobalRank = 30 } },
                     }
                 }
             },

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Tournament.Models
         {
             get
             {
-                var ranks = Players.Select(p => p.Statistics?.Ranks.Global)
+                var ranks = Players.Select(p => p.Statistics?.GlobalRank)
                                    .Where(i => i.HasValue)
                                    .Select(i => i.Value)
                                    .ToArray();

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                 };
 
                 foreach (var p in team.Players)
-                    fill.Add(new RowDisplay(p.Username, p.Statistics?.Ranks.Global?.ToString("\\##,0") ?? "-"));
+                    fill.Add(new RowDisplay(p.Username, p.Statistics?.GlobalRank?.ToString("\\##,0") ?? "-"));
             }
 
             internal class RowDisplay : CompositeDrawable

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Tournament
             {
                 foreach (var p in t.Players)
                 {
-                    if (string.IsNullOrEmpty(p.Username) || p.Statistics == null)
+                    if (string.IsNullOrEmpty(p.Username) || p.Statistics?.GlobalRank == null)
                     {
                         PopulateUser(p, immediate: true);
                         addedInfo = true;

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Overlays.Profile.Header
 
         private void updateDisplay(User user)
         {
-            hiddenDetailGlobal.Content = user?.Statistics?.Ranks.Global?.ToString("\\##,##0") ?? "-";
+            hiddenDetailGlobal.Content = user?.Statistics?.GlobalRank?.ToString("\\##,##0") ?? "-";
             hiddenDetailCountry.Content = user?.Statistics?.Ranks.Country?.ToString("\\##,##0") ?? "-";
         }
     }

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Overlays.Profile.Header
         private void updateDisplay(User user)
         {
             hiddenDetailGlobal.Content = user?.Statistics?.GlobalRank?.ToString("\\##,##0") ?? "-";
-            hiddenDetailCountry.Content = user?.Statistics?.Ranks.Country?.ToString("\\##,##0") ?? "-";
+            hiddenDetailCountry.Content = user?.Statistics?.CountryRank?.ToString("\\##,##0") ?? "-";
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Overlays.Profile.Header
                 scoreRankInfo.Value.RankCount = user?.Statistics?.GradesCount[scoreRankInfo.Key] ?? 0;
 
             detailGlobalRank.Content = user?.Statistics?.GlobalRank?.ToString("\\##,##0") ?? "-";
-            detailCountryRank.Content = user?.Statistics?.Ranks.Country?.ToString("\\##,##0") ?? "-";
+            detailCountryRank.Content = user?.Statistics?.CountryRank?.ToString("\\##,##0") ?? "-";
 
             rankGraph.Statistics.Value = user?.Statistics;
         }

--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Overlays.Profile.Header
             foreach (var scoreRankInfo in scoreRankInfos)
                 scoreRankInfo.Value.RankCount = user?.Statistics?.GradesCount[scoreRankInfo.Key] ?? 0;
 
-            detailGlobalRank.Content = user?.Statistics?.Ranks.Global?.ToString("\\##,##0") ?? "-";
+            detailGlobalRank.Content = user?.Statistics?.GlobalRank?.ToString("\\##,##0") ?? "-";
             detailCountryRank.Content = user?.Statistics?.Ranks.Country?.ToString("\\##,##0") ?? "-";
 
             rankGraph.Statistics.Value = user?.Statistics;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -164,7 +165,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID);
 
-            var currentModeRank = User.User?.GetStatisticsFor(ruleset)?.GlobalRank;
+            var currentModeRank = User.User?.AllStatistics.GetValueOrDefault(ruleset.ShortName)?.GlobalRank;
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
             userStateDisplay.UpdateStatus(User.State, User.BeatmapAvailability);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             const double fade_time = 50;
 
-            var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID);
+            var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID).CreateInstance();
 
             var currentModeRank = User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.GlobalRank;
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             // If the mods are updated at the end of the frame, the flow container will skip a reflow cycle: https://github.com/ppy/osu-framework/issues/4187
             // This looks particularly jarring here, so re-schedule the update to that start of our frame as a fix.
-            Schedule(() => userModsDisplay.Current.Value = User.Mods.Select(m => m.ToMod(ruleset.CreateInstance())).ToList());
+            Schedule(() => userModsDisplay.Current.Value = User.Mods.Select(m => m.ToMod(ruleset)).ToList());
         }
 
         public MenuItem[] ContextMenuItems

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID);
 
-            var currentModeRank = User.User?.AllStatistics.GetValueOrDefault(ruleset.ShortName)?.GlobalRank;
+            var currentModeRank = User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.GlobalRank;
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
             userStateDisplay.UpdateStatus(User.State, User.BeatmapAvailability);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID);
 
-            var currentModeRank = User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.GlobalRank;
+            var currentModeRank = User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.Ranks.Global;
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
             userStateDisplay.UpdateStatus(User.State, User.BeatmapAvailability);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -165,10 +165,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID);
 
             var currentModeRank = User.User?.GetStatisticsFor(ruleset)?.GlobalRank;
-
-            // fallback to current mode rank for testing purposes.
-            currentModeRank ??= User.User?.CurrentModeRank;
-
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
             userStateDisplay.UpdateStatus(User.State, User.BeatmapAvailability);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
             var ruleset = rulesets.GetRuleset(Room.Settings.RulesetID);
 
-            var currentModeRank = User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.Ranks.Global;
+            var currentModeRank = User.User?.RulesetsStatistics?.GetValueOrDefault(ruleset.ShortName)?.GlobalRank;
             userRankText.Text = currentModeRank != null ? $"#{currentModeRank.Value:N0}" : string.Empty;
 
             userStateDisplay.UpdateStatus(User.State, User.BeatmapAvailability);

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -248,7 +248,7 @@ namespace osu.Game.Users
         /// <summary>
         /// Retrieves the user statistics for a certain ruleset.
         /// If user is fetched from a <see cref="GetUserRequest"/>,
-        /// this will always return null, use <see cref="Statistics"/> instead.
+        /// this will always return empty instance, use <see cref="Statistics"/> instead.
         /// </summary>
         /// <param name="ruleset">The ruleset to retrieve statistics for.</param>
         // todo: this should likely be moved to a separate UserCompact class at some point.
@@ -263,7 +263,7 @@ namespace osu.Game.Users
         private UserStatistics parseStatisticsFor(RulesetInfo ruleset)
         {
             if (!(otherProperties.TryGetValue($"statistics_{ruleset.ShortName}", out var token)))
-                return null;
+                return new UserStatistics();
 
             var settings = JsonSerializableExtensions.CreateGlobalSettings();
             settings.DefaultValueHandling = DefaultValueHandling.Include;

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -267,9 +267,7 @@ namespace osu.Game.Users
             if (!(otherProperties.TryGetValue($"statistics_{ruleset.ShortName}", out var token)))
                 return new UserStatistics();
 
-            var settings = JsonSerializableExtensions.CreateGlobalSettings();
-            settings.DefaultValueHandling = DefaultValueHandling.Include;
-            return token.ToObject<UserStatistics>(JsonSerializer.Create(settings));
+            return token.ToObject<UserStatistics>(JsonSerializer.Create(JsonSerializableExtensions.CreateGlobalSettings()));
         }
 
         public override string ToString() => Username;

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -243,7 +243,10 @@ namespace osu.Game.Users
         [JsonExtensionData]
         private readonly IDictionary<string, JToken> otherProperties = new Dictionary<string, JToken>();
 
-        private readonly Dictionary<RulesetInfo, UserStatistics> statisticsCache = new Dictionary<RulesetInfo, UserStatistics>();
+        /// <summary>
+        /// Map for ruleset with their associated user statistics, can be altered for testing purposes.
+        /// </summary>
+        internal readonly Dictionary<RulesetInfo, UserStatistics> AllStatistics = new Dictionary<RulesetInfo, UserStatistics>();
 
         /// <summary>
         /// Retrieves the user statistics for a certain ruleset.
@@ -254,10 +257,10 @@ namespace osu.Game.Users
         // todo: this should likely be moved to a separate UserCompact class at some point.
         public UserStatistics GetStatisticsFor(RulesetInfo ruleset)
         {
-            if (statisticsCache.TryGetValue(ruleset, out var existing))
+            if (AllStatistics.TryGetValue(ruleset, out var existing))
                 return existing;
 
-            return statisticsCache[ruleset] = parseStatisticsFor(ruleset);
+            return AllStatistics[ruleset] = parseStatisticsFor(ruleset);
         }
 
         private UserStatistics parseStatisticsFor(RulesetInfo ruleset)

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -185,9 +185,8 @@ namespace osu.Game.Users
         private UserStatistics statistics;
 
         /// <summary>
-        /// The user statistics of the ruleset specified within the API request.
-        /// If the user is fetched from a <see cref="GetUsersRequest"/> or similar
-        /// (i.e. is a user compact instance), use <see cref="GetStatisticsFor"/> instead.
+        /// User statistics for the requested ruleset (in the case of a <see cref="GetUserRequest"/> response).
+        /// Otherwise empty.
         /// </summary>
         [JsonProperty(@"statistics")]
         public UserStatistics Statistics

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -5,12 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using osu.Framework.Bindables;
-using osu.Game.IO.Serialization;
 using osu.Game.Online.API.Requests;
 
 namespace osu.Game.Users
@@ -243,22 +240,9 @@ namespace osu.Game.Users
         /// Otherwise empty. Can be altered for testing purposes.
         /// </summary>
         // todo: this should likely be moved to a separate UserCompact class at some point.
-        [UsedImplicitly]
-        public readonly Dictionary<string, UserStatistics> AllStatistics = new Dictionary<string, UserStatistics>();
-
-        [UsedImplicitly]
-        [JsonExtensionData]
-        private readonly IDictionary<string, JToken> otherProperties = new Dictionary<string, JToken>();
-
-        [OnDeserialized]
-        private void onDeserialized(StreamingContext context)
-        {
-            foreach (var kvp in otherProperties.Where(kvp => kvp.Key.StartsWith("statistics_", StringComparison.Ordinal)))
-            {
-                var shortName = kvp.Key.Replace("statistics_", string.Empty);
-                AllStatistics[shortName] = kvp.Value.ToObject<UserStatistics>(JsonSerializer.Create(JsonSerializableExtensions.CreateGlobalSettings()));
-            }
-        }
+        [JsonProperty("statistics_rulesets")]
+        [CanBeNull]
+        public Dictionary<string, UserStatistics> RulesetsStatistics { get; set; }
 
         public override string ToString() => Username;
 

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -39,6 +39,9 @@ namespace osu.Game.Users
             set => CountryRank = value.Country;
         }
 
+        // populated via User model, as that's where the data currently lives.
+        public RankHistoryData RankHistory;
+
         [JsonProperty(@"pp")]
         public decimal? PP;
 
@@ -117,14 +120,12 @@ namespace osu.Game.Users
             }
         }
 
+#pragma warning disable 649
         private struct UserRanks
         {
-#pragma warning disable 649
             [JsonProperty(@"country")]
             public int? Country;
-#pragma warning restore 649
         }
-
-        public RankHistoryData RankHistory;
+#pragma warning restore 649
     }
 }

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Newtonsoft.Json;
-using osu.Game.Online.API.Requests;
 using osu.Game.Scoring;
 using osu.Game.Utils;
 using static osu.Game.Users.User;
@@ -27,24 +26,22 @@ namespace osu.Game.Users
             public int Progress;
         }
 
-        /// <remarks>
-        /// This must only be used when coming from condensed user responses (e.g. from <see cref="GetUsersRequest"/>), otherwise use <code>Ranks.Global</code>.
-        /// </remarks>
-        // todo: this should likely be moved to a separate UserStatisticsCompact class at some point.
+        [JsonProperty(@"rank")]
+        public UserRanks Ranks;
+
+        // eventually UserRanks object will be completely replaced with separate global and country rank properties, see https://github.com/ppy/osu-web/blob/cb79bb72186c8f1a25f6a6f5ef315123decb4231/app/Transformers/UserStatisticsTransformer.php#L53.
+        // but for now, always point UserRanks.Global to the global_rank property, as that is included solely for requests like GetUsersRequest.
         [JsonProperty(@"global_rank")]
-        public int? GlobalRank;
-
-        [JsonProperty(@"pp")]
-        public decimal? PP;
-
-        [JsonProperty(@"pp_rank")] // the API sometimes only returns this value in condensed user responses
-        private int? rank
+        private int? globalRank
         {
             set => Ranks.Global = value;
         }
 
-        [JsonProperty(@"rank")]
-        public UserRanks Ranks;
+        [JsonProperty(@"pp")]
+        public decimal? PP;
+
+        [JsonProperty(@"pp_rank")]
+        public int PPRank;
 
         [JsonProperty(@"ranked_score")]
         public long RankedScore;

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -122,8 +122,10 @@ namespace osu.Game.Users
 
         private struct UserRanks
         {
+#pragma warning disable 649
             [JsonProperty(@"country")]
             public int? Country;
+#pragma warning restore 649
         }
 
         public RankHistoryData RankHistory;

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -42,9 +42,6 @@ namespace osu.Game.Users
         [JsonProperty(@"pp")]
         public decimal? PP;
 
-        [JsonProperty(@"pp_rank")]
-        public int PPRank;
-
         [JsonProperty(@"ranked_score")]
         public long RankedScore;
 

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -26,16 +26,13 @@ namespace osu.Game.Users
             public int Progress;
         }
 
+        [JsonProperty(@"global_rank")]
+        public int? GlobalRank;
+
+        // eventually UserRanks object will be completely replaced with separate global rank (exists) and country rank properties
+        // see https://github.com/ppy/osu-web/blob/cb79bb72186c8f1a25f6a6f5ef315123decb4231/app/Transformers/UserStatisticsTransformer.php#L53.
         [JsonProperty(@"rank")]
         public UserRanks Ranks;
-
-        // eventually UserRanks object will be completely replaced with separate global and country rank properties, see https://github.com/ppy/osu-web/blob/cb79bb72186c8f1a25f6a6f5ef315123decb4231/app/Transformers/UserStatisticsTransformer.php#L53.
-        // but for now, always point UserRanks.Global to the global_rank property, as that is included solely for requests like GetUsersRequest.
-        [JsonProperty(@"global_rank")]
-        private int? globalRank
-        {
-            set => Ranks.Global = value;
-        }
 
         [JsonProperty(@"pp")]
         public decimal? PP;
@@ -120,9 +117,6 @@ namespace osu.Game.Users
 
         public struct UserRanks
         {
-            [JsonProperty(@"global")]
-            public int? Global;
-
             [JsonProperty(@"country")]
             public int? Country;
         }

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Newtonsoft.Json;
+using osu.Game.Online.API.Requests;
 using osu.Game.Scoring;
 using osu.Game.Utils;
 using static osu.Game.Users.User;
@@ -25,6 +26,13 @@ namespace osu.Game.Users
             [JsonProperty(@"progress")]
             public int Progress;
         }
+
+        /// <remarks>
+        /// This must only be used when coming from condensed user responses (e.g. from <see cref="GetUsersRequest"/>), otherwise use <code>Ranks.Global</code>.
+        /// </remarks>
+        // todo: this should likely be moved to a separate UserStatisticsCompact class at some point.
+        [JsonProperty(@"global_rank")]
+        public int? GlobalRank;
 
         [JsonProperty(@"pp")]
         public decimal? PP;

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -29,10 +29,15 @@ namespace osu.Game.Users
         [JsonProperty(@"global_rank")]
         public int? GlobalRank;
 
-        // eventually UserRanks object will be completely replaced with separate global rank (exists) and country rank properties
-        // see https://github.com/ppy/osu-web/blob/cb79bb72186c8f1a25f6a6f5ef315123decb4231/app/Transformers/UserStatisticsTransformer.php#L53.
+        public int? CountryRank;
+
         [JsonProperty(@"rank")]
-        public UserRanks Ranks;
+        private UserRanks ranks
+        {
+            // eventually that will also become an own json property instead of reading from a `rank` object.
+            // see https://github.com/ppy/osu-web/blob/cb79bb72186c8f1a25f6a6f5ef315123decb4231/app/Transformers/UserStatisticsTransformer.php#L53.
+            set => CountryRank = value.Country;
+        }
 
         [JsonProperty(@"pp")]
         public decimal? PP;
@@ -115,7 +120,7 @@ namespace osu.Game.Users
             }
         }
 
-        public struct UserRanks
+        private struct UserRanks
         {
             [JsonProperty(@"country")]
             public int? Country;


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/11799

![image](https://user-images.githubusercontent.com/22781491/107265668-989b2180-6a55-11eb-8905-3c54e7eb48a9.png)

(first user in above image has not submitted a score, hence no rank displayed; maybe display as `-`?)

For reason why this wasn't appearing, it's because it was relying on `CurrentModeRank`, which isn't passed in condensed user responses coming from `GetUsersRequest` (retrieved by `UserLookupCache`), therefore I've changed it to use the newly added `statistics_{osu/taiko/fruits/mania}` statistics instead.

The added dictionary property for retrieving `UserStatistics` from given ruleset should not exist in `User`, should be in a `UserCompact` class instead, but due to changes appear to be too complicated I've added a todo comment at the very least.

Visual test for this already exists, see `TestSceneMultiplayerParticipantsList.TestManyUsers()`.