### PR TITLE
Fix download button check icon not scaling on mouse down

### DIFF
--- a/osu.Game/Graphics/UserInterface/DownloadButton.cs
+++ b/osu.Game/Graphics/UserInterface/DownloadButton.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddInternal(checkmark = new SpriteIcon
+            Add(checkmark = new SpriteIcon
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,


### PR DESCRIPTION
Before:
![Kapture 2021-04-18 at 19 04 27](https://user-images.githubusercontent.com/35318437/115172085-53a8f200-a079-11eb-9594-4f72fb592d45.gif)

After:
![Kapture 2021-04-18 at 19 01 53](https://user-images.githubusercontent.com/35318437/115172094-599ed300-a079-11eb-92c0-eb12e66bbfb9.gif)