### PR TITLE
Fix SPM counter immediately disappearing/decreasing after spinner has already been completed

### DIFF
--- a/osu.Game.Rulesets.Osu/Judgements/OsuSpinnerJudgementResult.cs
+++ b/osu.Game.Rulesets.Osu/Judgements/OsuSpinnerJudgementResult.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Rulesets.Osu.Judgements
         public float RateAdjustedRotation;
 
         /// <summary>
+        /// Time instant at which the spin was started (the first user input which caused an increase in spin).
+        /// </summary>
+        public double? TimeStarted;
+
+        /// <summary>
         /// Time instant at which the spinner has been completed (the user has executed all required spins).
         /// Will be null if all required spins haven't been completed.
         /// </summary>

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -267,7 +267,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (!SpmCounter.IsPresent && RotationTracker.Tracking)
                 SpmCounter.FadeIn(HitObject.TimeFadeIn);
 
-            SpmCounter.SetRotation(Result.RateAdjustedRotation);
+            // don't update after end time to avoid the rate display dropping during fade out.
+            // this shouldn't be limited to StartTime as it causes weirdness with the underlying calculation, which is expecting updates during that period.
+            if (Time.Current <= HitObject.EndTime)
+                SpmCounter.SetRotation(Result.RateAdjustedRotation);
 
             updateBonusScore();
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -109,6 +109,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.OnFree();
 
             spinningSample.Samples = null;
+
+            // the counter handles its own fade in (when spinning begins) so we should only be responsible for resetting it here, for pooling.
+            SpmCounter.Hide();
         }
 
         protected override void LoadSamples()

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCounter.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCounter.cs
@@ -21,11 +21,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         private readonly OsuSpriteText spmText;
 
-        public override void ApplyTransformsAt(double time, bool propagateChildren = false)
-        {
-            // handles own fade in state.
-        }
-
         public SpinnerSpmCounter()
         {
             Children = new Drawable[]

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCounter.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCounter.cs
@@ -21,6 +21,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         private readonly OsuSpriteText spmText;
 
+        public override void ApplyTransformsAt(double time, bool propagateChildren = false)
+        {
+            // handles own fade in state.
+        }
+
         public SpinnerSpmCounter()
         {
             Children = new Drawable[]


### PR DESCRIPTION
Noticed this in https://github.com/ppy/osu/issues/7023#issuecomment-793428269

I've increased the fade out length so this is visible in the videos below:

Fixed disappearing immediately due to transform rewind:

Before:

https://user-images.githubusercontent.com/191335/110435540-7947f080-80f6-11eb-8bd2-e4b628ec0818.mp4

After:

https://user-images.githubusercontent.com/191335/110434914-b9f33a00-80f5-11eb-97a2-f65d2b69725e.mp4

Fixed decrementing counter after end time:

After:

https://user-images.githubusercontent.com/191335/110434976-cf686400-80f5-11eb-9f5b-f25672268f8e.mp4

The fix for the immediate disappearing is a bit unorthodox perhaps. I'm open to a better proposal. Important part to note is that currently the counter only appears after the user starts spinning, so if this was to be done in `UpdateHitTransforms` we would need to store the time when the spin started, and apply that transform there as well.