### PR TITLE
Fix header background being invisible in multiplayer/playlists

### DIFF
--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
@@ -34,8 +34,8 @@ namespace osu.Game.Beatmaps.Drawables
         /// </summary>
         protected virtual double UnloadDelay => 10000;
 
-        protected override DelayedLoadWrapper CreateDelayedLoadWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad)
-            => new DelayedLoadUnloadWrapper(createContentFunc, timeBeforeLoad, UnloadDelay);
+        protected override DelayedLoadWrapper CreateDelayedLoadWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad) =>
+            new DelayedLoadUnloadWrapper(createContentFunc, timeBeforeLoad, UnloadDelay) { RelativeSizeAxes = Axes.Both };
 
         protected override double TransformDuration => 400;
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/11756

Once again, `IsMaskedAway = true` at the edges of the screen with zero size, causing DLUW to not load.