### PR TITLE
Allow rulesets to specify custom song select filtering criteria

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -4,8 +4,10 @@
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
+using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Tests.NonVisual.Filtering
 {
@@ -213,6 +215,32 @@ namespace osu.Game.Tests.NonVisual.Filtering
             carouselItem.Filter(criteria);
 
             Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
+        public void TestCustomRulesetCriteria([Values(null, true, false)] bool? matchCustomCriteria)
+        {
+            var beatmap = getExampleBeatmap();
+
+            var customCriteria = matchCustomCriteria is bool match ? new CustomCriteria(match) : null;
+            var criteria = new FilterCriteria { RulesetCriteria = customCriteria };
+            var carouselItem = new CarouselBeatmap(beatmap);
+            carouselItem.Filter(criteria);
+
+            Assert.AreEqual(matchCustomCriteria == false, carouselItem.Filtered.Value);
+        }
+
+        private class CustomCriteria : IRulesetFilterCriteria
+        {
+            private readonly bool match;
+
+            public CustomCriteria(bool shouldMatch)
+            {
+                match = shouldMatch;
+            }
+
+            public bool Matches(BeatmapInfo beatmap) => match;
+            public bool TryParseCustomKeywordCriteria(string key, Operator op, string value) => false;
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -215,6 +215,17 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("unrecognised=keyword", filterCriteria.SearchText);
         }
 
+        [TestCase("cs=nope")]
+        [TestCase("bpm>=bad")]
+        [TestCase("divisor<nah")]
+        [TestCase("status=noidea")]
+        public void TestInvalidKeywordValueIsIgnored(string query)
+        {
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual(query, filterCriteria.SearchText);
+        }
+
         [Test]
         public void TestCustomKeywordIsParsed()
         {

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -194,5 +194,14 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("double\"quote", filterCriteria.Artist.SearchTerm);
         }
+
+        [Test]
+        public void TestOperatorParsing()
+        {
+            const string query = "artist=><something";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("><something", filterCriteria.Artist.SearchTerm);
+        }
     }
 }

--- a/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Rulesets.Filter
+{
+    /// <summary>
+    /// Allows for extending the beatmap filtering capabilities of song select (as implemented in <see cref="FilterCriteria"/>)
+    /// with ruleset-specific criteria.
+    /// </summary>
+    public interface IRulesetFilterCriteria
+    {
+        /// <summary>
+        /// Checks whether the supplied <paramref name="beatmap"/> satisfies ruleset-specific custom criteria,
+        /// in addition to the ones mandated by song select.
+        /// </summary>
+        /// <param name="beatmap">The beatmap to test the criteria against.</param>
+        /// <returns>
+        /// <c>true</c> if the beatmap matches the ruleset-specific custom filtering criteria,
+        /// <c>false</c> otherwise.
+        /// </returns>
+        bool Matches(BeatmapInfo beatmap);
+
+        /// <summary>
+        /// Attempts to parse a single custom keyword criterion, given by the user via the song select search box.
+        /// The format of the criterion is:
+        /// <code>
+        /// {key}{op}{value}
+        /// </code>
+        /// </summary>
+        /// <param name="key">The key (name) of the criterion.</param>
+        /// <param name="op">The operator in the criterion.</param>
+        /// <param name="value">The value of the criterion.</param>
+        /// <returns>
+        /// <c>true</c> if the keyword criterion is valid, <c>false</c> if it has been ignored.
+        /// Valid criteria are stripped from <see cref="FilterCriteria.SearchText"/>,
+        /// while ignored criteria are included in <see cref="FilterCriteria.SearchText"/>.
+        /// </returns>
+        bool TryParseCustomKeywordCriteria(string key, Operator op, string value);
+    }
+}

