### PR TITLE
Fix placement blueprints not being correctly removed after a rolled back placement

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         {
             base.UpdateTimeAndPosition(result);
 
-            if (PlacementActive)
+            if (PlacementActive == PlacementState.Active)
             {
                 if (result.Time is double endTime)
                 {

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/ManiaPlacementBlueprint.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         {
             base.UpdateTimeAndPosition(result);
 
-            if (!PlacementActive)
+            if (PlacementActive == PlacementState.Waiting)
                 Column = result.Playfield as Column;
         }
     }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private InputManager inputManager;
 
-        private PlacementState state;
+        private SliderPlacementState state;
         private PathControlPoint segmentStart;
         private PathControlPoint cursor;
         private int currentSegmentLength;
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 controlPointVisualiser = new PathControlPointVisualiser(HitObject, false)
             };
 
-            setState(PlacementState.Initial);
+            setState(SliderPlacementState.Initial);
         }
 
         protected override void LoadComplete()
@@ -73,12 +73,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             switch (state)
             {
-                case PlacementState.Initial:
+                case SliderPlacementState.Initial:
                     BeginPlacement();
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
                     break;
 
-                case PlacementState.Body:
+                case SliderPlacementState.Body:
                     updateCursor();
                     break;
             }
@@ -91,11 +91,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             switch (state)
             {
-                case PlacementState.Initial:
+                case SliderPlacementState.Initial:
                     beginCurve();
                     break;
 
-                case PlacementState.Body:
+                case SliderPlacementState.Body:
                     if (canPlaceNewControlPoint(out var lastPoint))
                     {
                         // Place a new point by detatching the current cursor.
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
-            if (state == PlacementState.Body && e.Button == MouseButton.Right)
+            if (state == SliderPlacementState.Body && e.Button == MouseButton.Right)
                 endCurve();
             base.OnMouseUp(e);
         }
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private void beginCurve()
         {
             BeginPlacement(commitStart: true);
-            setState(PlacementState.Body);
+            setState(SliderPlacementState.Body);
         }
 
         private void endCurve()
@@ -219,12 +219,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             tailCirclePiece.UpdateFrom(HitObject.TailCircle);
         }
 
-        private void setState(PlacementState newState)
+        private void setState(SliderPlacementState newState)
         {
             state = newState;
         }
 
-        private enum PlacementState
+        private enum SliderPlacementState
         {
             Initial,
             Body,

--- a/osu.Game.Rulesets.Taiko/Edit/Blueprints/TaikoSpanPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Blueprints/TaikoSpanPlacementBlueprint.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Blueprints
         {
             base.UpdateTimeAndPosition(result);
 
-            if (PlacementActive)
+            if (PlacementActive == PlacementState.Active)
             {
                 if (result.Time is double dragTime)
                 {

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -196,7 +196,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private void refreshTool()
         {
             removePlacement();
-            createPlacement();
+            ensurePlacementCreated();
         }
 
         private void updatePlacementPosition()
@@ -215,15 +215,26 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             base.Update();
 
-            if (Composer.CursorInPlacementArea)
-                createPlacement();
-            else if (currentPlacement?.PlacementActive == false)
-                removePlacement();
-
             if (currentPlacement != null)
             {
-                updatePlacementPosition();
+                switch (currentPlacement.PlacementActive)
+                {
+                    case PlacementBlueprint.PlacementState.Waiting:
+                        if (!Composer.CursorInPlacementArea)
+                            removePlacement();
+                        break;
+
+                    case PlacementBlueprint.PlacementState.Finished:
+                        removePlacement();
+                        break;
+                }
             }
+
+            if (Composer.CursorInPlacementArea)
+                ensurePlacementCreated();
+
+            if (currentPlacement != null)
+                updatePlacementPosition();
         }
 
         protected sealed override SelectionBlueprint CreateBlueprintFor(HitObject hitObject)
@@ -249,7 +260,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 NewCombo.Value = TernaryState.False;
         }
 
-        private void createPlacement()
+        private void ensurePlacementCreated()
         {
             if (currentPlacement != null) return;
 


### PR DESCRIPTION
This is hard to write a test for on its own since nothing actually uses the non-commit path apart from the `BlueprintContainer` itself (which handles correctly as a result), but will be used for upcoming work to fix #10959.

The issue is that the `.Expire` call is only triggered if the `removePlacement()` function is run, but as `PlacementActive` was returned to a `false` state on commit-revert, the `ComposeBlueprintContainer` is unable to know whether placement was never-started or has finished (and been reverted). I considered adding another entry in the enum for `RolledBack` or similar, but probably not worth doing so until we need it.

Before (can't exit placement):

![20210416 141426 (dotnet)](https://user-images.githubusercontent.com/191335/114974829-1c421600-9ebe-11eb-84b8-a7bfaf4a682e.gif)

After:

![20210416 141335 (dotnet)](https://user-images.githubusercontent.com/191335/114974768-fae12a00-9ebd-11eb-985f-96c20e9fda73.gif)
