### PR TITLE
Add classic mod setting to always play slider tail samples

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -79,6 +79,10 @@ namespace osu.Game.Rulesets.Osu.Mods
                     case DrawableSliderHead head:
                         head.TrackFollowCircle = !NoSliderHeadMovement.Value;
                         break;
+
+                    case DrawableSliderTail tail:
+                        tail.AlwaysPlaySample = true;
+                        break;
                 }
             }
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                         break;
 
                     case DrawableSliderTail tail:
-                        tail.AlwaysPlaySample = AlwaysPlayTailSample.Value;
+                        tail.SamplePlaysOnlyOnHit = !AlwaysPlayTailSample.Value;
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -44,6 +44,9 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Use fixed slider follow circle hit area", "Makes the slider follow circle track its final size at all times.")]
         public Bindable<bool> FixedFollowCircleHitArea { get; } = new BindableBool(true);
 
+        [SettingSource("Always play a slider's tail sample", "Always plays a slider's tail sample regardless of whether it was hit or not.")]
+        public Bindable<bool> AlwaysPlayTailSample { get; } = new BindableBool(true);
+
         public void ApplyToHitObject(HitObject hitObject)
         {
             switch (hitObject)
@@ -81,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                         break;
 
                     case DrawableSliderTail tail:
-                        tail.AlwaysPlaySample = true;
+                        tail.AlwaysPlaySample = AlwaysPlayTailSample.Value;
                         break;
                 }
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             // rather than doing it this way, we should probably attach the sample to the tail circle.
             // this can only be done after we stop using LegacyLastTick.
-            if (TailCircle.IsHit || TailCircle.AlwaysPlaySample)
+            if (!TailCircle.SamplePlaysOnlyOnHit || TailCircle.IsHit)
                 base.PlaySamples();
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -280,7 +280,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             // rather than doing it this way, we should probably attach the sample to the tail circle.
             // this can only be done after we stop using LegacyLastTick.
-            if (TailCircle.IsHit)
+            if (TailCircle.IsHit || TailCircle.AlwaysPlaySample)
                 base.PlaySamples();
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -26,6 +26,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// </summary>
         public override bool DisplayResult => false;
 
+        /// <summary>
+        /// Whether the hit sample should always be played, regardless of whether the tail was actually hit.
+        /// </summary>
+        public bool AlwaysPlaySample { get; set; }
+
         public bool Tracking { get; set; }
 
         private SkinnableDrawable circlePiece;
@@ -44,6 +49,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
+            AlwaysPlaySample = false;
             Origin = Anchor.Centre;
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -27,7 +27,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public override bool DisplayResult => false;
 
         /// <summary>
-        /// Whether the hit sample should always be played, regardless of whether the tail was actually hit.
+        /// Whether the hit samples only play on successful hits.
+        /// If <c>false</c>, the hit samples will also play on misses.
         /// </summary>
         public bool SamplePlaysOnlyOnHit { get; set; } = true;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// <summary>
         /// Whether the hit sample should always be played, regardless of whether the tail was actually hit.
         /// </summary>
-        public bool AlwaysPlaySample { get; set; }
+        public bool SamplePlaysOnlyOnHit { get; set; } = true;
 
         public bool Tracking { get; set; }
 
@@ -49,7 +49,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            AlwaysPlaySample = false;
             Origin = Anchor.Centre;
             Size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 


### PR DESCRIPTION
Closes #11921 

This is my first PR so I apologize if I've done anything dumb / missed things that I should have done. 

This implements the option to always play a slider's tail sample on the classic mod with the default of `true`. 