### PR TITLE
Fail all API requests sent to DummyAPIAccess

### DIFF
--- a/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
+++ b/osu.Game.Tests/Online/TestDummyAPIRequestHandling.cs
@@ -23,8 +23,10 @@ namespace osu.Game.Tests.Online
                 {
                     case CommentVoteRequest cRequest:
                         cRequest.TriggerSuccess(new CommentBundle());
-                        break;
+                        return true;
                 }
+
+                return false;
             });
 
             CommentVoteRequest request = null;
@@ -108,8 +110,10 @@ namespace osu.Game.Tests.Online
                 {
                     case LeaveChannelRequest cRequest:
                         cRequest.TriggerSuccess();
-                        break;
+                        return true;
                 }
+
+                return false;
             });
         }
     }

--- a/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneSeasonalBackgroundLoader.cs
@@ -135,13 +135,15 @@ namespace osu.Game.Tests.Visual.Background
                 dummyAPI.HandleRequest = request =>
                 {
                     if (dummyAPI.State.Value != APIState.Online || !(request is GetSeasonalBackgroundsRequest backgroundsRequest))
-                        return;
+                        return false;
 
                     backgroundsRequest.TriggerSuccess(new APISeasonalBackgrounds
                     {
                         Backgrounds = seasonal_background_urls.Select(url => new APISeasonalBackground { Url = url }).ToList(),
                         EndDate = endDate
                     });
+
+                    return true;
                 };
             });
 

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -30,13 +30,14 @@ namespace osu.Game.Tests.Visual.Online
 
             ((DummyAPIAccess)API).HandleRequest = req =>
             {
-                if (req is SearchBeatmapSetsRequest searchBeatmapSetsRequest)
+                if (!(req is SearchBeatmapSetsRequest searchBeatmapSetsRequest)) return false;
+
+                searchBeatmapSetsRequest.TriggerSuccess(new SearchBeatmapSetsResponse
                 {
-                    searchBeatmapSetsRequest.TriggerSuccess(new SearchBeatmapSetsResponse
-                    {
-                        BeatmapSets = setsForResponse,
-                    });
-                }
+                    BeatmapSets = setsForResponse,
+                });
+
+                return true;
             };
         }
 

--- a/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
@@ -63,13 +63,15 @@ namespace osu.Game.Tests.Visual.Online
                             Builds = builds.Values.ToList()
                         };
                         changelogRequest.TriggerSuccess(changelogResponse);
-                        break;
+                        return true;
 
                     case GetChangelogBuildRequest buildRequest:
                         if (requestedBuild != null)
                             buildRequest.TriggerSuccess(requestedBuild);
-                        break;
+                        return true;
                 }
+
+                return false;
             };
 
             Child = changelog = new TestChangelogOverlay();

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -11,6 +11,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Chat.Selection;
@@ -61,6 +63,24 @@ namespace osu.Game.Tests.Visual.Online
 
                 chatOverlay = container.ChatOverlay;
                 channelManager = container.ChannelManager;
+            });
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("register request handling", () =>
+            {
+                ((DummyAPIAccess)API).HandleRequest = req =>
+                {
+                    switch (req)
+                    {
+                        case JoinChannelRequest _:
+                            return true;
+                    }
+
+                    return false;
+                };
             });
         }
 

--- a/osu.Game.Tests/Visual/Online/TestSceneCommentsContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneCommentsContainer.cs
@@ -85,9 +85,10 @@ namespace osu.Game.Tests.Visual.Online
                 dummyAPI.HandleRequest = request =>
                 {
                     if (!(request is GetCommentsRequest getCommentsRequest))
-                        return;
+                        return false;
 
                     getCommentsRequest.TriggerSuccess(commentBundle);
+                    return true;
                 };
             });
 

--- a/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNewsOverlay.cs
@@ -33,9 +33,10 @@ namespace osu.Game.Tests.Visual.Online
                 dummyAPI.HandleRequest = request =>
                 {
                     if (!(request is GetNewsRequest getNewsRequest))
-                        return;
+                        return false;
 
                     getNewsRequest.TriggerSuccess(r);
+                    return true;
                 };
             });
 

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -170,6 +170,17 @@ namespace osu.Game.Tests.Visual.Playlists
 
         private void bindHandler(bool delayed = false, ScoreInfo userScore = null, bool failRequests = false) => ((DummyAPIAccess)API).HandleRequest = request =>
         {
+            // pre-check for requests we should be handling (as they are scheduled below).
+            switch (request)
+            {
+                case ShowPlaylistUserScoreRequest _:
+                case IndexPlaylistScoresRequest _:
+                    break;
+
+                default:
+                    return false;
+            }
+
             requestComplete = false;
 
             double delay = delayed ? 3000 : 0;
@@ -196,6 +207,8 @@ namespace osu.Game.Tests.Visual.Playlists
                         break;
                 }
             }, delay);
+
+            return true;
         };
 
         private void triggerSuccess<T>(APIRequest<T> req, T result)

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -32,8 +32,10 @@ namespace osu.Game.Tests.Visual.SongSelect
                     {
                         case GetUserRequest userRequest:
                             userRequest.TriggerSuccess(getUser(userRequest.Ruleset.ID));
-                            break;
+                            return true;
                     }
