### PR TITLE
Don't store online IDs from score submission responses for now

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -109,7 +109,12 @@ namespace osu.Game.Screens.Play
 
             request.Success += s =>
             {
-                score.ScoreInfo.OnlineScoreID = s.ID;
+                // For the time being, online ID responses are not really useful for anything.
+                // In addition, the IDs provided via new (lazer) endpoints are based on a different autoincrement from legacy (stable) scores.
+                //
+                // Until we better define the server-side logic behind this, let's not store the online ID to avoid potential unique constraint
+                // conflicts across various systems (ie. solo and multiplayer).
+                // score.ScoreInfo.OnlineScoreID = s.ID;
                 tcs.SetResult(true);
             };
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12372.

Still deciding on how the central storage of scores is going to work for the future. There's a lot in the air at the moment and the IDs returned by the existing systems are not useful in any way (and it is almost guaranteed all existing uploaded scores will be cleared at a point in the future).