### PR TITLE
Consume framework updates to input handling

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.211.1" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.309.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.317.0" />
   </ItemGroup>
 </Project>

--- a/osu.Desktop.slnf
+++ b/osu.Desktop.slnf
@@ -15,7 +15,9 @@
       "osu.Game.Tests\\osu.Game.Tests.csproj",
       "osu.Game.Tournament.Tests\\osu.Game.Tournament.Tests.csproj",
       "osu.Game.Tournament\\osu.Game.Tournament.csproj",
-      "osu.Game\\osu.Game.csproj"
+      "osu.Game\\osu.Game.csproj",
+      "../osu-framework/osu.Framework/osu.Framework.csproj",
+      "../osu-framework/osu.Framework/osu.Framework.NativeLibs.csproj"
     ]
   }
 }

--- a/osu.Desktop.slnf
+++ b/osu.Desktop.slnf
@@ -15,9 +15,7 @@
       "osu.Game.Tests\\osu.Game.Tests.csproj",
       "osu.Game.Tournament.Tests\\osu.Game.Tournament.Tests.csproj",
       "osu.Game.Tournament\\osu.Game.Tournament.csproj",
-      "osu.Game\\osu.Game.csproj",
-      "../osu-framework/osu.Framework/osu.Framework.csproj",
-      "../osu-framework/osu.Framework/osu.Framework.NativeLibs.csproj"
+      "osu.Game\\osu.Game.csproj"
     ]
   }
 }

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -136,24 +136,12 @@ namespace osu.Desktop
 
             var iconStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(GetType(), "lazer.ico");
 
