### PR TITLE
Fix misordered hit error in score meter types

### DIFF
--- a/osu.Game/Configuration/ScoreMeterType.cs
+++ b/osu.Game/Configuration/ScoreMeterType.cs
@@ -16,11 +16,11 @@ namespace osu.Game.Configuration
         [Description("Hit Error (right)")]
         HitErrorRight,
 
-        [Description("Hit Error (bottom)")]
-        HitErrorBottom,
-
         [Description("Hit Error (left+right)")]
         HitErrorBoth,
+
+        [Description("Hit Error (bottom)")]
+        HitErrorBottom,
 
         [Description("Colour (left)")]
         ColourLeft,


### PR DESCRIPTION
Enforcing `Hit Error` to be `left, right, left+right, bottom` just like the `Colours` types below it.

Closes https://github.com/ppy/osu/issues/11825