### PR TITLE
Defer playlist load to improve load time of the now playing overlay

### DIFF
--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -84,11 +84,6 @@ namespace osu.Game.Overlays
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
-                        playlist = new PlaylistOverlay
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Y = player_height + 10,
-                        },
                         playerContainer = new Container
                         {
                             RelativeSizeAxes = Axes.X,
@@ -171,7 +166,7 @@ namespace osu.Game.Overlays
                                             Anchor = Anchor.CentreRight,
                                             Position = new Vector2(-bottom_black_area_height / 2, 0),
                                             Icon = FontAwesome.Solid.Bars,
-                                            Action = () => playlist.ToggleVisibility(),
+                                            Action = togglePlaylist
                                         },
                                     }
                                 },
@@ -191,12 +186,34 @@ namespace osu.Game.Overlays
             };
         }
 
+        private void togglePlaylist()
+        {
+            if (playlist == null)
+            {
+                LoadComponentAsync(playlist = new PlaylistOverlay
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Y = player_height + 10,
+                }, _ =>
+                {
+                    dragContainer.Add(playlist);
+
+                    playlist.BeatmapSets.BindTo(musicController.BeatmapSets);
+                    playlist.State.BindValueChanged(s => playlistButton.FadeColour(s.NewValue == Visibility.Visible ? colours.Yellow : Color4.White, 200, Easing.OutQuint), true);
+
+                    togglePlaylist();
+                });
+
+                return;
+            }
+
+            if (!beatmap.Disabled)
+                playlist.ToggleVisibility();
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            playlist.BeatmapSets.BindTo(musicController.BeatmapSets);
-            playlist.State.BindValueChanged(s => playlistButton.FadeColour(s.NewValue == Visibility.Visible ? colours.Yellow : Color4.White, 200, Easing.OutQuint), true);
 
             beatmap.BindDisabledChanged(beatmapDisabledChanged, true);
 
@@ -306,7 +323,7 @@ namespace osu.Game.Overlays
         private void beatmapDisabledChanged(bool disabled)
         {
             if (disabled)
-                playlist.Hide();
+                playlist?.Hide();
 
             prevButton.Enabled.Value = !disabled;
             nextButton.Enabled.Value = !disabled;


### PR DESCRIPTION
This removes a multi-second delay for users with many beatmaps loaded. I was hoping to also fix the playlist itself, but this is more involved for two reasons:

- Bindable flow means binding to the remote list in BDL is unsafe. This can be avoided by loading the items once and then performing the actual binding in `LoadComplete` (which will be free if the items haven't changed).
- The actual overhead is not from loading the items alone, but also from `CheckVisibility` being called on each one (see screenshot below). This is actually the expensive part, and will need further consideration. Probably via pooling.

![20210209 194912 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/107353042-ed02d780-6b0f-11eb-92eb-ab39cc7c9667.png)
