### PR TITLE
Reset SessionStatics on inactivity

### DIFF
--- a/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
+++ b/osu.Game.Tests/NonVisual/SessionStaticsTest.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Configuration;
+using osu.Game.Input;
+
+namespace osu.Game.Tests.NonVisual
+{
+    [TestFixture]
+    public class SessionStaticsTest
+    {
+        private SessionStatics sessionStatics;
+        private IdleTracker sessionIdleTracker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            sessionStatics = new SessionStatics();
+            sessionIdleTracker = new GameIdleTracker(1000);
+
+            sessionStatics.SetValue(Static.LoginOverlayDisplayed, true);
+            sessionStatics.SetValue(Static.MutedAudioNotificationShownOnce, true);
+            sessionStatics.SetValue(Static.LowBatteryNotificationShownOnce, true);
+            sessionStatics.SetValue(Static.LastHoverSoundPlaybackTime, (double?)1d);
+
+            sessionIdleTracker.IsIdle.BindValueChanged(e =>
+            {
+                if (e.NewValue)
+                    sessionStatics.ResetValues();
+            });
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void TestSessionStaticsReset()
+        {
+            sessionIdleTracker.IsIdle.BindValueChanged(e =>
+            {
+                Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LoginOverlayDisplayed).IsDefault);
+                Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce).IsDefault);
+                Assert.IsTrue(sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce).IsDefault);
+                Assert.IsTrue(sessionStatics.GetBindable<double?>(Static.LastHoverSoundPlaybackTime).IsDefault);
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -141,6 +141,7 @@ namespace osu.Game.Tests.Visual.Components
 
             waitForAllIdle();
         }
+
         private void checkIdleStatus(int box, bool expectedIdle)
         {
             AddAssert($"box {box} is {(expectedIdle ? "idle" : "active")}", () => boxes[box - 1].IsIdle == expectedIdle);

--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tests.Visual.Components
 
         private IdleTrackingBox[] boxes;
 
-        public SessionStatics sessionStatics;
+        private SessionStatics sessionStatics;
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -175,6 +175,7 @@ namespace osu.Game.Tests.Visual.Components
 
             public IdleTrackingBox(int timeToIdle, SessionStatics statics)
             {
+
                 Box box;
 
                 Alpha = 0.6f;
@@ -182,7 +183,7 @@ namespace osu.Game.Tests.Visual.Components
 
                 InternalChildren = new Drawable[]
                 {
-                    idleTracker = new GameIdleTracker(timeToIdle, statics),
+                    idleTracker = new GameIdleTracker(timeToIdle),
                     box = new Box
                     {
                         Colour = Color4.White,
@@ -190,7 +191,11 @@ namespace osu.Game.Tests.Visual.Components
                     },
                 };
 
-                idleTracker.IsIdle.BindValueChanged(idle => box.Colour = idle.NewValue ? Color4.White : Color4.Black, true);
+                idleTracker.IsIdle.BindValueChanged(idle =>
+                {
+                    box.Colour = idle.NewValue ? Color4.White : Color4.Black;
+                    if (idle.NewValue) statics.ResetValues();
+                }, true);
             }
         }
     }

--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Configuration;
 using osu.Game.Input;
 using osuTK;
 using osuTK.Graphics;
@@ -22,17 +21,14 @@ namespace osu.Game.Tests.Visual.Components
 
         private IdleTrackingBox[] boxes;
 
