### PR TITLE
Fix an occasional crash when deleting a HitObject via internal means

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -438,8 +438,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void onBlueprintDeselected(SelectionBlueprint blueprint)
         {
-            SelectionHandler.HandleDeselected(blueprint);
             SelectionBlueprints.ChangeChildDepth(blueprint, 0);
+            SelectionHandler.HandleDeselected(blueprint);
 
             Composer.Playfield.SetKeepAlive(blueprint.HitObject, false);
         }


### PR DESCRIPTION
If the currently selected `HitObject` decides to remove itself from the beatmap, it's feasible that the removal of the drawable happens before the removal of the selection. Or something like that. The order of these two lines seems to resolve the issue as you'd expect.

An alternative would be checking `blueprint.Parent == null` or something like that.

I reproduced this while deleting the middle control point of a three-point perfect slider, but can't easily reproduce on further attempts.

```csharp

[runtime] 2021-04-16 06:44:56 [error]: System.InvalidOperationException: Can not change depth of drawable which is not contained within this CompositeDrawable.
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.ChangeInternalChildDepth(Drawable child, Single newDepth)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.Compose.Components.BlueprintContainer.onBlueprintDeselected(SelectionBlueprint blueprint) in /Users/dean/Projects/osu/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs:line 442
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.SelectionBlueprint.updateState() in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/SelectionBlueprint.cs:line 87
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.SelectionBlueprint.set_State(SelectionState value) in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/SelectionBlueprint.cs:line 70
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.SelectionBlueprint.Deselect() in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/SelectionBlueprint.cs:line 121
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.Compose.Components.BlueprintContainer.<load>b__32_1(Object selectedObjects, NotifyCollectionChangedEventArgs args) in /Users/dean/Projects/osu/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs:line 96
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Bindables.BindableList`1.remove(T item, BindableList`1 caller)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Bindables.BindableList`1.remove(T item, BindableList`1 caller)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Bindables.BindableList`1.Remove(T item)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.Compose.Components.SelectionHandler.HandleDeselected(SelectionBlueprint blueprint) in /Users/dean/Projects/osu/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs:line 214
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.Compose.Components.BlueprintContainer.onBlueprintDeselected(SelectionBlueprint blueprint) in /Users/dean/Projects/osu/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs:line 441
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.SelectionBlueprint.updateState() in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/SelectionBlueprint.cs:line 87
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.SelectionBlueprint.set_State(SelectionState value) in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/SelectionBlueprint.cs:line 70
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.SelectionBlueprint.Deselect() in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/SelectionBlueprint.cs:line 121
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.Compose.Components.BlueprintContainer.removeBlueprintFor(HitObject hitObject) in /Users/dean/Projects/osu/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs:line 304
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.UI.Playfield.<.ctor>b__27_5(HitObject o) in /Users/dean/Projects/osu/osu.Game/Rulesets/UI/Playfield.cs:line 106
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.UI.HitObjectContainer.removeDrawable(HitObjectLifetimeEntry entry) in /Users/dean/Projects/osu/osu.Game/Rulesets/UI/HitObjectContainer.cs:line 130
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.UI.HitObjectContainer.entryBecameDead(LifetimeEntry entry) in /Users/dean/Projects/osu/osu.Game/Rulesets/UI/HitObjectContainer.cs:line 93
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Graphics.Performance.LifetimeEntryManager.RemoveEntry(LifetimeEntry entry)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.UI.HitObjectContainer.Remove(HitObjectLifetimeEntry entry) in /Users/dean/Projects/osu/osu.Game/Rulesets/UI/HitObjectContainer.cs:line 89
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.UI.Playfield.Remove(HitObject hitObject) in /Users/dean/Projects/osu/osu.Game/Rulesets/UI/Playfield.cs:line 277
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.UI.DrawableRuleset`1.RemoveHitObject(TObject hitObject) in /Users/dean/Projects/osu/osu.Game/Rulesets/UI/DrawableRuleset.cs:line 260
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.DrawableEditRulesetWrapper`1.removeHitObject(HitObject hitObject) in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/DrawableEditRulesetWrapper.cs:line 73
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.EditorBeatmap.UpdateState() in /Users/dean/Projects/osu/osu.Game/Screens/Edit/EditorBeatmap.cs:line 265
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.TransactionalCommitComponent.EndChange() in /Users/dean/Projects/osu/osu.Game/Screens/Edit/TransactionalCommitComponent.cs:line 53
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.EditorBeatmap.RemoveAt(Int32 index) in /Users/dean/Projects/osu/osu.Game/Screens/Edit/EditorBeatmap.cs:line 231
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Screens.Edit.EditorBeatmap.Remove(HitObject hitObject) in /Users/dean/Projects/osu/osu.Game/Screens/Edit/EditorBeatmap.cs:line 192
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Edit.HitObjectComposer`1.Delete(HitObject hitObject) in /Users/dean/Projects/osu/osu.Game/Rulesets/Edit/HitObjectComposer.cs:line 339
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.SliderSelectionBlueprint.removeControlPoints(List`1 toRemove) in /Users/dean/Projects/osu/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs:line 220
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components.PathControlPointVisualiser.DeleteSelected() in /Users/dean/Projects/osu/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs:line 196
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components.PathControlPointVisualiser.<get_ContextMenuItems>b__22_1() in /Users/dean/Projects/osu/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs:line 232
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Graphics.UserInterface.Menu.DrawableMenuItem.OnClick(ClickEvent e)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Game.Graphics.UserInterface.DrawableOsuMenuItem.OnClick(ClickEvent e) in /Users/dean/Projects/osu/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs:line 101
[runtime] 2021-04-16 06:44:56 [error]: at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.ButtonEventManager`1.PropagateButtonEvent(IEnumerable`1 drawables, UIEvent e)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.MouseButtonEventManager.handleClick(InputState state, List`1 targets)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.MouseButtonEventManager.HandleButtonUp(InputState state, List`1 targets)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.ButtonEventManager`1.handleButtonUp(InputState state)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.InputManager.HandleMouseButtonStateChange(ButtonStateChangeEvent`1 e)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.StateChanges.ButtonInput`1.Apply(InputState state, IInputStateChangeHandler handler)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.PassThroughInputManager.Handle(UIEvent e)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Graphics.Drawable.OnMouseUp(MouseUpEvent e)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Graphics.Drawable.TriggerEvent(UIEvent e)
[runtime] 2021-04-16 06:44:56 [error]: at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.ButtonEventManager`1.PropagateButtonEvent(IEnumerable`1 drawables, UIEvent e)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.MouseButtonEventManager.HandleButtonUp(InputState state, List`1 targets)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.ButtonEventManager`1.handleButtonUp(InputState state)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.InputManager.HandleMouseButtonStateChange(ButtonStateChangeEvent`1 e)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.UserInputManager.HandleInputStateChange(InputStateChangeEvent inputStateChange)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.StateChanges.ButtonInput`1.Apply(InputState state, IInputStateChangeHandler handler)
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.InputManager.Update()
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Input.PassThroughInputManager.Update()
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Graphics.Drawable.UpdateSubTree()
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Platform.GameHost.UpdateFrame()
[runtime] 2021-04-16 06:44:56 [error]: at osu.Framework.Threading.GameThread.ProcessFrame()

```