### PR TITLE
Fix potential cross-thread drawable mutation in IntroTriangles

### DIFF
--- a/osu.Game/Screens/BackgroundScreen.cs
+++ b/osu.Game/Screens/BackgroundScreen.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Screens
     {
         private readonly bool animateOnEnter;
 
+        public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+
         protected BackgroundScreen(bool animateOnEnter = true)
         {
             this.animateOnEnter = animateOnEnter;

--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Screens.Menu
 
                 rulesets.Hide();
                 lazerLogo.Hide();
-                background.Hide();
+                background.ApplyToBackground(b => b.Hide());
 
                 using (BeginAbsoluteSequence(0, true))
                 {
@@ -231,7 +231,8 @@ namespace osu.Game.Screens.Menu
                             lazerLogo.Dispose(); // explicit disposal as we are pushing a new screen and the expire may not get run.
 
                             logo.FadeIn();
-                            background.FadeIn();
+
+                            background.ApplyToBackground(b => b.Show());
 
                             game.Add(new GameWideFlash());
 


### PR DESCRIPTION
Found this while testing on iOS. Seems to only happen if the background is insanely delayed in load time, but can cause a crash if so.