### PR TITLE
Fix chat scroll sticking visually when scrolling beyond bottom extent

### DIFF
--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -275,7 +275,8 @@ namespace osu.Game.Overlays.Chat
                     {
                         if (!UserScrolling)
                         {
-                            ScrollToEnd();
+                            if (Current < ScrollableExtent)
+                                ScrollToEnd();
                             lastExtent = ScrollableExtent;
                         }
                     });


### PR DESCRIPTION
Has been bugging me for a while

Before:
![20210329 180912 (dotnet)](https://user-images.githubusercontent.com/191335/112814109-e4636200-90b9-11eb-9de2-f9a32fa3bae9.gif)


After:
![20210329 180829 (dotnet)](https://user-images.githubusercontent.com/191335/112813991-ca298400-90b9-11eb-9993-de96b230b1bb.gif)

