### PR TITLE
Add the ability for PerformFromMenuRunner to inspect nested screen stacks

### DIFF
--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -103,7 +103,11 @@ namespace osu.Game
                 if (current is IHasSubScreenStack currentSubScreen)
                 {
                     if (findValidTarget(currentSubScreen.SubScreenStack.CurrentScreen))
+                    {
+                        // should be correct in theory, but currently untested/unused in existing implementations.
+                        current.MakeCurrent();
                         return true;
+                    }
                 }
 
                 if (validScreens.Any(t => t.IsAssignableFrom(type)))

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -13,6 +13,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Screens;
 using osu.Game.Screens.Menu;
 
 namespace osu.Game
@@ -81,27 +82,41 @@ namespace osu.Game
 
             game?.CloseAllOverlays(false);
 
-            // we may already be at the target screen type.
+            findValidTarget(current);
+        }
+
+        private bool findValidTarget(IScreen current)
+        {
             var type = current.GetType();
 
+            // check if we are already at a valid target screen.
             if (validScreens.Any(t => t.IsAssignableFrom(type)) && !beatmap.Disabled)
             {
                 finalAction(current);
                 Cancel();
-                return;
+                return true;
             }
 
             while (current != null)
             {
+                // if this has a sub stack, recursively check the screens within it.
+                if (current is IHasSubScreenStack currentSubScreen)
+                {
+                    if (findValidTarget(currentSubScreen.SubScreenStack.CurrentScreen))
+                        return true;
+                }
+
                 if (validScreens.Any(t => t.IsAssignableFrom(type)))
                 {
                     current.MakeCurrent();
-                    break;
+                    return true;
                 }
 
                 current = current.GetParentScreen();
                 type = current?.GetType();
             }
+
+            return false;
         }
 
         /// <summary>

--- a/osu.Game/Screens/IHasSubScreenStack.cs
+++ b/osu.Game/Screens/IHasSubScreenStack.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Screens;
+
+namespace osu.Game.Screens
+{
+    /// <summary>
+    /// A screen which manages a nested stack of screens within itself.
+    /// </summary>
+    public interface IHasSubScreenStack
+    {
+        ScreenStack SubScreenStack { get; }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -28,7 +28,7 @@ using osuTK;
 namespace osu.Game.Screens.OnlinePlay
 {
     [Cached]
-    public abstract class OnlinePlayScreen : OsuScreen
+    public abstract class OnlinePlayScreen : OsuScreen, IHasSubScreenStack
     {
         public override bool CursorVisible => (screenStack.CurrentScreen as IOnlinePlaySubScreen)?.CursorVisible ?? true;
 
@@ -355,5 +355,7 @@ namespace osu.Game.Screens.OnlinePlay
                 protected override double TransformDuration => 200;
             }
         }
+
+        ScreenStack IHasSubScreenStack.SubScreenStack => screenStack;
     }
 }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/issues/11365 (when performing the action while at song select). Not sure if this is enough to close the issue - we probably want to warn/block the user from exiting their multiplayer game if they try to change beatmaps from the match screen, for instance. Or somehow convey the update to the screen in a way it can handle it.

Adding a test for this is a bit awkward but can probably do one in the navigation section if required.