### PR TITLE
Fix incorrect header depth in OnlineOverlay

### DIFF
--- a/osu.Game/Overlays/OnlineOverlay.cs
+++ b/osu.Game/Overlays/OnlineOverlay.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            Header,
+                            Header.With(h => h.Depth = -float.MaxValue),
                             content = new Container
                             {
                                 RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/OnlineOverlay.cs
+++ b/osu.Game/Overlays/OnlineOverlay.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            Header.With(h => h.Depth = -float.MaxValue),
+                            Header.With(h => h.Depth = float.MinValue),
                             content = new Container
                             {
                                 RelativeSizeAxes = Axes.X,


### PR DESCRIPTION
Overlooked and removed in https://github.com/ppy/osu/pull/11527/commits/b5fa9508006c76decac0752a6bdaf47598196d4d commit.
master:
![master](https://user-images.githubusercontent.com/22874522/107403391-1d4d7480-6b16-11eb-899a-ff19502885de.png)
this pr:
![pr](https://user-images.githubusercontent.com/22874522/107403402-20e0fb80-6b16-11eb-9344-dc067778fef1.png)
