### PR TITLE
Fix ctrl-dragging on an existing selection unexpectedly causing deselection

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -83,8 +83,9 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("right click", () => InputManager.Click(MouseButton.Right));
             AddAssert("slider has 2 points", () => slider.Path.ControlPoints.Count == 2);
 
-            // second click should nuke the object completely.
             AddStep("right click", () => InputManager.Click(MouseButton.Right));
+
+            // second click should nuke the object completely.
             AddAssert("no hitobjects in beatmap", () => EditorBeatmap.HitObjects.Count == 0);
 
             AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorQuickDelete.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestQuickDeleteRemovesSliderControlPoint()
         {
-            Slider slider = new Slider { StartTime = 1000 };
+            Slider slider = null;
 
             PathControlPoint[] points =
             {
@@ -62,7 +62,12 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("add slider", () =>
             {
-                slider.Path = new SliderPath(points);
+                slider = new Slider
+                {
+                    StartTime = 1000,
+                    Path = new SliderPath(points)
+                };
+
                 EditorBeatmap.Add(slider);
             });
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
@@ -18,7 +18,7 @@ using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
 {
-    public class TestSceneEditorQuickDelete : EditorTestScene
+    public class TestSceneEditorSelection : EditorTestScene
     {
         protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            bool selectionPerformed = beginClickSelection(e);
+            bool selectionPerformed = performMouseDownActions(e);
 
             // even if a selection didn't occur, a drag event may still move the selection.
             prepareSelectionMovement();
@@ -343,7 +343,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <param name="e">The input event that triggered this selection.</param>
         /// <returns>Whether a selection was performed.</returns>
-        private bool beginClickSelection(MouseButtonEvent e)
+        private bool performMouseDownActions(MouseButtonEvent e)
         {
             // Iterate from the top of the input stack (blueprints closest to the front of the screen first).
             // Priority is given to already-selected blueprints.
@@ -351,7 +351,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 if (!blueprint.IsHovered) continue;
 
-                return clickSelectionBegan = SelectionHandler.HandleSelectionRequested(blueprint, e);
+                return clickSelectionBegan = SelectionHandler.MouseDownSelectionRequested(blueprint, e);
             }
 
             return false;
@@ -375,7 +375,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     {
                         if (!blueprint.IsHovered) continue;
 
-                        return clickSelectionBegan = SelectionHandler.HandleDeselectionRequested(blueprint, e);
+                        return clickSelectionBegan = SelectionHandler.MouseUpSelectionRequested(blueprint, e);
                     }
                 }
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -135,11 +135,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (!beginClickSelection(e)) return true;
+            bool selectionPerformed = beginClickSelection(e);
 
+            // even if a selection didn't occur, a drag event may still move the selection.
             prepareSelectionMovement();
 
-            return e.Button == MouseButton.Left;
+            return selectionPerformed || e.Button == MouseButton.Left;
         }
 
         private SelectionBlueprint clickedBlueprint;
@@ -154,7 +155,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // Deselection should only occur if no selected blueprints are hovered
             // A special case for when a blueprint was selected via this click is added since OnClick() may occur outside the hitobject and should not trigger deselection
-            if (endClickSelection() || clickedBlueprint != null)
+            if (endClickSelection(e) || clickedBlueprint != null)
                 return true;
 
             deselectAll();
@@ -177,7 +178,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override void OnMouseUp(MouseUpEvent e)
         {
             // Special case for when a drag happened instead of a click
-            Schedule(() => endClickSelection());
+            Schedule(() =>
+            {
+                endClickSelection(e);
+                clickSelectionBegan = false;
+                isDraggingBlueprint = false;
+            });
 
             finishSelectionMovement();
         }
@@ -226,7 +232,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     Beatmap.Update(obj);
 
                 changeHandler?.EndChange();
-                isDraggingBlueprint = false;
             }
 
             if (DragBox.State == Visibility.Visible)
@@ -355,13 +360,28 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Finishes the current blueprint selection.
         /// </summary>
+        /// <param name="e">The mouse event which triggered end of selection.</param>
         /// <returns>Whether a click selection was active.</returns>
-        private bool endClickSelection()
+        private bool endClickSelection(MouseButtonEvent e)
         {
-            if (!clickSelectionBegan)
-                return false;
+            if (!clickSelectionBegan && !isDraggingBlueprint)
+            {
+                // if a selection didn't occur, we may want to trigger a deselection.
+                if (e.ControlPressed && e.Button == MouseButton.Left)
+                {
+                    // Iterate from the top of the input stack (blueprints closest to the front of the screen first).
+                    // Priority is given to already-selected blueprints.
+                    foreach (SelectionBlueprint blueprint in SelectionBlueprints.AliveChildren.Reverse().OrderByDescending(b => b.IsSelected))
+                    {
+                        if (!blueprint.IsHovered) continue;
 
-            clickSelectionBegan = false;
+                        return clickSelectionBegan = SelectionHandler.HandleDeselectionRequested(blueprint, e);
+                    }
+                }
+
+                return false;
+            }
+
             return true;
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -220,12 +220,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         /// <param name="e">The mouse event responsible for selection.</param>
         /// <returns>Whether a selection was performed.</returns>
-        internal bool HandleSelectionRequested(SelectionBlueprint blueprint, MouseButtonEvent e)
+        internal bool MouseDownSelectionRequested(SelectionBlueprint blueprint, MouseButtonEvent e)
         {
             if (e.ShiftPressed && e.Button == MouseButton.Right)
             {
                 handleQuickDeletion(blueprint);
-                return false;
+                return true;
             }
 
             // while holding control, we only want to add to selection, not replace an existing selection.
@@ -244,7 +244,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         /// <param name="e">The mouse event responsible for deselection.</param>
         /// <returns>Whether a deselection was performed.</returns>
-        internal bool HandleDeselectionRequested(SelectionBlueprint blueprint, MouseButtonEvent e)
+        internal bool MouseUpSelectionRequested(SelectionBlueprint blueprint, MouseButtonEvent e)
         {
             if (blueprint.IsSelected)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -228,12 +228,31 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 return false;
             }
 
-            if (e.ControlPressed && e.Button == MouseButton.Left)
+            // while holding control, we only want to add to selection, not replace an existing selection.
+            if (e.ControlPressed && e.Button == MouseButton.Left && !blueprint.IsSelected)
+            {
                 blueprint.ToggleSelection();
-            else
-                ensureSelected(blueprint);
+                return true;
+            }
 
-            return true;
+            return ensureSelected(blueprint);
+        }
+
+        /// <summary>
+        /// Handle a blueprint requesting selection.
+        /// </summary>
+        /// <param name="blueprint">The blueprint.</param>
+        /// <param name="e">The mouse event responsible for deselection.</param>
+        /// <returns>Whether a deselection was performed.</returns>
+        internal bool HandleDeselectionRequested(SelectionBlueprint blueprint, MouseButtonEvent e)
+        {
+            if (blueprint.IsSelected)
+            {
+                blueprint.ToggleSelection();
+                return true;
+            }
+
+            return false;
         }
 
         private void handleQuickDeletion(SelectionBlueprint blueprint)
@@ -247,13 +266,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 deleteSelected();
         }
 
-        private void ensureSelected(SelectionBlueprint blueprint)
+        /// <summary>
+        /// Ensure the blueprint is in a selected state.
+        /// </summary>
+        /// <param name="blueprint">The blueprint to select.</param>
+        /// <returns>Whether selection state was changed.</returns>
+        private bool ensureSelected(SelectionBlueprint blueprint)
         {
             if (blueprint.IsSelected)
-                return;
+                return false;
 
             DeselectAll?.Invoke();
             blueprint.Select();
+            return true;
         }
 
         private void deleteSelected()


### PR DESCRIPTION
Before:

![20210413 135148 (dotnet)](https://user-images.githubusercontent.com/191335/114498640-6bd6d680-9c5f-11eb-8e86-8f8ef498b559.gif)

After:

![20210413 135046 (dotnet)](https://user-images.githubusercontent.com/191335/114498589-4e097180-9c5f-11eb-97c8-9ba5073c14cf.gif)

The logic here is unfortunately a touch complex, especially when looking at the diff. I would recommend just reading it as if for the first time. Generally I've:
- Added extra checks on current drag state
- Moved the drag reset to `MouseUp` so we can consume it there
- Moved selection logic to `MouseDown` for selection, `MouseUp` for deselection

We didn't have test coverage of editor selection in general until now, so I've added some basic scenarios, along with regression testing for this specific case.

Closes https://github.com/ppy/osu/issues/12373.