### PR TITLE
Fix multiple enumerations when ordering setting sources

### DIFF
--- a/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
+++ b/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
+
+namespace osu.Game.Tests.Mods
+{
+    [TestFixture]
+    public class SettingsSourceAttributeTest
+    {
+        [Test]
+        public void TestOrdering()
+        {
+            var objectWithSettings = new ClassWithSettings();
+
+            var orderedSettings = objectWithSettings.GetOrderedSettingsSourceProperties().ToArray();
+
+            Assert.That(orderedSettings, Has.Length.EqualTo(3));
+        }
+
+        private class ClassWithSettings
+        {
+            [SettingSource("Second setting", "Another description", 2)]
+            public BindableBool SecondSetting { get; set; } = new BindableBool();
+
+            [SettingSource("First setting", "A description", 1)]
+            public BindableDouble FirstSetting { get; set; } = new BindableDouble();
+
+            [SettingSource("Third setting", "Yet another description", 3)]
+            public BindableInt ThirdSetting { get; set; } = new BindableInt();
+        }
+    }
+}

--- a/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
+++ b/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
@@ -19,6 +19,10 @@ namespace osu.Game.Tests.Mods
             var orderedSettings = objectWithSettings.GetOrderedSettingsSourceProperties().ToArray();
 
             Assert.That(orderedSettings, Has.Length.EqualTo(3));
+
+            Assert.That(orderedSettings[0].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.FirstSetting)));
+            Assert.That(orderedSettings[1].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.SecondSetting)));
+            Assert.That(orderedSettings[2].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.ThirdSetting)));
         }
 
         private class ClassWithSettings

--- a/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
+++ b/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
@@ -18,15 +18,19 @@ namespace osu.Game.Tests.Mods
 
             var orderedSettings = objectWithSettings.GetOrderedSettingsSourceProperties().ToArray();
 
-            Assert.That(orderedSettings, Has.Length.EqualTo(3));
+            Assert.That(orderedSettings, Has.Length.EqualTo(4));
 
             Assert.That(orderedSettings[0].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.FirstSetting)));
             Assert.That(orderedSettings[1].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.SecondSetting)));
             Assert.That(orderedSettings[2].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.ThirdSetting)));
+            Assert.That(orderedSettings[3].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.UnorderedSetting)));
         }
 
         private class ClassWithSettings
         {
+            [SettingSource("Unordered setting", "Should be last")]
+            public BindableFloat UnorderedSetting { get; set; } = new BindableFloat();
+
             [SettingSource("Second setting", "Another description", 2)]
             public BindableBool SecondSetting { get; set; } = new BindableBool();
 

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -153,12 +153,8 @@ namespace osu.Game.Configuration
         }
 
         public static ICollection<(SettingSourceAttribute, PropertyInfo)> GetOrderedSettingsSourceProperties(this object obj)
-        {
-            var original = obj.GetSettingsSourceProperties().ToArray();
-
-            return original
-                   .OrderBy(attr => attr.Item1)
-                   .ToArray();
-        }
+            => obj.GetSettingsSourceProperties()
+                  .OrderBy(attr => attr.Item1)
+                  .ToArray();
     }
 }

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Configuration
     /// </remarks>
     [MeansImplicitUse]
     [AttributeUsage(AttributeTargets.Property)]
-    public class SettingSourceAttribute : Attribute
+    public class SettingSourceAttribute : Attribute, IComparable<SettingSourceAttribute>
     {
         public LocalisableString Label { get; }
 
@@ -41,6 +41,21 @@ namespace osu.Game.Configuration
             : this(label, description)
         {
             OrderPosition = orderPosition;
+        }
+
+        public int CompareTo(SettingSourceAttribute other)
+        {
+            if (OrderPosition == other.OrderPosition)
+                return 0;
+
+            // unordered items come last (are greater than any ordered items).
+            if (OrderPosition == null)
+                return 1;
+            if (other.OrderPosition == null)
+                return -1;
+
+            // ordered items are sorted by the order value.
+            return OrderPosition.Value.CompareTo(other.OrderPosition);
         }
     }
 
@@ -137,17 +152,13 @@ namespace osu.Game.Configuration
             }
         }
 
-        public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetOrderedSettingsSourceProperties(this object obj)
+        public static ICollection<(SettingSourceAttribute, PropertyInfo)> GetOrderedSettingsSourceProperties(this object obj)
         {
             var original = obj.GetSettingsSourceProperties().ToArray();
 
-            var orderedRelative = original
-                                  .Where(attr => attr.Item1.OrderPosition != null)
-                                  .OrderBy(attr => attr.Item1.OrderPosition)
-                                  .ToArray();
-            var unordered = original.Except(orderedRelative);
-
-            return orderedRelative.Concat(unordered);
+            return original
+                   .OrderBy(attr => attr.Item1)
+                   .ToArray();
         }
     }
 }

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -139,9 +139,12 @@ namespace osu.Game.Configuration
 
         public static IEnumerable<(SettingSourceAttribute, PropertyInfo)> GetOrderedSettingsSourceProperties(this object obj)
         {
-            var original = obj.GetSettingsSourceProperties();
+            var original = obj.GetSettingsSourceProperties().ToArray();
 
-            var orderedRelative = original.Where(attr => attr.Item1.OrderPosition != null).OrderBy(attr => attr.Item1.OrderPosition);
+            var orderedRelative = original
+                                  .Where(attr => attr.Item1.OrderPosition != null)
+                                  .OrderBy(attr => attr.Item1.OrderPosition)
+                                  .ToArray();
             var unordered = original.Except(orderedRelative);
 
             return orderedRelative.Concat(unordered);


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/11905.

This was not spotted previously, because the base `Attribute` [overrides `Equals()` to have semantics similar to structs (per-field equality) by using reflection](https://docs.microsoft.com/en-us/dotnet/api/system.attribute.equals?view=net-5.0). That masked the issue when strings were used, and migrating to `LocalisableString` revealed it, as that struct's implementation of equality currently uses instance checks.

Whether `LocalisableString.Equals()` is the correct implementation may still be up for discussion, but allowing multiple enumeration is wrong anyway, since the underlying enumerables are live (one especially is a yield iterator, causing new object instances to be allocated).