### PR TITLE
Improve "barrel roll" mod settings description

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "The whole playfield is on a wheel!";
         public override double ScoreMultiplier => 1;
 
-        public override string SettingDescription => $"{SpinSpeed.Value}rpm {Direction.Value.GetDescription().ToLowerInvariant()}";
+        public override string SettingDescription => $"{SpinSpeed.Value} rpm {Direction.Value.GetDescription().ToLowerInvariant()}";
 
         public void Update(Playfield playfield)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Description => "The whole playfield is on a wheel!";
         public override double ScoreMultiplier => 1;
 
-        public override string SettingDescription => $"{SpinSpeed.Value}rpm, {Direction.Value.GetDescription().ToLowerInvariant()}";
+        public override string SettingDescription => $"{SpinSpeed.Value}rpm {Direction.Value.GetDescription().ToLowerInvariant()}";
 
         public void Update(Playfield playfield)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
@@ -29,6 +31,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Acronym => "BR";
         public override string Description => "The whole playfield is on a wheel!";
         public override double ScoreMultiplier => 1;
+
+        public override string SettingDescription => $"{SpinSpeed.Value}rpm, {Direction.Value.GetDescription().ToLowerInvariant()}";
 
         public void Update(Playfield playfield)
         {


### PR DESCRIPTION
before:
![CleanShot 2021-04-17 at 03 35 16](https://user-images.githubusercontent.com/22781491/115096483-fd7b6800-9f2d-11eb-8046-c774f360c1c1.gif)

after:
![CleanShot 2021-04-17 at 03 31 30](https://user-images.githubusercontent.com/22781491/115096486-01a78580-9f2e-11eb-8cca-d3599c6410b7.gif)

- Very loosely depends on ppy/osu-framework#4372

May be better returning the "roll speed" prefix back, removed it as it sounds self-explanatory along with the `rpm`, not sure.