### PR TITLE
Fix global hotkeys not working from main menu before toolbar is initially shown

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -214,6 +214,21 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("Options overlay still visible", () => songSelect.BeatmapOptionsOverlay.State.Value == Visibility.Visible);
         }
 
+        [Test]
+        public void TestSettingsViaHotkeyFromMainMenu()
+        {
+            AddAssert("toolbar not displayed", () => Game.Toolbar.State.Value == Visibility.Hidden);
+
+            AddStep("press settings hotkey", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.O);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("settings displayed", () => Game.Settings.State.Value == Visibility.Visible);
+        }
+
         private void pushEscape() =>
             AddStep("Press escape", () => InputManager.Key(Key.Escape));
 

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -37,6 +37,15 @@ namespace osu.Game.Overlays.Toolbar
         {
             RelativeSizeAxes = Axes.X;
             Size = new Vector2(1, HEIGHT);
+            AlwaysPresent = true;
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            // this only needed to be set for the initial LoadComplete/Update, so layout completes and gets buttons in a state they can correctly handle keyboard input for hotkeys.
+            AlwaysPresent = false;
         }
 
         [BackgroundDependencyLoader(true)]


### PR DESCRIPTION
Not sure if there's a better way of doing this. Seems local enough to maybe be fine?