+
+                    return false;
                 };
             });
 

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -181,9 +181,13 @@ namespace osu.Game.Online.API
         /// <returns>Whether we are in a failed or cancelled state.</returns>
         private bool checkAndScheduleFailure()
         {
-            if (API == null || pendingFailure == null) return cancelled;
+            if (pendingFailure == null) return cancelled;
 
-            API.Schedule(pendingFailure);
+            if (API == null)
+                pendingFailure();
+            else
+                API.Schedule(pendingFailure);
+
             pendingFailure = null;
             return true;
         }

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -131,8 +131,11 @@ namespace osu.Game.Online.API
         {
         }
 
+        private bool succeeded;
+
         internal virtual void TriggerSuccess()
         {
+            succeeded = true;
             Success?.Invoke();
         }
 
@@ -145,10 +148,7 @@ namespace osu.Game.Online.API
 
         public void Fail(Exception e)
         {
-            if (WebRequest?.Completed == true)
-                return;
-
-            if (cancelled)
+            if (succeeded || cancelled)
                 return;
 
             cancelled = true;

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -34,8 +34,9 @@ namespace osu.Game.Online.API
 
         /// <summary>
         /// Provide handling logic for an arbitrary API request.
+        /// Should return true is a request was handled. If null or false return, the request will be failed with a <see cref="NotSupportedException"/>.
         /// </summary>
-        public Action<APIRequest> HandleRequest;
+        public Func<APIRequest, bool> HandleRequest;
 
         private readonly Bindable<APIState> state = new Bindable<APIState>(APIState.Online);
 
@@ -55,12 +56,12 @@ namespace osu.Game.Online.API
 
         public virtual void Queue(APIRequest request)
         {
-            if (HandleRequest != null)
-                HandleRequest.Invoke(request);
-            else
+            if (HandleRequest?.Invoke(request) != true)
+            {
                 // this will fail due to not receiving an APIAccess, and trigger a failure on the request.
                 // this is intended - any request in testing that needs non-failures should use HandleRequest.
                 request.Perform(this);
+            }
         }
 
         public void Perform(APIRequest request) => HandleRequest?.Invoke(request);

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -55,7 +55,12 @@ namespace osu.Game.Online.API
 
         public virtual void Queue(APIRequest request)
         {
-            HandleRequest?.Invoke(request);
+            if (HandleRequest != null)
+                HandleRequest.Invoke(request);
+            else
+                // this will fail due to not receiving an APIAccess, and trigger a failure on the request.
+                // this is intended - any request in testing that needs non-failures should use HandleRequest.
+                request.Perform(this);
         }
 
         public void Perform(APIRequest request) => HandleRequest?.Invoke(request);

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerRoomManager.cs
@@ -52,15 +52,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                         Rooms.Add(createdRoom);
                         createRoomRequest.TriggerSuccess(createdRoom);
-                        break;
+                        return true;
 
                     case JoinRoomRequest joinRoomRequest:
                         joinRoomRequest.TriggerSuccess();
-                        break;
+                        return true;
 
                     case PartRoomRequest partRoomRequest:
                         partRoomRequest.TriggerSuccess();
-                        break;
+                        return true;
 
                     case GetRoomsRequest getRoomsRequest:
                         var roomsWithoutParticipants = new List<Room>();
@@ -76,11 +76,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         }
 
                         getRoomsRequest.TriggerSuccess(roomsWithoutParticipants);
-                        break;
+                        return true;
 
                     case GetRoomRequest getRoomRequest:
                         getRoomRequest.TriggerSuccess(Rooms.Single(r => r.RoomID.Value == getRoomRequest.RoomId));
-                        break;
+                        return true;
 
                     case GetBeatmapSetRequest getBeatmapSetRequest:
                         var onlineReq = new GetBeatmapSetRequest(getBeatmapSetRequest.ID, getBeatmapSetRequest.Type);
@@ -89,11 +89,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                         // Get the online API from the game's dependencies.
                         game.Dependencies.Get<IAPIProvider>().Queue(onlineReq);
-                        break;
+                        return true;
 
                     case CreateRoomScoreRequest createRoomScoreRequest:
                         createRoomScoreRequest.TriggerSuccess(new APIScoreToken { ID = 1 });
-                        break;
+                        return true;
 
                     case SubmitRoomScoreRequest submitRoomScoreRequest:
                         submitRoomScoreRequest.TriggerSuccess(new MultiplayerScore
@@ -108,8 +108,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
                             User = api.LocalUser.Value,
                             Statistics = new Dictionary<HitResult, int>()
                         });
-                        break;
+                        return true;
                 }
+
+                return false;
             };
         }
 


### PR DESCRIPTION
Until now, API requests sent to dummy API were just lost in the void. In most cases this somehow worked as expected, but any logic which is waiting on a request to finish will potentially never get a response.

Going forward, I'm not 100% sure that every `Wait` on a web response will have local timeout logic (I think there is a certain amount of assumption that this is being managed for us by `APIAccess`), so I've made this change to better handle such cases going forward. Now, rather than nothing happening, requests will trigger a failure via the existing exception logic rather than silently pretending the request never arrived.

I've also made `HandleRequest` actually return whether a request was handled via it, so we can still throw failures for requests which were out of scope of the test's handling.