### PR TITLE
Remove explicit clockrate usage from catch Movement skill

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         public void Test(double expected, string name)
             => base.Test(expected, name);
 
-        [TestCase(5.0565038923984691d, "diffcalc-test")]
+        [TestCase(5.169743871843191d, "diffcalc-test")]
         public void TestClockRateAdjusted(double expected, string name)
             => Test(expected, name, new CatchModDoubleTime());
 

--- a/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchDifficultyCalculatorTest.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         public void Test(double expected, string name)
             => base.Test(expected, name);
 
-        [TestCase(5.169743871843191d, "diffcalc-test")]
+        [TestCase(5.1453165867279349d, "diffcalc-test")]
         public void TestClockRateAdjusted(double expected, string name)
             => Test(expected, name, new CatchModDoubleTime());
 

--- a/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
@@ -24,8 +24,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Preprocessing
         /// </summary>
         public readonly double StrainTime;
 
-        public readonly double ClockRate;
-
         public CatchDifficultyHitObject(HitObject hitObject, HitObject lastObject, double clockRate, float halfCatcherWidth)
             : base(hitObject, lastObject, clockRate)
         {
@@ -37,7 +35,6 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Preprocessing
 
             // Every strain interval is hard capped at the equivalent of 375 BPM streaming speed as a safety measure
             StrainTime = Math.Max(40, DeltaTime);
-            ClockRate = clockRate;
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
 
             float distanceMoved = playerPosition - lastPlayerPosition.Value;
 
-            double weightedStrainTime = catchCurrent.StrainTime + 13 + (3 / catchCurrent.ClockRate);
+            double weightedStrainTime = catchCurrent.StrainTime + 16;
 
             double distanceAddition = (Math.Pow(Math.Abs(distanceMoved), 1.3) / 510);
             double sqrtStrain = Math.Sqrt(weightedStrainTime);
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
                     playerPosition = catchCurrent.NormalizedPosition;
                 }
 
-                distanceAddition *= 1.0 + edgeDashBonus * ((20 - catchCurrent.LastObject.DistanceToHyperDash) / 20) * Math.Pow((Math.Min(catchCurrent.StrainTime * catchCurrent.ClockRate, 265) / 265), 1.5); // Edge Dashes are easier at lower ms values
+                distanceAddition *= 1.0 + edgeDashBonus * ((20 - catchCurrent.LastObject.DistanceToHyperDash) / 20) * Math.Pow(Math.Min(catchCurrent.StrainTime, 265) / 265, 1.5); // Edge Dashes are easier at lower ms values
             }
 
             lastPlayerPosition = playerPosition;

--- a/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaDifficultyCalculatorTest.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         public void Test(double expected, string name)
             => base.Test(expected, name);
 
-        [TestCase(2.7646128945056723d, "diffcalc-test")]
+        [TestCase(2.7879104989252959d, "diffcalc-test")]
         public void TestClockRateAdjusted(double expected, string name)
             => Test(expected, name, new ManiaModDoubleTime());
 

--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -71,8 +71,8 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
         }
 
         protected override double GetPeakStrain(double offset)
-            => applyDecay(individualStrain, offset - Previous[0].BaseObject.StartTime, individual_decay_base)
-               + applyDecay(overallStrain, offset - Previous[0].BaseObject.StartTime, overall_decay_base);
+            => applyDecay(individualStrain, offset - Previous[0].StartTime, individual_decay_base)
+               + applyDecay(overallStrain, offset - Previous[0].StartTime, overall_decay_base);
 
         private double applyDecay(double value, double deltaTime, double decayBase)
             => value * Math.Pow(decayBase, deltaTime / 1000);

--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -20,8 +20,8 @@ namespace osu.Game.Rulesets.Osu.Tests
         public void Test(double expected, string name)
             => base.Test(expected, name);
 
-        [TestCase(8.6228371119393064d, "diffcalc-test")]
-        [TestCase(1.2864585434597433d, "zero-length-sliders")]
+        [TestCase(8.7212283220504574d, "diffcalc-test")]
+        [TestCase(1.3212137310562277d, "zero-length-sliders")]
         public void TestClockRateAdjusted(double expected, string name)
             => Test(expected, name, new OsuModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -19,8 +19,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
         public void Test(double expected, string name)
             => base.Test(expected, name);
 
-        [TestCase(3.1473940254109078d, "diffcalc-test")]
-        [TestCase(3.1473940254109078d, "diffcalc-test-strong")]
+        [TestCase(3.1704781712282624d, "diffcalc-test")]
+        [TestCase(3.1704781712282624d, "diffcalc-test-strong")]
         public void TestClockRateAdjusted(double expected, string name)
             => Test(expected, name, new TaikoModDoubleTime());
 

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Difficulty
                     foreach (Skill s in skills)
                     {
                         s.SaveCurrentPeak();
-                        s.StartNewSectionFrom(currentSectionEnd);
+                        s.StartNewSectionFrom(currentSectionEnd / clockRate);
                     }
 
                     currentSectionEnd += sectionLength;

--- a/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
+++ b/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
@@ -26,6 +26,11 @@ namespace osu.Game.Rulesets.Difficulty.Preprocessing
         public readonly double DeltaTime;
 
         /// <summary>
+        /// Start time of <see cref="BaseObject"/>.
+        /// </summary>
+        public readonly double StartTime;
+
+        /// <summary>
         /// Creates a new <see cref="DifficultyHitObject"/>.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> which this <see cref="DifficultyHitObject"/> wraps.</param>
@@ -36,6 +41,7 @@ namespace osu.Game.Rulesets.Difficulty.Preprocessing
             BaseObject = hitObject;
             LastObject = lastObject;
             DeltaTime = (hitObject.StartTime - lastObject.StartTime) / clockRate;
+            StartTime = hitObject.StartTime / clockRate;
         }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/Skills/Skill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/Skill.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// <summary>
         /// Sets the initial strain level for a new section.
         /// </summary>
