### PR TITLE
Fix selecting a slider correcting its path

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorSelectInvalidPath.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorSelectInvalidPath.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public class TestSceneOsuEditorSelectInvalidPath : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        [Test]
+        public void TestSelectDoesNotModify()
+        {
+            Slider slider = new Slider { StartTime = 0, Position = new Vector2(320, 40) };
+
+            PathControlPoint[] points =
+            {
+                new PathControlPoint(new Vector2(0), PathType.PerfectCurve),
+                new PathControlPoint(new Vector2(-100, 0)),
+                new PathControlPoint(new Vector2(100, 20))
+            };
+
+            int preSelectVersion = -1;
+            AddStep("add slider", () =>
+            {
+                slider.Path = new SliderPath(points);
+                EditorBeatmap.Add(slider);
+                preSelectVersion = slider.Path.Version.Value;
+            });
+
+            AddStep("select added slider", () => EditorBeatmap.SelectedHitObjects.Add(slider));
+
+            AddAssert("slider same path", () => slider.Path.Version.Value == preSelectVersion);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -58,11 +58,13 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
             this.slider = slider;
             ControlPoint = controlPoint;
-            PointsInSegment = slider.Path.PointsInSegment(ControlPoint);
+
+            // we don't want to run the path type update on construction as it may inadvertently change the slider.
+            cachePoints(slider);
 
             slider.Path.Version.BindValueChanged(_ =>
             {
-                PointsInSegment = slider.Path.PointsInSegment(ControlPoint);
+                cachePoints(slider);
                 updatePathType();
             });
 
@@ -205,6 +207,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         }
 
         protected override void OnDragEnd(DragEndEvent e) => changeHandler?.EndChange();
+
+        private void cachePoints(Slider slider) => PointsInSegment = slider.Path.PointsInSegment(ControlPoint);
 
         /// <summary>
         /// Handles correction of invalid path types.

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -58,12 +58,13 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
             this.slider = slider;
             ControlPoint = controlPoint;
+            PointsInSegment = slider.Path.PointsInSegment(ControlPoint);
 
             slider.Path.Version.BindValueChanged(_ =>
             {
                 PointsInSegment = slider.Path.PointsInSegment(ControlPoint);
                 updatePathType();
-            }, runOnceImmediately: true);
+            });
 
             controlPoint.Type.BindValueChanged(_ => updateMarkerDisplay());
 


### PR DESCRIPTION
Currently, if you select a slider that has an invalid path (e.g. too large bounding box), it will be converted to Bezier. I figure this should only happen if you actually modify the path, else things like linking timestamps would potentially break things.

https://user-images.githubusercontent.com/30292137/114435303-4d6fcd00-9bc4-11eb-96da-eb7d9a98d808.mp4

Cause being the `runOnceImmediately` and `updatePathType` here:
```cs
slider.Path.Version.BindValueChanged(_ =>
{
    PointsInSegment = slider.Path.PointsInSegment(ControlPoint);
    updatePathType();
}, runOnceImmediately: true);
```

This fixes that. [Reference map](https://osu.ppy.sh/beatmapsets/756794#osu/1605148).