--- a/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
@@ -31,6 +31,17 @@ namespace osu.Game.Rulesets.Filter
         /// {key}{op}{value}
         /// </code>
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For adding optional string criteria, <see cref="FilterCriteria.OptionalTextFilter"/> can be used for matching,
+        /// along with <see cref="FilterQueryParser.TryUpdateCriteriaText"/> for parsing.
+        /// </para>
+        /// <para>
+        /// For adding numerical-type range criteria, <see cref="FilterCriteria.OptionalRange{T}"/> can be used for matching,
+        /// along with <see cref="FilterQueryParser.TryUpdateCriteriaRange{T}(ref osu.Game.Screens.Select.FilterCriteria.OptionalRange{T},osu.Game.Screens.Select.Filter.Operator,string,FilterQueryParser.TryParseFunction{T})"/>
+        /// and <see cref="float"/>- and <see cref="double"/>-typed overloads for parsing.
+        /// </para>
+        /// </remarks>
         /// <param name="key">The key (name) of the criterion.</param>
         /// <param name="op">The operator in the criterion.</param>
         /// <param name="value">The value of the criterion.</param>

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Testing;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Rulesets
@@ -306,5 +307,11 @@ namespace osu.Game.Rulesets
         /// <param name="result">The result type to get the name for.</param>
         /// <returns>The display name.</returns>
         public virtual string GetDisplayNameForHitResult(HitResult result) => result.GetDescription();
+
+        /// <summary>
+        /// Creates ruleset-specific beatmap filter criteria to be used on the song select screen.
+        /// </summary>
+        [CanBeNull]
+        public virtual IRulesetFilterCriteria CreateRulesetFilterCriteria() => null;
     }
 }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -73,6 +73,9 @@ namespace osu.Game.Screens.Select.Carousel
             if (match)
                 match &= criteria.Collection?.Beatmaps.Contains(Beatmap) ?? true;
 
+            if (match && criteria.RulesetCriteria != null)
+                match &= criteria.RulesetCriteria.Matches(Beatmap);
+
             Filtered.Value = !match;
         }
 

