### PR TITLE
Allow rulesets to specify custom song select filtering criteria

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -4,7 +4,7 @@
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
-using osu.Game.Screens.Select;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Carousel;
 
 namespace osu.Game.Tests.NonVisual.Filtering

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select;
 
 namespace osu.Game.Tests.NonVisual.Filtering

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -15,6 +15,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -20,6 +20,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;

--- a/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
+++ b/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using osu.Game.Collections;
-using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Rulesets.Filter

--- a/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
+++ b/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Game.Collections;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Rulesets.Filter
+{
+    /// <summary>
+    /// Structure used to pass data required to create a <see cref="FilterCriteria"/> instance
+    /// for use in the song selection screen.
+    /// </summary>
+    public class FilterCreationParameters
+    {
+        /// <summary>
+        /// The textual query, entered by the user in the song select search box.
+        /// </summary>
+        public string Query { get; set; }
+
+        /// <summary>
+        /// The group mode to use.
+        /// </summary>
+        public GroupMode GroupMode { get; set; }
+
+        /// <summary>
+        /// The sort mode to use.
+        /// </summary>
+        public SortMode SortMode { get; set; }
+
+        /// <summary>
+        /// Whether converted beatmaps are allowed to be included in the filtering results.
+        /// </summary>
+        public bool AllowConvertedBeatmaps { get; set; }
+
+        /// <summary>
+        /// The currently-selected collection.
+        /// </summary>
+        [CanBeNull]
+        public BeatmapCollection Collection { get; set; }
+
+        /// <summary>
+        /// The allowable star difficulty range, as set by the user in the game settings.
+        /// </summary>
+        public FilterCriteria.OptionalRange<double> UserStarDifficulty { get; set; } = new FilterCriteria.OptionalRange<double>
+        {
+            IsLowerInclusive = true,
+            IsUpperInclusive = true
+        };
+    }
+}

--- a/osu.Game/Rulesets/Filter/FilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria.cs
@@ -92,8 +92,8 @@ namespace osu.Game.Rulesets.Filter
         /// by this instance.
         /// </summary>
         /// <param name="beatmap">The beatmap to test the criteria against.</param>
-        /// <returns><c>true</c> if the beatmap matches the current filtering criteria.</returns>
-        public virtual bool Matches(BeatmapInfo beatmap)
+        /// <returns><c>true</c> if the beatmap matches the current filtering criteria, <c>false</c> otherwise.</returns>
+        public bool Matches(BeatmapInfo beatmap)
         {
             bool match =
                 Ruleset == null ||
@@ -141,8 +141,22 @@ namespace osu.Game.Rulesets.Filter
             if (match)
                 match &= Collection?.Beatmaps.Contains(beatmap) ?? true;
 
+            if (match)
+                match &= MatchesCustomCriteria(beatmap);
+
             return match;
         }
+
+        /// <summary>
+        /// Checks whether the supplied <paramref name="beatmap"/> satisfies ruleset-specific custom criteria,
+        /// in addition to the ones mandated by song select.
+        /// </summary>
+        /// <param name="beatmap">The beatmap to test the criteria against.</param>
+        /// <returns>
+        /// <c>true</c> if the beatmap matches the ruleset-specific custom filtering criteria,
+        /// <c>false</c> otherwise.
+        /// </returns>
+        protected virtual bool MatchesCustomCriteria(BeatmapInfo beatmap) => true;
 
         public struct OptionalRange<T> : IEquatable<OptionalRange<T>>
             where T : struct

--- a/osu.Game/Rulesets/Filter/FilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria.cs
@@ -7,10 +7,9 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
-using osu.Game.Rulesets;
 using osu.Game.Screens.Select.Filter;
 
-namespace osu.Game.Screens.Select
+namespace osu.Game.Rulesets.Filter
 {
     public class FilterCriteria
     {

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Testing;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets
@@ -306,5 +307,11 @@ namespace osu.Game.Rulesets
         /// <param name="result">The result type to get the name for.</param>
         /// <returns>The display name.</returns>
         public virtual string GetDisplayNameForHitResult(HitResult result) => result.GetDescription();
+
+        /// <summary>
+        /// Creates a <see cref="FilterCriteria"/> instance for filtering beatmaps in the song select screen.
+        /// </summary>
+        /// <param name="parameters">The creation parameters for the filter criteria.</param>
+        public virtual FilterCriteria CreateFilterCriteria(FilterCreationParameters parameters) => new FilterCriteria(RulesetInfo, parameters);
     }
 }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -22,6 +22,7 @@ using osu.Game.Extensions;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Input.Bindings;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Carousel;
 using osuTK;
 using osuTK.Input;

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select.Carousel

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
@@ -27,54 +25,7 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Filter(criteria);
 
