### PR TITLE
Adjust timeline ticks to be more visible

### DIFF
--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Colour;
 using osu.Game.Graphics;
 using osuTK.Graphics;
 
@@ -48,7 +47,7 @@ namespace osu.Game.Screens.Edit
         /// <param name="beatDivisor">The beat divisor.</param>
         /// <param name="colours">The set of colours.</param>
         /// <returns>The applicable colour from <paramref name="colours"/> for <paramref name="beatDivisor"/>.</returns>
-        public static ColourInfo GetColourFor(int beatDivisor, OsuColour colours)
+        public static Color4 GetColourFor(int beatDivisor, OsuColour colours)
         {
             switch (beatDivisor)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             var colour = BindableBeatDivisor.GetColourFor(BindableBeatDivisor.GetDivisorForBeatIndex(beatIndex + placementIndex + 1, beatDivisor.Value), Colours);
 
             int repeatIndex = placementIndex / beatDivisor.Value;
-            return colour.MultiplyAlpha(0.5f / (repeatIndex + 1));
+            return ColourInfo.SingleColour(colour).MultiplyAlpha(0.5f / (repeatIndex + 1));
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
@@ -124,25 +126,28 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         if (beat == 0 && i == 0)
                             nextMinTick = float.MinValue;
 
-                        var indexInBar = beat % ((int)point.TimeSignature * beatDivisor.Value);
+                        int indexInBar = beat % ((int)point.TimeSignature * beatDivisor.Value);
 
                         var divisor = BindableBeatDivisor.GetDivisorForBeatIndex(beat, beatDivisor.Value);
                         var colour = BindableBeatDivisor.GetColourFor(divisor, colours);
 
+                        bool isMainBeat = indexInBar == 0;
+
                         // even though "bar lines" take up the full vertical space, we render them in two pieces because it allows for less anchor/origin churn.
-                        var height = indexInBar == 0 ? 0.5f : 0.1f - (float)divisor / highestDivisor * 0.08f;
+                        float height = isMainBeat ? 0.5f : 0.4f - (float)divisor / highestDivisor * 0.2f;
+                        float gradientOpacity = isMainBeat ? 1 : 0;
 
                         var topPoint = getNextUsablePoint();
                         topPoint.X = xPos;
-                        topPoint.Colour = colour;
                         topPoint.Height = height;
+                        topPoint.Colour = ColourInfo.GradientVertical(colour, colour.Opacity(gradientOpacity));
                         topPoint.Anchor = Anchor.TopLeft;
                         topPoint.Origin = Anchor.TopCentre;
 
                         var bottomPoint = getNextUsablePoint();
                         bottomPoint.X = xPos;
-                        bottomPoint.Colour = colour;
                         bottomPoint.Anchor = Anchor.BottomLeft;
+                        bottomPoint.Colour = ColourInfo.GradientVertical(colour.Opacity(gradientOpacity), colour);
                         bottomPoint.Origin = Anchor.BottomCentre;
                         bottomPoint.Height = height;
                     }


### PR DESCRIPTION
As mentioned in #12020, the ticks in the editor are quite far away from the blueprints, making it hard to visually discern which timing divisors objects are resting on. This attempts to fix that issue without moving things around, just by increasing the vertical presence of all ticks.

Before:

![20210319 194933 (dotnet)](https://user-images.githubusercontent.com/191335/111769181-3c48de80-88ec-11eb-83a7-e1f78c93cd50.png)

After:

![20210319 194628 (dotnet)](https://user-images.githubusercontent.com/191335/111768855-d0ff0c80-88eb-11eb-832e-03e5abae182d.png)
