### PR TITLE
Add sounds to notifications

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -106,6 +106,15 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestError()
+        {
+            setState(Visibility.Visible);
+            AddStep(@"error #1", sendErrorNotification);
+            AddAssert("Is visible", () => notificationOverlay.State.Value == Visibility.Visible);
+            checkDisplayedCount(1);
+        }
+
+        [Test]
         public void TestSpam()
         {
             setState(Visibility.Visible);
@@ -179,7 +188,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private void sendBarrage()
         {
-            switch (RNG.Next(0, 4))
+            switch (RNG.Next(0, 5))
             {
                 case 0:
                     sendHelloNotification();
@@ -195,6 +204,10 @@ namespace osu.Game.Tests.Visual.UserInterface
 
                 case 3:
                     sendDownloadProgress();
+                    break;
+
+                case 4:
+                    sendErrorNotification();
                     break;
             }
         }
@@ -212,6 +225,11 @@ namespace osu.Game.Tests.Visual.UserInterface
         private void sendBackgroundNotification()
         {
             notificationOverlay.Post(new BackgroundNotification { Text = @"Welcome to osu!. Enjoy your stay!" });
+        }
+
+        private void sendErrorNotification()
+        {
+            notificationOverlay.Post(new SimpleErrorNotification { Text = @"Rut roh!. Something went wrong!" });
         }
 
         private void sendManyNotifications()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -778,7 +778,7 @@ namespace osu.Game
 
                 if (recentLogCount < short_term_display_limit)
                 {
-                    Schedule(() => notifications.Post(new SimpleNotification
+                    Schedule(() => notifications.Post(new SimpleErrorNotification
                     {
                         Icon = entry.Level == LogLevel.Important ? FontAwesome.Solid.ExclamationCircle : FontAwesome.Solid.Bomb,
                         Text = entry.Message.Truncate(256) + (entry.Exception != null && IsDeployedBuild ? "\n\nThis error has been automatically reported to the devs." : string.Empty),

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Overlays.Notifications
                         closeButton = new CloseButton
                         {
                             Alpha = 0,
-                            Action = Close,
+                            Action = () => Close(),
                             Anchor = Anchor.CentreRight,
                             Origin = Anchor.CentreRight,
                             Margin = new MarginPadding
@@ -167,9 +167,7 @@ namespace osu.Game.Overlays.Notifications
 
         public bool WasClosed;
 
-        public virtual void Close() => Close(true);
-
-        public virtual void Close(bool playSound)
+        public virtual void Close(bool playSound = true)
         {
             if (WasClosed) return;
 

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -3,6 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -39,6 +41,11 @@ namespace osu.Game.Overlays.Notifications
         /// Should we show at the top of our section on display?
         /// </summary>
         public virtual bool DisplayOnTop => true;
+
+        private SampleChannel samplePopIn;
+        private SampleChannel samplePopOut;
+        protected virtual string PopInSampleName => "UI/notification-pop-in";
+        protected virtual string PopOutSampleName => "UI/overlay-pop-out"; // TODO: replace with a unique sample?
 
         protected NotificationLight Light;
         private readonly CloseButton closeButton;
@@ -120,6 +127,13 @@ namespace osu.Game.Overlays.Notifications
             });
         }
 
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            samplePopIn = audio.Samples.Get(PopInSampleName);
+            samplePopOut = audio.Samples.Get(PopOutSampleName);
+        }
+
         protected override bool OnHover(HoverEvent e)
         {
             closeButton.FadeIn(75);
@@ -143,6 +157,9 @@ namespace osu.Game.Overlays.Notifications
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            samplePopIn?.Play();
+
             this.FadeInFromZero(200);
             NotificationContent.MoveToX(DrawSize.X);
             NotificationContent.MoveToX(0, 500, Easing.OutQuint);
@@ -150,11 +167,16 @@ namespace osu.Game.Overlays.Notifications
 
         public bool WasClosed;
 
-        public virtual void Close()
+        public virtual void Close() => Close(true);
+
+        public virtual void Close(bool playSound)
         {
             if (WasClosed) return;
 
             WasClosed = true;
+
+            if (playSound)
+                samplePopOut?.Play();
 
             Closed?.Invoke();
             this.FadeOut(100);

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -109,7 +109,12 @@ namespace osu.Game.Overlays.Notifications
 
         private void clearAll()
         {
-            notifications.Children.ForEach(c => c.Close());
+            bool playSound = true;
+            notifications.Children.ForEach(c =>
+            {
+                c.Close(playSound);
+                playSound = false;
+            });
         }
 
         protected override void Update()

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -109,11 +109,11 @@ namespace osu.Game.Overlays.Notifications
 
         private void clearAll()
         {
-            bool playSound = true;
+            bool first = true;
             notifications.Children.ForEach(c =>
             {
-                c.Close(playSound);
-                playSound = false;
+                c.Close(first);
+                first = false;
             });
         }
 

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -150,12 +150,12 @@ namespace osu.Game.Overlays.Notifications
             colourCancelled = colours.Red;
         }
 
-        public override void Close()
+        public override void Close(bool playSound = true)
         {
             switch (State)
             {
                 case ProgressNotificationState.Cancelled:
-                    base.Close();
+                    base.Close(playSound);
                     break;
 
                 case ProgressNotificationState.Active:

--- a/osu.Game/Overlays/Notifications/SimpleErrorNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleErrorNotification.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Game.Overlays.Notifications
+{
+    public class SimpleErrorNotification : SimpleNotification
+    {
+        protected override string PopInSampleName => "UI/error-notification-pop-in";
+
+        public SimpleErrorNotification()
+        {
+            Icon = FontAwesome.Solid.Bomb;
+        }
+    }
+}


### PR DESCRIPTION
This also adds a `SimpleErrorNotification` subclass that plays a unique "error" sound instead of the default notification sound.

- [x] Depends on ppy/osu-resources#118