### PR TITLE
Fix confine mode dropdown becoming visible again after filtering

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -68,7 +68,21 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             };
 
             windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
-            windowMode.BindValueChanged(mode => confineMouseModeSetting.Alpha = mode.NewValue == WindowMode.Fullscreen ? 0 : 1, true);
+            windowMode.BindValueChanged(mode =>
+            {
+                var isFullscreen = mode.NewValue == WindowMode.Fullscreen;
+
+                if (isFullscreen)
+                {
+                    confineMouseModeSetting.Current.Disabled = true;
+                    confineMouseModeSetting.TooltipText = "Not applicable in full screen mode";
+                }
+                else
+                {
+                    confineMouseModeSetting.Current.Disabled = false;
+                    confineMouseModeSetting.TooltipText = string.Empty;
+                }
+            }, true);
 
             if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
             {


### PR DESCRIPTION
Changes from a hidden to a disabled state, with a tooltip explaining why.

Closes #11851.