### PR TITLE
Fix requests being indefinitely queued when user is offline

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -381,7 +381,13 @@ namespace osu.Game.Online.API
 
         public void Queue(APIRequest request)
         {
-            lock (queue) queue.Enqueue(request);
+            lock (queue)
+            {
+                if (state.Value == APIState.Offline)
+                    return;
+
+                queue.Enqueue(request);
+            }
         }
 
         private void flushQueue(bool failOldRequests = true)
@@ -402,8 +408,6 @@ namespace osu.Game.Online.API
 
         public void Logout()
         {
-            flushQueue();
-
             password = null;
             authentication.Clear();
 
@@ -415,6 +419,7 @@ namespace osu.Game.Online.API
             });
 
             state.Value = APIState.Offline;
+            flushQueue();
         }
 
         private static User createGuestUser() => new GuestUser();

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Ranking
                 return null;
 
             getScoreRequest = new GetScoresRequest(Score.Beatmap, Score.Ruleset);
-            getScoreRequest.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => s.OnlineScoreID != this.Score.OnlineScoreID).Select(s => s.CreateScoreInfo(rulesets)));
+            getScoreRequest.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => s.OnlineScoreID != Score.OnlineScoreID).Select(s => s.CreateScoreInfo(rulesets)));
             return getScoreRequest;
         }
 

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Screens.Ranking
 {
     public class SoloResultsScreen : ResultsScreen
     {
+        private GetScoresRequest getScoreRequest;
+
         [Resolved]
         private RulesetStore rulesets { get; set; }
 
@@ -28,9 +30,16 @@ namespace osu.Game.Screens.Ranking
             if (Score.Beatmap.OnlineBeatmapID == null || Score.Beatmap.Status <= BeatmapSetOnlineStatus.Pending)
                 return null;
 
-            var req = new GetScoresRequest(Score.Beatmap, Score.Ruleset);
-            req.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => s.OnlineScoreID != Score.OnlineScoreID).Select(s => s.CreateScoreInfo(rulesets)));
-            return req;
+            getScoreRequest = new GetScoresRequest(Score.Beatmap, Score.Ruleset);
+            getScoreRequest.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => s.OnlineScoreID != this.Score.OnlineScoreID).Select(s => s.CreateScoreInfo(rulesets)));
+            return getScoreRequest;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            getScoreRequest?.Cancel();
         }
     }
 }


### PR DESCRIPTION
Generally we avoid firing requests when offline, but there seem to be some instances where we are. As pointed out on discord, this can lead to memory leaks due to held references (especially in success callbacks). For the time being, let's not queue requests when in an offline state.

![](https://cdn.discordapp.com/attachments/188630652340404224/814084602527875072/unknown.png)

Note that this is generally already handled when switching between states (see calls to `flushQueue`).

I've also added local logic for the results screen case for good measures (although on its own it would not help to resolve the memory leak, as the cancelled request would not be removed from the queue).