### PR TITLE
Make `Mod.Description` abstract and add missing descriptions

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Mirror";
         public override string Acronym => "MR";
         public override ModType Type => ModType.Conversion;
+        public override string Description => "Notes are flipped horizontally";
         public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Mirror";
         public override string Acronym => "MR";
         public override ModType Type => ModType.Conversion;
-        public override string Description => "Notes are flipped horizontally";
+        public override string Description => "Notes are flipped horizontally.";
         public override double ScoreMultiplier => 1;
         public override bool Ranked => true;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
@@ -9,6 +9,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Touch Device";
         public override string Acronym => "TD";
+        public override string Description => "Automatically applied to plays on devices with a touchscreen.";
         public override double ScoreMultiplier => 1;
 
         public override ModType Type => ModType.System;

--- a/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
+++ b/osu.Game.Tests/NonVisual/DifficultyAdjustmentModCombinationsTest.cs
@@ -144,6 +144,7 @@ namespace osu.Game.Tests.NonVisual
         {
             public override string Name => nameof(ModA);
             public override string Acronym => nameof(ModA);
+            public override string Description => string.Empty;
             public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModIncompatibleWithA), typeof(ModIncompatibleWithAAndB) };
@@ -152,6 +153,7 @@ namespace osu.Game.Tests.NonVisual
         private class ModB : Mod
         {
             public override string Name => nameof(ModB);
+            public override string Description => string.Empty;
             public override string Acronym => nameof(ModB);
             public override double ScoreMultiplier => 1;
 
@@ -162,6 +164,7 @@ namespace osu.Game.Tests.NonVisual
         {
             public override string Name => nameof(ModC);
             public override string Acronym => nameof(ModC);
+            public override string Description => string.Empty;
             public override double ScoreMultiplier => 1;
         }
 
@@ -169,6 +172,7 @@ namespace osu.Game.Tests.NonVisual
         {
             public override string Name => $"Incompatible With {nameof(ModA)}";
             public override string Acronym => $"Incompatible With {nameof(ModA)}";
+            public override string Description => string.Empty;
             public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModA) };
@@ -187,6 +191,7 @@ namespace osu.Game.Tests.NonVisual
         {
             public override string Name => $"Incompatible With {nameof(ModA)} and {nameof(ModB)}";
             public override string Acronym => $"Incompatible With {nameof(ModA)} and {nameof(ModB)}";
+            public override string Description => string.Empty;
             public override double ScoreMultiplier => 1;
 
             public override Type[] IncompatibleMods => new[] { typeof(ModA), typeof(ModB) };

--- a/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModJsonSerialization.cs
@@ -140,6 +140,7 @@ namespace osu.Game.Tests.Online
         {
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
+            public override string Description => "This is a test mod.";
             public override double ScoreMultiplier => 1;
 
             [SettingSource("Test")]
@@ -156,6 +157,7 @@ namespace osu.Game.Tests.Online
         {
             public override string Name => "Test Mod";
             public override string Acronym => "TMTR";
+            public override string Description => "This is a test mod.";
             public override double ScoreMultiplier => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]

--- a/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
+++ b/osu.Game.Tests/Online/TestAPIModMessagePackSerialization.cs
@@ -100,6 +100,7 @@ namespace osu.Game.Tests.Online
         {
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
+            public override string Description => "This is a test mod.";
             public override double ScoreMultiplier => 1;
 
             [SettingSource("Test")]
@@ -116,6 +117,7 @@ namespace osu.Game.Tests.Online
         {
             public override string Name => "Test Mod";
             public override string Acronym => "TMTR";
+            public override string Description => "This is a test mod.";
             public override double ScoreMultiplier => 1;
 
             [SettingSource("Initial rate", "The starting speed of the track")]
@@ -150,6 +152,7 @@ namespace osu.Game.Tests.Online
         {
             public override string Name => "Test Mod";
             public override string Acronym => "TM";
+            public override string Description => "This is a test mod.";
             public override double ScoreMultiplier => 1;
 
             [SettingSource("Test")]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -321,6 +321,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             public override string Name => string.Empty;
             public override string Acronym => string.Empty;
             public override double ScoreMultiplier => 1;
+            public override string Description => string.Empty;
 
             public bool Applied { get; private set; }
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModButton.cs
@@ -57,6 +57,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         private abstract class TestMod : Mod, IApplicableMod
         {
             public override double ScoreMultiplier => 1.0;
+
+            public override string Description => "This is a test mod.";
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSettings.cs
@@ -226,6 +226,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             public override double ScoreMultiplier => 1.0;
 
+            public override string Description => "This is a customisable test mod.";
+
             public override ModType Type => ModType.Conversion;
 
             [SettingSource("Sample float", "Change something for a mod")]

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Mods
         /// The user readable description of this mod.
         /// </summary>
         [JsonIgnore]
-        public virtual string Description => string.Empty;
+        public abstract string Description { get; }
 
         /// <summary>
         /// The tooltip to display for this mod when used in a <see cref="ModIcon"/>.

--- a/osu.Game/Rulesets/Mods/ModNoMod.cs
+++ b/osu.Game/Rulesets/Mods/ModNoMod.cs
@@ -12,6 +12,7 @@ namespace osu.Game.Rulesets.Mods
     {
         public override string Name => "No Mod";
         public override string Acronym => "NM";
+        public override string Description => "No mods applied.";
         public override double ScoreMultiplier => 1;
         public override IconUsage? Icon => FontAwesome.Solid.Ban;
         public override ModType Type => ModType.System;


### PR DESCRIPTION
Seems like something we generally expect mods to implement (else it can be forgotten).