-            switch (host.Window)
-            {
-                // Legacy osuTK DesktopGameWindow
-                case OsuTKDesktopWindow desktopGameWindow:
-                    desktopGameWindow.CursorState |= CursorState.Hidden;
-                    desktopGameWindow.SetIconFromStream(iconStream);
-                    desktopGameWindow.Title = Name;
-                    desktopGameWindow.FileDrop += (_, e) => fileDrop(e.FileNames);
-                    break;
+            var desktopWindow = (SDL2DesktopWindow)host.Window;
 
-                // SDL2 DesktopWindow
-                case SDL2DesktopWindow desktopWindow:
-                    desktopWindow.CursorState |= CursorState.Hidden;
-                    desktopWindow.SetIconFromStream(iconStream);
-                    desktopWindow.Title = Name;
-                    desktopWindow.DragDrop += f => fileDrop(new[] { f });
-                    break;
-            }
+            desktopWindow.CursorState |= CursorState.Hidden;
+            desktopWindow.SetIconFromStream(iconStream);
+            desktopWindow.Title = Name;
+            desktopWindow.DragDrop += f => fileDrop(new[] { f });
         }
 
         private void fileDrop(string[] filePaths)

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -22,7 +22,6 @@ namespace osu.Desktop
         {
             // Back up the cwd before DesktopGameHost changes it
             var cwd = Environment.CurrentDirectory;
-            bool useOsuTK = args.Contains("--tk");
 
             using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
             {

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -24,7 +24,7 @@ namespace osu.Desktop
             var cwd = Environment.CurrentDirectory;
             bool useOsuTK = args.Contains("--tk");
 
-            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true, useOsuTK: useOsuTK))
+            using (DesktopGameHost host = Host.GetSuitableHost(@"osu", true))
             {
                 host.ExceptionThrown += handleException;
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [BackgroundDependencyLoader]
         private void load()
         {
-            LocalConfig.Set(OsuSetting.IncreaseFirstObjectVisibility, false);
+            LocalConfig.SetValue(OsuSetting.IncreaseFirstObjectVisibility, false);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         public void TestHitLightingColour()
         {
             var fruitColour = SkinConfiguration.DefaultComboColours[1];
-            AddStep("enable hit lighting", () => config.Set(OsuSetting.HitLighting, true));
+            AddStep("enable hit lighting", () => config.SetValue(OsuSetting.HitLighting, true));
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             AddAssert("correct hit lighting colour", () =>
                 catcher.ChildrenOfType<HitExplosion>().First()?.ObjectColour == fruitColour);
@@ -211,7 +211,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         [Test]
         public void TestHitLightingDisabled()
         {
-            AddStep("disable hit lighting", () => config.Set(OsuSetting.HitLighting, false));
+            AddStep("disable hit lighting", () => config.SetValue(OsuSetting.HitLighting, false));
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             AddAssert("no hit lighting", () => !catcher.ChildrenOfType<HitExplosion>().Any());
         }

--- a/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
@@ -20,8 +20,8 @@ namespace osu.Game.Rulesets.Mania.Configuration
         {
             base.InitialiseDefaults();
 
-            Set(ManiaRulesetSetting.ScrollTime, 1500.0, DrawableManiaRuleset.MIN_TIME_RANGE, DrawableManiaRuleset.MAX_TIME_RANGE, 5);
-            Set(ManiaRulesetSetting.ScrollDirection, ManiaScrollingDirection.Down);
+            SetDefault(ManiaRulesetSetting.ScrollTime, 1500.0, DrawableManiaRuleset.MIN_TIME_RANGE, DrawableManiaRuleset.MAX_TIME_RANGE, 5);
+            SetDefault(ManiaRulesetSetting.ScrollDirection, ManiaScrollingDirection.Down);
         }
 
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneDrawableJudgement.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestHitLightingDisabled()
         {
-            AddStep("hit lighting disabled", () => config.Set(OsuSetting.HitLighting, false));
+            AddStep("hit lighting disabled", () => config.SetValue(OsuSetting.HitLighting, false));
 
             showResult(HitResult.Great);
 
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestHitLightingEnabled()
         {
-            AddStep("hit lighting enabled", () => config.Set(OsuSetting.HitLighting, true));
+            AddStep("hit lighting enabled", () => config.SetValue(OsuSetting.HitLighting, true));
 
             showResult(HitResult.Great);
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddSliderStep("circle size", 0f, 10f, 0f, val =>
             {
-                config.Set(OsuSetting.AutoCursorSize, true);
+                config.SetValue(OsuSetting.AutoCursorSize, true);
                 gameplayBeatmap.BeatmapInfo.BaseDifficulty.CircleSize = val;
                 Scheduler.AddOnce(recreate);
             });
@@ -64,21 +64,21 @@ namespace osu.Game.Rulesets.Osu.Tests
         [TestCase(10, 1.5f)]
         public void TestSizing(int circleSize, float userScale)
         {
-            AddStep($"set user scale to {userScale}", () => config.Set(OsuSetting.GameplayCursorSize, userScale));
+            AddStep($"set user scale to {userScale}", () => config.SetValue(OsuSetting.GameplayCursorSize, userScale));
             AddStep($"adjust cs to {circleSize}", () => gameplayBeatmap.BeatmapInfo.BaseDifficulty.CircleSize = circleSize);
-            AddStep("turn on autosizing", () => config.Set(OsuSetting.AutoCursorSize, true));
+            AddStep("turn on autosizing", () => config.SetValue(OsuSetting.AutoCursorSize, true));
 
             AddStep("load content", loadContent);
 
             AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == OsuCursorContainer.GetScaleForCircleSize(circleSize) * userScale);
 
-            AddStep("set user scale to 1", () => config.Set(OsuSetting.GameplayCursorSize, 1f));
+            AddStep("set user scale to 1", () => config.SetValue(OsuSetting.GameplayCursorSize, 1f));
             AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == OsuCursorContainer.GetScaleForCircleSize(circleSize));
 
-            AddStep("turn off autosizing", () => config.Set(OsuSetting.AutoCursorSize, false));
+            AddStep("turn off autosizing", () => config.SetValue(OsuSetting.AutoCursorSize, false));
             AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == 1);
 
-            AddStep($"set user scale to {userScale}", () => config.Set(OsuSetting.GameplayCursorSize, userScale));
+            AddStep($"set user scale to {userScale}", () => config.SetValue(OsuSetting.GameplayCursorSize, userScale));
             AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == userScale);
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSkinFallbacks.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSkinFallbacks.cs
@@ -42,10 +42,10 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             AddStep("enable user provider", () => testUserSkin.Enabled = true);
 
-            AddStep("enable beatmap skin", () => LocalConfig.Set<bool>(OsuSetting.BeatmapSkins, true));
+            AddStep("enable beatmap skin", () => LocalConfig.SetValue(OsuSetting.BeatmapSkins, true));
             checkNextHitObject("beatmap");
 
-            AddStep("disable beatmap skin", () => LocalConfig.Set<bool>(OsuSetting.BeatmapSkins, false));
+            AddStep("disable beatmap skin", () => LocalConfig.SetValue(OsuSetting.BeatmapSkins, false));
             checkNextHitObject("user");
 
             AddStep("disable user provider", () => testUserSkin.Enabled = false);
@@ -57,20 +57,20 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             AddStep("enable user provider", () => testUserSkin.Enabled = true);
 
-            AddStep("enable beatmap skin", () => LocalConfig.Set<bool>(OsuSetting.BeatmapSkins, true));
-            AddStep("enable beatmap colours", () => LocalConfig.Set<bool>(OsuSetting.BeatmapColours, true));
+            AddStep("enable beatmap skin", () => LocalConfig.SetValue(OsuSetting.BeatmapSkins, true));
+            AddStep("enable beatmap colours", () => LocalConfig.SetValue(OsuSetting.BeatmapColours, true));
             checkNextHitObject("beatmap");
 
-            AddStep("enable beatmap skin", () => LocalConfig.Set<bool>(OsuSetting.BeatmapSkins, true));
-            AddStep("disable beatmap colours", () => LocalConfig.Set<bool>(OsuSetting.BeatmapColours, false));
+            AddStep("enable beatmap skin", () => LocalConfig.SetValue(OsuSetting.BeatmapSkins, true));
+            AddStep("disable beatmap colours", () => LocalConfig.SetValue(OsuSetting.BeatmapColours, false));
             checkNextHitObject("beatmap");
 
-            AddStep("disable beatmap skin", () => LocalConfig.Set<bool>(OsuSetting.BeatmapSkins, false));
-            AddStep("enable beatmap colours", () => LocalConfig.Set<bool>(OsuSetting.BeatmapColours, true));
+            AddStep("disable beatmap skin", () => LocalConfig.SetValue(OsuSetting.BeatmapSkins, false));
+            AddStep("enable beatmap colours", () => LocalConfig.SetValue(OsuSetting.BeatmapColours, true));
             checkNextHitObject("user");
 
-            AddStep("disable beatmap skin", () => LocalConfig.Set<bool>(OsuSetting.BeatmapSkins, false));
-            AddStep("disable beatmap colours", () => LocalConfig.Set<bool>(OsuSetting.BeatmapColours, false));
+            AddStep("disable beatmap skin", () => LocalConfig.SetValue(OsuSetting.BeatmapSkins, false));
+            AddStep("disable beatmap colours", () => LocalConfig.SetValue(OsuSetting.BeatmapColours, false));
             checkNextHitObject("user");
 
             AddStep("disable user provider", () => testUserSkin.Enabled = false);

--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -17,10 +17,10 @@ namespace osu.Game.Rulesets.Osu.Configuration
         protected override void InitialiseDefaults()
         {
             base.InitialiseDefaults();
-            Set(OsuRulesetSetting.SnakingInSliders, true);
-            Set(OsuRulesetSetting.SnakingOutSliders, true);
-            Set(OsuRulesetSetting.ShowCursorTrail, true);
-            Set(OsuRulesetSetting.PlayfieldBorderStyle, PlayfieldBorderStyle.None);
+            SetDefault(OsuRulesetSetting.SnakingInSliders, true);
+            SetDefault(OsuRulesetSetting.SnakingOutSliders, true);
+            SetDefault(OsuRulesetSetting.ShowCursorTrail, true);
+            SetDefault(OsuRulesetSetting.PlayfieldBorderStyle, PlayfieldBorderStyle.None);
         }
     }
 

--- a/osu.Game.Tests/Input/ConfineMouseTrackerTest.cs
+++ b/osu.Game.Tests/Input/ConfineMouseTrackerTest.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Input
             => AddStep($"make window {mode}", () => frameworkConfigManager.GetBindable<WindowMode>(FrameworkSetting.WindowMode).Value = mode);
 
         private void setGameSideModeTo(OsuConfineMouseMode mode)
-            => AddStep($"set {mode} game-side", () => Game.LocalConfig.Set(OsuSetting.ConfineMouseMode, mode));
+            => AddStep($"set {mode} game-side", () => Game.LocalConfig.SetValue(OsuSetting.ConfineMouseMode, mode));
 
         private void setLocalUserPlayingTo(bool playing)
             => AddStep($"local user {(playing ? "playing" : "not playing")}", () => Game.LocalUserPlaying.Value = playing);

--- a/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
+++ b/osu.Game.Tests/NonVisual/CustomDataDirectoryTest.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.NonVisual
             using (var host = new CustomTestHeadlessGameHost())
             {
                 using (var storageConfig = new StorageConfigManager(host.InitialStorage))
-                    storageConfig.Set(StorageConfig.FullPath, customPath);
+                    storageConfig.SetValue(StorageConfig.FullPath, customPath);
 
                 try
                 {
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.NonVisual
             using (var host = new CustomTestHeadlessGameHost())
             {
                 using (var storageConfig = new StorageConfigManager(host.InitialStorage))
-                    storageConfig.Set(StorageConfig.FullPath, customPath);
+                    storageConfig.SetValue(StorageConfig.FullPath, customPath);
 
                 try
                 {

--- a/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Tests.Visual.Background
         public void SetUp() => Schedule(() =>
         {
             // reset API response in statics to avoid test crosstalk.
-            statics.Set<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
+            statics.SetValue<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
             textureStore.PerformedLookups.Clear();
             dummyAPI.SetState(APIState.Online);
 
@@ -146,7 +146,7 @@ namespace osu.Game.Tests.Visual.Background
             });
 
         private void setSeasonalBackgroundMode(SeasonalBackgroundMode mode)
-            => AddStep($"set seasonal mode to {mode}", () => config.Set(OsuSetting.SeasonalBackgroundMode, mode));
+            => AddStep($"set seasonal mode to {mode}", () => config.SetValue(OsuSetting.SeasonalBackgroundMode, mode));
 
         private void createLoader()
             => AddStep("create loader", () =>

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneFailingLayer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneFailingLayer.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddStep("show health", () => showHealth.Value = true);
-            AddStep("enable layer", () => config.Set(OsuSetting.FadePlayfieldWhenHealthLow, true));
+            AddStep("enable layer", () => config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, true));
             AddUntilStep("layer is visible", () => layer.IsPresent);
         }
 
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestLayerDisabledViaConfig()
         {
-            AddStep("disable layer", () => config.Set(OsuSetting.FadePlayfieldWhenHealthLow, false));
+            AddStep("disable layer", () => config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, false));
             AddStep("set health to 0.10", () => layer.Current.Value = 0.1);
             AddUntilStep("layer is not visible", () => !layer.IsPresent);
         }
@@ -81,19 +81,19 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("set health to 0.10", () => layer.Current.Value = 0.1);
 
             AddStep("don't show health", () => showHealth.Value = false);
-            AddStep("disable FadePlayfieldWhenHealthLow", () => config.Set(OsuSetting.FadePlayfieldWhenHealthLow, false));
+            AddStep("disable FadePlayfieldWhenHealthLow", () => config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, false));
             AddUntilStep("layer fade is invisible", () => !layer.IsPresent);
 
             AddStep("don't show health", () => showHealth.Value = false);
-            AddStep("enable FadePlayfieldWhenHealthLow", () => config.Set(OsuSetting.FadePlayfieldWhenHealthLow, true));
+            AddStep("enable FadePlayfieldWhenHealthLow", () => config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, true));
             AddUntilStep("layer fade is invisible", () => !layer.IsPresent);
 
             AddStep("show health", () => showHealth.Value = true);
-            AddStep("disable FadePlayfieldWhenHealthLow", () => config.Set(OsuSetting.FadePlayfieldWhenHealthLow, false));
+            AddStep("disable FadePlayfieldWhenHealthLow", () => config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, false));
             AddUntilStep("layer fade is invisible", () => !layer.IsPresent);
 
             AddStep("show health", () => showHealth.Value = true);
