### PR TITLE
Fix editor clock test scene not re-enabling beatmap

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
@@ -77,5 +77,11 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("start clock again", Clock.Start);
             AddAssert("clock looped to start", () => Clock.IsRunning && Clock.CurrentTime < 500);
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            Beatmap.Disabled = false;
+            base.Dispose(isDisposing);
+        }
     }
 }


### PR DESCRIPTION
Could interfere with other tests in the visual test browser opened after it, due to causing crashes on attempts to change `Beatmap.Value`.