### PR TITLE
Hide toolbar forever when the user hides it

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -229,6 +229,35 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("settings displayed", () => Game.Settings.State.Value == Visibility.Visible);
         }
 
+        [Test]
+        public void TestToolbarHiddenByUser()
+        {
+            AddStep("Enter menu", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("Wait for toolbar to load", () => Game.Toolbar.IsLoaded);
+
+            AddStep("Hide toolbar", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.T);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            pushEscape();
+
+            AddStep("Enter menu", () => InputManager.Key(Key.Enter));
+
+            AddAssert("Toolbar is hidden", () => Game.Toolbar.State.Value == Visibility.Hidden);
+
+            AddStep("Enter song select", () =>
+            {
+                InputManager.Key(Key.Enter);
+                InputManager.Key(Key.Enter);
+            });
+
+            AddAssert("Toolbar is hidden", () => Game.Toolbar.State.Value == Visibility.Hidden);
+        }
+
         private void pushEscape() =>
             AddStep("Press escape", () => InputManager.Key(Key.Escape));
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -983,7 +983,7 @@ namespace osu.Game
 
                 if (newOsuScreen.HideOverlaysOnEnter)
                     CloseAllOverlays();
-                else if (!Toolbar.HiddenByUser)
+                else
                     Toolbar.Show();
 
                 if (newOsuScreen.AllowBackButton)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -983,7 +983,7 @@ namespace osu.Game
 
                 if (newOsuScreen.HideOverlaysOnEnter)
                     CloseAllOverlays();
-                else
+                else if (!Toolbar.HiddenByUser)
                     Toolbar.Show();
 
                 if (newOsuScreen.AllowBackButton)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -885,10 +885,6 @@ namespace osu.Game
                     frameworkConfig.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode).SetDefault();
                     return true;
 
-                case GlobalAction.ToggleToolbar:
-                    Toolbar.ToggleVisibility();
-                    return true;
-
                 case GlobalAction.ToggleGameplayMouseButtons:
                     LocalConfig.Set(OsuSetting.MouseDisableButtons, !LocalConfig.Get<bool>(OsuSetting.MouseDisableButtons));
                     return true;

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Overlays.Toolbar
         public const float HEIGHT = 40;
         public const float TOOLTIP_HEIGHT = 30;
 
