### PR TITLE
Keep pausing gameplay on focus loss if cannot on first attempt

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePauseWhenInactive.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePauseWhenInactive.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("set active", () => ((Bindable<bool>)host.IsActive).Value = true);
 
             AddStep("resume player", () => Player.Resume());
+            AddAssert("unpaused", () => !Player.GameplayClockContainer.IsPaused.Value);
 
             bool pauseCooldownActive = false;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePauseWhenInactive.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePauseWhenInactive.cs
@@ -2,21 +2,18 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
-using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Storyboards;
 using osu.Game.Tests.Beatmaps;
-using osuTK.Input;
+using osuTK;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -45,6 +42,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestPauseWhileInCooldown()
         {
+            AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));
+
             AddStep("resume player", () => Player.GameplayClockContainer.Start());
             AddStep("skip to gameplay", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.GameplayStartTime));
 
@@ -54,14 +53,15 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("set active", () => ((Bindable<bool>)host.IsActive).Value = true);
 
             AddStep("resume player", () => Player.Resume());
-            AddStep("click resume overlay", () =>
-            {
-                InputManager.MoveMouseTo(this.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single());
-                InputManager.Click(MouseButton.Left);
-            });
 
-            AddAssert("pause cooldown active", () => Player.PauseCooldownActive);
-            AddStep("set inactive again", () => ((Bindable<bool>)host.IsActive).Value = false);
+            bool pauseCooldownActive = false;
+
+            AddStep("set inactive again", () =>
+            {
+                pauseCooldownActive = Player.PauseCooldownActive;
+                ((Bindable<bool>)host.IsActive).Value = false;
+            });
+            AddAssert("pause cooldown active", () => pauseCooldownActive);
             AddUntilStep("wait for pause", () => Player.GameplayClockContainer.IsPaused.Value);
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -667,6 +667,9 @@ namespace osu.Game.Screens.Play
 
         private double? lastPauseActionTime;
 
+        public bool PauseCooldownActive =>
+            lastPauseActionTime.HasValue && GameplayClockContainer.GameplayClock.CurrentTime < lastPauseActionTime + pause_cooldown;
+
         private bool canPause =>
             // must pass basic screen conditions (beatmap loaded, instance allows pause)
             LoadedBeatmapSuccessfully && Configuration.AllowPause && ValidForResume
@@ -675,10 +678,7 @@ namespace osu.Game.Screens.Play
             // cannot pause if we are already in a fail state
             && !HasFailed
             // cannot pause if already paused (or in a cooldown state) unless we are in a resuming state.
-            && (IsResuming || (GameplayClockContainer.IsPaused.Value == false && !pauseCooldownActive));
-
-        private bool pauseCooldownActive =>
-            lastPauseActionTime.HasValue && GameplayClockContainer.GameplayClock.CurrentTime < lastPauseActionTime + pause_cooldown;
+            && (IsResuming || (GameplayClockContainer.IsPaused.Value == false && !PauseCooldownActive));
 
         private bool canResume =>
             // cannot resume from a non-paused state
@@ -812,7 +812,7 @@ namespace osu.Game.Screens.Play
             // ValidForResume is false when restarting
             if (ValidForResume)
             {
-                if (pauseCooldownActive && !GameplayClockContainer.IsPaused.Value)
+                if (PauseCooldownActive && !GameplayClockContainer.IsPaused.Value)
                     // still want to block if we are within the cooldown period and not already paused.
                     return true;
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -672,7 +672,7 @@ namespace osu.Game.Screens.Play
 
         private double? lastPauseActionTime;
 
-        public bool PauseCooldownActive =>
+        protected bool PauseCooldownActive =>
             lastPauseActionTime.HasValue && GameplayClockContainer.GameplayClock.CurrentTime < lastPauseActionTime + pause_cooldown;
 
         private bool canPause =>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -427,7 +427,7 @@ namespace osu.Game.Screens.Play
 
         private void updatePauseOnFocusLostState()
         {
-            if (!PauseOnFocusLost || DrawableRuleset.HasReplayLoaded.Value || breakTracker.IsBreakTime.Value)
+            if (!PauseOnFocusLost || pausingSupportedByCurrentState || breakTracker.IsBreakTime.Value)
                 return;
 
             if (gameActive.Value == false)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -434,6 +434,8 @@ namespace osu.Game.Screens.Play
             {
                 bool paused = Pause();
 
+                // if the initial pause could not be satisfied, the pause cooldown may be active.
+                // reschedule the pause attempt until it can be achieved.
                 if (!paused)
                     Scheduler.AddOnce(updatePauseOnFocusLostState);
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -427,7 +427,7 @@ namespace osu.Game.Screens.Play
 
         private void updatePauseOnFocusLostState()
         {
-            if (!PauseOnFocusLost || pausingSupportedByCurrentState || breakTracker.IsBreakTime.Value)
+            if (!PauseOnFocusLost || !pausingSupportedByCurrentState || breakTracker.IsBreakTime.Value)
                 return;
 
             if (gameActive.Value == false)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -435,7 +435,7 @@ namespace osu.Game.Screens.Play
                 if (canPause)
                     Pause();
                 else
-                    Scheduler.AddDelayed(updatePauseOnFocusLostState, 200);
+                    Scheduler.AddOnce(updatePauseOnFocusLostState);
             }
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -427,11 +427,16 @@ namespace osu.Game.Screens.Play
 
         private void updatePauseOnFocusLostState()
         {
-            if (!PauseOnFocusLost || breakTracker.IsBreakTime.Value)
+            if (!PauseOnFocusLost || DrawableRuleset.HasReplayLoaded.Value || breakTracker.IsBreakTime.Value)
                 return;
 
             if (gameActive.Value == false)
-                Pause();
+            {
+                if (canPause)
+                    Pause();
+                else
+                    Scheduler.AddDelayed(updatePauseOnFocusLostState, 200);
+            }
         }
 
         private IBeatmap loadPlayableBeatmap()

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Tests.Visual
 
         public new HealthProcessor HealthProcessor => base.HealthProcessor;
 
+        public new bool PauseCooldownActive => base.PauseCooldownActive;
+
         public readonly List<JudgementResult> Results = new List<JudgementResult>();
 
         public TestPlayer(bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false)


### PR DESCRIPTION
Closes #5740 

I was initially planning to fix this by changing the `pauseCooldownActive` property into being a bindable and making the player call `updatePauseOnFocusLost` once the cooldown is off (if window lost focus), but felt like it's starting to lead the whole "pause on focus lost" logic into becoming more complicated, than just making it try pausing again if cannot on first attempt.

Arbitrarily chose `200ms` as the delay between each pause attempts, wasn't feeling alright making it `50ms` or *`10ms`*, can change per suggestion.

Also improved `TestScenePauseWhenInactive` to not be interrupted by beatmap breaks and have a regular clock (not [headless's fast clock](https://github.com/ppy/osu-framework/blob/2b15aa3bbe6723d29d66c1eb866221f426147bcc/osu.Framework/Platform/HeadlessGameHost.cs#L73-L91)) for testing properly.