### PR TITLE
Fix multiplayer test failure

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("match started", () => Client.Room?.State == MultiplayerRoomState.WaitingForLoad);
+            AddUntilStep("match started", () => Client.Room?.State == MultiplayerRoomState.WaitingForLoad);
         }
     }
 }


### PR DESCRIPTION
I believe this is related to the schedule inside `TestMultiplayerClient.ChangeUserState()`, which is there to ensure proper ordering with the schedules inside `StatefulMultiplayerClient`...