### PR TITLE
Fix selection blueprint misbehaving with overlapping objects

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -28,6 +29,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         protected SliderBodyPiece BodyPiece { get; private set; }
         protected SliderCircleSelectionBlueprint HeadBlueprint { get; private set; }
         protected SliderCircleSelectionBlueprint TailBlueprint { get; private set; }
+
+        [CanBeNull]
         protected PathControlPointVisualiser ControlPointVisualiser { get; private set; }
 
         private readonly DrawableSlider slider;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -114,6 +114,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             // throw away frame buffers on deselection.
             ControlPointVisualiser?.Expire();
+            ControlPointVisualiser = null;
+
             BodyPiece.RecyclePath();
         }
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneBlueprintSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBlueprintSelection.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public class TestSceneBlueprintSelection : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        private BlueprintContainer blueprintContainer
+            => Editor.ChildrenOfType<BlueprintContainer>().First();
+
+        [Test]
+        public void TestSelectedObjectHasPriorityWhenOverlapping()
+        {
+            var firstSlider = new Slider
+            {
+                Path = new SliderPath(new[]
+                {
+                    new PathControlPoint(new Vector2()),
+                    new PathControlPoint(new Vector2(150, -50)),
+                    new PathControlPoint(new Vector2(300, 0))
+                }),
+                Position = new Vector2(0, 100)
+            };
+            var secondSlider = new Slider
+            {
+                Path = new SliderPath(new[]
+                {
+                    new PathControlPoint(new Vector2()),
+                    new PathControlPoint(new Vector2(-50, 50)),
+                    new PathControlPoint(new Vector2(-100, 100))
+                }),
+                Position = new Vector2(200, 0)
+            };
+
+            AddStep("add overlapping sliders", () =>
+            {
+                EditorBeatmap.Add(firstSlider);
+                EditorBeatmap.Add(secondSlider);
+            });
+            AddStep("select first slider", () => EditorBeatmap.SelectedHitObjects.Add(firstSlider));
+
+            AddStep("move mouse to common point", () =>
+            {
+                var pos = blueprintContainer.ChildrenOfType<PathControlPointPiece>().ElementAt(1).ScreenSpaceDrawQuad.Centre;
+                InputManager.MoveMouseTo(pos);
+            });
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+
+            AddAssert("selection is unchanged", () => EditorBeatmap.SelectedHitObjects.Single() == firstSlider);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -338,7 +338,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private bool beginClickSelection(MouseButtonEvent e)
         {
             // Iterate from the top of the input stack (blueprints closest to the front of the screen first).
-            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren.Reverse())
+            // Priority is given to already-selected blueprints.
+            foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren.Reverse().OrderByDescending(b => b.IsSelected))
             {
                 if (!blueprint.IsHovered) continue;
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/12089.

When it comes to the crash, it was caused by the fact that `SliderSelectionBlueprint.OnDeselected()` would expire the `ControlPointVisualiser` on deselection, leading to its removal from the blueprint and eventual disposal, but still kept a separate reference to said visualiser in another field.

This could lead to that stale reference to a disposed child getting read in `ReceivePositionalInputAt()`, crashing quite a ways down over at the framework side when futilely trying to compute the bounding box of a drawable with no parent.

As for fixing the selection flip-flopping between multiple overlapping objects, I've just made it so that already-selected objects get priority on handling mouse down inputs. I think it makes sense, but am definitely willing to discuss alternative resolutions.