### PR TITLE
Fix crash on two collections existing with the same name

### DIFF
--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Collections
             {
                 manager = new CollectionManager(LocalStorage),
                 Content,
-                dialogOverlay = new DialogOverlay()
+                dialogOverlay = new DialogOverlay(),
             });
 
             Dependencies.Cache(manager);
@@ -132,6 +132,27 @@ namespace osu.Game.Tests.Visual.Collections
             AddStep("remove first collection", () => manager.Collections.RemoveAt(0));
             assertCollectionCount(1);
             assertCollectionName(0, "2");
+        }
+
+        [Test]
+        public void TestCollectionNameCollisions()
+        {
+            AddStep("add dropdown", () =>
+            {
+                Add(new CollectionFilterDropdown
+                    {
+                        Anchor = Anchor.TopRight,
+                        Origin = Anchor.TopRight,
+                        RelativeSizeAxes = Axes.X,
+                        Width = 0.4f,
+                    }
+                );
+            });
+            AddStep("add two collections with same name", () => manager.Collections.AddRange(new[]
+            {
+                new BeatmapCollection { Name = { Value = "1" } },
+                new BeatmapCollection { Name = { Value = "1" }, Beatmaps = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0] } },
+            }));
         }
 
         [Test]

--- a/osu.Game/Collections/CollectionFilterMenuItem.cs
+++ b/osu.Game/Collections/CollectionFilterMenuItem.cs
@@ -36,7 +36,19 @@ namespace osu.Game.Collections
         }
 
         public bool Equals(CollectionFilterMenuItem other)
-            => other != null && CollectionName.Value == other.CollectionName.Value;
+        {
+            if (other == null)
+                return false;
+
+            // collections may have the same name, so compare first on reference equality.
+            // this relies on the assumption that only one instance of the BeatmapCollection exists game-wide, managed by CollectionManager.
+            if (Collection != null)
+                return Collection == other.Collection;
+
+            // fallback to name-based comparison.
+            // this is required for special dropdown items which don't have a collection (all beatmaps / manage collections items below).
+            return CollectionName.Value == other.CollectionName.Value;
+        }
 
         public override int GetHashCode() => CollectionName.Value.GetHashCode();
     }


### PR DESCRIPTION
See https://github.com/ppy/osu/issues/11876 for discussion. This feels like the most amicable solution.

Not sure if we still want the changes I proposed for textbox only updating on commit. Seems like probably not necessary with this fix in?

Also closes #11876.