### PR TITLE
Fix carousel items' borders getting blown out when selected and hovered

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
@@ -24,7 +24,8 @@ namespace osu.Game.Screens.Select.Carousel
         public Container BorderContainer;
 
         public readonly Bindable<CarouselItemState> State = new Bindable<CarouselItemState>(CarouselItemState.NotSelected);
-        private HoverLayer hoverLayer;
+
+        private readonly HoverLayer hoverLayer;
 
         protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
 

--- a/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
@@ -24,8 +24,12 @@ namespace osu.Game.Screens.Select.Carousel
         public Container BorderContainer;
 
         public readonly Bindable<CarouselItemState> State = new Bindable<CarouselItemState>(CarouselItemState.NotSelected);
+        private HoverLayer hoverLayer;
 
         protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+
+        private const float corner_radius = 10;
+        private const float border_thickness = 2.5f;
 
         public CarouselHeader()
         {
@@ -36,12 +40,12 @@ namespace osu.Game.Screens.Select.Carousel
             {
                 RelativeSizeAxes = Axes.Both,
                 Masking = true,
-                CornerRadius = 10,
+                CornerRadius = corner_radius,
                 BorderColour = new Color4(221, 255, 255, 255),
                 Children = new Drawable[]
                 {
                     Content,
-                    new HoverLayer()
+                    hoverLayer = new HoverLayer()
                 }
             };
         }
@@ -59,6 +63,8 @@ namespace osu.Game.Screens.Select.Carousel
             {
                 case CarouselItemState.Collapsed:
                 case CarouselItemState.NotSelected:
+                    hoverLayer.InsetForBorder = false;
+
                     BorderContainer.BorderThickness = 0;
                     BorderContainer.EdgeEffect = new EdgeEffectParameters
                     {
@@ -70,7 +76,9 @@ namespace osu.Game.Screens.Select.Carousel
                     break;
 
                 case CarouselItemState.Selected:
-                    BorderContainer.BorderThickness = 2.5f;
+                    hoverLayer.InsetForBorder = true;
+
+                    BorderContainer.BorderThickness = border_thickness;
                     BorderContainer.EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
@@ -105,6 +113,26 @@ namespace osu.Game.Screens.Select.Carousel
                 };
 
                 sampleHover = audio.Samples.Get("SongSelect/song-ping");
+            }
+
+            public bool InsetForBorder
+            {
+                set
+                {
+                    if (value)
+                    {
+                        // apply same border as above to avoid applying additive overlay to it (and blowing out the colour).
+                        Masking = true;
+                        CornerRadius = corner_radius;
+                        BorderThickness = border_thickness;
+                    }
+                    else
+                    {
+                        BorderThickness = 0;
+                        CornerRadius = 0;
+                        Masking = false;
+                    }
+                }
             }
 
             protected override bool OnHover(HoverEvent e)


### PR DESCRIPTION
I tried restructuring the hierarchy to avoid needing this added property
(moving the hover layer out of the border container) but this leads to
some subpixel leakage outside the borders which looks even worse.

Closes #6915.

Before:

![20210218 170130 (dotnet)](https://user-images.githubusercontent.com/191335/108324217-f294a780-720a-11eb-8e30-fa4e1962fae7.png)

After:

![20210218 170048 (dotnet)](https://user-images.githubusercontent.com/191335/108324144-dd1f7d80-720a-11eb-8794-f4fdce724a56.png)
