### PR TITLE
Fix beatmap removed post-creation in multiplayer tests

### DIFF
--- a/osu.Game.Tests/OnlinePlay/StatefulMultiplayerClientTest.cs
+++ b/osu.Game.Tests/OnlinePlay/StatefulMultiplayerClientTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Tests.Visual.Multiplayer;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.OnlinePlay
+{
+    [HeadlessTest]
+    public class StatefulMultiplayerClientTest : MultiplayerTestScene
+    {
+        [Test]
+        public void TestUserAddedOnJoin()
+        {
+            var user = new User { Id = 33 };
+
+            AddRepeatStep("add user multiple times", () => Client.AddUser(user), 3);
+            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
+        }
+
+        [Test]
+        public void TestUserRemovedOnLeave()
+        {
+            var user = new User { Id = 44 };
+
+            AddStep("add user", () => Client.AddUser(user));
+            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
+
+            AddRepeatStep("remove user multiple times", () => Client.RemoveUser(user), 3);
+            AddAssert("room has 1 user", () => Client.Room?.Users.Count == 1);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -9,12 +9,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayer : ScreenTestScene
     {
+        private TestMultiplayer multiplayerScreen;
+
         public TestSceneMultiplayer()
         {
-            var multi = new TestMultiplayer();
+            AddStep("show", () =>
+            {
+                multiplayerScreen = new TestMultiplayer();
 
-            AddStep("show", () => LoadScreen(multi));
-            AddUntilStep("wait for loaded", () => multi.IsLoaded);
+                // Needs to be added at a higher level since the multiplayer screen becomes non-current.
+                Child = multiplayerScreen.Client;
+
+                LoadScreen(multiplayerScreen);
+            });
+
+            AddUntilStep("wait for loaded", () => multiplayerScreen.IsLoaded);
         }
 
         private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
@@ -24,7 +33,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             public TestMultiplayer()
             {
-                AddInternal(Client = new TestMultiplayerClient((TestMultiplayerRoomManager)RoomManager));
+                Client = new TestMultiplayerClient((TestMultiplayerRoomManager)RoomManager);
             }
 
             protected override RoomManager CreateRoomManager() => new TestMultiplayerRoomManager();

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -1,13 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Components;
-using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    public class TestSceneMultiplayer : MultiplayerTestScene
+    public class TestSceneMultiplayer : ScreenTestScene
     {
         public TestSceneMultiplayer()
         {
@@ -17,30 +17,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for loaded", () => multi.IsLoaded);
         }
 
-        [Test]
-        public void TestOneUserJoinedMultipleTimes()
-        {
-            var user = new User { Id = 33 };
-
-            AddRepeatStep("add user multiple times", () => Client.AddUser(user), 3);
-
-            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
-        }
-
-        [Test]
-        public void TestOneUserLeftMultipleTimes()
-        {
-            var user = new User { Id = 44 };
-
-            AddStep("add user", () => Client.AddUser(user));
-            AddAssert("room has 2 users", () => Client.Room?.Users.Count == 2);
-
-            AddRepeatStep("remove user multiple times", () => Client.RemoveUser(user), 3);
-            AddAssert("room has 1 user", () => Client.Room?.Users.Count == 1);
-        }
-
         private class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplayer
         {
+            [Cached(typeof(StatefulMultiplayerClient))]
+            public readonly TestMultiplayerClient Client;
+
+            public TestMultiplayer()
+            {
+                AddInternal(Client = new TestMultiplayerClient((TestMultiplayerRoomManager)RoomManager));
+            }
+
             protected override RoomManager CreateRoomManager() => new TestMultiplayerRoomManager();
         }
     }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -3,12 +3,10 @@
 
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Tests.Beatmaps;
@@ -19,9 +17,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
     public class TestSceneMultiplayerMatchSubScreen : MultiplayerTestScene
     {
         private MultiplayerMatchSubScreen screen;
-
-        [Cached]
-        private OngoingOperationTracker ongoingOperationTracker = new OngoingOperationTracker();
 
         public TestSceneMultiplayerMatchSubScreen()
             : base(false)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerRoomManager.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerRoomManager.cs
@@ -1,10 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Components;
+using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -21,15 +24,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 createRoomManager().With(d => d.OnLoadComplete += _ =>
                 {
-                    roomManager.CreateRoom(new Room { Name = { Value = "1" } });
+                    roomManager.CreateRoom(createRoom(r => r.Name.Value = "1"));
                     roomManager.PartRoom();
-                    roomManager.CreateRoom(new Room { Name = { Value = "2" } });
+                    roomManager.CreateRoom(createRoom(r => r.Name.Value = "2"));
                     roomManager.PartRoom();
                     roomManager.ClearRooms();
                 });
             });
 
-            AddAssert("manager polled for rooms", () => roomManager.Rooms.Count == 2);
+            AddAssert("manager polled for rooms", () => ((RoomManager)roomManager).Rooms.Count == 2);
             AddAssert("initial rooms received", () => roomManager.InitialRoomsReceived.Value);
         }
 
@@ -40,16 +43,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 createRoomManager().With(d => d.OnLoadComplete += _ =>
                 {
-                    roomManager.CreateRoom(new Room());
+                    roomManager.CreateRoom(createRoom());
                     roomManager.PartRoom();
-                    roomManager.CreateRoom(new Room());
+                    roomManager.CreateRoom(createRoom());
                     roomManager.PartRoom();
                 });
             });
 
             AddStep("disconnect", () => roomContainer.Client.Disconnect());
 
