### PR TITLE
Move HubClientConnector retrieval to IAPIProvider

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -12,7 +12,6 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Online;
-using osu.Game.Online.API;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Osu;
@@ -243,8 +242,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                 : base(new DevelopmentEndpointConfiguration())
             {
             }
-
-            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api) => null;
 
             public void StartPlay(int beatmapId)
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -13,7 +13,6 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Database;
 using osu.Game.Online;
-using osu.Game.Online.API;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Osu.Scoring;
@@ -105,8 +104,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 this.totalUsers = totalUsers;
             }
-
-            protected override HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api) => null;
 
             public void Start(int beatmapId)
             {

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -243,6 +243,8 @@ namespace osu.Game.Online.API
             this.password = password;
         }
 
+        public IHubClientConnector GetHubConnector(string clientName, string endpoint) => new HubClientConnector(clientName, endpoint, this);
+
         public RegistrationRequest.RegistrationRequestErrors CreateAccount(string email, string username, string password)
         {
             Debug.Assert(State.Value == APIState.Offline);

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -83,6 +83,8 @@ namespace osu.Game.Online.API
             state.Value = APIState.Offline;
         }
 
+        public IHubClientConnector GetHubConnector(string clientName, string endpoint) => null;
+
         public RegistrationRequest.RegistrationRequestErrors CreateAccount(string email, string username, string password)
         {
             Thread.Sleep(200);

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -111,6 +111,6 @@ namespace osu.Game.Online.API
         /// <param name="username">The username to create the account with.</param>
         /// <param name="password">The password to create the account with.</param>
         /// <returns>Any errors encoutnered during account creation.</returns>
-        RegistrationRequest.RegistrationRequestErrors CreateAccount(string email, string username, string password);
+        RegistrationRequest.RegistrationRequestErrors? CreateAccount(string email, string username, string password);
     }
 }

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Game.Users;
@@ -94,6 +96,13 @@ namespace osu.Game.Online.API
         /// Log out the current user.
         /// </summary>
         void Logout();
+
+        /// <summary>
+        /// Constructs a new <see cref="IHubClientConnector"/>. May be null if not supported.
+        /// </summary>
+        /// <param name="clientName">The name of the client this connector connects for, used for logging.</param>
+        /// <param name="endpoint">The endpoint to the hub.</param>
+        IHubClientConnector? GetHubConnector(string clientName, string endpoint);
 
         /// <summary>
         /// Create a new user account. This is a blocking operation.

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -16,15 +16,12 @@ using osu.Game.Online.API;
 
 namespace osu.Game.Online
 {
-    /// <summary>
-    /// A component that manages the life cycle of a connection to a SignalR Hub.
-    /// </summary>
-    public class HubClientConnector : IDisposable
+    public class HubClientConnector : IHubClientConnector
     {
         /// <summary>
         /// Invoked whenever a new hub connection is built, to configure it before it's started.
         /// </summary>
-        public Action<HubConnection>? ConfigureConnection;
+        public Action<HubConnection>? ConfigureConnection { get; set; }
 
         private readonly string clientName;
         private readonly string endpoint;

--- a/osu.Game/Online/IHubClientConnector.cs
+++ b/osu.Game/Online/IHubClientConnector.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using Microsoft.AspNetCore.SignalR.Client;
+using osu.Framework.Bindables;
+using osu.Game.Online.API;
+
+namespace osu.Game.Online
+{
+    /// <summary>
+    /// A component that manages the life cycle of a connection to a SignalR Hub.
+    /// Should generally be retrieved from an <see cref="IAPIProvider"/>.
+    /// </summary>
+    public interface IHubClientConnector : IDisposable
+    {
+        /// <summary>
+        /// The current connection opened by this connector.
+        /// </summary>
+        HubConnection? CurrentConnection { get; }
+
+        /// <summary>
+        /// Whether this is connected to the hub, use <see cref="CurrentConnection"/> to access the connection, if this is <c>true</c>.
+        /// </summary>
+        IBindable<bool> IsConnected { get; }
+
+        /// <summary>
+        /// Invoked whenever a new hub connection is built, to configure it before it's started.
+        /// </summary>
+        public Action<HubConnection>? ConfigureConnection { get; set; }
+    }
+}

--- a/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorStreamingClient.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Online.Spectator
         private readonly string endpoint;
 
         [CanBeNull]
-        private HubClientConnector connector;
+        private IHubClientConnector connector;
 
         private readonly IBindable<bool> isConnected = new BindableBool();
 
@@ -86,7 +86,7 @@ namespace osu.Game.Online.Spectator
         [BackgroundDependencyLoader]
         private void load(IAPIProvider api)
         {
-            connector = CreateConnector(nameof(SpectatorStreamingClient), endpoint, api);
+            connector = api.GetHubConnector(nameof(SpectatorStreamingClient), endpoint);
 
             if (connector != null)
             {
@@ -128,8 +128,6 @@ namespace osu.Game.Online.Spectator
                 }, true);
             }
         }
-
-        protected virtual HubClientConnector CreateConnector(string name, string endpoint, IAPIProvider api) => new HubClientConnector(name, endpoint, api);
 
         Task ISpectatorClient.UserBeganPlaying(int userId, SpectatorState state)
         {


### PR DESCRIPTION
This seems like a more logical way to structure things (and have it automatically handled at a test level).

A future refactor could see the endpoints changed into an enum, and the `GetConnector` call simply taking a single enum (the endpoint and name resolution should be done by the `IAPIProvider`).

Fixes [errors occurring](https://ci.appveyor.com/project/peppy/osu/builds/37746666) due to connection attempts during tests with a token of `token` provided by `DummyAPIAccess` (which is of course invalid).

