### PR TITLE
Send client version hash on hub connection

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Online.API
     {
         private readonly OsuConfigManager config;
 
+        private readonly string versionHash;
+
         private readonly OAuth authentication;
 
         private readonly Queue<APIRequest> queue = new Queue<APIRequest>();
@@ -56,9 +58,10 @@ namespace osu.Game.Online.API
 
         private readonly Logger log;
 
-        public APIAccess(OsuConfigManager config, EndpointConfiguration endpointConfiguration)
+        public APIAccess(OsuConfigManager config, EndpointConfiguration endpointConfiguration, string versionHash)
         {
             this.config = config;
+            this.versionHash = versionHash;
 
             APIEndpointUrl = endpointConfiguration.APIEndpointUrl;
             WebsiteRootUrl = endpointConfiguration.WebsiteRootUrl;
@@ -243,7 +246,7 @@ namespace osu.Game.Online.API
             this.password = password;
         }
 
-        public IHubClientConnector GetHubConnector(string clientName, string endpoint) => new HubClientConnector(clientName, endpoint, this);
+        public IHubClientConnector GetHubConnector(string clientName, string endpoint) => new HubClientConnector(clientName, endpoint, this, versionHash);
 
         public RegistrationRequest.RegistrationRequestErrors CreateAccount(string email, string username, string password)
         {

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Online
 
         private readonly string clientName;
         private readonly string endpoint;
+        private readonly string versionHash;
         private readonly IAPIProvider api;
 
         /// <summary>
@@ -49,11 +50,13 @@ namespace osu.Game.Online
         /// <param name="clientName">The name of the client this connector connects for, used for logging.</param>
         /// <param name="endpoint">The endpoint to the hub.</param>
         /// <param name="api"> An API provider used to react to connection state changes.</param>
-        public HubClientConnector(string clientName, string endpoint, IAPIProvider api)
+        /// <param name="versionHash">The hash representing the current game version, used for verification purposes.</param>
+        public HubClientConnector(string clientName, string endpoint, IAPIProvider api, string versionHash)
         {
             this.clientName = clientName;
             this.endpoint = endpoint;
             this.api = api;
+            this.versionHash = versionHash;
 
             apiState.BindTo(api.State);
             apiState.BindValueChanged(state =>
@@ -129,7 +132,11 @@ namespace osu.Game.Online
         private HubConnection buildConnection(CancellationToken cancellationToken)
         {
             var builder = new HubConnectionBuilder()
-                .WithUrl(endpoint, options => { options.Headers.Add("Authorization", $"Bearer {api.AccessToken}"); });
+                .WithUrl(endpoint, options =>
+                {
+                    options.Headers.Add("Authorization", $"Bearer {api.AccessToken}");
+                    options.Headers.Add("OsuVersionHash", versionHash);
+                });
 
             if (RuntimeInfo.SupportsJIT)
                 builder.AddMessagePackProtocol();

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -228,7 +228,7 @@ namespace osu.Game
 
             MessageFormatter.WebsiteRootUrl = endpoints.WebsiteRootUrl;
 
-            dependencies.CacheAs(API ??= new APIAccess(LocalConfig, endpoints));
+            dependencies.CacheAs(API ??= new APIAccess(LocalConfig, endpoints, VersionHash));
 
             dependencies.CacheAs(spectatorStreaming = new SpectatorStreamingClient(endpoints));
             dependencies.CacheAs(multiplayerClient = new MultiplayerClient(endpoints));


### PR DESCRIPTION
- [x] Depends on #11782

This can be used to limit which versions of the client can connect to hubs, to gracefully obsolete old clients. Not used yet server-side (and won't be until a future release where this is already present in the newest version of the client at least).