### PR TITLE
Extend the rate setting range of values for TimeRamp mods

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.IO;
 using osu.Game.Rulesets;
@@ -90,6 +91,7 @@ namespace osu.Game.Tests.Gameplay
         public void TestSamplePlaybackWithRateMods(Type expectedMod, double expectedRate)
         {
             GameplayClockContainer gameplayContainer = null;
+            StoryboardSampleInfo sampleInfo = null;
             TestDrawableStoryboardSample sample = null;
 
             Mod testedMod = Activator.CreateInstance(expectedMod) as Mod;
@@ -117,7 +119,7 @@ namespace osu.Game.Tests.Gameplay
                     Child = beatmapSkinSourceContainer
                 });
 
-                beatmapSkinSourceContainer.Add(sample = new TestDrawableStoryboardSample(new StoryboardSampleInfo("test-sample", 1, 1))
+                beatmapSkinSourceContainer.Add(sample = new TestDrawableStoryboardSample(sampleInfo = new StoryboardSampleInfo("test-sample", 1, 1))
                 {
                     Clock = gameplayContainer.GameplayClock
                 });
@@ -125,7 +127,10 @@ namespace osu.Game.Tests.Gameplay
 
             AddStep("start", () => gameplayContainer.Start());
 
-            AddAssert("sample playback rate matches mod rates", () => sample.ChildrenOfType<DrawableSample>().First().AggregateFrequency.Value == expectedRate);
+            AddAssert("sample playback rate matches mod rates", () =>
+                testedMod != null && Precision.AlmostEquals(
+                    sample.ChildrenOfType<DrawableSample>().First().AggregateFrequency.Value,
+                    ((IApplicableToRate)testedMod).ApplyToRate(sampleInfo.StartTime)));
         }
 
         private class TestSkin : LegacySkin

--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Gameplay
                     break;
 
                 case ModTimeRamp m:
-                    m.InitialRate.Value = m.FinalRate.Value = expectedRate;
+                    m.FinalRate.Value = m.InitialRate.Value = expectedRate;
                     break;
             }
 

--- a/osu.Game/Rulesets/Mods/ModRateAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModRateAdjust.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
@@ -23,6 +24,8 @@ namespace osu.Game.Rulesets.Mods
         }
 
         public double ApplyToRate(double time, double rate) => rate * SpeedChange.Value;
