### PR TITLE
Ensure the tournament test runner is ready before performing the test run

### DIFF
--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -163,7 +164,13 @@ namespace osu.Game.Tournament.Tests
                 }));
             }
 
-            public void RunTestBlocking(TestScene test) => runner.RunTestBlocking(test);
+            public void RunTestBlocking(TestScene test)
+            {
+                while (runner?.IsLoaded != true && Host.ExecutionState == ExecutionState.Running)
+                    Thread.Sleep(10);
+
+                runner?.RunTestBlocking(test);
+            }
         }
     }
 }


### PR DESCRIPTION
A bit ugly but seems like the easiest way to resolve this issue. Execution state check is taken from `RunTestBlocking` as a safety measure to avoid endless runs.

Resolves test failures as seen [here](https://ci.appveyor.com/project/peppy/osu/builds/37772315) (regressed in #11762).