### PR TITLE
Fix disable mouse buttons setting not showing default indicator when using keybind

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -887,7 +887,6 @@ namespace osu.Game
 
                 case GlobalAction.ToggleGameplayMouseButtons:
                     var mouseDisableButtons = LocalConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons);
-
                     mouseDisableButtons.Value = !mouseDisableButtons.Value;
                     return true;
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -886,7 +886,9 @@ namespace osu.Game
                     return true;
 
                 case GlobalAction.ToggleGameplayMouseButtons:
-                    LocalConfig.Set(OsuSetting.MouseDisableButtons, !LocalConfig.Get<bool>(OsuSetting.MouseDisableButtons));
+                    var mouseDisableButtons = LocalConfig.GetBindable<bool>(OsuSetting.MouseDisableButtons);
+
+                    mouseDisableButtons.Value = !mouseDisableButtons.Value;
                     return true;
 
                 case GlobalAction.RandomSkin:


### PR DESCRIPTION
The problem is that `ConfigManager`'s `Set` changes the default value to the changed one.

https://github.com/ppy/osu-framework/blob/1a0a270c9c933fdd469398b2db4086bef56b7101/osu.Framework/Configuration/ConfigManager.cs#L108-L125

| Before | After |
| --- | --- |
|  ![f5QmEntIlj](https://user-images.githubusercontent.com/35318437/111109570-3fbd1e00-8518-11eb-8bee-d38e58310774.gif) | ![4XNiyeY1HD](https://user-images.githubusercontent.com/35318437/111109787-ab06f000-8518-11eb-917d-60443f014bcd.gif) |