### PR TITLE
Rework multiplayer playlist handling to support multiple items

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Online.Multiplayer
         /// Only used for client-side mutation.
         /// </summary>
         [Key(6)]
-        public int PlaylistItemId { get; set; }
+        public long PlaylistItemId { get; set; }
 
         public bool Equals(MultiplayerRoomSettings other)
             => BeatmapID == other.BeatmapID

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -36,9 +36,6 @@ namespace osu.Game.Online.Multiplayer
         [Key(5)]
         public IEnumerable<APIMod> AllowedMods { get; set; } = Enumerable.Empty<APIMod>();
 
-        /// <summary>
-        /// Only used for client-side mutation.
-        /// </summary>
         [Key(6)]
         public long PlaylistItemId { get; set; }
 

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomSettings.cs
@@ -36,18 +36,26 @@ namespace osu.Game.Online.Multiplayer
         [Key(5)]
         public IEnumerable<APIMod> AllowedMods { get; set; } = Enumerable.Empty<APIMod>();
 
+        /// <summary>
+        /// Only used for client-side mutation.
+        /// </summary>
+        [Key(6)]
+        public int PlaylistItemId { get; set; }
+
         public bool Equals(MultiplayerRoomSettings other)
             => BeatmapID == other.BeatmapID
                && BeatmapChecksum == other.BeatmapChecksum
                && RequiredMods.SequenceEqual(other.RequiredMods)
                && AllowedMods.SequenceEqual(other.AllowedMods)
                && RulesetID == other.RulesetID
-               && Name.Equals(other.Name, StringComparison.Ordinal);
+               && Name.Equals(other.Name, StringComparison.Ordinal)
+               && PlaylistItemId == other.PlaylistItemId;
 
         public override string ToString() => $"Name:{Name}"
                                              + $" Beatmap:{BeatmapID} ({BeatmapChecksum})"
                                              + $" RequiredMods:{string.Join(',', RequiredMods)}"
                                              + $" AllowedMods:{string.Join(',', AllowedMods)}"
-                                             + $" Ruleset:{RulesetID}";
+                                             + $" Ruleset:{RulesetID}"
+                                             + $" Item:{PlaylistItemId}";
     }
 }

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -217,7 +217,6 @@ namespace osu.Game.Online.Multiplayer
                 RulesetID = item.GetOr(existingPlaylistItem).RulesetID,
                 RequiredMods = item.HasValue ? item.Value.AsNonNull().RequiredMods.Select(m => new APIMod(m)).ToList() : Room.Settings.RequiredMods,
                 AllowedMods = item.HasValue ? item.Value.AsNonNull().AllowedMods.Select(m => new APIMod(m)).ToList() : Room.Settings.AllowedMods,
-                PlaylistItemId = Room.Settings.PlaylistItemId,
             });
         }
 

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -539,10 +539,7 @@ namespace osu.Game.Online.Multiplayer
             var allowedMods = settings.AllowedMods.Select(m => m.ToMod(ruleset));
 
             // Update an existing playlist item from the API room, or create a new item.
-            var playlistItem = apiRoom.Playlist.FirstOrDefault(i => i.ID == settings.PlaylistItemId);
-
-            if (playlistItem == null)
-                apiRoom.Playlist.Add(playlistItem = new PlaylistItem());
+            var playlistItem = apiRoom.Playlist.FirstOrDefault(i => i.ID == settings.PlaylistItemId) ?? new PlaylistItem();
 
             playlistItem.ID = settings.PlaylistItemId;
             playlistItem.Beatmap.Value = beatmap;
@@ -551,6 +548,9 @@ namespace osu.Game.Online.Multiplayer
             playlistItem.RequiredMods.AddRange(mods);
             playlistItem.AllowedMods.Clear();
             playlistItem.AllowedMods.AddRange(allowedMods);
+
+            if (!apiRoom.Playlist.Contains(playlistItem))
+                apiRoom.Playlist.Add(playlistItem);
 
             CurrentMatchPlayingItem.Value = playlistItem;
         }

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -94,6 +94,10 @@ namespace osu.Game.Online.Multiplayer
         [Resolved]
         private RulesetStore rulesets { get; set; } = null!;
 
