### PR TITLE
Limit EditorClock to be within the current track's time.

### DIFF
--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -216,7 +216,13 @@ namespace osu.Game.Screens.Edit
 
         public bool IsRunning => underlyingClock.IsRunning;
 
-        public void ProcessFrame() => underlyingClock.ProcessFrame();
+        public void ProcessFrame()
+        {
+            if (underlyingClock.CurrentTime >= TrackLength)
+                underlyingClock.Stop();
+            else
+                underlyingClock.ProcessFrame();
+        }
 
         public double ElapsedFrameTime => underlyingClock.ElapsedFrameTime;
 


### PR DESCRIPTION
* Fixes https://github.com/ppy/osu/issues/8134
* Supersedes / closes #8238

Adds a check in `EditorClock.ProcessFrame` to check whether the current time is still within the track's length. Do note as per discussion in Discord that It doesn't follow storyboards for now as the design tab is still unimplemented.