--- a/osu.Game/Screens/Select/Filter/Operator.cs
+++ b/osu.Game/Screens/Select/Filter/Operator.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Screens.Select.Filter
+{
+    /// <summary>
+    /// Defines logical operators that can be used in the song select search box keyword filters.
+    /// </summary>
+    public enum Operator
+    {
+        Less,
+        LessOrEqual,
+        Equal,
+        GreaterOrEqual,
+        Greater
+    }
+}

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -34,8 +35,13 @@ namespace osu.Game.Screens.Select
 
         private Bindable<GroupMode> groupMode;
 
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
         public FilterCriteria CreateCriteria()
         {
+            Debug.Assert(ruleset.Value.ID != null);
+
             var query = searchTextBox.Text;
 
             var criteria = new FilterCriteria
@@ -52,6 +58,8 @@ namespace osu.Game.Screens.Select
 
             if (!maximumStars.IsDefault)
                 criteria.UserStarDifficulty.Max = maximumStars.Value;
+
+            criteria.RulesetCriteria = rulesets.GetRuleset(ruleset.Value.ID.Value).CreateInstance().CreateRulesetFilterCriteria();
 
             FilterQueryParser.ApplyQueries(criteria, query);
             return criteria;

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -35,9 +35,6 @@ namespace osu.Game.Screens.Select
 
         private Bindable<GroupMode> groupMode;
 
-        [Resolved]
-        private RulesetStore rulesets { get; set; }
-
         public FilterCriteria CreateCriteria()
         {
             Debug.Assert(ruleset.Value.ID != null);
@@ -59,7 +56,7 @@ namespace osu.Game.Screens.Select
             if (!maximumStars.IsDefault)
                 criteria.UserStarDifficulty.Max = maximumStars.Value;
 
-            criteria.RulesetCriteria = rulesets.GetRuleset(ruleset.Value.ID.Value).CreateInstance().CreateRulesetFilterCriteria();
+            criteria.RulesetCriteria = ruleset.Value.CreateInstance().CreateRulesetFilterCriteria();
 
             FilterQueryParser.ApplyQueries(criteria, query);
             return criteria;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select
@@ -68,6 +69,9 @@ namespace osu.Game.Screens.Select
         /// </summary>
         [CanBeNull]
         public BeatmapCollection Collection;
+
+        [CanBeNull]
+        public IRulesetFilterCriteria RulesetCriteria { get; set; }
 
         public struct OptionalRange<T> : IEquatable<OptionalRange<T>>
             where T : struct

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Select
                     return updateCriteriaText(ref criteria.Artist, op, value);
 
                 default:
-                    return false;
+                    return criteria.RulesetCriteria?.TryParseCustomKeywordCriteria(key, op, value) ?? false;
             }
         }
 

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -9,7 +9,10 @@ using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select
 {
-    internal static class FilterQueryParser
+    /// <summary>
+    /// Utility class used for parsing song select filter queries entered via the search box.
+    /// </summary>
+    public static class FilterQueryParser
     {
         private static readonly Regex query_syntax_regex = new Regex(
             @"\b(?<key>\w+)(?<op>(:|=|(>|<)(:|=)?))(?<value>("".*"")|(\S*))",
@@ -35,36 +38,36 @@ namespace osu.Game.Screens.Select
             switch (key)
             {
                 case "stars":
-                    return tryUpdateCriteriaRange(ref criteria.StarDifficulty, op, value, 0.01d / 2);
+                    return TryUpdateCriteriaRange(ref criteria.StarDifficulty, op, value, 0.01d / 2);
 
                 case "ar":
-                    return tryUpdateCriteriaRange(ref criteria.ApproachRate, op, value);
+                    return TryUpdateCriteriaRange(ref criteria.ApproachRate, op, value);
 
                 case "dr":
                 case "hp":
-                    return tryUpdateCriteriaRange(ref criteria.DrainRate, op, value);
+                    return TryUpdateCriteriaRange(ref criteria.DrainRate, op, value);
 
                 case "cs":
-                    return tryUpdateCriteriaRange(ref criteria.CircleSize, op, value);
+                    return TryUpdateCriteriaRange(ref criteria.CircleSize, op, value);
 
                 case "bpm":
-                    return tryUpdateCriteriaRange(ref criteria.BPM, op, value, 0.01d / 2);
+                    return TryUpdateCriteriaRange(ref criteria.BPM, op, value, 0.01d / 2);
 
                 case "length":
                     return tryUpdateLengthRange(criteria, op, value);
 
                 case "divisor":
-                    return tryUpdateCriteriaRange(ref criteria.BeatDivisor, op, value, tryParseInt);
+                    return TryUpdateCriteriaRange(ref criteria.BeatDivisor, op, value, tryParseInt);
 
                 case "status":
-                    return tryUpdateCriteriaRange(ref criteria.OnlineStatus, op, value,
+                    return TryUpdateCriteriaRange(ref criteria.OnlineStatus, op, value,
                         (string s, out BeatmapSetOnlineStatus val) => Enum.TryParse(value, true, out val));
 
                 case "creator":
-                    return tryUpdateCriteriaText(ref criteria.Creator, op, value);
+                    return TryUpdateCriteriaText(ref criteria.Creator, op, value);
 
                 case "artist":
-                    return tryUpdateCriteriaText(ref criteria.Artist, op, value);
+                    return TryUpdateCriteriaText(ref criteria.Artist, op, value);
 
                 default:
                     return criteria.RulesetCriteria?.TryParseCustomKeywordCriteria(key, op, value) ?? false;
@@ -113,7 +116,18 @@ namespace osu.Game.Screens.Select
         private static bool tryParseInt(string value, out int result) =>
             int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
 
-        private static bool tryUpdateCriteriaText(ref FilterCriteria.OptionalTextFilter textFilter, Operator op, string value)
+        /// <summary>
+        /// Attempts to parse a keyword filter with the specified <paramref name="op"/> and textual <paramref name="value"/>.
+        /// If the value indicates a valid textual filter, the function returns <c>true</c> and the resulting data is stored into
+        /// <paramref name="textFilter"/>.
+        /// </summary>
+        /// <param name="textFilter">The <see cref="FilterCriteria.OptionalTextFilter"/> to store the parsed data into, if successful.</param>
+        /// <param name="op">
+        /// The operator for the keyword filter.
+        /// Only <see cref="Operator.Equal"/> is valid for textual filters.
+        /// </param>
+        /// <param name="value">The value of the keyword filter.</param>
+        public static bool TryUpdateCriteriaText(ref FilterCriteria.OptionalTextFilter textFilter, Operator op, string value)
         {
             switch (op)
             {
@@ -126,7 +140,20 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private static bool tryUpdateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, Operator op, string val, float tolerance = 0.05f)
+        /// <summary>
+        /// Attempts to parse a keyword filter of type <see cref="float"/>
+        /// from the specified <paramref name="op"/> and <paramref name="val"/>.
+        /// If <paramref name="val"/> can be parsed as a <see cref="float"/>, the function returns <c>true</c>
+        /// and the resulting range constraint is stored into <paramref name="range"/>.
+        /// </summary>
+        /// <param name="range">
+        /// The <see cref="float"/>-typed <see cref="FilterCriteria.OptionalRange{T}"/>
+        /// to store the parsed data into, if successful.
+        /// </param>
+        /// <param name="op">The operator for the keyword filter.</param>
+        /// <param name="val">The value of the keyword filter.</param>
+        /// <param name="tolerance">Allowed tolerance of the parsed range boundary value.</param>
+        public static bool TryUpdateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, Operator op, string val, float tolerance = 0.05f)
             => tryParseFloatWithPoint(val, out float value) && tryUpdateCriteriaRange(ref range, op, value, tolerance);
 
         private static bool tryUpdateCriteriaRange(ref FilterCriteria.OptionalRange<float> range, Operator op, float value, float tolerance = 0.05f)
@@ -161,7 +188,20 @@ namespace osu.Game.Screens.Select
             return true;
         }
 
-        private static bool tryUpdateCriteriaRange(ref FilterCriteria.OptionalRange<double> range, Operator op, string val, double tolerance = 0.05)
+        /// <summary>
+        /// Attempts to parse a keyword filter of type <see cref="double"/>
+        /// from the specified <paramref name="op"/> and <paramref name="val"/>.
+        /// If <paramref name="val"/> can be parsed as a <see cref="double"/>, the function returns <c>true</c>
+        /// and the resulting range constraint is stored into <paramref name="range"/>.
+        /// </summary>
+        /// <param name="range">
+        /// The <see cref="double"/>-typed <see cref="FilterCriteria.OptionalRange{T}"/>
+        /// to store the parsed data into, if successful.
+        /// </param>
+        /// <param name="op">The operator for the keyword filter.</param>
+        /// <param name="val">The value of the keyword filter.</param>
+        /// <param name="tolerance">Allowed tolerance of the parsed range boundary value.</param>
+        public static bool TryUpdateCriteriaRange(ref FilterCriteria.OptionalRange<double> range, Operator op, string val, double tolerance = 0.05)
             => tryParseDoubleWithPoint(val, out double value) && tryUpdateCriteriaRange(ref range, op, value, tolerance);
 
         private static bool tryUpdateCriteriaRange(ref FilterCriteria.OptionalRange<double> range, Operator op, double value, double tolerance = 0.05)
@@ -196,11 +236,28 @@ namespace osu.Game.Screens.Select
             return true;
         }
 
-        private delegate bool TryParseFunction<T>(string val, out T value);
+        /// <summary>
+        /// Used to determine whether the string value <paramref name="val"/> can be converted to type <typeparamref name="T"/>.
+        /// If conversion can be performed, the delegate returns <c>true</c>
+        /// and the conversion result is returned in the <c>out</c> parameter <paramref name="parsed"/>.
+        /// </summary>
+        /// <param name="val">The string value to attempt parsing for.</param>
+        /// <param name="parsed">The parsed value, if conversion is possible.</param>
+        public delegate bool TryParseFunction<T>(string val, out T parsed);
 
-        private static bool tryUpdateCriteriaRange<T>(ref FilterCriteria.OptionalRange<T> range, Operator op, string value, TryParseFunction<T> conversionFunc)
+        /// <summary>
+        /// Attempts to parse a keyword filter of type <typeparamref name="T"/>,
+        /// from the specified <paramref name="op"/> and <paramref name="val"/>.
+        /// If <paramref name="val"/> can be parsed into <typeparamref name="T"/> using <paramref name="parseFunction"/>, the function returns <c>true</c>
+        /// and the resulting range constraint is stored into <paramref name="range"/>.
+        /// </summary>
+        /// <param name="range">The <see cref="FilterCriteria.OptionalRange{T}"/> to store the parsed data into, if successful.</param>
+        /// <param name="op">The operator for the keyword filter.</param>
+        /// <param name="val">The value of the keyword filter.</param>
+        /// <param name="parseFunction">Function used to determine if <paramref name="val"/> can be converted to type <typeparamref name="T"/>.</param>
+        public static bool TryUpdateCriteriaRange<T>(ref FilterCriteria.OptionalRange<T> range, Operator op, string val, TryParseFunction<T> parseFunction)
             where T : struct
-            => conversionFunc.Invoke(value, out var converted) && tryUpdateCriteriaRange(ref range, op, converted);
+            => parseFunction.Invoke(val, out var converted) && tryUpdateCriteriaRange(ref range, op, converted);
 
         private static bool tryUpdateCriteriaRange<T>(ref FilterCriteria.OptionalRange<T> range, Operator op, T value)
             where T : struct

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Screens.Select
     internal static class FilterQueryParser
     {
         private static readonly Regex query_syntax_regex = new Regex(
-            @"\b(?<key>stars|ar|dr|hp|cs|divisor|length|objects|bpm|status|creator|artist)(?<op>[=:><]+)(?<value>("".*"")|(\S*))",
+            @"\b(?<key>\w+)(?<op>[=:><]+)(?<value>("".*"")|(\S*))",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         internal static void ApplyQueries(FilterCriteria criteria, string query)
@@ -22,15 +22,14 @@ namespace osu.Game.Screens.Select
                 var op = match.Groups["op"].Value;
                 var value = match.Groups["value"].Value;
 
-                parseKeywordCriteria(criteria, key, value, op);
-
-                query = query.Replace(match.ToString(), "");
+                if (tryParseKeywordCriteria(criteria, key, value, op))
+                    query = query.Replace(match.ToString(), "");
             }
 
             criteria.SearchText = query;
         }
 
-        private static void parseKeywordCriteria(FilterCriteria criteria, string key, string value, string op)
+        private static bool tryParseKeywordCriteria(FilterCriteria criteria, string key, string value, string op)
         {
             switch (key)
             {
@@ -75,7 +74,12 @@ namespace osu.Game.Screens.Select
                 case "artist":
                     updateCriteriaText(ref criteria.Artist, op, value);
                     break;
+
+                default:
+                    return false;
             }
+
+            return true;
         }
 
         private static int getLengthScale(string value) =>


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu/pull/11925 + https://github.com/ppy/osu/pull/11926.

Intended towards https://github.com/ppy/osu/issues/5668.

This is mostly the branch [I linked in this comment](https://github.com/ppy/osu/pull/11925#issuecomment-789159734), with the last two commits being the sole difference. The goal of those commits is to expose a better interface of the parsing helpers to the end users (so that they don't have to call `TryParseFloat...` and then `TryUpdateCriteria...` as I had it initially in the "lazy exposition" version).

They're still a bit obtuse, unfortunately, as can be seen by the length of the xmldoc. I tried to explain to the best of my ability what those do, but I don't know if I've succeeded in that.

(On the upside, that change gets rid of some `case...when` usages, so maybe a plus?)