### PR TITLE
Avoid potential crash if an overlay is toggled before it has been loaded

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -756,11 +756,11 @@ namespace osu.Game
 
         private void showOverlayAboveOthers(OverlayContainer overlay, OverlayContainer[] otherOverlays)
         {
+            otherOverlays.Where(o => o != overlay).ForEach(o => o.Hide());
+
             // generally shouldn't ever hit this state, but protects against a crash on attempting to change ChildDepth.
             if (overlay.LoadState < LoadState.Ready)
                 return;
-
-            otherOverlays.Where(o => o != overlay).ForEach(o => o.Hide());
 
             // show above others if not visible at all, else leave at current depth.
             if (!overlay.IsPresent)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -758,13 +758,15 @@ namespace osu.Game
         {
             otherOverlays.Where(o => o != overlay).ForEach(o => o.Hide());
 
-            // generally shouldn't ever hit this state, but protects against a crash on attempting to change ChildDepth.
-            if (overlay.LoadState < LoadState.Ready)
+            // Partially visible so leave it at the current depth.
+            if (overlay.IsPresent)
                 return;
 
-            // show above others if not visible at all, else leave at current depth.
-            if (!overlay.IsPresent)
+            // Show above all other overlays.
+            if (overlay.IsLoaded)
                 overlayContent.ChangeChildDepth(overlay, (float)-Clock.CurrentTime);
+            else
+                overlay.Depth = (float)-Clock.CurrentTime;
         }
 
         private void forwardLoggedErrorsToNotifications()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -756,6 +756,10 @@ namespace osu.Game
 
         private void showOverlayAboveOthers(OverlayContainer overlay, OverlayContainer[] otherOverlays)
         {
+            // generally shouldn't ever hit this state, but protects against a crash on attempting to change ChildDepth.
+            if (overlay.LoadState < LoadState.Ready)
+                return;
+
             otherOverlays.Where(o => o != overlay).ForEach(o => o.Hide());
 
             // show above others if not visible at all, else leave at current depth.


### PR DESCRIPTION
Fixes a crash I encountered while attempting to open chat too early in game startup:

```
Unhandled exception. System.InvalidOperationException: Can not change depth of drawable which is not contained within this CompositeDrawable.
   at osu.Framework.Graphics.Containers.CompositeDrawable.ChangeInternalChildDepth(Drawable child, Single newDepth)
   at osu.Framework.Graphics.Containers.Container`1.ChangeChildDepth(T child, Single newDepth)
   at osu.Game.OsuGame.showOverlayAboveOthers(OverlayContainer overlay, OverlayContainer[] otherOverlays) in /Users/dean/Projects/osu/osu.Game/OsuGame.cs:line 763
   at osu.Game.OsuGame.<>c__DisplayClass59_4.<LoadComplete>b__29(ValueChangedEvent`1 state) in /Users/dean/Projects/osu/osu.Game/OsuGame.cs:line 732
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks)
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source)
   at osu.Framework.Bindables.Bindable`1.set_Value(T value)
   at osu.Framework.Graphics.Containers.VisibilityContainer.ToggleVisibility()
   at osu.Framework.Graphics.Containers.ClickableContainer.OnClick(ClickEvent e)
   at osu.Game.Overlays.Toolbar.ToolbarButton.OnClick(ClickEvent e) in /Users/dean/Projects/osu/osu.Game/Overlays/Toolbar/ToolbarButton.cs:line 189
   at osu.Framework.Graphics.Drawable.TriggerEvent(UIEvent e)
   at osu.Framework.Graphics.Drawable.Click()
   at osu.Game.Overlays.Toolbar.ToolbarButton.OnPressed(GlobalAction action) in /Users/dean/Projects/osu/osu.Game/Overlays/Toolbar/ToolbarButton.cs:line 211
   at osu.Framework.Input.Bindings.KeyBindingContainer`1.<>c__DisplayClass20_0.<PropagatePressed>b__1(IKeyBindingHandler`1 d)
```

I experimented with handling this in the `ToolbarOverlayToggleButton` implementation, but ended up reverting that as I wasn't sure we wanted to "cancel" the user's toggle just because the overlay wasn't loaded yet. I can imagine a scenario where the user reaches the main menu and clicks the chat toggle button, but nothing happens due to an early return.

I guess there is a potential that the ordering will be correct in such an edge case, but not sure this deserves more time unless we actually encounter that.