### PR TITLE
Fix floating point error in slider path encoding

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -18,10 +18,14 @@ using osu.Game.IO;
 using osu.Game.IO.Serialization;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Skinning;
 using osu.Game.Tests.Resources;
+using osuTK;
 
 namespace osu.Game.Tests.Beatmaps.Formats
 {
@@ -43,6 +47,33 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
             Assert.That(decodedAfterEncode.beatmap.Serialize(), Is.EqualTo(decoded.beatmap.Serialize()));
             Assert.IsTrue(areComboColoursEqual(decodedAfterEncode.beatmapSkin.Configuration, decoded.beatmapSkin.Configuration));
+        }
+
+        [Test]
+        public void TestEncodeMultiSegmentSliderWithFloatingPointError()
+        {
+            var beatmap = new Beatmap
+            {
+                HitObjects =
+                {
+                    new Slider
+                    {
+                        Position = new Vector2(0.6f),
+                        Path = new SliderPath(new[]
+                        {
+                            new PathControlPoint(Vector2.Zero, PathType.Bezier),
+                            new PathControlPoint(new Vector2(0.5f)),
+                            new PathControlPoint(new Vector2(0.51f)), // This is actually on the same position as the previous one in legacy beatmaps (truncated to int).
+                            new PathControlPoint(new Vector2(1f), PathType.Bezier),
+                            new PathControlPoint(new Vector2(2f))
+                        })
+                    },
+                }
+            };
+
+            var decodedAfterEncode = decodeFromLegacy(encodeToLegacy((beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty))), string.Empty);
+            var decodedSlider = (Slider)decodedAfterEncode.beatmap.HitObjects[0];
+            Assert.That(decodedSlider.Path.ControlPoints.Count, Is.EqualTo(5));
         }
 
         private bool areComboColoursEqual(IHasComboColours a, IHasComboColours b)


### PR DESCRIPTION
As I tried to mention in https://github.com/ppy/osu/pull/12303 and in the voice chat, lazer already doesn't merge the last two control points of any explicit segment if they're equal. This is done at a decode time via the changes in #12303.

The reason why this happened in voice chat was because of a FP error. At encode time, lazer tries to preserve compatibility with stable as much as possible so it transforms explicit segments into implicit ones by duplicating control points.
In #12303 I had an exception for this when the explicit segment was already preceded by an implicit segment, but it died to an FP error because I was only considering the relative position of each control point.

So with this, and #12303:
1. If you move the last two control points of a segment on top of each other, they will remain as is.
2. If you move any other two control points of a segment on top of each other, a segment will be created at decode time and they'll be merged into a single purple point in the editor upon undo, etc.