### PR TITLE
Fix slider not displaying in timeline during zero-duration placement

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             var comboColours = skin.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value ?? Array.Empty<Color4>();
             var comboColour = combo.GetComboColour(comboColours);
 
-            if (HitObject is IHasDuration)
+            if (HitObject is IHasDuration duration && duration.Duration > 0)
                 circle.Colour = ColourInfo.GradientHorizontal(comboColour, comboColour.Lighten(0.4f));
             else
                 circle.Colour = comboColour;


### PR DESCRIPTION
Turns out placing a gradient on something which has no width doesn't work so well. Repro is entering slider placement mode and noting that the fill is missing in the timeline until duration is greater than zero.

Before:

![20210416 134036 (dotnet)](https://user-images.githubusercontent.com/191335/114972384-5ceb6080-9eb9-11eb-8ed5-5215cf4e7853.gif)


After:

![20210416 133949 (dotnet)](https://user-images.githubusercontent.com/191335/114972320-434a1900-9eb9-11eb-8b28-d3669ac084f9.gif)
