### PR TITLE
Fix mania beatmaps sometimes never ending

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -320,21 +320,24 @@ namespace osu.Game.Rulesets.Mania.Tests
             }, beatmap);
 
             assertHeadJudgement(HitResult.Perfect);
-            AddAssert("one tick missed", () => judgementResults.Where(j => j.HitObject is HoldNoteTick).Count(j => j.Type == HitResult.LargeTickMiss) == 1);
+            assertLastTickJudgement(HitResult.LargeTickMiss);
             assertTailJudgement(HitResult.Ok);
         }
 
         private void assertHeadJudgement(HitResult result)
-            => AddAssert($"head judged as {result}", () => judgementResults[0].Type == result);
+            => AddAssert($"head judged as {result}", () => judgementResults.First(j => j.HitObject is Note).Type == result);
 
         private void assertTailJudgement(HitResult result)
-            => AddAssert($"tail judged as {result}", () => judgementResults[^2].Type == result);
+            => AddAssert($"tail judged as {result}", () => judgementResults.Single(j => j.HitObject is TailNote).Type == result);
 
         private void assertNoteJudgement(HitResult result)
-            => AddAssert($"hold note judged as {result}", () => judgementResults[^1].Type == result);
+            => AddAssert($"hold note judged as {result}", () => judgementResults.Single(j => j.HitObject is HoldNote).Type == result);
 
         private void assertTickJudgement(HitResult result)
-            => AddAssert($"tick judged as {result}", () => judgementResults[6].Type == result); // arbitrary tick
+            => AddAssert($"any tick judged as {result}", () => judgementResults.Where(j => j.HitObject is HoldNoteTick).Any(j => j.Type == result));
+
+        private void assertLastTickJudgement(HitResult result)
+            => AddAssert($"last tick judged as {result}", () => judgementResults.Last(j => j.HitObject is HoldNoteTick).Type == result);
 
         private ScoreAccessibleReplayPlayer currentPlayer;
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -233,6 +233,12 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         {
             if (Tail.AllJudged)
             {
+                foreach (var tick in tickContainer)
+                {
+                    if (!tick.Judged)
+                        tick.MissForcefully();
+                }
+
                 ApplyResult(r => r.Type = r.Judgement.MaxResult);
                 endHold();
             }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12226

Doing this as a local fix for now, because mania's kinda special in the way it handles hold notes - it updates the hold notes' judgement based on the judged state of a nested hitobject, and it disappears immediately upon judgement. It also provides the `MissForcefully` method to do this already.

`OnKilled()` currently calls `UpdateResult()` but doesn't necessarily force a judgement, especially not for hold note ticks where they don't get judged unless `CurrentTime > HitObject.StartTime`.
Eventually we'll probably want `OnKilled()` to force a judgement, but there's a few things to consider that makes it too complicated for the time being:
1. Should it go through `CheckForResult()`, in-case hitobjects need to set custom properties on the results? E.g. something like `DrawbleSpinner` (`Result.TimeCompleted`).
2. How should `OnKilled()` determine if it's killed based on `EndTime` or based on `StartTime`? A bool provided to it?