### PR TITLE
Enable pooling for taiko judgements

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
@@ -12,16 +11,6 @@ namespace osu.Game.Rulesets.Taiko.UI
     /// </summary>
     public class DrawableTaikoJudgement : DrawableJudgement
     {
-        /// <summary>
-        /// Creates a new judgement text.
-        /// </summary>
-        /// <param name="judgedObject">The object which is being judged.</param>
-        /// <param name="result">The judgement to visualise.</param>
-        public DrawableTaikoJudgement(JudgementResult result, DrawableHitObject judgedObject)
-            : base(result, judgedObject)
-        {
-        }
-
         protected override void ApplyHitAnimations()
         {
             this.MoveToY(-100, 500);

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -17,6 +19,7 @@ using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Scoring;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -37,6 +40,8 @@ namespace osu.Game.Rulesets.Taiko.UI
         private ScrollingHitObjectContainer drumRollHitContainer;
         internal Drawable HitTarget;
         private SkinnableDrawable mascot;
+
+        private readonly IDictionary<HitResult, DrawablePool<DrawableTaikoJudgement>> judgementPools = new Dictionary<HitResult, DrawablePool<DrawableTaikoJudgement>>();
 
         private ProxyContainer topLevelHitContainer;
         private Container rightArea;
@@ -159,6 +164,12 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             RegisterPool<Swell, DrawableSwell>(5);
             RegisterPool<SwellTick, DrawableSwellTick>(100);
+
+            var hitWindows = new TaikoHitWindows();
+            foreach (var result in Enum.GetValues(typeof(HitResult)).OfType<HitResult>().Where(r => hitWindows.IsHitResultAllowed(r)))
+                judgementPools.Add(result, new DrawablePool<DrawableTaikoJudgement>(15));
+
+            AddRangeInternal(judgementPools.Values);
         }
 
         protected override void LoadComplete()
@@ -283,13 +294,15 @@ namespace osu.Game.Rulesets.Taiko.UI
                     break;
 
                 default:
-                    judgementContainer.Add(new DrawableTaikoJudgement(result, judgedObject)
+                    judgementContainer.Add(judgementPools[result.Type].Get(j =>
                     {
-                        Anchor = result.IsHit ? Anchor.TopLeft : Anchor.CentreLeft,
-                        Origin = result.IsHit ? Anchor.BottomCentre : Anchor.Centre,
-                        RelativePositionAxes = Axes.X,
-                        X = result.IsHit ? judgedObject.Position.X : 0,
-                    });
+                        j.Apply(result, judgedObject);
+
+                        j.Anchor = result.IsHit ? Anchor.TopLeft : Anchor.CentreLeft;
+                        j.Origin = result.IsHit ? Anchor.BottomCentre : Anchor.Centre;
+                        j.RelativePositionAxes = Axes.X;
+                        j.X = result.IsHit ? judgedObject.Position.X : 0;
+                    }));
 
                     var type = (judgedObject.HitObject as Hit)?.Type ?? HitType.Centre;
                     addExplosion(judgedObject, result.Type, type);


### PR DESCRIPTION
- [x] Soft-depends on #11970 (in order for the pooling to work as expected on legacy skins).

Pretty low hanging fruit, so I decided to grab it. Note that this is for *judgements* and not *explosions*, which are only visible on the default skin. Still should save on allocations regardless, though.

![osu_2021-03-06_17-38-57](https://user-images.githubusercontent.com/20418176/110214003-dba8b300-7ea2-11eb-9933-222629530b7e.jpg)

Decided to not overthink this one with extra classes/overrides, at least initially. I internally debated moving the layout logic from the playfield into `Apply()`, but I decided against it on the basis that it feels more like code specific to the playfield. I'll move it (along with making the base virtual) on request.