### PR TITLE
Add beatmap search filter row "General"

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -34,6 +34,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void SetUp() => Schedule(() =>
         {
             OsuSpriteText query;
+            OsuSpriteText general;
             OsuSpriteText ruleset;
             OsuSpriteText category;
             OsuSpriteText genre;
@@ -58,6 +59,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Children = new Drawable[]
                     {
                         query = new OsuSpriteText(),
+                        general = new OsuSpriteText(),
                         ruleset = new OsuSpriteText(),
                         category = new OsuSpriteText(),
                         genre = new OsuSpriteText(),
@@ -71,6 +73,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             };
 
             control.Query.BindValueChanged(q => query.Text = $"Query: {q.NewValue}", true);
+            control.General.BindCollectionChanged((u, v) => general.Text = $"General: {(control.General.Any() ? string.Join('.', control.General.Select(i => i.ToString().ToLowerInvariant())) : "")}", true);
             control.Ruleset.BindValueChanged(r => ruleset.Text = $"Ruleset: {r.NewValue}", true);
             control.Category.BindValueChanged(c => category.Text = $"Category: {c.NewValue}", true);
             control.Genre.BindValueChanged(g => genre.Text = $"Genre: {g.NewValue}", true);

--- a/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
+++ b/osu.Game/Online/API/Requests/SearchBeatmapSetsRequest.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Online.API.Requests
 {
     public class SearchBeatmapSetsRequest : APIRequest<SearchBeatmapSetsResponse>
     {
+        [CanBeNull]
+        public IReadOnlyCollection<SearchGeneral> General { get; }
+
         public SearchCategory SearchCategory { get; }
 
         public SortCriteria SortCriteria { get; }
@@ -45,6 +48,7 @@ namespace osu.Game.Online.API.Requests
             string query,
             RulesetInfo ruleset,
             Cursor cursor = null,
+            IReadOnlyCollection<SearchGeneral> general = null,
             SearchCategory searchCategory = SearchCategory.Any,
             SortCriteria sortCriteria = SortCriteria.Ranked,
             SortDirection sortDirection = SortDirection.Descending,
@@ -59,6 +63,7 @@ namespace osu.Game.Online.API.Requests
             this.ruleset = ruleset;
             this.cursor = cursor;
 
+            General = general;
             SearchCategory = searchCategory;
             SortCriteria = sortCriteria;
             SortDirection = sortDirection;
@@ -74,6 +79,9 @@ namespace osu.Game.Online.API.Requests
         {
             var req = base.CreateWebRequest();
             req.AddParameter("q", query);
+
+            if (General != null && General.Any())
+                req.AddParameter("c", string.Join('.', General.Select(e => e.ToString().ToLowerInvariant())));
 
             if (ruleset.ID.HasValue)
                 req.AddParameter("m", ruleset.ID.Value.ToString());

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -134,6 +134,7 @@ namespace osu.Game.Overlays.BeatmapListing
                 queueUpdateSearch(true);
             });
 
+            searchControl.General.CollectionChanged += (_, __) => queueUpdateSearch();
             searchControl.Ruleset.BindValueChanged(_ => queueUpdateSearch());
             searchControl.Category.BindValueChanged(_ => queueUpdateSearch());
             searchControl.Genre.BindValueChanged(_ => queueUpdateSearch());
@@ -187,6 +188,7 @@ namespace osu.Game.Overlays.BeatmapListing
                 searchControl.Query.Value,
                 searchControl.Ruleset.Value,
                 lastResponse?.Cursor,
+                searchControl.General,
                 searchControl.Category.Value,
                 sortControl.Current.Value,
                 sortControl.SortDirection.Value,

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
         public Bindable<string> Query => textBox.Current;
 
+        public BindableList<SearchGeneral> General => generalFilter.Current;
+
         public Bindable<RulesetInfo> Ruleset => modeFilter.Current;
 
         public Bindable<SearchCategory> Category => categoryFilter.Current;
@@ -61,6 +63,7 @@ namespace osu.Game.Overlays.BeatmapListing
         }
 
         private readonly BeatmapSearchTextBox textBox;
+        private readonly BeatmapSearchMultipleSelectionFilterRow<SearchGeneral> generalFilter;
         private readonly BeatmapSearchRulesetFilterRow modeFilter;
         private readonly BeatmapSearchFilterRow<SearchCategory> categoryFilter;
         private readonly BeatmapSearchFilterRow<SearchGenre> genreFilter;
@@ -123,6 +126,7 @@ namespace osu.Game.Overlays.BeatmapListing
                                 Padding = new MarginPadding { Horizontal = 10 },
                                 Children = new Drawable[]
                                 {
+                                    generalFilter = new BeatmapSearchMultipleSelectionFilterRow<SearchGeneral>(@"General"),
                                     modeFilter = new BeatmapSearchRulesetFilterRow(),
                                     categoryFilter = new BeatmapSearchFilterRow<SearchCategory>(@"Categories"),
                                     genreFilter = new BeatmapSearchFilterRow<SearchGenre>(@"Genre"),

--- a/osu.Game/Overlays/BeatmapListing/SearchGeneral.cs
+++ b/osu.Game/Overlays/BeatmapListing/SearchGeneral.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Game.Overlays.BeatmapListing
+{
+    public enum SearchGeneral
+    {
+        [Description("Recommended difficulty")]
+        Recommended,
+
+        [Description("Include converted beatmaps")]
+        Converts,
+
+        [Description("Subscribed mappers")]
+        Follows
+    }
+}


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/46070579/112552827-589cbd80-8dbb-11eb-9731-c2df18df257e.PNG)

Note that this is missing the `Recommended difficulty (x.xx)` value part 
as that requires sharing logic with `DifficultyRecommender` and the current filtered Ruleset.

If required, I can try to add that with some assistance.