### PR TITLE
Display separate "replays watched" tooltip for replays subsection

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserHistoryGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserHistoryGraph.cs
@@ -19,13 +19,12 @@ namespace osu.Game.Tests.Visual.Online
         {
             UserHistoryGraph graph;
 
-            Add(graph = new UserHistoryGraph
+            Add(graph = new UserHistoryGraph("Test")
             {
                 RelativeSizeAxes = Axes.X,
                 Height = 200,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                TooltipCounterName = "Test"
             });
 
             var values = new[]

--- a/osu.Game/Overlays/Profile/Sections/Historical/ChartProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ChartProfileSubsection.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
     {
         private ProfileLineChart chart;
 
+        /// <summary>
+        /// Text describing the value being plotted on the graph, which will be displayed as a prefix to the value in the history graph tooltip.
+        /// </summary>
+        protected abstract string GraphCounterName { get; }
+
         protected ChartProfileSubsection(Bindable<User> user, string headerText)
             : base(user, headerText)
         {
@@ -30,7 +35,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
                 Left = 20,
                 Right = 40
             },
-            Child = chart = new ProfileLineChart()
+            Child = chart = new ProfileLineChart(GraphCounterName)
         };
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
@@ -9,6 +9,8 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public class PlayHistorySubsection : ChartProfileSubsection
     {
+        protected override string GraphCounterName => "Plays";
+
         public PlayHistorySubsection(Bindable<User> user)
             : base(user, "Play History")
         {

--- a/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
         private readonly Container<TickLine> rowLinesContainer;
         private readonly Container<TickLine> columnLinesContainer;
 
-        public ProfileLineChart()
+        public ProfileLineChart(string graphCounterName)
         {
             RelativeSizeAxes = Axes.X;
             Height = 250;
@@ -88,7 +88,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
                                         }
                                     }
                                 },
-                                graph = new UserHistoryGraph
+                                graph = new UserHistoryGraph(graphCounterName)
                                 {
                                     RelativeSizeAxes = Axes.Both
                                 }

--- a/osu.Game/Overlays/Profile/Sections/Historical/ReplaysSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ReplaysSubsection.cs
@@ -9,6 +9,8 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public class ReplaysSubsection : ChartProfileSubsection
     {
+        protected override string GraphCounterName => "Replays Watched";
+
         public ReplaysSubsection(Bindable<User> user)
             : base(user, "Replays Watched History")
         {

--- a/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
@@ -11,20 +11,22 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public class UserHistoryGraph : UserGraph<DateTime, long>
     {
+        private readonly string tooltipCounterName;
+
         [CanBeNull]
         public UserHistoryCount[] Values
         {
             set => Data = value?.Select(v => new KeyValuePair<DateTime, long>(v.Date, v.Count)).ToArray();
         }
 
-        /// <summary>
-        /// Text describing the value being plotted on the graph, which will be displayed as a prefix to the value in the <see cref="HistoryGraphTooltip"/>.
-        /// </summary>
-        public string TooltipCounterName { get; set; } = "Plays";
+        public UserHistoryGraph(string tooltipCounterName)
+        {
+            this.tooltipCounterName = tooltipCounterName;
+        }
 
         protected override float GetDataPointHeight(long playCount) => playCount;
 
-        protected override UserGraphTooltip GetTooltip() => new HistoryGraphTooltip(TooltipCounterName);
+        protected override UserGraphTooltip GetTooltip() => new HistoryGraphTooltip(tooltipCounterName);
 
         protected override object GetTooltipContent(DateTime date, long playCount)
         {

--- a/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
         {
             return new TooltipDisplayContent
             {
+                Name = tooltipCounterName,
                 Count = playCount.ToString("N0"),
                 Date = date.ToString("MMMM yyyy")
             };
@@ -39,14 +40,17 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected class HistoryGraphTooltip : UserGraphTooltip
         {
+            private readonly string tooltipCounterName;
+
             public HistoryGraphTooltip(string tooltipCounterName)
                 : base(tooltipCounterName)
             {
+                this.tooltipCounterName = tooltipCounterName;
             }
 
             public override bool SetContent(object content)
             {
-                if (!(content is TooltipDisplayContent info))
+                if (!(content is TooltipDisplayContent info) || info.Name != tooltipCounterName)
                     return false;
 
                 Counter.Text = info.Count;
@@ -57,6 +61,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         private class TooltipDisplayContent
         {
+            public string Name;
             public string Count;
             public string Date;
         }

--- a/osu.Game/Overlays/Profile/UserGraph.cs
+++ b/osu.Game/Overlays/Profile/UserGraph.cs
@@ -208,7 +208,6 @@ namespace osu.Game.Overlays.Profile
 
         protected abstract class UserGraphTooltip : VisibilityContainer, ITooltip
         {
-            protected new readonly OsuSpriteText Name;
             protected readonly OsuSpriteText Counter, BottomText;
             private readonly Box background;
 
@@ -238,7 +237,7 @@ namespace osu.Game.Overlays.Profile
                                 Spacing = new Vector2(3, 0),
                                 Children = new Drawable[]
                                 {
-                                    Name = new OsuSpriteText
+                                    new OsuSpriteText
                                     {
                                         Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
                                         Text = tooltipCounterName

--- a/osu.Game/Overlays/Profile/UserGraph.cs
+++ b/osu.Game/Overlays/Profile/UserGraph.cs
@@ -208,6 +208,7 @@ namespace osu.Game.Overlays.Profile
 
         protected abstract class UserGraphTooltip : VisibilityContainer, ITooltip
         {
+            protected new readonly OsuSpriteText Name;
             protected readonly OsuSpriteText Counter, BottomText;
             private readonly Box background;
 
@@ -237,7 +238,7 @@ namespace osu.Game.Overlays.Profile
                                 Spacing = new Vector2(3, 0),
                                 Children = new Drawable[]
                                 {
-                                    new OsuSpriteText
+                                    Name = new OsuSpriteText
                                     {
                                         Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
                                         Text = tooltipCounterName


### PR DESCRIPTION
Closes #12381

Also fixes `HistoryGraphTooltip` on each graph leaking each other's contents, due to no check present in `SetContent()` guarding against what graph is the given content part of.