### PR TITLE
Hide top-right HUD overlay elements as part of HUD visibility

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -24,9 +24,9 @@ namespace osu.Game.Screens.Play
     [Cached]
     public class HUDOverlay : Container, IKeyBindingHandler<GlobalAction>
     {
-        public const float FADE_DURATION = 400;
+        public const float FADE_DURATION = 300;
 
-        public const Easing FADE_EASING = Easing.Out;
+        public const Easing FADE_EASING = Easing.OutQuint;
 
         /// <summary>
         /// The total height of all the top of screen scoring elements.

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Screens.Play
 
         private bool holdingForHUD;
 
-        private IEnumerable<Drawable> hideTargets => new Drawable[] { visibilityContainer, KeyCounter };
+        private IEnumerable<Drawable> hideTargets => new Drawable[] { visibilityContainer, KeyCounter, topRightElements };
 
         public HUDOverlay(ScoreProcessor scoreProcessor, HealthProcessor healthProcessor, DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods)
         {


### PR DESCRIPTION
While reviewing https://github.com/ppy/osu/pull/12395 this came up as an odd remaining piece of HUD that is not actually required (or useful) to be displayed.

I think this is universally better behaviour. For cases where the user *only* wants to hide the options overlay, this can still be done via `Ctrl+H`, but otherwise the `Shift+Tab` combination will now also hide the top-right elements in replay/autoplay. I can't think of a case where a user would want only the options to display, but not the gameplay HUD.

This has no effect when a replay is not loaded, so will not affect gameplay.