### PR TITLE
Fix comment edited at date not showing tooltip

### DIFF
--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -9,7 +9,6 @@ using osuTK;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Users.Drawables;
 using osu.Game.Graphics.Containers;
-using osu.Game.Utils;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Bindables;
 using System.Linq;
@@ -245,11 +244,32 @@ namespace osu.Game.Overlays.Comments
 
             if (Comment.EditedAt.HasValue)
             {
-                info.Add(new OsuSpriteText
+                var font = OsuFont.GetFont(size: 12, weight: FontWeight.Regular);
+                var colour = colourProvider.Foreground1;
+
+                info.Add(new FillFlowContainer
                 {
-                    Font = OsuFont.GetFont(size: 12, weight: FontWeight.Regular),
-                    Text = $@"edited {HumanizerUtils.Humanize(Comment.EditedAt.Value)} by {Comment.EditedUser.Username}",
-                    Colour = colourProvider.Foreground1
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Font = font,
+                            Text = "edited ",
+                            Colour = colour
+                        },
+                        new DrawableDate(Comment.EditedAt.Value)
+                        {
+                            Font = font,
+                            Colour = colour
+                        },
+                        new OsuSpriteText
+                        {
+                            Font = font,
+                            Text = $@" by {Comment.EditedUser.Username}",
+                            Colour = colour
+                        },
+                    }
                 });
             }
 


### PR DESCRIPTION
Before:
![dotnet_rvUCog3GLB](https://user-images.githubusercontent.com/35318437/108013571-d4d40200-6fc0-11eb-92c8-d66f5198183d.jpg)

After:
![dotnet_BqMRtDCGkT](https://user-images.githubusercontent.com/35318437/108013567-d30a3e80-6fc0-11eb-8162-6f7ef8f8e133.jpg)