### PR TITLE
Fix taiko leaving behind empty judgements on legacy skins

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             {
                 // if a taiko skin is providing explosion sprites, hide the judgements completely
                 if (hasExplosion.Value)
-                    return Drawable.Empty().With(d => d.LifetimeEnd = double.MinValue);
+                    return Drawable.Empty().With(d => d.Expire());
             }
 
             if (!(component is TaikoSkinComponent taikoComponent))
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                     // suppress the default kiai explosion if the skin brings its own sprites.
                     // the drawable needs to expire as soon as possible to avoid accumulating empty drawables on the playfield.
                     if (hasExplosion.Value)
-                        return Drawable.Empty().With(d => d.LifetimeEnd = double.MinValue);
+                        return Drawable.Empty().With(d => d.Expire());
 
                     return null;
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             {
                 // if a taiko skin is providing explosion sprites, hide the judgements completely
                 if (hasExplosion.Value)
-                    return Drawable.Empty();
+                    return Drawable.Empty().With(d => d.LifetimeEnd = double.MinValue);
             }
 
             if (!(component is TaikoSkinComponent taikoComponent))

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -150,17 +150,13 @@ namespace osu.Game.Rulesets.Judgements
                 }
 
                 if (JudgementBody.Drawable is IAnimatableJudgement animatable)
-                {
-                    var drawableAnimation = (Drawable)animatable;
-
                     animatable.PlayAnimation();
 
-                    // a derived version of DrawableJudgement may be proposing a lifetime.
-                    // if not adjusted (or the skinned portion requires greater bounds than calculated) use the skinned source's lifetime.
-                    double lastTransformTime = drawableAnimation.LatestTransformEndTime;
-                    if (LifetimeEnd == double.MaxValue || lastTransformTime > LifetimeEnd)
-                        LifetimeEnd = lastTransformTime;
-                }
+                // a derived version of DrawableJudgement may be proposing a lifetime.
+                // if not adjusted (or the skinned portion requires greater bounds than calculated) use the skinned source's lifetime.
+                double lastTransformTime = JudgementBody.Drawable.LatestTransformEndTime;
+                if (LifetimeEnd == double.MaxValue || lastTransformTime > LifetimeEnd)
+                    LifetimeEnd = lastTransformTime;
             }
         }
 


### PR DESCRIPTION
Noticed this while I was adding pooling support for judgements in taiko.

Legacy taiko skins suppress judgements entirely in favour of explosions:

https://github.com/ppy/osu/blob/b24174911908fb6c7a640d1ac56689cd3d4bb8d7/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs#L34-L39

Because `EmptyDrawable` is not an `IAnimatableJudgement`, the lifetime end adjustment code in `DrawableJudgement`:

https://github.com/ppy/osu/blob/b24174911908fb6c7a640d1ac56689cd3d4bb8d7/osu.Game/Rulesets/Judgements/DrawableJudgement.cs#L152-L163

wouldn't run for them, leading to the empty drawables accumulating in their parenting judgement container:

![osu_2021-03-06_16-31-14](https://user-images.githubusercontent.com/20418176/110212121-2f62ce80-7e9a-11eb-9688-285b055962b9.jpg)

To resolve, also allow non-`IAnimatableJudgement`s to adjust their parenting `DrawableJudgement`'s lifetime if it wasn't adjusted (or if extends past the one dictated by the parent).

For added WTF, the impact of this wasn't as huge as it might seem (in that current `master` doesn't accumulate N empty drawables after N judgements), because of the following logic:

https://github.com/ppy/osu/blob/b24174911908fb6c7a640d1ac56689cd3d4bb8d7/osu.Game/Rulesets/UI/JudgementContainer.cs#L17-L19

Note the reference equality. Because taiko is pooled, the judgement instances would get swapped out on add, creating an implicit 1-1 correspondence between a pooled DHO and its infinite-lifetime empty judgement.