### PR TITLE
Fix cursor sensitivity disabled at host level from reset input action

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -880,13 +880,8 @@ namespace osu.Game
             switch (action)
             {
                 case GlobalAction.ResetInputSettings:
-                    var sensitivity = frameworkConfig.GetBindable<double>(FrameworkSetting.CursorSensitivity);
-
-                    sensitivity.Disabled = false;
-                    sensitivity.Value = 1;
-                    sensitivity.Disabled = true;
-
-                    frameworkConfig.Set(FrameworkSetting.IgnoredInputHandlers, string.Empty);
+                    frameworkConfig.GetBindable<string>(FrameworkSetting.IgnoredInputHandlers).SetDefault();
+                    frameworkConfig.GetBindable<double>(FrameworkSetting.CursorSensitivity).SetDefault();
                     frameworkConfig.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode).SetDefault();
                     return true;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -76,7 +76,15 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.LoadComplete();
 
-            configSensitivity.BindValueChanged(val => localSensitivity.Value = val.NewValue, true);
+            configSensitivity.BindValueChanged(val =>
+            {
+                var disabled = localSensitivity.Disabled;
+
+                localSensitivity.Disabled = false;
+                localSensitivity.Value = val.NewValue;
+                localSensitivity.Disabled = disabled;
+            }, true);
+
             localSensitivity.BindValueChanged(val => configSensitivity.Value = val.NewValue);
 
             windowMode.BindValueChanged(mode =>


### PR DESCRIPTION
Resolves the second part of https://github.com/ppy/osu/issues/3364#issuecomment-782031226, which has appeared to be irrelevant and simple to fix from the whole issue thread.

`MouseSettings` creates a local bindable for cursor sensitivity decoupled from the framework config bindable to avoid disabling it at a host-level when raw input is off (see [PR](https://github.com/ppy/osu/pull/9031)), but `OsuGame` appeared to have disabled the sensitivity globally whenever `GlobalAction.ResetInputSettings` is pressed, leaving the config bindable disabled forever and causing "bindable disabled" exceptions when re-enabling raw input and attempt changing sensitivity value.

Therefore I fixed this by never disabling the sensitivity at `OsuGame`, and propagate changes from `configSensitvity` to local regardless of whether local is disabled.

Seems adding a test case for resetting input settings and asserting won't be possible, as `HeadlessGameHost` behaves differently from `GameHost` in terms of default ignored input handlers.