### PR TITLE
Fix retry count not updating correctly

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -44,6 +44,29 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestRetryCountIncrements()
+        {
+            Player player = null;
+
+            PushAndConfirm(() => new TestSongSelect());
+
+            AddStep("import beatmap", () => ImportBeatmapTest.LoadQuickOszIntoOsu(Game).Wait());
+
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("wait for player", () => (player = Game.ScreenStack.CurrentScreen as Player) != null);
+            AddAssert("retry count is 0", () => player.RestartCount == 0);
+
+            AddStep("attempt to retry", () => player.ChildrenOfType<HotkeyRetryOverlay>().First().Action());
+            AddUntilStep("wait for old player gone", () => Game.ScreenStack.CurrentScreen != player);
+
+            AddUntilStep("get new player", () => (player = Game.ScreenStack.CurrentScreen as Player) != null);
+            AddAssert("retry count is 1", () => player.RestartCount == 1);
+        }
+
+        [Test]
         public void TestRetryFromResults()
         {
             Player player = null;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -310,7 +310,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             player = createPlayer();
-            player.RestartCount = ++restartCount;
+            player.RestartCount = restartCount++;
             player.RestartRequested = restartRequested;
 
             LoadTask = LoadComponentAsync(player, _ => MetadataInfo.Loading = false);

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -309,10 +309,8 @@ namespace osu.Game.Screens.Play
             if (!this.IsCurrentScreen())
                 return;
 
-            var restartCount = player?.RestartCount + 1 ?? 0;
-
             player = createPlayer();
-            player.RestartCount = restartCount;
+            player.RestartCount = ++restartCount;
             player.RestartRequested = restartRequested;
 
             LoadTask = LoadComponentAsync(player, _ => MetadataInfo.Loading = false);
@@ -427,6 +425,8 @@ namespace osu.Game.Screens.Play
         #region Mute warning
 
         private Bindable<bool> muteWarningShownOnce;
+
+        private int restartCount;
 
         private void showMuteWarningIfNeeded()
         {


### PR DESCRIPTION
Regressed with changes to player reference retention logic. Could add a
test but the logic is so local now it seems quite redundant.

Closes https://github.com/ppy/osu/issues/12234.