### PR TITLE
Fix multiple issues with user population in tournament client

### DIFF
--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -277,8 +277,7 @@ namespace osu.Game.Tournament.Screens.Editors
                         userId.Value = user.Id.ToString();
                         userId.BindValueChanged(idString =>
                         {
-                            if (!(int.TryParse(idString.NewValue, out var parsed)))
-                                return;
+                            int.TryParse(idString.NewValue, out var parsed);
 
                             user.Id = parsed;
 

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -277,7 +277,8 @@ namespace osu.Game.Tournament.Screens.Editors
                         userId.Value = user.Id.ToString();
                         userId.BindValueChanged(idString =>
                         {
-                            int.TryParse(idString.NewValue, out var parsed);
+                            if (!(int.TryParse(idString.NewValue, out var parsed)))
+                                return;
 
                             user.Id = parsed;
 

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Tournament
                 {
                     if (string.IsNullOrEmpty(p.Username) || p.Statistics == null)
                     {
-                        PopulateUser(p);
+                        PopulateUser(p, immediate: true);
                         addedInfo = true;
                     }
                 }
@@ -211,7 +211,7 @@ namespace osu.Game.Tournament
             return addedInfo;
         }
 
-        public void PopulateUser(User user, Action success = null, Action failure = null)
+        public void PopulateUser(User user, Action success = null, Action failure = null, bool immediate = false)
         {
             var req = new GetUserRequest(user.Id, Ruleset.Value);
 
@@ -231,7 +231,10 @@ namespace osu.Game.Tournament
                 failure?.Invoke();
             };
 
-            API.Queue(req);
+            if (immediate)
+                API.Perform(req);
+            else
+                API.Queue(req);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -225,11 +225,7 @@ namespace osu.Game.Tournament
                 success?.Invoke();
             };
 
-            req.Failure += _ =>
-            {
-                user.Id = 1;
-                failure?.Invoke();
-            };
+            req.Failure += _ => failure?.Invoke();
 
             if (immediate)
                 API.Perform(req);

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -217,6 +217,8 @@ namespace osu.Game.Tournament
 
             req.Success += res =>
             {
+                user.Id = res.Id;
+
                 user.Username = res.Username;
                 user.Statistics = res.Statistics;
                 user.Country = res.Country;
@@ -225,7 +227,11 @@ namespace osu.Game.Tournament
                 success?.Invoke();
             };
 
-            req.Failure += _ => failure?.Invoke();
+            req.Failure += _ =>
+            {
+                user.Id = 1;
+                failure?.Invoke();
+            };
 
             if (immediate)
                 API.Perform(req);


### PR DESCRIPTION
This fixes multiple issues with user population in tournament clients, spotted while I was looking at re-fetching user on null global rank (see https://github.com/ppy/osu/pull/11708#discussion_r576599990).

- https://github.com/ppy/osu/commit/3b4e02e5c78fd77325f188c0379785e47b61d6aa
   This fixes user population on bracket loading not being performed synchronously, opposed to `addBeatmaps`, as the API might be busy performing other requests while the user request is hanging there in the queue, causing the brackets to be saved with unpopulated user instances.

- https://github.com/ppy/osu/commit/85ebc8e06cd45be8e66f40c059dac6b20c926cc8
  This fixes user requests failure overwriting the user ID, which causes issues if the failed request was to be performed after the user ID is set to a valid one. For example, run a tournament client on `master` and do the following:
  1. go to team editor screen and add a player 
  2. set to an invalid ID then quickly to a valid ID before the user request with the invalid ID is performed
  3. wait until user requests are performed then save changes and re-run the tournament again.
  
  expected: the added player would have the valid ID saved to the bracket file from the previous session.
  actual: the added player [would have ID `1`](https://github.com/ppy/osu/blob/bef0e5cfa17c79f352528cd559ffa9a10b011d31/osu.Game.Tournament/TournamentGameBase.cs#L230) saved to the bracket file from the previous session, because of the failed request overwriting the valid user ID.

EDIT: Last two commits (https://github.com/ppy/osu/commit/705e9267497bc1eec01da9d73ec2630ad2be327d  and https://github.com/ppy/osu/commit/85ebc8e06cd45be8e66f40c059dac6b20c926cc8) are reverted with  https://github.com/ppy/osu/pull/11799/commits/61bf9a64bb117483093318b99ce135cd50a2e8c0 instead, now the user ID will become overwritten if the successful request isn't performed afterwards, which makes sense somewhat.