### PR TITLE
Fix audio previews not being adjusted in volume correctly

### DIFF
--- a/osu.Game/Audio/PreviewTrackManager.cs
+++ b/osu.Game/Audio/PreviewTrackManager.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Audio
 
         protected TrackManagerPreviewTrack CurrentTrack;
 
+        private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(OsuGameBase.GLOBAL_TRACK_VOLUME_ADJUST);
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -35,6 +37,7 @@ namespace osu.Game.Audio
             trackStore = new PreviewTrackStore(new OnlineStore());
 
             audio.AddItem(trackStore);
+            trackStore.AddAdjustment(AdjustableProperty.Volume, globalTrackVolumeAdjust);
             trackStore.AddAdjustment(AdjustableProperty.Volume, audio.VolumeTrack);
         }
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -156,7 +156,12 @@ namespace osu.Game
 
         protected override UserInputManager CreateUserInputManager() => new OsuUserInputManager();
 
-        private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(0.5f);
+        /// <summary>
+        /// The maximum volume at which audio tracks should playback. This can be set lower than 1 to create some head-room for sound effects.
+        /// </summary>
+        internal const double GLOBAL_TRACK_VOLUME_ADJUST = 0.5;
+
+        private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(GLOBAL_TRACK_VOLUME_ADJUST);
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
I was going to use https://github.com/ppy/osu-framework/pull/4201 and use `Audio.Track.AggregateVolume`, but it turns out that this is not a great idea when `PreviewTrackManger` is applying a mute to that precise bindable.

This seems like the cleanest implementation we're going to get for this with the current audio hierarchy setup.

Closes #11807.