### PR TITLE
Add Pitch Shift Mod

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -113,6 +113,7 @@ namespace osu.Game.Rulesets.Catch
                     return new Mod[]
                     {
                         new CatchModDifficultyAdjust(),
+                        new ModPitchShift(),
                     };
 
                 case ModType.Automation:
@@ -126,7 +127,6 @@ namespace osu.Game.Rulesets.Catch
                     return new Mod[]
                     {
                         new MultiMod(new ModWindUp(), new ModWindDown()),
-                        new ModPitchShift()
                     };
 
                 default:

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -125,7 +125,8 @@ namespace osu.Game.Rulesets.Catch
                 case ModType.Fun:
                     return new Mod[]
                     {
-                        new MultiMod(new ModWindUp(), new ModWindDown())
+                        new MultiMod(new ModWindUp(), new ModWindDown()),
+                        new ModPitchShift()
                     };
 
                 default:

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -250,7 +250,8 @@ namespace osu.Game.Rulesets.Mania
                 case ModType.Fun:
                     return new Mod[]
                     {
-                        new MultiMod(new ModWindUp(), new ModWindDown())
+                        new MultiMod(new ModWindUp(), new ModWindDown()),
+                        new ModPitchShift()
                     };
 
                 default:

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -238,7 +238,8 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModMirror(),
                         new ManiaModDifficultyAdjust(),
                         new ManiaModInvert(),
-                        new ManiaModConstantSpeed()
+                        new ManiaModConstantSpeed(),
+                        new ModPitchShift(),
                     };
 
                 case ModType.Automation:
@@ -251,7 +252,6 @@ namespace osu.Game.Rulesets.Mania
                     return new Mod[]
                     {
                         new MultiMod(new ModWindUp(), new ModWindDown()),
-                        new ModPitchShift()
                     };
 
                 default:

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -163,7 +163,8 @@ namespace osu.Game.Rulesets.Osu
                     {
                         new OsuModTarget(),
                         new OsuModDifficultyAdjust(),
-                        new OsuModClassic()
+                        new OsuModClassic(),
+                        new ModPitchShift(),
                     };
 
                 case ModType.Automation:
@@ -184,7 +185,6 @@ namespace osu.Game.Rulesets.Osu
                         new MultiMod(new OsuModGrow(), new OsuModDeflate()),
                         new MultiMod(new ModWindUp(), new ModWindDown()),
                         new OsuModTraceable(),
-                        new ModPitchShift()
                     };
 
                 case ModType.System:

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -184,6 +184,7 @@ namespace osu.Game.Rulesets.Osu
                         new MultiMod(new OsuModGrow(), new OsuModDeflate()),
                         new MultiMod(new ModWindUp(), new ModWindDown()),
                         new OsuModTraceable(),
+                        new ModPitchShift()
                     };
 
                 case ModType.System:

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -146,7 +146,8 @@ namespace osu.Game.Rulesets.Taiko
                 case ModType.Fun:
                     return new Mod[]
                     {
-                        new MultiMod(new ModWindUp(), new ModWindDown())
+                        new MultiMod(new ModWindUp(), new ModWindDown()),
+                        new ModPitchShift()
                     };
 
                 default:

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -134,6 +134,7 @@ namespace osu.Game.Rulesets.Taiko
                     {
                         new TaikoModRandom(),
                         new TaikoModDifficultyAdjust(),
+                        new ModPitchShift(),
                     };
 
                 case ModType.Automation:
@@ -147,7 +148,6 @@ namespace osu.Game.Rulesets.Taiko
                     return new Mod[]
                     {
                         new MultiMod(new ModWindUp(), new ModWindDown()),
-                        new ModPitchShift()
                     };
 
                 default:

