### PR TITLE
Fix AutoPilot mod failing to block touch input

### DIFF
--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu
 
         protected override bool Handle(UIEvent e)
         {
-            if (e is MouseMoveEvent && !AllowUserCursorMovement) return false;
+            if ((e is MouseMoveEvent || e is TouchMoveEvent) && !AllowUserCursorMovement) return false;
 
             return base.Handle(e);
         }


### PR DESCRIPTION
The mapping from touch to mouse is done in the `base.Handle` call (from `TouchMoveEvent` to `MouseMoveEvent`). The easiest way to block this is to just include the touch events in the early exit conditional.

Closes #11700.