### PR TITLE
Fix restore-to-default buttons never showing if initially hidden

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Tests.Visual.Settings
+{
+    [TestFixture]
+    public class TestSceneSettingsItem : OsuTestScene
+    {
+        [Test]
+        public void TestRestoreDefaultValueButtonVisibility()
+        {
+            TestSettingsTextBox textBox = null;
+
+            AddStep("create settings item", () => Child = textBox = new TestSettingsTextBox
+            {
+                Current = new Bindable<string>
+                {
+                    Default = "test",
+                    Value = "test"
+                }
+            });
+            AddAssert("restore button hidden", () => textBox.RestoreDefaultValueButton.Alpha == 0);
+
+            AddStep("change value from default", () => textBox.Current.Value = "non-default");
+            AddUntilStep("restore button shown", () => textBox.RestoreDefaultValueButton.Alpha > 0);
+
+            AddStep("restore default", () => textBox.Current.SetDefault());
+            AddUntilStep("restore button hidden", () => textBox.RestoreDefaultValueButton.Alpha == 0);
+        }
+
+        private class TestSettingsTextBox : SettingsTextBox
+        {
+            public new Drawable RestoreDefaultValueButton => this.ChildrenOfType<RestoreDefaultValueButton>().Single();
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Overlays.Settings
                 labelText.Alpha = controlWithCurrent.Current.Disabled ? 0.3f : 1;
         }
 
-        private class RestoreDefaultValueButton : Container, IHasTooltip
+        protected internal class RestoreDefaultValueButton : Container, IHasTooltip
         {
             private Bindable<T> bindable;
 

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -147,6 +147,7 @@ namespace osu.Game.Overlays.Settings
                 RelativeSizeAxes = Axes.Y;
                 Width = SettingsPanel.CONTENT_MARGINS;
                 Alpha = 0f;
+                AlwaysPresent = true;
             }
 
             [BackgroundDependencyLoader]


### PR DESCRIPTION
[As reported on discord](https://discord.com/channels/188630481301012481/188630652340404224/816364828851568670). Regressed in https://github.com/ppy/osu/pull/11916, for reasons that should be immediately obvious upon reading the single added line.

No excuses, should have tested more thoroughly. I *do* think it's a bit of a gotcha, though...

Fixes https://github.com/ppy/osu/issues/11954.