### PR TITLE
Show URLs in tooltips when custom text has replaced the link

### DIFF
--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -38,7 +38,12 @@ namespace osu.Game.Graphics.Containers
             foreach (var link in links)
             {
                 AddText(text[previousLinkEnd..link.Index]);
-                AddLink(text.Substring(link.Index, link.Length), link.Action, link.Argument ?? link.Url);
+
+                string displayText = text.Substring(link.Index, link.Length);
+                string linkArgument = link.Argument ?? link.Url;
+                string tooltip = displayText == link.Url ? null : link.Url;
+
+                AddLink(displayText, link.Action, linkArgument, tooltip);
                 previousLinkEnd = link.Index + link.Length;
             }
 
@@ -52,7 +57,7 @@ namespace osu.Game.Graphics.Containers
             => createLink(AddText(text, creationParameters), new LinkDetails(LinkAction.Custom, null), tooltipText, action);
 
         public void AddLink(string text, LinkAction action, string argument, string tooltipText = null, Action<SpriteText> creationParameters = null)
-            => createLink(AddText(text, creationParameters), new LinkDetails(action, argument), null);
+            => createLink(AddText(text, creationParameters), new LinkDetails(action, argument), tooltipText);
 
         public void AddLink(IEnumerable<SpriteText> text, LinkAction action = LinkAction.External, string linkArgument = null, string tooltipText = null)
         {


### PR DESCRIPTION
![20210212 153217 (dotnet)](https://user-images.githubusercontent.com/191335/107737337-8cf67600-6d47-11eb-934c-79d5e7094cee.gif)

Closes #11751.