+        // Only exists for compatibility with old osu-server-spectator build.
+        // Todo: Can be removed on 2021/02/26.
+        private long defaultPlaylistItemId;
+
         private Room? apiRoom;
 
         [BackgroundDependencyLoader]
@@ -141,6 +145,7 @@ namespace osu.Game.Online.Multiplayer
                 {
                     Room = joinedRoom;
                     apiRoom = room;
+                    defaultPlaylistItemId = apiRoom.Playlist.FirstOrDefault()?.ID ?? 0;
                 }, cancellationSource.Token);
 
                 // Update room settings.
@@ -553,7 +558,7 @@ namespace osu.Game.Online.Multiplayer
 
             void updateItem(PlaylistItem item)
             {
-                item.ID = settings.PlaylistItemId;
+                item.ID = settings.PlaylistItemId == 0 ? defaultPlaylistItemId : settings.PlaylistItemId;
                 item.Beatmap.Value = beatmap;
                 item.Ruleset.Value = ruleset.RulesetInfo;
                 item.RequiredMods.Clear();

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -537,21 +537,30 @@ namespace osu.Game.Online.Multiplayer
             var mods = settings.RequiredMods.Select(m => m.ToMod(ruleset));
             var allowedMods = settings.AllowedMods.Select(m => m.ToMod(ruleset));
 
-            // Update an existing playlist item from the API room, or create a new item.
-            var playlistItem = apiRoom.Playlist.FirstOrDefault(i => i.ID == settings.PlaylistItemId) ?? new PlaylistItem();
+            // Try to retrieve the existing playlist item from the API room.
+            var playlistItem = apiRoom.Playlist.FirstOrDefault(i => i.ID == settings.PlaylistItemId);
 
-            playlistItem.ID = settings.PlaylistItemId;
-            playlistItem.Beatmap.Value = beatmap;
-            playlistItem.Ruleset.Value = ruleset.RulesetInfo;
-            playlistItem.RequiredMods.Clear();
-            playlistItem.RequiredMods.AddRange(mods);
-            playlistItem.AllowedMods.Clear();
-            playlistItem.AllowedMods.AddRange(allowedMods);
-
-            if (!apiRoom.Playlist.Contains(playlistItem))
+            if (playlistItem != null)
+                updateItem(playlistItem);
+            else
+            {
+                // An existing playlist item does not exist, so append a new one.
+                updateItem(playlistItem = new PlaylistItem());
                 apiRoom.Playlist.Add(playlistItem);
+            }
 
             CurrentMatchPlayingItem.Value = playlistItem;
+
+            void updateItem(PlaylistItem item)
+            {
+                item.ID = settings.PlaylistItemId;
+                item.Beatmap.Value = beatmap;
+                item.Ruleset.Value = ruleset.RulesetInfo;
+                item.RequiredMods.Clear();
+                item.RequiredMods.AddRange(mods);
+                item.AllowedMods.Clear();
+                item.AllowedMods.AddRange(allowedMods);
+            }
         }
 
         /// <summary>

--- a/osu.Game/Online/Rooms/PlaylistItem.cs
+++ b/osu.Game/Online/Rooms/PlaylistItem.cs
@@ -23,6 +23,12 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("ruleset_id")]
         public int RulesetID { get; set; }
 
+        /// <summary>
+        /// Whether this <see cref="PlaylistItem"/> is still a valid selection for the <see cref="Room"/>.
+        /// </summary>
+        [JsonProperty("expired")]
+        public bool Expired { get; set; }
+
         [JsonIgnore]
         public readonly Bindable<BeatmapInfo> Beatmap = new Bindable<BeatmapInfo>();
 

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -148,6 +148,12 @@ namespace osu.Game.Online.Rooms
             if (EndDate.Value != null && DateTimeOffset.Now >= EndDate.Value)
                 Status.Value = new RoomStatusEnded();
 