+
+        public override Type[] IncompatibleMods => new[] { typeof(ModTimeRamp) };
 
         public override string SettingDescription => SpeedChange.IsDefault ? string.Empty : $"{SpeedChange.Value:N2}x";
     }

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Mods
         [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
         public abstract BindableBool AdjustPitch { get; }
 
+        public override Type[] IncompatibleMods => new[] { typeof(ModRateAdjust) };
+
         public override string SettingDescription => $"{InitialRate.Value:N2}x to {FinalRate.Value:N2}x";
 
         private double finalRateTime;

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -49,10 +49,16 @@ namespace osu.Game.Rulesets.Mods
         public ModWindDown()
         {
             InitialRate.BindValueChanged(val =>
-                FinalRate.Value = Math.Min(FinalRate.Value, val.NewValue - FinalRate.Precision));
+            {
+                if (val.NewValue <= FinalRate.Value)
+                    FinalRate.Value = val.NewValue - FinalRate.Precision;
+            });
 
             FinalRate.BindValueChanged(val =>
-                InitialRate.Value = Math.Max(InitialRate.Value, val.NewValue + InitialRate.Precision));
+            {
+                if (val.NewValue >= InitialRate.Value)
+                    InitialRate.Value = val.NewValue + FinalRate.Precision;
+            });
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         [SettingSource("Initial rate", "The starting speed of the track")]
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble
         {
-            MinValue = 0.5,
+            MinValue = 0.51,
             MaxValue = 2,
             Default = 1,
             Value = 1,
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Mods
         public override BindableNumber<double> FinalRate { get; } = new BindableDouble
         {
             MinValue = 0.5,
-            MaxValue = 2,
+            MaxValue = 1.99,
             Default = 0.75,
             Value = 0.75,
             Precision = 0.01,
@@ -49,10 +49,10 @@ namespace osu.Game.Rulesets.Mods
         public ModWindDown()
         {
             InitialRate.BindValueChanged(val =>
-                InitialRate.Value = Math.Max(val.NewValue, FinalRate.Value + 0.01));
+                FinalRate.Value = Math.Min(FinalRate.Value, val.NewValue - 0.01));
 
             FinalRate.BindValueChanged(val =>
-                FinalRate.Value = Math.Min(val.NewValue, InitialRate.Value - 0.01));
+                InitialRate.Value = Math.Max(InitialRate.Value, val.NewValue + 0.01));
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         [SettingSource("Initial rate", "The starting speed of the track")]
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble
         {
-            MinValue = 1,
+            MinValue = 0.5,
             MaxValue = 2,
             Default = 1,
             Value = 1,
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Mods
         public override BindableNumber<double> FinalRate { get; } = new BindableDouble
         {
             MinValue = 0.5,
-            MaxValue = 0.99,
+            MaxValue = 2,
             Default = 0.75,
             Value = 0.75,
             Precision = 0.01,
@@ -45,5 +45,14 @@ namespace osu.Game.Rulesets.Mods
         };
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModWindUp)).ToArray();
+
+        public ModWindDown()
+        {
+            InitialRate.BindValueChanged(val =>
+                InitialRate.Value = Math.Max(val.NewValue, FinalRate.Value + 0.01));
+
+            FinalRate.BindValueChanged(val =>
+                FinalRate.Value = Math.Min(val.NewValue, InitialRate.Value - 0.01));
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -49,10 +49,10 @@ namespace osu.Game.Rulesets.Mods
         public ModWindDown()
         {
             InitialRate.BindValueChanged(val =>
-                FinalRate.Value = Math.Min(FinalRate.Value, val.NewValue - 0.01));
+                FinalRate.Value = Math.Min(FinalRate.Value, val.NewValue - FinalRate.Precision));
 
             FinalRate.BindValueChanged(val =>
-                InitialRate.Value = Math.Max(InitialRate.Value, val.NewValue + 0.01));
+                InitialRate.Value = Math.Max(InitialRate.Value, val.NewValue + InitialRate.Precision));
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModWindDown.cs
+++ b/osu.Game/Rulesets/Mods/ModWindDown.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Mods
             FinalRate.BindValueChanged(val =>
             {
                 if (val.NewValue >= InitialRate.Value)
-                    InitialRate.Value = val.NewValue + FinalRate.Precision;
+                    InitialRate.Value = val.NewValue + InitialRate.Precision;
             });
         }
     }

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Mods
             FinalRate.BindValueChanged(val =>
             {
                 if (val.NewValue <= InitialRate.Value)
-                    InitialRate.Value = val.NewValue - FinalRate.Precision;
+                    InitialRate.Value = val.NewValue - InitialRate.Precision;
             });
         }
     }

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mods
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble
         {
             MinValue = 0.5,
-            MaxValue = 1,
+            MaxValue = 2,
             Default = 1,
             Value = 1,
             Precision = 0.01,
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mods
         [SettingSource("Final rate", "The speed increase to ramp towards")]
         public override BindableNumber<double> FinalRate { get; } = new BindableDouble
         {
-            MinValue = 1.01,
+            MinValue = 0.5,
             MaxValue = 2,
             Default = 1.5,
             Value = 1.5,
@@ -45,5 +45,14 @@ namespace osu.Game.Rulesets.Mods
         };
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModWindDown)).ToArray();
+
+        public ModWindUp()
+        {
+            InitialRate.BindValueChanged(val =>
+                InitialRate.Value = Math.Min(val.NewValue, FinalRate.Value - 0.01));
+
+            FinalRate.BindValueChanged(val =>
+                FinalRate.Value = Math.Max(val.NewValue, InitialRate.Value + 0.01));
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -49,10 +49,10 @@ namespace osu.Game.Rulesets.Mods
         public ModWindUp()
         {
             InitialRate.BindValueChanged(val =>
-                FinalRate.Value = Math.Max(FinalRate.Value, val.NewValue + 0.01));
+                FinalRate.Value = Math.Max(FinalRate.Value, val.NewValue + FinalRate.Precision));
 
             FinalRate.BindValueChanged(val =>
-                InitialRate.Value = Math.Min(InitialRate.Value, val.NewValue - 0.01));
+                InitialRate.Value = Math.Min(InitialRate.Value, val.NewValue - InitialRate.Precision));
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -49,10 +49,16 @@ namespace osu.Game.Rulesets.Mods
         public ModWindUp()
         {
             InitialRate.BindValueChanged(val =>
-                FinalRate.Value = Math.Max(FinalRate.Value, val.NewValue + FinalRate.Precision));
+            {
+                if (val.NewValue >= FinalRate.Value)
+                    FinalRate.Value = val.NewValue + FinalRate.Precision;
+            });
 
             FinalRate.BindValueChanged(val =>
-                InitialRate.Value = Math.Min(InitialRate.Value, val.NewValue - InitialRate.Precision));
+            {
+                if (val.NewValue <= InitialRate.Value)
+                    InitialRate.Value = val.NewValue - FinalRate.Precision;
+            });
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModWindUp.cs
+++ b/osu.Game/Rulesets/Mods/ModWindUp.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mods
         public override BindableNumber<double> InitialRate { get; } = new BindableDouble
         {
             MinValue = 0.5,
-            MaxValue = 2,
+            MaxValue = 1.99,
             Default = 1,
             Value = 1,
             Precision = 0.01,
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mods
         [SettingSource("Final rate", "The speed increase to ramp towards")]
         public override BindableNumber<double> FinalRate { get; } = new BindableDouble
         {
-            MinValue = 0.5,
+            MinValue = 0.51,
             MaxValue = 2,
             Default = 1.5,
             Value = 1.5,
@@ -49,10 +49,10 @@ namespace osu.Game.Rulesets.Mods
         public ModWindUp()
         {
             InitialRate.BindValueChanged(val =>
-                InitialRate.Value = Math.Min(val.NewValue, FinalRate.Value - 0.01));
+                FinalRate.Value = Math.Max(FinalRate.Value, val.NewValue + 0.01));
 
             FinalRate.BindValueChanged(val =>
-                FinalRate.Value = Math.Max(val.NewValue, InitialRate.Value + 0.01));
+                InitialRate.Value = Math.Min(InitialRate.Value, val.NewValue - 0.01));
         }
     }
 }


### PR DESCRIPTION
This change extends the range of values allowed for both Initial and Final Rate in windup and winddown. This now allows Windup to have initial rates greater than 1.0.
Change will also correctly prevent initial rate equalling/exceeding final rate (and vice-versa for wind-down). 

Also now makes `ModTimeRamp` incompatible with `ModRateAdjust` since there is now no reason to combine both mods.

Intention was to replace the only potential use-case for combining DT and a TimeRamp mod with an easier to use/understand system.