-        private SessionStatics sessionStatics;
-
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            sessionStatics = new SessionStatics();
             InputManager.MoveMouseTo(Vector2.Zero);
 
             Children = boxes = new[]
             {
-                box1 = new IdleTrackingBox(2000, sessionStatics)
+                box1 = new IdleTrackingBox(2000)
                 {
                     Name = "TopLeft",
                     RelativeSizeAxes = Axes.Both,
@@ -40,7 +36,7 @@ namespace osu.Game.Tests.Visual.Components
                     Anchor = Anchor.TopLeft,
                     Origin = Anchor.TopLeft,
                 },
-                box2 = new IdleTrackingBox(4000, sessionStatics)
+                box2 = new IdleTrackingBox(4000)
                 {
                     Name = "TopRight",
                     RelativeSizeAxes = Axes.Both,
@@ -48,7 +44,7 @@ namespace osu.Game.Tests.Visual.Components
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
                 },
-                box3 = new IdleTrackingBox(6000, sessionStatics)
+                box3 = new IdleTrackingBox(6000)
                 {
                     Name = "BottomLeft",
                     RelativeSizeAxes = Axes.Both,
@@ -56,7 +52,7 @@ namespace osu.Game.Tests.Visual.Components
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                 },
-                box4 = new IdleTrackingBox(8000, sessionStatics)
+                box4 = new IdleTrackingBox(8000)
                 {
                     Name = "BottomRight",
                     RelativeSizeAxes = Axes.Both,
@@ -145,27 +141,6 @@ namespace osu.Game.Tests.Visual.Components
 
             waitForAllIdle();
         }
-
-        [Test]
-        public void TestSessionStaticsReset()
-        {
-            AddStep("move to top left", () => InputManager.MoveMouseTo(box1));
-            AddStep("set session statics", () =>
-            {
-                sessionStatics.SetValue(Static.LoginOverlayDisplayed, true);
-                sessionStatics.SetValue(Static.MutedAudioNotificationShownOnce, true);
-                sessionStatics.SetValue(Static.LowBatteryNotificationShownOnce, true);
-                sessionStatics.SetValue(Static.LastHoverSoundPlaybackTime, (double?)1d);
-            });
-
-            AddStep("move away from box1", () => InputManager.MoveMouseTo(box4));
-            AddUntilStep("Wait for idle", () => box1.IsIdle);
-            AddAssert("LoginOverlayDisplayed is default", () => sessionStatics.Get<bool>(Static.LoginOverlayDisplayed) == false);
-            AddAssert("MutedAudioNotificationShownOnce is default", () => sessionStatics.Get<bool>(Static.MutedAudioNotificationShownOnce) == false);
-            AddAssert("LowBatteryNotificationShownOnce is default", () => sessionStatics.Get<bool>(Static.LowBatteryNotificationShownOnce) == false);
-            AddAssert("LastHoverSoundPlaybackTime is default", () => sessionStatics.Get<double?>(Static.LastHoverSoundPlaybackTime) == null);
-        }
-
         private void checkIdleStatus(int box, bool expectedIdle)
         {
             AddAssert($"box {box} is {(expectedIdle ? "idle" : "active")}", () => boxes[box - 1].IsIdle == expectedIdle);
@@ -182,7 +157,7 @@ namespace osu.Game.Tests.Visual.Components
 
             public bool IsIdle => idleTracker.IsIdle.Value;
 
-            public IdleTrackingBox(int timeToIdle, SessionStatics statics)
+            public IdleTrackingBox(int timeToIdle)
             {
                 Box box;
 
@@ -198,12 +173,6 @@ namespace osu.Game.Tests.Visual.Components
                         RelativeSizeAxes = Axes.Both,
                     },
                 };
-
-                idleTracker.IsIdle.BindValueChanged(idle =>
-                {
-                    box.Colour = idle.NewValue ? Color4.White : Color4.Black;
-                    if (idle.NewValue) statics.ResetValues();
-                }, true);
             }
         }
     }

--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -173,6 +173,8 @@ namespace osu.Game.Tests.Visual.Components
                         RelativeSizeAxes = Axes.Both,
                     },
                 };
+
+                idleTracker.IsIdle.BindValueChanged(idle => box.Colour = idle.NewValue ? Color4.White : Color4.Black, true);
             }
         }
     }

--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -175,7 +175,6 @@ namespace osu.Game.Tests.Visual.Components
 
             public IdleTrackingBox(int timeToIdle, SessionStatics statics)
             {
-
                 Box box;
 
                 Alpha = 0.6f;

--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -65,7 +65,6 @@ namespace osu.Game.Tests.Visual.Components
                     Origin = Anchor.BottomRight,
                 },
             };
-
         });
 
         [Test]

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -23,11 +23,11 @@ namespace osu.Game.Configuration
 
         public void ResetValues()
         {
-            SetValue(Static.LoginOverlayDisplayed, false);
-            SetValue(Static.MutedAudioNotificationShownOnce, false);
-            SetValue(Static.LowBatteryNotificationShownOnce, false);
-            SetValue(Static.LastHoverSoundPlaybackTime, (double?)null);
-            SetValue<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
+            GetOriginalBindable<bool>(Static.LoginOverlayDisplayed).SetDefault();
+            GetOriginalBindable<bool>(Static.MutedAudioNotificationShownOnce).SetDefault();
+            GetOriginalBindable<bool>(Static.LowBatteryNotificationShownOnce).SetDefault();
+            GetOriginalBindable<double?>(Static.LastHoverSoundPlaybackTime).SetDefault();
+            GetOriginalBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).SetDefault();
         }
     }
 

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -20,6 +20,14 @@ namespace osu.Game.Configuration
             SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null);
             SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
