### PR TITLE
Add more mod incompatibilities

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -1,18 +1,20 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics;
+using System;
+using System.Linq;
 using osu.Game.Rulesets.Mania.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModFadeIn : ManiaModHidden
+    public class ManiaModFadeIn : ManiaModPlayfieldCover
     {
         public override string Name => "Fade In";
         public override string Acronym => "FI";
-        public override IconUsage? Icon => OsuIcon.ModHidden;
         public override string Description => @"Keys appear out of nowhere!";
+        public override double ScoreMultiplier => 1;
+
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModHidden)).ToArray();
 
         protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AlongScroll;
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -3,43 +3,14 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.Mania.UI;
-using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModHidden : ModHidden, IApplicableToDrawableRuleset<ManiaHitObject>
+    public class ManiaModHidden : ManiaModPlayfieldCover
     {
         public override string Description => @"Keys fade out before you hit them!";
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => new[] { typeof(ModFlashlight<ManiaHitObject>) };
 
-        /// <summary>
-        /// The direction in which the cover should expand.
-        /// </summary>
-        protected virtual CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
-
-        public virtual void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)
-        {
-            ManiaPlayfield maniaPlayfield = (ManiaPlayfield)drawableRuleset.Playfield;
-
-            foreach (Column column in maniaPlayfield.Stages.SelectMany(stage => stage.Columns))
-            {
-                HitObjectContainer hoc = column.HitObjectArea.HitObjectContainer;
-                Container hocParent = (Container)hoc.Parent;
-
-                hocParent.Remove(hoc);
-                hocParent.Add(new PlayfieldCoveringWrapper(hoc).With(c =>
-                {
-                    c.RelativeSizeAxes = Axes.Both;
-                    c.Direction = ExpandDirection;
-                    c.Coverage = 0.5f;
-                }));
-            }
-        }
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModFadeIn)).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using osu.Game.Rulesets.Mania.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -12,5 +13,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override double ScoreMultiplier => 1;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModFadeIn)).ToArray();
+
+        protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         /// <summary>
         /// The direction in which the cover should expand.
         /// </summary>
-        protected virtual CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
+        protected abstract CoverExpandDirection ExpandDirection { get; }
 
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public abstract class ManiaModPlayfieldCover : ModHidden, IApplicableToDrawableRuleset<ManiaHitObject>
+    {
+        public override Type[] IncompatibleMods => new[] { typeof(ModFlashlight<ManiaHitObject>) };
+
+        /// <summary>
+        /// The direction in which the cover should expand.
+        /// </summary>
+        protected virtual CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
+
+        public virtual void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)
+        {
+            ManiaPlayfield maniaPlayfield = (ManiaPlayfield)drawableRuleset.Playfield;
+
+            foreach (Column column in maniaPlayfield.Stages.SelectMany(stage => stage.Columns))
+            {
+                HitObjectContainer hoc = column.HitObjectArea.HitObjectContainer;
+                Container hocParent = (Container)hoc.Parent;
+
+                hocParent.Remove(hoc);
+                hocParent.Add(new PlayfieldCoveringWrapper(hoc).With(c =>
+                {
+                    c.RelativeSizeAxes = Axes.Both;
+                    c.Direction = ExpandDirection;
+                    c.Coverage = 0.5f;
+                }));
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Automation;
         public override string Description => @"Automatic cursor movement - just follow the rhythm.";
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModSpunOut), typeof(ModRelax), typeof(ModSuddenDeath), typeof(ModNoFail), typeof(ModAutoplay) };
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModSpunOut), typeof(ModRelax), typeof(ModFailCondition), typeof(ModNoFail), typeof(ModAutoplay) };
 
         public bool PerformFail() => false;
 

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Mods
 
         public bool RestartOnFail => false;
 
-        public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModSuddenDeath), typeof(ModNoFail) };
+        public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModFailCondition), typeof(ModNoFail) };
 
         public override bool HasImplementation => GetType().GenericTypeArguments.Length == 0;
 

