### PR TITLE
Add login placeholder logic to OnlineOverlay

### DIFF
--- a/osu.Game/Online/OnlineViewContainer.cs
+++ b/osu.Game/Online/OnlineViewContainer.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Online
     /// A <see cref="Container"/> for displaying online content which require a local user to be logged in.
     /// Shows its children only when the local user is logged in and supports displaying a placeholder if not.
     /// </summary>
-    public abstract class OnlineViewContainer : Container
+    public class OnlineViewContainer : Container
     {
         protected LoadingSpinner LoadingSpinner { get; private set; }
 
@@ -30,7 +30,7 @@ namespace osu.Game.Online
         [Resolved]
         protected IAPIProvider API { get; private set; }
 
-        protected OnlineViewContainer(string placeholderMessage)
+        public OnlineViewContainer(string placeholderMessage)
         {
             this.placeholderMessage = placeholderMessage;
         }

--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Overlays
         protected List<APIUpdateStream> Streams;
 
         public ChangelogOverlay()
-            : base(OverlayColourScheme.Purple)
+            : base(OverlayColourScheme.Purple, false)
         {
         }
 

--- a/osu.Game/Overlays/NewsOverlay.cs
+++ b/osu.Game/Overlays/NewsOverlay.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Overlays
         private readonly Bindable<string> article = new Bindable<string>(null);
 
         public NewsOverlay()
-            : base(OverlayColourScheme.Purple)
+            : base(OverlayColourScheme.Purple, false)
         {
         }
 

--- a/osu.Game/Overlays/OnlineOverlay.cs
+++ b/osu.Game/Overlays/OnlineOverlay.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online;
 
 namespace osu.Game.Overlays
 {
@@ -16,10 +17,16 @@ namespace osu.Game.Overlays
         protected readonly LoadingLayer Loading;
         private readonly Container content;
 
-        protected OnlineOverlay(OverlayColourScheme colourScheme)
+        protected OnlineOverlay(OverlayColourScheme colourScheme, bool requiresSignIn = true)
             : base(colourScheme)
         {
-            base.Content.AddRange(new Drawable[]
+            var mainContent = requiresSignIn
+                ? new OnlineViewContainer($"Sign in to view the {Header.Title.Title}")
+                : new Container();
+
+            mainContent.RelativeSizeAxes = Axes.Both;
+
+            mainContent.AddRange(new Drawable[]
             {
                 ScrollFlow = new OverlayScrollContainer
                 {
@@ -41,8 +48,10 @@ namespace osu.Game.Overlays
                         }
                     }
                 },
-                Loading = new LoadingLayer(true)
+                Loading = new LoadingLayer()
             });
+
+            base.Content.Add(mainContent);
         }
     }
 }

--- a/osu.Game/Overlays/OnlineOverlay.cs
+++ b/osu.Game/Overlays/OnlineOverlay.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays
                         }
                     }
                 },
-                Loading = new LoadingLayer()
+                Loading = new LoadingLayer(true)
             });
 
             base.Content.Add(mainContent);

--- a/osu.Game/Overlays/TabbableOnlineOverlay.cs
+++ b/osu.Game/Overlays/TabbableOnlineOverlay.cs
@@ -61,8 +61,7 @@ namespace osu.Game.Overlays
 
             LoadComponentAsync(display, loaded =>
             {
-                if (API.IsLoggedIn)
-                    Loading.Hide();
+                Loading.Hide();
 
                 Child = loaded;
             }, (cancellationToken = new CancellationTokenSource()).Token);


### PR DESCRIPTION
A perfect implementation of this would probably leave the filter/header content visible, but that requires some re-thinking and restructuring to how the content is displayed in these overlays (ie. the header component shouldn't be inside the `ScrollContainer` as it is fixed).

Supersedes and closes #10774.
Closes #933. 
Addresses most pieces of #7417.

![20210218 180933 (dotnet)](https://user-images.githubusercontent.com/191335/108333655-89199680-7214-11eb-8904-a8f832970266.gif)
