### PR TITLE
Fix selecting a beatmap at the multiplayer match screen exiting the match

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -361,10 +361,6 @@ namespace osu.Game
 
             PerformFromScreen(screen =>
             {
-                // we might even already be at the song
-                if (Beatmap.Value.BeatmapSetInfo.Hash == databasedSet.Hash && (difficultyCriteria?.Invoke(Beatmap.Value.BeatmapInfo) ?? true))
-                    return;
-
                 // Find beatmaps that match our predicate.
                 var beatmaps = databasedSet.Beatmaps.Where(b => difficultyCriteria?.Invoke(b) ?? true).ToList();
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -361,10 +361,6 @@ namespace osu.Game
 
             PerformFromScreen(screen =>
             {
-                // we might already be at song select, so a check is required before performing the load to solo.
-                if (screen is MainMenu)
-                    menuScreen.LoadToSolo();
-
                 // we might even already be at the song
                 if (Beatmap.Value.BeatmapSetInfo.Hash == databasedSet.Hash && (difficultyCriteria?.Invoke(Beatmap.Value.BeatmapInfo) ?? true))
                     return;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -381,9 +381,16 @@ namespace osu.Game
                                 ?? beatmaps.FirstOrDefault(b => b.Ruleset.Equals(Ruleset.Value))
                                 ?? beatmaps.First();
 
-                Ruleset.Value = selection.Ruleset;
-                Beatmap.Value = BeatmapManager.GetWorkingBeatmap(selection);
-            }, validScreens: new[] { typeof(SongSelect) });
+                if (screen is IHandlePresentBeatmap presentableScreen)
+                {
+                    presentableScreen.PresentBeatmap(BeatmapManager.GetWorkingBeatmap(selection), selection.Ruleset);
+                }
+                else
+                {
+                    Ruleset.Value = selection.Ruleset;
+                    Beatmap.Value = BeatmapManager.GetWorkingBeatmap(selection);
+                }
+            }, validScreens: new[] { typeof(SongSelect), typeof(IHandlePresentBeatmap) });
         }
 
         /// <summary>

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -5,11 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
-using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Notifications;
@@ -29,9 +27,6 @@ namespace osu.Game
 
         [Resolved]
         private DialogOverlay dialogOverlay { get; set; }
-
-        [Resolved]
-        private IBindable<WorkingBeatmap> beatmap { get; set; }
 
         [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
@@ -90,7 +85,7 @@ namespace osu.Game
             var type = current.GetType();
 
             // check if we are already at a valid target screen.
-            if (validScreens.Any(t => t.IsAssignableFrom(type)) && !beatmap.Disabled)
+            if (validScreens.Any(t => t.IsAssignableFrom(type)))
             {
                 finalAction(current);
                 Cancel();

--- a/osu.Game/Screens/IHandlePresentBeatmap.cs
+++ b/osu.Game/Screens/IHandlePresentBeatmap.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+
+namespace osu.Game.Screens
+{
+    /// <summary>
+    /// Denotes a screen which can handle beatmap / ruleset selection via local logic.
+    /// This is used in the <see cref="OsuGame.PresentBeatmap"/> flow to handle cases which require custom logic,
+    /// for instance, if a lease is held on the Beatmap.
+    /// </summary>
+    public interface IHandlePresentBeatmap
+    {
+        /// <summary>
+        /// Invoked with a requested beatmap / ruleset for selection.
+        /// </summary>
+        /// <param name="beatmap">The beatmap to be selected.</param>
+        /// <param name="ruleset">The ruleset to be selected.</param>
+        public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset);
+    }
+}

--- a/osu.Game/Screens/IHandlePresentBeatmap.cs
+++ b/osu.Game/Screens/IHandlePresentBeatmap.cs
@@ -18,6 +18,6 @@ namespace osu.Game.Screens
         /// </summary>
         /// <param name="beatmap">The beatmap to be selected.</param>
         /// <param name="ruleset">The ruleset to be selected.</param>
-        public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset);
+        void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset);
     }
 }

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -9,12 +9,14 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.IO;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
+using osu.Game.Rulesets;
 using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
