### PR TITLE
Fix multiplayer/spectator not working on iOS

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -10,7 +10,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -247,14 +246,8 @@ namespace osu.Game.Online.API
             this.password = password;
         }
 
-        public IHubClientConnector GetHubConnector(string clientName, string endpoint)
-        {
-            // disabled until the underlying runtime issue is resolved, see https://github.com/mono/mono/issues/20805.
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.iOS)
-                return null;
-
-            return new HubClientConnector(clientName, endpoint, this, versionHash);
-        }
+        public IHubClientConnector GetHubConnector(string clientName, string endpoint) =>
+            new HubClientConnector(clientName, endpoint, this, versionHash);
 
         public RegistrationRequest.RegistrationRequestErrors CreateAccount(string email, string username, string password)
         {

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -172,18 +172,6 @@ namespace osu.Game.Screens.Menu
                 return;
             }
 
-            // disabled until the underlying runtime issue is resolved, see https://github.com/mono/mono/issues/20805.
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.iOS)
-            {
-                notifications?.Post(new SimpleNotification
-                {
-                    Text = "Multiplayer is temporarily unavailable on iOS as we figure out some low level issues.",
-                    Icon = FontAwesome.Solid.AppleAlt,
-                });
-
-                return;
-            }
-
             OnMultiplayer?.Invoke();
         }
 

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -77,12 +77,14 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
+  <!-- Workaround to make SignalR 5.x work properly, avoiding a runtime error (https://github.com/mono/mono/issues/20805#issuecomment-791440473) -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.3" />
-    <PackageReference Include="MessagePack" Version="1.7.3.7" />
-    <PackageReference Include="MessagePack.Annotations" Version="2.2.85" />
+    <PackageReference Include="System.Memory" Version="4.5.4">
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Buffers" Version="4.5.1">
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">


### PR DESCRIPTION
There's still some issues with iOS release builds in general, but this part is fixed at least, thanks to the workaround provided at https://github.com/mono/mono/issues/20805#issuecomment-791440473.