### PR TITLE
Add "free mod" user mod selection support to the playlists system

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -172,7 +172,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
             Ruleset.Value = selected.Ruleset.Value;
 
-            if (selected.AllowedMods.Any() != true)
+            if (!selected.AllowedMods.Any())
             {
                 UserModsSection?.Hide();
                 userModsSelectOverlay.Hide();

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -166,19 +166,21 @@ namespace osu.Game.Screens.OnlinePlay.Match
         {
             updateWorkingBeatmap();
 
-            if (SelectedItem.Value == null)
+            var selected = SelectedItem.Value;
+
+            if (selected == null)
                 return;
 
             // Remove any user mods that are no longer allowed.
             UserMods.Value = UserMods.Value
-                                     .Where(m => SelectedItem.Value.AllowedMods.Any(a => m.GetType() == a.GetType()))
+                                     .Where(m => selected.AllowedMods.Any(a => m.GetType() == a.GetType()))
                                      .ToList();
 
             UpdateMods();
 
-            Ruleset.Value = SelectedItem.Value.Ruleset.Value;
+            Ruleset.Value = selected.Ruleset.Value;
 
-            if (SelectedItem.Value?.AllowedMods.Any() != true)
+            if (selected.AllowedMods.Any() != true)
             {
                 UserModsSection?.Hide();
                 userModsSelectOverlay.Hide();
@@ -187,7 +189,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
             else
             {
                 UserModsSection?.Show();
-                userModsSelectOverlay.IsValidMod = m => SelectedItem.Value.AllowedMods.Any(a => a.GetType() == m.GetType());
+                userModsSelectOverlay.IsValidMod = m => selected.AllowedMods.Any(a => a.GetType() == m.GetType());
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
@@ -16,7 +15,6 @@ using osu.Framework.Threading;
 using osu.Game.Configuration;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
-using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Match;
@@ -43,9 +41,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private OngoingOperationTracker ongoingOperationTracker { get; set; }
 
-        private ModSelectOverlay userModsSelectOverlay;
         private MultiplayerMatchSettingsOverlay settingsOverlay;
-        private Drawable userModsSection;
 
         private IBindable<bool> isConnected;
 
@@ -155,7 +151,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                                             new BeatmapSelectionControl { RelativeSizeAxes = Axes.X }
                                                                         }
                                                                     },
-                                                                    userModsSection = new FillFlowContainer
+                                                                    UserModsSection = new FillFlowContainer
                                                                     {
                                                                         RelativeSizeAxes = Axes.X,
                                                                         AutoSizeAxes = Axes.Y,
@@ -176,7 +172,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                                                                         Origin = Anchor.CentreLeft,
                                                                                         Width = 90,
                                                                                         Text = "Select",
-                                                                                        Action = () => userModsSelectOverlay.Show()
+                                                                                        Action = ShowUserModSelect,
                                                                                     },
                                                                                     new ModDisplay
                                                                                     {
@@ -231,19 +227,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                         new Dimension(GridSizeMode.AutoSize),
                     }
                 },
-                new Container
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    RelativeSizeAxes = Axes.Both,
-                    Height = 0.5f,
-                    Padding = new MarginPadding { Horizontal = HORIZONTAL_OVERFLOW_PADDING },
-                    Child = userModsSelectOverlay = new UserModSelectOverlay
-                    {
-                        SelectedMods = { BindTarget = UserMods },
-                        IsValidMod = _ => false
-                    }
-                },
                 settingsOverlay = new MultiplayerMatchSettingsOverlay
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -269,7 +252,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
-            Playlist.BindCollectionChanged(onPlaylistChanged, true);
             BeatmapAvailability.BindValueChanged(updateBeatmapAvailability, true);
             UserMods.BindValueChanged(onUserModsChanged);
 
@@ -303,30 +285,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 return true;
             }
 
-            if (userModsSelectOverlay.State.Value == Visibility.Visible)
-            {
-                userModsSelectOverlay.Hide();
-                return true;
-            }
-
             return base.OnBackButton();
-        }
-
-        private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            SelectedItem.Value = Playlist.FirstOrDefault();
-
-            if (SelectedItem.Value?.AllowedMods.Any() != true)
-            {
-                userModsSection.Hide();
-                userModsSelectOverlay.Hide();
-                userModsSelectOverlay.IsValidMod = _ => false;
-            }
-            else
-            {
-                userModsSection.Show();
-                userModsSelectOverlay.IsValidMod = m => SelectedItem.Value.AllowedMods.Any(a => a.GetType() == m.GetType());
-            }
         }
 
         private ModSettingChangeTracker modSettingChangeTracker;
@@ -432,10 +391,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }
 
             modSettingChangeTracker?.Dispose();
-        }
-
-        private class UserModSelectOverlay : LocalPlayerModSelectOverlay
-        {
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -31,7 +31,8 @@ namespace osu.Game.Screens.OnlinePlay
         [Resolved(typeof(Room), nameof(Room.Playlist))]
         protected BindableList<PlaylistItem> Playlist { get; private set; }
 
-        private readonly Bindable<IReadOnlyList<Mod>> freeMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+        protected readonly Bindable<IReadOnlyList<Mod>> FreeMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+
         private readonly FreeModSelectOverlay freeModSelectOverlay;
 
         private WorkingBeatmap initialBeatmap;
@@ -45,7 +46,7 @@ namespace osu.Game.Screens.OnlinePlay
 
             freeModSelectOverlay = new FreeModSelectOverlay
             {
-                SelectedMods = { BindTarget = freeMods },
+                SelectedMods = { BindTarget = FreeMods },
                 IsValidMod = IsValidFreeMod,
             };
         }
