### PR TITLE
Fix current selection not updating visually after creating a new playlist

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -69,7 +69,15 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
             rooms.BindTo(roomManager.Rooms);
 
             filter?.BindValueChanged(criteria => Filter(criteria.NewValue));
+
+            selectedRoom.BindValueChanged(selection =>
+            {
+                updateSelection();
+            }, true);
         }
+
+        private void updateSelection() =>
+            roomFlow.Children.ForEach(r => r.State = r.Room == selectedRoom.Value ? SelectionState.Selected : SelectionState.NotSelected);
 
         public void Filter(FilterCriteria criteria)
         {
@@ -125,6 +133,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
             }
 
             Filter(filter?.Value);
+
+            updateSelection();
         }
 
         private void removeRooms(IEnumerable<Room> rooms)
@@ -146,11 +156,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 roomFlow.SetLayoutPosition(room, room.Room.Position.Value);
         }
 
-        private void selectRoom(Room room)
-        {
-            roomFlow.Children.ForEach(r => r.State = r.Room == room ? SelectionState.Selected : SelectionState.NotSelected);
-            selectedRoom.Value = room;
-        }
+        private void selectRoom(Room room) => selectedRoom.Value = room;
 
         private void joinSelected()
         {


### PR DESCRIPTION
Steps to reproduce failure:
- On `master`, create a new playlist
- Exit back to the playlist listing
- Observe the current playlist does not have the selected item border, but a single click will enter it (signifying it *is* in fact selected).