### PR TITLE
Fix intro beatmap always being imported even if already in a good state

### DIFF
--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -111,12 +111,10 @@ namespace osu.Game.Screens.Menu
             {
                 setInfo = beatmaps.QueryBeatmapSet(b => b.Hash == BeatmapHash);
 
-                if (setInfo != null)
-                {
-                    initialBeatmap = beatmaps.GetWorkingBeatmap(setInfo.Beatmaps[0]);
-                }
+                if (setInfo == null)
+                    return false;
 
-                return UsingThemedIntro;
+                return (initialBeatmap = beatmaps.GetWorkingBeatmap(setInfo.Beatmaps[0])) != null;
             }
         }
 


### PR DESCRIPTION
Not sure what drugs were involved when writing this function.

Due to the checks during import, this wasn't as bad as it could have been, but also likely the reason that android was sticking on startup when a large import was requested by the user.
