### PR TITLE
Fix tournament drawings screen flags being too big

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneDrawingsScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneDrawingsScreen.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+using osu.Game.Graphics.Cursor;
+using osu.Game.Tournament.Screens.Drawings;
+
+namespace osu.Game.Tournament.Tests.Screens
+{
+    public class TestSceneDrawingsScreen : TournamentTestScene
+    {
+        [BackgroundDependencyLoader]
+        private void load(Storage storage)
+        {
+            using (var stream = storage.GetStream("drawings.txt", FileAccess.Write))
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.WriteLine("KR : South Korea : KOR");
+                writer.WriteLine("US : United States : USA");
+                writer.WriteLine("PH : Philippines : PHL");
+                writer.WriteLine("BR : Brazil : BRA");
+                writer.WriteLine("JP : Japan : JPN");
+            }
+
+            Add(new OsuContextMenuContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new DrawingsScreen()
+            });
+        }
+    }
+}

--- a/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
@@ -345,7 +345,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
                 Flag.Anchor = Anchor.Centre;
                 Flag.Origin = Anchor.Centre;
-                Flag.Scale = new Vector2(0.9f);
+                Flag.Scale = new Vector2(0.7f);
 
                 InternalChildren = new Drawable[]
                 {


### PR DESCRIPTION
Regressed with the standardisation of flags.

Before:

![](https://puu.sh/HkheK/5593436456.png)

After
![20210226 175930 (dotnet)](https://user-images.githubusercontent.com/191335/109278863-60208380-785c-11eb-94aa-290f828f6af9.png)


Also added test coverage (i swear we used to have a test scene for this?)