### PR TITLE
Guard against same ruleset file with filenames of loaded assembly location instead

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -173,7 +174,7 @@ namespace osu.Game.Rulesets
         {
             var filename = Path.GetFileNameWithoutExtension(file);
 
-            if (loadedAssemblies.Values.Any(t => t.Namespace == filename))
+            if (loadedAssemblies.Values.Any(t => Path.GetFileNameWithoutExtension(t.Assembly.Location) == filename))
                 return;
 
             try


### PR DESCRIPTION
This came up to me at https://github.com/Beamographic/rush/pull/127, which essentially makes the ruleset project compile with different assembly names for builds separation purposes, but still use one shared root namespace.

---

There appears to be a guard in `loadRulesetFromFile` that presumably disallows loading the same ruleset assembly twice.

Since the guard compares the ruleset namespace (root namespace of the project) with the filename to load, if a different ruleset assembly name is loaded first, then the ruleset assembly name with the same root namespace would be blocked by this guard and therefore not load the ruleset, although it should.
```csharp
loadRulesetFromFile(".../osu.Game.Rulesets.Rush-dev.dll");
/* loaded,
 * typeof(RushRuleset).Namespace = root namespace = "osu.Game.Rulesets.Rush"
 * typeof(RushRuleset).Assembly.Location = ".../osu.Game.Rulesets.Rush-dev.dll"
 */

loadRulesetFromFile(".../osu.Game.Rulesets.Rush.dll");
/* not loaded due to guard,
 * typeof(RushRuleset).Namespace = root namespace = "osu.Game.Rulesets.Rush"
 * typeof(RushRuleset).Assembly.Location = ".../osu.Game.Rulesets.Rush.dll"
 */
```

Therefore I've changed the guard to compare using the assembly filename from its location instead. (`Path.GetFileNameWithoutExtension(t.Assembly.Location`)

---

Worthy to note that this check looks to be added from a couple of years ago, and now doesn't seem to help with anything on loading rulesets from files as far as I can see, only early returns when trying to load the same ruleset file again, or load a referenced ruleset assembly within the user ruleset folder.

Looking at that, I'm starting to think about just not having this guard at all and consider logging the caught exception on loading to be enough, but I'll leave that for you to decide before I make any further changes in this.