### PR TITLE
Add an 'Adjust Pitch' setting for RateAdjust mods

### DIFF
--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -5,6 +5,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -14,6 +15,12 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "DC";
         public override IconUsage? Icon => null;
         public override string Description => "Whoaaaaa...";
+
+        [SettingSource("Adjust pitch", "Should pitch be adjusted with speed", 1)]
+        public override BindableBool AdjustPitch { get; } = new BindableBool
+        {
+            Disabled = true
+        };
 
         private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
         private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModHalfTime)).ToArray();
 
-        [SettingSource("Speed increase", "The actual increase to apply")]
+        [SettingSource("Speed increase", "The actual increase to apply", 0)]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble
         {
             MinValue = 1.01,
@@ -30,5 +30,8 @@ namespace osu.Game.Rulesets.Mods
             Value = 1.5,
             Precision = 0.01,
         };
+
+        [SettingSource("Adjust pitch", "Should pitch be adjusted with speed", 1)]
+        public override BindableBool AdjustPitch { get; } = new BindableBool();
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModDoubleTime)).ToArray();
 
-        [SettingSource("Speed decrease", "The actual decrease to apply")]
+        [SettingSource("Speed decrease", "The actual decrease to apply", 0)]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble
         {
             MinValue = 0.5,
@@ -30,5 +30,8 @@ namespace osu.Game.Rulesets.Mods
             Value = 0.75,
             Precision = 0.01,
         };
+
+        [SettingSource("Adjust pitch", "Should pitch be adjusted with speed", 1)]
+        public override BindableBool AdjustPitch { get; } = new BindableBool();
     }
 }

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Objects;
@@ -24,6 +25,12 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "NC";
         public override IconUsage? Icon => OsuIcon.ModNightcore;
         public override string Description => "Uguuuuuuuu...";
+
+        [SettingSource("Adjust pitch", "Should pitch be adjusted with speed", 1)]
+        public override BindableBool AdjustPitch { get; } = new BindableBool
+        {
+            Disabled = true
+        };
     }
 
     public abstract class ModNightcore<TObject> : ModNightcore, IApplicableToDrawableRuleset<TObject>


### PR DESCRIPTION
As discussed in #11878, an adjust pitch setting has been added to ModRateAdjust. Nightcore and Daycore currently has this setting disabled.

- [ ] Depends on [ppy/osu-framework#4039](https://github.com/ppy/osu-framework/pull/4039)

Closes #9958