### PR TITLE
Allow beatmap imports from any derived version of SongSelect, rather than only PlaySongSelect

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -383,7 +383,7 @@ namespace osu.Game
 
                 Ruleset.Value = selection.Ruleset;
                 Beatmap.Value = BeatmapManager.GetWorkingBeatmap(selection);
-            }, validScreens: new[] { typeof(PlaySongSelect) });
+            }, validScreens: new[] { typeof(SongSelect) });
         }
 
         /// <summary>

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -84,7 +84,7 @@ namespace osu.Game
             // we may already be at the target screen type.
             var type = current.GetType();
 
-            if (validScreens.Any(t => type.IsAssignableFrom(t)) && !beatmap.Disabled)
+            if (validScreens.Any(t => t.IsAssignableFrom(type)) && !beatmap.Disabled)
             {
                 finalAction(current);
                 Cancel();
@@ -93,7 +93,7 @@ namespace osu.Game
 
             while (current != null)
             {
-                if (validScreens.Any(t => type.IsAssignableFrom(t)))
+                if (validScreens.Any(t => t.IsAssignableFrom(type)))
                 {
                     current.MakeCurrent();
                     break;

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -82,7 +82,9 @@ namespace osu.Game
             game?.CloseAllOverlays(false);
 
             // we may already be at the target screen type.
-            if (validScreens.Contains(current.GetType()) && !beatmap.Disabled)
+            var type = current.GetType();
+
+            if (validScreens.Any(t => type.IsAssignableFrom(t)) && !beatmap.Disabled)
             {
                 finalAction(current);
                 Cancel();
@@ -91,13 +93,14 @@ namespace osu.Game
 
             while (current != null)
             {
-                if (validScreens.Contains(current.GetType()))
+                if (validScreens.Any(t => type.IsAssignableFrom(t)))
                 {
                     current.MakeCurrent();
                     break;
                 }
 
                 current = current.GetParentScreen();
+                type = current?.GetType();
             }
         }
 


### PR DESCRIPTION
This doesn't actually apply anywhere, but seems like an OK change to have anyway.