### PR TITLE
Fix crashes when accessing changelog too early in game startup

### DIFF
--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Overlays
                 await API.PerformAsync(req).ConfigureAwait(false);
 
                 return tcs.Task;
-            });
+            }).Unwrap();
         }
 
         private CancellationTokenSource loadContentCancellation;

--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Overlays
 {
     public class ChangelogOverlay : OnlineOverlay<ChangelogHeader>
     {
+        public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
+
         public readonly Bindable<APIChangelogBuild> Current = new Bindable<APIChangelogBuild>();
 
         private Sample sampleBack;
@@ -126,8 +128,11 @@ namespace osu.Game.Overlays
 
         private Task initialFetchTask;
 
-        private void performAfterFetch(Action action) => fetchListing()?.ContinueWith(_ =>
-            Schedule(action), TaskContinuationOptions.OnlyOnRanToCompletion);
+        private void performAfterFetch(Action action) => Schedule(() =>
+        {
+            fetchListing()?.ContinueWith(_ =>
+                Schedule(action), TaskContinuationOptions.OnlyOnRanToCompletion);
+        });
 
         private Task fetchListing()
         {


### PR DESCRIPTION
This fixes two separate issues, both causing crashes in the same kind of scenarios:

- It was possible to trigger a `Show` operation before DI has run, resulting in a request being run against a null `API`.
- If slightly later, it was possible for the process to start and run with `ContinueWith`. Unfortunately, we were returning the wrong task, meaning the continuation would usually run before the actual task, and the fields which are expected to be populated were not.

Closes https://github.com/ppy/osu/issues/12000.