### PR TITLE
Remove catcher fade during hyperdash

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -384,16 +384,7 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             updateTrailVisibility();
 
-            if (hyperDashing)
-            {
-                this.FadeColour(hyperDashColour, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-                this.FadeTo(0.2f, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-            }
-            else
-            {
-                this.FadeColour(Color4.White, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-                this.FadeTo(1f, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
-            }
+            this.FadeColour(hyperDashing ? hyperDashColour : Color4.White, HYPER_DASH_TRANSITION_DURATION, Easing.OutQuint);
         }
 
         private void updateTrailVisibility() => trails.DisplayTrail = Dashing || HyperDashing;


### PR DESCRIPTION
I believe I added this because it objectively looked better, but that was before we had skinning support, and people expecting unchanged behaviour from stable. Can reconsider at a later point.

Closes https://github.com/ppy/osu/issues/12472.