--- a/osu.Game.Tests/Rulesets/Mods/ModPitchShiftTest.cs
+++ b/osu.Game.Tests/Rulesets/Mods/ModPitchShiftTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Tests.Rulesets.Mods
+{
+    [TestFixture]
+    public class ModPitchShiftTest
+    {
+        private TrackVirtual track;
+
+        [SetUp]
+        public void SetUp()
+        {
+            track = new TrackVirtual(20_000);
+        }
+
+        [TestCase(0.5)]
+        [TestCase(1.0)]
+        [TestCase(1.5)]
+        public void TestModPitchShift(double pitch)
+        {
+            var mod = new ModPitchShift();
+            mod.ApplyToTrack(track);
+
+            mod.PitchChange.Value = pitch;
+
+            Assert.That(track.AggregateTempo.Value, Is.EqualTo(1.0 / pitch));
+            Assert.That(track.AggregateFrequency.Value, Is.EqualTo(pitch));
+            Assert.That(track.Rate, Is.EqualTo(1.0));
+        }
+
+        [TestCase(0.5)]
+        [TestCase(1.0)]
+        [TestCase(1.5)]
+        public void TestMatchTempo(double tempo)
+        {
+            track.AddAdjustment(AdjustableProperty.Tempo, new BindableDouble(tempo));
+
+            var mod = new ModPitchShift();
+            mod.ApplyToTrack(track);
+
+            mod.MatchTempo.Value = true;
+
+            mod.Update(null);
+
+            Assert.That(track.AggregateFrequency.Value, Is.EqualTo(tempo));
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModPitchShift.cs
+++ b/osu.Game/Rulesets/Mods/ModPitchShift.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Pitch Shift";
         public override string Acronym => "PS";
         public override IconUsage? Icon => FontAwesome.Solid.WaveSquare;
-        public override ModType Type => ModType.Fun;
+        public override ModType Type => ModType.Conversion;
         public override string Description => "Raise or lower the track's pitch.";
         public override double ScoreMultiplier => 1;
 
@@ -26,11 +26,13 @@ namespace osu.Game.Rulesets.Mods
             Default = 1,
             Value = 1,
             Precision = 0.01,
-            Disabled = false
         };
 
         [SettingSource("Match tempo", "Match the pitch with the current tempo")]
         public BindableBool MatchTempo { get; } = new BindableBool();
+
+        [SettingSource("Flatten pitch", "Counteract current pitch adjustments")]
+        public BindableBool FlattenPitch { get; } = new BindableBool();
 
         private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
         private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
@@ -46,6 +48,7 @@ namespace osu.Game.Rulesets.Mods
             }, true);
 
             MatchTempo.BindValueChanged(applyMatchTempo);
+            FlattenPitch.BindValueChanged(applyFlattenTempo);
         }
 
         public void ApplyToTrack(ITrack track)
