### PR TITLE
Add multiplayer spectating user state and button

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
     public class TestSceneMultiplayerMatchFooter : MultiplayerTestScene
     {
         [Cached]
-        private readonly OnlinePlayBeatmapAvailablilityTracker availablilityTracker = new OnlinePlayBeatmapAvailablilityTracker();
+        private readonly OnlinePlayBeatmapAvailabilityTracker availablilityTracker = new OnlinePlayBeatmapAvailabilityTracker();
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchFooter.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
+
+namespace osu.Game.Tests.Visual.Multiplayer
+{
+    public class TestSceneMultiplayerMatchFooter : MultiplayerTestScene
+    {
+        [Cached]
+        private readonly OnlinePlayBeatmapAvailablilityTracker availablilityTracker = new OnlinePlayBeatmapAvailablilityTracker();
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new MultiplayerMatchFooter
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Height = 50
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -3,13 +3,21 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Resources;
+using osu.Game.Users;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -18,9 +26,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
     {
         private MultiplayerMatchSubScreen screen;
 
+        private BeatmapManager beatmaps;
+        private RulesetStore rulesets;
+        private BeatmapSetInfo importedSet;
+
         public TestSceneMultiplayerMatchSubScreen()
             : base(false)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host, AudioManager audio)
+        {
+            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, host, Beatmap.Default));
+            beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).Wait();
+
+            importedSet = beatmaps.GetAllUsableBeatmapSetsEnumerable(IncludedDetails.All).First();
         }
 
         [SetUp]
@@ -72,6 +94,45 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddWaitStep("wait", 10);
+        }
+
+        [Test]
+        public void TestStartMatchWhileSpectating()
+        {
+            AddStep("set playlist", () =>
+            {
+                Room.Playlist.Add(new PlaylistItem
+                {
+                    Beatmap = { Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First()).BeatmapInfo },
+                    Ruleset = { Value = new OsuRuleset().RulesetInfo },
+                });
+            });
+
+            AddStep("click create button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("join other user (ready)", () =>
+            {
+                Client.AddUser(new User { Id = 55 });
+                Client.ChangeUserState(55, MultiplayerUserState.Ready);
+            });
+
+            AddStep("click spectate button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerSpectateButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("click ready button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerReadyButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("match started", () => Client.Room?.State == MultiplayerRoomState.WaitingForLoad);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -127,6 +127,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
+        public void TestToggleSpectateState()
+        {
+            AddStep("make user spectating", () => Client.ChangeState(MultiplayerUserState.Spectating));
+            AddStep("make user idle", () => Client.ChangeState(MultiplayerUserState.Idle));
+        }
+
+        [Test]
         public void TestCrownChangesStateWhenHostTransferred()
         {
             AddStep("add user", () => Client.AddUser(new User

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerReadyButton.cs
@@ -209,9 +209,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             addClickButtonStep();
             AddAssert("user waiting for load", () => Client.Room?.Users[0].State == MultiplayerUserState.WaitingForLoad);
-            AddAssert("ready button disabled", () => !button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
 
+            AddAssert("ready button disabled", () => !button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
             AddStep("transitioned to gameplay", () => readyClickOperation.Dispose());
+
+            AddStep("finish gameplay", () =>
+            {
+                Client.ChangeUserState(Client.Room?.Users[0].UserID ?? 0, MultiplayerUserState.Loaded);
+                Client.ChangeUserState(Client.Room?.Users[0].UserID ?? 0, MultiplayerUserState.FinishedPlay);
+            });
+
             AddAssert("ready button enabled", () => button.ChildrenOfType<OsuButton>().Single().Enabled.Value);
         }
     }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -2,10 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
+using osu.Game.Tests.Resources;
 using osuTK;
 using osuTK.Input;
 
@@ -13,22 +25,96 @@ namespace osu.Game.Tests.Visual.Multiplayer
 {
     public class TestSceneMultiplayerSpectateButton : MultiplayerTestScene
     {
-        private MultiplayerSpectateButton button;
+        private MultiplayerSpectateButton spectateButton;
+        private MultiplayerReadyButton readyButton;
+
+        private readonly Bindable<PlaylistItem> selectedItem = new Bindable<PlaylistItem>();
+
+        private BeatmapSetInfo importedSet;
+        private BeatmapManager beatmaps;
+        private RulesetStore rulesets;
+
         private IDisposable readyClickOperation;
+
+        protected override Container<Drawable> Content => content;
+        private readonly Container content;
+
+        public TestSceneMultiplayerSpectateButton()
+        {
+            base.Content.Add(content = new Container
+            {
+                RelativeSizeAxes = Axes.Both
+            });
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
+            return dependencies;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host, AudioManager audio)
+        {
+            Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
+            Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, host, Beatmap.Default));
+
+            var beatmapTracker = new OnlinePlayBeatmapAvailablilityTracker { SelectedItem = { BindTarget = selectedItem } };
+            base.Content.Add(beatmapTracker);
+            Dependencies.Cache(beatmapTracker);
+
+            beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).Wait();
+        }
 
         [SetUp]
         public new void Setup() => Schedule(() =>
         {
-            Child = button = new MultiplayerSpectateButton
+            importedSet = beatmaps.GetAllUsableBeatmapSetsEnumerable(IncludedDetails.All).First();
+            Beatmap.Value = beatmaps.GetWorkingBeatmap(importedSet.Beatmaps.First());
+            selectedItem.Value = new PlaylistItem
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Size = new Vector2(200, 50),
-                OnSpectateClick = async () =>
+                Beatmap = { Value = Beatmap.Value.BeatmapInfo },
+                Ruleset = { Value = Beatmap.Value.BeatmapInfo.Ruleset },
+            };
+
+            Child = new FillFlowContainer
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
                 {
-                    readyClickOperation = OngoingOperationTracker.BeginOperation();
-                    await Client.ToggleSpectate();
-                    readyClickOperation.Dispose();
+                    spectateButton = new MultiplayerSpectateButton
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(200, 50),
+                        OnSpectateClick = async () =>
+                        {
+                            readyClickOperation = OngoingOperationTracker.BeginOperation();
+                            await Client.ToggleSpectate();
+                            readyClickOperation.Dispose();
+                        }
+                    },
+                    readyButton = new MultiplayerReadyButton
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(200, 50),
+                        OnReadyClick = async () =>
+                        {
+                            readyClickOperation = OngoingOperationTracker.BeginOperation();
+
+                            if (Client.IsHost && Client.LocalUser?.State == MultiplayerUserState.Ready)
+                            {
+                                await Client.StartMatch();
+                                return;
+                            }
+
+                            await Client.ToggleReady();
+                            readyClickOperation.Dispose();
+                        }
+                    }
                 }
             };
         });
