### PR TITLE
Fix legacy control point precision having an adverse effect on the editor

### DIFF
--- a/osu.Game/Screens/Edit/Timing/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Timing/DifficultySection.cs
@@ -28,7 +28,16 @@ namespace osu.Game.Screens.Edit.Timing
         {
             if (point.NewValue != null)
             {
-                multiplierSlider.Current = point.NewValue.SpeedMultiplierBindable;
+                var selectedPointBindable = point.NewValue.SpeedMultiplierBindable;
+
+                // there may be legacy control points, which contain infinite precision for compatibility reasons (see LegacyDifficultyControlPoint).
+                // generally that level of precision could only be set by externally editing the .osu file, so at the point
+                // a user is looking to update this within the editor it should be safe to obliterate this additional precision.
+                double expectedPrecision = new DifficultyControlPoint().SpeedMultiplierBindable.Precision;
+                if (selectedPointBindable.Precision < expectedPrecision)
+                    selectedPointBindable.Precision = expectedPrecision;
+
+                multiplierSlider.Current = selectedPointBindable;
                 multiplierSlider.Current.BindValueChanged(_ => ChangeHandler?.SaveState());
             }
         }


### PR DESCRIPTION
Not sure about having this implemented where it is, but seems like the least destructive place to put it for the time being. Have confirmed that osu-stable's editor only allows the new precision value via GUI edits, so it should be *very* rare that a map is being edited with control points where this would ever trigger an actual value change.

We can probably revisit this once we are encoding beatmaps into a non-legacy format, but for now it affects all beatmaps, even those created in lazer.

Closes an issue reported in #12020.