+        /// <summary>
+        /// Whether the user hid this <see cref="Toolbar"/> with <see cref="GlobalAction.ToggleToolbar"/>.
+        /// </summary>
         public bool HiddenByUser;
 
         public Action OnHome;

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -13,10 +13,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets;
+using osu.Framework.Input.Bindings;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Overlays.Toolbar
 {
-    public class Toolbar : VisibilityContainer
+    public class Toolbar : VisibilityContainer, IKeyBindingHandler<GlobalAction>
     {
         public const float HEIGHT = 40;
         public const float TOOLTIP_HEIGHT = 30;
@@ -30,7 +32,7 @@ namespace osu.Game.Overlays.Toolbar
 
         protected readonly IBindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>(OverlayActivation.All);
 
-        // Toolbar components like RulesetSelector should receive keyboard input events even when the toolbar is hidden.
+        // Toolbar and its components need keyboard input even when hidden.
         public override bool PropagateNonPositionalInputSubTree => true;
 
         public Toolbar()
@@ -163,6 +165,22 @@ namespace osu.Game.Overlays.Toolbar
 
             this.MoveToY(-DrawSize.Y, transition_time, Easing.OutQuint);
             this.FadeOut(transition_time, Easing.InQuint);
+        }
+
+        public bool OnPressed(GlobalAction action)
+        {
+            switch (action)
+            {
+                case GlobalAction.ToggleToolbar:
+                    ToggleVisibility();
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(GlobalAction action)
+        {
         }
     }
 }

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Overlays.Toolbar
 
         /// <summary>
         /// Whether the user hid this <see cref="Toolbar"/> with <see cref="GlobalAction.ToggleToolbar"/>.
+        /// In this state, automatic toggles should not occur, respecting the user's preference to have no toolbar.
         /// </summary>
         private bool hiddenByUser;
 

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -28,8 +28,6 @@ namespace osu.Game.Overlays.Toolbar
         /// </summary>
         private bool hiddenByUser;
 
-        private bool userToggled;
-
         public Action OnHome;
 
         private ToolbarUserButton userButton;
@@ -151,9 +149,9 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override void UpdateState(ValueChangedEvent<Visibility> state)
         {
-            var blockShow = !userToggled && hiddenByUser;
+            bool blockShow = hiddenByUser || OverlayActivationMode.Value == OverlayActivation.Disabled;
 
-            if (state.NewValue == Visibility.Visible && (OverlayActivationMode.Value == OverlayActivation.Disabled || blockShow))
+            if (state.NewValue == Visibility.Visible && blockShow)
             {
                 State.Value = Visibility.Hidden;
                 return;
@@ -184,10 +182,8 @@ namespace osu.Game.Overlays.Toolbar
             switch (action)
             {
                 case GlobalAction.ToggleToolbar:
-                    userToggled = true;
+                    hiddenByUser = State.Value == Visibility.Visible; // set before toggling to allow the operation to always succeed.
                     ToggleVisibility();
-                    hiddenByUser = State.Value == Visibility.Hidden;
-                    userToggled = false;
                     return true;
             }
 

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Overlays.Toolbar
         public const float HEIGHT = 40;
         public const float TOOLTIP_HEIGHT = 30;
 
+        public bool HiddenByUser;
+
         public Action OnHome;
 
         private ToolbarUserButton userButton;
@@ -169,10 +171,14 @@ namespace osu.Game.Overlays.Toolbar
 
         public bool OnPressed(GlobalAction action)
         {
+            if (OverlayActivationMode.Value == OverlayActivation.Disabled)
+                return false;
+
             switch (action)
             {
                 case GlobalAction.ToggleToolbar:
                     ToggleVisibility();
+                    HiddenByUser = State.Value == Visibility.Hidden;
                     return true;
             }
 

--- a/osu.Game/Overlays/Toolbar/Toolbar.cs
+++ b/osu.Game/Overlays/Toolbar/Toolbar.cs
@@ -26,7 +26,9 @@ namespace osu.Game.Overlays.Toolbar
         /// <summary>
         /// Whether the user hid this <see cref="Toolbar"/> with <see cref="GlobalAction.ToggleToolbar"/>.
         /// </summary>
-        public bool HiddenByUser;
+        private bool hiddenByUser;
+
+        private bool userToggled;
 
         public Action OnHome;
 
@@ -149,7 +151,9 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override void UpdateState(ValueChangedEvent<Visibility> state)
         {
-            if (state.NewValue == Visibility.Visible && OverlayActivationMode.Value == OverlayActivation.Disabled)
+            var blockShow = !userToggled && hiddenByUser;
+
+            if (state.NewValue == Visibility.Visible && (OverlayActivationMode.Value == OverlayActivation.Disabled || blockShow))
             {
                 State.Value = Visibility.Hidden;
                 return;
@@ -180,8 +184,10 @@ namespace osu.Game.Overlays.Toolbar
             switch (action)
             {
                 case GlobalAction.ToggleToolbar:
+                    userToggled = true;
                     ToggleVisibility();
-                    HiddenByUser = State.Value == Visibility.Hidden;
+                    hiddenByUser = State.Value == Visibility.Hidden;
+                    userToggled = false;
                     return true;
             }
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -352,8 +352,7 @@ namespace osu.Game.Screens.Menu
                                 if (impact)
                                     logo.Impact();
 
-                                if (game?.Toolbar.HiddenByUser == false)
-                                    game.Toolbar.Show();
+                                game?.Toolbar.Show();
                             }, 200);
                             break;
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -352,7 +352,8 @@ namespace osu.Game.Screens.Menu
                                 if (impact)
                                     logo.Impact();
 
-                                game?.Toolbar.Show();
+                                if (game?.Toolbar.HiddenByUser == false)
+                                    game.Toolbar.Show();
                             }, 200);
                             break;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/8052.

Simple implementation by adding a `Toolbar.HiddenByUser` condition to every `Toolbar.Show()`. Not sure if the state should be kept per session.