### PR TITLE
Prevent the default on-click sample from playing for OsuCheckbox

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Graphics.UserInterface
                     RelativeSizeAxes = Axes.X,
                 },
                 Nub = new Nub(),
-                new HoverClickSounds()
+                new HoverSounds()
             };
 
             if (nubOnRight)


### PR DESCRIPTION
Prevents two overlapping samples playing when you click a checkbox