### PR TITLE
Further refactor FrameReplayInputHandler, simplify the template code

### DIFF
--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Replays/EmptyFreeformFramedReplayInputHandler.cs
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Replays/EmptyFreeformFramedReplayInputHandler.cs
@@ -7,7 +7,6 @@ using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
-using osuTK;
 
 namespace osu.Game.Rulesets.EmptyFreeform.Replays
 {
@@ -20,24 +19,13 @@ namespace osu.Game.Rulesets.EmptyFreeform.Replays
 
         protected override bool IsImportant(EmptyFreeformReplayFrame frame) => frame.Actions.Any();
 
-        protected Vector2 Position
-        {
-            get
-            {
-                var frame = CurrentFrame;
-
-                if (frame == null)
-                    return Vector2.Zero;
-
-                return Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time);
-            }
-        }
-
         public override void CollectPendingInputs(List<IInput> inputs)
         {
+            var position = Interpolation.ValueAt(CurrentTime, StartFrame.Position, EndFrame.Position, StartFrame.Time, EndFrame.Time);
+
             inputs.Add(new MousePositionAbsoluteInput
             {
-                Position = GamefieldToScreenSpace(Position),
+                Position = GamefieldToScreenSpace(position),
             });
             inputs.Add(new ReplayState<EmptyFreeformAction>
             {

--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Replays/EmptyFreeformFramedReplayInputHandler.cs
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Replays/EmptyFreeformFramedReplayInputHandler.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
@@ -30,9 +29,7 @@ namespace osu.Game.Rulesets.EmptyFreeform.Replays
                 if (frame == null)
                     return Vector2.Zero;
 
-                Debug.Assert(CurrentTime != null);
-
-                return Interpolation.ValueAt(CurrentTime.Value, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time);
+                return Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time);
             }
         }
 

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
@@ -6,7 +6,6 @@ using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
-using osuTK;
 
 namespace osu.Game.Rulesets.Pippidon.Replays
 {
@@ -19,24 +18,13 @@ namespace osu.Game.Rulesets.Pippidon.Replays
 
         protected override bool IsImportant(PippidonReplayFrame frame) => true;
 
-        protected Vector2 Position
-        {
-            get
-            {
-                var frame = CurrentFrame;
-
-                if (frame == null)
-                    return Vector2.Zero;
-
-                return NextFrame != null ? Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
-            }
-        }
-
         public override void CollectPendingInputs(List<IInput> inputs)
         {
+            var position = Interpolation.ValueAt(CurrentTime, StartFrame.Position, EndFrame.Position, StartFrame.Time, EndFrame.Time);
+
             inputs.Add(new MousePositionAbsoluteInput
             {
-                Position = GamefieldToScreenSpace(Position)
+                Position = GamefieldToScreenSpace(position)
             });
         }
     }

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
 using osu.Game.Replays;
@@ -29,9 +28,7 @@ namespace osu.Game.Rulesets.Pippidon.Replays
                 if (frame == null)
                     return Vector2.Zero;
 
-                Debug.Assert(CurrentTime != null);
-
-                return NextFrame != null ? Interpolation.ValueAt(CurrentTime.Value, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
+                return NextFrame != null ? Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchAutoGenerator.cs
@@ -125,10 +125,6 @@ namespace osu.Game.Rulesets.Catch.Replays
 
         private void addFrame(double time, float? position = null, bool dashing = false)
         {
-            // todo: can be removed once FramedReplayInputHandler correctly handles rewinding before first frame.
-            if (Replay.Frames.Count == 0)
-                Replay.Frames.Add(new CatchReplayFrame(time - 1, position, false, null));
-
             var last = currentFrame;
             currentFrame = new CatchReplayFrame(time, position, dashing, last);
             Replay.Frames.Add(currentFrame);

--- a/osu.Game.Rulesets.Catch/Replays/CatchFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchFramedReplayInputHandler.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
@@ -29,9 +28,7 @@ namespace osu.Game.Rulesets.Catch.Replays
                 if (frame == null)
                     return null;
 
-                Debug.Assert(CurrentTime != null);
-
-                return NextFrame != null ? Interpolation.ValueAt(CurrentTime.Value, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
+                return NextFrame != null ? Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Replays/CatchFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchFramedReplayInputHandler.cs
@@ -19,27 +19,14 @@ namespace osu.Game.Rulesets.Catch.Replays
 
         protected override bool IsImportant(CatchReplayFrame frame) => frame.Actions.Any();
 
-        protected float? Position
-        {
-            get
-            {
-                var frame = CurrentFrame;
-
-                if (frame == null)
-                    return null;
-
-                return NextFrame != null ? Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
-            }
-        }
-
         public override void CollectPendingInputs(List<IInput> inputs)
         {
-            if (!Position.HasValue) return;
+            var position = Interpolation.ValueAt(CurrentTime, StartFrame.Position, EndFrame.Position, StartFrame.Time, EndFrame.Time);
 
             inputs.Add(new CatchReplayState
             {
                 PressedActions = CurrentFrame?.Actions ?? new List<CatchAction>(),
-                CatcherX = Position.Value
+                CatcherX = position
             });
         }
 

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         /// <summary>
         /// The number of frames which are generated at the start of a replay regardless of hitobject content.
         /// </summary>
-        private const int frame_offset = 1;
+        private const int frame_offset = 0;
 
         [Test]
         public void TestSingleNote()
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.IsTrue(generated.Frames.Count == frame_offset + 2, "Replay must have 3 frames");
+            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
             Assert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
             Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Special1), "Special1 has not been pressed");
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.IsTrue(generated.Frames.Count == frame_offset + 2, "Replay must have 3 frames");
+            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
             Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
             Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Special1), "Special1 has not been pressed");
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.IsTrue(generated.Frames.Count == frame_offset + 2, "Replay must have 3 frames");
+            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
             Assert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
             Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1, ManiaAction.Key2), "Key1 & Key2 have not been pressed");
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.IsTrue(generated.Frames.Count == frame_offset + 2, "Replay must have 3 frames");
+            Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
 
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
             Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
