### PR TITLE
Fix a potential crash when exiting play during the results screen transition

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -108,19 +108,19 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestExitTooSoon()
+        public void TestExitSoonAfterResumeSucceeds()
         {
             AddStep("seek before gameplay", () => Player.GameplayClockContainer.Seek(-5000));
 
             pauseAndConfirm();
             resume();
 
-            AddStep("exit too soon", () => Player.Exit());
+            AddStep("exit quick", () => Player.Exit());
 
             confirmClockRunning(true);
             confirmPauseOverlayShown(false);
 
-            AddAssert("not exited", () => Player.IsCurrentScreen());
+            AddAssert("exited", () => !Player.IsCurrentScreen());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -69,13 +69,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for hitobjects", () => Player.HealthProcessor.Health.Value < 1);
 
             pauseAndConfirm();
-
             resume();
+
             confirmPausedWithNoOverlay();
             pauseAndConfirm();
 
             AddUntilStep("resume overlay is not active", () => Player.DrawableRuleset.ResumeOverlay.State.Value == Visibility.Hidden);
             confirmPaused();
+            confirmNotExited();
         }
 
         [Test]
@@ -100,7 +101,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseExternally();
 
             confirmResumed();
-            AddAssert("not exited", () => Player.IsCurrentScreen());
+            confirmNotExited();
         }
 
         [Test]
@@ -114,7 +115,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("pause via exit key", () => Player.ExitViaPause());
 
             confirmResumed();
-            AddAssert("not exited", () => Player.IsCurrentScreen());
+            confirmNotExited();
         }
 
         [Test]
@@ -277,7 +278,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void exitAndConfirm()
         {
-            AddUntilStep("player not exited", () => Player.IsCurrentScreen());
+            confirmNotExited();
             AddStep("exit", () => Player.Exit());
             confirmExited();
             confirmNoTrackAdjustments();
@@ -286,7 +287,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void confirmPaused()
         {
             confirmClockRunning(false);
-            AddAssert("player not exited", () => Player.IsCurrentScreen());
+            confirmNotExited();
             AddAssert("player not failed", () => !Player.HasFailed);
             AddAssert("pause overlay shown", () => Player.PauseOverlayVisible);
         }
@@ -303,10 +304,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             confirmPauseOverlayShown(false);
         }
 
-        private void confirmExited()
-        {
-            AddUntilStep("player exited", () => !Player.IsCurrentScreen());
-        }
+        private void confirmExited() => AddUntilStep("player exited", () => !Player.IsCurrentScreen());
+        private void confirmNotExited() => AddAssert("player not exited", () => Player.IsCurrentScreen());
 
         private void confirmNoTrackAdjustments()
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             confirmClockRunning(false);
 
-            pauseFromUserExitKey();
+            AddStep("pause via forced pause", () => Player.Pause());
 
             confirmPausedWithNoOverlay();
             AddAssert("fail overlay still shown", () => Player.FailOverlayVisible);
@@ -149,11 +149,28 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestExitFromFailedGameplay()
+        public void TestExitFromFailedGameplayAfterFailAnimation()
         {
             AddUntilStep("wait for fail", () => Player.HasFailed);
-            AddStep("exit", () => Player.Exit());
+            AddUntilStep("wait for fail overlay shown", () => Player.FailOverlayVisible);
 
+            confirmClockRunning(false);
+
+            AddStep("exit via user pause", () => Player.ExitViaPause());
+            confirmExited();
+        }
+
+        [Test]
+        public void TestExitFromFailedGameplayDuringFailAnimation()
+        {
+            AddUntilStep("wait for fail", () => Player.HasFailed);
+
+            // will finish the fail animation and show the fail/pause screen.
+            AddStep("attempt exit via pause key", () => Player.ExitViaPause());
+            AddAssert("fail overlay shown", () => Player.FailOverlayVisible);
+
+            // will actually exit.
+            AddStep("exit via pause key", () => Player.ExitViaPause());
             confirmExited();
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -56,9 +56,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseAndConfirm();
             resume();
 
-            confirmClockRunning(false);
-            confirmPauseOverlayShown(false);
-
+            confirmPausedWithNoOverlay();
             AddStep("click to resume", () => InputManager.Click(MouseButton.Left));
 
             confirmClockRunning(true);
@@ -73,9 +71,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseAndConfirm();
 
             resume();
-            confirmClockRunning(false);
-            confirmPauseOverlayShown(false);
-
+            confirmPausedWithNoOverlay();
             pauseAndConfirm();
 
             AddUntilStep("resume overlay is not active", () => Player.DrawableRuleset.ResumeOverlay.State.Value == Visibility.Hidden);
@@ -94,7 +90,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestPauseTooSoon()
+        public void TestPauseDuringCooldownTooSoon()
         {
             AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
 
@@ -103,8 +99,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             resume();
             pause();
 
-            confirmClockRunning(true);
-            confirmPauseOverlayShown(false);
+            confirmResumed();
+            AddAssert("not exited", () => Player.IsCurrentScreen());
         }
 
         [Test]
@@ -117,9 +113,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("exit quick", () => Player.Exit());
 
-            confirmClockRunning(true);
-            confirmPauseOverlayShown(false);
-
+            confirmResumed();
             AddAssert("exited", () => !Player.IsCurrentScreen());
         }
 