@@ -23,7 +25,7 @@ using osu.Game.Screens.Select;
 
 namespace osu.Game.Screens.Menu
 {
-    public class MainMenu : OsuScreen
+    public class MainMenu : OsuScreen, IHandlePresentBeatmap
     {
         public const float FADE_IN_DURATION = 300;
 
@@ -104,7 +106,7 @@ namespace osu.Game.Screens.Menu
                                 Beatmap.SetDefault();
                                 this.Push(new Editor());
                             },
-                            OnSolo = onSolo,
+                            OnSolo = loadSoloSongSelect,
                             OnMultiplayer = () => this.Push(new Multiplayer()),
                             OnPlaylists = () => this.Push(new Playlists()),
                             OnExit = confirmAndExit,
@@ -160,9 +162,7 @@ namespace osu.Game.Screens.Menu
                 LoadComponentAsync(songSelect = new PlaySongSelect());
         }
 
-        public void LoadToSolo() => Schedule(onSolo);
-
-        private void onSolo() => this.Push(consumeSongSelect());
+        private void loadSoloSongSelect() => this.Push(consumeSongSelect());
 
         private Screen consumeSongSelect()
         {
@@ -288,6 +288,14 @@ namespace osu.Game.Screens.Menu
 
             this.FadeOut(3000);
             return base.OnExiting(next);
+        }
+
+        public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)
+        {
+            Beatmap.Value = beatmap;
+            Ruleset.Value = ruleset;
+
+            Schedule(loadSoloSongSelect);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -4,9 +4,11 @@
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 
@@ -18,6 +20,23 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private StatefulMultiplayerClient client { get; set; }
 
         private LoadingLayer loadingLayer;
+
+        /// <summary>
+        /// Construct a new instance of multiplayer song select.
+        /// </summary>
+        /// <param name="beatmap">An optional initial beatmap selection to perform.</param>
+        /// <param name="ruleset">An optional initial ruleset selection to perform.</param>
+        public MultiplayerMatchSongSelect(WorkingBeatmap beatmap = null, RulesetInfo ruleset = null)
+        {
+            if (beatmap != null || ruleset != null)
+            {
+                Schedule(() =>
+                {
+                    if (beatmap != null) Beatmap.Value = beatmap;
+                    if (ruleset != null) Ruleset.Value = ruleset;
+                });
+            }
+        }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -12,9 +12,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.OnlinePlay.Match;
@@ -29,7 +31,7 @@ using ParticipantsList = osu.Game.Screens.OnlinePlay.Multiplayer.Participants.Pa
 namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
     [Cached]
-    public class MultiplayerMatchSubScreen : RoomSubScreen
+    public class MultiplayerMatchSubScreen : RoomSubScreen, IHandlePresentBeatmap
     {
         public override string Title { get; }
 
@@ -393,6 +395,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             }
 
             modSettingChangeTracker?.Dispose();
+        }
+
+        public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)
+        {
+            if (!this.IsCurrentScreen())
+                return;
+
+            this.Push(new MultiplayerMatchSongSelect(beatmap, ruleset));
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -402,6 +402,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!this.IsCurrentScreen())
                 return;
 
+            if (!client.IsHost)
+            {
+                // todo: should handle this when the request queue is implemented.
+                // if we decide that the presentation should exit the user from the multiplayer game, the PresentBeatmap
+                // flow may need to change to support an "unable to present" return value.
+                return;
+            }
+
             this.Push(new MultiplayerMatchSongSelect(beatmap, ruleset));
         }
     }


### PR DESCRIPTION
Closes #11365.

https://user-images.githubusercontent.com/191335/109756581-8f077280-7c2b-11eb-8d97-e75c0f845af9.mp4


Note that this also changes the present behaviour to still run even if the current beatmap is the one requested for presentation. I've changed this both to fix the case of creating a new multiplayer match (where the current beatmap will not display in the beatmap selection panel until a selection is made), but this in general feels closer to what a user would expect all-round.

Another path I looked into was allowing the custom present logic return a `bool` as to whether it "succeeeded". This could keep the beatmap/ruleset changes occurring in the single `OsuGame.PresentBeatmap` implementation and the custom `IHandlePresentBeatmap` would only be responsible for switching to the appropriate `SongSelect` screen. Not sure about this direction – it potentially offers more flexibility as the implementor can choose which method to use, but requires more changes to existing usages (which now require returning `true`).