-            AddStep("enable FadePlayfieldWhenHealthLow", () => config.Set(OsuSetting.FadePlayfieldWhenHealthLow, true));
+            AddStep("enable FadePlayfieldWhenHealthLow", () => config.SetValue(OsuSetting.FadePlayfieldWhenHealthLow, true));
             AddUntilStep("layer fade is visible", () => layer.IsPresent);
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("get original config value", () => originalConfigValue = config.Get<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode));
 
-            AddStep("set hud to never show", () => config.Set(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
+            AddStep("set hud to never show", () => config.SetValue(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Never));
 
             AddUntilStep("wait for fade", () => !hideTarget.IsPresent);
 
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("stop trigering", () => InputManager.ReleaseKey(Key.ControlLeft));
             AddUntilStep("wait for fade", () => !hideTarget.IsPresent);
 
-            AddStep("set original config value", () => config.Set(OsuSetting.HUDVisibilityMode, originalConfigValue));
+            AddStep("set original config value", () => config.SetValue(OsuSetting.HUDVisibilityMode, originalConfigValue));
         }
 
         [Test]
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("set keycounter visible false", () =>
             {
-                config.Set<bool>(OsuSetting.KeyOverlay, false);
+                config.SetValue(OsuSetting.KeyOverlay, false);
                 hudOverlay.KeyCounter.AlwaysVisible.Value = false;
             });
 
@@ -132,7 +132,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("hidetarget is visible", () => hideTarget.IsPresent);
             AddAssert("key counters still hidden", () => !keyCounterFlow.IsPresent);
 
-            AddStep("return value", () => config.Set<bool>(OsuSetting.KeyOverlay, keyCounterVisibleValue));
+            AddStep("return value", () => config.SetValue(OsuSetting.KeyOverlay, keyCounterVisibleValue));
         }
 
         private void createNew(Action<HUDOverlay> action = null)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardSamplePlayback.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            config.Set(OsuSetting.ShowStoryboard, true);
+            config.SetValue(OsuSetting.ShowStoryboard, true);
 
             storyboard = new Storyboard();
             var backgroundLayer = storyboard.GetLayer("Background");

--- a/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
+++ b/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Platform;
@@ -61,10 +60,6 @@ namespace osu.Game.Tests.Visual.Navigation
                 }
 
                 RecycleLocalStorage();
-
-                // see MouseSettings
-                var frameworkConfig = host.Dependencies.Get<FrameworkConfigManager>();
-                frameworkConfig.GetBindable<double>(FrameworkSetting.CursorSensitivity).Disabled = false;
 
                 CreateGame();
             });

--- a/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
+++ b/osu.Game.Tests/Visual/Navigation/OsuGameTestScene.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.Navigation
 
             // todo: this can be removed once we can run audio tracks without a device present
             // see https://github.com/ppy/osu/issues/1302
-            Game.LocalConfig.Set(OsuSetting.IntroSequence, IntroSequence.Circles);
+            Game.LocalConfig.SetValue(OsuSetting.IntroSequence, IntroSequence.Circles);
 
             Add(Game);
         }
@@ -136,7 +136,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 base.LoadComplete();
                 API.Login("Rhythm Champion", "osu!");
 
-                Dependencies.Get<SessionStatics>().Set(Static.MutedAudioNotificationShownOnce, true);
+                Dependencies.Get<SessionStatics>().SetValue(Static.MutedAudioNotificationShownOnce, true);
             }
         }
 

--- a/osu.Game.Tests/Visual/Navigation/TestSettingsMigration.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSettingsMigration.cs
@@ -15,8 +15,8 @@ namespace osu.Game.Tests.Visual.Navigation
 
             using (var config = new OsuConfigManager(LocalStorage))
             {
-                config.Set(OsuSetting.Version, "2020.101.0");
-                config.Set(OsuSetting.DisplayStarsMaximum, 10.0);
+                config.SetValue(OsuSetting.Version, "2020.101.0");
+                config.SetValue(OsuSetting.DisplayStarsMaximum, 10.0);
             }
         }
 
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.Navigation
         {
             AddAssert("config has migrated value", () => Precision.AlmostEquals(Game.LocalConfig.Get<double>(OsuSetting.DisplayStarsMaximum), 10.1));
 
-            AddStep("set value again", () => Game.LocalConfig.Set<double>(OsuSetting.DisplayStarsMaximum, 10));
+            AddStep("set value again", () => Game.LocalConfig.SetValue(OsuSetting.DisplayStarsMaximum, 10));
 
             AddStep("force save config", () => Game.LocalConfig.Save());
 

--- a/osu.Game.Tests/Visual/Navigation/TestSettingsMigration.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSettingsMigration.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Tests.Visual.Navigation
         {
             AddAssert("config has migrated value", () => Precision.AlmostEquals(Game.LocalConfig.Get<double>(OsuSetting.DisplayStarsMaximum), 10.1));
 
-            AddStep("set value again", () => Game.LocalConfig.SetValue(OsuSetting.DisplayStarsMaximum, 10));
+            AddStep("set value again", () => Game.LocalConfig.SetValue(OsuSetting.DisplayStarsMaximum, 10.0));
 
             AddStep("force save config", () => Game.LocalConfig.Save());
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Tests.Visual.Ranking
             }));
 
             AddAssert("mapped by text not present", () =>
-                this.ChildrenOfType<OsuSpriteText>().All(spriteText => !containsAny(spriteText.Current.Value, "mapped", "by")));
+                this.ChildrenOfType<OsuSpriteText>().All(spriteText => !containsAny(spriteText.Text.ToString(), "mapped", "by")));
         }
 
         private void showPanel(ScoreInfo score) => Child = new ExpandedPanelMiddleContentContainer(score);

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -207,14 +207,14 @@ namespace osu.Game.Tests.Visual.SongSelect
             addRulesetImportStep(0);
             addRulesetImportStep(0);
 
