### PR TITLE
Fix import multiple file types via drag potentially reaching the wrong importer

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -433,12 +433,15 @@ namespace osu.Game
             if (paths.Length == 0)
                 return;
 
-            var extension = Path.GetExtension(paths.First())?.ToLowerInvariant();
+            var filesPerExtension = paths.GroupBy(p => Path.GetExtension(p).ToLowerInvariant());
 
-            foreach (var importer in fileImporters)
+            foreach (var groups in filesPerExtension)
             {
-                if (importer.HandledExtensions.Contains(extension))
-                    await importer.Import(paths).ConfigureAwait(false);
+                foreach (var importer in fileImporters)
+                {
+                    if (importer.HandledExtensions.Contains(groups.Key))
+                        await importer.Import(groups.ToArray()).ConfigureAwait(false);
+                }
             }
         }
 


### PR DESCRIPTION
Haven't added a test because it's a bit of a pain. This is mainly just copying the existing proven logic from the method right below it, so shouldn't be a huge deal.


https://user-images.githubusercontent.com/191335/114499582-5b276000-9c61-11eb-8f83-eecd19913704.mp4

Closes https://github.com/ppy/osu/issues/12379.