### PR TITLE
Add support for sliderwhistle

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -109,15 +109,23 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override void LoadSamples()
         {
-            base.LoadSamples();
+            // Note: base.LoadSamples() isn't called since the slider plays the tail's hitsounds for the time being.
+
+            if (HitObject.SampleControlPoint == null)
+            {
+                throw new InvalidOperationException($"{nameof(HitObject)}s must always have an attached {nameof(HitObject.SampleControlPoint)}."
+                                                    + $" This is an indication that {nameof(HitObject.ApplyDefaults)} has not been invoked on {this}.");
+            }
+
+            Samples.Samples = HitObject.TailSamples.Select(s => HitObject.SampleControlPoint.ApplyTo(s)).Cast<ISampleInfo>().ToArray();
 
             var slidingSamples = new List<ISampleInfo>();
 
-            var normalSample = HitObject.OriginalSamples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL);
+            var normalSample = HitObject.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL);
             if (normalSample != null)
                 slidingSamples.Add(HitObject.SampleControlPoint.ApplyTo(normalSample).With("sliderslide"));
 
-            var whistleSample = HitObject.OriginalSamples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_WHISTLE);
+            var whistleSample = HitObject.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_WHISTLE);
             if (whistleSample != null)
                 slidingSamples.Add(HitObject.SampleControlPoint.ApplyTo(whistleSample).With("sliderwhistle"));
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using osuTK;
@@ -110,13 +111,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.LoadSamples();
 
-            var firstSample = HitObject.Samples.FirstOrDefault();
+            var firstSample = HitObject.OriginalSamples.FirstOrDefault();
 
             if (firstSample != null)
             {
-                var clone = HitObject.SampleControlPoint.ApplyTo(firstSample).With("sliderslide");
+                var samples = new List<ISampleInfo> { HitObject.SampleControlPoint.ApplyTo(firstSample).With("sliderslide") };
 
-                slidingSample.Samples = new ISampleInfo[] { clone };
+                if (HitObject.OriginalSamples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE))
+                    samples.Add(HitObject.SampleControlPoint.ApplyTo(firstSample).With("sliderwhistle"));
+
+                slidingSample.Samples = samples.ToArray();
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -111,17 +111,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.LoadSamples();
 
-            var firstSample = HitObject.OriginalSamples.FirstOrDefault();
+            var slidingSamples = new List<ISampleInfo>();
 
-            if (firstSample != null)
-            {
-                var samples = new List<ISampleInfo> { HitObject.SampleControlPoint.ApplyTo(firstSample).With("sliderslide") };
+            var normalSample = HitObject.OriginalSamples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL);
+            if (normalSample != null)
+                slidingSamples.Add(HitObject.SampleControlPoint.ApplyTo(normalSample).With("sliderslide"));
 
-                if (HitObject.OriginalSamples.Any(s => s.Name == HitSampleInfo.HIT_WHISTLE))
-                    samples.Add(HitObject.SampleControlPoint.ApplyTo(firstSample).With("sliderwhistle"));
+            var whistleSample = HitObject.OriginalSamples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_WHISTLE);
+            if (whistleSample != null)
+                slidingSamples.Add(HitObject.SampleControlPoint.ApplyTo(whistleSample).With("sliderwhistle"));
 
-                slidingSample.Samples = samples.ToArray();
-            }
+            slidingSample.Samples = slidingSamples.ToArray();
         }
 
         public override void StopAllSamples()

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public List<IList<HitSampleInfo>> NodeSamples { get; set; } = new List<IList<HitSampleInfo>>();
 
         [JsonIgnore]
-        public IList<HitSampleInfo> OriginalSamples { get; private set; }
+        public IList<HitSampleInfo> TailSamples { get; private set; }
 
         private int repeatCount;
 
@@ -146,12 +146,6 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             Velocity = scoringDistance / timingPoint.BeatLength;
             TickDistance = scoringDistance / difficulty.SliderTickRate * TickDistanceMultiplier;
