### PR TITLE
Add comments count to user profile overlay

### DIFF
--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -114,6 +115,11 @@ namespace osu.Game.Overlays.Profile.Header
 
             topLinkContainer.AddText("Contributed ");
             topLinkContainer.AddLink($@"{user.PostCount:#,##0} forum posts", $"{api.WebsiteRootUrl}/users/{user.Id}/posts", creationParameters: embolden);
+
+            addSpacer(topLinkContainer);
+
+            topLinkContainer.AddText("Posted ");
+            topLinkContainer.AddLink("comment".ToQuantity(user.CommentsCount, "#,##0"), $"{api.WebsiteRootUrl}/comments?user_id={user.Id}", creationParameters: embolden);
 
             string websiteWithoutProtocol = user.Website;
 

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Overlays.Profile.Header
             }
 
             topLinkContainer.AddText("Contributed ");
-            topLinkContainer.AddLink($@"{user.PostCount:#,##0} forum posts", $"{api.WebsiteRootUrl}/users/{user.Id}/posts", creationParameters: embolden);
+            topLinkContainer.AddLink("forum post".ToQuantity(user.PostCount, "#,##0"), $"{api.WebsiteRootUrl}/users/{user.Id}/posts", creationParameters: embolden);
 
             addSpacer(topLinkContainer);
 

--- a/osu.Game/Users/User.cs
+++ b/osu.Game/Users/User.cs
@@ -120,6 +120,9 @@ namespace osu.Game.Users
         [JsonProperty(@"post_count")]
         public int PostCount;
 
+        [JsonProperty(@"comments_count")]
+        public int CommentsCount;
+
         [JsonProperty(@"follower_count")]
         public int FollowerCount;
 


### PR DESCRIPTION
To be in line with https://github.com/ppy/osu-web/pull/6838.

The second commit was originally part of https://github.com/ppy/osu/pull/4357, but was reverted due to a conflict resolution merge partway in https://github.com/ppy/osu/pull/3904.