### PR TITLE
Allow rulesets to parse custom song select filtering criteria from search box

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -4,7 +4,7 @@
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
-using osu.Game.Screens.Select;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Carousel;
 
 namespace osu.Game.Tests.NonVisual.Filtering

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -5,7 +5,6 @@ using System;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
-using osu.Game.Screens.Select;
 
 namespace osu.Game.Tests.NonVisual.Filtering
 {

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -193,6 +193,14 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
+        public void TestOperatorParsing()
+        {
+            const string query = "custom=><something";
+            var filterCriteria = new CustomFilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
+            Assert.AreEqual("><something", filterCriteria.CustomValue);
+        }
+
+        [Test]
         public void TestCustomKeywordIsParsed()
         {
             const string query = "custom=readme unrecognised=keyword";
@@ -210,9 +218,9 @@ namespace osu.Game.Tests.NonVisual.Filtering
 
             public string CustomValue { get; set; }
 
-            protected override bool TryParseCustomKeywordCriteria(string key, string value, string op)
+            protected override bool TryParseCustomKeywordCriteria(string key, string value, Operator op)
             {
-                if (key == "custom" && op == "=")
+                if (key == "custom" && op == Operator.Equal)
                 {
                     CustomValue = value;
                     return true;

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select;
 
 namespace osu.Game.Tests.NonVisual.Filtering

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -5,6 +5,7 @@ using System;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
+using osu.Game.Rulesets.Osu;
 
 namespace osu.Game.Tests.NonVisual.Filtering
 {
@@ -15,8 +16,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyQueriesBareWords()
         {
             const string query = "looking for a beatmap";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("looking for a beatmap", filterCriteria.SearchText);
             Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
         }
@@ -35,8 +35,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyStarQueries()
         {
             const string query = "stars<4 easy";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("easy", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
             Assert.IsNotNull(filterCriteria.StarDifficulty.Max);
@@ -49,8 +48,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyApproachRateQueries()
         {
             const string query = "ar>=9 difficult";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("difficult", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
             Assert.IsNotNull(filterCriteria.ApproachRate.Min);
@@ -63,8 +61,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyDrainRateQueriesByDrKeyword()
         {
             const string query = "dr>2 quite specific dr<:6";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
             Assert.AreEqual(2, filterCriteria.SearchTerms.Length);
             Assert.Greater(filterCriteria.DrainRate.Min, 2.0f);
@@ -77,8 +74,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyDrainRateQueriesByHpKeyword()
         {
             const string query = "hp>2 quite specific hp<=6";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("quite specific", filterCriteria.SearchText.Trim());
             Assert.AreEqual(2, filterCriteria.SearchTerms.Length);
             Assert.Greater(filterCriteria.DrainRate.Min, 2.0f);
@@ -91,8 +87,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyBPMQueries()
         {
             const string query = "bpm>:200 gotta go fast";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("gotta go fast", filterCriteria.SearchText.Trim());
             Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
             Assert.IsNotNull(filterCriteria.BPM.Min);
@@ -115,8 +110,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyLengthQueries(string lengthQuery, TimeSpan expectedLength, TimeSpan scale)
         {
             string query = $"length={lengthQuery} time";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("time", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
             Assert.AreEqual(expectedLength.TotalMilliseconds - scale.TotalMilliseconds / 2.0, filterCriteria.Length.Min);
@@ -127,8 +121,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyDivisorQueries()
         {
             const string query = "that's a time signature alright! divisor:12";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("that's a time signature alright!", filterCriteria.SearchText.Trim());
             Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
             Assert.AreEqual(12, filterCriteria.BeatDivisor.Min);
@@ -141,8 +134,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyStatusQueries()
         {
             const string query = "I want the pp status=ranked";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("I want the pp", filterCriteria.SearchText.Trim());
             Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
             Assert.AreEqual(BeatmapSetOnlineStatus.Ranked, filterCriteria.OnlineStatus.Min);
@@ -155,8 +147,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyCreatorQueries()
         {
             const string query = "beatmap specifically by creator=my_fav";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("beatmap specifically by", filterCriteria.SearchText.Trim());
             Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("my_fav", filterCriteria.Creator.SearchTerm);
@@ -166,8 +157,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyArtistQueries()
         {
             const string query = "find me songs by artist=singer please";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("find me songs by  please", filterCriteria.SearchText.Trim());
             Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("singer", filterCriteria.Artist.SearchTerm);
@@ -177,8 +167,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyArtistQueriesWithSpaces()
         {
             const string query = "really like artist=\"name with space\" yes";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("really like  yes", filterCriteria.SearchText.Trim());
             Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("name with space", filterCriteria.Artist.SearchTerm);
@@ -188,8 +177,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         public void TestApplyArtistQueriesOneDoubleQuote()
         {
             const string query = "weird artist=double\"quote";
-            var filterCriteria = new FilterCriteria();
-            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
             Assert.AreEqual("weird", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("double\"quote", filterCriteria.Artist.SearchTerm);

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Osu;
 
@@ -181,6 +182,44 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("weird", filterCriteria.SearchText.Trim());
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("double\"quote", filterCriteria.Artist.SearchTerm);
+        }
+
+        [Test]
+        public void TestUnrecognisedKeywordIsIgnored()
+        {
+            const string query = "unrecognised=keyword";
+            var filterCriteria = new FilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
+            Assert.AreEqual("unrecognised=keyword", filterCriteria.SearchText.Trim());
+        }
+
+        [Test]
+        public void TestCustomKeywordIsParsed()
+        {
+            const string query = "custom=readme unrecognised=keyword";
+            var filterCriteria = new CustomFilterCriteria(new OsuRuleset().RulesetInfo, new FilterCreationParameters { Query = query });
+            Assert.AreEqual("readme", filterCriteria.CustomValue);
+            Assert.AreEqual("unrecognised=keyword", filterCriteria.SearchText.Trim());
+        }
+
+        private class CustomFilterCriteria : FilterCriteria
+        {
+            public CustomFilterCriteria(RulesetInfo rulesetInfo, FilterCreationParameters filterCreationParameters)
+                : base(rulesetInfo, filterCreationParameters)
+            {
+            }
+
+            public string CustomValue { get; set; }
+
+            protected override bool TryParseCustomKeywordCriteria(string key, string value, string op)
+            {
+                if (key == "custom" && op == "=")
+                {
+                    CustomValue = value;
+                    return true;
+                }
+
+                return false;
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -15,6 +15,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -20,6 +20,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;

--- a/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
+++ b/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using osu.Game.Collections;
-using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Rulesets.Filter

--- a/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
+++ b/osu.Game/Rulesets/Filter/FilterCreationParameters.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Game.Collections;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Rulesets.Filter
+{
+    /// <summary>
+    /// Structure used to pass data required to create a <see cref="FilterCriteria"/> instance
+    /// for use in the song selection screen.
+    /// </summary>
+    public class FilterCreationParameters
+    {
+        /// <summary>
+        /// The textual query, entered by the user in the song select search box.
+        /// </summary>
+        public string Query { get; set; }
+
+        /// <summary>
+        /// The group mode to use.
+        /// </summary>
+        public GroupMode GroupMode { get; set; }
+
+        /// <summary>
+        /// The sort mode to use.
+        /// </summary>
+        public SortMode SortMode { get; set; }
+
+        /// <summary>
+        /// Whether converted beatmaps are allowed to be included in the filtering results.
+        /// </summary>
+        public bool AllowConvertedBeatmaps { get; set; }
+
+        /// <summary>
+        /// The currently-selected collection.
+        /// </summary>
+        [CanBeNull]
+        public BeatmapCollection Collection { get; set; }
+
+        /// <summary>
+        /// The allowable star difficulty range, as set by the user in the game settings.
+        /// </summary>
+        public FilterCriteria.OptionalRange<double> UserStarDifficulty { get; set; } = new FilterCriteria.OptionalRange<double>
+        {
+            IsLowerInclusive = true,
+            IsUpperInclusive = true
+        };
+    }
+}

--- a/osu.Game/Rulesets/Filter/FilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria.cs
@@ -92,8 +92,8 @@ namespace osu.Game.Rulesets.Filter
         /// by this instance.
         /// </summary>
         /// <param name="beatmap">The beatmap to test the criteria against.</param>
-        /// <returns><c>true</c> if the beatmap matches the current filtering criteria.</returns>
-        public virtual bool Matches(BeatmapInfo beatmap)
+        /// <returns><c>true</c> if the beatmap matches the current filtering criteria, <c>false</c> otherwise.</returns>
+        public bool Matches(BeatmapInfo beatmap)
         {
             bool match =
                 Ruleset == null ||
@@ -141,8 +141,22 @@ namespace osu.Game.Rulesets.Filter
             if (match)
                 match &= Collection?.Beatmaps.Contains(beatmap) ?? true;
 
+            if (match)
+                match &= MatchesCustomCriteria(beatmap);
+
             return match;
         }
+
+        /// <summary>
+        /// Checks whether the supplied <paramref name="beatmap"/> satisfies ruleset-specific custom criteria,
+        /// in addition to the ones mandated by song select.
+        /// </summary>
+        /// <param name="beatmap">The beatmap to test the criteria against.</param>
+        /// <returns>
+        /// <c>true</c> if the beatmap matches the ruleset-specific custom filtering criteria,
+        /// <c>false</c> otherwise.
+        /// </returns>
+        protected virtual bool MatchesCustomCriteria(BeatmapInfo beatmap) => true;
 
         public struct OptionalRange<T> : IEquatable<OptionalRange<T>>
             where T : struct

--- a/osu.Game/Rulesets/Filter/FilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria.cs
@@ -7,10 +7,9 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
-using osu.Game.Rulesets;
 using osu.Game.Screens.Select.Filter;
 
-namespace osu.Game.Screens.Select
+namespace osu.Game.Rulesets.Filter
 {
     public class FilterCriteria
     {

--- a/osu.Game/Rulesets/Filter/FilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
+using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Rulesets.Filter
@@ -37,7 +38,9 @@ namespace osu.Game.Rulesets.Filter
 
         public string[] SearchTerms = Array.Empty<string>();
 
+        [CanBeNull]
         public RulesetInfo Ruleset;
+
         public bool AllowConvertedBeatmaps;
 
         private string searchText;
@@ -67,6 +70,73 @@ namespace osu.Game.Rulesets.Filter
         /// </summary>
         [CanBeNull]
         public BeatmapCollection Collection;
+
+        public FilterCriteria(RulesetInfo ruleset, FilterCreationParameters parameters)
+        {
+            Group = parameters.GroupMode;
+            Sort = parameters.SortMode;
+            AllowConvertedBeatmaps = parameters.AllowConvertedBeatmaps;
+            Ruleset = ruleset;
+            Collection = parameters.Collection;
+            UserStarDifficulty = parameters.UserStarDifficulty;
+
+            FilterQueryParser.ApplyQueries(this, parameters.Query);
+        }
+
+        internal FilterCriteria()
+        {
+        }
+
+        public virtual bool Matches(BeatmapInfo beatmap)
+        {
+            bool match =
+                Ruleset == null ||
+                beatmap.RulesetID == Ruleset.ID ||
+                (beatmap.RulesetID == 0 && Ruleset.ID > 0 && AllowConvertedBeatmaps);
+
+            if (beatmap.BeatmapSet?.Equals(SelectedBeatmapSet) == true)
+            {
+                // only check ruleset equality or convertability for selected beatmap
+                return match;
+            }
+
+            match &= !StarDifficulty.HasFilter || StarDifficulty.IsInRange(beatmap.StarDifficulty);
+            match &= !ApproachRate.HasFilter || ApproachRate.IsInRange(beatmap.BaseDifficulty.ApproachRate);
+            match &= !DrainRate.HasFilter || DrainRate.IsInRange(beatmap.BaseDifficulty.DrainRate);
+            match &= !CircleSize.HasFilter || CircleSize.IsInRange(beatmap.BaseDifficulty.CircleSize);
+            match &= !Length.HasFilter || Length.IsInRange(beatmap.Length);
+            match &= !BPM.HasFilter || BPM.IsInRange(beatmap.BPM);
+
+            match &= !BeatDivisor.HasFilter || BeatDivisor.IsInRange(beatmap.BeatDivisor);
+            match &= !OnlineStatus.HasFilter || OnlineStatus.IsInRange(beatmap.Status);
+
+            match &= !Creator.HasFilter || Creator.Matches(beatmap.Metadata.AuthorString);
+            match &= !Artist.HasFilter || Artist.Matches(beatmap.Metadata.Artist) ||
+                     Artist.Matches(beatmap.Metadata.ArtistUnicode);
+
+            match &= !UserStarDifficulty.HasFilter || UserStarDifficulty.IsInRange(beatmap.StarDifficulty);
+
+            if (match)
+            {
+                var terms = beatmap.SearchableTerms;
+
+                foreach (var criteriaTerm in SearchTerms)
+                    match &= terms.Any(term => term.Contains(criteriaTerm, StringComparison.InvariantCultureIgnoreCase));
+
+                // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
+                // this should be done after text matching so we can prioritise matching numbers in metadata.
+                if (!match && SearchNumber.HasValue)
+                {
+                    match = (beatmap.OnlineBeatmapID == SearchNumber.Value) ||
+                            (beatmap.BeatmapSet?.OnlineBeatmapSetID == SearchNumber.Value);
+                }
+            }
+
+            if (match)
+                match &= Collection?.Beatmaps.Contains(beatmap) ?? true;
+
+            return match;
+        }
 
         public struct OptionalRange<T> : IEquatable<OptionalRange<T>>
             where T : struct

--- a/osu.Game/Rulesets/Filter/FilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria.cs
@@ -7,12 +7,11 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
-using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Rulesets.Filter
 {
-    public class FilterCriteria
+    public partial class FilterCriteria
     {
         public GroupMode Group;
         public SortMode Sort;
@@ -80,7 +79,7 @@ namespace osu.Game.Rulesets.Filter
             Collection = parameters.Collection;
             UserStarDifficulty = parameters.UserStarDifficulty;
 
-            FilterQueryParser.ApplyQueries(this, parameters.Query);
+            applyQueries(parameters.Query);
         }
 
         internal FilterCriteria()

--- a/osu.Game/Rulesets/Filter/FilterCriteria_QueryParser.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria_QueryParser.cs
@@ -82,6 +82,21 @@ namespace osu.Game.Rulesets.Filter
             return true;
         }
 
+        /// <summary>
+        /// Attempts to parse a single custom keyword criterion, given by the user via the song select search box.
+        /// The format of the criterion is:
+        /// <code>
+        /// {key}{op}{value}
+        /// </code>
+        /// </summary>
+        /// <param name="key">The key (name) of the criterion.</param>
+        /// <param name="value">The value of the criterion.</param>
+        /// <param name="op">The operator in the criterion.</param>
+        /// <returns>
+        /// <c>true</c> if the keyword criterion is valid, <c>false</c> if it has been ignored.
+        /// Valid criteria are stripped from <see cref="SearchText"/>,
+        /// while ignored criteria are included in <see cref="SearchText"/>.
+        /// </returns>
         protected virtual bool TryParseCustomKeywordCriteria(string key, string value, string op) => false;
 
         private static int getLengthScale(string value) =>

--- a/osu.Game/Rulesets/Filter/FilterCriteria_QueryParser.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria_QueryParser.cs
@@ -68,12 +68,10 @@ namespace osu.Game.Rulesets.Filter
                     break;
 
                 case "creator":
-                    updateCriteriaText(ref Creator, op, value);
-                    break;
+                    return updateCriteriaText(ref Creator, op, value);
 
                 case "artist":
-                    updateCriteriaText(ref Artist, op, value);
-                    break;
+                    return updateCriteriaText(ref Artist, op, value);
 
                 default:
                     return TryParseCustomKeywordCriteria(key, value, op);
@@ -141,13 +139,16 @@ namespace osu.Game.Rulesets.Filter
         private static bool parseInt(string value, out int result) =>
             int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
 
-        private static void updateCriteriaText(ref OptionalTextFilter textFilter, Operator op, string value)
+        private static bool updateCriteriaText(ref OptionalTextFilter textFilter, Operator op, string value)
         {
             switch (op)
             {
                 case Operator.Equal:
                     textFilter.SearchTerm = value.Trim('"');
-                    break;
+                    return true;
+
+                default:
+                    return false;
             }
         }
 

--- a/osu.Game/Rulesets/Filter/FilterCriteria_QueryParser.cs
+++ b/osu.Game/Rulesets/Filter/FilterCriteria_QueryParser.cs
@@ -5,17 +5,16 @@ using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Filter;
 
-namespace osu.Game.Screens.Select
+namespace osu.Game.Rulesets.Filter
 {
-    internal static class FilterQueryParser
+    public partial class FilterCriteria
     {
         private static readonly Regex query_syntax_regex = new Regex(
             @"\b(?<key>stars|ar|dr|hp|cs|divisor|length|objects|bpm|status|creator|artist)(?<op>[=:><]+)(?<value>("".*"")|(\S*))",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        internal static void ApplyQueries(FilterCriteria criteria, string query)
+        private void applyQueries(string query)
         {
             foreach (Match match in query_syntax_regex.Matches(query))
             {
@@ -23,58 +22,58 @@ namespace osu.Game.Screens.Select
                 var op = match.Groups["op"].Value;
                 var value = match.Groups["value"].Value;
 
-                parseKeywordCriteria(criteria, key, value, op);
+                parseKeywordCriteria(key, value, op);
 
                 query = query.Replace(match.ToString(), "");
             }
 
-            criteria.SearchText = query;
+            SearchText = query;
         }
 
-        private static void parseKeywordCriteria(FilterCriteria criteria, string key, string value, string op)
+        private void parseKeywordCriteria(string key, string value, string op)
         {
             switch (key)
             {
                 case "stars" when parseFloatWithPoint(value, out var stars):
-                    updateCriteriaRange(ref criteria.StarDifficulty, op, stars, 0.01f / 2);
+                    updateCriteriaRange(ref StarDifficulty, op, stars, 0.01f / 2);
                     break;
 
                 case "ar" when parseFloatWithPoint(value, out var ar):
-                    updateCriteriaRange(ref criteria.ApproachRate, op, ar, 0.1f / 2);
+                    updateCriteriaRange(ref ApproachRate, op, ar, 0.1f / 2);
                     break;
 
                 case "dr" when parseFloatWithPoint(value, out var dr):
                 case "hp" when parseFloatWithPoint(value, out dr):
-                    updateCriteriaRange(ref criteria.DrainRate, op, dr, 0.1f / 2);
+                    updateCriteriaRange(ref DrainRate, op, dr, 0.1f / 2);
                     break;
 
                 case "cs" when parseFloatWithPoint(value, out var cs):
-                    updateCriteriaRange(ref criteria.CircleSize, op, cs, 0.1f / 2);
+                    updateCriteriaRange(ref CircleSize, op, cs, 0.1f / 2);
                     break;
 
                 case "bpm" when parseDoubleWithPoint(value, out var bpm):
-                    updateCriteriaRange(ref criteria.BPM, op, bpm, 0.01d / 2);
+                    updateCriteriaRange(ref BPM, op, bpm, 0.01d / 2);
                     break;
 
                 case "length" when parseDoubleWithPoint(value.TrimEnd('m', 's', 'h'), out var length):
                     var scale = getLengthScale(value);
-                    updateCriteriaRange(ref criteria.Length, op, length * scale, scale / 2.0);
+                    updateCriteriaRange(ref Length, op, length * scale, scale / 2.0);
                     break;
 
                 case "divisor" when parseInt(value, out var divisor):
-                    updateCriteriaRange(ref criteria.BeatDivisor, op, divisor);
+                    updateCriteriaRange(ref BeatDivisor, op, divisor);
                     break;
 
                 case "status" when Enum.TryParse<BeatmapSetOnlineStatus>(value, true, out var statusValue):
-                    updateCriteriaRange(ref criteria.OnlineStatus, op, statusValue);
+                    updateCriteriaRange(ref OnlineStatus, op, statusValue);
                     break;
 
                 case "creator":
-                    updateCriteriaText(ref criteria.Creator, op, value);
+                    updateCriteriaText(ref Creator, op, value);
                     break;
 
                 case "artist":
-                    updateCriteriaText(ref criteria.Artist, op, value);
+                    updateCriteriaText(ref Artist, op, value);
                     break;
             }
         }
@@ -94,7 +93,7 @@ namespace osu.Game.Screens.Select
         private static bool parseInt(string value, out int result) =>
             int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
 
-        private static void updateCriteriaText(ref FilterCriteria.OptionalTextFilter textFilter, string op, string value)
+        private static void updateCriteriaText(ref OptionalTextFilter textFilter, string op, string value)
         {
             switch (op)
             {
@@ -105,7 +104,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, string op, float value, float tolerance = 0.05f)
+        private static void updateCriteriaRange(ref OptionalRange<float> range, string op, float value, float tolerance = 0.05f)
         {
             switch (op)
             {
@@ -138,7 +137,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private static void updateCriteriaRange(ref FilterCriteria.OptionalRange<double> range, string op, double value, double tolerance = 0.05)
+        private static void updateCriteriaRange(ref OptionalRange<double> range, string op, double value, double tolerance = 0.05)
         {
             switch (op)
             {
@@ -171,7 +170,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private static void updateCriteriaRange<T>(ref FilterCriteria.OptionalRange<T> range, string op, T value)
+        private static void updateCriteriaRange<T>(ref OptionalRange<T> range, string op, T value)
             where T : struct
         {
             switch (op)

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Testing;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets
@@ -306,5 +307,11 @@ namespace osu.Game.Rulesets
         /// <param name="result">The result type to get the name for.</param>
         /// <returns>The display name.</returns>
         public virtual string GetDisplayNameForHitResult(HitResult result) => result.GetDescription();
+
+        /// <summary>
+        /// Creates a <see cref="FilterCriteria"/> instance for filtering beatmaps in the song select screen.
+        /// </summary>
+        /// <param name="parameters">The creation parameters for the filter criteria.</param>
+        public virtual FilterCriteria CreateFilterCriteria(FilterCreationParameters parameters) => new FilterCriteria(RulesetInfo, parameters);
     }
 }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -22,6 +22,7 @@ using osu.Game.Extensions;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Input.Bindings;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Carousel;
 using osuTK;
 using osuTK.Input;

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select.Carousel

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
@@ -27,54 +25,7 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Filter(criteria);
 
-            bool match =
-                criteria.Ruleset == null ||
-                Beatmap.RulesetID == criteria.Ruleset.ID ||
-                (Beatmap.RulesetID == 0 && criteria.Ruleset.ID > 0 && criteria.AllowConvertedBeatmaps);
-
-            if (Beatmap.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
-            {
-                // only check ruleset equality or convertability for selected beatmap
-                Filtered.Value = !match;
-                return;
-            }
-
-            match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(Beatmap.StarDifficulty);
-            match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(Beatmap.BaseDifficulty.ApproachRate);
-            match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(Beatmap.BaseDifficulty.DrainRate);
-            match &= !criteria.CircleSize.HasFilter || criteria.CircleSize.IsInRange(Beatmap.BaseDifficulty.CircleSize);
-            match &= !criteria.Length.HasFilter || criteria.Length.IsInRange(Beatmap.Length);
-            match &= !criteria.BPM.HasFilter || criteria.BPM.IsInRange(Beatmap.BPM);
-
-            match &= !criteria.BeatDivisor.HasFilter || criteria.BeatDivisor.IsInRange(Beatmap.BeatDivisor);
-            match &= !criteria.OnlineStatus.HasFilter || criteria.OnlineStatus.IsInRange(Beatmap.Status);
-
-            match &= !criteria.Creator.HasFilter || criteria.Creator.Matches(Beatmap.Metadata.AuthorString);
-            match &= !criteria.Artist.HasFilter || criteria.Artist.Matches(Beatmap.Metadata.Artist) ||
-                     criteria.Artist.Matches(Beatmap.Metadata.ArtistUnicode);
-
-            match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(Beatmap.StarDifficulty);
-
-            if (match)
-            {
-                var terms = Beatmap.SearchableTerms;
-
-                foreach (var criteriaTerm in criteria.SearchTerms)
-                    match &= terms.Any(term => term.Contains(criteriaTerm, StringComparison.InvariantCultureIgnoreCase));
-
-                // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
-                // this should be done after text matching so we can prioritise matching numbers in metadata.
-                if (!match && criteria.SearchNumber.HasValue)
-                {
-                    match = (Beatmap.OnlineBeatmapID == criteria.SearchNumber.Value) ||
-                            (Beatmap.BeatmapSet?.OnlineBeatmapSetID == criteria.SearchNumber.Value);
-                }
-            }
-
-            if (match)
-                match &= criteria.Collection?.Beatmaps.Contains(Beatmap) ?? true;
-
-            Filtered.Value = !match;
+            Filtered.Value = !criteria.Matches(Beatmap);
         }
 
         public override int CompareTo(FilterCriteria criteria, CarouselItem other)

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select.Carousel

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select.Carousel
 {

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select.Carousel
 {

--- a/osu.Game/Screens/Select/Carousel/CarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select.Carousel
 {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
 using osuTK.Graphics;

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
 
 namespace osu.Game.Screens.Select
 {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -37,6 +37,7 @@ using osu.Game.Collections;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Scoring;
 using System.Diagnostics;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Play;
 
 namespace osu.Game.Screens.Select


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu/pull/11925

This pull request is the second step towards adding a mania keymode song select filter (https://github.com/ppy/osu/issues/5668).

It expands upon the aforementioned pull by moving the parsing logic out from the static `FilterQueryParser` to inside `FilterCriteria`. Thanks to that, `FilterCriteria` has now gained a second virtual method:

```csharp
protected virtual bool TryParseCustomKeywordCriteria(string key, string value, Operator op)
```

which allows the ruleset implementors to store their custom criteria (using the same format as the built-in ones) into their implementations of `FilterCriteria`, completing the entire flow of customising filters.

To that end, I have tacked on some quality-of-life improvements to the existing code, namely:

* Changed the regex to allow any key, instead of hard-coding the ones that are valid - the ones that an instance of `FilterCriteria` cannot understand (due to `tryParse...()` returning `false`) will behave the same way still
* Changed the operation-parsing portion of the regex to not accept arbitrary sequences of the 4 characters: `=:<>` - now it will only accept operators as defined in `parseOperator`
* Made operator a proper enum instead of a string

I've added some tests covering these changes. I've still got some things I'm not sure about with this one, too, so comments definitely appreciated.