### PR TITLE
Fix "failed to import" message showing when importing from a stable install with no beatmaps

### DIFF
--- a/osu.Game/Database/ArchiveModelManager.cs
+++ b/osu.Game/Database/ArchiveModelManager.cs
@@ -141,6 +141,13 @@ namespace osu.Game.Database
 
         protected async Task<IEnumerable<TModel>> Import(ProgressNotification notification, params ImportTask[] tasks)
         {
+            if (tasks.Length == 0)
+            {
+                notification.CompletionText = $"No {HumanisedModelName}s were found to import!";
+                notification.State = ProgressNotificationState.Completed;
+                return Enumerable.Empty<TModel>();
+            }
+
             notification.Progress = 0;
             notification.Text = $"{HumanisedModelName.Humanize(LetterCasing.Title)} import is initialising...";
 


### PR DESCRIPTION
Fixes imports triggering with no tasks incorrectly showing a failed notification.

Before:
![20210226 173241 (dotnet)](https://user-images.githubusercontent.com/191335/109275848-a1169900-7858-11eb-8188-0b2cb5d61300.png)


After:
![20210226 173334 (dotnet)](https://user-images.githubusercontent.com/191335/109275941-c2778500-7858-11eb-973b-b89b873091b2.png)