-        /// <param name="time">The beginning of the new section in milliseconds.</param>
+        /// <param name="time">The beginning of the new section in milliseconds, adjusted by clockrate.</param>
         public void StartNewSectionFrom(double time)
         {
             // The maximum strain of the new section is not zero by default, strain decays as usual regardless of section boundaries.
@@ -87,9 +87,9 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// <summary>
         /// Retrieves the peak strain at a point in time.
         /// </summary>
-        /// <param name="time">The time to retrieve the peak strain at.</param>
+        /// <param name="time">The time to retrieve the peak strain at, adjusted by clockrate.</param>
         /// <returns>The peak strain.</returns>
-        protected virtual double GetPeakStrain(double time) => CurrentStrain * strainDecay(time - Previous[0].BaseObject.StartTime);
+        protected virtual double GetPeakStrain(double time) => CurrentStrain * strainDecay(time - Previous[0].StartTime);
 
         /// <summary>
         /// Returns the calculated difficulty value representing all processed <see cref="DifficultyHitObject"/>s.


### PR DESCRIPTION
## What

Removes explicit clockrate usage within the catch calculator's `Movement` skill.

## Why

The current implementation of the catch difficulty calculator has explicit usages of clockrate in its calculations for edge bonuses and weighting the strain time in general.
I'm not overly familiar with catch, but assuming there are no physical differences between a map with 1.5x clockrate and the same map with manually modified 1.5x speed timings played at 1.0x clockrate (as it is in every other ruleset), this is a bug that causes a ~2% error in 1.5x clockrate star rating calculation.

This can be seen by running the catch calculator against a base map with DT and the same map with manually modified timings as described above.

  | manual dt | base +DT | error | abs error %
-- | -- | -- | -- | --
master | 5.144380624 | 5.056503892 | 0.087876732 | 1.737895073
decay + catch fix | 5.144380624 | 5.145316587 | -0.0009359623336 | 0.01819056841

Decay fix details and test maps can be found in #11849

I'm sure there was a reason this was originally implemented, but it has been done so without a full understanding of the implications.

---

The proper solution to this issue is to replace the explicit clockrate usage with simply using the clockrate adjusted delta times of `DifficultyHitObject`s, for example by using a curve that is more harsh at lower ms values.
However since I know almost nothing about the reasons behind the catch calculator's algorithm, I am not able to make such changes myself.

Simply removing the clockrate doesn't have very much of an impact at all (~2% change at extremes; numbers below), so I think it is alright to leave the reimplementation of this feature to another PR, if it is desired so.

## Changes in DT values

  | master | decay fix | remove clockrate | % of decay fix | % of master
-- | -- | -- | -- | -- | --
[image-material](https://osu.ppy.sh/beatmapsets/432720#fruits/933017) | 10.65933461 | 10.67048979 | 10.5716336 | 99.07355535 | 99.17723756
[ragnarok](https://osu.ppy.sh/beatmapsets/928515#fruits/1939410) | 11.0569002 | 11.05871021 | 10.95616942 | 99.07275999 | 99.08897812
[ill-basic](https://osu.ppy.sh/beatmapsets/777109#fruits/2160131) | 2.461424568 | 2.461921776 | 2.453373223 | 99.6527691 | 99.67289897
[ill-dys](https://osu.ppy.sh/beatmapsets/777109#fruits/1632808) | 12.12056832 | 12.13107711 | 12.02173019 | 99.09862153 | 99.18454215
[ill-dys-crystal](https://osu.ppy.sh/beatmapsets/777109#fruits/2160014) | 12.40962423 | 12.41679868 | 12.30743075 | 99.11919385 | 99.17649822
diffcalc-test | 5.056503892 | 5.169743872 | 5.145316587 | 99.52749525 | 101.7564051

As I am not very familiar with catch, there very well may be certain types of maps that are impacted to a greater extent than this, so it would be helpful if some catch players could help me out in testing this further.

Depends on #11849