### PR TITLE
Always fade out approach circles at a HitObject's start time to better match stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -164,27 +164,28 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             ApproachCircle.Expire(true);
         }
 
+        protected override void UpdateStartTimeStateTransforms()
+        {
+            base.UpdateStartTimeStateTransforms();
+
+            ApproachCircle.FadeOut(50);
+        }
+
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             Debug.Assert(HitObject.HitWindows != null);
 
+            // todo: temporary / arbitrary, used for lifetime optimisation.
+            this.Delay(800).FadeOut();
+
             switch (state)
             {
                 case ArmedState.Idle:
-                    this.Delay(HitObject.TimePreempt).FadeOut(500);
                     HitArea.HitAction = null;
                     break;
 
                 case ArmedState.Miss:
-                    ApproachCircle.FadeOut(50);
                     this.FadeOut(100);
-                    break;
-
-                case ArmedState.Hit:
-                    ApproachCircle.FadeOut(50);
-
-                    // todo: temporary / arbitrary
-                    this.Delay(800).FadeOut();
                     break;
             }
 


### PR DESCRIPTION
Closes #11209.

Before:

![20210323 192123 (dotnet)](https://user-images.githubusercontent.com/191335/112131522-fbfba000-8c0c-11eb-94e1-fd57459250ff.gif)

After:

![20210323 192009 (dotnet)](https://user-images.githubusercontent.com/191335/112131401-dd95a480-8c0c-11eb-9f77-720f32abffe5.gif)
