### PR TITLE
Update the displayed BPM at song select with rate adjust mods

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets;
@@ -111,8 +112,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private void testInfoLabels(int expectedCount)
         {
-            AddAssert("check info labels exists", () => infoWedge.Info.InfoLabelContainer.Children.Any());
-            AddAssert("check info labels count", () => infoWedge.Info.InfoLabelContainer.Children.Count == expectedCount);
+            AddAssert("check info labels exists", () => infoWedge.Info.ChildrenOfType<BeatmapInfoWedge.BufferedWedgeInfo.InfoLabel>().Any());
+            AddAssert("check info labels count", () => infoWedge.Info.ChildrenOfType<BeatmapInfoWedge.BufferedWedgeInfo.InfoLabel>().Count() == expectedCount);
         }
 
         [Test]
@@ -123,7 +124,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("check default title", () => infoWedge.Info.TitleLabel.Current.Value == Beatmap.Default.BeatmapInfo.Metadata.Title);
             AddAssert("check default artist", () => infoWedge.Info.ArtistLabel.Current.Value == Beatmap.Default.BeatmapInfo.Metadata.Artist);
             AddAssert("check empty author", () => !infoWedge.Info.MapperContainer.Children.Any());
-            AddAssert("check no info labels", () => !infoWedge.Info.InfoLabelContainer.Children.Any());
+            AddAssert("check no info labels", () => !infoWedge.Info.ChildrenOfType<BeatmapInfoWedge.BufferedWedgeInfo.InfoLabel>().Any());
         }
 
         [Test]

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -383,10 +383,18 @@ namespace osu.Game.Screens.Select
                 return labels.ToArray();
             }
 
+            [Resolved]
+            private IBindable<IReadOnlyList<Mod>> mods { get; set; }
+
             private string getBPMRange(IBeatmap beatmap)
             {
-                double bpmMax = beatmap.ControlPointInfo.BPMMaximum;
-                double bpmMin = beatmap.ControlPointInfo.BPMMinimum;
+                // this doesn't consider mods which apply variable rates, yet.
+                double rate = 1;
+                foreach (var mod in mods.Value.OfType<IApplicableToRate>())
+                    rate = mod.ApplyToRate(0, rate);
+
+                double bpmMax = beatmap.ControlPointInfo.BPMMaximum * rate;
+                double bpmMin = beatmap.ControlPointInfo.BPMMinimum * rate;
 
                 if (Precision.AlmostEquals(bpmMin, bpmMax))
                     return $"{bpmMin:0}";

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -67,10 +67,10 @@ namespace osu.Game.Screens.Select
             };
         }
 
-        protected override void LoadComplete()
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            base.LoadComplete();
-            ruleset.BindValueChanged(_ => updateDisplay(), true);
+            ruleset.BindValueChanged(_ => updateDisplay());
         }
 
         protected override void PopIn()

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -395,11 +395,12 @@ namespace osu.Game.Screens.Select
 
                 double bpmMax = beatmap.ControlPointInfo.BPMMaximum * rate;
                 double bpmMin = beatmap.ControlPointInfo.BPMMinimum * rate;
+                double mostCommonBPM = 60000 / beatmap.GetMostCommonBeatLength() * rate;
 
                 if (Precision.AlmostEquals(bpmMin, bpmMax))
                     return $"{bpmMin:0}";
 
-                return $"{bpmMin:0}-{bpmMax:0} (mostly {60000 / beatmap.GetMostCommonBeatLength():0})";
+                return $"{bpmMin:0}-{bpmMax:0} (mostly {mostCommonBPM:0})";
             }
 
             private OsuSpriteText[] getMapper(BeatmapMetadata metadata)

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using JetBrains.Annotations;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Allocation;
@@ -39,8 +38,11 @@ namespace osu.Game.Screens.Select
 
         private static readonly Vector2 wedged_container_shear = new Vector2(shear_width / SongSelect.WEDGE_HEIGHT, 0);
 
-        private readonly IBindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
-        private readonly IBindable<IReadOnlyList<Mod>> mods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; }
+
+        [Resolved]
+        private IBindable<IReadOnlyList<Mod>> mods { get; set; }
 
         [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; }
@@ -65,13 +67,10 @@ namespace osu.Game.Screens.Select
             };
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load([CanBeNull] Bindable<RulesetInfo> parentRuleset, [CanBeNull] Bindable<IReadOnlyList<Mod>> parentMods)
+        protected override void LoadComplete()
         {
-            ruleset.BindTo(parentRuleset);
-            mods.BindTo(parentMods);
-
-            ruleset.ValueChanged += _ => updateDisplay();
+            base.LoadComplete();
+            ruleset.BindValueChanged(_ => updateDisplay(), true);
         }
 
         protected override void PopIn()


### PR DESCRIPTION
This only covers constant rate rate adjust mods. Mods like wind up/wind down will need a more complex implementation which we haven't really planned yet.

Addresses a portion of https://github.com/ppy/osu/issues/10580.

https://user-images.githubusercontent.com/191335/109124700-8f68bf00-778e-11eb-9ea7-e745cbcbd55b.mp4

