### PR TITLE
Allow overlays to override generic pop-in/pop-out samples (and specify new samples for certain overlays)

### DIFF
--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Graphics.Containers
     {
         private SampleChannel samplePopIn;
         private SampleChannel samplePopOut;
+        protected virtual string PopInSampleName => "UI/overlay-pop-in";
+        protected virtual string PopOutSampleName => "UI/overlay-pop-out";
 
         protected override bool BlockNonPositionalInput => true;
 
@@ -40,8 +42,8 @@ namespace osu.Game.Graphics.Containers
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio)
         {
-            samplePopIn = audio.Samples.Get(@"UI/overlay-pop-in");
-            samplePopOut = audio.Samples.Get(@"UI/overlay-pop-out");
+            samplePopIn = audio.Samples.Get(PopInSampleName);
+            samplePopOut = audio.Samples.Get(PopOutSampleName);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -14,6 +14,9 @@ namespace osu.Game.Overlays
     {
         private readonly Container dialogContainer;
 
+        protected override string PopInSampleName => "UI/dialog-pop-in";
+        protected override string PopOutSampleName => "UI/dialog-pop-out";
+
         public PopupDialog CurrentDialog { get; private set; }
 
         public DialogOverlay()

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -51,6 +51,9 @@ namespace osu.Game.Overlays
         private Container dragContainer;
         private Container playerContainer;
 
+        protected override string PopInSampleName => "UI/now-playing-pop-in";
+        protected override string PopOutSampleName => "UI/now-playing-pop-out";
+
         /// <summary>
         /// Provide a source for the toolbar height.
         /// </summary>

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -40,6 +40,8 @@ namespace osu.Game.Overlays
 
         private SeekLimitedSearchTextBox searchTextBox;
 
+        protected override string PopInSampleName => "UI/settings-pop-in";
+
         /// <summary>
         /// Provide a source for the toolbar height.
         /// </summary>

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Overlays
 
         protected override bool StartHidden => true;
 
+        protected override string PopInSampleName => "UI/wave-pop-in";
+
         protected WaveOverlayContainer()
         {
             AddInternal(Waves = new WaveContainer


### PR DESCRIPTION
This makes changes to `OsuFocusedOverlayContainer` to allow children to specify their own pop-in/pop-out samples.

Also updates `DialogOverlay`, `NowPlayingOverlay`, `SettingsPanel` and `WaveOverlayContainer` to use new samples through this method.

- [x] Depends on ppy/osu-resources#118