### PR TITLE
Adjust legacy spinner components placements to match osu!stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
@@ -37,9 +37,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             AddInternal(scaleContainer = new Container
             {
                 Scale = new Vector2(SPRITE_SCALE),
-                Anchor = Anchor.Centre,
+                Anchor = Anchor.TopCentre,
                 Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
+                Y = SPINNER_Y_CENTRE,
                 Children = new Drawable[]
                 {
                     glow = new Sprite

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         // this anchor makes no sense, but that's what stable uses.
                         Anchor = Anchor.TopLeft,
                         Origin = Anchor.TopLeft,
-                        Margin = new MarginPadding { Top = LegacyCoordinatesContainer.SPINNER_TOP_OFFSET },
+                        Margin = new MarginPadding { Top = SPINNER_TOP_OFFSET },
                         Masking = true,
                         Child = metreSprite = new Sprite
                         {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
@@ -37,35 +37,34 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             {
                 new Sprite
                 {
-                    Anchor = Anchor.Centre,
+                    Anchor = Anchor.TopCentre,
                     Origin = Anchor.Centre,
                     Texture = source.GetTexture("spinner-background"),
-                    Scale = new Vector2(SPRITE_SCALE)
+                    Scale = new Vector2(SPRITE_SCALE),
+                    Y = SPINNER_Y_CENTRE,
                 },
                 disc = new Sprite
                 {
-                    Anchor = Anchor.Centre,
+                    Anchor = Anchor.TopCentre,
                     Origin = Anchor.Centre,
                     Texture = source.GetTexture("spinner-circle"),
-                    Scale = new Vector2(SPRITE_SCALE)
+                    Scale = new Vector2(SPRITE_SCALE),
+                    Y = SPINNER_Y_CENTRE,
                 },
-                new LegacyCoordinatesContainer
+                metre = new Container
                 {
-                    Child = metre = new Container
+                    AutoSizeAxes = Axes.Both,
+                    // this anchor makes no sense, but that's what stable uses.
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Margin = new MarginPadding { Top = SPINNER_TOP_OFFSET },
+                    Masking = true,
+                    Child = metreSprite = new Sprite
                     {
-                        AutoSizeAxes = Axes.Both,
-                        // this anchor makes no sense, but that's what stable uses.
+                        Texture = source.GetTexture("spinner-metre"),
                         Anchor = Anchor.TopLeft,
                         Origin = Anchor.TopLeft,
-                        Margin = new MarginPadding { Top = SPINNER_TOP_OFFSET },
-                        Masking = true,
-                        Child = metreSprite = new Sprite
-                        {
-                            Texture = source.GetTexture("spinner-metre"),
-                            Anchor = Anchor.TopLeft,
-                            Origin = Anchor.TopLeft,
-                            Scale = new Vector2(SPRITE_SCALE)
-                        }
+                        Scale = new Vector2(SPRITE_SCALE)
                     }
                 }
             });

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
@@ -33,39 +33,31 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             spinnerBlink = source.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.SpinnerNoBlink)?.Value != true;
 
-            AddInternal(new Container
+            AddRangeInternal(new Drawable[]
             {
-                // the old-style spinner relied heavily on absolute screen-space coordinate values.
-                // wrap everything in a container simulating absolute coords to preserve alignment
-                // as there are skins that depend on it.
-                Width = 640,
-                Height = 480,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Children = new Drawable[]
+                new Sprite
                 {
-                    new Sprite
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Texture = source.GetTexture("spinner-background"),
-                        Scale = new Vector2(SPRITE_SCALE)
-                    },
-                    disc = new Sprite
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Texture = source.GetTexture("spinner-circle"),
-                        Scale = new Vector2(SPRITE_SCALE)
-                    },
-                    metre = new Container
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Texture = source.GetTexture("spinner-background"),
+                    Scale = new Vector2(SPRITE_SCALE)
+                },
+                disc = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Texture = source.GetTexture("spinner-circle"),
+                    Scale = new Vector2(SPRITE_SCALE)
+                },
+                new LegacyCoordinatesContainer
+                {
+                    Child = metre = new Container
                     {
                         AutoSizeAxes = Axes.Both,
                         // this anchor makes no sense, but that's what stable uses.
                         Anchor = Anchor.TopLeft,
                         Origin = Anchor.TopLeft,
-                        // adjustment for stable (metre has additional offset)
-                        Margin = new MarginPadding { Top = 20 },
+                        Margin = new MarginPadding { Top = LegacyCoordinatesContainer.SPINNER_TOP_OFFSET },
                         Masking = true,
                         Child = metreSprite = new Sprite
                         {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             /// for positioning some legacy spinner components perfectly as in stable.
             /// (e.g. 'spin' sprite, 'clear' sprite, metre in old-style spinners)
             /// </summary>
-            public const float SPINNER_TOP_OFFSET = 29f;
+            public static readonly float SPINNER_TOP_OFFSET = (float)Math.Ceiling(45f * SPRITE_SCALE);
 
             public LegacyCoordinatesContainer()
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -16,6 +16,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 {
     public abstract class LegacySpinner : CompositeDrawable
     {
+        /// <summary>
+        /// An offset that simulates stable's spinner top offset, can be used with <see cref="LegacyCoordinatesContainer"/>
+        /// for positioning some legacy spinner components perfectly as in stable.
+        /// (e.g. 'spin' sprite, 'clear' sprite, metre in old-style spinners)
+        /// </summary>
+        public static readonly float SPINNER_TOP_OFFSET = (float)Math.Ceiling(45f * SPRITE_SCALE);
+
         protected const float SPRITE_SCALE = 0.625f;
 
         protected DrawableSpinner DrawableSpinner { get; private set; }
@@ -41,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         Origin = Anchor.Centre,
                         Texture = source.GetTexture("spinner-spin"),
                         Scale = new Vector2(SPRITE_SCALE),
-                        Y = LegacyCoordinatesContainer.SPINNER_TOP_OFFSET + 335,
+                        Y = SPINNER_TOP_OFFSET + 335,
                     },
                     clear = new Sprite
                     {
@@ -50,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         Origin = Anchor.Centre,
                         Texture = source.GetTexture("spinner-clear"),
                         Scale = new Vector2(SPRITE_SCALE),
-                        Y = LegacyCoordinatesContainer.SPINNER_TOP_OFFSET + 115,
+                        Y = SPINNER_TOP_OFFSET + 115,
                     },
                 }
             });
@@ -136,13 +143,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         /// </summary>
         protected class LegacyCoordinatesContainer : Container
         {
-            /// <summary>
-            /// An offset that simulates stable's spinner top offset,
-            /// for positioning some legacy spinner components perfectly as in stable.
-            /// (e.g. 'spin' sprite, 'clear' sprite, metre in old-style spinners)
-            /// </summary>
-            public static readonly float SPINNER_TOP_OFFSET = (float)Math.Ceiling(45f * SPRITE_SCALE);
-
             public LegacyCoordinatesContainer()
             {
                 // legacy spinners relied heavily on absolute screen-space coordinate values.

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
-using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Skinning;
 using osuTK;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -18,8 +18,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
     public abstract class LegacySpinner : CompositeDrawable
     {
         /// <remarks>
-        /// All constant spinner coordinates are in osu!stable's gamefield space, which is shifted 16px downwards.
-        /// This offset is negated in both osu!stable and osu!lazer to bring all constant coordinates into window-space.
+        /// All constants are in osu!stable's gamefield space, which is shifted 16px downwards.
+        /// This offset is negated in both osu!stable and osu!lazer to bring all constants into window-space.
         /// Note: SPINNER_Y_CENTRE + SPINNER_TOP_OFFSET - Position.Y = 240 (=480/2, or half the window-space in osu!stable)
         /// </remarks>
         protected const float SPINNER_TOP_OFFSET = 45f - 16f;
@@ -36,15 +36,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject drawableHitObject, ISkinSource source)
         {
-            // legacy spinners relied heavily on absolute screen-space coordinate values.
-            // wrap everything in a container simulating absolute coords to preserve alignment
-            // as there are skins that depend on it.
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
-            Size = new Vector2(640, 480);
 
-            // osu!stable positions components of the spinner in window-space (as opposed to gamefield-space).
-            // in lazer, the gamefield-space transformation is applied in OsuPlayfieldAdjustmentContainer, which is inverted here to bring coordinates back into window-space.
+            // osu!stable positions spinner components in window-space (as opposed to gamefield-space). This is a 640x480 area taking up the entire screen.
+            // In lazer, the gamefield-space positional transformation is applied in OsuPlayfieldAdjustmentContainer, which is inverted here to make this area take up the entire window space.
+            Size = new Vector2(640, 480);
             Position = new Vector2(0, -8f);
 
             DrawableSpinner = (DrawableSpinner)drawableHitObject;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -152,8 +152,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 Origin = Anchor.Centre;
                 Size = new Vector2(640, 480);
 
-                // since legacy coordinates were on screen-space, they were accounting for the playfield shift offset.
-                // therefore cancel it from here.
+                // counteracts the playfield shift from OsuPlayfieldAdjustmentContainer.
                 Position = new Vector2(0, -8f);
             }
         }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -16,7 +17,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 {
     public abstract class LegacySpinner : CompositeDrawable
     {
-        protected static readonly float SPINNER_TOP_OFFSET = MathF.Ceiling(45f * SPRITE_SCALE);
+        /// <remarks>
+        /// osu!stable applies this adjustment conditionally, locally in the spinner.
+        /// in lazer this is handled at a higher level in <see cref="OsuPlayfieldAdjustmentContainer"/>,
+        /// therefore it's safe to apply it unconditionally in this component.
+        /// </remarks>
+        protected static readonly float SPINNER_TOP_OFFSET = 45f - 16f;
+
         protected static readonly float SPINNER_Y_CENTRE = SPINNER_TOP_OFFSET + 219f;
 
         protected const float SPRITE_SCALE = 0.625f;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -18,13 +18,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
     public abstract class LegacySpinner : CompositeDrawable
     {
         /// <remarks>
-        /// osu!stable applies this adjustment conditionally, locally in the spinner.
-        /// in lazer this is handled at a higher level in <see cref="OsuPlayfieldAdjustmentContainer"/>,
-        /// therefore it's safe to apply it unconditionally in this component.
+        /// All constant spinner coordinates are in osu!stable's gamefield space, which is shifted 16px downwards.
+        /// This offset is negated in both osu!stable and osu!lazer to bring all constant coordinates into window-space.
+        /// Note: SPINNER_Y_CENTRE + SPINNER_TOP_OFFSET - Position.Y = 240 (=480/2, or half the window-space in osu!stable)
         /// </remarks>
-        protected static readonly float SPINNER_TOP_OFFSET = 45f - 16f;
+        protected const float SPINNER_TOP_OFFSET = 45f - 16f;
 
-        protected static readonly float SPINNER_Y_CENTRE = SPINNER_TOP_OFFSET + 219f;
+        protected const float SPINNER_Y_CENTRE = SPINNER_TOP_OFFSET + 219f;
 
         protected const float SPRITE_SCALE = 0.625f;
 
@@ -43,9 +43,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             Origin = Anchor.Centre;
             Size = new Vector2(640, 480);
 
-            // stable applies this adjustment conditionally, locally in the spinner.
-            // in lazer this is handled at a higher level in OsuPlayfieldAdjustmentContainer,
-            // therefore it's safe to apply it unconditionally in this component.
+            // osu!stable positions components of the spinner in window-space (as opposed to gamefield-space).
+            // in lazer, the gamefield-space transformation is applied in OsuPlayfieldAdjustmentContainer, which is inverted here to bring coordinates back into window-space.
             Position = new Vector2(0, -8f);
 
             DrawableSpinner = (DrawableSpinner)drawableHitObject;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         /// for positioning some legacy spinner components perfectly as in stable.
         /// (e.g. 'spin' sprite, 'clear' sprite, metre in old-style spinners)
         /// </summary>
-        public static readonly float SPINNER_TOP_OFFSET = (float)Math.Ceiling(45f * SPRITE_SCALE);
+        public static readonly float SPINNER_TOP_OFFSET = MathF.Ceiling(45f * SPRITE_SCALE);
 
         protected const float SPRITE_SCALE = 0.625f;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -152,7 +152,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 Origin = Anchor.Centre;
                 Size = new Vector2(640, 480);
 
-                // counteracts the playfield shift from OsuPlayfieldAdjustmentContainer.
+                // stable applies this adjustment conditionally, locally in the spinner.
+                // in lazer this is handled at a higher level in OsuPlayfieldAdjustmentContainer,
+                // therefore it's safe to apply it unconditionally in this component.
                 Position = new Vector2(0, -8f);
             }
         }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -30,27 +30,29 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             DrawableSpinner = (DrawableSpinner)drawableHitObject;
 
-            AddRangeInternal(new[]
+            AddInternal(new LegacyCoordinatesContainer
             {
-                spin = new Sprite
+                Depth = float.MinValue,
+                Children = new Drawable[]
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Depth = float.MinValue,
-                    Texture = source.GetTexture("spinner-spin"),
-                    Scale = new Vector2(SPRITE_SCALE),
-                    Y = 120 - 45 // offset temporarily to avoid overlapping default spin counter
-                },
-                clear = new Sprite
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Depth = float.MinValue,
-                    Alpha = 0,
-                    Texture = source.GetTexture("spinner-clear"),
-                    Scale = new Vector2(SPRITE_SCALE),
-                    Y = -60
-                },
+                    spin = new Sprite
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.Centre,
+                        Texture = source.GetTexture("spinner-spin"),
+                        Scale = new Vector2(SPRITE_SCALE),
+                        Y = LegacyCoordinatesContainer.SPINNER_TOP_OFFSET + 335,
+                    },
+                    clear = new Sprite
+                    {
+                        Alpha = 0,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.Centre,
+                        Texture = source.GetTexture("spinner-clear"),
+                        Scale = new Vector2(SPRITE_SCALE),
+                        Y = LegacyCoordinatesContainer.SPINNER_TOP_OFFSET + 115,
+                    },
+                }
             });
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -127,5 +127,33 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             if (DrawableSpinner != null)
                 DrawableSpinner.ApplyCustomUpdateState -= UpdateStateTransforms;
         }
+
+        /// <summary>
+        /// A <see cref="Container"/> simulating osu!stable's absolute screen-space,
+        /// for perfect placements of legacy spinner components with legacy coordinates.
+        /// </summary>
+        protected class LegacyCoordinatesContainer : Container
+        {
+            /// <summary>
+            /// An offset that simulates stable's spinner top offset,
+            /// for positioning some legacy spinner components perfectly as in stable.
+            /// (e.g. 'spin' sprite, 'clear' sprite, metre in old-style spinners)
+            /// </summary>
+            public const float SPINNER_TOP_OFFSET = 29f;
+
+            public LegacyCoordinatesContainer()
+            {
+                // legacy spinners relied heavily on absolute screen-space coordinate values.
+                // wrap everything in a container simulating absolute coords to preserve alignment
+                // as there are skins that depend on it.
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+                Size = new Vector2(640, 480);
+
+                // since legacy coordinates were on screen-space, they were accounting for the playfield shift offset.
+                // therefore cancel it from here.
+                Position = new Vector2(0, -8f);
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #10835 

This adds a new nested internal `LegacyCoordinatesContainer` that roughly simulates osu!stable's screen-space coordinates, such that legacy components can be placed perfectly just like they were in osu!stable, without having to duplicate alignment code everywhere. Wasn't entirely sure about doing that in the first place, but feels better that way instead of using very arbitrary coordinates around, making this low-effort and practically nonsense.

Due to the magic scaling of `OsuPlayfieldAdjustmentContainer`, `SPINNER_TOP_OFFSET` has to be multiplied by the scale to match with stable, the ceiling is pretty much arbitrary though, but that's required to be perfectly placed. Can always revert to just using a plain `29f` and call it a day, if that's better.

| skin | spin (stable left, lazer right) | clear (stable left, lazer right) |
|-----|-----------------------------|-----------------------------|
| osu!classic | ![default-spin](https://user-images.githubusercontent.com/22781491/110214290-fb48d700-7eb4-11eb-8614-fb836cdc91dc.png) | ![default-clear](https://user-images.githubusercontent.com/22781491/110214297-04d23f00-7eb5-11eb-821d-55d6b3168693.png) |
| https://github.com/ppy/osu/issues/10835 ([u200B](https://github.com/LittleEndu/osuSkin/tree/master/u200B)) | ![custom-spin](https://user-images.githubusercontent.com/22781491/110214299-07cd2f80-7eb5-11eb-82fc-2bc6567caa46.png) | ![custom-clear](https://user-images.githubusercontent.com/22781491/110214301-08fe5c80-7eb5-11eb-814c-9e65f1345a47.png) |

This also fixes the spinner metre not being perfectly aligned previously, by using the proper `SPINNER_TOP_OFFSET` constant with `LegacyCoordinatesContainer` instead:
| skin | master | this PR |
|-----|--------|----|
| [link](https://osuskins.net/skin/ekynLzX) | ![special-metre-before](https://user-images.githubusercontent.com/22781491/110214535-1b2cca80-7eb6-11eb-94d9-256e59e82fbe.png) | ![special-metre](https://user-images.githubusercontent.com/22781491/110214318-1582b500-7eb5-11eb-995b-330591475dd5.png) |

I'm presuming that the metre had the `SPINNER_TOP_OFFSET` applied in osu!stable though, just like spin and clear sprites; would like confirmation on that to be extra sure.