### PR TITLE
Share connection logic between SignalR clients

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -12,6 +12,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Online;
+using osu.Game.Online.API;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Osu;
@@ -241,6 +242,12 @@ namespace osu.Game.Tests.Visual.Gameplay
             public TestSpectatorStreamingClient()
                 : base(new DevelopmentEndpointConfiguration())
             {
+            }
+
+            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api)
+            {
+                // do not pass API to prevent attempting failing connections on an actual hub.
+                return base.CreateConnector(name, endpoint, null);
             }
 
             public void StartPlay(int beatmapId)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -233,6 +232,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         public class TestSpectatorStreamingClient : SpectatorStreamingClient
         {
+            protected override IBindable<bool> IsConnected { get; } = new BindableBool(false);
+
             public readonly User StreamingUser = new User { Id = 55, Username = "Test user" };
 
             public new BindableList<int> PlayingUsers => (BindableList<int>)base.PlayingUsers;
@@ -242,11 +243,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             public TestSpectatorStreamingClient()
                 : base(new DevelopmentEndpointConfiguration())
             {
-            }
-
-            protected override Task Connect()
-            {
-                return Task.CompletedTask;
             }
 
             public void StartPlay(int beatmapId)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -232,8 +232,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         public class TestSpectatorStreamingClient : SpectatorStreamingClient
         {
-            protected override IBindable<bool> IsConnected { get; } = new BindableBool(false);
-
             public readonly User StreamingUser = new User { Id = 55, Username = "Test user" };
 
             public new BindableList<int> PlayingUsers => (BindableList<int>)base.PlayingUsers;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -244,11 +244,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
             }
 
-            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api)
-            {
-                // do not pass API to prevent attempting failing connections on an actual hub.
-                return base.CreateConnector(name, endpoint, null);
-            }
+            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api) => null;
 
             public void StartPlay(int beatmapId)
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -95,8 +95,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public class TestMultiplayerStreaming : SpectatorStreamingClient
         {
-            protected override IBindable<bool> IsConnected { get; } = new BindableBool(false);
-
             public new BindableList<int> PlayingUsers => (BindableList<int>)base.PlayingUsers;
 
             private readonly int totalUsers;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -106,11 +106,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 this.totalUsers = totalUsers;
             }
 
-            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api)
-            {
-                // do not pass API to prevent attempting failing connections on an actual hub.
-                return base.CreateConnector(name, endpoint, null);
-            }
+            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api) => null;
 
             public void Start(int beatmapId)
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -96,6 +95,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public class TestMultiplayerStreaming : SpectatorStreamingClient
         {
+            protected override IBindable<bool> IsConnected { get; } = new BindableBool(false);
+
             public new BindableList<int> PlayingUsers => (BindableList<int>)base.PlayingUsers;
 
             private readonly int totalUsers;
@@ -163,8 +164,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     ((ISpectatorClient)this).UserSentFrames(userId, new FrameDataBundle(header, Array.Empty<LegacyReplayFrame>()));
                 }
             }
-
-            protected override Task Connect() => Task.CompletedTask;
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -13,6 +13,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Database;
 using osu.Game.Online;
