### PR TITLE
Fix multiplayer download progress showing incorrectly after an aborted download

### DIFF
--- a/osu.Game/Online/DownloadTrackingComposite.cs
+++ b/osu.Game/Online/DownloadTrackingComposite.cs
@@ -123,13 +123,13 @@ namespace osu.Game.Online
             {
                 if (attachedRequest.Progress == 1)
                 {
-                    State.Value = DownloadState.Importing;
                     Progress.Value = 1;
+                    State.Value = DownloadState.Importing;
                 }
                 else
                 {
-                    State.Value = DownloadState.Downloading;
                     Progress.Value = attachedRequest.Progress;
+                    State.Value = DownloadState.Downloading;
 
                     attachedRequest.Failure += onRequestFailure;
                     attachedRequest.DownloadProgressed += onRequestProgress;

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailablilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailablilityTracker.cs
@@ -45,6 +45,9 @@ namespace osu.Game.Online.Rooms
 
             Progress.BindValueChanged(_ =>
             {
+                if (State.Value != DownloadState.Downloading)
+                    return;
+
                 // incoming progress changes are going to be at a very high rate.
                 // we don't want to flood the network with this, so rate limit how often we send progress updates.
                 if (progressUpdate?.Completed != false)


### PR DESCRIPTION
This was occurring due to the progress bindable being updated only after the state change was performed. It's a bit dodgy that the order here is important, but I'm not really wanting to rewrite this to combine the two, so just making a localised fix for now.

One could argue that the progress should be reset to zero on a failed download. I can do that if it sounds like a good idea, but it's not specifically required to fix this issue (and the state reset code is in a few places which may add complexity to peforming the reset).

Closes #11836.