### PR TITLE
Change editor speed adjust to adjust frequency (and restore 25% option)

### DIFF
--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Edit.Components
         [Resolved]
         private EditorClock editorClock { get; set; }
 
-        private readonly BindableNumber<double> tempo = new BindableDouble(1);
+        private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
 
         [BackgroundDependencyLoader]
         private void load()
@@ -58,16 +58,16 @@ namespace osu.Game.Screens.Edit.Components
                     RelativeSizeAxes = Axes.Both,
                     Height = 0.5f,
                     Padding = new MarginPadding { Left = 45 },
-                    Child = new PlaybackTabControl { Current = tempo },
+                    Child = new PlaybackTabControl { Current = freqAdjust },
                 }
             };
 
-            Track.BindValueChanged(tr => tr.NewValue?.AddAdjustment(AdjustableProperty.Tempo, tempo), true);
+            Track.BindValueChanged(tr => tr.NewValue?.AddAdjustment(AdjustableProperty.Frequency, freqAdjust), true);
         }
 
         protected override void Dispose(bool isDisposing)
         {
-            Track.Value?.RemoveAdjustment(AdjustableProperty.Tempo, tempo);
+            Track.Value?.RemoveAdjustment(AdjustableProperty.Frequency, freqAdjust);
 
             base.Dispose(isDisposing);
         }
@@ -101,7 +101,7 @@ namespace osu.Game.Screens.Edit.Components
 
         private class PlaybackTabControl : OsuTabControl<double>
         {
-            private static readonly double[] tempo_values = { 0.5, 0.75, 1 };
+            private static readonly double[] tempo_values = { 0.25, 0.5, 0.75, 1 };
 
             protected override TabItem<double> CreateTabItem(double value) => new PlaybackTabItem(value);
 


### PR DESCRIPTION
Rationale being that adjusting frequency doesn't decimate the track beyond use. The fact that people keep asking for 25% playback and when asked why, they claim they use it for timing is absolutely wrong. At least this way it can be used for such cases with lower chance of causing mistimings.

This also adds a 25% playback option back.

Closes #2393 (doesn't add variable adjustment, but I don't think that's necessary - four settings are enough for now).