### PR TITLE
Fix incorrect mod copying behaviour when settings arrive from external change

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -143,7 +143,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         /// Tests that the same <see cref="Mod"/> instances are not shared between two playlist items.
         /// </summary>
         [Test]
-        [Ignore("Temporarily disabled due to a non-trivial test failure")]
         public void TestNewItemHasNewModInstances()
         {
             AddStep("set dt mod", () => SelectedMods.Value = new[] { new OsuModDoubleTime() });

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -87,6 +87,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 Ruleset.Value = new OsuRuleset().RulesetInfo;
                 Beatmap.SetDefault();
+                SelectedMods.Value = Array.Empty<Mod>();
             });
 
             AddStep("create song select", () => LoadScreen(songSelect = new TestPlaylistsSongSelect()));

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -171,6 +171,31 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestExternallySetModIsReplacedByOverlayInstance()
+        {
+            Mod external = new OsuModDoubleTime();
+            Mod overlayButtonMod = null;
+
+            changeRuleset(0);
+
+            AddStep("set mod externally", () => { SelectedMods.Value = new[] { external }; });
+
+            AddAssert("ensure button is selected", () =>
+            {
+                var button = modSelect.GetModButton(SelectedMods.Value.Single());
+                overlayButtonMod = button.SelectedMod;
+                return overlayButtonMod.GetType() == external.GetType();
+            });
+
+            // Right now, when an external change occurs, the ModSelectOverlay will replace the global instance with its own
+            AddAssert("mod instance doesn't match", () => external != overlayButtonMod);
+
+            AddAssert("one mod present in global selected", () => SelectedMods.Value.Count == 1);
+            AddAssert("globally selected matches button's mod instance", () => SelectedMods.Value.Contains(overlayButtonMod));
+            AddAssert("globally selected doesn't contain original external change", () => !SelectedMods.Value.Contains(external));
+        }
+
+        [Test]
         public void TestNonStacked()
         {
             changeRuleset(0);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -171,6 +171,20 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestSettingsAreRetainedOnReload()
+        {
+            changeRuleset(0);
+
+            AddStep("set customized mod externally", () => SelectedMods.Value = new[] { new OsuModDoubleTime { SpeedChange = { Value = 1.01 } } });
+
+            AddAssert("setting remains", () => (SelectedMods.Value.SingleOrDefault() as OsuModDoubleTime)?.SpeedChange.Value == 1.01);
+
+            AddStep("create overlay", () => createDisplay(() => new TestNonStackedModSelectOverlay()));
+
+            AddAssert("setting remains", () => (SelectedMods.Value.SingleOrDefault() as OsuModDoubleTime)?.SpeedChange.Value == 1.01);
+        }
+
+        [Test]
         public void TestExternallySetModIsReplacedByOverlayInstance()
         {
             Mod external = new OsuModDoubleTime();

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -48,6 +48,24 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestSettingsResetOnDeselection()
+        {
+            var osuModDoubleTime = new OsuModDoubleTime { SpeedChange = { Value = 1.2 } };
+
+            changeRuleset(0);
+
+            AddStep("set dt mod with custom rate", () => { SelectedMods.Value = new[] { osuModDoubleTime }; });
+
+            AddAssert("selected mod matches", () => (SelectedMods.Value.Single() as OsuModDoubleTime)?.SpeedChange.Value == 1.2);
+
+            AddStep("deselect", () => modSelect.DeselectAllButton.Click());
+            AddAssert("selected mods empty", () => SelectedMods.Value.Count == 0);
+
+            AddStep("reselect", () => modSelect.GetModButton(osuModDoubleTime).Click());
+            AddAssert("selected mod has default value", () => (SelectedMods.Value.Single() as OsuModDoubleTime)?.SpeedChange.IsDefault == true);
+        }
+
+        [Test]
         public void TestAnimationFlushOnClose()
         {
             changeRuleset(0);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -39,7 +39,11 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [SetUp]
-        public void SetUp() => Schedule(() => createDisplay(() => new TestModSelectOverlay()));
+        public void SetUp() => Schedule(() =>
+        {
+            SelectedMods.Value = Array.Empty<Mod>();
+            createDisplay(() => new TestModSelectOverlay());
+        });
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -370,7 +374,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private void createDisplay(Func<TestModSelectOverlay> createOverlayFunc)
         {
-            SelectedMods.Value = Array.Empty<Mod>();
             Children = new Drawable[]
             {
                 modSelect = createOverlayFunc().With(d =>

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -98,7 +98,14 @@ namespace osu.Game
         [Cached(typeof(IBindable<RulesetInfo>))]
         protected readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
 
-        // todo: move this to SongSelect once Screen has the ability to unsuspend.
+        /// <summary>
+        /// The current mod selection for the local user.
+        /// </summary>
+        /// <remarks>
+        /// If a mod select overlay is present, mod instances set to this value are not guaranteed to remain as the provided instance and will be overwritten by a copy.
+        /// In such a case, changes to settings of a mod will *not* propagate after a mod is added to this collection.
+        /// As such, all settings should be finalised before adding a mod to this collection.
+        /// </remarks>
         [Cached]
         [Cached(typeof(IBindable<IReadOnlyList<Mod>>))]
         protected readonly Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -46,8 +46,9 @@ namespace osu.Game.Overlays.Mods
         /// Change the selected mod index of this button.
         /// </summary>
         /// <param name="newIndex">The new index.</param>
+        /// <param name="resetSettings">Whether any settings applied to the mod should be reset on selection.</param>
         /// <returns>Whether the selection changed.</returns>
-        private bool changeSelectedIndex(int newIndex)
+        private bool changeSelectedIndex(int newIndex, bool resetSettings = true)
         {
             if (newIndex == selectedIndex) return false;
 
@@ -69,7 +70,8 @@ namespace osu.Game.Overlays.Mods
 
             Mod newSelection = SelectedMod ?? Mods[0];
 
-            newSelection.ResetSettingsToDefaults();
+            if (resetSettings)
+                newSelection.ResetSettingsToDefaults();
 
             Schedule(() =>
             {
@@ -211,11 +213,17 @@ namespace osu.Game.Overlays.Mods
             Deselect();
         }
 
-        public bool SelectAt(int index)
+        /// <summary>
+        /// Select the mod at the provided index.
+        /// </summary>
+        /// <param name="index">The index to select.</param>
+        /// <param name="resetSettings">Whether any settings applied to the mod should be reset on selection.</param>
+        /// <returns>Whether the selection changed.</returns>
+        public bool SelectAt(int index, bool resetSettings = true)
         {
             if (!Mods[index].HasImplementation) return false;
 
-            changeSelectedIndex(index);
+            changeSelectedIndex(index, resetSettings);
             return true;
         }
 

--- a/osu.Game/Overlays/Mods/ModButton.cs
+++ b/osu.Game/Overlays/Mods/ModButton.cs
@@ -69,6 +69,8 @@ namespace osu.Game.Overlays.Mods
 
             Mod newSelection = SelectedMod ?? Mods[0];
 
+            newSelection.ResetSettingsToDefaults();
+
             Schedule(() =>
             {
                 if (beforeSelected != Selected)

--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -198,10 +198,10 @@ namespace osu.Game.Overlays.Mods
 
                 var buttonMod = button.Mods[index];
 
-                button.SelectAt(index, false);
-
                 // as this is likely coming from an external change, ensure the settings of the mod are in sync.
                 buttonMod.CopyFrom(mod);
+
+                button.SelectAt(index, false);
                 return;
             }
 

--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -197,9 +197,10 @@ namespace osu.Game.Overlays.Mods
                     continue;
 
                 var buttonMod = button.Mods[index];
-                button.SelectAt(index);
 
-                // the selection above will reset settings to defaults, but as this is an external change we want to copy the new settings across.
+                button.SelectAt(index, false);
+
+                // as this is likely coming from an external change, ensure the settings of the mod are in sync.
                 buttonMod.CopyFrom(mod);
                 return;
             }

--- a/osu.Game/Overlays/Mods/ModSection.cs
+++ b/osu.Game/Overlays/Mods/ModSection.cs
@@ -197,8 +197,10 @@ namespace osu.Game.Overlays.Mods
                     continue;
 
                 var buttonMod = button.Mods[index];
-                buttonMod.CopyFrom(mod);
                 button.SelectAt(index);
+
+                // the selection above will reset settings to defaults, but as this is an external change we want to copy the new settings across.
+                buttonMod.CopyFrom(mod);
                 return;
             }
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -371,8 +371,11 @@ namespace osu.Game.Overlays.Mods
         {
             base.LoadComplete();
 
-            SelectedMods.BindValueChanged(_ => updateSelectedButtons());
             availableMods.BindValueChanged(_ => updateAvailableMods(), true);
+
+            // intentionally bound after the above line to avoid a potential update feedback cycle.
+            // i haven't actually observed this happening but as updateAvailableMods() changes the selection it is plausible.
+            SelectedMods.BindValueChanged(_ => updateSelectedButtons());
         }
 
         protected override void PopOut()

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -371,8 +371,8 @@ namespace osu.Game.Overlays.Mods
         {
             base.LoadComplete();
 
+            SelectedMods.BindValueChanged(_ => updateSelectedButtons());
             availableMods.BindValueChanged(_ => updateAvailableMods(), true);
-            SelectedMods.BindValueChanged(_ => updateSelectedButtons(), true);
         }
 
         protected override void PopOut()

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -479,10 +479,10 @@ namespace osu.Game.Overlays.Mods
             foreach (var section in ModSectionsContainer.Children)
                 section.UpdateSelectedButtons(selectedMods);
 
-            updateMods();
+            updateMultiplier();
         }
 
-        private void updateMods()
+        private void updateMultiplier()
         {
             var multiplier = 1.0;
 

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -173,5 +173,10 @@ namespace osu.Game.Rulesets.Mods
         }
 
         public bool Equals(IMod other) => GetType() == other?.GetType();
+
+        /// <summary>
+        /// Reset all custom settings for this mod back to their defaults.
+        /// </summary>
+        public virtual void ResetSettingsToDefaults() => CopyFrom((Mod)Activator.CreateInstance(GetType()));
     }
 }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Mods
         }
 
         /// <summary>
-        /// Copies mod setting values from <paramref name="source"/> into this instance.
+        /// Copies mod setting values from <paramref name="source"/> into this instance, overwriting all existing settings.
         /// </summary>
         /// <param name="source">The mod to copy properties from.</param>
         public void CopyFrom(Mod source)
@@ -147,9 +147,7 @@ namespace osu.Game.Rulesets.Mods
                 var targetBindable = (IBindable)prop.GetValue(this);
                 var sourceBindable = (IBindable)prop.GetValue(source);
 
-                // we only care about changes that have been made away from defaults.
-                if (!sourceBindable.IsDefault)
-                    CopyAdjustedSetting(targetBindable, sourceBindable);
+                CopyAdjustedSetting(targetBindable, sourceBindable);
             }
         }
 

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -141,5 +141,16 @@ namespace osu.Game.Rulesets.Mods
             ApplySetting(DrainRate, dr => difficulty.DrainRate = dr);
             ApplySetting(OverallDifficulty, od => difficulty.OverallDifficulty = od);
         }
+
+        public override void ResetSettingsToDefaults()
+        {
+            base.ResetSettingsToDefaults();
+
+            if (difficulty != null)
+            {
+                // base implementation potentially overwrite modified defaults that came from a beatmap selection.
+                TransferSettings(difficulty);
+            }
+        }
     }
 }


### PR DESCRIPTION
This attempts to fix an edge case where incoming settings would not be respected if the local user had set a custom setting on a mod which matched the incoming type. Note that this would only happen is a `ModSelectOverlay` was active, as it is responsible for the copying of mods over the local values.

This makes a change to the actual user flow: when a mod is deselected at song select (or anywhere a mod select overlay exists) settings are now restored to the defaults immediately. Previously they would be retained internally by the select overlay, as long as it was still alive. I'm guessing there will be some divide over this change of behaviour, but given that the retention was limited (ie. exiting song select would cause it to no longer apply) this seems like a better/simpler initial direction.

Supersedes and closes https://github.com/ppy/osu/pull/11678.