### PR TITLE
Don't fill beatmap metadata with template values on creating a new beatmap

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -113,8 +113,6 @@ namespace osu.Game.Beatmaps
         {
             var metadata = new BeatmapMetadata
             {
-                Artist = "artist",
-                Title = "title",
                 Author = user,
             };
 
@@ -128,7 +126,6 @@ namespace osu.Game.Beatmaps
                         BaseDifficulty = new BeatmapDifficulty(),
                         Ruleset = ruleset,
                         Metadata = metadata,
-                        Version = "difficulty"
                     }
                 }
             };

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Graphics.UserInterfaceV2
@@ -52,6 +53,14 @@ namespace osu.Game.Graphics.UserInterfaceV2
             RelativeSizeAxes = Axes.X,
             CornerRadius = CORNER_RADIUS,
         };
+
+        public override bool AcceptsFocus => true;
+
+        protected override void OnFocus(FocusEvent e)
+        {
+            base.OnFocus(e);
+            GetContainingInputManager().ChangeFocus(Component);
+        }
 
         protected override OsuTextBox CreateComponent() => CreateTextBox().With(t =>
         {

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -56,6 +56,14 @@ namespace osu.Game.Screens.Edit.Setup
                 item.OnCommit += onCommit;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (string.IsNullOrEmpty(artistTextBox.Current.Value))
+                GetContainingInputManager().ChangeFocus(artistTextBox);
+        }
+
         private void onCommit(TextBox sender, bool newText)
         {
             if (!newText) return;

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -28,25 +28,25 @@ namespace osu.Game.Screens.Edit.Setup
                 },
                 artistTextBox = new LabelledTextBox
                 {
-                    PlaceholderText = "Artist",
+                    Label = "Artist",
                     Current = { Value = Beatmap.Metadata.Artist },
                     TabbableContentContainer = this
                 },
                 titleTextBox = new LabelledTextBox
                 {
-                    PlaceholderText = "Title",
+                    Label = "Title",
                     Current = { Value = Beatmap.Metadata.Title },
                     TabbableContentContainer = this
                 },
                 creatorTextBox = new LabelledTextBox
                 {
-                    PlaceholderText = "Creator",
+                    Label = "Creator",
                     Current = { Value = Beatmap.Metadata.AuthorString },
                     TabbableContentContainer = this
                 },
                 difficultyTextBox = new LabelledTextBox
                 {
-                    PlaceholderText = "Difficulty Name",
+                    Label = "Difficulty Name",
                     Current = { Value = Beatmap.BeatmapInfo.Version },
                     TabbableContentContainer = this
                 },

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -28,25 +28,25 @@ namespace osu.Game.Screens.Edit.Setup
                 },
                 artistTextBox = new LabelledTextBox
                 {
-                    Label = "Artist",
+                    PlaceholderText = "Artist",
                     Current = { Value = Beatmap.Metadata.Artist },
                     TabbableContentContainer = this
                 },
                 titleTextBox = new LabelledTextBox
                 {
-                    Label = "Title",
+                    PlaceholderText = "Title",
                     Current = { Value = Beatmap.Metadata.Title },
                     TabbableContentContainer = this
                 },
                 creatorTextBox = new LabelledTextBox
                 {
-                    Label = "Creator",
+                    PlaceholderText = "Creator",
                     Current = { Value = Beatmap.Metadata.AuthorString },
                     TabbableContentContainer = this
                 },
                 difficultyTextBox = new LabelledTextBox
                 {
-                    Label = "Difficulty Name",
+                    PlaceholderText = "Difficulty Name",
                     Current = { Value = Beatmap.BeatmapInfo.Version },
                     TabbableContentContainer = this
                 },


### PR DESCRIPTION
This converts the textboxes to have placeholders rather than prefilled values. It also redirects focus to the first textbox to hint to the user that the data needs to be filled.

Closes https://github.com/ppy/osu/issues/10589.