### PR TITLE
Fix IPC Location to be in line with TournamentStorage changes

### DIFF
--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Platform;
+using osu.Game.Tournament.IO;
+using osu.Game.Tournament.IPC;
+
+namespace osu.Game.Tournament.Tests.NonVisual
+{
+    [TestFixture]
+    public class IPCLocationTest
+    {
+        [Test]
+        public void CheckIPCLocation()
+        {
+            // don't use clean run because files are being written before osu! launches.
+            using (HeadlessGameHost host = new HeadlessGameHost(nameof(CheckIPCLocation)))
+            {
+                string basePath = Path.Combine(RuntimeInfo.StartupDirectory, "headless", nameof(CheckIPCLocation));
+
+                // Set up a fake IPC client for the IPC Storage to switch to.
+                string testCeDir = Path.Combine(basePath, "stable-ce");
+                Directory.CreateDirectory(testCeDir);
+
+                string ipcFile = Path.Combine(testCeDir, "ipc.txt");
+                File.WriteAllText(ipcFile, string.Empty);
+
+                try
+                {
+                    var osu = loadOsu(host);
+                    TournamentStorage storage = (TournamentStorage)osu.Dependencies.Get<Storage>();
+                    FileBasedIPC ipc = (FileBasedIPC)osu.Dependencies.Get<MatchIPCInfo>();
+
+                    Assert.True(ipc.SetIPCLocation(testCeDir));
+                    Assert.True(storage.AllTournaments.Exists("stable.json"));
+                }
+                finally
+                {
+                    host.Storage.DeleteDirectory(testCeDir);
+                    host.Storage.DeleteDirectory("tournaments");
+                    host.Exit();
+                }
+            }
+        }
+
+        private TournamentGameBase loadOsu(GameHost host)
+        {
+            var osu = new TournamentGameBase();
+            Task.Run(() => host.Run(osu));
+            waitForOrAssert(() => osu.IsLoaded, @"osu! failed to start in a reasonable amount of time");
+            return osu;
+        }
+
+        private static void waitForOrAssert(Func<bool> result, string failureMessage, int timeout = 90000)
+        {
+            Task task = Task.Run(() =>
+            {
+                while (!result()) Thread.Sleep(200);
+            });
+
+            Assert.IsTrue(task.Wait(timeout), failureMessage);
+        }
+    }
+}

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Tournament.Tests.NonVisual
                     TournamentStorage storage = (TournamentStorage)osu.Dependencies.Get<Storage>();
                     FileBasedIPC ipc = (FileBasedIPC)osu.Dependencies.Get<MatchIPCInfo>();
 
+                    waitForOrAssert(() => ipc != null, @"ipc could not be populated in a reasonable amount of time");
+
                     Assert.True(ipc.SetIPCLocation(testCeDir));
                     Assert.True(storage.AllTournaments.Exists("stable.json"));
                 }

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using System;
 using System.IO;
 using System.Threading;

--- a/osu.Game.Tournament/IO/TournamentStorage.cs
+++ b/osu.Game.Tournament/IO/TournamentStorage.cs
@@ -1,12 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.IO;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.IO;
-using System.IO;
-using System.Collections.Generic;
 using osu.Game.Tournament.Configuration;
 
 namespace osu.Game.Tournament.IO
@@ -15,7 +15,12 @@ namespace osu.Game.Tournament.IO
     {
         private const string default_tournament = "default";
         private readonly Storage storage;
-        private readonly Storage allTournaments;
+
+        /// <summary>
+        /// The storage where all tournaments are located.
+        /// </summary>
+        public readonly Storage AllTournaments;
+
         private readonly TournamentStorageManager storageConfig;
         public readonly Bindable<string> CurrentTournament;
 
@@ -23,16 +28,16 @@ namespace osu.Game.Tournament.IO
             : base(storage.GetStorageForDirectory("tournaments"), string.Empty)
         {
             this.storage = storage;
-            allTournaments = UnderlyingStorage;
+            AllTournaments = UnderlyingStorage;
 
             storageConfig = new TournamentStorageManager(storage);
 
             if (storage.Exists("tournament.ini"))
             {
-                ChangeTargetStorage(allTournaments.GetStorageForDirectory(storageConfig.Get<string>(StorageConfig.CurrentTournament)));
+                ChangeTargetStorage(AllTournaments.GetStorageForDirectory(storageConfig.Get<string>(StorageConfig.CurrentTournament)));
             }
             else
-                Migrate(allTournaments.GetStorageForDirectory(default_tournament));
+                Migrate(AllTournaments.GetStorageForDirectory(default_tournament));
 
             CurrentTournament = storageConfig.GetBindable<string>(StorageConfig.CurrentTournament);
             Logger.Log("Using tournament storage: " + GetFullPath(string.Empty));
@@ -42,11 +47,11 @@ namespace osu.Game.Tournament.IO
 
         private void updateTournament(ValueChangedEvent<string> newTournament)
         {
-            ChangeTargetStorage(allTournaments.GetStorageForDirectory(newTournament.NewValue));
+            ChangeTargetStorage(AllTournaments.GetStorageForDirectory(newTournament.NewValue));
             Logger.Log("Changing tournament storage: " + GetFullPath(string.Empty));
         }
 
-        public IEnumerable<string> ListTournaments() => allTournaments.GetDirectories(string.Empty);
+        public IEnumerable<string> ListTournaments() => AllTournaments.GetDirectories(string.Empty);
 
         public override void Migrate(Storage newStorage)
         {

--- a/osu.Game.Tournament/Models/StableInfo.cs
+++ b/osu.Game.Tournament/Models/StableInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using Newtonsoft.Json;
 using osu.Framework.Platform;
+using osu.Game.Tournament.IO;
 
 namespace osu.Game.Tournament.Models
 {
@@ -24,13 +25,14 @@ namespace osu.Game.Tournament.Models
         /// </summary>
         public event Action OnStableInfoSaved;
 
-        private const string config_path = "tournament/stable.json";
+        private const string config_path = "stable.json";
 
         private readonly Storage storage;
 
         public StableInfo(Storage storage)
         {
-            this.storage = storage;
+            TournamentStorage tStorage = (TournamentStorage)storage;
+            this.storage = tStorage.AllTournaments;
 
             if (!storage.Exists(config_path))
                 return;


### PR DESCRIPTION
This one supposedly went unnoticed for quite a while considering it's probably a very niche feature, but after the TournamentStorage rework (#9256) the `stable.json` file ended up in `tournaments/<tournament-name>/tournament/stable.json` instead of `tournaments/stable.json`.

This PR addresses that and also adds a headless test for this. 

Not sure if it's worth writing a migration for this, considering there's a possibility people might have ended up with multiple files in their own separate tournament configurations.

---
The alternative (and also easier) solution would be to allow users to have a `stable.json` on a per-tournament basis, because some streamers have a separate tourney client for every tournament. I've had people express interest in a tournament community discord for such a thing. 

I'll leave it up to you to decide which would be the desirable solution. 