### PR TITLE
Fix slider tails wiggling independently

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             var osuObject = (OsuHitObject)drawable.HitObject;
             Vector2 origin = drawable.Position;
 
-            // Wiggle the repeat points with the slider instead of independently.
+            // Wiggle the repeat points and the tail with the slider instead of independently.
             // Also fixes an issue with repeat points being positioned incorrectly.
             if (osuObject is SliderRepeat || osuObject is SliderTailCircle)
                 return;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModWiggle.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             // Wiggle the repeat points with the slider instead of independently.
             // Also fixes an issue with repeat points being positioned incorrectly.
-            if (osuObject is SliderRepeat)
+            if (osuObject is SliderRepeat || osuObject is SliderTailCircle)
                 return;
 
             Random objRand = new Random((int)osuObject.StartTime);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12505

Simply stopped the slider tails from wiggling independently altogether, which fixes the issue. Imo this looks better anyway as I always thought it was weird that it looked like there were two objects at the tail.