### PR TITLE
Fix incorrect trash icon being used on deleted comments counter

### DIFF
--- a/osu.Game/Overlays/Comments/DeletedCommentsCounter.cs
+++ b/osu.Game/Overlays/Comments/DeletedCommentsCounter.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays.Comments
                 {
                     new SpriteIcon
                     {
-                        Icon = FontAwesome.Solid.Trash,
+                        Icon = FontAwesome.Regular.TrashAlt,
                         Size = new Vector2(14),
                     },
                     countText = new OsuSpriteText


### PR DESCRIPTION
https://github.com/ppy/osu-web/blob/77bdc41687e77f7315ffb15e8b6beb04ea61c391/resources/assets/lib/deleted-comments-count.tsx#L24

Inconsistent since osu!-side implementation: https://github.com/ppy/osu/commit/107d39c3e97edb17e56bc9377d7e6cf76574ed43#diff-a02dfde5eb2ae9d591573ff6e2e2a9f75ab38f1cbad520ef51cf35727ab98f48R35

Web:
![chrome_AmWIrcLd1E](https://user-images.githubusercontent.com/35318437/112084728-8d540f00-8b46-11eb-9659-9c39f40664e8.jpg)

Before:
![osu!_R4JcGzymYD](https://user-images.githubusercontent.com/35318437/112084789-a52b9300-8b46-11eb-9d96-80513ad0292c.jpg)

After:
![dotnet_fJqlCgkjuy](https://user-images.githubusercontent.com/35318437/112084754-97760d80-8b46-11eb-9c3c-afe405b86427.jpg)