### PR TITLE
Fix idle tracker assuming time starts at 0

### DIFF
--- a/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
+++ b/osu.Game.Tests/Visual/Components/TestSceneIdleTracker.cs
@@ -81,6 +81,13 @@ namespace osu.Game.Tests.Visual.Components
         [Test]
         public void TestMovement()
         {
+            checkIdleStatus(1, false);
+            checkIdleStatus(2, false);
+            checkIdleStatus(3, false);
+            checkIdleStatus(4, false);
+
+            waitForAllIdle();
+
             AddStep("move to top right", () => InputManager.MoveMouseTo(box2));
 
             checkIdleStatus(1, true);
@@ -102,6 +109,8 @@ namespace osu.Game.Tests.Visual.Components
         [Test]
         public void TestTimings()
         {
+            waitForAllIdle();
+
             AddStep("move to centre", () => InputManager.MoveMouseTo(Content));
 
             checkIdleStatus(1, false);

--- a/osu.Game/Input/IdleTracker.cs
+++ b/osu.Game/Input/IdleTracker.cs
@@ -42,6 +42,12 @@ namespace osu.Game.Input
             RelativeSizeAxes = Axes.Both;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            updateLastInteractionTime();
+        }
+
         protected override void Update()
         {
             base.Update();


### PR DESCRIPTION
Intended to help with test failures in #12446.

`IdleTracker` in its construction quietly assumed that the clock it receives from its parent starts ticking from 0 at the point at which it is passed down. This is not necessarily the case when headless executions are involved, which means that the initial state of the tracker could be computed as idle incorrectly.

Resolve by explicitly reading the clock time at the point of `LoadComplete()`. This essentially changes the behaviour of idle trackers to always be not-idle by default at the time of `LoadComplete()`.

The reason why this particular problem was causing the test failures in the aforementioned PR can be seen [in this comment](https://github.com/ppy/osu/pull/12446#issuecomment-821812575).

I've also had to adjust some existing test cases as it seems they relied on the now-removed assumption.