### PR TITLE
Fix storyboard commands occurring before the earliest point of visibility delaying gameplay

### DIFF
--- a/osu.Game/Storyboards/CommandTimelineGroup.cs
+++ b/osu.Game/Storyboards/CommandTimelineGroup.cs
@@ -45,11 +45,30 @@ namespace osu.Game.Storyboards
             };
         }
 
+        /// <summary>
+        /// Returns the earliest visible time. Will be null unless this group has an <see cref="Alpha"/> command with a start value of zero.
+        /// </summary>
+        public double? EarliestDisplayedTime
+        {
+            get
+            {
+                var first = Alpha.Commands.FirstOrDefault();
+
+                return first?.StartValue == 0 ? first.StartTime : (double?)null;
+            }
+        }
+
         [JsonIgnore]
         public double CommandsStartTime
         {
             get
             {
+                // if the first alpha command starts at zero it should be given priority over anything else.
+                // this is due to it creating a state where the target is not present before that time, causing any other events to not be visible.
+                var earliestDisplay = EarliestDisplayedTime;
+                if (earliestDisplay != null)
+                    return earliestDisplay.Value;
+
                 double min = double.MaxValue;
 
                 for (int i = 0; i < timelines.Length; i++)

--- a/osu.Game/Storyboards/CommandTimelineGroup.cs
+++ b/osu.Game/Storyboards/CommandTimelineGroup.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Storyboards
         }
 
         /// <summary>
-        /// Returns the earliest visible time. Will be null unless this group has an <see cref="Alpha"/> command with a start value of zero.
+        /// Returns the earliest visible time. Will be null unless this group's first <see cref="Alpha"/> command has a start value of zero.
         /// </summary>
         public double? EarliestDisplayedTime
         {


### PR DESCRIPTION
In osu-stable, storyboard intros start from the first command, but in the case of storyboard drawables which have an initial hidden state, all commands before the time at which they become visible (ie. the first command where `Alpha` increases to a non-zero value) are ignored.

This brings lazer in line with that behaviour. It also removes several unnecessary LINQ calls.

Note that the alpha check being done in its own pass is important, as it must be the "minimum present alpha across all command groups, including loops". This is what makes the implementation slightly complex.

Closes #11981.