+
+        public void ResetValues()
+        {
+            SetValue(Static.LoginOverlayDisplayed, false);
+            SetValue(Static.MutedAudioNotificationShownOnce, false);
+            SetValue(Static.LowBatteryNotificationShownOnce, false);
+            SetValue(Static.LastHoverSoundPlaybackTime, (double?)null);
+        }
     }
 
     public enum Static

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -23,10 +23,8 @@ namespace osu.Game.Configuration
 
         public void ResetValues()
         {
-            SetValue(Static.LoginOverlayDisplayed, false);
-            SetValue(Static.MutedAudioNotificationShownOnce, false);
-            SetValue(Static.LowBatteryNotificationShownOnce, false);
-            SetValue(Static.LastHoverSoundPlaybackTime, (double?)null);
+            ConfigStore.Clear();
+            InitialiseDefaults();
         }
     }
 

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
@@ -12,23 +13,18 @@ namespace osu.Game.Configuration
     /// </summary>
     public class SessionStatics : InMemoryConfigManager<Static>
     {
-        protected override void InitialiseDefaults()
-        {
-            SetDefault(Static.LoginOverlayDisplayed, false);
-            SetDefault(Static.MutedAudioNotificationShownOnce, false);
-            SetDefault(Static.LowBatteryNotificationShownOnce, false);
-            SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null);
-            SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
-        }
+        protected override void InitialiseDefaults() => ResetValues();
 
         public void ResetValues()
         {
-            GetOriginalBindable<bool>(Static.LoginOverlayDisplayed).SetDefault();
-            GetOriginalBindable<bool>(Static.MutedAudioNotificationShownOnce).SetDefault();
-            GetOriginalBindable<bool>(Static.LowBatteryNotificationShownOnce).SetDefault();
-            GetOriginalBindable<double?>(Static.LastHoverSoundPlaybackTime).SetDefault();
-            GetOriginalBindable<APISeasonalBackgrounds>(Static.SeasonalBackgrounds).SetDefault();
+            ensureDefault(SetDefault(Static.LoginOverlayDisplayed, false));
+            ensureDefault(SetDefault(Static.MutedAudioNotificationShownOnce, false));
+            ensureDefault(SetDefault(Static.LowBatteryNotificationShownOnce, false));
+            ensureDefault(SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null));
+            ensureDefault(SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null));
         }
+
+        private void ensureDefault<T>(Bindable<T> bindable) => bindable.SetDefault();
     }
 
     public enum Static

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -23,8 +23,11 @@ namespace osu.Game.Configuration
 
         public void ResetValues()
         {
-            ConfigStore.Clear();
-            InitialiseDefaults();
+            SetValue(Static.LoginOverlayDisplayed, false);
+            SetValue(Static.MutedAudioNotificationShownOnce, false);
+            SetValue(Static.LowBatteryNotificationShownOnce, false);
+            SetValue(Static.LastHoverSoundPlaybackTime, (double?)null);
+            SetValue<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
     }
 

