### PR TITLE
Move frame-handling spectator logic into abstract base class

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -11,6 +13,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online;
 using osu.Game.Online.Spectator;
 using osu.Game.Replays.Legacy;
@@ -28,6 +31,9 @@ namespace osu.Game.Tests.Visual.Gameplay
     {
         [Cached(typeof(SpectatorStreamingClient))]
         private TestSpectatorStreamingClient testSpectatorStreamingClient = new TestSpectatorStreamingClient();
+
+        [Cached(typeof(UserLookupCache))]
+        private UserLookupCache lookupCache = new TestUserLookupCache();
 
         // used just to show beatmap card for the time being.
         protected override bool UseOnlineAPI => true;
@@ -300,6 +306,15 @@ namespace osu.Game.Tests.Visual.Gameplay
                     RulesetID = 0,
                 });
             }
+        }
+
+        internal class TestUserLookupCache : UserLookupCache
+        {
+            protected override Task<User> ComputeValueAsync(int lookup, CancellationToken token = default) => Task.FromResult(new User
+            {
+                Id = lookup,
+                Username = $"User {lookup}"
+            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         // used just to show beatmap card for the time being.
         protected override bool UseOnlineAPI => true;
 
-        private Spectator spectatorScreen;
+        private SoloSpectator spectatorScreen;
 
         [Resolved]
         private OsuGameBase game { get; set; }
@@ -69,7 +69,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             loadSpectatingScreen();
 
-            AddAssert("screen hasn't changed", () => Stack.CurrentScreen is Spectator);
+            AddAssert("screen hasn't changed", () => Stack.CurrentScreen is SoloSpectator);
 
             start();
             sendFrames();
@@ -195,7 +195,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             start(-1234);
             sendFrames();
 
-            AddAssert("screen didn't change", () => Stack.CurrentScreen is Spectator);
+            AddAssert("screen didn't change", () => Stack.CurrentScreen is SoloSpectator);
         }
 
         private OsuFramedReplayInputHandler replayHandler =>
@@ -226,7 +226,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void loadSpectatingScreen()
         {
-            AddStep("load screen", () => LoadScreen(spectatorScreen = new Spectator(testSpectatorStreamingClient.StreamingUser)));
+            AddStep("load screen", () => LoadScreen(spectatorScreen = new SoloSpectator(testSpectatorStreamingClient.StreamingUser)));
             AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded);
         }
 

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Overlays.Dashboard
                                 Text = "Watch",
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
-                                Action = () => game?.PerformFromScreen(s => s.Push(new Spectator(User))),
+                                Action = () => game?.PerformFromScreen(s => s.Push(new SoloSpectator(User))),
                                 Enabled = { Value = User.Id != api.LocalUser.Value.Id }
                             }
                         }

--- a/osu.Game/Screens/Play/SoloSpectator.cs
+++ b/osu.Game/Screens/Play/SoloSpectator.cs
@@ -37,7 +37,7 @@ using osuTK;
 namespace osu.Game.Screens.Play
 {
     [Cached(typeof(IPreviewTrackOwner))]
-    public class Spectator : OsuScreen, IPreviewTrackOwner
+    public class SoloSpectator : OsuScreen, IPreviewTrackOwner
     {
         private readonly User targetUser;
 
@@ -88,7 +88,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         private bool newStatePending;
 
-        public Spectator([NotNull] User targetUser)
+        public SoloSpectator([NotNull] User targetUser)
         {
             this.targetUser = targetUser ?? throw new ArgumentNullException(nameof(targetUser));
         }

--- a/osu.Game/Screens/Spectate/GameplayState.cs
+++ b/osu.Game/Screens/Spectate/GameplayState.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+
+namespace osu.Game.Screens.Spectate
+{
+    /// <summary>
+    /// The gameplay state of a spectated user. This class is immutable.
+    /// </summary>
+    public class GameplayState
+    {
+        /// <summary>
+        /// The score which the user is playing.
+        /// </summary>
+        public readonly Score Score;
+
+        /// <summary>
+        /// The ruleset which the user is playing.
+        /// </summary>
+        public readonly Ruleset Ruleset;
+
+        /// <summary>
+        /// The beatmap which the user is playing.
+        /// </summary>
+        public readonly WorkingBeatmap Beatmap;
+
+        public GameplayState(Score score, Ruleset ruleset, WorkingBeatmap beatmap)
+        {
+            Score = score;
+            Ruleset = ruleset;
+            Beatmap = beatmap;
+        }
+    }
+}

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Screens.Spectate
         [Resolved]
         private UserLookupCache userLookupCache { get; set; }
 
+        // A lock is used to synchronise access to spectator/gameplay states, since this class is a screen which may become non-current and stop receiving updates at any point.
         private readonly object stateLock = new object();
 
         private readonly Dictionary<int, User> userMap = new Dictionary<int, User>();

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.Spectate
                     return;
 
                 spectatorStates[userId] = state;
-                OnUserStateChanged(userId, state);
+                Schedule(() => OnUserStateChanged(userId, state));
 
                 updateGameplayState(userId);
             }
@@ -148,7 +148,7 @@ namespace osu.Game.Screens.Spectate
                 var gameplayState = new GameplayState(score, resolvedRuleset, beatmaps.GetWorkingBeatmap(resolvedBeatmap));
 
                 gameplayStates[userId] = gameplayState;
-                StartGameplay(userId, gameplayState);
+                Schedule(() => StartGameplay(userId, gameplayState));
             }
         }
 
