### PR TITLE
Open editor file selector in the directory of the previous selection

### DIFF
--- a/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
+++ b/osu.Game/Screens/Edit/Setup/FileChooserLabelledTextBox.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.Edit.Setup
         {
             FileSelector fileSelector;
 
-            Target.Child = fileSelector = new FileSelector(validFileExtensions: ResourcesSection.AudioExtensions)
+            Target.Child = fileSelector = new FileSelector(currentFile.Value?.DirectoryName, ResourcesSection.AudioExtensions)
             {
                 RelativeSizeAxes = Axes.X,
                 Height = 400,

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -73,7 +73,8 @@ namespace osu.Game.Screens.Edit.Setup
                 audioTrackTextBox = new FileChooserLabelledTextBox
                 {
                     Label = "Audio Track",
-                    Current = { Value = working.Value.Metadata.AudioFile ?? "Click to select a track" },
+                    PlaceholderText = "Click to select a track",
+                    Current = { Value = working.Value.Metadata.AudioFile },
                     Target = audioTrackFileChooserContainer,
                     TabbableContentContainer = this
                 },


### PR DESCRIPTION
Fixes (?) part of #12020 (next to last one)
>clicking on the song file name doesnt bring you to the map file, it just opens your computer files

My understanding is that the OP was suggesting the file selector reopen in the directory of the previously selected file.
(@DeviousPanda, could you please confirm?)

Either way it seems like the correct behavior to me. (Compared to a few desktop applications)