--- a/osu.Game/Input/GameIdleTracker.cs
+++ b/osu.Game/Input/GameIdleTracker.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Input;
+using osu.Game.Configuration;
 
 namespace osu.Game.Input
 {
@@ -9,9 +11,16 @@ namespace osu.Game.Input
     {
         private InputManager inputManager;
 
-        public GameIdleTracker(int time)
+        public GameIdleTracker(int time, SessionStatics statics)
             : base(time)
         {
+            IsIdle.ValueChanged += _ => UpdateStatics(_, statics);
+        }
+
+        protected static void UpdateStatics(ValueChangedEvent<bool> e, SessionStatics statics)
+        {
+            if (e.OldValue != e.NewValue && e.NewValue)
+                statics.ResetValues();
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Input/GameIdleTracker.cs
+++ b/osu.Game/Input/GameIdleTracker.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Framework.Input;
-using osu.Game.Configuration;
 
 namespace osu.Game.Input
 {
@@ -11,16 +9,9 @@ namespace osu.Game.Input
     {
         private InputManager inputManager;
 
-        public GameIdleTracker(int time, SessionStatics statics)
+        public GameIdleTracker(int time)
             : base(time)
         {
-            IsIdle.ValueChanged += _ => UpdateStatics(_, statics);
-        }
-
-        protected static void UpdateStatics(ValueChangedEvent<bool> e, SessionStatics statics)
-        {
-            if (e.OldValue != e.NewValue && e.NewValue)
-                statics.ResetValues();
         }
 
         protected override void LoadComplete()

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -580,7 +580,7 @@ namespace osu.Game
             GameIdleTracker sessionIdleTracker = new GameIdleTracker(300_000);
             Add(sessionIdleTracker);
 
-            sessionIdleTracker.IsIdle.BindValueChanged((e) =>
+            sessionIdleTracker.IsIdle.BindValueChanged(e =>
             {
                 if (e.NewValue)
                     Dependencies.Get<SessionStatics>().ResetValues();

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -584,7 +584,7 @@ namespace osu.Game
                     SessionStatics.ResetValues();
             });
 
-            Add(new GameIdleTracker(300000));
+            Add(sessionIdleTracker);
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -575,7 +575,7 @@ namespace osu.Game
             Container logoContainer;
             BackButton.Receptor receptor;
 
-            dependencies.CacheAs(idleTracker = new GameIdleTracker(6000));
+            dependencies.CacheAs(idleTracker = new GameIdleTracker(6000, Dependencies.Get<SessionStatics>()));
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -575,7 +575,7 @@ namespace osu.Game
             Container logoContainer;
             BackButton.Receptor receptor;
 
-            dependencies.CacheAs(idleTracker = new GameIdleTracker(6000, Dependencies.Get<SessionStatics>()));
+            dependencies.CacheAs(idleTracker = new GameIdleTracker(300_000, Dependencies.Get<SessionStatics>()));
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -577,14 +577,14 @@ namespace osu.Game
 
             dependencies.CacheAs(idleTracker = new GameIdleTracker(6000));
 
-            GameIdleTracker sessionIdleTracker = new GameIdleTracker(300_000);
-            Add(sessionIdleTracker);
-
-            sessionIdleTracker.IsIdle.BindValueChanged(e =>
+            var sessionIdleTracker = new GameIdleTracker(300000);
+            sessionIdleTracker.IsIdle.BindValueChanged(idle =>
             {
-                if (e.NewValue)
-                    Dependencies.Get<SessionStatics>().ResetValues();
+                if (idle.NewValue)
+                    SessionStatics.ResetValues();
             });
+
+            Add(new GameIdleTracker(300000));
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -575,7 +575,16 @@ namespace osu.Game
             Container logoContainer;
             BackButton.Receptor receptor;
 
-            dependencies.CacheAs(idleTracker = new GameIdleTracker(300_000, Dependencies.Get<SessionStatics>()));
+            dependencies.CacheAs(idleTracker = new GameIdleTracker(6000));
+
+            GameIdleTracker sessionIdleTracker = new GameIdleTracker(300_000);
+            Add(sessionIdleTracker);
+
+            sessionIdleTracker.IsIdle.BindValueChanged((e) =>
+            {
+                if (e.NewValue)
+                    Dependencies.Get<SessionStatics>().ResetValues();
+            });
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -61,6 +61,8 @@ namespace osu.Game
 
         protected OsuConfigManager LocalConfig;
 
+        protected SessionStatics SessionStatics { get; private set; }
+
         protected BeatmapManager BeatmapManager;
 
         protected ScoreManager ScoreManager;
@@ -289,7 +291,7 @@ namespace osu.Game
             if (powerStatus != null)
                 dependencies.CacheAs(powerStatus);
 
-            dependencies.Cache(new SessionStatics());
+            dependencies.Cache(SessionStatics = new SessionStatics());
             dependencies.Cache(new OsuColour());
 
             RegisterImportHandler(BeatmapManager);


### PR DESCRIPTION
Closes #12424

- [x] Depends on #12460 

This is my first time properly working with the codebase in general, so if I've done anything weird that's probably why.

I ended up hardcoding the values in the reset method because there wasn't an *exposed* `GetDefault()` (or similar) function for `ConfigManager`.