### PR TITLE
Use long type where required in multiplayer

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIUserScoreAggregate.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUserScoreAggregate.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Online.API.Requests.Responses
         public double? PP { get; set; }
 
         [JsonProperty(@"room_id")]
-        public int RoomID { get; set; }
+        public long RoomID { get; set; }
 
         [JsonProperty("total_score")]
         public long TotalScore { get; set; }

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Online.Multiplayer
         private Room? apiRoom;
 
         // Todo: This is temporary, until the multiplayer server returns the item id on match start or otherwise.
-        private int playlistItemId;
+        private long playlistItemId;
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Online/Rooms/CreateRoomScoreRequest.cs
+++ b/osu.Game/Online/Rooms/CreateRoomScoreRequest.cs
@@ -9,11 +9,11 @@ namespace osu.Game.Online.Rooms
 {
     public class CreateRoomScoreRequest : APIRequest<APIScoreToken>
     {
-        private readonly int roomId;
-        private readonly int playlistItemId;
+        private readonly long roomId;
+        private readonly long playlistItemId;
         private readonly string versionHash;
 
-        public CreateRoomScoreRequest(int roomId, int playlistItemId, string versionHash)
+        public CreateRoomScoreRequest(long roomId, long playlistItemId, string versionHash)
         {
             this.roomId = roomId;
             this.playlistItemId = playlistItemId;

--- a/osu.Game/Online/Rooms/GetRoomLeaderboardRequest.cs
+++ b/osu.Game/Online/Rooms/GetRoomLeaderboardRequest.cs
@@ -7,9 +7,9 @@ namespace osu.Game.Online.Rooms
 {
     public class GetRoomLeaderboardRequest : APIRequest<APILeaderboard>
     {
-        private readonly int roomId;
+        private readonly long roomId;
 
-        public GetRoomLeaderboardRequest(int roomId)
+        public GetRoomLeaderboardRequest(long roomId)
         {
             this.roomId = roomId;
         }

--- a/osu.Game/Online/Rooms/GetRoomRequest.cs
+++ b/osu.Game/Online/Rooms/GetRoomRequest.cs
@@ -7,9 +7,9 @@ namespace osu.Game.Online.Rooms
 {
     public class GetRoomRequest : APIRequest<Room>
     {
-        public readonly int RoomId;
+        public readonly long RoomId;
 
-        public GetRoomRequest(int roomId)
+        public GetRoomRequest(long roomId)
         {
             RoomId = roomId;
         }

--- a/osu.Game/Online/Rooms/IndexPlaylistScoresRequest.cs
+++ b/osu.Game/Online/Rooms/IndexPlaylistScoresRequest.cs
@@ -15,8 +15,8 @@ namespace osu.Game.Online.Rooms
     /// </summary>
     public class IndexPlaylistScoresRequest : APIRequest<IndexedMultiplayerScores>
     {
-        public readonly int RoomId;
-        public readonly int PlaylistItemId;
+        public readonly long RoomId;
+        public readonly long PlaylistItemId;
 
         [CanBeNull]
         public readonly Cursor Cursor;
@@ -24,13 +24,13 @@ namespace osu.Game.Online.Rooms
         [CanBeNull]
         public readonly IndexScoresParams IndexParams;
 
-        public IndexPlaylistScoresRequest(int roomId, int playlistItemId)
+        public IndexPlaylistScoresRequest(long roomId, long playlistItemId)
         {
             RoomId = roomId;
             PlaylistItemId = playlistItemId;
         }
 
-        public IndexPlaylistScoresRequest(int roomId, int playlistItemId, [NotNull] Cursor cursor, [NotNull] IndexScoresParams indexParams)
+        public IndexPlaylistScoresRequest(long roomId, long playlistItemId, [NotNull] Cursor cursor, [NotNull] IndexScoresParams indexParams)
             : this(roomId, playlistItemId)
         {
             Cursor = cursor;

--- a/osu.Game/Online/Rooms/MultiplayerScore.cs
+++ b/osu.Game/Online/Rooms/MultiplayerScore.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Online.Rooms
     public class MultiplayerScore
     {
         [JsonProperty("id")]
-        public int ID { get; set; }
+        public long ID { get; set; }
 
         [JsonProperty("user")]
         public User User { get; set; }

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Online.Rooms
     public class PlaylistItem : IEquatable<PlaylistItem>
     {
         [JsonProperty("id")]
-        public int ID { get; set; }
+        public long ID { get; set; }
 
         [JsonProperty("beatmap_id")]
         public int BeatmapID { get; set; }

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Online.Rooms
     {
         [Cached]
         [JsonProperty("id")]
-        public readonly Bindable<int?> RoomID = new Bindable<int?>();
+        public readonly Bindable<long?> RoomID = new Bindable<long?>();
 
         [Cached]
         [JsonProperty("name")]

--- a/osu.Game/Online/Rooms/ShowPlaylistUserScoreRequest.cs
+++ b/osu.Game/Online/Rooms/ShowPlaylistUserScoreRequest.cs
@@ -7,11 +7,11 @@ namespace osu.Game.Online.Rooms
 {
     public class ShowPlaylistUserScoreRequest : APIRequest<MultiplayerScore>
     {
-        private readonly int roomId;
-        private readonly int playlistItemId;
+        private readonly long roomId;
+        private readonly long playlistItemId;
         private readonly long userId;
 
-        public ShowPlaylistUserScoreRequest(int roomId, int playlistItemId, long userId)
+        public ShowPlaylistUserScoreRequest(long roomId, long playlistItemId, long userId)
         {
             this.roomId = roomId;
             this.playlistItemId = playlistItemId;

--- a/osu.Game/Online/Rooms/SubmitRoomScoreRequest.cs
+++ b/osu.Game/Online/Rooms/SubmitRoomScoreRequest.cs
@@ -11,12 +11,12 @@ namespace osu.Game.Online.Rooms
 {
     public class SubmitRoomScoreRequest : APIRequest<MultiplayerScore>
     {
-        private readonly int scoreId;
-        private readonly int roomId;
-        private readonly int playlistItemId;
+        private readonly long scoreId;
+        private readonly long roomId;
+        private readonly long playlistItemId;
         private readonly ScoreInfo scoreInfo;
 
-        public SubmitRoomScoreRequest(int scoreId, int roomId, int playlistItemId, ScoreInfo scoreInfo)
+        public SubmitRoomScoreRequest(long scoreId, long roomId, long playlistItemId, ScoreInfo scoreInfo)
         {
             this.scoreId = scoreId;
             this.roomId = roomId;

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
             joinedRoom.Value = null;
         }
 
-        private readonly HashSet<int> ignoredRooms = new HashSet<int>();
+        private readonly HashSet<long> ignoredRooms = new HashSet<long>();
 
         private void onRoomsReceived(List<Room> received)
         {

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchChatDisplay.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
     public class MatchChatDisplay : StandAloneChatDisplay
     {
         [Resolved(typeof(Room), nameof(Room.RoomID))]
-        private Bindable<int?> roomId { get; set; }
+        private Bindable<long?> roomId { get; set; }
 
         [Resolved(typeof(Room), nameof(Room.ChannelId))]
         private Bindable<int> channelId { get; set; }

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchLeaderboard.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
     public class MatchLeaderboard : Leaderboard<MatchLeaderboardScope, APIUserScoreAggregate>
     {
         [Resolved(typeof(Room), nameof(Room.RoomID))]
-        private Bindable<int?> roomId { get; set; }
+        private Bindable<long?> roomId { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -357,7 +357,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         public class CreateOrUpdateButton : TriangleButton
         {
             [Resolved(typeof(Room), nameof(Room.RoomID))]
-            private Bindable<int?> roomId { get; set; }
+            private Bindable<long?> roomId { get; set; }
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerResultsScreen.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
     public class MultiplayerResultsScreen : PlaylistsResultsScreen
     {
-        public MultiplayerResultsScreen(ScoreInfo score, int roomId, PlaylistItem playlistItem)
+        public MultiplayerResultsScreen(ScoreInfo score, long roomId, PlaylistItem playlistItem)
             : base(score, roomId, playlistItem, false, false)
         {
         }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Screens.OnlinePlay
     public class OnlinePlayComposite : CompositeDrawable
     {
         [Resolved(typeof(Room))]
-        protected Bindable<int?> RoomID { get; private set; }
+        protected Bindable<long?> RoomID { get; private set; }
 
         [Resolved(typeof(Room), nameof(Room.Name))]
         protected Bindable<string> RoomName { get; private set; }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         public Action Exited;
 
         [Resolved(typeof(Room), nameof(Room.RoomID))]
-        protected Bindable<int?> RoomId { get; private set; }
+        protected Bindable<long?> RoomId { get; private set; }
 
         protected readonly PlaylistItem PlaylistItem;
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsResultsScreen.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 {
     public class PlaylistsResultsScreen : ResultsScreen
     {
-        private readonly int roomId;
+        private readonly long roomId;
         private readonly PlaylistItem playlistItem;
 
         protected LoadingSpinner LeftSpinner { get; private set; }
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         [Resolved]
         private IAPIProvider api { get; set; }
 
-        public PlaylistsResultsScreen(ScoreInfo score, int roomId, PlaylistItem playlistItem, bool allowRetry, bool allowWatchingReplay = true)
+        public PlaylistsResultsScreen(ScoreInfo score, long roomId, PlaylistItem playlistItem, bool allowRetry, bool allowWatchingReplay = true)
             : base(score, allowRetry, allowWatchingReplay)
         {
             this.roomId = roomId;

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         public override string ShortTitle => "playlist";
 
         [Resolved(typeof(Room), nameof(Room.RoomID))]
-        private Bindable<int?> roomId { get; set; }
+        private Bindable<long?> roomId { get; set; }
 
         private MatchSettingsOverlay settingsOverlay;
         private MatchLeaderboard leaderboard;


### PR DESCRIPTION
Went through the database models and noticed these were wrong. Note that `MultiplayerSettings.BeatmapId` is also wrong, but that one's a bit more involved because `BeatmapInfo.OnlineBeatmapId` is also wrong, but that has game-wide impacts.