### PR TITLE
Add mobile logs location to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-issues.md
+++ b/.github/ISSUE_TEMPLATE/01-bug-issues.md
@@ -13,4 +13,6 @@ about: Issues regarding encountered bugs.
 *please attach logs here, which are located at:*
 - `%AppData%/osu/logs` *(on Windows),*
 - `~/.local/share/osu/logs` *(on Linux & macOS).*
+- `Android/Data/sh.ppy.osulazer/logs` *(on Android)*,
+- on iOS they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
 -->

--- a/.github/ISSUE_TEMPLATE/02-crash-issues.md
+++ b/.github/ISSUE_TEMPLATE/02-crash-issues.md
@@ -13,6 +13,8 @@ about: Issues regarding crashes or permanent freezes.
 *please attach logs here, which are located at:*
 - `%AppData%/osu/logs` *(on Windows),*
 - `~/.local/share/osu/logs` *(on Linux & macOS).*
+- `Android/Data/sh.ppy.osulazer/logs` *(on Android)*,
+- on iOS they can be obtained by connecting your device to your desktop and copying the `logs` directory from the app's own document storage using iTunes. (https://support.apple.com/en-us/HT201301#copy-to-computer)
 -->
 
 **Computer Specifications:** 


### PR DESCRIPTION
For guiding mobile users where the logs are when reporting game issues, instead of opening useless ones. Taken from the contributing guidelines.