### PR TITLE
Add tests for clockrate adjusted difficulty calculations

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Difficulty;
+using osu.Game.Rulesets.Catch.Mods;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Tests.Beatmaps;
 
@@ -16,6 +17,10 @@ namespace osu.Game.Rulesets.Catch.Tests
         [TestCase(4.050601681491468d, "diffcalc-test")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
+
+        [TestCase(5.0565038923984691d, "diffcalc-test")]
+        public void TestClockRateAdjusted(double expected, string name)
+            => Test(expected, name, new CatchModDoubleTime());
 
         protected override DifficultyCalculator CreateDifficultyCalculator(WorkingBeatmap beatmap) => new CatchDifficultyCalculator(new CatchRuleset(), beatmap);
 

--- a/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania.Difficulty;
+using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Rulesets.Mania.Tests
@@ -16,6 +17,10 @@ namespace osu.Game.Rulesets.Mania.Tests
         [TestCase(2.3449735700206298d, "diffcalc-test")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
+
+        [TestCase(2.7646128945056723d, "diffcalc-test")]
+        public void TestClockRateAdjusted(double expected, string name)
+            => Test(expected, name, new ManiaModDoubleTime());
 
         protected override DifficultyCalculator CreateDifficultyCalculator(WorkingBeatmap beatmap) => new ManiaDifficultyCalculator(new ManiaRuleset(), beatmap);
 

--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Osu.Difficulty;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Rulesets.Osu.Tests
@@ -18,6 +19,11 @@ namespace osu.Game.Rulesets.Osu.Tests
         [TestCase(1.0736587013228804d, "zero-length-sliders")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
+
+        [TestCase(8.6228371119393064d, "diffcalc-test")]
+        [TestCase(1.2864585434597433d, "zero-length-sliders")]
+        public void TestClockRateAdjusted(double expected, string name)
+            => Test(expected, name, new OsuModDoubleTime());
 
         protected override DifficultyCalculator CreateDifficultyCalculator(WorkingBeatmap beatmap) => new OsuDifficultyCalculator(new OsuRuleset(), beatmap);
 

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Taiko.Difficulty;
+using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Rulesets.Taiko.Tests
@@ -17,6 +18,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
         [TestCase(2.2867022617692685d, "diffcalc-test-strong")]
         public void Test(double expected, string name)
             => base.Test(expected, name);
+
+        [TestCase(3.1473940254109078d, "diffcalc-test")]
+        [TestCase(3.1473940254109078d, "diffcalc-test-strong")]
+        public void TestClockRateAdjusted(double expected, string name)
+            => Test(expected, name, new TaikoModDoubleTime());
 
         protected override DifficultyCalculator CreateDifficultyCalculator(WorkingBeatmap beatmap) => new TaikoDifficultyCalculator(new TaikoRuleset(), beatmap);
 


### PR DESCRIPTION
## What

This PR simply adds tests for difficulty calculations with DoubleTime enabled.
DoubleTime is used simply as an arbitrary clockrate modification.

## Why

Clockrate adjustments are a potentially buggy area of difficulty calculation and there are currently no tests to help identify issues there.

I recently discovered and fixed a bug with clockrate adjusted difficulty calculations, but didn't want to add the tests in the same PR incase it would be considered out of scope.

PR with bug fix: #11849