### PR TITLE
Update user statistics models in line with web API changes

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneFriendDisplay.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Tests.Visual.Online
                 Username = "flyte",
                 Id = 3103765,
                 IsOnline = true,
-                CurrentModeRank = 1111,
+                Statistics = new UserStatistics { GlobalRank = 1111 },
                 Country = new Country { FlagName = "JP" },
                 CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c6.jpg"
             },
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Visual.Online
                 Username = "peppy",
                 Id = 2,
                 IsOnline = false,
-                CurrentModeRank = 2222,
+                Statistics = new UserStatistics { GlobalRank = 2222 },
                 Country = new Country { FlagName = "AU" },
                 CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
                 IsSupporter = true,

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsParticipantsList.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.Playlists
                 Room.RecentParticipants.Add(new User
                 {
                     Username = "peppy",
-                    CurrentModeRank = 1234,
+                    Statistics = new UserStatistics { GlobalRank = 1234 },
                     Id = 2
                 });
             }

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -150,7 +150,9 @@ namespace osu.Game.Tournament
             {
                 foreach (var p in t.Players)
                 {
-                    if (string.IsNullOrEmpty(p.Username) || p.Statistics?.GlobalRank == null)
+                    if (string.IsNullOrEmpty(p.Username)
+                        || p.Statistics?.GlobalRank == null
+                        || p.Statistics?.CountryRank == null)
                     {
                         PopulateUser(p, immediate: true);
                         addedInfo = true;

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -244,7 +244,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                     return unsorted.OrderByDescending(u => u.LastVisit).ToList();
 
                 case UserSortCriteria.Rank:
-                    return unsorted.OrderByDescending(u => u.CurrentModeRank.HasValue).ThenBy(u => u.CurrentModeRank ?? 0).ToList();
+                    return unsorted.OrderByDescending(u => u.Statistics.GlobalRank.HasValue).ThenBy(u => u.Statistics.GlobalRank ?? 0).ToList();
 
                 case UserSortCriteria.Username:
                     return unsorted.OrderBy(u => u.Username).ToList();

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -72,9 +72,6 @@ namespace osu.Game.Users
         [JsonProperty(@"support_level")]
         public int SupportLevel;
 
-        [JsonProperty(@"current_mode_rank")]
-        public int? CurrentModeRank;
-
         [JsonProperty(@"is_gmt")]
         public bool IsGMT;
 
@@ -182,7 +179,7 @@ namespace osu.Game.Users
         private UserStatistics statistics;
 
         /// <summary>
-        /// User statistics for the requested ruleset (in the case of a <see cref="GetUserRequest"/> response).
+        /// User statistics for the requested ruleset (in the case of a <see cref="GetUserRequest"/> or <see cref="GetFriendsRequest"/> response).
         /// Otherwise empty.
         /// </summary>
         [JsonProperty(@"statistics")]

--- a/osu.Game/Users/UserStatistics.cs
+++ b/osu.Game/Users/UserStatistics.cs
@@ -29,15 +29,8 @@ namespace osu.Game.Users
         [JsonProperty(@"global_rank")]
         public int? GlobalRank;
 
+        [JsonProperty(@"country_rank")]
         public int? CountryRank;
-
-        [JsonProperty(@"rank")]
-        private UserRanks ranks
-        {
-            // eventually that will also become an own json property instead of reading from a `rank` object.
-            // see https://github.com/ppy/osu-web/blob/cb79bb72186c8f1a25f6a6f5ef315123decb4231/app/Transformers/UserStatisticsTransformer.php#L53.
-            set => CountryRank = value.Country;
-        }
 
         // populated via User model, as that's where the data currently lives.
         public RankHistoryData RankHistory;
@@ -119,13 +112,5 @@ namespace osu.Game.Users
                 }
             }
         }
-
-#pragma warning disable 649
-        private struct UserRanks
-        {
-            [JsonProperty(@"country")]
-            public int? Country;
-        }
-#pragma warning restore 649
     }
 }


### PR DESCRIPTION
See https://github.com/ppy/osu-web/pull/7245.

1. Moves away from using `rank.country` as it's deprecated and will be removed soon, and also nukes the whole `UserRanks` object in favour of those outer JSON properties.
2. Nukes no longer existing `current_mode_rank` and use the now included `statistics` property for friends display.

Also makes tournament client refetch users on null country rank, may not be a nice thing, but seems to be the easiest way to do the migration for brackets file as done with global rank API change, not sure if it deserves an inline comment?