-            bool match =
-                criteria.Ruleset == null ||
-                Beatmap.RulesetID == criteria.Ruleset.ID ||
-                (Beatmap.RulesetID == 0 && criteria.Ruleset.ID > 0 && criteria.AllowConvertedBeatmaps);
-
-            if (Beatmap.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
-            {
-                // only check ruleset equality or convertability for selected beatmap
-                Filtered.Value = !match;
-                return;
-            }
-
-            match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(Beatmap.StarDifficulty);
-            match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(Beatmap.BaseDifficulty.ApproachRate);
-            match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(Beatmap.BaseDifficulty.DrainRate);
-            match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(Beatmap.BaseDifficulty.CircleSize);
-            match &= !criteria.Length.HasFilter || criteria.Length.IsInRange(Beatmap.Length);
-            match &= !criteria.BPM.HasFilter || criteria.BPM.IsInRange(Beatmap.BPM);
-
-            match &= !criteria.BeatDivisor.HasFilter || criteria.BeatDivisor.IsInRange(Beatmap.BeatDivisor);
-            match &= !criteria.OnlineStatus.HasFilter || criteria.OnlineStatus.IsInRange(Beatmap.Status);
-
-            match &= !criteria.Creator.HasFilter || criteria.Creator.Matches(Beatmap.Metadata.AuthorString);
-            match &= !criteria.Artist.HasFilter || criteria.Artist.Matches(Beatmap.Metadata.Artist) ||
-                     criteria.Artist.Matches(Beatmap.Metadata.ArtistUnicode);
-
-            match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(Beatmap.StarDifficulty);
-
-            if (match)
-            {
-                var terms = Beatmap.SearchableTerms;
-
-                foreach (var criteriaTerm in criteria.SearchTerms)
-                    match &= terms.Any(term => term.Contains(criteriaTerm, StringComparison.InvariantCultureIgnoreCase));
-
-                // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
-                // this should be done after text matching so we can prioritise matching numbers in metadata.
-                if (!match && criteria.SearchNumber.HasValue)
-                {
-                    match = (Beatmap.OnlineBeatmapID == criteria.SearchNumber.Value) ||
-                            (Beatmap.BeatmapSet?.OnlineBeatmapSetID == criteria.SearchNumber.Value);
-                }
-            }
-
-            if (match)
-                match &= criteria.Collection?.Beatmaps.Contains(Beatmap) ?? true;
-
-            Filtered.Value = !match;
+            Filtered.Value = !criteria.Matches(Beatmap);
         }
 
         public override int CompareTo(FilterCriteria criteria, CarouselItem other)

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select.Carousel

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select.Carousel
 {

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select.Carousel
 {

--- a/osu.Game/Screens/Select/Carousel/CarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select.Carousel
 {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
 using osuTK.Graphics;

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select
 {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -37,6 +37,7 @@ using osu.Game.Collections;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Scoring;
 using System.Diagnostics;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Play;
 
 namespace osu.Game.Screens.Select


### PR DESCRIPTION
This pull request is the first step towards adding a mania keymode song select filter (https://github.com/ppy/osu/issues/5668).

It adds a new filtering API for rulesets:

```csharp
public virtual FilterCriteria CreateFilterCriteria(FilterCreationParameters parameters);
```

that they will be able to use to extend the song select filtering capabilities to their own liking. This pull also introduces a new public virtual method in `FilterCriteria.Matches(BeatmapInfo beatmap)`. The intended usage for ruleset developers is to subclass `FilterCriteria`, add their own filters, and then override `Matches()` to make sure song select respects them.

Note that this pull does not yet enable easy extensibility of the parsing process, which currently resides in a static `FilterQueryParser`. This will be addressed in another pull that I've got queued up.

This pull mostly moves code, but I split it because the code being moved is a bit on the larger side. It's a bit of a request for comments, as there are a few places I'm not certain of - I'll add review comments to denote them.