### PR TITLE
Fix test failures in PerformFromScreen tests

### DIFF
--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -176,6 +176,7 @@ namespace osu.Game.Overlays.Volume
                     }
                 }
             };
+
             Bindable.ValueChanged += volume =>
             {
                 this.TransformTo("DisplayVolume",
@@ -183,6 +184,7 @@ namespace osu.Game.Overlays.Volume
                     400,
                     Easing.OutQuint);
             };
+
             bgProgress.Current.Value = 0.75f;
         }
 

--- a/osu.Game/Screens/BackgroundScreen.cs
+++ b/osu.Game/Screens/BackgroundScreen.cs
@@ -68,15 +68,19 @@ namespace osu.Game.Screens
 
         public override bool OnExiting(IScreen next)
         {
-            this.FadeOut(transition_length, Easing.OutExpo);
-            this.MoveToX(x_movement_amount, transition_length, Easing.OutExpo);
+            if (IsLoaded)
+            {
+                this.FadeOut(transition_length, Easing.OutExpo);
+                this.MoveToX(x_movement_amount, transition_length, Easing.OutExpo);
+            }
 
             return base.OnExiting(next);
         }
 
         public override void OnResuming(IScreen last)
         {
-            this.MoveToX(0, transition_length, Easing.OutExpo);
+            if (IsLoaded)
+                this.MoveToX(0, transition_length, Easing.OutExpo);
             base.OnResuming(last);
         }
     }


### PR DESCRIPTION
The case causing these failures is `BackgroundScreen`s getting exited before they have finished loading, causing a transform from the *Update* thread, which is deemed invalid as the drawables are not in a loaded state yet.

While attempting to reproduce these I did encounter a couple of other failures, but this is the main one, so prioritising getting it fixed first.

![20210215 171115 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/107921218-91be6280-6fb1-11eb-95aa-f585b21e56f1.png)
