### PR TITLE
Fix scores not being accepted due to missing ruleset ID

### DIFF
--- a/osu.Game/Online/Solo/CreateSoloScoreRequest.cs
+++ b/osu.Game/Online/Solo/CreateSoloScoreRequest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Globalization;
 using System.Net.Http;
 using osu.Framework.IO.Network;
 using osu.Game.Online.API;
@@ -11,11 +12,13 @@ namespace osu.Game.Online.Solo
     public class CreateSoloScoreRequest : APIRequest<APIScoreToken>
     {
         private readonly int beatmapId;
+        private readonly int rulesetId;
         private readonly string versionHash;
 
-        public CreateSoloScoreRequest(int beatmapId, string versionHash)
+        public CreateSoloScoreRequest(int beatmapId, int rulesetId, string versionHash)
         {
             this.beatmapId = beatmapId;
+            this.rulesetId = rulesetId;
             this.versionHash = versionHash;
         }
 
@@ -24,6 +27,7 @@ namespace osu.Game.Online.Solo
             var req = base.CreateWebRequest();
             req.Method = HttpMethod.Post;
             req.AddParameter("version_hash", versionHash);
+            req.AddParameter("ruleset_id", rulesetId.ToString(CultureInfo.InvariantCulture));
             return req;
         }
 

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -17,7 +17,10 @@ namespace osu.Game.Screens.Play
             if (!(Beatmap.Value.BeatmapInfo.OnlineBeatmapID is int beatmapId))
                 return null;
 
-            return new CreateSoloScoreRequest(beatmapId, Game.VersionHash);
+            if (!(Ruleset.Value.ID is int rulesetId))
+                return null;
+
+            return new CreateSoloScoreRequest(beatmapId, rulesetId, Game.VersionHash);
         }
 
         protected override bool HandleTokenRetrievalFailure(Exception exception) => false;


### PR DESCRIPTION
This is required for non-room score submissions as there's no playlist_id as a reference.