### PR TITLE
Fix APIScoreToken's data type not matching server side

### DIFF
--- a/osu.Game/Online/Rooms/APIScoreToken.cs
+++ b/osu.Game/Online/Rooms/APIScoreToken.cs
@@ -8,6 +8,6 @@ namespace osu.Game.Online.Rooms
     public class APIScoreToken
     {
         [JsonProperty("id")]
-        public int ID { get; set; }
+        public long ID { get; set; }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsPlayer.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         protected readonly PlaylistItem PlaylistItem;
 
-        protected int? Token { get; private set; }
+        protected long? Token { get; private set; }
 
         [Resolved]
         private IAPIProvider api { get; set; }


### PR DESCRIPTION
Noticed in passing. This is one of the cases where an `int` will definitely not hold up. Still not sure if we'll use `int` going forward (instead of `Guid`) but best to fix this as long as we are using numeric types.