@@ -133,9 +127,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             pause();
 
-            confirmClockRunning(false);
-            confirmPauseOverlayShown(false);
-
+            confirmPausedWithNoOverlay();
             AddAssert("fail overlay still shown", () => Player.FailOverlayVisible);
 
             exitAndConfirm();
@@ -274,6 +266,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void confirmResumed()
         {
             confirmClockRunning(true);
+            confirmPauseOverlayShown(false);
+        }
+
+        private void confirmPausedWithNoOverlay()
+        {
+            confirmClockRunning(false);
             confirmPauseOverlayShown(false);
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -90,17 +90,45 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestPauseDuringCooldownTooSoon()
+        public void TestExternalPauseDuringCooldownTooSoon()
         {
             AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
 
             pauseAndConfirm();
 
             resume();
-            pause();
+            pauseExternally();
 
             confirmResumed();
             AddAssert("not exited", () => Player.IsCurrentScreen());
+        }
+
+        [Test]
+        public void TestUserPauseDuringCooldownTooSoon()
+        {
+            AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
+
+            pauseAndConfirm();
+
+            resume();
+            AddStep("pause via exit key", () => Player.ExitViaPause());
+
+            confirmResumed();
+            AddAssert("not exited", () => Player.IsCurrentScreen());
+        }
+
+        [Test]
+        public void TestQuickExitDuringCooldownTooSoon()
+        {
+            AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
+
+            pauseAndConfirm();
+
+            resume();
+            AddStep("pause via exit key", () => Player.ExitViaQuickExit());
+
+            confirmResumed();
+            AddAssert("exited", () => !Player.IsCurrentScreen());
         }
 
         [Test]
@@ -125,7 +153,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             confirmClockRunning(false);
 
-            pause();
+            pauseExternally();
 
             confirmPausedWithNoOverlay();
             AddAssert("fail overlay still shown", () => Player.FailOverlayVisible);
@@ -237,7 +265,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void pauseAndConfirm()
         {
-            pause();
+            pauseExternally();
             confirmPaused();
         }
 
@@ -286,7 +314,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         private void restart() => AddStep("restart", () => Player.Restart());
-        private void pause() => AddStep("pause", () => Player.Pause());
+        private void pauseExternally() => AddStep("pause", () => Player.Pause());
         private void resume() => AddStep("resume", () => Player.Resume());
 
         private void confirmPauseOverlayShown(bool isShown) =>
@@ -304,6 +332,10 @@ namespace osu.Game.Tests.Visual.Gameplay
             public bool FailOverlayVisible => FailOverlay.State.Value == Visibility.Visible;
 
             public bool PauseOverlayVisible => PauseOverlay.State.Value == Visibility.Visible;
+
+            public void ExitViaPause() => PerformExit(true);
+
+            public void ExitViaQuickExit() => PerformExit(false);
 
             public override void OnEntering(IScreen last)
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -91,20 +91,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestExternalPauseDuringCooldownTooSoon()
-        {
-            AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
-
-            pauseAndConfirm();
-
-            resume();
-            pauseExternally();
-
-            confirmResumed();
-            confirmNotExited();
-        }
-
-        [Test]
         public void TestUserPauseDuringCooldownTooSoon()
         {
             AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
@@ -112,7 +98,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             pauseAndConfirm();
 
             resume();
-            AddStep("pause via exit key", () => Player.ExitViaPause());
+            pauseFromUserExitKey();
 
             confirmResumed();
             confirmNotExited();
@@ -154,7 +140,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             confirmClockRunning(false);
 
-            pauseExternally();
+            pauseFromUserExitKey();
 
             confirmPausedWithNoOverlay();
             AddAssert("fail overlay still shown", () => Player.FailOverlayVisible);
@@ -266,7 +252,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void pauseAndConfirm()
         {
-            pauseExternally();
+            pauseFromUserExitKey();
             confirmPaused();
         }
 
@@ -313,7 +299,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         private void restart() => AddStep("restart", () => Player.Restart());
-        private void pauseExternally() => AddStep("pause", () => Player.Pause());
+        private void pauseFromUserExitKey() => AddStep("user pause", () => Player.ExitViaPause());
         private void resume() => AddStep("resume", () => Player.Resume());
 
         private void confirmPauseOverlayShown(bool isShown) =>

--- a/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
+++ b/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
@@ -17,6 +17,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens;
 using osu.Game.Screens.Menu;
@@ -114,6 +115,8 @@ namespace osu.Game.Tests.Visual.Navigation
             public new Bindable<WorkingBeatmap> Beatmap => base.Beatmap;
 
             public new Bindable<RulesetInfo> Ruleset => base.Ruleset;
+
+            public new Bindable<IReadOnlyList<Mod>> SelectedMods => base.SelectedMods;
 
             // if we don't do this, when running under nUnit the version that gets populated is that of nUnit.
             public override string Version => "test game";

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -11,7 +11,9 @@ using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Toolbar;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Options;
 using osu.Game.Tests.Beatmaps.IO;
@@ -39,6 +41,30 @@ namespace osu.Game.Tests.Visual.Navigation
             pushEscape();
             AddAssert("Overlay was hidden", () => songSelect.ModSelectOverlay.State.Value == Visibility.Hidden);
             exitViaEscapeAndConfirm();
+        }
+
+        [Test]
+        public void TestRetryFromResults()
+        {
+            Player player = null;
+            ResultsScreen results = null;
+
+            WorkingBeatmap beatmap() => Game.Beatmap.Value;
+
+            PushAndConfirm(() => new TestSongSelect());
+
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadOszIntoOsu(Game, virtualTrack: true).Wait());
+
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("set autoplay", () => Game.SelectedMods.Value = new[] { new OsuModAutoplay() });
+
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+            AddUntilStep("wait for player", () => (player = Game.ScreenStack.CurrentScreen as Player) != null);
+            AddStep("seek to end", () => beatmap().Track.Seek(beatmap().Track.Length));
+            AddUntilStep("wait for pass", () => (results = Game.ScreenStack.CurrentScreen as ResultsScreen) != null && results.IsLoaded);
+            AddStep("attempt to retry", () => results.ChildrenOfType<HotkeyRetryOverlay>().First().Action());
+            AddUntilStep("wait for player", () => Game.ScreenStack.CurrentScreen != player && Game.ScreenStack.CurrentScreen is Player);
         }
 
         [TestCase(true)]

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -478,11 +478,11 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Exits the <see cref="Player"/>.
         /// </summary>
