### PR TITLE
Fix support for instant exit if pausing is not allowed in the current game mode

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -91,6 +91,15 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestUserPauseWhenPauseNotAllowed()
+        {
+            AddStep("disable pause support", () => Player.Configuration.AllowPause = false);
+
+            pauseFromUserExitKey();
+            confirmExited();
+        }
+
+        [Test]
         public void TestUserPauseDuringCooldownTooSoon()
         {
             AddStep("move cursor outside", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.TopLeft - new Vector2(10)));


### PR DESCRIPTION
I understand this code is pretty complex, so I've spent due diligence to try and make this more readable with each change. Probably easier to checkout and examine this code rather than attempt to compare the diff.

Hoping to get this out in a hotfix build as it's a pretty serious regression.