### PR TITLE
Fix restore default button potentially mutating transforms during load

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -207,7 +207,9 @@ namespace osu.Game.Overlays.Settings
                 UpdateState();
             }
 
-            public void UpdateState()
+            public void UpdateState() => Scheduler.AddOnce(updateState);
+
+            private void updateState()
             {
                 if (bindable == null)
                     return;


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/issues/11913 (see runtime log):

```
2021-02-27 00:57:37 [error]: osu.Framework.Graphics.Drawable+InvalidThreadForMutationException: Cannot mutate the Transforms of a Loading Drawable while not on the load thread. Consider using Schedule to schedule the mutation operation.
(...)
2021-02-27 00:57:37 [error]: at osu.Game.Overlays.Settings.SettingsItem`1.RestoreDefaultValueButton.UpdateState()
2021-02-27 00:57:37 [error]: at osu.Game.Overlays.Settings.SettingsItem`1.RestoreDefaultValueButton.<set_Bindable>b__3_0(ValueChangedEvent`1 _)
(...)
2021-02-27 00:57:37 [error]: at osu.Framework.Bindables.BindableNumber`1.set_Value(T value)
2021-02-27 00:57:37 [error]: at osu.Game.Overlays.Volume.VolumeMeter.adjust(Double delta, Boolean isPrecise)
2021-02-27 00:57:37 [error]: at osu.Game.Overlays.Volume.VolumeMeter.OnScroll(ScrollEvent e)
2021-02-27 00:57:37 [error]: at osu.Framework.Graphics.Drawable.TriggerEvent(UIEvent e)
```

Don't think this has to do anything with the input blockage, but I figure it makes sense to grab it now that it's popped up. Also theoretically reduces the number of calls due to the `AddOnce`.

Opted to have this public-private setup instead of adding to all calls due to number of usages (would have to fix up 8 places).