@@ -37,17 +123,26 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [TestCase(MultiplayerUserState.Ready)]
         public void TestToggleWhenIdle(MultiplayerUserState initialState)
         {
-            addClickButtonStep();
+            addClickSpectateButtonStep();
             AddAssert("user is spectating", () => Client.Room?.Users[0].State == MultiplayerUserState.Spectating);
 
-            addClickButtonStep();
+            addClickSpectateButtonStep();
             AddAssert("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
         }
 
-        private void addClickButtonStep() => AddStep("click button", () =>
+        private void addClickSpectateButtonStep() => AddStep("click spectate button", () =>
         {
-            InputManager.MoveMouseTo(button);
+            InputManager.MoveMouseTo(spectateButton);
             InputManager.Click(MouseButton.Left);
         });
+
+        private void addClickReadyButtonStep() => AddStep("click ready button", () =>
+        {
+            InputManager.MoveMouseTo(readyButton);
+            InputManager.Click(MouseButton.Left);
+        });
+
+        private void assertReadyButtonEnablement(bool shouldBeEnabled)
+            => AddAssert($"ready button {(shouldBeEnabled ? "is" : "is not")} enabled", () => readyButton.ChildrenOfType<OsuButton>().Single().Enabled.Value == shouldBeEnabled);
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -184,12 +184,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             InputManager.Click(MouseButton.Left);
         });
 
-        private void addClickReadyButtonStep() => AddStep("click ready button", () =>
-        {
-            InputManager.MoveMouseTo(readyButton);
-            InputManager.Click(MouseButton.Left);
-        });
-
         private void assertSpectateButtonEnablement(bool shouldBeEnabled)
             => AddAssert($"spectate button {(shouldBeEnabled ? "is" : "is not")} enabled", () => spectateButton.ChildrenOfType<OsuButton>().Single().Enabled.Value == shouldBeEnabled);
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Dependencies.Cache(rulesets = new RulesetStore(ContextFactory));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, ContextFactory, rulesets, null, audio, host, Beatmap.Default));
 
