### PR TITLE
Remove usage of Lazy<List<...>> by always allocating an empty list

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         public virtual IEnumerable<HitSampleInfo> GetSamples() => HitObject.Samples;
 
-        private readonly Lazy<List<DrawableHitObject>> nestedHitObjects = new Lazy<List<DrawableHitObject>>();
-        public IReadOnlyList<DrawableHitObject> NestedHitObjects => nestedHitObjects.IsValueCreated ? nestedHitObjects.Value : (IReadOnlyList<DrawableHitObject>)Array.Empty<DrawableHitObject>();
+        private readonly List<DrawableHitObject> nestedHitObjects = new List<DrawableHitObject>();
+        public IReadOnlyList<DrawableHitObject> NestedHitObjects => nestedHitObjects;
 
         /// <summary>
         /// Whether this object should handle any user input events.
@@ -249,7 +249,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
                 // Must be done before the nested DHO is added to occur before the nested Apply()!
                 drawableNested.ParentHitObject = this;
 
-                nestedHitObjects.Value.Add(drawableNested);
+                nestedHitObjects.Add(drawableNested);
                 AddNestedHitObject(drawableNested);
             }
 
@@ -305,18 +305,15 @@ namespace osu.Game.Rulesets.Objects.Drawables
             if (Samples != null)
                 Samples.Samples = null;
 
-            if (nestedHitObjects.IsValueCreated)
+            foreach (var obj in nestedHitObjects)
             {
-                foreach (var obj in nestedHitObjects.Value)
-                {
-                    obj.OnNewResult -= onNewResult;
-                    obj.OnRevertResult -= onRevertResult;
-                    obj.ApplyCustomUpdateState -= onApplyCustomUpdateState;
-                }
-
-                nestedHitObjects.Value.Clear();
-                ClearNestedHitObjects();
+                obj.OnNewResult -= onNewResult;
+                obj.OnRevertResult -= onRevertResult;
+                obj.ApplyCustomUpdateState -= onApplyCustomUpdateState;
             }
+
+            nestedHitObjects.Clear();
+            ClearNestedHitObjects();
 
             HitObject.DefaultsApplied -= onDefaultsApplied;
 

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Rulesets.UI
 
                 var enumerable = HitObjectContainer.Objects;
 
-                if (nestedPlayfields.IsValueCreated)
+                if (nestedPlayfields.Count != 0)
                     enumerable = enumerable.Concat(NestedPlayfields.SelectMany(p => p.AllHitObjects));
 
                 return enumerable;
@@ -76,9 +76,9 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// All <see cref="Playfield"/>s nested inside this <see cref="Playfield"/>.
         /// </summary>
-        public IEnumerable<Playfield> NestedPlayfields => nestedPlayfields.IsValueCreated ? nestedPlayfields.Value : Enumerable.Empty<Playfield>();
+        public IEnumerable<Playfield> NestedPlayfields => nestedPlayfields;
 
-        private readonly Lazy<List<Playfield>> nestedPlayfields = new Lazy<List<Playfield>>();
+        private readonly List<Playfield> nestedPlayfields = new List<Playfield>();
 
         /// <summary>
         /// Whether judgements should be displayed by this and and all nested <see cref="Playfield"/>s.
@@ -217,7 +217,7 @@ namespace osu.Game.Rulesets.UI
             otherPlayfield.HitObjectUsageBegan += h => HitObjectUsageBegan?.Invoke(h);
             otherPlayfield.HitObjectUsageFinished += h => HitObjectUsageFinished?.Invoke(h);
 
-            nestedPlayfields.Value.Add(otherPlayfield);
+            nestedPlayfields.Add(otherPlayfield);
         }
 
         protected override void LoadComplete()
@@ -279,12 +279,7 @@ namespace osu.Game.Rulesets.UI
                 return true;
             }
 
-            bool removedFromNested = false;
-
-            if (nestedPlayfields.IsValueCreated)
-                removedFromNested = nestedPlayfields.Value.Any(p => p.Remove(hitObject));
-
-            return removedFromNested;
+            return nestedPlayfields.Any(p => p.Remove(hitObject));
         }
 
         /// <summary>
@@ -429,10 +424,7 @@ namespace osu.Game.Rulesets.UI
                 return;
             }
 
-            if (!nestedPlayfields.IsValueCreated)
-                return;
-
-            foreach (var p in nestedPlayfields.Value)
+            foreach (var p in nestedPlayfields)
                 p.SetKeepAlive(hitObject, keepAlive);
         }
 
@@ -444,10 +436,7 @@ namespace osu.Game.Rulesets.UI
             foreach (var (_, entry) in lifetimeEntryMap)
                 entry.KeepAlive = true;
 
-            if (!nestedPlayfields.IsValueCreated)
-                return;
-
-            foreach (var p in nestedPlayfields.Value)
+            foreach (var p in nestedPlayfields)
                 p.KeepAllAlive();
         }
 
@@ -461,10 +450,7 @@ namespace osu.Game.Rulesets.UI
             {
                 HitObjectContainer.PastLifetimeExtension = value;
 
-                if (!nestedPlayfields.IsValueCreated)
-                    return;
-
-                foreach (var nested in nestedPlayfields.Value)
+                foreach (var nested in nestedPlayfields)
                     nested.PastLifetimeExtension = value;
             }
         }
@@ -479,10 +465,7 @@ namespace osu.Game.Rulesets.UI
             {
                 HitObjectContainer.FutureLifetimeExtension = value;
 
-                if (!nestedPlayfields.IsValueCreated)
-                    return;
-
-                foreach (var nested in nestedPlayfields.Value)
+                foreach (var nested in nestedPlayfields)
                     nested.FutureLifetimeExtension = value;
             }
         }


### PR DESCRIPTION
As discussed in Discord, `Lazy` is actually less efficient than allocating an empty list.
And the code is now more clear.