### PR TITLE
Fix IPC Source getting read from the incorrect location

### DIFF
--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -10,6 +10,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Tests.Visual;
+using osu.Game.Tournament.IO;
 using osu.Game.Tournament.IPC;
 using osu.Game.Tournament.Models;
 using osu.Game.Users;
@@ -28,7 +29,7 @@ namespace osu.Game.Tournament.Tests
         protected MatchIPCInfo IPCInfo { get; private set; } = new MatchIPCInfo();
 
         [BackgroundDependencyLoader]
-        private void load(Storage storage)
+        private void load(TournamentStorage storage)
         {
             Ladder.Ruleset.Value ??= rulesetStore.AvailableRulesets.First();
 

--- a/osu.Game.Tournament/Models/StableInfo.cs
+++ b/osu.Game.Tournament/Models/StableInfo.cs
@@ -34,10 +34,10 @@ namespace osu.Game.Tournament.Models
             TournamentStorage tStorage = (TournamentStorage)storage;
             this.storage = tStorage.AllTournaments;
 
-            if (!storage.Exists(config_path))
+            if (!this.storage.Exists(config_path))
                 return;
 
-            using (Stream stream = storage.GetStream(config_path, FileAccess.Read, FileMode.Open))
+            using (Stream stream = this.storage.GetStream(config_path, FileAccess.Read, FileMode.Open))
             using (var sr = new StreamReader(stream))
             {
                 JsonConvert.PopulateObject(sr.ReadToEnd(), this);

--- a/osu.Game.Tournament/Models/StableInfo.cs
+++ b/osu.Game.Tournament/Models/StableInfo.cs
@@ -27,17 +27,17 @@ namespace osu.Game.Tournament.Models
 
         private const string config_path = "stable.json";
 
-        private readonly Storage storage;
+        private readonly Storage configStorage;
 
         public StableInfo(Storage storage)
         {
             TournamentStorage tStorage = (TournamentStorage)storage;
-            this.storage = tStorage.AllTournaments;
+            configStorage = tStorage.AllTournaments;
 
-            if (!this.storage.Exists(config_path))
+            if (!configStorage.Exists(config_path))
                 return;
 
-            using (Stream stream = this.storage.GetStream(config_path, FileAccess.Read, FileMode.Open))
+            using (Stream stream = configStorage.GetStream(config_path, FileAccess.Read, FileMode.Open))
             using (var sr = new StreamReader(stream))
             {
                 JsonConvert.PopulateObject(sr.ReadToEnd(), this);
@@ -46,7 +46,7 @@ namespace osu.Game.Tournament.Models
 
         public void SaveChanges()
         {
-            using (var stream = storage.GetStream(config_path, FileAccess.Write, FileMode.Create))
+            using (var stream = configStorage.GetStream(config_path, FileAccess.Write, FileMode.Create))
             using (var sw = new StreamWriter(stream))
             {
                 sw.Write(JsonConvert.SerializeObject(this,

--- a/osu.Game.Tournament/Models/StableInfo.cs
+++ b/osu.Game.Tournament/Models/StableInfo.cs
@@ -29,10 +29,9 @@ namespace osu.Game.Tournament.Models
 
         private readonly Storage configStorage;
 
-        public StableInfo(Storage storage)
+        public StableInfo(TournamentStorage storage)
         {
-            TournamentStorage tStorage = (TournamentStorage)storage;
-            configStorage = tStorage.AllTournaments;
+            configStorage = storage.AllTournaments;
 
             if (!configStorage.Exists(config_path))
                 return;


### PR DESCRIPTION
Closes #12289 

I called the ctor parameter for storage instead of `this.storage` in subsequent calls in ctor causing the attempts to read to fall in the incorrect `Storage`.