### PR TITLE
Fix osu-web beatmap links not linking to specific beatmap

### DIFF
--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -21,6 +21,21 @@ namespace osu.Game.Tests.Chat
             Assert.AreEqual(36, result.Links[0].Length);
         }
 
+        [TestCase(LinkAction.OpenBeatmap, "456", "https://osu.ppy.sh/beatmapsets/123#osu/456")]
+        [TestCase(LinkAction.OpenBeatmap, "456", "https://osu.ppy.sh/beatmapsets/123#osu/456?whatever")]
+        [TestCase(LinkAction.OpenBeatmap, "456", "https://osu.ppy.sh/beatmapsets/123/456")]
+        [TestCase(LinkAction.OpenBeatmapSet, "123", "https://osu.ppy.sh/beatmapsets/123")]
+        [TestCase(LinkAction.OpenBeatmapSet, "123", "https://osu.ppy.sh/beatmapsets/123/whatever")]
+        public void TestBeatmapLinks(LinkAction expectedAction, string expectedArg, string link)
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = link });
+
+            Assert.AreEqual(result.Content, result.DisplayContent);
+            Assert.AreEqual(1, result.Links.Count);
+            Assert.AreEqual(expectedAction, result.Links[0].Action);
+            Assert.AreEqual(expectedArg, result.Links[0].Argument);
+        }
+
         [Test]
         public void TestMultipleComplexLinks()
         {

--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -24,8 +24,10 @@ namespace osu.Game.Tests.Chat
         [TestCase(LinkAction.OpenBeatmap, "456", "https://osu.ppy.sh/beatmapsets/123#osu/456")]
         [TestCase(LinkAction.OpenBeatmap, "456", "https://osu.ppy.sh/beatmapsets/123#osu/456?whatever")]
         [TestCase(LinkAction.OpenBeatmap, "456", "https://osu.ppy.sh/beatmapsets/123/456")]
+        [TestCase(LinkAction.External, null, "https://osu.ppy.sh/beatmapsets/abc/def")]
         [TestCase(LinkAction.OpenBeatmapSet, "123", "https://osu.ppy.sh/beatmapsets/123")]
         [TestCase(LinkAction.OpenBeatmapSet, "123", "https://osu.ppy.sh/beatmapsets/123/whatever")]
+        [TestCase(LinkAction.External, null, "https://osu.ppy.sh/beatmapsets/abc")]
         public void TestBeatmapLinks(LinkAction expectedAction, string expectedArg, string link)
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = link });
@@ -34,6 +36,8 @@ namespace osu.Game.Tests.Chat
             Assert.AreEqual(1, result.Links.Count);
             Assert.AreEqual(expectedAction, result.Links[0].Action);
             Assert.AreEqual(expectedArg, result.Links[0].Argument);
+            if (expectedAction == LinkAction.External)
+                Assert.AreEqual(link, result.Links[0].Url);
         }
 
         [Test]

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -146,7 +146,10 @@ namespace osu.Game.Online.Chat
 
                                 // https://osu.ppy.sh/beatmapsets/1154158#whatever
                                 string trimmed = mainArg.Split('#').First();
-                                return new LinkDetails(LinkAction.OpenBeatmapSet, trimmed);
+                                if (int.TryParse(trimmed, out id))
+                                    return new LinkDetails(LinkAction.OpenBeatmapSet, id.ToString());
+
+                                break;
                             }
 
                             case "u":


### PR DESCRIPTION
The URL format was not completely supported. This adds test coverage and adds a bit more resilience to the parsing of links, along with supporting the `/beatmapsetid#osu/beatmapid` style link.