### PR TITLE
Fix default skin's glow resetting fade on miss

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
@@ -74,10 +74,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         private void updateState(DrawableHitObject drawableObject, ArmedState state)
         {
-            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime, true))
-            {
+            using (BeginAbsoluteSequence(drawableObject.StateUpdateTime))
                 glow.FadeOut(400);
 
+            using (BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
+            {
                 switch (state)
                 {
                     case ArmedState.Hit:


### PR DESCRIPTION
Before:

![20210323 192521 (dotnet)](https://user-images.githubusercontent.com/191335/112132112-965be380-8c0d-11eb-800a-bbb1713021bd.gif)

After:
![20210323 192627 (dotnet)](https://user-images.githubusercontent.com/191335/112132238-b9869300-8c0d-11eb-936f-ad2fdec9dd44.gif)

Note the glow in the "before" version getting slightly brighter before finally fading.

