### PR TITLE
Fix storyboard samples not getting a lifetime end if initially seeked past

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneStoryboardSamples.cs
@@ -77,7 +77,33 @@ namespace osu.Game.Tests.Gameplay
 
             AddStep("start time", () => gameplayContainer.Start());
 
-            AddUntilStep("sample playback succeeded", () => sample.LifetimeEnd < double.MaxValue);
+            AddUntilStep("sample played", () => sample.RequestedPlaying);
+            AddUntilStep("sample has lifetime end", () => sample.LifetimeEnd < double.MaxValue);
+        }
+
+        [Test]
+        public void TestSampleHasLifetimeEndWithInitialClockTime()
+        {
+            GameplayClockContainer gameplayContainer = null;
+            DrawableStoryboardSample sample = null;
+
+            AddStep("create container", () =>
+            {
+                var working = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
+                working.LoadTrack();
+
+                Add(gameplayContainer = new GameplayClockContainer(working, 1000, true));
+
+                gameplayContainer.Add(sample = new DrawableStoryboardSample(new StoryboardSampleInfo(string.Empty, 0, 1))
+                {
+                    Clock = gameplayContainer.GameplayClock
+                });
+            });
+
+            AddStep("start time", () => gameplayContainer.Start());
+
+            AddUntilStep("sample not played", () => !sample.RequestedPlaying);
+            AddUntilStep("sample has lifetime end", () => sample.LifetimeEnd < double.MaxValue);
         }
 
         [TestCase(typeof(OsuModDoubleTime), 1.5)]

--- a/osu.Game/Skinning/PausableSkinnableSound.cs
+++ b/osu.Game/Skinning/PausableSkinnableSound.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Skinning
     {
         public double Length => !DrawableSamples.Any() ? 0 : DrawableSamples.Max(sample => sample.Length);
 
-        protected bool RequestedPlaying { get; private set; }
+        public bool RequestedPlaying { get; private set; }
 
         public PausableSkinnableSound()
         {

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSample.cs
@@ -61,28 +61,32 @@ namespace osu.Game.Storyboards.Drawables
         {
             base.Update();
 
+            // Check if we've yet to pass the sample start time.
             if (Time.Current < sampleInfo.StartTime)
             {
-                // We've rewound before the start time of the sample
                 Stop();
 
-                // In the case that the user fast-forwards to a point far beyond the start time of the sample,
-                // we want to be able to fall into the if-conditional below (therefore we must not have a life time end)
+                // Playback has stopped, but if the user fast-forwards to a point after the start time of the sample then
+                // we must not have a lifetime end in order to continue receiving updates and start the sample below.
                 LifetimeStart = sampleInfo.StartTime;
                 LifetimeEnd = double.MaxValue;
+
+                return;
             }
-            else if (Time.Current - Time.Elapsed <= sampleInfo.StartTime)
+
+            // Ensure that we've elapsed from a point before the sample's start time before playing.
+            if (Time.Current - Time.Elapsed <= sampleInfo.StartTime)
             {
                 // We've passed the start time of the sample. We only play the sample if we're within an allowable range
                 // from the sample's start, to reduce layering if we've been fast-forwarded far into the future
                 if (!RequestedPlaying && Time.Current - sampleInfo.StartTime < allowable_late_start)
                     Play();
-
-                // In the case that the user rewinds to a point far behind the start time of the sample,
-                // we want to be able to fall into the if-conditional above (therefore we must not have a life time start)
-                LifetimeStart = double.MinValue;
-                LifetimeEnd = sampleInfo.StartTime;
             }
+
+            // Playback has started, but if the user rewinds to a point before the start time of the sample then
+            // we must not have a lifetime start in order to continue receiving updates and stop the sample above.
+            LifetimeStart = double.MinValue;
+            LifetimeEnd = sampleInfo.StartTime;
         }
     }
 }


### PR DESCRIPTION
Noticed this in passing. Unconditionally sets `LifetimeEnd` in the case that the clock is currently at a point far ahead of the start time of the sample. This could happen in e.g. spectator via `gameplayStartTime` as per the newly-added test.