-            AddStep("change convert setting", () => config.Set(OsuSetting.ShowConvertedBeatmaps, false));
+            AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, false));
 
             createSongSelect();
 
             AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
             AddUntilStep("wait for not current", () => !songSelect.IsCurrentScreen());
 
-            AddStep("change convert setting", () => config.Set(OsuSetting.ShowConvertedBeatmaps, true));
+            AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
 
             AddStep("return", () => songSelect.MakeCurrent());
             AddUntilStep("wait for current", () => songSelect.IsCurrentScreen());
@@ -297,13 +297,13 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddAssert("random map selected", () => songSelect.CurrentBeatmap != defaultBeatmap);
 
-            AddStep(@"Sort by Artist", () => config.Set(OsuSetting.SongSelectSortingMode, SortMode.Artist));
-            AddStep(@"Sort by Title", () => config.Set(OsuSetting.SongSelectSortingMode, SortMode.Title));
-            AddStep(@"Sort by Author", () => config.Set(OsuSetting.SongSelectSortingMode, SortMode.Author));
-            AddStep(@"Sort by DateAdded", () => config.Set(OsuSetting.SongSelectSortingMode, SortMode.DateAdded));
-            AddStep(@"Sort by BPM", () => config.Set(OsuSetting.SongSelectSortingMode, SortMode.BPM));
-            AddStep(@"Sort by Length", () => config.Set(OsuSetting.SongSelectSortingMode, SortMode.Length));
-            AddStep(@"Sort by Difficulty", () => config.Set(OsuSetting.SongSelectSortingMode, SortMode.Difficulty));
+            AddStep(@"Sort by Artist", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Artist));
+            AddStep(@"Sort by Title", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Title));
+            AddStep(@"Sort by Author", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Author));
+            AddStep(@"Sort by DateAdded", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.DateAdded));
+            AddStep(@"Sort by BPM", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.BPM));
+            AddStep(@"Sort by Length", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Length));
+            AddStep(@"Sort by Difficulty", () => config.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Difficulty));
         }
 
         [Test]
@@ -470,7 +470,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             changeRuleset(0);
 
             // used for filter check below