-            var beatmapTracker = new OnlinePlayBeatmapAvailablilityTracker { SelectedItem = { BindTarget = selectedItem } };
+            var beatmapTracker = new OnlinePlayBeatmapAvailabilityTracker { SelectedItem = { BindTarget = selectedItem } };
             base.Content.Add(beatmapTracker);
             Dependencies.Cache(beatmapTracker);
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSpectateButton.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Multiplayer
+{
+    public class TestSceneMultiplayerSpectateButton : MultiplayerTestScene
+    {
+        private MultiplayerSpectateButton button;
+        private IDisposable readyClickOperation;
+
+        [SetUp]
+        public new void Setup() => Schedule(() =>
+        {
+            Child = button = new MultiplayerSpectateButton
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(200, 50),
+                OnSpectateClick = async () =>
+                {
+                    readyClickOperation = OngoingOperationTracker.BeginOperation();
+                    await Client.ToggleSpectate();
+                    readyClickOperation.Dispose();
+                }
+            };
+        });
+
+        [TestCase(MultiplayerUserState.Idle)]
+        [TestCase(MultiplayerUserState.Ready)]
+        public void TestToggleWhenIdle(MultiplayerUserState initialState)
+        {
+            addClickButtonStep();
+            AddAssert("user is spectating", () => Client.Room?.Users[0].State == MultiplayerUserState.Spectating);
+
+            addClickButtonStep();
+            AddAssert("user is idle", () => Client.Room?.Users[0].State == MultiplayerUserState.Idle);
+        }
+
+        private void addClickButtonStep() => AddStep("click button", () =>
+        {
+            InputManager.MoveMouseTo(button);
+            InputManager.Click(MouseButton.Left);
+        });
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -96,6 +96,9 @@ namespace osu.Game.Online.Multiplayer
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
+            if (newState == MultiplayerUserState.Spectating)
+                return Task.CompletedTask; // Not supported yet.
+
             return connection.InvokeAsync(nameof(IMultiplayerServer.ChangeState), newState);
         }
 

--- a/osu.Game/Online/Multiplayer/MultiplayerUserState.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerUserState.cs
@@ -55,5 +55,10 @@ namespace osu.Game.Online.Multiplayer
         /// The user is currently viewing results. This is a reserved state, and is set by the server.
         /// </summary>
         Results,
+
+        /// <summary>
+        /// The user is currently spectating this room.
+        /// </summary>
+        Spectating
     }
 }

--- a/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/StatefulMultiplayerClient.cs
@@ -249,6 +249,33 @@ namespace osu.Game.Online.Multiplayer
             }
         }
 
+        /// <summary>
+        /// Toggles the <see cref="LocalUser"/>'s spectating state.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If a toggle of the spectating state is not valid at this time.</exception>
+        public async Task ToggleSpectate()
+        {
+            var localUser = LocalUser;
+
+            if (localUser == null)
+                return;
+
+            switch (localUser.State)
+            {
+                case MultiplayerUserState.Idle:
+                case MultiplayerUserState.Ready:
+                    await ChangeState(MultiplayerUserState.Spectating).ConfigureAwait(false);
+                    return;
+
+                case MultiplayerUserState.Spectating:
+                    await ChangeState(MultiplayerUserState.Idle).ConfigureAwait(false);
+                    return;
+
+                default:
+                    throw new InvalidOperationException($"Cannot toggle spectate when in {localUser.State}");
+            }
+        }
+
         public abstract Task TransferHost(int userId);
 
         public abstract Task ChangeSettings(MultiplayerRoomSettings settings);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchFooter.cs
@@ -8,21 +8,28 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
-using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 {
     public class MultiplayerMatchFooter : CompositeDrawable
     {
         public const float HEIGHT = 50;
+        private const float ready_button_width = 600;
+        private const float spectate_button_width = 200;
 
         public Action OnReadyClick
         {
             set => readyButton.OnReadyClick = value;
         }
 
+        public Action OnSpectateClick
+        {
+            set => spectateButton.OnSpectateClick = value;
+        }
+
         private readonly Drawable background;
         private readonly MultiplayerReadyButton readyButton;
+        private readonly MultiplayerSpectateButton spectateButton;
 
         public MultiplayerMatchFooter()
         {
@@ -32,11 +39,34 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             InternalChildren = new[]
             {
                 background = new Box { RelativeSizeAxes = Axes.Both },
-                readyButton = new MultiplayerReadyButton
+                new GridContainer
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Size = new Vector2(600, 50),
+                    RelativeSizeAxes = Axes.Both,
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            null,
+                            spectateButton = new MultiplayerSpectateButton
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                            },
+                            null,
+                            readyButton = new MultiplayerReadyButton
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                            },
+                            null
+                        }
+                    },
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension(maxSize: spectate_button_width),
+                        new Dimension(GridSizeMode.Absolute, 10),
+                        new Dimension(maxSize: ready_button_width),
+                        new Dimension()
+                    }
                 }
             };
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -105,14 +105,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     break;
             }
 