+using osu.Game.Online.API;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Osu.Scoring;
@@ -103,6 +104,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 : base(new DevelopmentEndpointConfiguration())
             {
                 this.totalUsers = totalUsers;
+            }
+
+            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api)
+            {
+                // do not pass API to prevent attempting failing connections on an actual hub.
+                return base.CreateConnector(name, endpoint, null);
             }
 
             public void Start(int beatmapId)

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -18,7 +18,7 @@ using osu.Game.Online.API;
 namespace osu.Game.Online
 {
     /// <summary>
-    /// A component that maintains over a hub connection between client and server.
+    /// A component that manages the life cycle of a connection to a SignalR Hub.
     /// </summary>
     public class HubClientConnector : IDisposable
     {
@@ -52,7 +52,7 @@ namespace osu.Game.Online
         /// </summary>
         /// <param name="clientName">The name of the client this connector connects for, used for logging.</param>
         /// <param name="endpoint">The endpoint to the hub.</param>
-        /// <param name="api">The API provider for listening to state changes, or null to not listen.</param>
+        /// <param name="api"> An API provider used to react to connection state changes, or null to not establish connection at all (for testing purposes).</param>
         public HubClientConnector(string clientName, string endpoint, IAPIProvider? api)
         {
             this.clientName = clientName;

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Online
     public class HubClientConnector : IDisposable
     {
         /// <summary>
-        /// Invoked whenever a new hub connection is built.
+        /// Invoked whenever a new hub connection is built, to configure it before it's started.
         /// </summary>
         public Action<HubConnection>? ConfigureConnection;
 

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -3,17 +3,11 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
-using osu.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Logging;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 
@@ -21,106 +15,37 @@ namespace osu.Game.Online.Multiplayer
 {
     public class MultiplayerClient : StatefulMultiplayerClient
     {
-        public override IBindable<bool> IsConnected => isConnected;
+        private readonly HubClientConnector connector;
 
-        private readonly Bindable<bool> isConnected = new Bindable<bool>();
-        private readonly IBindable<APIState> apiState = new Bindable<APIState>();
+        public override IBindable<bool> IsConnected => connector.IsConnected;
 
-        private readonly SemaphoreSlim connectionLock = new SemaphoreSlim(1);
-
-        [Resolved]
-        private IAPIProvider api { get; set; } = null!;
-
-        private HubConnection? connection;
-
-        private CancellationTokenSource connectCancelSource = new CancellationTokenSource();
-
-        private readonly string endpoint;
+        private HubConnection? connection => connector.CurrentConnection;
 
         public MultiplayerClient(EndpointConfiguration endpoints)
         {
-            endpoint = endpoints.MultiplayerEndpointUrl;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            apiState.BindTo(api.State);
-            apiState.BindValueChanged(apiStateChanged, true);
-        }
-
-        private void apiStateChanged(ValueChangedEvent<APIState> state)
-        {
-            switch (state.NewValue)
+            InternalChild = connector = new HubClientConnector("Multiplayer client", endpoints.MultiplayerEndpointUrl)
             {
-                case APIState.Failing:
-                case APIState.Offline:
-                    Task.Run(() => disconnect(true));
-                    break;
-
-                case APIState.Online:
-                    Task.Run(connect);
-                    break;
-            }
-        }
-
-        private async Task connect()
-        {
-            cancelExistingConnect();
-
-            if (!await connectionLock.WaitAsync(10000))
-                throw new TimeoutException("Could not obtain a lock to connect. A previous attempt is likely stuck.");
-
-            try
-            {
-                while (api.State.Value == APIState.Online)
+                OnNewConnection = newConnection =>
                 {
-                    // ensure any previous connection was disposed.
-                    // this will also create a new cancellation token source.
-                    await disconnect(false);
-
-                    // this token will be valid for the scope of this connection.
-                    // if cancelled, we can be sure that a disconnect or reconnect is handled elsewhere.
-                    var cancellationToken = connectCancelSource.Token;
-
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    Logger.Log("Multiplayer client connecting...", LoggingTarget.Network);
-
-                    try
-                    {
-                        // importantly, rebuild the connection each attempt to get an updated access token.
-                        connection = createConnection(cancellationToken);
-
-                        await connection.StartAsync(cancellationToken);
-
-                        Logger.Log("Multiplayer client connected!", LoggingTarget.Network);
-                        isConnected.Value = true;
-                        return;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        //connection process was cancelled.
-                        throw;
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.Log($"Multiplayer client connection error: {e}", LoggingTarget.Network);
-
-                        // retry on any failure.
-                        await Task.Delay(5000, cancellationToken);
-                    }
-                }
-            }
-            finally
-            {
-                connectionLock.Release();
-            }
+                    // this is kind of SILLY
+                    // https://github.com/dotnet/aspnetcore/issues/15198
+                    newConnection.On<MultiplayerRoomState>(nameof(IMultiplayerClient.RoomStateChanged), ((IMultiplayerClient)this).RoomStateChanged);
+                    newConnection.On<MultiplayerRoomUser>(nameof(IMultiplayerClient.UserJoined), ((IMultiplayerClient)this).UserJoined);
+                    newConnection.On<MultiplayerRoomUser>(nameof(IMultiplayerClient.UserLeft), ((IMultiplayerClient)this).UserLeft);
+                    newConnection.On<int>(nameof(IMultiplayerClient.HostChanged), ((IMultiplayerClient)this).HostChanged);
+                    newConnection.On<MultiplayerRoomSettings>(nameof(IMultiplayerClient.SettingsChanged), ((IMultiplayerClient)this).SettingsChanged);
+                    newConnection.On<int, MultiplayerUserState>(nameof(IMultiplayerClient.UserStateChanged), ((IMultiplayerClient)this).UserStateChanged);
+                    newConnection.On(nameof(IMultiplayerClient.LoadRequested), ((IMultiplayerClient)this).LoadRequested);
+                    newConnection.On(nameof(IMultiplayerClient.MatchStarted), ((IMultiplayerClient)this).MatchStarted);
+                    newConnection.On(nameof(IMultiplayerClient.ResultsReady), ((IMultiplayerClient)this).ResultsReady);
+                    newConnection.On<int, IEnumerable<APIMod>>(nameof(IMultiplayerClient.UserModsChanged), ((IMultiplayerClient)this).UserModsChanged);
+                },
+            };
         }
 
         protected override Task<MultiplayerRoom> JoinRoom(long roomId)
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.FromCanceled<MultiplayerRoom>(new CancellationToken(true));
 
             return connection.InvokeAsync<MultiplayerRoom>(nameof(IMultiplayerServer.JoinRoom), roomId);
@@ -128,7 +53,7 @@ namespace osu.Game.Online.Multiplayer
 
         protected override Task LeaveRoomInternal()
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.FromCanceled(new CancellationToken(true));
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.LeaveRoom));
@@ -136,7 +61,7 @@ namespace osu.Game.Online.Multiplayer
 
         public override Task TransferHost(int userId)
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.TransferHost), userId);
@@ -144,7 +69,7 @@ namespace osu.Game.Online.Multiplayer
 
         public override Task ChangeSettings(MultiplayerRoomSettings settings)
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeSettings), settings);
@@ -152,7 +77,7 @@ namespace osu.Game.Online.Multiplayer
 
         public override Task ChangeState(MultiplayerUserState newState)
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeState), newState);
@@ -160,7 +85,7 @@ namespace osu.Game.Online.Multiplayer
 
         public override Task ChangeBeatmapAvailability(BeatmapAvailability newBeatmapAvailability)
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeBeatmapAvailability), newBeatmapAvailability);
@@ -168,7 +93,7 @@ namespace osu.Game.Online.Multiplayer
 
         public override Task ChangeUserMods(IEnumerable<APIMod> newMods)
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeUserMods), newMods);
@@ -176,90 +101,10 @@ namespace osu.Game.Online.Multiplayer
 
         public override Task StartMatch()
         {
-            if (!isConnected.Value)
+            if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.StartMatch));
-        }
-
-        private async Task disconnect(bool takeLock)
-        {
-            cancelExistingConnect();
-
-            if (takeLock)
-            {
-                if (!await connectionLock.WaitAsync(10000))
-                    throw new TimeoutException("Could not obtain a lock to disconnect. A previous attempt is likely stuck.");
-            }
-
-            try
-            {
-                if (connection != null)
-                    await connection.DisposeAsync();
-            }
-            finally
-            {
-                connection = null;
-                if (takeLock)
-                    connectionLock.Release();
-            }
-        }
-
-        private void cancelExistingConnect()
-        {
-            connectCancelSource.Cancel();
-            connectCancelSource = new CancellationTokenSource();
-        }
-
-        private HubConnection createConnection(CancellationToken cancellationToken)
-        {
-            var builder = new HubConnectionBuilder()
-                .WithUrl(endpoint, options => { options.Headers.Add("Authorization", $"Bearer {api.AccessToken}"); });
-
-            if (RuntimeInfo.SupportsJIT)
-                builder.AddMessagePackProtocol();
-            else
-            {
-                // eventually we will precompile resolvers for messagepack, but this isn't working currently
-                // see https://github.com/neuecc/MessagePack-CSharp/issues/780#issuecomment-768794308.
-                builder.AddNewtonsoftJsonProtocol(options => { options.PayloadSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; });
-            }
-
-            var newConnection = builder.Build();
-
-            // this is kind of SILLY
-            // https://github.com/dotnet/aspnetcore/issues/15198
-            newConnection.On<MultiplayerRoomState>(nameof(IMultiplayerClient.RoomStateChanged), ((IMultiplayerClient)this).RoomStateChanged);
-            newConnection.On<MultiplayerRoomUser>(nameof(IMultiplayerClient.UserJoined), ((IMultiplayerClient)this).UserJoined);
-            newConnection.On<MultiplayerRoomUser>(nameof(IMultiplayerClient.UserLeft), ((IMultiplayerClient)this).UserLeft);
-            newConnection.On<int>(nameof(IMultiplayerClient.HostChanged), ((IMultiplayerClient)this).HostChanged);
-            newConnection.On<MultiplayerRoomSettings>(nameof(IMultiplayerClient.SettingsChanged), ((IMultiplayerClient)this).SettingsChanged);
-            newConnection.On<int, MultiplayerUserState>(nameof(IMultiplayerClient.UserStateChanged), ((IMultiplayerClient)this).UserStateChanged);
-            newConnection.On(nameof(IMultiplayerClient.LoadRequested), ((IMultiplayerClient)this).LoadRequested);
-            newConnection.On(nameof(IMultiplayerClient.MatchStarted), ((IMultiplayerClient)this).MatchStarted);
-            newConnection.On(nameof(IMultiplayerClient.ResultsReady), ((IMultiplayerClient)this).ResultsReady);
-            newConnection.On<int, IEnumerable<APIMod>>(nameof(IMultiplayerClient.UserModsChanged), ((IMultiplayerClient)this).UserModsChanged);
-
-            newConnection.Closed += ex =>
-            {
-                isConnected.Value = false;
-
-                Logger.Log(ex != null ? $"Multiplayer client lost connection: {ex}" : "Multiplayer client disconnected", LoggingTarget.Network);
-
-                // make sure a disconnect wasn't triggered (and this is still the active connection).
-                if (!cancellationToken.IsCancellationRequested)
-                    Task.Run(connect, default);
-
-                return Task.CompletedTask;
-            };
-            return newConnection;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            cancelExistingConnect();
         }
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Online.Multiplayer
         {
             connector = new HubClientConnector(nameof(MultiplayerClient), endpoint, api)
             {
-                OnNewConnection = connection =>
+                ConfigureConnection = connection =>
                 {
                     // this is kind of SILLY
                     // https://github.com/dotnet/aspnetcore/issues/15198

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -28,7 +28,7 @@ using osu.Game.Utils;
 
 namespace osu.Game.Online.Multiplayer
 {
-    public abstract class StatefulMultiplayerClient : CompositeDrawable, IMultiplayerClient, IMultiplayerRoomServer
+    public abstract class StatefulMultiplayerClient : Component, IMultiplayerClient, IMultiplayerRoomServer
     {
         /// <summary>
         /// Invoked when any change occurs to the multiplayer room.

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -28,7 +28,7 @@ using osu.Game.Utils;
 
 namespace osu.Game.Online.Multiplayer
 {
-    public abstract class StatefulMultiplayerClient : Component, IMultiplayerClient, IMultiplayerRoomServer
+    public abstract class StatefulMultiplayerClient : CompositeDrawable, IMultiplayerClient, IMultiplayerRoomServer
     {
         /// <summary>
         /// Invoked when any change occurs to the multiplayer room.
@@ -97,7 +97,8 @@ namespace osu.Game.Online.Multiplayer
         // Todo: This is temporary, until the multiplayer server returns the item id on match start or otherwise.
         private int playlistItemId;
 
-        protected StatefulMultiplayerClient()
+        [BackgroundDependencyLoader]
+        private void load()
         {
             IsConnected.BindValueChanged(connected =>
             {

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -10,7 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.AspNetCore.SignalR.Client;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Replays.Legacy;
@@ -23,7 +23,7 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.Online.Spectator
 {
-    public class SpectatorStreamingClient : CompositeDrawable, ISpectatorClient
+    public class SpectatorStreamingClient : Component, ISpectatorClient
     {
         /// <summary>
         /// The maximum milliseconds between frame bundle sends.

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Online.Spectator
         private void load(IAPIProvider api)
         {
             connector = CreateConnector(nameof(SpectatorStreamingClient), endpoint, api);
-            connector.OnNewConnection = connection =>
+            connector.ConfigureConnection = connection =>
             {
                 // until strong typed client support is added, each method must be manually bound
                 // (see https://github.com/dotnet/aspnetcore/issues/15198)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11248

Since `MultiplayerClient` inherits `StatefulMultiplayerClient` which should not have connection logic added to, I've decided to instead move the connection logic to a `HubClientConnector` component and let both `MultiplayerClient` and `SpectatorStreamingClient` create one and add to their hierarchy.

`MultiplayerClient` looks nicely clean now with the conneciton logic being moved to a separate component.

Worthy to note:
 - I've moved the binding of `IsConnected` in `StatefulMultiplayerClient` to happen in BDL instead, as previously SMC would eat a null reference exception due to accessing `IsConnected` while `MultiplayerClient` has not created the connector yet. Feels more correct that way anyways.

- [x] Look into stopping test spectator clients from attempting to connect at all.