-
-            // The samples should be attached to the slider tail, however this can only be done after LegacyLastTick is removed otherwise they would play earlier than they're intended to.
-            // For now, the samples are attached to and played by the slider itself at the correct end time.
-            // ToArray call is required as GetNodeSamples may fallback to Samples itself (without it it will get cleared due to the list reference being live).
-            OriginalSamples = Samples.ToList();
-            Samples = this.GetNodeSamples(repeatCount + 1).ToArray();
         }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
@@ -242,6 +236,10 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             if (HeadCircle != null)
                 HeadCircle.Samples = this.GetNodeSamples(0);
+
+            // The samples should be attached to the slider tail, however this can only be done after LegacyLastTick is removed otherwise they would play earlier than they're intended to.
+            // For now, the samples are played by the slider itself at the correct end time.
+            TailSamples = this.GetNodeSamples(repeatCount + 1);
         }
 
         public override Judgement CreateJudgement() => OnlyJudgeNestedObjects ? new OsuIgnoreJudgement() : new OsuJudgement();

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -81,6 +81,8 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public List<IList<HitSampleInfo>> NodeSamples { get; set; } = new List<IList<HitSampleInfo>>();
 
+        public IList<HitSampleInfo> OriginalSamples { get; private set; }
+
         private int repeatCount;
 
         public int RepeatCount
@@ -147,6 +149,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             // The samples should be attached to the slider tail, however this can only be done after LegacyLastTick is removed otherwise they would play earlier than they're intended to.
             // For now, the samples are attached to and played by the slider itself at the correct end time.
             // ToArray call is required as GetNodeSamples may fallback to Samples itself (without it it will get cleared due to the list reference being live).
+            OriginalSamples = Samples.ToList();
             Samples = this.GetNodeSamples(repeatCount + 1).ToArray();
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -81,6 +81,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public List<IList<HitSampleInfo>> NodeSamples { get; set; } = new List<IList<HitSampleInfo>>();
 
+        [JsonIgnore]
         public IList<HitSampleInfo> OriginalSamples { get; private set; }
 
         private int repeatCount;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -273,7 +273,7 @@ namespace osu.Game.Beatmaps.Formats
             if (hitObject is IHasPath path)
             {
                 addPathData(writer, path, position);
-                writer.Write(getSampleBank(hitObject.Samples, zeroBanks: true));
+                writer.Write(getSampleBank(hitObject.Samples));
             }
             else
             {
@@ -420,15 +420,15 @@ namespace osu.Game.Beatmaps.Formats
             writer.Write(FormattableString.Invariant($"{endTimeData.EndTime}{suffix}"));
         }
 
-        private string getSampleBank(IList<HitSampleInfo> samples, bool banksOnly = false, bool zeroBanks = false)
+        private string getSampleBank(IList<HitSampleInfo> samples, bool banksOnly = false)
         {
             LegacySampleBank normalBank = toLegacySampleBank(samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank);
             LegacySampleBank addBank = toLegacySampleBank(samples.FirstOrDefault(s => !string.IsNullOrEmpty(s.Name) && s.Name != HitSampleInfo.HIT_NORMAL)?.Bank);
 
             StringBuilder sb = new StringBuilder();
 
-            sb.Append(FormattableString.Invariant($"{(zeroBanks ? 0 : (int)normalBank)}:"));
-            sb.Append(FormattableString.Invariant($"{(zeroBanks ? 0 : (int)addBank)}"));
+            sb.Append(FormattableString.Invariant($"{(int)normalBank}:"));
+            sb.Append(FormattableString.Invariant($"{(int)addBank}"));
 
             if (!banksOnly)
             {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12325

Turns out `sliderwhistle` samples were just not used at all. Confirmed to fix via disco prince and the map mentioned by the twitter user in the above issue.

This `Sample` overriding stuff has to go from `Slider`, but that's a task for another day I think - maybe it's time to place a judgement-less hitobject at the correct time for playing the tail samples.