### PR TITLE
Fix mods not being serialised correctly in ScoreInfo

### DIFF
--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -11,7 +11,10 @@ using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
 
 namespace osu.Game.Tests.Online
 {
@@ -82,6 +85,36 @@ namespace osu.Game.Tests.Online
 
             Assert.That(converted?.ExtendedLimits.Value, Is.True);
             Assert.That(converted?.OverallDifficulty.Value, Is.EqualTo(11));
+        }
+
+        [Test]
+        public void TestDeserialiseScoreInfoWithEmptyMods()
+        {
+            var score = new ScoreInfo { Ruleset = new OsuRuleset().RulesetInfo };
+
+            var deserialised = JsonConvert.DeserializeObject<ScoreInfo>(JsonConvert.SerializeObject(score));
+
+            if (deserialised != null)
+                deserialised.Ruleset = new OsuRuleset().RulesetInfo;
+
+            Assert.That(deserialised?.Mods.Length, Is.Zero);
+        }
+
+        [Test]
+        public void TestDeserialiseScoreInfoWithCustomModSetting()
+        {
+            var score = new ScoreInfo
+            {
+                Ruleset = new OsuRuleset().RulesetInfo,
+                Mods = new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = 2 } } }
+            };
+
+            var deserialised = JsonConvert.DeserializeObject<ScoreInfo>(JsonConvert.SerializeObject(score));
+
+            if (deserialised != null)
+                deserialised.Ruleset = new OsuRuleset().RulesetInfo;
+
+            Assert.That(((OsuModDoubleTime)deserialised?.Mods[0])?.SpeedChange.Value, Is.EqualTo(2));
         }
 
         private class TestRuleset : Ruleset

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -105,8 +105,9 @@ namespace osu.Game.Scoring
         }
 
         // Used for database serialisation/deserialisation.
+        [JsonIgnore]
         [Column("Mods")]
-        private string modsString
+        public string ModsString
         {
             get => JsonConvert.SerializeObject(apiMods);
             set => apiMods = JsonConvert.DeserializeObject<APIMod[]>(value);

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Converters;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -55,9 +56,10 @@ namespace osu.Game.Scoring
         [JsonIgnore]
         public virtual RulesetInfo Ruleset { get; set; }
 
+        private APIMod[] localAPIMods;
         private Mod[] mods;
 
-        [JsonProperty("mods")]
+        [JsonIgnore]
         [NotMapped]
         public Mod[] Mods
         {
@@ -66,43 +68,48 @@ namespace osu.Game.Scoring
                 if (mods != null)
                     return mods;
 
-                if (modsJson == null)
+                if (apiMods == null)
                     return Array.Empty<Mod>();
 
-                return getModsFromRuleset(JsonConvert.DeserializeObject<DeserializedMod[]>(modsJson));
+                var rulesetInstance = Ruleset.CreateInstance();
+                return apiMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
             }
             set
             {
-                modsJson = null;
+                localAPIMods = null;
                 mods = value;
             }
         }
 
-        private Mod[] getModsFromRuleset(DeserializedMod[] mods) => Ruleset.CreateInstance().GetAllMods().Where(mod => mods.Any(d => d.Acronym == mod.Acronym)).ToArray();
-
-        private string modsJson;
-
-        [JsonIgnore]
-        [Column("Mods")]
-        public string ModsJson
+        // Used for API serialisation/deserialisation.
+        [JsonProperty("mods")]
+        private APIMod[] apiMods
         {
             get
             {
-                if (modsJson != null)
-                    return modsJson;
+                if (localAPIMods != null)
+                    return localAPIMods;
 
                 if (mods == null)
-                    return null;
+                    return Array.Empty<APIMod>();
 
-                return modsJson = JsonConvert.SerializeObject(mods.Select(m => new DeserializedMod { Acronym = m.Acronym }));
+                return localAPIMods = mods.Select(m => new APIMod(m)).ToArray();
             }
             set
             {
-                modsJson = value;
+                localAPIMods = value;
 
-                // we potentially can't update this yet due to Ruleset being late-bound, so instead update on read as necessary.
+                // We potentially can't update this yet due to Ruleset being late-bound, so instead update on read as necessary.
                 mods = null;
             }
+        }
+
+        // Used for database serialisation/deserialisation.
+        [Column("Mods")]
+        private string modsString
+        {
+            get => JsonConvert.SerializeObject(apiMods);
+            set => apiMods = JsonConvert.DeserializeObject<APIMod[]>(value);
         }
 
         [NotMapped]
@@ -249,14 +256,6 @@ namespace osu.Game.Scoring
                         break;
                 }
             }
-        }
-
-        [Serializable]
-        protected class DeserializedMod : IMod
-        {
-            public string Acronym { get; set; }
-
-            public bool Equals(IMod other) => Acronym == other?.Acronym;
         }
 
         public override string ToString() => $"{User} playing {Beatmap}";

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Scoring
         // Used for database serialisation/deserialisation.
         [JsonIgnore]
         [Column("Mods")]
-        public string ModsString
+        public string ModsJson
         {
             get => JsonConvert.SerializeObject(apiMods);
             set => apiMods = JsonConvert.DeserializeObject<APIMod[]>(value);

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Scoring
                 if (mods != null)
                     return mods;
 
-                if (apiMods == null)
+                if (localAPIMods == null)
                     return Array.Empty<Mod>();
 
                 var rulesetInstance = Ruleset.CreateInstance();

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -83,6 +83,7 @@ namespace osu.Game.Scoring
 
         // Used for API serialisation/deserialisation.
         [JsonProperty("mods")]
+        [NotMapped]
         private APIMod[] apiMods
         {
             get


### PR DESCRIPTION
Fixes the submission portion of https://github.com/ppy/osu/issues/12372

Before:
```
"mods": [
    {
        "acronym": "DT",
        "SpeedChange": 1.67,
        "SettingDescription": "1.67x"
    }
],
```

After:
```
"mods": [
    {
        "acronym": "DT",
        "settings": {
            "speed_change": 1.67
        }
    }
],
```

Note that the issue still fails with a database unique constraint exception on `OnlineScoreId`. Not sure of the best solution here - removing the unique constraint sounds wrong.