-            button.Enabled.Value = Client.Room?.State == MultiplayerRoomState.Open && !operationInProgress.Value;
+            bool enableButton = Client.Room?.State == MultiplayerRoomState.Open && !operationInProgress.Value;
 
-            // When the local user is the host and spectating the match, the "start match" state should be enabled.
+            // When the local user is the host and spectating the match, the "start match" state should be enabled if any users are ready.
             if (localUser.State == MultiplayerUserState.Spectating)
-            {
-                button.Enabled.Value &= Room?.Host?.Equals(localUser) == true;
-                button.Enabled.Value &= newCountReady > 0;
-            }
+                enableButton &= Room?.Host?.Equals(localUser) == true && newCountReady > 0;
+
+            button.Enabled.Value = enableButton;
 
             if (newCountReady != countReady)
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerReadyButton.cs
@@ -78,8 +78,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             Debug.Assert(Room != null);
 
             int newCountReady = Room.Users.Count(u => u.State == MultiplayerUserState.Ready);
+            int newCountTotal = Room.Users.Count(u => u.State != MultiplayerUserState.Spectating);
 
-            string countText = $"({newCountReady} / {Room.Users.Count} ready)";
+            string countText = $"({newCountReady} / {newCountTotal} ready)";
 
             switch (localUser.State)
             {
@@ -88,6 +89,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     updateButtonColour(true);
                     break;
 
+                case MultiplayerUserState.Spectating:
                 case MultiplayerUserState.Ready:
                     if (Room?.Host?.Equals(localUser) == true)
                     {
@@ -104,6 +106,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             }
 
             button.Enabled.Value = Client.Room?.State == MultiplayerRoomState.Open && !operationInProgress.Value;
+
+            // When the local user is the host and spectating the match, the "start match" state should be enabled.
+            if (localUser.State == MultiplayerUserState.Spectating)
+            {
+                button.Enabled.Value &= Room?.Host?.Equals(localUser) == true;
+                button.Enabled.Value &= newCountReady > 0;
+            }
 
             if (newCountReady != countReady)
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Backgrounds;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.Multiplayer;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
+{
+    public class MultiplayerSpectateButton : MultiplayerRoomComposite
+    {
+        public Action OnSpectateClick
+        {
+            set => button.Action = value;
+        }
+
+        [Resolved]
+        private OngoingOperationTracker ongoingOperationTracker { get; set; }
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        private IBindable<bool> operationInProgress;
+
+        private readonly ButtonWithTrianglesExposed button;
+
+        public MultiplayerSpectateButton()
+        {
+            InternalChild = button = new ButtonWithTrianglesExposed
+            {
+                RelativeSizeAxes = Axes.Both,
+                Size = Vector2.One,
+                Enabled = { Value = true },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            operationInProgress = ongoingOperationTracker.InProgress.GetBoundCopy();
+            operationInProgress.BindValueChanged(_ => updateState());
+        }
+
+        protected override void OnRoomUpdated()
+        {
+            base.OnRoomUpdated();
+
+            updateState();
+        }
+
+        private void updateState()
+        {
+            var localUser = Client.LocalUser;
+
+            if (localUser == null)
+                return;
+
+            Debug.Assert(Room != null);
+
+            switch (localUser.State)
+            {
+                default:
+                    button.Text = "Spectate";
+                    button.BackgroundColour = colours.Blue;
+                    button.Triangles.ColourDark = colours.Blue;
+                    button.Triangles.ColourLight = colours.BlueLight;
+                    break;
+
+                case MultiplayerUserState.Spectating:
+                    button.Text = "Stop spectating";
+                    button.BackgroundColour = colours.Red;
+                    button.Triangles.ColourDark = colours.Red;
+                    button.Triangles.ColourLight = colours.RedLight;
+                    break;
+            }
+
+            button.Enabled.Value = Client.Room?.State == MultiplayerRoomState.Open && !operationInProgress.Value;
+        }
+
+        private class ButtonWithTrianglesExposed : TriangleButton
+        {
+            public new Triangles Triangles => base.Triangles;
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
@@ -68,16 +68,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             {
                 default:
                     button.Text = "Spectate";
-                    button.BackgroundColour = colours.Blue;
-                    button.Triangles.ColourDark = colours.Blue;
-                    button.Triangles.ColourLight = colours.BlueLight;
+                    button.BackgroundColour = colours.BlueDark;
+                    button.Triangles.ColourDark = colours.BlueDarker;
+                    button.Triangles.ColourLight = colours.Blue;
                     break;
 
                 case MultiplayerUserState.Spectating:
                     button.Text = "Stop spectating";
-                    button.BackgroundColour = colours.Red;
-                    button.Triangles.ColourDark = colours.Red;
-                    button.Triangles.ColourLight = colours.RedLight;
+                    button.BackgroundColour = colours.Gray4;
+                    button.Triangles.ColourDark = colours.Gray5;
+                    button.Triangles.ColourLight = colours.Gray6;
                     break;
             }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -221,7 +221,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                         {
                             new MultiplayerMatchFooter
                             {
-                                OnReadyClick = onReadyClick
+                                OnReadyClick = onReadyClick,
+                                OnSpectateClick = onSpectateClick
                             }
                         }
                     },
@@ -363,7 +364,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             Debug.Assert(readyClickOperation == null);
             readyClickOperation = ongoingOperationTracker.BeginOperation();
 
-            if (client.IsHost && client.LocalUser?.State == MultiplayerUserState.Ready)
+            if (client.IsHost && (client.LocalUser?.State == MultiplayerUserState.Ready || client.LocalUser?.State == MultiplayerUserState.Spectating))
             {
                 client.StartMatch()
                       .ContinueWith(t =>
@@ -382,6 +383,20 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             client.ToggleReady()
                   .ContinueWith(t => endOperation());
+
+            void endOperation()
+            {
+                readyClickOperation?.Dispose();
+                readyClickOperation = null;
+            }
+        }
+
+        private void onSpectateClick()
+        {
+            Debug.Assert(readyClickOperation == null);
+            readyClickOperation = ongoingOperationTracker.BeginOperation();
+
+            client.ToggleSpectate().ContinueWith(t => endOperation());
 
             void endOperation()
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
@@ -135,6 +135,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     icon.Colour = colours.BlueLighter;
                     break;
 
+                case MultiplayerUserState.Spectating:
+                    text.Text = "spectating";
+                    icon.Icon = FontAwesome.Solid.Eye;
+                    icon.Colour = colours.BlueLight;
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(state), state, null);
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
 
                 case MultiplayerUserState.Spectating:
                     text.Text = "spectating";
-                    icon.Icon = FontAwesome.Solid.Eye;
+                    icon.Icon = FontAwesome.Solid.Binoculars;
                     icon.Colour = colours.BlueLight;
                     break;
 

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -58,6 +58,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
         }
 
+        public void ChangeRoomState(MultiplayerRoomState newState)
+        {
+            Debug.Assert(Room != null);
+            ((IMultiplayerClient)this).RoomStateChanged(newState);
+        }
+
         public void ChangeUserState(int userId, MultiplayerUserState newState)
         {
             Debug.Assert(Room != null);

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -77,6 +77,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     case MultiplayerUserState.Loaded:
                         if (Room.Users.All(u => u.State != MultiplayerUserState.WaitingForLoad))
                         {
+                            ChangeRoomState(MultiplayerRoomState.Playing);
                             foreach (var u in Room.Users.Where(u => u.State == MultiplayerUserState.Loaded))
                                 ChangeUserState(u.UserID, MultiplayerUserState.Playing);
 
@@ -88,6 +89,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     case MultiplayerUserState.FinishedPlay:
                         if (Room.Users.All(u => u.State != MultiplayerUserState.Playing))
                         {
+                            ChangeRoomState(MultiplayerRoomState.Open);
                             foreach (var u in Room.Users.Where(u => u.State == MultiplayerUserState.FinishedPlay))
                                 ChangeUserState(u.UserID, MultiplayerUserState.Results);
 
@@ -179,6 +181,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             Debug.Assert(Room != null);
 
+            ChangeRoomState(MultiplayerRoomState.WaitingForLoad);
             foreach (var user in Room.Users.Where(u => u.State == MultiplayerUserState.Ready))
                 ChangeUserState(user.UserID, MultiplayerUserState.WaitingForLoad);
 


### PR DESCRIPTION
This adds the `MultiplayerUserState.Spectating` state, the spectate button, the logic which toggles the spectating state and the ready button, and the footer design change to accommodate the spectate button.

The `Spectating` user state is a constant state - once you have it, the multiplayer server will not switch you out from that state by itself. The user can go back into the idle state themselves when they want.

Although I'm still finalising the osu-server-spectator changes, the `Spectating` state is pretty much just used for signalling other clients, with the rest of the logic such as entering gameplay being handled client-side. The only exception to this is a special case for a spectating host which is allowed to start the match even though they aren't in the `Ready` state.

To keep things simple I've currently made the operation a no-op in the SignalR `MultiplayerClient`, so that errors aren't spewed to the client but tests keep working.

Can be merged as is, or waiting for the other 800+ LOC actually implementing the spectator screen.