-            AddAssert("rooms cleared", () => roomManager.Rooms.Count == 0);
+            AddAssert("rooms cleared", () => ((RoomManager)roomManager).Rooms.Count == 0);
             AddAssert("initial rooms not received", () => !roomManager.InitialRoomsReceived.Value);
         }
 
@@ -60,9 +63,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 createRoomManager().With(d => d.OnLoadComplete += _ =>
                 {
-                    roomManager.CreateRoom(new Room());
+                    roomManager.CreateRoom(createRoom());
                     roomManager.PartRoom();
-                    roomManager.CreateRoom(new Room());
+                    roomManager.CreateRoom(createRoom());
                     roomManager.PartRoom();
                 });
             });
@@ -70,7 +73,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("disconnect", () => roomContainer.Client.Disconnect());
             AddStep("connect", () => roomContainer.Client.Connect());
 
-            AddAssert("manager polled for rooms", () => roomManager.Rooms.Count == 2);
+            AddAssert("manager polled for rooms", () => ((RoomManager)roomManager).Rooms.Count == 2);
             AddAssert("initial rooms received", () => roomManager.InitialRoomsReceived.Value);
         }
 
@@ -81,12 +84,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 createRoomManager().With(d => d.OnLoadComplete += _ =>
                 {
-                    roomManager.CreateRoom(new Room());
+                    roomManager.CreateRoom(createRoom());
                     roomManager.ClearRooms();
                 });
             });
 
-            AddAssert("manager not polled for rooms", () => roomManager.Rooms.Count == 0);
+            AddAssert("manager not polled for rooms", () => ((RoomManager)roomManager).Rooms.Count == 0);
             AddAssert("initial rooms not received", () => !roomManager.InitialRoomsReceived.Value);
         }
 
@@ -97,7 +100,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 createRoomManager().With(d => d.OnLoadComplete += _ =>
                 {
-                    roomManager.CreateRoom(new Room());
+                    roomManager.CreateRoom(createRoom());
                 });
             });
 
@@ -111,7 +114,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 createRoomManager().With(d => d.OnLoadComplete += _ =>
                 {
-                    roomManager.CreateRoom(new Room());
+                    roomManager.CreateRoom(createRoom());
                     roomManager.PartRoom();
                 });
             });
@@ -126,7 +129,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             {
                 createRoomManager().With(d => d.OnLoadComplete += _ =>
                 {
-                    var r = new Room();
+                    var r = createRoom();
                     roomManager.CreateRoom(r);
                     roomManager.PartRoom();
                     roomManager.JoinRoom(r);
@@ -134,6 +137,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("multiplayer room joined", () => roomContainer.Client.Room != null);
+        }
+
+        private Room createRoom(Action<Room> initFunc = null)
+        {
+            var room = new Room();
+
+            room.Name.Value = "test room";
+            room.Playlist.Add(new PlaylistItem
+            {
+                Beatmap = { Value = new TestBeatmap(Ruleset.Value).BeatmapInfo },
+                Ruleset = { Value = Ruleset.Value }
+            });
+
+            initFunc?.Invoke(room);
+            return room;
         }
 
         private TestMultiplayerRoomManager createRoomManager()

--- a/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/MultiplayerTestScene.cs
@@ -7,8 +7,10 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
+using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -48,7 +50,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
             RoomManager.Schedule(() => RoomManager.PartRoom());
 
             if (joinRoom)
+            {
+                Room.Name.Value = "test name";
+                Room.Playlist.Add(new PlaylistItem
+                {
+                    Beatmap = { Value = new TestBeatmap(Ruleset.Value).BeatmapInfo },
+                    Ruleset = { Value = Ruleset.Value }
+                });
+
                 RoomManager.Schedule(() => RoomManager.CreateRoom(Room));
+            }
         });
 
         public override void SetUpSteps()

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -29,10 +29,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private Room apiRoom { get; set; } = null!;
-
-        [Resolved]
         private BeatmapManager beatmaps { get; set; } = null!;
