### PR TITLE
Record every 60fps interval

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
@@ -118,8 +118,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestBasic()
         {
             AddStep("move to center", () => InputManager.MoveMouseTo(recordingManager.ScreenSpaceDrawQuad.Centre));
-            AddUntilStep("one frame recorded", () => replay.Frames.Count == 1);
-            AddAssert("position matches", () => playbackManager.ChildrenOfType<Box>().First().Position == recordingManager.ChildrenOfType<Box>().First().Position);
+            AddUntilStep("at least one frame recorded", () => replay.Frames.Count > 0);
+            AddUntilStep("position matches", () => playbackManager.ChildrenOfType<Box>().First().Position == recordingManager.ChildrenOfType<Box>().First().Position);
         }
 
         [Test]
@@ -139,14 +139,16 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestLimitedFrameRate()
         {
             ScheduledDelegate moveFunction = null;
+            int initialFrameCount = 0;
 
             AddStep("lower rate", () => recorder.RecordFrameRate = 2);
+            AddStep("count frames", () => initialFrameCount = replay.Frames.Count);
             AddStep("move to center", () => InputManager.MoveMouseTo(recordingManager.ScreenSpaceDrawQuad.Centre));
             AddStep("much move", () => moveFunction = Scheduler.AddDelayed(() =>
                 InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(-1, 0)), 10, true));
             AddWaitStep("move", 10);
             AddStep("stop move", () => moveFunction.Cancel());
-            AddAssert("less than 10 frames recorded", () => replay.Frames.Count < 10);
+            AddAssert("less than 10 frames recorded", () => replay.Frames.Count - initialFrameCount < 10);
         }
 
         [Test]

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -58,6 +58,12 @@ namespace osu.Game.Rulesets.UI
             spectatorStreaming?.EndPlaying();
         }
 
+        protected override void Update()
+        {
+            base.Update();
+            recordFrame(false);
+        }
+
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
             recordFrame(false);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/11277

Because no frames are recorded unless a mouse move/press action occurs, a spectating user will pause on `WaitingOnFrames = true`. https://drive.google.com/file/d/1GCOyn9HW1hYgtI3CWGb00oA9M7o9NDLI/view?usp=sharing

I've tested that this also behaves correctly with pausing (spectating user stops until unpause).