### PR TITLE
Remove release delay for hold notes when generating autoplay

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             Assert.IsTrue(generated.Frames.Count == frame_offset + 2, "Replay must have 3 frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
-            Assert.AreEqual(3000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
+            Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
             Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Special1), "Special1 has not been pressed");
             Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Special1), "Special1 has not been released");
         }
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             Assert.IsTrue(generated.Frames.Count == frame_offset + 2, "Replay must have 3 frames");
 
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
-            Assert.AreEqual(3000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
+            Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
 
             Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
             Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been released");
@@ -148,9 +148,9 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             Assert.IsTrue(generated.Frames.Count == frame_offset + 4, "Replay must have 4 generated frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
-            Assert.AreEqual(3000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 2].Time, "Incorrect first note release time");
+            Assert.AreEqual(3000, generated.Frames[frame_offset + 2].Time, "Incorrect first note release time");
             Assert.AreEqual(2000, generated.Frames[frame_offset + 1].Time, "Incorrect second note hit time");
-            Assert.AreEqual(4000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 3].Time, "Incorrect second note release time");
+            Assert.AreEqual(4000, generated.Frames[frame_offset + 3].Time, "Incorrect second note release time");
             Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
             Assert.IsTrue(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
             Assert.IsFalse(checkContains(generated.Frames[frame_offset + 2], ManiaAction.Key1), "Key1 has not been released");
@@ -168,7 +168,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             // |   |   |
 
             var beatmap = new ManiaBeatmap(new StageDefinition { Columns = 2 });
-            beatmap.HitObjects.Add(new HoldNote { StartTime = 1000, Duration = 2000 - ManiaAutoGenerator.RELEASE_DELAY });
+            beatmap.HitObjects.Add(new HoldNote { StartTime = 1000, Duration = 2000 });
             beatmap.HitObjects.Add(new Note { StartTime = 3000, Column = 1 });
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();

--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Replays;
 
@@ -85,18 +86,26 @@ namespace osu.Game.Rulesets.Mania.Replays
             {
                 var currentObject = Beatmap.HitObjects[i];
                 var nextObjectInColumn = GetNextObject(i); // Get the next object that requires pressing the same button
-
-                double endTime = currentObject.GetEndTime();
-
-                bool canDelayKeyUp = nextObjectInColumn == null ||
-                                     nextObjectInColumn.StartTime > endTime + RELEASE_DELAY;
-
-                double calculatedDelay = canDelayKeyUp ? RELEASE_DELAY : (nextObjectInColumn.StartTime - endTime) * 0.9;
+                var releaseTime = calculateReleaseTime(currentObject, nextObjectInColumn);
 
                 yield return new HitPoint { Time = currentObject.StartTime, Column = currentObject.Column };
 
-                yield return new ReleasePoint { Time = endTime + calculatedDelay, Column = currentObject.Column };
+                yield return new ReleasePoint { Time = releaseTime, Column = currentObject.Column };
             }
+        }
+
+        private double calculateReleaseTime(HitObject currentObject, HitObject nextObject)
+        {
+            double endTime = currentObject.GetEndTime();
+
+            if (currentObject is HoldNote)
+                // hold note releases must be timed exactly.
+                return endTime;
+
+            bool canDelayKeyUpFully = nextObject == null ||
+                                      nextObject.StartTime > endTime + RELEASE_DELAY;
+
+            return endTime + (canDelayKeyUpFully ? RELEASE_DELAY : (nextObject.StartTime - endTime) * 0.9);
         }
 
         protected override HitObject GetNextObject(int currentIndex)


### PR DESCRIPTION
Resolves (at least the mania part of) https://github.com/ppy/osu/issues/12129.

Not sure whether there's much to be done for the other rulesets, to be honest. osu! technically also holds sliders for an additional 50ms, but that release is not timed, so that's not really a huge priority. taiko, on the other hand, has no held hitobjects at all, so I'm not sure there's any issue of this sort there.