+
+        private readonly TestMultiplayerRoomManager roomManager;
+
+        public TestMultiplayerClient(TestMultiplayerRoomManager roomManager)
+        {
+            this.roomManager = roomManager;
+        }
 
         public void Connect() => isConnected.Value = true;
 
@@ -98,7 +102,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         protected override Task<MultiplayerRoom> JoinRoom(long roomId)
         {
-            Debug.Assert(apiRoom != null);
+            var apiRoom = roomManager.Rooms.Single(r => r.RoomID.Value == roomId);
 
             var user = new MultiplayerRoomUser(api.LocalUser.Value.Id)
             {
@@ -178,8 +182,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         protected override Task<BeatmapSetInfo> GetOnlineBeatmapSet(int beatmapId, CancellationToken cancellationToken = default)
         {
             Debug.Assert(Room != null);
-            Debug.Assert(apiRoom != null);
 
+            var apiRoom = roomManager.Rooms.Single(r => r.RoomID.Value == Room.RoomID);
             var set = apiRoom.Playlist.FirstOrDefault(p => p.BeatmapID == beatmapId)?.Beatmap.Value.BeatmapSet
                       ?? beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == beatmapId)?.BeatmapSet;
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomContainer.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomContainer.cs
@@ -32,11 +32,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             RelativeSizeAxes = Axes.Both;
 
+            RoomManager = new TestMultiplayerRoomManager();
+            Client = new TestMultiplayerClient(RoomManager);
+            OngoingOperationTracker = new OngoingOperationTracker();
+
             AddRangeInternal(new Drawable[]
             {
-                Client = new TestMultiplayerClient(),
-                RoomManager = new TestMultiplayerRoomManager(),
-                OngoingOperationTracker = new OngoingOperationTracker(),
+                Client,
+                RoomManager,
+                OngoingOperationTracker,
                 content = new Container { RelativeSizeAxes = Axes.Both }
             });
         }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Cached]
         public readonly Bindable<FilterCriteria> Filter = new Bindable<FilterCriteria>(new FilterCriteria());
 
-        private readonly List<Room> rooms = new List<Room>();
+        public new readonly List<Room> Rooms = new List<Room>();
 
         protected override void LoadComplete()
         {
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         for (int i = 0; i < createdRoom.Playlist.Count; i++)
                             createdRoom.Playlist[i].ID = currentPlaylistItemId++;
 
-                        rooms.Add(createdRoom);
+                        Rooms.Add(createdRoom);
                         createRoomRequest.TriggerSuccess(createdRoom);
                         break;
 
@@ -65,7 +65,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     case GetRoomsRequest getRoomsRequest:
                         var roomsWithoutParticipants = new List<Room>();
 
-                        foreach (var r in rooms)
+                        foreach (var r in Rooms)
                         {
                             var newRoom = new Room();
 
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         break;
 
                     case GetRoomRequest getRoomRequest:
-                        getRoomRequest.TriggerSuccess(rooms.Single(r => r.RoomID.Value == getRoomRequest.RoomId));
+                        getRoomRequest.TriggerSuccess(Rooms.Single(r => r.RoomID.Value == getRoomRequest.RoomId));
                         break;
 
                     case GetBeatmapSetRequest getBeatmapSetRequest:

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             int currentScoreId = 0;
             int currentRoomId = 0;
+            int currentPlaylistItemId = 0;
 
             ((DummyAPIAccess)api).HandleRequest = req =>
             {
@@ -45,6 +46,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                         createdRoom.CopyFrom(createRoomRequest.Room);
                         createdRoom.RoomID.Value ??= currentRoomId++;
+
+                        for (int i = 0; i < createdRoom.Playlist.Count; i++)
+                            createdRoom.Playlist[i].ID = currentPlaylistItemId++;
 
                         rooms.Add(createdRoom);
                         createRoomRequest.TriggerSuccess(createdRoom);


### PR DESCRIPTION
The main part of this is the addition of `GetOnlineBeatmapSet()`, which is overridden in tests to provide the given beatmap set.