### PR TITLE
Make server authoritative in which mods the client should be using when gameplay starts

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             managerUpdated = beatmapManager.ItemUpdated.GetBoundCopy();
             managerUpdated.BindValueChanged(beatmapUpdated);
 
-            UserMods.BindValueChanged(_ => UpdateMods());
+            UserMods.BindValueChanged(_ => Scheduler.AddOnce(UpdateMods));
         }
 
         public override void OnEntering(IScreen last)
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
         {
             base.OnResuming(last);
             beginHandlingTrack();
-            UpdateMods();
+            Scheduler.AddOnce(UpdateMods);
         }
 
         public override bool OnExiting(IScreen next)

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             managerUpdated = beatmapManager.ItemUpdated.GetBoundCopy();
             managerUpdated.BindValueChanged(beatmapUpdated);
 
-            UserMods.BindValueChanged(_ => updateMods());
+            UserMods.BindValueChanged(_ => UpdateMods());
         }
 
         public override void OnEntering(IScreen last)
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
         {
             base.OnResuming(last);
             beginHandlingTrack();
-            updateMods();
+            UpdateMods();
         }
 
         public override bool OnExiting(IScreen next)
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
                                      .Where(m => SelectedItem.Value.AllowedMods.Any(a => m.GetType() == a.GetType()))
                                      .ToList();
 
-            updateMods();
+            UpdateMods();
 
             Ruleset.Value = SelectedItem.Value.Ruleset.Value;
         }
@@ -145,7 +145,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             Beatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
         }
 
-        private void updateMods()
+        protected virtual void UpdateMods()
         {
             if (SelectedItem.Value == null)
                 return;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -290,7 +290,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return;
 
             // update local mods based on room's reported status for the local user (omitting the base call implementation).
-            // this makes the server authoritative, and avoids the local user potentially settings mods that the server is not aware of (ie. if the match was started during the selection being changed).
+            // this makes the server authoritative, and avoids the local user potentially setting mods that the server is not aware of (ie. if the match was started during the selection being changed).
             var ruleset = Ruleset.Value.CreateInstance();
             Mods.Value = client.LocalUser.Mods.Select(m => m.ToMod(ruleset)).Concat(SelectedItem.Value.RequiredMods).ToList();
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -271,7 +271,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             Playlist.BindCollectionChanged(onPlaylistChanged, true);
             BeatmapAvailability.BindValueChanged(updateBeatmapAvailability, true);
-            UserMods.BindValueChanged(onUserModsChanged);
 
             client.LoadRequested += onLoadRequested;
             client.RoomUpdated += onRoomUpdated;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -271,6 +271,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             Playlist.BindCollectionChanged(onPlaylistChanged, true);
             BeatmapAvailability.BindValueChanged(updateBeatmapAvailability, true);
+            UserMods.BindValueChanged(onUserModsChanged);
 
             client.LoadRequested += onLoadRequested;
             client.RoomUpdated += onRoomUpdated;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -281,6 +281,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }, true);
         }
 
+        protected override void UpdateMods()
+        {
+            if (SelectedItem.Value == null || client.LocalUser == null)
+                return;
+
+            // update local mods based on room's reported status for the local user (omitting the base call implementation).
+            // this makes the server authoritative, and avoids the local user potentially settings mods that the server is not aware of (ie. if the match was started during the selection being changed).
+            var ruleset = Ruleset.Value.CreateInstance();
+            Mods.Value = client.LocalUser.Mods.Select(m => m.ToMod(ruleset)).Concat(SelectedItem.Value.RequiredMods).ToList();
+        }
+
         public override bool OnBackButton()
         {
             if (client.Room != null && settingsOverlay.State.Value == Visibility.Visible)
@@ -370,23 +381,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void onRoomUpdated()
         {
-            UpdateMods(); // user mods may have changed.
-        }
-
-        protected override void UpdateMods()
-        {
-            if (SelectedItem.Value == null || client.LocalUser == null)
-                return;
-
-            // update local mods based on room's reported status for the local user (omitting the base call implementation).
-            // this makes the server authoritative, and avoids the local user potentially settings mods that the server is not aware of (ie. if the match was started during the selection being changed).
-            var localUserMods = client.LocalUser.Mods.ToList();
-
-            Schedule(() =>
-            {
-                var ruleset = Ruleset.Value.CreateInstance();
-                Mods.Value = localUserMods.Select(m => m.ToMod(ruleset)).Concat(SelectedItem.Value.RequiredMods).ToList();
-            });
+            // user mods may have changed.
+            Scheduler.AddOnce(UpdateMods);
         }
 
         private void onLoadRequested()


### PR DESCRIPTION
I noticed while reviewing https://github.com/ppy/osu/pull/11725#issuecomment-777219388 that there was a potential scenario where the client would be using mods that the local user has selected which were never conveyed to the server.

This change intends to handle the case more correctly by applying to the game-wise selected mods what the server is reporting, rather than the imminent selection by the user.