@@ -59,8 +62,19 @@ namespace osu.Game.Rulesets.Mods
         private void applyMatchTempo(ValueChangedEvent<bool> val)
         {
             if (val.NewValue)
-                PitchChange.Value = track.Tempo.Value; // track.Rate;
-            PitchChange.Disabled = val.NewValue;
+                PitchChange.Value = track.Tempo.Value;
+
+            //PitchChange.Disabled = val.NewValue;
+            //FlattenPitch.Disabled = val.NewValue;
+        }
+
+        private void applyFlattenTempo(ValueChangedEvent<bool> val)
+        {
+            if (val.NewValue)
+                PitchChange.Value = 1.0 / track.Frequency.Value;
+
+            //PitchChange.Disabled = val.NewValue;
+            //MatchTempo.Disabled = val.NewValue;
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModPitchShift.cs
+++ b/osu.Game/Rulesets/Mods/ModPitchShift.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public class ModPitchShift : Mod, IApplicableToTrack
+    {
+        public override string Name => "Pitch Shift";
+        public override string Acronym => "PS";
+        public override IconUsage? Icon => FontAwesome.Solid.WaveSquare;
+        public override ModType Type => ModType.Fun;
+        public override string Description => "Raise or lower the track's pitch.";
+        public override double ScoreMultiplier => 1;
+
+        [SettingSource("Pitch shift", "Raise or lower the track's pitch")]
+        public BindableNumber<double> PitchChange { get; } = new BindableDouble()
+        {
+            MinValue = 0.5,
+            MaxValue = 1.5,
+            Default = 1,
+            Value = 1,
+            Precision = 0.01,
+            Disabled = false
+        };
+
+        [SettingSource("Match tempo", "Match the pitch with the current tempo")]
+        public BindableBool MatchTempo { get; } = new BindableBool();
+
+        private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
+        private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
+
+        private ITrack track;
+
+        public ModPitchShift()
+        {
+            PitchChange.BindValueChanged(val =>
+            {
+                tempoAdjust.Value = 1 / val.NewValue;
+                freqAdjust.Value = val.NewValue;
+            }, true);
+
+            MatchTempo.BindValueChanged(applyMatchTempo);
+        }
+
+        public void ApplyToTrack(ITrack track)
+        {
+            this.track = track;
+
+            track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjust);
+            track.AddAdjustment(AdjustableProperty.Frequency, freqAdjust);
+        }
+
+        private void applyMatchTempo(ValueChangedEvent<bool> val)
+        {
+            if (val.NewValue)
+                PitchChange.Value = track.Tempo.Value; // track.Rate;
+            PitchChange.Disabled = val.NewValue;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModPitchShift.cs
+++ b/osu.Game/Rulesets/Mods/ModPitchShift.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         public override double ScoreMultiplier => 1;
 
         [SettingSource("Pitch shift", "Raise or lower the track's pitch")]
-        public BindableNumber<double> PitchChange { get; } = new BindableDouble()
+        public BindableNumber<double> PitchChange { get; } = new BindableDouble
         {
             MinValue = 0.5,
             MaxValue = 2.0,

--- a/osu.Game/Rulesets/Mods/ModPitchShift.cs
+++ b/osu.Game/Rulesets/Mods/ModPitchShift.cs
@@ -6,10 +6,11 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public class ModPitchShift : Mod, IApplicableToTrack
+    public class ModPitchShift : Mod, IUpdatableByPlayfield, IApplicableToTrack
     {
         public override string Name => "Pitch Shift";
         public override string Acronym => "PS";
@@ -22,17 +23,14 @@ namespace osu.Game.Rulesets.Mods
         public BindableNumber<double> PitchChange { get; } = new BindableDouble()
         {
             MinValue = 0.5,
-            MaxValue = 1.5,
+            MaxValue = 2.0,
             Default = 1,
             Value = 1,
             Precision = 0.01,
         };
 
-        [SettingSource("Match tempo", "Match the pitch with the current tempo")]
+        [SettingSource("Match tempo", "Match pitch with the tempo")]
         public BindableBool MatchTempo { get; } = new BindableBool();
-
-        [SettingSource("Flatten pitch", "Counteract current pitch adjustments")]
-        public BindableBool FlattenPitch { get; } = new BindableBool();
 
         private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
         private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
@@ -42,13 +40,9 @@ namespace osu.Game.Rulesets.Mods
         public ModPitchShift()
         {
             PitchChange.BindValueChanged(val =>
-            {
-                tempoAdjust.Value = 1 / val.NewValue;
-                freqAdjust.Value = val.NewValue;
-            }, true);
+                setPitch(val.NewValue), true);
 
-            MatchTempo.BindValueChanged(applyMatchTempo);
-            FlattenPitch.BindValueChanged(applyFlattenTempo);
+            MatchTempo.BindValueChanged(matchTempoChanged);
         }
 
         public void ApplyToTrack(ITrack track)
@@ -59,22 +53,27 @@ namespace osu.Game.Rulesets.Mods
             track.AddAdjustment(AdjustableProperty.Frequency, freqAdjust);
         }
 
-        private void applyMatchTempo(ValueChangedEvent<bool> val)
+        public void Update(Playfield playfield)
         {
-            if (val.NewValue)
-                PitchChange.Value = track.Tempo.Value;
-
-            //PitchChange.Disabled = val.NewValue;
-            //FlattenPitch.Disabled = val.NewValue;
+            if (MatchTempo.Value)
+                setPitch(getMatchTempoPitchAdjustment());
         }
 
-        private void applyFlattenTempo(ValueChangedEvent<bool> val)
+        private void setPitch(double pitch)
+        {
+            tempoAdjust.Value = 1 / pitch;
+            freqAdjust.Value = pitch;
+        }
+
+        private void matchTempoChanged(ValueChangedEvent<bool> val)
         {
             if (val.NewValue)
-                PitchChange.Value = 1.0 / track.Frequency.Value;
+                PitchChange.Value = getMatchTempoPitchAdjustment();
 
-            //PitchChange.Disabled = val.NewValue;
-            //MatchTempo.Disabled = val.NewValue;
+            PitchChange.Disabled = val.NewValue;
         }
+
+        private double getMatchTempoPitchAdjustment()
+            => track.AggregateTempo.Value / tempoAdjust.Value;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModPitchShift.cs
+++ b/osu.Game/Rulesets/Mods/ModPitchShift.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Mods
 
         private void setPitch(double pitch)
         {
-            tempoAdjust.Value = 1 / pitch;
+            tempoAdjust.Value = 1.0 / pitch;
             freqAdjust.Value = pitch;
         }
 
@@ -74,6 +74,6 @@ namespace osu.Game.Rulesets.Mods
         }
 
         private double getMatchTempoPitchAdjustment()
-            => track.AggregateTempo.Value / tempoAdjust.Value;
+            => track != null ? track.AggregateTempo.Value / tempoAdjust.Value : 1.0;
     }
 }


### PR DESCRIPTION
Adds a new mod that allows players to adjust the playback pitch of a song without affecting tempo.

The mod also provides a 'Match tempo' setting which will match the pitch to the songs tempo allowing users to effectively have double-time with a pitch adjustment. (I personally believe this is a better alternative to having local settings for each mod, open to others opinions on this however)

Only concern is that match tempo does not automatically update pitch at song select if tempo is changed after it is selected. This is because the match tempo pitch is done as a playfield update and not as a binding (since I couldn't figure out a way to avoid circular bindings) any feedback on this would be appreciated.

- [ ] Depends on [ppy/osu-framework#4118](https://github.com/ppy/osu-framework/pull/4118)

Closes #9805 #9958