-        /// <param name="userRequested">
-        /// Whether the exit is requested by the user, or a higher-level game component.
-        /// Pausing is allowed only in the former case.
+        /// <param name="showDialogFirst">
+        /// Whether the pause or fail dialog should be shown before performing an exit.
+        /// If true and a dialog is not yet displayed, the exit will be blocked the the relevant dialog will display instead.
         /// </param>
-        protected void PerformExit(bool userRequested)
+        protected void PerformExit(bool showDialogFirst)
         {
             // if a restart has been requested, cancel any pending completion (user has shown intent to restart).
             completionProgressDelegate?.Cancel();
@@ -495,7 +495,7 @@ namespace osu.Game.Screens.Play
                 this.MakeCurrent();
             }
 
-            if (userRequested)
+            if (showDialogFirst)
             {
                 if (ValidForResume && HasFailed && !FailOverlay.IsPresent)
                 {
@@ -503,7 +503,7 @@ namespace osu.Game.Screens.Play
                     return;
                 }
 
-                if (canPause)
+                if (canPause && !GameplayClockContainer.IsPaused.Value)
                 {
                     Pause();
                     return;
@@ -540,10 +540,7 @@ namespace osu.Game.Screens.Play
             sampleRestart?.Play();
             RestartRequested?.Invoke();
 
-            if (this.IsCurrentScreen())
-                PerformExit(true);
-            else
-                this.MakeCurrent();
+            PerformExit(false);
         }
 
         private ScheduledDelegate completionProgressDelegate;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -503,14 +503,17 @@ namespace osu.Game.Screens.Play
                     return;
                 }
 
