### PR TITLE
Fix the star rating display at song select flashing to zero when changing mods

### DIFF
--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using osu.Game.Rulesets.Mods;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
@@ -137,8 +138,6 @@ namespace osu.Game.Screens.Select.Details
             updateStarDifficulty();
         }
 
-        private IBindable<StarDifficulty> normalStarDifficulty;
-        private IBindable<StarDifficulty> moddedStarDifficulty;
         private CancellationTokenSource starDifficultyCancellationSource;
 
         private void updateStarDifficulty()
@@ -150,13 +149,13 @@ namespace osu.Game.Screens.Select.Details
 
             starDifficultyCancellationSource = new CancellationTokenSource();
 
-            normalStarDifficulty = difficultyCache.GetBindableDifficulty(Beatmap, ruleset.Value, null, starDifficultyCancellationSource.Token);
-            moddedStarDifficulty = difficultyCache.GetBindableDifficulty(Beatmap, ruleset.Value, mods.Value, starDifficultyCancellationSource.Token);
+            var normalStarDifficulty = difficultyCache.GetDifficultyAsync(Beatmap, ruleset.Value, null, starDifficultyCancellationSource.Token);
+            var moddedStarDifficulty = difficultyCache.GetDifficultyAsync(Beatmap, ruleset.Value, mods.Value, starDifficultyCancellationSource.Token);
 
-            normalStarDifficulty.BindValueChanged(_ => updateDisplay());
-            moddedStarDifficulty.BindValueChanged(_ => updateDisplay(), true);
-
-            void updateDisplay() => starDifficulty.Value = ((float)normalStarDifficulty.Value.Stars, (float)moddedStarDifficulty.Value.Stars);
+            Task.WhenAll(normalStarDifficulty, moddedStarDifficulty).ContinueWith(_ => Schedule(() =>
+            {
+                starDifficulty.Value = ((float)normalStarDifficulty.Result.Stars, (float)moddedStarDifficulty.Result.Stars);
+            }), starDifficultyCancellationSource.Token, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Current);
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Due to the use of bindable flow provided by `BeatmapDifficultyCache` in this usage, the display would briefly flash to zero while difficulty calculation was still running (as there is no way for a consumer of the provided bindable to know whether the returned 0 is an actual 0 SR or a "pending" calculation).

While I hope to fix this by making the bindable flow return nullable values, I think this particular use case works better with non-bindable flow so have switched across to that.


Previously:

https://user-images.githubusercontent.com/191335/109116444-e4530800-7783-11eb-88be-086a0b4d28bb.mov