--- a/osu.Game/Rulesets/Mods/ModFailCondition.cs
+++ b/osu.Game/Rulesets/Mods/ModFailCondition.cs
@@ -11,9 +11,9 @@ namespace osu.Game.Rulesets.Mods
     {
         public override Type[] IncompatibleMods => new[] { typeof(ModNoFail), typeof(ModRelax), typeof(ModAutoplay) };
 
-        public bool PerformFail() => true;
+        public virtual bool PerformFail() => true;
 
-        public bool RestartOnFail => true;
+        public virtual bool RestartOnFail => true;
 
         public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
         {

--- a/osu.Game/Rulesets/Mods/ModFailCondition.cs
+++ b/osu.Game/Rulesets/Mods/ModFailCondition.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModFailCondition : Mod, IApplicableToHealthProcessor, IApplicableFailOverride
+    {
+        public override Type[] IncompatibleMods => new[] { typeof(ModNoFail), typeof(ModRelax), typeof(ModAutoplay) };
+
+        public bool PerformFail() => true;
+
+        public bool RestartOnFail => true;
+
+        public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
+        {
+            healthProcessor.FailConditions += FailCondition;
+        }
+
+        protected abstract bool FailCondition(HealthProcessor healthProcessor, JudgementResult result);
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -16,6 +16,6 @@ namespace osu.Game.Rulesets.Mods
         public override string Description => "You can't fail, no matter what.";
         public override double ScoreMultiplier => 0.5;
         public override bool Ranked => true;
-        public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModSuddenDeath), typeof(ModAutoplay) };
+        public override Type[] IncompatibleMods => new[] { typeof(ModRelax), typeof(ModFailCondition), typeof(ModAutoplay) };
     }
 }

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
@@ -8,12 +10,17 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModPerfect : ModSuddenDeath
+    public abstract class ModPerfect : ModFailCondition
     {
         public override string Name => "Perfect";
         public override string Acronym => "PF";
         public override IconUsage? Icon => OsuIcon.ModPerfect;
+        public override ModType Type => ModType.DifficultyIncrease;
+        public override bool Ranked => true;
+        public override double ScoreMultiplier => 1;
         public override string Description => "SS or quit.";
+
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModSuddenDeath)).ToArray();
 
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
             => result.Type.AffectsAccuracy()

--- a/osu.Game/Rulesets/Mods/ModRelax.cs
+++ b/osu.Game/Rulesets/Mods/ModRelax.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModRelax;
         public override ModType Type => ModType.Automation;
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModNoFail), typeof(ModSuddenDeath) };
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModNoFail), typeof(ModFailCondition) };
     }
 }

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
@@ -9,7 +10,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModSuddenDeath : Mod, IApplicableToHealthProcessor, IApplicableFailOverride
+    public abstract class ModSuddenDeath : ModFailCondition
     {
         public override string Name => "Sudden Death";
         public override string Acronym => "SD";
@@ -18,18 +19,10 @@ namespace osu.Game.Rulesets.Mods
         public override string Description => "Miss and fail.";
         public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
-        public override Type[] IncompatibleMods => new[] { typeof(ModNoFail), typeof(ModRelax), typeof(ModAutoplay) };
 
-        public bool PerformFail() => true;
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModPerfect)).ToArray();
 
-        public bool RestartOnFail => true;
-
-        public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
-        {
-            healthProcessor.FailConditions += FailCondition;
-        }
-
-        protected virtual bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
+        protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
             => result.Type.AffectsCombo()
                && !result.IsHit;
     }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/pull/11864#discussion_r580599189

Mania's FI/HD are straight-up incompatible with each other, and also defined this way in [osu-web](https://github.com/ppy/osu-web/blob/18ec49f59e35f770441827c8d5679a394e6e32a5/app/Libraries/Multiplayer/Mod.php#L281-L285).

SD/PF have also been marked incompatible with each other. Technically it should be valid to select PF as freemod with SD as required, however the way our validation works does not support this sort of interaction - neither [web-side](https://github.com/ppy/osu-web/blob/18ec49f59e35f770441827c8d5679a394e6e32a5/app/Libraries/Multiplayer/Mod.php#L89-L96) nor osu!-side.