### PR TITLE
Disable multiplayer/spectator on iOS until it can be supported again

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -10,6 +10,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -246,7 +247,14 @@ namespace osu.Game.Online.API
             this.password = password;
         }
 
-        public IHubClientConnector GetHubConnector(string clientName, string endpoint) => new HubClientConnector(clientName, endpoint, this, versionHash);
+        public IHubClientConnector GetHubConnector(string clientName, string endpoint)
+        {
+            // disabled until the underlying runtime issue is resolved, see https://github.com/mono/mono/issues/20805.
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.iOS)
+                return null;
+
+            return new HubClientConnector(clientName, endpoint, this, versionHash);
+        }
 
         public RegistrationRequest.RegistrationRequestErrors CreateAccount(string email, string username, string password)
         {

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -172,6 +172,23 @@ namespace osu.Game.Screens.Menu
                 return;
             }
 
+            // disabled until the underlying runtime issue is resolved, see https://github.com/mono/mono/issues/20805.
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.iOS)
+            {
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = "Multiplayer is temporarily unavailable on iOS as we figure out some low level issues.",
+                    Icon = FontAwesome.Solid.AppleAlt,
+                    Activated = () =>
+                    {
+                        loginOverlay?.Show();
+                        return true;
+                    }
+                });
+
+                return;
+            }
+
             OnMultiplayer?.Invoke();
         }
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -179,11 +179,6 @@ namespace osu.Game.Screens.Menu
                 {
                     Text = "Multiplayer is temporarily unavailable on iOS as we figure out some low level issues.",
                     Icon = FontAwesome.Solid.AppleAlt,
-                    Activated = () =>
-                    {
-                        loginOverlay?.Show();
-                        return true;
-                    }
                 });
 
                 return;


### PR DESCRIPTION
This stops a connection failure loop from occurring in the background while using the iOS client. I've looked into alternatives to get this working in the mean time but it doesn't seem worth it (or possible).

This is in preparation for an attempted re-deploy to testflight, which also isn't guaranteed to be successful.