### PR TITLE
Fix crash when right clicking online score

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -391,7 +391,7 @@ namespace osu.Game.Online.Leaderboards
                 if (score.Mods.Length > 0 && modsContainer.Any(s => s.IsHovered) && songSelect != null)
                     items.Add(new OsuMenuItem("Use these mods", MenuItemType.Highlighted, () => songSelect.Mods.Value = score.Mods));
 
-                if (score.Files.Count > 0)
+                if (score.Files?.Count > 0)
                     items.Add(new OsuMenuItem("Export", MenuItemType.Standard, () => scoreManager.Export(score)));
 
                 if (score.ID != 0)


### PR DESCRIPTION
This is null if the score is not downloaded
![image](https://user-images.githubusercontent.com/50285552/113496267-8e177880-952a-11eb-9430-adfc9a0402fc.png)
