### PR TITLE
Add osu!mania key count filtering using "keys=4" at song select

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             originalTargetColumns = TargetColumns;
         }
 
-        internal static int GetColumnCountForNonConvert(BeatmapInfo beatmap)
+        public static int GetColumnCountForNonConvert(BeatmapInfo beatmap)
         {
             var roundedCircleSize = Math.Round(beatmap.BaseDifficulty.CircleSize);
             return (int)Math.Max(1, roundedCircleSize);

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
 
             if (IsForCurrentRuleset)
             {
-                TargetColumns = (int)Math.Max(1, roundedCircleSize);
+                TargetColumns = GetColumnCountForNonConvert(beatmap.BeatmapInfo);
 
                 if (TargetColumns > ManiaRuleset.MAX_STAGE_KEYS)
                 {
@@ -69,6 +69,12 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             }
 
             originalTargetColumns = TargetColumns;
+        }
+
+        internal static int GetColumnCountForNonConvert(BeatmapInfo beatmap)
+        {
+            var roundedCircleSize = Math.Round(beatmap.BaseDifficulty.CircleSize);
+            return (int)Math.Max(1, roundedCircleSize);
         }
 
         public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasXPosition);

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mania
 
         public bool Matches(BeatmapInfo beatmap)
         {
-            return !keys.HasFilter || (beatmap.RulesetID == new ManiaRuleset().LegacyID) && keys.IsInRange(ManiaBeatmapConverter.GetColumnCountForNonConvert(beatmap));
+            return !keys.HasFilter || (beatmap.RulesetID == new ManiaRuleset().LegacyID && keys.IsInRange(ManiaBeatmapConverter.GetColumnCountForNonConvert(beatmap)));
         }
 
         public bool TryParseCustomKeywordCriteria(string key, Operator op, string value)

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Filter;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+
+namespace osu.Game.Rulesets.Mania
+{
+    public class ManiaFilterCriteria : IRulesetFilterCriteria
+    {
+        private FilterCriteria.OptionalRange<float> keys;
+
+        public bool Matches(BeatmapInfo beatmap)
+        {
+            return !keys.HasFilter || (beatmap.RulesetID == new ManiaRuleset().LegacyID) && keys.IsInRange(ManiaBeatmapConverter.GetColumnCountForNonConvert(beatmap));
+        }
+
+        public bool TryParseCustomKeywordCriteria(string key, Operator op, string value)
+        {
+            switch (key)
+            {
+                case "key":
+                case "keys":
+                    return FilterQueryParser.TryUpdateCriteriaRange(ref keys, op, value);
+            }
+
+            return false;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -22,6 +22,7 @@ using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.Difficulty;
@@ -382,6 +383,11 @@ namespace osu.Game.Rulesets.Mania
                 }
             }
         };
+
+        public override IRulesetFilterCriteria CreateRulesetFilterCriteria()
+        {
+            return new ManiaFilterCriteria();
+        }
     }
 
     public enum PlayfieldType


### PR DESCRIPTION
This is a pretty simplistic implementation of functionality here, but without database level changes this is about the best we can offer. Luckily, it almost matches what stable does (apart from not considering mods). Not intended to be a proper/final implementation but seems like it's better to have this level than nothing?

Was able to test out the flow of per-ruleset criteria specifications in the process; feels pretty good.

Closes(?) https://github.com/ppy/osu/issues/5668.