@@ -191,7 +191,7 @@ namespace osu.Game.Screens.Spectate
                 gameplayState.Score.Replay.HasReceivedAllFrames = true;
 
                 gameplayStates.Remove(userId);
-                EndGameplay(userId);
+                Schedule(() => EndGameplay(userId));
             }
         }
 

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -83,9 +83,9 @@ namespace osu.Game.Screens.Spectate
             managerUpdated.BindValueChanged(beatmapUpdated);
         }
 
-        private void beatmapUpdated(ValueChangedEvent<WeakReference<BeatmapSetInfo>> beatmap)
+        private void beatmapUpdated(ValueChangedEvent<WeakReference<BeatmapSetInfo>> e)
         {
-            if (!beatmap.NewValue.TryGetTarget(out var beatmapSet))
+            if (!e.NewValue.TryGetTarget(out var beatmapSet))
                 return;
 
             lock (stateLock)

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -1,0 +1,237 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Online.Spectator;
+using osu.Game.Replays;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Replays.Types;
+using osu.Game.Scoring;
+using osu.Game.Users;
+
+namespace osu.Game.Screens.Spectate
+{
+    /// <summary>
+    /// A <see cref="OsuScreen"/> which spectates one or more users.
+    /// </summary>
+    public abstract class SpectatorScreen : OsuScreen
+    {
+        private readonly int[] userIds;
+
+        [Resolved]
+        private BeatmapManager beatmaps { get; set; }
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        [Resolved]
+        private SpectatorStreamingClient spectatorClient { get; set; }
+
+        [Resolved]
+        private UserLookupCache userLookupCache { get; set; }
+
+        private readonly object stateLock = new object();
+
+        private readonly Dictionary<int, User> userMap = new Dictionary<int, User>();
+        private readonly Dictionary<int, SpectatorState> spectatorStates = new Dictionary<int, SpectatorState>();
+        private readonly Dictionary<int, GameplayState> gameplayStates = new Dictionary<int, GameplayState>();
+
+        private IBindable<WeakReference<BeatmapSetInfo>> managerUpdated;
+
+        /// <summary>
+        /// Creates a new <see cref="SpectatorScreen"/>.
+        /// </summary>
+        /// <param name="userIds">The users to spectate.</param>
+        protected SpectatorScreen(params int[] userIds)
+        {
+            this.userIds = userIds;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            spectatorClient.OnUserBeganPlaying += userBeganPlaying;
+            spectatorClient.OnUserFinishedPlaying += userFinishedPlaying;
+            spectatorClient.OnNewFrames += userSentFrames;
+
+            foreach (var id in userIds)
+            {
+                userLookupCache.GetUserAsync(id).ContinueWith(u => Schedule(() =>
+                {
+                    if (u.Result == null)
+                        return;
+
+                    lock (stateLock)
+                        userMap[id] = u.Result;
+
+                    spectatorClient.WatchUser(id);
+                }), TaskContinuationOptions.OnlyOnRanToCompletion);
+            }
+
+            managerUpdated = beatmaps.ItemUpdated.GetBoundCopy();
+            managerUpdated.BindValueChanged(beatmapUpdated);
+        }
+
+        private void beatmapUpdated(ValueChangedEvent<WeakReference<BeatmapSetInfo>> beatmap)
+        {
+            if (!beatmap.NewValue.TryGetTarget(out var beatmapSet))
+                return;
+
+            lock (stateLock)
+            {
+                foreach (var (userId, state) in spectatorStates)
+                {
+                    if (beatmapSet.Beatmaps.Any(b => b.OnlineBeatmapID == state.BeatmapID))
+                        updateGameplayState(userId);
+                }
+            }
+        }
+
+        private void userBeganPlaying(int userId, SpectatorState state)
+        {
+            if (state.RulesetID == null || state.BeatmapID == null)
+                return;
+
+            lock (stateLock)
+            {
+                if (!userMap.ContainsKey(userId))
+                    return;
+
+                spectatorStates[userId] = state;
+                OnUserStateChanged(userId, state);
+
+                updateGameplayState(userId);
+            }
+        }
+
+        private void updateGameplayState(int userId)
+        {
+            lock (stateLock)
+            {
+                Debug.Assert(userMap.ContainsKey(userId));
+
+                var spectatorState = spectatorStates[userId];
+                var user = userMap[userId];
+
+                var resolvedRuleset = rulesets.AvailableRulesets.FirstOrDefault(r => r.ID == spectatorState.RulesetID)?.CreateInstance();
+                if (resolvedRuleset == null)
+                    return;
+
+                var resolvedBeatmap = beatmaps.QueryBeatmap(b => b.OnlineBeatmapID == spectatorState.BeatmapID);
+                if (resolvedBeatmap == null)
+                    return;
+
+                var score = new Score
+                {
+                    ScoreInfo = new ScoreInfo
+                    {
+                        Beatmap = resolvedBeatmap,
+                        User = user,
+                        Mods = spectatorState.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
+                        Ruleset = resolvedRuleset.RulesetInfo,
+                    },
+                    Replay = new Replay { HasReceivedAllFrames = false },
+                };
+
+                var gameplayState = new GameplayState(score, resolvedRuleset, beatmaps.GetWorkingBeatmap(resolvedBeatmap));
+
+                gameplayStates[userId] = gameplayState;
+                StartGameplay(userId, gameplayState);
+            }
+        }
+
+        private void userSentFrames(int userId, FrameDataBundle bundle)
+        {
+            lock (stateLock)
+            {
+                if (!userMap.ContainsKey(userId))
+                    return;
+
+                if (!gameplayStates.TryGetValue(userId, out var gameplayState))
+                    return;
+
+                // The ruleset instance should be guaranteed to be in sync with the score via ScoreLock.
+                Debug.Assert(gameplayState.Ruleset != null && gameplayState.Ruleset.RulesetInfo.Equals(gameplayState.Score.ScoreInfo.Ruleset));
+
+                foreach (var frame in bundle.Frames)
+                {
+                    IConvertibleReplayFrame convertibleFrame = gameplayState.Ruleset.CreateConvertibleReplayFrame();
+                    convertibleFrame.FromLegacy(frame, gameplayState.Beatmap.Beatmap);
+
+                    var convertedFrame = (ReplayFrame)convertibleFrame;
+                    convertedFrame.Time = frame.Time;
+
+                    gameplayState.Score.Replay.Frames.Add(convertedFrame);
+                }
+            }
+        }
+
+        private void userFinishedPlaying(int userId, SpectatorState state)
+        {
+            lock (stateLock)
+            {
+                if (!userMap.ContainsKey(userId))
+                    return;
+
+                if (!gameplayStates.TryGetValue(userId, out var gameplayState))
+                    return;
+
+                gameplayState.Score.Replay.HasReceivedAllFrames = true;
+
+                gameplayStates.Remove(userId);
+                EndGameplay(userId);
+            }
+        }
+
+        /// <summary>
+        /// Invoked when a spectated user's state has changed.
+        /// </summary>
+        /// <param name="userId">The user whose state has changed.</param>
+        /// <param name="spectatorState">The new state.</param>
+        protected abstract void OnUserStateChanged(int userId, [NotNull] SpectatorState spectatorState);
+
+        /// <summary>
+        /// Starts gameplay for a user.
+        /// </summary>
+        /// <param name="userId">The user to start gameplay for.</param>
+        /// <param name="gameplayState">The gameplay state.</param>
+        protected abstract void StartGameplay(int userId, [NotNull] GameplayState gameplayState);
+
+        /// <summary>
+        /// Ends gameplay for a user.
+        /// </summary>
+        /// <param name="userId">The user to end gameplay for.</param>
+        protected abstract void EndGameplay(int userId);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (spectatorClient != null)
+            {
+                spectatorClient.OnUserBeganPlaying -= userBeganPlaying;
+                spectatorClient.OnUserFinishedPlaying -= userFinishedPlaying;
+                spectatorClient.OnNewFrames -= userSentFrames;
+
+                lock (stateLock)
+                {
+                    foreach (var (userId, _) in userMap)
+                        spectatorClient.StopWatchingUser(userId);
+                }
+            }
+
+            managerUpdated?.UnbindAll();
+        }
+    }
+}


### PR DESCRIPTION
The current `Spectator` screen is quite inextensible since the UI logic is very coupled to the frame-handling business logic.

In this PR, the business logic has been moved to a base `SpectatorScreen` class. This class handles an arbitrary number of users, and exposes three methods:
1. `OnUserStateChanged` which is invoked when a spectate state changes. This is used to show the beatmap panel in the solo spectator.
2. `StartGameplay` which is invoked when a spectated user begins playing _and_ the client is able to play the map.
3. `EndGameplay` which is invoked when a spectated user stops playing.

There will be a `MultiplayerSpectator` screen inheriting from this that provides more custom logic and shares none of the UI logic of the current `Spectator` screen. Current implementation can be found in https://github.com/smoogipoo/osu/blob/multiplayer-spectate/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiplayerSpectator.cs