@@ -119,7 +119,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.IsTrue(generated.Frames.Count == frame_offset + 4, "Replay must have 4 generated frames");
+            Assert.AreEqual(generated.Frames.Count, frame_offset + 4, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
             Assert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect first note release time");
             Assert.AreEqual(2000, generated.Frames[frame_offset + 2].Time, "Incorrect second note hit time");
@@ -146,7 +146,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.IsTrue(generated.Frames.Count == frame_offset + 4, "Replay must have 4 generated frames");
+            Assert.AreEqual(generated.Frames.Count, frame_offset + 4, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
             Assert.AreEqual(3000, generated.Frames[frame_offset + 2].Time, "Incorrect first note release time");
             Assert.AreEqual(2000, generated.Frames[frame_offset + 1].Time, "Incorrect second note hit time");
@@ -173,7 +173,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
             var generated = new ManiaAutoGenerator(beatmap).Generate();
 
-            Assert.IsTrue(generated.Frames.Count == frame_offset + 3, "Replay must have 3 generated frames");
+            Assert.AreEqual(generated.Frames.Count, frame_offset + 3, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect first note hit time");
             Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect second note press time + first note release time");
             Assert.AreEqual(3000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 2].Time, "Incorrect second note release time");

--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -70,10 +70,6 @@ namespace osu.Game.Rulesets.Mania.Replays
                     }
                 }
 
-                // todo: can be removed once FramedReplayInputHandler correctly handles rewinding before first frame.
-                if (Replay.Frames.Count == 0)
-                    Replay.Frames.Add(new ManiaReplayFrame(group.First().Time - 1));
-
                 Replay.Frames.Add(new ManiaReplayFrame(group.First().Time, actions.ToArray()));
             }
 

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -71,8 +71,6 @@ namespace osu.Game.Rulesets.Osu.Replays
 
             buttonIndex = 0;
 
-            AddFrameToReplay(new OsuReplayFrame(-100000, new Vector2(256, 500)));
-            AddFrameToReplay(new OsuReplayFrame(Beatmap.HitObjects[0].StartTime - 1500, new Vector2(256, 500)));
             AddFrameToReplay(new OsuReplayFrame(Beatmap.HitObjects[0].StartTime - 1500, new Vector2(256, 500)));
 
             for (int i = 0; i < Beatmap.HitObjects.Count; i++)

--- a/osu.Game.Rulesets.Osu/Replays/OsuFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuFramedReplayInputHandler.cs
@@ -7,7 +7,6 @@ using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Replays
 {
@@ -20,22 +19,11 @@ namespace osu.Game.Rulesets.Osu.Replays
 
         protected override bool IsImportant(OsuReplayFrame frame) => frame.Actions.Any();
 
-        protected Vector2? Position
-        {
-            get
-            {
-                var frame = CurrentFrame;
-
-                if (frame == null)
-                    return null;
-
-                return NextFrame != null ? Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
-            }
-        }
-
         public override void CollectPendingInputs(List<IInput> inputs)
         {
-            inputs.Add(new MousePositionAbsoluteInput { Position = GamefieldToScreenSpace(Position ?? Vector2.Zero) });
+            var position = Interpolation.ValueAt(CurrentTime, StartFrame.Position, EndFrame.Position, StartFrame.Time, EndFrame.Time);
+
+            inputs.Add(new MousePositionAbsoluteInput { Position = GamefieldToScreenSpace(position) });
             inputs.Add(new ReplayState<OsuAction> { PressedActions = CurrentFrame?.Actions ?? new List<OsuAction>() });
         }
     }

