### PR TITLE
Fix click-to-resume cursor location being incorrect when playfield is transformed

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.UI
             base.PopIn();
 
             GameplayCursor.ActiveCursor.Hide();
-            cursorScaleContainer.MoveTo(GameplayCursor.ActiveCursor.Position);
+            cursorScaleContainer.Position = ToLocalSpace(GameplayCursor.ActiveCursor.ScreenSpaceDrawQuad.Centre);
             clickToResumeCursor.Appear();
 
             if (localCursorContainer == null)


### PR DESCRIPTION
Closes #12501.

Note that the scale adjustment of the cursor doesn't match currently. In two minds as to whether it should, but I think this can be easily added if that's decided as the correct path forward.