### PR TITLE
Fix converted mania scores not accounting for GREATs

### DIFF
--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -164,7 +164,9 @@ namespace osu.Game.Scoring
                 {
                     if (score.RulesetID == 3)
                     {
-                        // Recalculate mania's accuracy based on hit statistics.
+                        // In osu!stable, a full-GREAT score has 100% accuracy in mania. Along with a full combo, the score becomes indistinguishable from a full-PERFECT score.
+                        // To get around this, recalculate accuracy based on the hit statistics.
+                        // Note: This cannot be applied universally to all legacy scores, as some rulesets (e.g. catch) group multiple judgements together.
                         double maxBaseScore = score.Statistics.Select(kvp => kvp.Value).Sum() * Judgement.ToNumericResult(HitResult.Perfect);
                         double baseScore = score.Statistics.Select(kvp => Judgement.ToNumericResult(kvp.Key) * kvp.Value).Sum();
                         if (maxBaseScore > 0)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12032

I'm not sure whether to put this code where I've put it, but it's part of a "legacy" code path, so I think it's reasonable?
Tested on https://osu.ppy.sh/beatmapsets/571547#mania/1211270.

Before:
![image](https://user-images.githubusercontent.com/1329837/111611663-0b9b7300-8820-11eb-8178-db85a1534c72.png)

After:
![image](https://user-images.githubusercontent.com/1329837/111611534-e870c380-881f-11eb-8e12-91f164213bbb.png)

Note that combo calculation is still wrong as mentioned in the above issue, but I'm not sure about changing it just yet. Maybe when the spotlights iteration ends (don't know when) as it's a bit of a breaking change.