### PR TITLE
Fix volume controls not supporting key repeat

### DIFF
--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -9,6 +9,9 @@ namespace osu.Game.Extensions
 {
     public static class DrawableExtensions
     {
+        public const double REPEAT_INTERVAL = 70;
+        public const double INITIAL_DELAY = 250;
+
         /// <summary>
         /// Helper method that is used while <see cref="IKeyBindingHandler"/> doesn't support repetitions of <see cref="IKeyBindingHandler{T}.OnPressed"/>.
         /// Simulates repetitions by continually invoking a delegate according to the default key repeat rate.
@@ -19,12 +22,13 @@ namespace osu.Game.Extensions
         /// <param name="handler">The <see cref="IKeyBindingHandler{T}"/> which is handling the repeat.</param>
         /// <param name="scheduler">The <see cref="Scheduler"/> to schedule repetitions on.</param>
         /// <param name="action">The <see cref="Action"/> to be invoked once immediately and with every repetition.</param>
+        /// <param name="initialRepeatDelay">The delay imposed on the first repeat. Defaults to <see cref="INITIAL_DELAY"/>.</param>
         /// <returns>A <see cref="ScheduledDelegate"/> which can be cancelled to stop the repeat events from firing.</returns>
-        public static ScheduledDelegate BeginKeyRepeat(this IKeyBindingHandler handler, Scheduler scheduler, Action action)
+        public static ScheduledDelegate BeginKeyRepeat(this IKeyBindingHandler handler, Scheduler scheduler, Action action, double initialRepeatDelay = INITIAL_DELAY)
         {
             action();
 
-            ScheduledDelegate repeatDelegate = new ScheduledDelegate(action, handler.Time.Current + 250, 70);
+            ScheduledDelegate repeatDelegate = new ScheduledDelegate(action, handler.Time.Current + initialRepeatDelay, REPEAT_INTERVAL);
             scheduler.Add(repeatDelegate);
             return repeatDelegate;
         }

--- a/osu.Game/Overlays/Volume/VolumeControlReceptor.cs
+++ b/osu.Game/Overlays/Volume/VolumeControlReceptor.cs
@@ -6,6 +6,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Threading;
+using osu.Game.Extensions;
 using osu.Game.Input.Bindings;
 
 namespace osu.Game.Overlays.Volume
@@ -15,8 +17,30 @@ namespace osu.Game.Overlays.Volume
         public Func<GlobalAction, bool> ActionRequested;
         public Func<GlobalAction, float, bool, bool> ScrollActionRequested;
 
-        public bool OnPressed(GlobalAction action) =>
-            ActionRequested?.Invoke(action) ?? false;
+        private ScheduledDelegate keyRepeat;
+
+        public bool OnPressed(GlobalAction action)
+        {
+            switch (action)
+            {
+                case GlobalAction.DecreaseVolume:
+                case GlobalAction.IncreaseVolume:
+                    keyRepeat?.Cancel();
+                    keyRepeat = this.BeginKeyRepeat(Scheduler, () => ActionRequested?.Invoke(action), 150);
+                    return true;
+
+                case GlobalAction.ToggleMute:
+                    ActionRequested?.Invoke(action);
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(GlobalAction action)
+        {
+            keyRepeat?.Cancel();
+        }
 
         protected override bool OnScroll(ScrollEvent e)
         {
@@ -27,9 +51,5 @@ namespace osu.Game.Overlays.Volume
 
         public bool OnScroll(GlobalAction action, float amount, bool isPrecise) =>
             ScrollActionRequested?.Invoke(action, amount, isPrecise) ?? false;
-
-        public void OnReleased(GlobalAction action)
-        {
-        }
     }
 }


### PR DESCRIPTION
Closes #2891.

![20210414 131613 (dotnet)](https://user-images.githubusercontent.com/191335/114653724-a7d36f80-9d23-11eb-96c8-1391d3aea8eb.gif)


The initial repeat value has been tweaked with #12404 in mind (which should probably be merged first to provide better repeat adjustment behaviour).