### PR TITLE
Fix timeline seeking to an incorrect initial location

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -65,6 +65,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             this.userContent = userContent;
 
             RelativeSizeAxes = Axes.X;
+            Height = timeline_height;
 
             ZoomDuration = 200;
             ZoomEasing = Easing.OutQuint;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -128,7 +128,21 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             });
 
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
+
             Beatmap.BindTo(beatmap);
+            Beatmap.BindValueChanged(b =>
+            {
+                waveform.Waveform = b.NewValue.Waveform;
+                track = b.NewValue.Track;
+
+                // todo: i don't think this is safe, the track may not be loaded yet.
+                if (track.Length > 0)
+                {
+                    MaxZoom = getZoomLevelForVisibleMilliseconds(500);
+                    MinZoom = getZoomLevelForVisibleMilliseconds(10000);
+                    Zoom = getZoomLevelForVisibleMilliseconds(2000);
+                }
+            }, true);
         }
 
         protected override void LoadComplete()
@@ -156,20 +170,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     // likewise, delay the resize until the fade is complete.
                     this.Delay(180).ResizeHeightTo(timeline_height, 200, Easing.OutQuint);
                     mainContent.Delay(180).MoveToY(0, 200, Easing.OutQuint);
-                }
-            }, true);
-
-            Beatmap.BindValueChanged(b =>
-            {
-                waveform.Waveform = b.NewValue.Waveform;
-                track = b.NewValue.Track;
-
-                // todo: i don't think this is safe, the track may not be loaded yet.
-                if (track.Length > 0)
-                {
-                    MaxZoom = getZoomLevelForVisibleMilliseconds(500);
-                    MinZoom = getZoomLevelForVisibleMilliseconds(10000);
-                    Zoom = getZoomLevelForVisibleMilliseconds(2000);
                 }
             }, true);
         }


### PR DESCRIPTION
This fixes the failing tests. Turns out that if the zoom setting is adjusted post-`LoadComplete` it applies a tween, which in turn was causing the seek logic in `Timeline` itself to behave incorrectly.

As conveyed in the in-line comment, this is probably not that safe. I'm just restoring it to a known working state for now.