### PR TITLE
Fix OS cursor hidden in TournamentGame when high precision mouse is enabled

### DIFF
--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -51,8 +51,12 @@ namespace osu.Game.Tournament
                 Margin = new MarginPadding(40),
             });
 
-            var m = (MouseHandler)host.AvailableInputHandlers.Single(t => t is MouseHandler);
-            m.UseRelativeMode.Value = false;
+            // in order to have the OS mouse cursor visible, relative mode needs to be disabled.
+            // can potentially be removed when https://github.com/ppy/osu-framework/issues/4309 is resolved.
+            var mouseHandler = host.AvailableInputHandlers.OfType<MouseHandler>().FirstOrDefault();
+
+            if (mouseHandler != null)
+                mouseHandler.UseRelativeMode.Value = false;
 
             loadingSpinner.Show();
 

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -2,18 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Drawing;
-using osu.Framework.Extensions.Color4Extensions;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Colour;
-using osu.Game.Graphics.Cursor;
-using osu.Game.Tournament.Models;
+using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Tournament.Models;
 using osuTK;
 using osuTK.Graphics;
 
@@ -36,7 +39,7 @@ namespace osu.Game.Tournament
         private LoadingSpinner loadingSpinner;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager frameworkConfig)
+        private void load(FrameworkConfigManager frameworkConfig, GameHost host)
         {
             windowSize = frameworkConfig.GetBindable<Size>(FrameworkSetting.WindowedSize);
             windowMode = frameworkConfig.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
@@ -47,6 +50,9 @@ namespace osu.Game.Tournament
                 Origin = Anchor.BottomRight,
                 Margin = new MarginPadding(40),
             });
+
+            var m = (MouseHandler)host.AvailableInputHandlers.Single(t => t is MouseHandler);
+            m.UseRelativeMode.Value = false;
 
             loadingSpinner.Show();
 


### PR DESCRIPTION
This small PR fixes the cursor hiding/unhiding in an odd fashion whenever "High Precision Mouse" is enabled in osu!lazer.
Disabling relative mode specifically for tournament game shows the OS cursor again. 

This one got reported in the osu! Tournament Hub by a user.

Fwiw this was the before situation: 
https://user-images.githubusercontent.com/803255/112222097-8ef60380-8c28-11eb-9cd8-f4df65d01f8f.mp4


