### PR TITLE
Fix transform mutations from invalid thread on tablet disconnection/reconnection

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -125,15 +125,18 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             }, true);
 
             tablet.BindTo(handler.Tablet);
-            tablet.BindValueChanged(val =>
-            {
-                tabletContainer.Size = val.NewValue?.Size ?? Vector2.Zero;
-                tabletName.Text = val.NewValue?.Name ?? string.Empty;
-                checkBounds();
-            }, true);
+            tablet.BindValueChanged(_ => Scheduler.AddOnce(updateTabletDetails));
 
+            updateTabletDetails();
             // initial animation should be instant.
             FinishTransforms(true);
+        }
+
+        private void updateTabletDetails()
+        {
+            tabletContainer.Size = tablet.Value?.Size ?? Vector2.Zero;
+            tabletName.Text = tablet.Value?.Name ?? string.Empty;
+            checkBounds();
         }
 
         private static int greatestCommonDivider(int a, int b)

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -196,19 +196,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             tablet.BindTo(tabletHandler.Tablet);
             tablet.BindValueChanged(val =>
             {
+                Scheduler.AddOnce(toggleVisibility);
+
                 var tab = val.NewValue;
 
                 bool tabletFound = tab != null;
-
                 if (!tabletFound)
-                {
-                    mainSettings.Hide();
-                    noTabletMessage.Show();
                     return;
-                }
-
-                mainSettings.Show();
-                noTabletMessage.Hide();
 
                 offsetX.MaxValue = tab.Size.X;
                 offsetX.Default = tab.Size.X / 2;
@@ -220,6 +214,21 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
                 areaSize.Default = new Vector2(sizeX.Default, sizeY.Default);
             }, true);
+        }
+
+        private void toggleVisibility()
+        {
+            bool tabletFound = tablet.Value != null;
+
+            if (!tabletFound)
+            {
+                mainSettings.Hide();
+                noTabletMessage.Show();
+                return;
+            }
+
+            mainSettings.Show();
+            noTabletMessage.Hide();
         }
 
         private void applyAspectRatio(BindableNumber<float> sizeChanged)

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 if (!aspectLock.Value)
                 {
-                    float proposedAspectRatio = curentAspectRatio;
+                    float proposedAspectRatio = currentAspectRatio;
 
                     if (proposedAspectRatio >= aspectRatio.MinValue && proposedAspectRatio <= aspectRatio.MaxValue)
                     {
@@ -278,8 +278,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             aspectLock.Value = true;
         }
 
-        private void updateAspectRatio() => aspectRatio.Value = curentAspectRatio;
+        private void updateAspectRatio() => aspectRatio.Value = currentAspectRatio;
 
-        private float curentAspectRatio => sizeX.Value / sizeY.Value;
+        private float currentAspectRatio => sizeX.Value / sizeY.Value;
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12099.

Fixes `InvalidThreadForMutationException`s that pop up when disconnecting/reconnecting tablets during the game's operation. In those cases the value change callback executes from  an OpenTabletDriver thread.

Note that in `TabletAreaSelection` I drop the `true` argument on `BindValueChanged()`, and call once manually unscheduled. This is to ensure that the `FinishTransforms(true)` call right after actually does anything. It is also safe since it's called from `LoadComplete()`.

Also fixed a typo while I was poking around (86b569f).