### PR TITLE
Fix timeline not visually ordering hitobjects in a stable way

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
@@ -71,7 +71,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // Put earlier blueprints towards the end of the list, so they handle input first
             int i = yObj.HitObject.StartTime.CompareTo(xObj.HitObject.StartTime);
-            return i == 0 ? CompareReverseChildID(x, y) : i;
+
+            if (i != 0) return i;
+
+            // Fall back to end time if the start time is equal.
+            i = yObj.HitObject.GetEndTime().CompareTo(xObj.HitObject.GetEndTime());
+
+            return i == 0 ? CompareReverseChildID(y, x) : i;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             Stack<HitObject> currentConcurrentObjects = new Stack<HitObject>();
 
-            foreach (var b in SelectionBlueprints.OrderBy(b => b.HitObject.StartTime).ThenBy(b => b.HitObject.GetEndTime()))
+            foreach (var b in SelectionBlueprints.Reverse())
             {
                 // remove objects from the stack as long as their end time is in the past.
                 while (currentConcurrentObjects.TryPeek(out HitObject hitObject))


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/12076.
- [x] Depends on https://twitter.com/ppy/status/1375349750493368322.