### PR TITLE
Reduce allocation overhead when notification overlay has visible notifications

### DIFF
--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -10,9 +10,9 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osuTK;
-using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Notifications
 {
@@ -122,7 +122,20 @@ namespace osu.Game.Overlays.Notifications
         {
             base.Update();
 
-            countDrawable.Text = notifications.Children.Count(c => c.Alpha > 0.99f).ToString();
+            countDrawable.Text = getVisibleCount().ToString();
+        }
+
+        private int getVisibleCount()
+        {
+            int count = 0;
+
+            foreach (var c in notifications)
+            {
+                if (c.Alpha > 0.99f)
+                    count++;
+            }
+
+            return count;
         }
 
         private class ClearAllButton : OsuClickableContainer


### PR DESCRIPTION
Noticed in passing.

Before:
![20210226 171245 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/109273721-eab1b480-7855-11eb-960e-4d335b689b29.png)

After:
![20210226 171215 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/109273620-c6ee6e80-7855-11eb-9ab6-1a7c2450f7cd.png)
