### PR TITLE
Increase the precision of speed multiplier to match osu-stable

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/DifficultyControlPoint.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         public readonly BindableDouble SpeedMultiplierBindable = new BindableDouble(1)
         {
-            Precision = 0.1,
+            Precision = 0.01,
             Default = 1,
             MinValue = 0.1,
             MaxValue = 10

--- a/osu.Game/Screens/Edit/Timing/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Timing/DifficultySection.cs
@@ -18,7 +18,8 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 multiplierSlider = new SliderWithTextBoxInput<double>("Speed Multiplier")
                 {
-                    Current = new DifficultyControlPoint().SpeedMultiplierBindable
+                    Current = new DifficultyControlPoint().SpeedMultiplierBindable,
+                    KeyboardStep = 0.1f
                 }
             });
         }

--- a/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
@@ -69,6 +69,15 @@ namespace osu.Game.Screens.Edit.Timing
             }, true);
         }
 
+        /// <summary>
+        /// A custom step value for each key press which actuates a change on this control.
+        /// </summary>
+        public float KeyboardStep
+        {
+            get => slider.KeyboardStep;
+            set => slider.KeyboardStep = value;
+        }
+
         public Bindable<T> Current
         {
             get => slider.Current;


### PR DESCRIPTION
Note that stable doesn't seem to limit precision during parsing (which we are handling locally in the `LegacyDecoder` https://github.com/ppy/osu/blob/5b0d75ee56690dbb3a121d741768515417f51ee8/osu.Game/Beatmaps/Formats/LegacyDecoder.cs#L178), but does in the editor dialogs. For now, let's match it at 2DP.

Closes #12041.