-            AddStep("allow convert display", () => config.Set(OsuSetting.ShowConvertedBeatmaps, true));
+            AddStep("allow convert display", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
 
             AddUntilStep("has selection", () => songSelect.Carousel.SelectedBeatmap != null);
 
@@ -648,7 +648,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             int changeCount = 0;
 
-            AddStep("change convert setting", () => config.Set(OsuSetting.ShowConvertedBeatmaps, false));
+            AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, false));
             AddStep("bind beatmap changed", () =>
             {
                 Beatmap.ValueChanged += onChange;
@@ -686,7 +686,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("selection changed only fired twice", () => changeCount == 2);
 
             AddStep("unbind beatmap changed", () => Beatmap.ValueChanged -= onChange);
-            AddStep("change convert setting", () => config.Set(OsuSetting.ShowConvertedBeatmaps, true));
+            AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
 
             // ReSharper disable once AccessToModifiedClosure
             void onChange(ValueChangedEvent<WorkingBeatmap> valueChangedEvent) => changeCount++;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -92,10 +92,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestExplicitConfig()
         {
-            AddStep("configure explicit content to allowed", () => localConfig.Set(OsuSetting.ShowOnlineExplicitContent, true));
+            AddStep("configure explicit content to allowed", () => localConfig.SetValue(OsuSetting.ShowOnlineExplicitContent, true));
             AddAssert("explicit control set to show", () => control.ExplicitContent.Value == SearchExplicit.Show);
 
-            AddStep("configure explicit content to disallowed", () => localConfig.Set(OsuSetting.ShowOnlineExplicitContent, false));
+            AddStep("configure explicit content to disallowed", () => localConfig.SetValue(OsuSetting.ShowOnlineExplicitContent, false));
             AddAssert("explicit control set to hide", () => control.ExplicitContent.Value == SearchExplicit.Hide);
         }
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOnScreenDisplay.cs
@@ -44,22 +44,22 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             protected override void InitialiseDefaults()
             {
-                Set(TestConfigSetting.ToggleSettingNoKeybind, false);
-                Set(TestConfigSetting.EnumSettingNoKeybind, EnumSetting.Setting1);
-                Set(TestConfigSetting.ToggleSettingWithKeybind, false);
-                Set(TestConfigSetting.EnumSettingWithKeybind, EnumSetting.Setting1);
+                SetDefault(TestConfigSetting.ToggleSettingNoKeybind, false);
+                SetDefault(TestConfigSetting.EnumSettingNoKeybind, EnumSetting.Setting1);
+                SetDefault(TestConfigSetting.ToggleSettingWithKeybind, false);
+                SetDefault(TestConfigSetting.EnumSettingWithKeybind, EnumSetting.Setting1);
 
                 base.InitialiseDefaults();
             }
 
-            public void ToggleSetting(TestConfigSetting setting) => Set(setting, !Get<bool>(setting));
+            public void ToggleSetting(TestConfigSetting setting) => SetValue(setting, !Get<bool>(setting));
 
             public void IncrementEnumSetting(TestConfigSetting setting)
             {
                 var nextValue = Get<EnumSetting>(setting) + 1;
                 if (nextValue > EnumSetting.Setting4)
                     nextValue = EnumSetting.Setting1;
-                Set(setting, nextValue);
+                SetValue(setting, nextValue);
             }
 
             public override TrackedSettings CreateTrackedSettings() => new TrackedSettings

--- a/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/CustomTourneyDirectoryTest.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 storage.DeleteDirectory(string.Empty);
 
                 using (var storageConfig = new TournamentStorageManager(storage))
-                    storageConfig.Set(StorageConfig.CurrentTournament, custom_tournament);
+                    storageConfig.SetValue(StorageConfig.CurrentTournament, custom_tournament);
 
                 try
                 {

--- a/osu.Game.Tournament/IO/TournamentStorage.cs
+++ b/osu.Game.Tournament/IO/TournamentStorage.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tournament.IO
             moveFileIfExists("drawings.ini", destination);
 
             ChangeTargetStorage(newStorage);
-            storageConfig.Set(StorageConfig.CurrentTournament, default_tournament);
+            storageConfig.SetValue(StorageConfig.CurrentTournament, default_tournament);
             storageConfig.Save();
         }
 

--- a/osu.Game.Tournament/Screens/Drawings/Components/DrawingsConfigManager.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/DrawingsConfigManager.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
         protected override void InitialiseDefaults()
         {
-            Set(DrawingsConfig.Groups, 8, 1, 8);
-            Set(DrawingsConfig.TeamsPerGroup, 8, 1, 8);
+            SetDefault(DrawingsConfig.Groups, 8, 1, 8);
+            SetDefault(DrawingsConfig.TeamsPerGroup, 8, 1, 8);
         }
 
         public DrawingsConfigManager(Storage storage)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -24,126 +24,126 @@ namespace osu.Game.Configuration
         protected override void InitialiseDefaults()
         {
             // UI/selection defaults
-            Set(OsuSetting.Ruleset, 0, 0, int.MaxValue);
-            Set(OsuSetting.Skin, 0, -1, int.MaxValue);
+            SetDefault(OsuSetting.Ruleset, 0, 0, int.MaxValue);
+            SetDefault(OsuSetting.Skin, 0, -1, int.MaxValue);
 
-            Set(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
-            Set(OsuSetting.BeatmapDetailModsFilter, false);
+            SetDefault(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
+            SetDefault(OsuSetting.BeatmapDetailModsFilter, false);
 
-            Set(OsuSetting.ShowConvertedBeatmaps, true);
-            Set(OsuSetting.DisplayStarsMinimum, 0.0, 0, 10, 0.1);
-            Set(OsuSetting.DisplayStarsMaximum, 10.1, 0, 10.1, 0.1);
+            SetDefault(OsuSetting.ShowConvertedBeatmaps, true);
+            SetDefault(OsuSetting.DisplayStarsMinimum, 0.0, 0, 10, 0.1);
+            SetDefault(OsuSetting.DisplayStarsMaximum, 10.1, 0, 10.1, 0.1);
 
-            Set(OsuSetting.SongSelectGroupingMode, GroupMode.All);
-            Set(OsuSetting.SongSelectSortingMode, SortMode.Title);
+            SetDefault(OsuSetting.SongSelectGroupingMode, GroupMode.All);
+            SetDefault(OsuSetting.SongSelectSortingMode, SortMode.Title);
 
-            Set(OsuSetting.RandomSelectAlgorithm, RandomSelectAlgorithm.RandomPermutation);
+            SetDefault(OsuSetting.RandomSelectAlgorithm, RandomSelectAlgorithm.RandomPermutation);
 
-            Set(OsuSetting.ChatDisplayHeight, ChatOverlay.DEFAULT_HEIGHT, 0.2f, 1f);
+            SetDefault(OsuSetting.ChatDisplayHeight, ChatOverlay.DEFAULT_HEIGHT, 0.2f, 1f);
 
             // Online settings
-            Set(OsuSetting.Username, string.Empty);
-            Set(OsuSetting.Token, string.Empty);
+            SetDefault(OsuSetting.Username, string.Empty);
+            SetDefault(OsuSetting.Token, string.Empty);
 
-            Set(OsuSetting.AutomaticallyDownloadWhenSpectating, false);
+            SetDefault(OsuSetting.AutomaticallyDownloadWhenSpectating, false);
 
-            Set(OsuSetting.SavePassword, false).ValueChanged += enabled =>
+            SetDefault(OsuSetting.SavePassword, false).ValueChanged += enabled =>
             {
-                if (enabled.NewValue) Set(OsuSetting.SaveUsername, true);
+                if (enabled.NewValue) SetValue(OsuSetting.SaveUsername, true);
             };
 
-            Set(OsuSetting.SaveUsername, true).ValueChanged += enabled =>
+            SetDefault(OsuSetting.SaveUsername, true).ValueChanged += enabled =>
             {
-                if (!enabled.NewValue) Set(OsuSetting.SavePassword, false);
+                if (!enabled.NewValue) SetValue(OsuSetting.SavePassword, false);
             };
 
-            Set(OsuSetting.ExternalLinkWarning, true);
-            Set(OsuSetting.PreferNoVideo, false);
+            SetDefault(OsuSetting.ExternalLinkWarning, true);
+            SetDefault(OsuSetting.PreferNoVideo, false);
 
-            Set(OsuSetting.ShowOnlineExplicitContent, false);
+            SetDefault(OsuSetting.ShowOnlineExplicitContent, false);
 
             // Audio
-            Set(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
 
-            Set(OsuSetting.MenuVoice, true);
-            Set(OsuSetting.MenuMusic, true);
+            SetDefault(OsuSetting.MenuVoice, true);
+            SetDefault(OsuSetting.MenuMusic, true);
 
-            Set(OsuSetting.AudioOffset, 0, -500.0, 500.0, 1);
+            SetDefault(OsuSetting.AudioOffset, 0, -500.0, 500.0, 1);
 
             // Input
-            Set(OsuSetting.MenuCursorSize, 1.0f, 0.5f, 2f, 0.01f);
-            Set(OsuSetting.GameplayCursorSize, 1.0f, 0.1f, 2f, 0.01f);
-            Set(OsuSetting.AutoCursorSize, false);
+            SetDefault(OsuSetting.MenuCursorSize, 1.0f, 0.5f, 2f, 0.01f);
+            SetDefault(OsuSetting.GameplayCursorSize, 1.0f, 0.1f, 2f, 0.01f);
+            SetDefault(OsuSetting.AutoCursorSize, false);
 
-            Set(OsuSetting.MouseDisableButtons, false);
-            Set(OsuSetting.MouseDisableWheel, false);
-            Set(OsuSetting.ConfineMouseMode, OsuConfineMouseMode.DuringGameplay);
+            SetDefault(OsuSetting.MouseDisableButtons, false);
+            SetDefault(OsuSetting.MouseDisableWheel, false);
+            SetDefault(OsuSetting.ConfineMouseMode, OsuConfineMouseMode.DuringGameplay);
 
             // Graphics
-            Set(OsuSetting.ShowFpsDisplay, false);
+            SetDefault(OsuSetting.ShowFpsDisplay, false);
 
-            Set(OsuSetting.ShowStoryboard, true);
-            Set(OsuSetting.BeatmapSkins, true);
-            Set(OsuSetting.BeatmapColours, true);
-            Set(OsuSetting.BeatmapHitsounds, true);
+            SetDefault(OsuSetting.ShowStoryboard, true);
+            SetDefault(OsuSetting.BeatmapSkins, true);
+            SetDefault(OsuSetting.BeatmapColours, true);
+            SetDefault(OsuSetting.BeatmapHitsounds, true);
 
-            Set(OsuSetting.CursorRotation, true);
+            SetDefault(OsuSetting.CursorRotation, true);
 
-            Set(OsuSetting.MenuParallax, true);
+            SetDefault(OsuSetting.MenuParallax, true);
 
             // Gameplay
-            Set(OsuSetting.DimLevel, 0.8, 0, 1, 0.01);
-            Set(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
-            Set(OsuSetting.LightenDuringBreaks, true);
+            SetDefault(OsuSetting.DimLevel, 0.8, 0, 1, 0.01);
+            SetDefault(OsuSetting.BlurLevel, 0, 0, 1, 0.01);
+            SetDefault(OsuSetting.LightenDuringBreaks, true);
 
-            Set(OsuSetting.HitLighting, true);
+            SetDefault(OsuSetting.HitLighting, true);
 
-            Set(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always);
-            Set(OsuSetting.ShowProgressGraph, true);
-            Set(OsuSetting.ShowHealthDisplayWhenCantFail, true);
-            Set(OsuSetting.FadePlayfieldWhenHealthLow, true);
-            Set(OsuSetting.KeyOverlay, false);
-            Set(OsuSetting.PositionalHitSounds, true);
-            Set(OsuSetting.AlwaysPlayFirstComboBreak, true);
-            Set(OsuSetting.ScoreMeter, ScoreMeterType.HitErrorBoth);
+            SetDefault(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always);
+            SetDefault(OsuSetting.ShowProgressGraph, true);
+            SetDefault(OsuSetting.ShowHealthDisplayWhenCantFail, true);
+            SetDefault(OsuSetting.FadePlayfieldWhenHealthLow, true);
+            SetDefault(OsuSetting.KeyOverlay, false);
+            SetDefault(OsuSetting.PositionalHitSounds, true);
+            SetDefault(OsuSetting.AlwaysPlayFirstComboBreak, true);
+            SetDefault(OsuSetting.ScoreMeter, ScoreMeterType.HitErrorBoth);
 
-            Set(OsuSetting.FloatingComments, false);
+            SetDefault(OsuSetting.FloatingComments, false);
 
-            Set(OsuSetting.ScoreDisplayMode, ScoringMode.Standardised);
+            SetDefault(OsuSetting.ScoreDisplayMode, ScoringMode.Standardised);
 
-            Set(OsuSetting.IncreaseFirstObjectVisibility, true);
-            Set(OsuSetting.GameplayDisableWinKey, true);
+            SetDefault(OsuSetting.IncreaseFirstObjectVisibility, true);
+            SetDefault(OsuSetting.GameplayDisableWinKey, true);
 
             // Update
-            Set(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
+            SetDefault(OsuSetting.ReleaseStream, ReleaseStream.Lazer);
 
-            Set(OsuSetting.Version, string.Empty);
+            SetDefault(OsuSetting.Version, string.Empty);
 
-            Set(OsuSetting.ScreenshotFormat, ScreenshotFormat.Jpg);
-            Set(OsuSetting.ScreenshotCaptureMenuCursor, false);
+            SetDefault(OsuSetting.ScreenshotFormat, ScreenshotFormat.Jpg);
+            SetDefault(OsuSetting.ScreenshotCaptureMenuCursor, false);
 
-            Set(OsuSetting.SongSelectRightMouseScroll, false);
+            SetDefault(OsuSetting.SongSelectRightMouseScroll, false);
 
-            Set(OsuSetting.Scaling, ScalingMode.Off);
+            SetDefault(OsuSetting.Scaling, ScalingMode.Off);
 
-            Set(OsuSetting.ScalingSizeX, 0.8f, 0.2f, 1f);
-            Set(OsuSetting.ScalingSizeY, 0.8f, 0.2f, 1f);
+            SetDefault(OsuSetting.ScalingSizeX, 0.8f, 0.2f, 1f);
+            SetDefault(OsuSetting.ScalingSizeY, 0.8f, 0.2f, 1f);
 
-            Set(OsuSetting.ScalingPositionX, 0.5f, 0f, 1f);
-            Set(OsuSetting.ScalingPositionY, 0.5f, 0f, 1f);
+            SetDefault(OsuSetting.ScalingPositionX, 0.5f, 0f, 1f);
+            SetDefault(OsuSetting.ScalingPositionY, 0.5f, 0f, 1f);
 
-            Set(OsuSetting.UIScale, 1f, 0.8f, 1.6f, 0.01f);
+            SetDefault(OsuSetting.UIScale, 1f, 0.8f, 1.6f, 0.01f);
 
-            Set(OsuSetting.UIHoldActivationDelay, 200f, 0f, 500f, 50f);
+            SetDefault(OsuSetting.UIHoldActivationDelay, 200f, 0f, 500f, 50f);
 
-            Set(OsuSetting.IntroSequence, IntroSequence.Triangles);
+            SetDefault(OsuSetting.IntroSequence, IntroSequence.Triangles);
 
-            Set(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin);
-            Set(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Sometimes);
+            SetDefault(OsuSetting.MenuBackgroundSource, BackgroundSource.Skin);
+            SetDefault(OsuSetting.SeasonalBackgroundMode, SeasonalBackgroundMode.Sometimes);
 
-            Set(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Full);
+            SetDefault(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Full);
 
-            Set(OsuSetting.EditorWaveformOpacity, 1f);
+            SetDefault(OsuSetting.EditorWaveformOpacity, 1f);
         }
 
         public OsuConfigManager(Storage storage)

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -14,10 +14,10 @@ namespace osu.Game.Configuration
     {
         protected override void InitialiseDefaults()
         {
-            Set(Static.LoginOverlayDisplayed, false);
-            Set(Static.MutedAudioNotificationShownOnce, false);
-            Set(Static.LastHoverSoundPlaybackTime, (double?)null);
-            Set<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
+            SetDefault(Static.LoginOverlayDisplayed, false);
+            SetDefault(Static.MutedAudioNotificationShownOnce, false);
+            SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null);
+            SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
     }
 

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Humanizer;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
@@ -162,7 +163,7 @@ namespace osu.Game.Configuration
                     {
                         var val = property.GetValue(obj);
                         string description = (val as IHasDescription)?.Description ?? string.Empty;
-                        yield return (new SettingSourceAttribute(property.Name, description), property);
+                        yield return (new SettingSourceAttribute(property.Name.Humanize(), description), property);
                     }
                 }
             }

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -63,15 +63,20 @@ namespace osu.Game.Configuration
 
     public static class SettingSourceExtensions
     {
-        public static IEnumerable<Drawable> CreateSettingsControls(this object obj) => createSettingsControls(obj, obj.GetOrderedSettingsSourceProperties());
+        public static IReadOnlyList<Drawable> CreateSettingsControls(this object obj, bool includeDisabled = true) =>
+            createSettingsControls(obj, obj.GetOrderedSettingsSourceProperties(), includeDisabled).ToArray();
 
-        public static IEnumerable<Drawable> CreateSettingsControlsFromAllBindables(this object obj) => createSettingsControls(obj, obj.GetSettingsSourcePropertiesFromBindables());
+        public static IReadOnlyList<Drawable> CreateSettingsControlsFromAllBindables(this object obj, bool includeDisabled = true) =>
+            createSettingsControls(obj, obj.GetSettingsSourcePropertiesFromBindables(), includeDisabled).ToArray();
 
-        private static IEnumerable<Drawable> createSettingsControls(object obj, IEnumerable<(SettingSourceAttribute, PropertyInfo)> sourceAttribs)
+        private static IEnumerable<Drawable> createSettingsControls(object obj, IEnumerable<(SettingSourceAttribute, PropertyInfo)> sourceAttribs, bool includeDisabled = true)
         {
             foreach (var (attr, property) in sourceAttribs)
             {
                 object value = property.GetValue(obj);
+
+                if ((value as IBindable)?.Disabled == true)
+                    continue;
 
                 switch (value)
                 {

--- a/osu.Game/Configuration/StorageConfigManager.cs
+++ b/osu.Game/Configuration/StorageConfigManager.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Configuration
         {
             base.InitialiseDefaults();
 
-            Set(StorageConfig.FullPath, string.Empty);
+            SetDefault(StorageConfig.FullPath, string.Empty);
         }
     }
 

--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -58,7 +58,7 @@ namespace osu.Game.IO
         /// </summary>
         public void ResetCustomStoragePath()
         {
-            storageConfig.Set(StorageConfig.FullPath, string.Empty);
+            storageConfig.SetValue(StorageConfig.FullPath, string.Empty);
             storageConfig.Save();
 
             ChangeTargetStorage(defaultStorage);
@@ -103,7 +103,7 @@ namespace osu.Game.IO
         public override void Migrate(Storage newStorage)
         {
             base.Migrate(newStorage);
-            storageConfig.Set(StorageConfig.FullPath, newStorage.GetFullPath("."));
+            storageConfig.SetValue(StorageConfig.FullPath, newStorage.GetFullPath("."));
             storageConfig.Save();
         }
     }

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Online.API
             thread.Start();
         }
 
-        private void onTokenChanged(ValueChangedEvent<OAuthToken> e) => config.Set(OsuSetting.Token, config.Get<bool>(OsuSetting.SavePassword) ? authentication.TokenString : string.Empty);
+        private void onTokenChanged(ValueChangedEvent<OAuthToken> e) => config.SetValue(OsuSetting.Token, config.Get<bool>(OsuSetting.SavePassword) ? authentication.TokenString : string.Empty);
 
         internal new void Schedule(Action action) => base.Schedule(action);
 
@@ -134,7 +134,7 @@ namespace osu.Game.Online.API
                         state.Value = APIState.Connecting;
 
                         // save the username at this point, if the user requested for it to be.
-                        config.Set(OsuSetting.Username, config.Get<bool>(OsuSetting.SaveUsername) ? ProvidedUsername : string.Empty);
+                        config.SetValue(OsuSetting.Username, config.Get<bool>(OsuSetting.SaveUsername) ? ProvidedUsername : string.Empty);
 
                         if (!authentication.HasValidAccessToken && !authentication.AuthenticateWithLogin(ProvidedUsername, password))
                         {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -880,8 +880,7 @@ namespace osu.Game
             switch (action)
             {
                 case GlobalAction.ResetInputSettings:
-                    frameworkConfig.GetBindable<string>(FrameworkSetting.IgnoredInputHandlers).SetDefault();
-                    frameworkConfig.GetBindable<double>(FrameworkSetting.CursorSensitivity).SetDefault();
+                    Host.ResetInputHandlers();
                     frameworkConfig.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode).SetDefault();
                     return true;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
@@ -5,17 +5,17 @@ using osu.Framework.Graphics;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
 {
-    public class KeyboardSettings : SettingsSubsection
+    public class BindingSettings : SettingsSubsection
     {
-        protected override string Header => "Keyboard";
+        protected override string Header => "Shortcut and gameplay bindings";
 
-        public KeyboardSettings(KeyBindingPanel keyConfig)
+        public BindingSettings(KeyBindingPanel keyConfig)
         {
             Children = new Drawable[]
             {
                 new SettingsButton
                 {
-                    Text = "Key configuration",
+                    Text = "Configure",
                     TooltipText = "change global shortcut keys and gameplay bindings",
                     Action = keyConfig.ToggleVisibility
                 },

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Handlers.Mouse;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
@@ -14,35 +14,39 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public class MouseSettings : SettingsSubsection
     {
+        private readonly MouseHandler mouseHandler;
+
         protected override string Header => "Mouse";
 
-        private readonly BindableBool rawInputToggle = new BindableBool();
-
-        private Bindable<double> configSensitivity;
+        private Bindable<double> handlerSensitivity;
 
         private Bindable<double> localSensitivity;
 
-        private Bindable<string> ignoredInputHandlers;
-
         private Bindable<WindowMode> windowMode;
         private SettingsEnumDropdown<OsuConfineMouseMode> confineMouseModeSetting;
+        private Bindable<bool> relativeMode;
+
+        public MouseSettings(MouseHandler mouseHandler)
+        {
+            this.mouseHandler = mouseHandler;
+        }
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager osuConfig, FrameworkConfigManager config)
         {
             // use local bindable to avoid changing enabled state of game host's bindable.
-            configSensitivity = config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
-            localSensitivity = configSensitivity.GetUnboundCopy();
+            handlerSensitivity = mouseHandler.Sensitivity.GetBoundCopy();
+            localSensitivity = handlerSensitivity.GetUnboundCopy();
 
+            relativeMode = mouseHandler.UseRelativeMode.GetBoundCopy();
             windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
-            ignoredInputHandlers = config.GetBindable<string>(FrameworkSetting.IgnoredInputHandlers);
 
             Children = new Drawable[]
             {
                 new SettingsCheckbox
                 {
-                    LabelText = "Raw input",
-                    Current = rawInputToggle
+                    LabelText = "High precision mouse",
+                    Current = relativeMode
                 },
                 new SensitivitySetting
                 {
@@ -76,7 +80,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.LoadComplete();
 
-            configSensitivity.BindValueChanged(val =>
+            relativeMode.BindValueChanged(relative => localSensitivity.Disabled = !relative.NewValue, true);
+
+            handlerSensitivity.BindValueChanged(val =>
             {
                 var disabled = localSensitivity.Disabled;
 
@@ -85,7 +91,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 localSensitivity.Disabled = disabled;
             }, true);
 
-            localSensitivity.BindValueChanged(val => configSensitivity.Value = val.NewValue);
+            localSensitivity.BindValueChanged(val => handlerSensitivity.Value = val.NewValue);
 
             windowMode.BindValueChanged(mode =>
             {
@@ -102,32 +108,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     confineMouseModeSetting.TooltipText = string.Empty;
                 }
             }, true);
-
-            if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
-            {
-                rawInputToggle.Disabled = true;
-                localSensitivity.Disabled = true;
-            }
-            else
-            {
-                rawInputToggle.ValueChanged += enabled =>
-                {
-                    // this is temporary until we support per-handler settings.
-                    const string raw_mouse_handler = @"OsuTKRawMouseHandler";
-                    const string standard_mouse_handlers = @"OsuTKMouseHandler MouseHandler";
-
-                    ignoredInputHandlers.Value = enabled.NewValue ? standard_mouse_handlers : raw_mouse_handler;
-                };
-
-                ignoredInputHandlers.ValueChanged += handler =>
-                {
-                    bool raw = !handler.NewValue.Contains("Raw");
-                    rawInputToggle.Value = raw;
-                    localSensitivity.Disabled = !raw;
-                };
-
-                ignoredInputHandlers.TriggerChange();
-            }
         }
 
         private class SensitivitySetting : SettingsSlider<double, SensitivitySlider>
@@ -141,7 +121,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private class SensitivitySlider : OsuSliderBar<double>
         {
-            public override string TooltipText => Current.Disabled ? "enable raw input to adjust sensitivity" : $"{base.TooltipText}x";
+            public override string TooltipText => Current.Disabled ? "enable high precision mouse to adjust sensitivity" : $"{base.TooltipText}x";
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -53,11 +53,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     LabelText = "Cursor sensitivity",
                     Current = localSensitivity
                 },
-                new SettingsCheckbox
-                {
-                    LabelText = "Map absolute input to window",
-                    Current = config.GetBindable<bool>(FrameworkSetting.MapAbsoluteInputToWindow)
-                },
                 confineMouseModeSetting = new SettingsEnumDropdown<OsuConfineMouseMode>
                 {
                     LabelText = "Confine mouse cursor to window",

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -9,7 +9,6 @@ using osu.Framework.Input.Handlers.Joystick;
 using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Platform;
-using osu.Game.Configuration;
 using osu.Game.Overlays.Settings.Sections.Input;
 
 namespace osu.Game.Overlays.Settings.Sections
@@ -70,13 +69,6 @@ namespace osu.Game.Overlays.Settings.Sections
                     return null;
             }
 
-            var settingsControls = handler.CreateSettingsControlsFromAllBindables(false);
-
-            if (settingsControls.Count == 0)
-                return null;
-
-            section.AddRange(settingsControls);
-
             return section;
         }
 
@@ -87,6 +79,19 @@ namespace osu.Game.Overlays.Settings.Sections
             public HandlerSection(InputHandler handler)
             {
                 this.handler = handler;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Children = new Drawable[]
+                {
+                    new SettingsCheckbox
+                    {
+                        LabelText = "Enabled",
+                        Current = handler.Enabled
+                    },
+                };
             }
 
             protected override string Header => handler.Description;

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -5,6 +5,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Handlers;
+using osu.Framework.Input.Handlers.Joystick;
+using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Platform;
 using osu.Game.Configuration;
@@ -50,11 +52,6 @@ namespace osu.Game.Overlays.Settings.Sections
 
         private SettingsSubsection createSectionFor(InputHandler handler)
         {
-            var settingsControls = handler.CreateSettingsControlsFromAllBindables(false);
-
-            if (settingsControls.Count == 0)
-                return null;
-
             SettingsSubsection section;
 
             switch (handler)
@@ -63,10 +60,20 @@ namespace osu.Game.Overlays.Settings.Sections
                     section = new MouseSettings(mh);
                     break;
 
-                default:
+                // whitelist the handlers which should be displayed to avoid any weird cases of users touching settings they shouldn't.
+                case JoystickHandler _:
+                case MidiHandler _:
                     section = new HandlerSection(handler);
                     break;
+
+                default:
+                    return null;
             }
+
+            var settingsControls = handler.CreateSettingsControlsFromAllBindables(false);
+
+            if (settingsControls.Count == 0)
+                return null;
 
             section.AddRange(settingsControls);
 

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -1,15 +1,25 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Handlers;
+using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform;
+using osu.Game.Configuration;
 using osu.Game.Overlays.Settings.Sections.Input;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
     public class InputSection : SettingsSection
     {
+        private readonly KeyBindingPanel keyConfig;
+
         public override string Header => "Input";
+
+        [Resolved]
+        private GameHost host { get; set; }
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
@@ -18,11 +28,61 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public InputSection(KeyBindingPanel keyConfig)
         {
+            this.keyConfig = keyConfig;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             Children = new Drawable[]
             {
-                new MouseSettings(),
-                new KeyboardSettings(keyConfig),
+                new BindingSettings(keyConfig),
             };
+
+            foreach (var handler in host.AvailableInputHandlers)
+            {
+                var handlerSection = createSectionFor(handler);
+
+                if (handlerSection != null)
+                    Add(handlerSection);
+            }
+        }
+
+        private SettingsSubsection createSectionFor(InputHandler handler)
+        {
+            var settingsControls = handler.CreateSettingsControlsFromAllBindables(false);
+
+            if (settingsControls.Count == 0)
+                return null;
+
+            SettingsSubsection section;
+
+            switch (handler)
+            {
+                case MouseHandler mh:
+                    section = new MouseSettings(mh);
+                    break;
+
+                default:
+                    section = new HandlerSection(handler);
+                    break;
+            }
+
+            section.AddRange(settingsControls);
+
+            return section;
+        }
+
+        private class HandlerSection : SettingsSubsection
+        {
+            private readonly InputHandler handler;
+
+            public HandlerSection(InputHandler handler)
+            {
+                this.handler = handler;
+            }
+
+            protected override string Header => handler.Description;
         }
     }
 }

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Updater
 
             // debug / local compilations will reset to a non-release string.
             // can be useful to check when an install has transitioned between release and otherwise (see OsuConfigManager's migrations).
-            config.Set(OsuSetting.Version, version);
+            config.SetValue(OsuSetting.Version, version);
         }
 
         private readonly object updateTaskLock = new object();

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.309.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.317.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.211.1" />
     <PackageReference Include="Sentry" Version="3.0.7" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -29,13 +29,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.309.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.211.1" />
     <PackageReference Include="Sentry" Version="3.0.7" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\osu-framework\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
 </Project>

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -29,11 +29,13 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.309.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.211.1" />
     <PackageReference Include="Sentry" Version="3.0.7" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\osu-framework\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
 </Project>

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.309.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.317.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.211.1" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -91,7 +91,7 @@
     <PackageReference Include="DiffPlex" Version="1.6.3" />
     <PackageReference Include="Humanizer" Version="2.8.26" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.309.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.317.0" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <ProjectReference Include="../../osu-framework/osu.Framework.iOS/osu.Framework.iOS.csproj" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.309.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.211.1" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <ProjectReference Include="../../osu-framework/osu.Framework/osu.Framework.csproj" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.309.0" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.309.0" />
+    <ProjectReference Include="../../osu-framework/osu.Framework.iOS/osu.Framework.iOS.csproj" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.211.1" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.309.0" />
+    <ProjectReference Include="../../osu-framework/osu.Framework/osu.Framework.csproj" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />

--- a/osu.sln
+++ b/osu.sln
@@ -66,12 +66,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Game.Benchmarks", "osu.Game.Benchmarks\osu.Game.Benchmarks.csproj", "{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework", "..\osu-framework\osu.Framework\osu.Framework.csproj", "{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.iOS", "..\osu-framework\osu.Framework.iOS\osu.Framework.iOS.csproj", "{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.NativeLibs", "..\osu-framework\osu.Framework.NativeLibs\osu.Framework.NativeLibs.csproj", "{500039B3-0706-40C3-B6E7-1FD9187644A5}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -418,42 +412,6 @@ Global
 		{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}.Release|iPhone.Build.0 = Release|Any CPU
 		{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhone.Build.0 = Release|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhone.Build.0 = Release|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhone.Build.0 = Release|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/osu.sln
+++ b/osu.sln
@@ -66,6 +66,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Game.Benchmarks", "osu.Game.Benchmarks\osu.Game.Benchmarks.csproj", "{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework", "..\osu-framework\osu.Framework\osu.Framework.csproj", "{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.iOS", "..\osu-framework\osu.Framework.iOS\osu.Framework.iOS.csproj", "{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.NativeLibs", "..\osu-framework\osu.Framework.NativeLibs\osu.Framework.NativeLibs.csproj", "{500039B3-0706-40C3-B6E7-1FD9187644A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -412,6 +418,42 @@ Global
 		{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}.Release|iPhone.Build.0 = Release|Any CPU
 		{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{93632F2D-2BB4-46C1-A7B8-F8CF2FB27118}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhone.Build.0 = Release|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7EBA330C-6DD9-4F30-9332-6542D86D5BE1}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhone.Build.0 = Release|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7A6EEFF0-760C-4EE5-BB5E-101E7D013392}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhone.Build.0 = Release|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{500039B3-0706-40C3-B6E7-1FD9187644A5}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This updates osu! to handle the changes we've made framework-side to input handling in general.

- No longer uses obsoleted `FrameworkConfig` settings, switching to `MouseHandler` directly.
- Experimentally uses reflection to grab any available options from `InputHandlers`. Note that this isn't really used for more than the `Enabled` state of some auxilliary handlers right now, but it's pretty low maintenance so figured we might as well leave it in for now. I originally intended on having this handle all exposed settings, but after visiting `MouseSubsection` it was clear that we have quite a bit of custom requirements when it comes to handling the bindables (ie. delaying the update of the sensitivity value during a drag).
- Updates the method we use to reset input settings via hotkey.
- Removes remants of osuTK to allow for framework bump.
- [x] Depends on https://github.com/ppy/osu-framework/pull/4272 (loosely, for display naming purposes).
- [x] Depends on https://github.com/ppy/osu-framework/pull/4274
- [x] Depends on https://github.com/ppy/osu-framework/pull/4271 (for persistence).
- [x] Depends on framework bump.