### PR TITLE
Fix deadlock on token retrieval failure

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -71,6 +71,8 @@ namespace osu.Game.Screens.Play
 
             void handleTokenFailure(Exception exception)
             {
+                tcs.SetResult(false);
+
                 if (HandleTokenRetrievalFailure(exception))
                 {
                     if (string.IsNullOrEmpty(exception.Message))
@@ -84,8 +86,6 @@ namespace osu.Game.Screens.Play
                         this.Exit();
                     });
                 }
-
-                tcs.SetResult(false);
             }
         }
 


### PR DESCRIPTION
Closes #12491.

Not sure if we can fix this framework side, but the case here is attempting to call `Schedule()` from another thread while blocking inside of `LoadAsyncComplete`.

![20210420 223822 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/115408286-b2ae6880-a22b-11eb-8760-c5b2e837cadb.png)
