### PR TITLE
Fix mania hold note heads hiding when frozen

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -5,11 +5,13 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Objects;
@@ -345,12 +347,22 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
             AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+
+            AddUntilStep("wait for head", () => currentPlayer.GameplayClockContainer.GameplayClock.CurrentTime >= time_head);
+            AddAssert("head is visible",
+                () => currentPlayer.ChildrenOfType<DrawableHoldNote>()
+                                   .Single(note => note.HitObject == beatmap.HitObjects[0])
+                                   .Head
+                                   .Alpha == 1);
+
             AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
         }
 
         private class ScoreAccessibleReplayPlayer : ReplayPlayer
         {
             public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            public new GameplayClockContainer GameplayClockContainer => base.GameplayClockContainer;
 
             protected override bool PauseOnFocusLost => false;
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Objects.Drawables;
+
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {
     /// <summary>
@@ -23,6 +25,14 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
             // This hitobject should never expire, so this is just a safe maximum.
             LifetimeEnd = LifetimeStart + 30000;
+        }
+
+        protected override void UpdateHitStateTransforms(ArmedState state)
+        {
+            // suppress the base call explicitly.
+            // the hold note head should never change its visual state on its own due to the "freezing" mechanic
+            // (when hit, it remains visible in place at the judgement line; when dropped, it will scroll past the line).
+            // it will be hidden along with its parenting hold note when required.
         }
 
         public override bool OnPressed(ManiaAction action) => false; // Handled by the hold note


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12127.

This was an insidious regression from a3dc1d5. Prior to that commit, `DrawableHoldNoteHead` had `UpdateStateTransforms()` overridden, to set the hold note head's lifetime:

https://github.com/ppy/osu/blob/988ad378a7c7ccfe0e20c11b334e47a1cc368082/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs#L22-L26

When that method was split into `UpdateInitialStateTransforms()` and `UpdateHitStateTransforms()`, the lifetime set was moved to the former.

Unfortunately, that override served two purposes: both to set the lifetime, and to suppress hit animations which would normally be added by the base `DrawableManiaHitObject`. That fact being missed led to `UpdateHitStateTransforms()` hiding the hold note head immediately on hit and with a slight delay on miss.

To resolve, explicitly override `UpdateHitStateTransforms()` and suppress the base call, with an explanatory comment.

---

Not super sure about the test case. I wanted to add *something* at least. Hijacking `TestSceneHoldNoteInput` is not super pretty, but I would have had to essentially mostly duplicate it anyway to be able to test this.