### PR TITLE
Fix intermittent test failure

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddWaitStep("wait", 10);
+            AddUntilStep("wait for join", () => Client.Room != null);
         }
 
         [Test]
@@ -113,6 +113,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
                 InputManager.Click(MouseButton.Left);
             });
+
+            AddUntilStep("wait for room join", () => Client.Room != null);
 
             AddStep("join other user (ready)", () =>
             {


### PR DESCRIPTION
Can be tested by adding `await Task.Delay(3000).ConfigureAwait(false);` to `StatefulMultiplayerClient.JoinRoom()`.

As seen in https://ci.appveyor.com/project/peppy/osu/builds/38609912/tests