-                if (canPause && !GameplayClockContainer.IsPaused.Value)
+                if (!GameplayClockContainer.IsPaused.Value)
                 {
-                    if (pauseCooldownActive && !GameplayClockContainer.IsPaused.Value)
-                        // still want to block if we are within the cooldown period and not already paused.
+                    // if we are within the cooldown period and not already paused, the operation should block completely.
+                    if (pauseCooldownActive)
                         return;
 
-                    Pause();
-                    return;
+                    if (canPause)
+                    {
+                        Pause();
+                        return;
+                    }
                 }
             }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -379,7 +379,7 @@ namespace osu.Game.Screens.Play
                             if (!this.IsCurrentScreen()) return;
 
                             fadeOut(true);
-                            PerformExit(true);
+                            PerformExit(false);
                         },
                     },
                     failAnimation = new FailAnimation(DrawableRuleset) { OnComplete = onFailComplete, },

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -493,6 +493,7 @@ namespace osu.Game.Screens.Play
                 // we want to give the user what they want, so forcefully return to this screen (to proceed with the upwards exit process).
                 ValidForResume = false;
                 this.MakeCurrent();
+                return;
             }
 
             if (showDialogFirst)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -496,12 +496,13 @@ namespace osu.Game.Screens.Play
                 return;
             }
 
-            bool pauseDialogShown = PauseOverlay.State.Value == Visibility.Visible;
+            bool pauseOrFailDialogVisible =
+                PauseOverlay.State.Value == Visibility.Visible || FailOverlay.State.Value == Visibility.Visible;
 
-            if (showDialogFirst && !pauseDialogShown)
+            if (showDialogFirst && !pauseOrFailDialogVisible)
             {
                 // if the fail animation is currently in progress, accelerate it (it will show the pause dialog on completion).
-                if (ValidForResume && HasFailed && !FailOverlay.IsPresent)
+                if (ValidForResume && HasFailed)
                 {
                     failAnimation.FinishTransforms(true);
                     return;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -505,6 +505,10 @@ namespace osu.Game.Screens.Play
 
                 if (canPause && !GameplayClockContainer.IsPaused.Value)
                 {
+                    if (pauseCooldownActive && !GameplayClockContainer.IsPaused.Value)
+                        // still want to block if we are within the cooldown period and not already paused.
+                        return;
+
                     Pause();
                     return;
                 }
@@ -806,14 +810,6 @@ namespace osu.Game.Screens.Play
                 // proceed to result screen if beatmap already finished playing
                 completionProgressDelegate.RunTask();
                 return true;
-            }
-
-            // ValidForResume is false when restarting
-            if (ValidForResume)
-            {
-                if (pauseCooldownActive && !GameplayClockContainer.IsPaused.Value)
-                    // still want to block if we are within the cooldown period and not already paused.
-                    return true;
             }
 
             // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.


### PR DESCRIPTION
The Confirm call in `HoldToConfirmContainer`s is chained to transforms, so it can potentially run during the transition to a new screen. We were guarding against this in the `Restart` flow already, but not the exit flow.

Closes https://github.com/ppy/osu/issues/11682.