@@ -67,14 +68,14 @@ namespace osu.Game.Screens.OnlinePlay
             // At this point, Mods contains both the required and allowed mods. For selection purposes, it should only contain the required mods.
             // Similarly, freeMods is currently empty but should only contain the allowed mods.
             Mods.Value = Playlist.FirstOrDefault()?.RequiredMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
-            freeMods.Value = Playlist.FirstOrDefault()?.AllowedMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
+            FreeMods.Value = Playlist.FirstOrDefault()?.AllowedMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
 
             Ruleset.BindValueChanged(onRulesetChanged);
         }
 
         private void onRulesetChanged(ValueChangedEvent<RulesetInfo> ruleset)
         {
-            freeMods.Value = Array.Empty<Mod>();
+            FreeMods.Value = Array.Empty<Mod>();
         }
 
         protected sealed override bool OnStart()
@@ -90,7 +91,7 @@ namespace osu.Game.Screens.OnlinePlay
             item.RequiredMods.AddRange(Mods.Value.Select(m => m.CreateCopy()));
 
             item.AllowedMods.Clear();
-            item.AllowedMods.AddRange(freeMods.Value.Select(m => m.CreateCopy()));
+            item.AllowedMods.AddRange(FreeMods.Value.Select(m => m.CreateCopy()));
 
             SelectItem(item);
             return true;
@@ -133,7 +134,7 @@ namespace osu.Game.Screens.OnlinePlay
         protected override IEnumerable<(FooterButton, OverlayContainer)> CreateFooterButtons()
         {
             var buttons = base.CreateFooterButtons().ToList();
-            buttons.Insert(buttons.FindIndex(b => b.Item1 is FooterButtonMods) + 1, (new FooterButtonFreeMods { Current = freeMods }, freeModSelectOverlay));
+            buttons.Insert(buttons.FindIndex(b => b.Item1 is FooterButtonMods) + 1, (new FooterButtonFreeMods { Current = FreeMods }, freeModSelectOverlay));
             return buttons;
         }
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -13,7 +13,9 @@ using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Match;
 using osu.Game.Screens.OnlinePlay.Match.Components;
+using osu.Game.Screens.Play.HUD;
 using osu.Game.Users;
+using osuTK;
 using Footer = osu.Game.Screens.OnlinePlay.Match.Components.Footer;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
@@ -140,13 +142,55 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                                             RelativeSizeAxes = Axes.Both,
                                                             Content = new[]
                                                             {
-                                                                new Drawable[] { new OverlinedHeader("Leaderboard"), },
+                                                                new[]
+                                                                {
+                                                                    UserModsSection = new FillFlowContainer
+                                                                    {
+                                                                        RelativeSizeAxes = Axes.X,
+                                                                        AutoSizeAxes = Axes.Y,
+                                                                        Margin = new MarginPadding { Bottom = 10 },
+                                                                        Children = new Drawable[]
+                                                                        {
+                                                                            new OverlinedHeader("Extra mods"),
+                                                                            new FillFlowContainer
+                                                                            {
+                                                                                AutoSizeAxes = Axes.Both,
+                                                                                Direction = FillDirection.Horizontal,
+                                                                                Spacing = new Vector2(10, 0),
+                                                                                Children = new Drawable[]
+                                                                                {
+                                                                                    new PurpleTriangleButton
+                                                                                    {
+                                                                                        Anchor = Anchor.CentreLeft,
+                                                                                        Origin = Anchor.CentreLeft,
+                                                                                        Width = 90,
+                                                                                        Text = "Select",
+                                                                                        Action = ShowUserModSelect,
+                                                                                    },
+                                                                                    new ModDisplay
+                                                                                    {
+                                                                                        Anchor = Anchor.CentreLeft,
+                                                                                        Origin = Anchor.CentreLeft,
+                                                                                        DisplayUnrankedText = false,
+                                                                                        Current = UserMods,
+                                                                                        Scale = new Vector2(0.8f),
+                                                                                    },
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                },
+                                                                new Drawable[]
+                                                                {
+                                                                    new OverlinedHeader("Leaderboard")
+                                                                },
                                                                 new Drawable[] { leaderboard = new MatchLeaderboard { RelativeSizeAxes = Axes.Both }, },
                                                                 new Drawable[] { new OverlinedHeader("Chat"), },
                                                                 new Drawable[] { new MatchChatDisplay { RelativeSizeAxes = Axes.Both } }
                                                             },
                                                             RowDimensions = new[]
                                                             {
+                                                                new Dimension(GridSizeMode.AutoSize),
                                                                 new Dimension(GridSizeMode.AutoSize),
                                                                 new Dimension(),
                                                                 new Dimension(GridSizeMode.AutoSize),

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -56,6 +56,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             item.RequiredMods.Clear();
             item.RequiredMods.AddRange(Mods.Value.Select(m => m.CreateCopy()));
+
+            item.AllowedMods.Clear();
+            item.AllowedMods.AddRange(FreeMods.Value.Select(m => m.CreateCopy()));
         }
     }
 }


### PR DESCRIPTION
A bit of an oversight when implementing. The available user mods for selection are not shown anywhere on playlist items yet, but I think that can come as a later step (once we have a better design for the playlists cards which can hold more information, such as the "maximum attempts" count as well).

Not 100% sure on having the selection region constructed in each of the screen implementations (the only difference between them is some padding). Could potentially reverse the direction and have it created in the base screen and inserted in the correct place for each usage if that sounds better.

Closes https://github.com/ppy/osu/issues/11737.