--- a/osu.Game.Rulesets.Osu/Replays/OsuFramedReplayInputHandler.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuFramedReplayInputHandler.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Utils;
@@ -30,9 +29,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                 if (frame == null)
                     return null;
 
-                Debug.Assert(CurrentTime != null);
-
-                return NextFrame != null ? Interpolation.ValueAt(CurrentTime.Value, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
+                return NextFrame != null ? Interpolation.ValueAt(CurrentTime, frame.Position, NextFrame.Position, frame.Time, NextFrame.Time) : frame.Position;
             }
         }
 

--- a/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
+++ b/osu.Game.Rulesets.Taiko/Replays/TaikoAutoGenerator.cs
@@ -35,7 +35,6 @@ namespace osu.Game.Rulesets.Taiko.Replays
 
             bool hitButton = true;
 
-            Frames.Add(new TaikoReplayFrame(-100000));
             Frames.Add(new TaikoReplayFrame(Beatmap.HitObjects[0].StartTime - 1000));
 
             for (int i = 0; i < Beatmap.HitObjects.Count; i++)

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
@@ -32,7 +34,7 @@ namespace osu.Game.Rulesets.Replays
         /// </summary>
         /// <remarks>Returns null if the current time is strictly before the first frame.</remarks>
         /// <exception cref="InvalidOperationException">The replay is empty.</exception>
-        public TFrame CurrentFrame
+        public TFrame? CurrentFrame
         {
             get
             {
@@ -49,7 +51,7 @@ namespace osu.Game.Rulesets.Replays
         /// </summary>
         /// <remarks>Returns null if the current frame is the last frame.</remarks>
         /// <exception cref="InvalidOperationException">The replay is empty.</exception>
-        public TFrame NextFrame
+        public TFrame? NextFrame
         {
             get
             {
@@ -69,8 +71,7 @@ namespace osu.Game.Rulesets.Replays
         // This input handler should be enabled only if there is at least one replay frame.
         public override bool IsActive => HasFrames;
 
-        // Can make it non-null but that is a breaking change.
-        protected double? CurrentTime { get; private set; }
+        protected double CurrentTime { get; private set; }
 
         protected virtual double AllowedImportantTimeSpan => sixty_frame_time * 1.2;
 
@@ -101,7 +102,7 @@ namespace osu.Game.Rulesets.Replays
                     return false;
 
                 return IsImportant(CurrentFrame) && // a button is in a pressed state
-                       Math.Abs(CurrentTime - NextFrame.Time ?? 0) <= AllowedImportantTimeSpan; // the next frame is within an allowable time span
+                       Math.Abs(CurrentTime - NextFrame?.Time ?? 0) <= AllowedImportantTimeSpan; // the next frame is within an allowable time span
             }
         }
 
@@ -151,7 +152,7 @@ namespace osu.Game.Rulesets.Replays
             CurrentTime = Math.Clamp(time, frameStart, frameEnd);
 
             // In an important section, a mid-frame time cannot be used and a null is returned instead.
-            return inImportantSection && frameStart < time && time < frameEnd ? null : CurrentTime;
+            return inImportantSection && frameStart < time && time < frameEnd ? null : (double?)CurrentTime;
         }
 
         private double getFrameTime(int index)

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -11,7 +10,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osu.Game.Configuration;
@@ -101,17 +99,6 @@ namespace osu.Game.Rulesets.UI
         }
 
         #endregion
-
-        // to avoid allocation
-        private readonly List<IInput> emptyInputList = new List<IInput>();
-
-        protected override List<IInput> GetPendingInputs()
-        {
-            if (replayInputHandler?.IsActive == false)
-                return emptyInputList;
-
-            return base.GetPendingInputs();
-        }
 
         #region Setting application (disables etc.)
 


### PR DESCRIPTION
`StartFrame` and `EndFrame` are non-null "clipped" version of `CurrentFrame` and `NextFrame`.
The frame interpolation logic is now one-linear, and if it is used for interpolating position,

- Before the first frame, the position stays at the first frame's position
- The position is interpolated correctly during the replay
- After the last frame, the position stays at the last frame's position

This is the desired behavior of most cases.

Two "todo"s in `AutoGenerator` are removed, not sure what was the issue, but it works better now.

Note: I noticed mania autoplay misses notes when I rewind it to the start, but this issue is not related to this/previous PR.

---

### Breaking changes

The template code to deriving `FramedReplayInputHandler` is changed.
`CurrentTime` is now non-null.
You can also use `StartFrame` and `EndFrame` for the interpolation logic, as it simplifies the code.