### PR TITLE
Centralise cases of performing actions on the current selection

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Rulesets.Mania.Edit
             int minColumn = int.MaxValue;
             int maxColumn = int.MinValue;
 
+            // find min/max in an initial pass before actually performing the movement.
             foreach (var obj in EditorBeatmap.SelectedHitObjects.OfType<ManiaHitObject>())
             {
                 if (obj.Column < minColumn)
@@ -55,8 +56,11 @@ namespace osu.Game.Rulesets.Mania.Edit
 
             columnDelta = Math.Clamp(columnDelta, -minColumn, maniaPlayfield.TotalColumns - 1 - maxColumn);
 
-            foreach (var obj in EditorBeatmap.SelectedHitObjects.OfType<ManiaHitObject>())
-                obj.Column += columnDelta;
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                if (h is ManiaHitObject maniaObj)
+                    maniaObj.Column += columnDelta;
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -52,32 +52,24 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
         public void SetStrongState(bool state)
         {
-            var hits = EditorBeatmap.SelectedHitObjects.OfType<Hit>();
-
-            EditorBeatmap.BeginChange();
-
-            foreach (var h in hits)
+            EditorBeatmap.PerformOnSelection(h =>
             {
-                if (h.IsStrong != state)
-                {
-                    h.IsStrong = state;
-                    EditorBeatmap.Update(h);
-                }
-            }
+                if (!(h is Hit taikoHit)) return;
 
-            EditorBeatmap.EndChange();
+                if (taikoHit.IsStrong != state)
+                {
+                    taikoHit.IsStrong = state;
+                    EditorBeatmap.Update(taikoHit);
+                }
+            });
         }
 
         public void SetRimState(bool state)
         {
-            var hits = EditorBeatmap.SelectedHitObjects.OfType<Hit>();
-
-            EditorBeatmap.BeginChange();
-
-            foreach (var h in hits)
-                h.Type = state ? HitType.Rim : HitType.Centre;
-
-            EditorBeatmap.EndChange();
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                if (h is Hit taikoHit) taikoHit.Type = state ? HitType.Rim : HitType.Centre;
+            });
         }
 
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint> selection)

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -495,8 +495,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 // Apply the start time at the newly snapped-to position
                 double offset = result.Time.Value - movementBlueprints.First().HitObject.StartTime;
 
-                foreach (HitObject obj in Beatmap.SelectedHitObjects)
-                    obj.StartTime += offset;
+                Beatmap.PerformOnSelection(obj => obj.StartTime += offset);
             }
 
             return true;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -320,18 +320,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="sampleName">The name of the hit sample.</param>
         public void AddHitSample(string sampleName)
         {
-            EditorBeatmap.BeginChange();
-
-            foreach (var h in EditorBeatmap.SelectedHitObjects)
+            EditorBeatmap.PerformOnSelection(h =>
             {
                 // Make sure there isn't already an existing sample
                 if (h.Samples.Any(s => s.Name == sampleName))
-                    continue;
+                    return;
 
                 h.Samples.Add(new HitSampleInfo(sampleName));
-            }
-
-            EditorBeatmap.EndChange();
+            });
         }
 
         /// <summary>
@@ -341,19 +337,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <exception cref="InvalidOperationException">Throws if any selected object doesn't implement <see cref="IHasComboInformation"/></exception>
         public void SetNewCombo(bool state)
         {
-            EditorBeatmap.BeginChange();
-
-            foreach (var h in EditorBeatmap.SelectedHitObjects)
+            EditorBeatmap.PerformOnSelection(h =>
             {
                 var comboInfo = h as IHasComboInformation;
 
-                if (comboInfo == null || comboInfo.NewCombo == state) continue;
+                if (comboInfo == null || comboInfo.NewCombo == state) return;
 
                 comboInfo.NewCombo = state;
                 EditorBeatmap.Update(h);
-            }
-
-            EditorBeatmap.EndChange();
+            });
         }
 
         /// <summary>
@@ -362,12 +354,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="sampleName">The name of the hit sample.</param>
         public void RemoveHitSample(string sampleName)
         {
-            EditorBeatmap.BeginChange();
-
-            foreach (var h in EditorBeatmap.SelectedHitObjects)
-                h.SamplesBindable.RemoveAll(s => s.Name == sampleName);
-
-            EditorBeatmap.EndChange();
+            EditorBeatmap.PerformOnSelection(h => h.SamplesBindable.RemoveAll(s => s.Name == sampleName));
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -101,6 +101,22 @@ namespace osu.Game.Screens.Edit
         private readonly HashSet<HitObject> batchPendingUpdates = new HashSet<HitObject>();
 
         /// <summary>
+        /// Perform the provided action on every selected hitobject.
+        /// Changes will be grouped as one history action.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        public void PerformOnSelection(Action<HitObject> action)
+        {
+            if (SelectedHitObjects.Count == 0)
+                return;
+
+            BeginChange();
+            foreach (var h in SelectedHitObjects)
+                action(h);
+            EndChange();
+        }
+
+        /// <summary>
         /// Adds a collection of <see cref="HitObject"/>s to this <see cref="EditorBeatmap"/>.
         /// </summary>
         /// <param name="hitObjects">The <see cref="HitObject"/>s to add.</param>


### PR DESCRIPTION
By moving this to a central location, we can avoid invoking theEditorChangeHandler when there is no selection made. This helps alleviate the issue pointed out in https://github.com/ppy/osu/issues/11901, but not fix it completely.

This should be considered a code-quality improvement at best. If it doesn't read better than the old code then feel free to close.