### PR TITLE
Change default waveform opacity

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Full);
 
-            SetDefault(OsuSetting.EditorWaveformOpacity, 1f);
+            SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f);
         }
 
         public OsuConfigManager(Storage storage)

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -169,14 +169,9 @@ namespace osu.Game.Configuration
 
             int combined = (year * 10000) + monthDay;
 
-            if (combined < 20200305)
+            if (combined < 20210413)
             {
-                // the maximum value of this setting was changed.
-                // if we don't manually increase this, it causes song select to filter out beatmaps the user expects to see.
-                var maxStars = (BindableDouble)GetOriginalBindable<double>(OsuSetting.DisplayStarsMaximum);
-
-                if (maxStars.Value == 10)
-                    maxStars.Value = maxStars.MaxValue;
+                SetValue(OsuSetting.EditorWaveformOpacity, 0.25f);
             }
         }
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
 using osu.Framework.Extensions;


### PR DESCRIPTION
Before:

![20210413 165138 (dotnet)](https://user-images.githubusercontent.com/191335/114516610-87021000-9c78-11eb-9cc5-f5085eea9a2a.png)

After:

![20210413 165153 (dotnet)](https://user-images.githubusercontent.com/191335/114516643-8f5a4b00-9c78-11eb-9a19-4aca45e49432.png)

We may decide to force full opacity when in the timing screen at a later point, but for now I'm prioritising usability in compose mode.