### PR TITLE
Fix scores being initially visible incorrectly in gameplay screen

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -1,9 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Testing;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Screens.Gameplay;
+using osu.Game.Tournament.Screens.Gameplay.Components;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
@@ -18,5 +22,24 @@ namespace osu.Game.Tournament.Tests.Screens
             Add(new GameplayScreen());
             Add(chat);
         }
+
+        [Test]
+        public void TestWarmup()
+        {
+            checkScoreVisibility(false);
+
+            toggleWarmup();
+            checkScoreVisibility(true);
+
+            toggleWarmup();
+            checkScoreVisibility(false);
+        }
+
+        private void checkScoreVisibility(bool visible)
+            => AddUntilStep($"scores {(visible ? "shown" : "hidden")}",
+                () => this.ChildrenOfType<TeamScore>().All(score => score.Alpha == (visible ? 1 : 0)));
+
+        private void toggleWarmup()
+            => AddStep("toggle warmup", () => this.ChildrenOfType<TourneyButton>().First().Click());
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
@@ -95,7 +95,11 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                     Origin = Anchor.TopRight,
                 },
             };
+        }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
             updateDisplay();
         }
 

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -14,9 +14,21 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
     {
         private readonly TeamScore score;
 
+        private bool showScore;
+
         public bool ShowScore
         {
-            set => score.FadeTo(value ? 1 : 0, 200);
+            get => showScore;
+            set
+            {
+                if (showScore == value)
+                    return;
+
+                showScore = value;
+
+                if (IsLoaded)
+                    score.FadeTo(value ? 1 : 0, 200);
+            }
         }
 
         public TeamDisplay(TournamentTeam team, TeamColour colour, Bindable<int?> currentTeamScore, int pointsToWin)
@@ -91,6 +103,12 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                     },
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            score.Alpha = ShowScore ? 1 : 0;
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
                 showScore = value;
 
                 if (IsLoaded)
-                    score.FadeTo(value ? 1 : 0, 200);
+                    updateDisplay();
             }
         }
 
@@ -108,7 +108,14 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            score.Alpha = ShowScore ? 1 : 0;
+
+            updateDisplay();
+            FinishTransforms(true);
+        }
+
+        private void updateDisplay()
+        {
+            score.FadeTo(ShowScore ? 1 : 0, 200);
         }
     }
 }


### PR DESCRIPTION
Resolves #12282.

As can be probably surmised by the fix, the issue was that a set to `MatchHeader.ShowScores` took place after its BDL (and, notably, the `updateDisplay` call at the end of it) finished executing, but before the `IsLoaded` guard became `true`. The fix in that case is to remove that window of opportunity by moving the display update to `LoadComplete()`, which is what 0d97937 does.

0febefd is an additional change that aims to prevent the display fading out for 200ms immediately after entering the screen.