### PR TITLE
Add rounded corners to timeline ticks display

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
     /// <summary>
     /// Represents a singular point on a timeline part.
     /// </summary>
-    public class PointVisualisation : Box
+    public class PointVisualisation : Circle
     {
         public const float MAX_WIDTH = 4;
 


### PR DESCRIPTION
With the width/height modulation we are applying, thicker lines felt pretty jank. This just gives a bit of smoothing to.. take the edge off.

Before:

![20210415 152816 (dotnet)](https://user-images.githubusercontent.com/191335/114824172-7a5bf400-9dff-11eb-82b3-9c00cf28fbec.png)

After:

![unknown](https://user-images.githubusercontent.com/191335/114824218-8fd11e00-9dff-11eb-82e6-2a997e6882df.png)