+            // Todo: This is not the best way/place to do this, but the intention is to display all playlist items when the room has ended,
+            // and display only the non-expired playlist items while the room is still active.
+            // In order to achieve this, all expired items are removed from the source Room.
+            if (!(Status.Value is RoomStatusEnded))
+                other.Playlist.RemoveAll(i => i.Expired);
+
             if (!Playlist.SequenceEqual(other.Playlist))
             {
                 Playlist.Clear();

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -149,8 +149,8 @@ namespace osu.Game.Online.Rooms
                 Status.Value = new RoomStatusEnded();
 
             // Todo: This is not the best way/place to do this, but the intention is to display all playlist items when the room has ended,
-            // and display only the non-expired playlist items while the room is still active.
-            // In order to achieve this, all expired items are removed from the source Room.
+            // and display only the non-expired playlist items while the room is still active. In order to achieve this, all expired items are removed from the source Room.
+            // More refactoring is required before this can be done locally instead - DrawableRoomPlaylist is currently directly bound to the playlist to display items in the room.
             if (!(Status.Value is RoomStatusEnded))
                 other.Playlist.RemoveAll(i => i.Expired);
 

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
     [Cached(typeof(IPreviewTrackOwner))]
     public abstract class RoomSubScreen : OnlinePlaySubScreen, IPreviewTrackOwner
     {
+        [Cached(typeof(IBindable<PlaylistItem>))]
         protected readonly Bindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
 
         public override bool DisallowExternalBeatmapRulesetChanges => true;

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -28,9 +28,6 @@ namespace osu.Game.Screens.OnlinePlay.Match
 
         private Sample sampleStart;
 
-        [Resolved(typeof(Room), nameof(Room.Playlist))]
-        protected BindableList<PlaylistItem> Playlist { get; private set; }
-
         /// <summary>
         /// Any mods applied by/to the local user.
         /// </summary>
@@ -74,7 +71,6 @@ namespace osu.Game.Screens.OnlinePlay.Match
             base.LoadComplete();
 
             SelectedItem.BindValueChanged(_ => Scheduler.AddOnce(selectedItemChanged));
-            SelectedItem.Value = Playlist.FirstOrDefault();
 
             managerUpdated = beatmapManager.ItemUpdated.GetBoundCopy();
             managerUpdated.BindValueChanged(beatmapUpdated);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
@@ -1,15 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Screens;
 using osu.Game.Online.API;
-using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
@@ -61,10 +58,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         {
             base.LoadComplete();
 
-            Debug.Assert(SelectedItem != null);
-            SelectedItem.BindValueChanged(_ => updateBeatmap());
-            Playlist.BindCollectionChanged((_, __) => updateBeatmap(), true);
-
+            SelectedItem.BindValueChanged(_ => updateBeatmap(), true);
             Host.BindValueChanged(host =>
             {
                 if (RoomID.Value == null || host.NewValue?.Equals(api.LocalUser.Value) == true)
@@ -76,15 +70,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
         private void updateBeatmap()
         {
-            Debug.Assert(SelectedItem != null);
-
-            // When the selected item is null, the match hasn't yet been created. Use the playlist directly, which is mutated by song selection.
-            PlaylistItem item = SelectedItem.Value ?? Playlist.FirstOrDefault();
-
-            if (item == null)
+            if (SelectedItem.Value == null)
                 beatmapPanelContainer.Clear();
             else
-                beatmapPanelContainer.Child = new DrawableRoomPlaylistItem(item, false, false);
+                beatmapPanelContainer.Child = new DrawableRoomPlaylistItem(SelectedItem.Value, false, false);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
@@ -1,14 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Specialized;
-using System.Linq;
+using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Screens;
 using osu.Game.Online.API;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
@@ -60,7 +61,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         {
             base.LoadComplete();
 
-            Playlist.BindCollectionChanged(onPlaylistChanged, true);
+            Debug.Assert(SelectedItem != null);
+            SelectedItem.BindValueChanged(onSelectedItemChanged, true);
+
             Host.BindValueChanged(host =>
             {
                 if (RoomID.Value == null || host.NewValue?.Equals(api.LocalUser.Value) == true)
@@ -70,12 +73,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             }, true);
         }
 
-        private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void onSelectedItemChanged(ValueChangedEvent<PlaylistItem> selectedItem)
         {
-            if (Playlist.Any())
-                beatmapPanelContainer.Child = new DrawableRoomPlaylistItem(Playlist.Single(), false, false);
-            else
+            if (selectedItem.NewValue == null)
                 beatmapPanelContainer.Clear();
+            else
+                beatmapPanelContainer.Child = new DrawableRoomPlaylistItem(selectedItem.NewValue, false, false);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
@@ -2,8 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -62,7 +62,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             base.LoadComplete();
 
             Debug.Assert(SelectedItem != null);
-            SelectedItem.BindValueChanged(onSelectedItemChanged, true);
+            SelectedItem.BindValueChanged(_ => updateBeatmap());
+            Playlist.BindCollectionChanged((_, __) => updateBeatmap(), true);
 
             Host.BindValueChanged(host =>
             {
@@ -73,12 +74,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             }, true);
         }
 
-        private void onSelectedItemChanged(ValueChangedEvent<PlaylistItem> selectedItem)
+        private void updateBeatmap()
         {
-            if (selectedItem.NewValue == null)
+            Debug.Assert(SelectedItem != null);
+            PlaylistItem item = SelectedItem.Value ?? Playlist.FirstOrDefault();
+
+            if (item == null)
                 beatmapPanelContainer.Clear();
             else
-                beatmapPanelContainer.Child = new DrawableRoomPlaylistItem(selectedItem.NewValue, false, false);
+                beatmapPanelContainer.Child = new DrawableRoomPlaylistItem(item, false, false);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
@@ -11,7 +11,7 @@ using osu.Game.Screens.OnlinePlay.Match.Components;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 {
-    public class BeatmapSelectionControl : OnlinePlayComposite
+    public class BeatmapSelectionControl : RoomSubScreenComposite
     {
         [Resolved]
         private MultiplayerMatchSubScreen matchSubScreen { get; set; }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/BeatmapSelectionControl.cs
@@ -77,6 +77,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
         private void updateBeatmap()
         {
             Debug.Assert(SelectedItem != null);
+
+            // When the selected item is null, the match hasn't yet been created. Use the playlist directly, which is mutated by song selection.
             PlaylistItem item = SelectedItem.Value ?? Playlist.FirstOrDefault();
 
             if (item == null)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -47,7 +47,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private Drawable userModsSection;
 
         private readonly IBindable<bool> isConnected = new Bindable<bool>();
-        private readonly IBindable<PlaylistItem> matchCurrentItem = new Bindable<PlaylistItem>();
 
         [CanBeNull]
         private IDisposable readyClickOperation;
@@ -269,8 +268,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
-            matchCurrentItem.BindTo(client.CurrentMatchPlayingItem);
-            matchCurrentItem.BindValueChanged(onCurrentItemChanged, true);
+            SelectedItem.BindTo(client.CurrentMatchPlayingItem);
+            SelectedItem.BindValueChanged(onSelectedItemChanged, true);
 
             BeatmapAvailability.BindValueChanged(updateBeatmapAvailability, true);
             UserMods.BindValueChanged(onUserModsChanged);
@@ -286,19 +285,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }, true);
         }
 
-        private void onCurrentItemChanged(ValueChangedEvent<PlaylistItem> item)
+        private void onSelectedItemChanged(ValueChangedEvent<PlaylistItem> item)
         {
             if (client?.LocalUser == null)
                 return;
-
-            // If we're about to enter gameplay, schedule the item to be set at a later time.
-            if (client.LocalUser.State > MultiplayerUserState.Ready)
-            {
-                Schedule(() => onCurrentItemChanged(item));
-                return;
-            }
-
-            SelectedItem.Value = item.NewValue;
 
             if (item.NewValue?.AllowedMods.Any() != true)
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
@@ -269,7 +268,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
-            Playlist.BindCollectionChanged(onPlaylistChanged, true);
+            SelectedItem.BindValueChanged(onSelectedItemChanged);
+            SelectedItem.BindTo(client.CurrentMatchPlayingItem);
+
             BeatmapAvailability.BindValueChanged(updateBeatmapAvailability, true);
             UserMods.BindValueChanged(onUserModsChanged);
 
@@ -300,11 +301,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             return base.OnBackButton();
         }
 
-        private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void onSelectedItemChanged(ValueChangedEvent<PlaylistItem> item)
         {
-            SelectedItem.Value = Playlist.LastOrDefault();
-
-            if (SelectedItem.Value?.AllowedMods.Any() != true)
+            if (item.NewValue?.AllowedMods.Any() != true)
             {
                 userModsSection.Hide();
                 userModsSelectOverlay.Hide();
@@ -313,7 +312,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             else
             {
                 userModsSection.Show();
-                userModsSelectOverlay.IsValidMod = m => SelectedItem.Value.AllowedMods.Any(a => a.GetType() == m.GetType());
+                userModsSelectOverlay.IsValidMod = m => item.NewValue.AllowedMods.Any(a => a.GetType() == m.GetType());
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -302,7 +302,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            SelectedItem.Value = Playlist.FirstOrDefault();
+            SelectedItem.Value = Playlist.LastOrDefault();
 
             if (SelectedItem.Value?.AllowedMods.Any() != true)
             {

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Match;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.OnlinePlay
@@ -50,5 +52,13 @@ namespace osu.Game.Screens.OnlinePlay
 
         [Resolved(typeof(Room))]
         protected Bindable<TimeSpan?> Duration { get; private set; }
+
+        /// <summary>
+        /// The currently selected item in the <see cref="RoomSubScreen"/>.
+        /// May be null if this <see cref="OnlinePlayComposite"/> is not inside a <see cref="RoomSubScreen"/>.
+        /// </summary>
+        [CanBeNull]
+        [Resolved(typeof(Room), CanBeNull = true)]
+        protected IBindable<PlaylistItem> SelectedItem { get; private set; }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Screens.OnlinePlay
         /// May be null if this <see cref="OnlinePlayComposite"/> is not inside a <see cref="RoomSubScreen"/>.
         /// </summary>
         [CanBeNull]
-        [Resolved(typeof(Room), CanBeNull = true)]
+        [Resolved(CanBeNull = true)]
         protected IBindable<PlaylistItem> SelectedItem { get; private set; }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Specialized;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
@@ -14,6 +12,9 @@ using osu.Game.Users;
 
 namespace osu.Game.Screens.OnlinePlay
 {
+    /// <summary>
+    /// A <see cref="CompositeDrawable"/> that exposes bindables for <see cref="Room"/> properties.
+    /// </summary>
     public class OnlinePlayComposite : CompositeDrawable
     {
         [Resolved(typeof(Room))]
@@ -62,41 +63,18 @@ namespace osu.Game.Screens.OnlinePlay
         /// The currently selected item in the <see cref="RoomSubScreen"/>, or the first item from <see cref="Playlist"/>
         /// if this <see cref="OnlinePlayComposite"/> is not within a <see cref="RoomSubScreen"/>.
         /// </summary>
-        protected IBindable<PlaylistItem> SelectedItem => selectedItem;
-
-        private readonly Bindable<PlaylistItem> selectedItem = new Bindable<PlaylistItem>();
-
-        [CanBeNull]
-        [Resolved(CanBeNull = true)]
-        private IBindable<PlaylistItem> subScreenSelectedItem { get; set; }
+        protected readonly Bindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            if (subScreenSelectedItem != null)
-                subScreenSelectedItem.BindValueChanged(onSelectedItemChanged, true);
-            else
-                Playlist.BindCollectionChanged(onPlaylistChanged, true);
+            Playlist.BindCollectionChanged((_, __) => UpdateSelectedItem(), true);
         }
 
-        /// <summary>
-        /// Invoked when the selected item from within a <see cref="RoomSubScreen"/> changes.
-        /// Does not occur when this <see cref="OnlinePlayComposite"/> is outside a <see cref="RoomSubScreen"/>.
-        /// </summary>
-        private void onSelectedItemChanged(ValueChangedEvent<PlaylistItem> item)
+        protected virtual void UpdateSelectedItem()
         {
-            // If the room hasn't been created yet, fall-back to the first item from the playlist.
-            selectedItem.Value = RoomID.Value == null ? Playlist.FirstOrDefault() : item.NewValue;
-        }
-
-        /// <summary>
-        /// Invoked when the playlist changes.
-        /// Does not occur when this <see cref="OnlinePlayComposite"/> is inside a <see cref="RoomSubScreen"/>.
-        /// </summary>
-        private void onPlaylistChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            selectedItem.Value = Playlist.FirstOrDefault();
+            SelectedItem.Value = Playlist.FirstOrDefault();
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlaySongSelect.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -30,6 +31,10 @@ namespace osu.Game.Screens.OnlinePlay
 
         [Resolved(typeof(Room), nameof(Room.Playlist))]
         protected BindableList<PlaylistItem> Playlist { get; private set; }
+
+        [CanBeNull]
+        [Resolved(CanBeNull = true)]
+        private IBindable<PlaylistItem> selectedItem { get; set; }
 
         private readonly Bindable<IReadOnlyList<Mod>> freeMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
         private readonly FreeModSelectOverlay freeModSelectOverlay;
@@ -66,8 +71,8 @@ namespace osu.Game.Screens.OnlinePlay
 
             // At this point, Mods contains both the required and allowed mods. For selection purposes, it should only contain the required mods.
             // Similarly, freeMods is currently empty but should only contain the allowed mods.
-            Mods.Value = Playlist.FirstOrDefault()?.RequiredMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
-            freeMods.Value = Playlist.FirstOrDefault()?.AllowedMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
+            Mods.Value = selectedItem?.Value?.RequiredMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
+            freeMods.Value = selectedItem?.Value?.AllowedMods.Select(m => m.CreateCopy()).ToArray() ?? Array.Empty<Mod>();
 
             Ruleset.BindValueChanged(onRulesetChanged);
         }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         [Resolved(typeof(Room), nameof(Room.RoomID))]
         private Bindable<int?> roomId { get; set; }
 
+        [Resolved(typeof(Room), nameof(Room.Playlist))]
+        private BindableList<PlaylistItem> playlist { get; set; }
+
         private MatchSettingsOverlay settingsOverlay;
         private MatchLeaderboard leaderboard;
 
@@ -117,7 +120,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                                                         new DrawableRoomPlaylistWithResults
                                                                         {
                                                                             RelativeSizeAxes = Axes.Both,
-                                                                            Items = { BindTarget = Playlist },
+                                                                            Items = { BindTarget = playlist },
                                                                             SelectedItem = { BindTarget = SelectedItem },
                                                                             RequestShowResults = item =>
                                                                             {
@@ -222,7 +225,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
                     // Set the first playlist item.
                     // This is scheduled since updating the room and playlist may happen in an arbitrary order (via Room.CopyFrom()).
-                    Schedule(() => SelectedItem.Value = Playlist.FirstOrDefault());
+                    Schedule(() => SelectedItem.Value = playlist.FirstOrDefault());
                 }
             }, true);
         }

--- a/osu.Game/Screens/OnlinePlay/RoomSubScreenComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/RoomSubScreenComposite.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Match;
+
+namespace osu.Game.Screens.OnlinePlay
+{
+    /// <summary>
+    /// An <see cref="OnlinePlayComposite"/> with additional logic tracking the currently-selected <see cref="PlaylistItem"/> inside a <see cref="RoomSubScreen"/>.
+    /// </summary>
+    public class RoomSubScreenComposite : OnlinePlayComposite
+    {
+        [Resolved]
+        private IBindable<PlaylistItem> subScreenSelectedItem { get; set; }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            subScreenSelectedItem.BindValueChanged(_ => UpdateSelectedItem(), true);
+        }
+
+        protected override void UpdateSelectedItem()
+        {
+            if (RoomID.Value == null)
+            {
+                // If the room hasn't been created yet, fall-back to the base logic.
+                base.UpdateSelectedItem();
+                return;
+            }
+
+            SelectedItem.Value = subScreenSelectedItem.Value;
+        }
+    }
+}


### PR DESCRIPTION
Multiplayer currently works by clearing and adding a new playlist item tracking the room settings. This should not be a thing going forward.

Several things were done in this PR to achieve this:
1. `StatefulMultiplayerClient` which now exposes a bindable for the currently-selected playlist item, which is directly bound to `RoomSubScreen.SelectedItem`.
2. `RoomSubScreen.SelectedItem` is cached for sub-components to use.
3. `StatefulMultiplayerClient` no longer clears the playlist - only changes an existing item, but also sets its own bindable that tracks the current playlist item.