### PR TITLE
Show tablet preview with physical tablet counter-rotated for supplied user area

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 tabletContainer.RotateTo(-val.NewValue, 800, Easing.OutQuint);
                 usableAreaContainer.RotateTo(val.NewValue, 100, Easing.OutQuint)
                                    .OnComplete(_ => checkBounds()); // required as we are using SSDQ.
-            });
+            }, true);
 
             tablet.BindTo(handler.Tablet);
             tablet.BindValueChanged(_ => Scheduler.AddOnce(updateTabletDetails));

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             rotation.BindTo(handler.Rotation);
             rotation.BindValueChanged(val =>
             {
+                tabletContainer.RotateTo(-val.NewValue, 800, Easing.OutQuint);
                 usableAreaContainer.RotateTo(val.NewValue, 100, Easing.OutQuint)
                                    .OnComplete(_ => checkBounds()); // required as we are using SSDQ.
             });
@@ -183,8 +184,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             if (!(tablet.Value?.Size is Vector2 size))
                 return;
 
-            float fitX = size.X / (DrawWidth - Padding.Left - Padding.Right);
-            float fitY = size.Y / DrawHeight;
+            float maxDimension = size.LengthFast;
+
+            float fitX = maxDimension / (DrawWidth - Padding.Left - Padding.Right);
+            float fitY = maxDimension / DrawHeight;
 
             float adjust = MathF.Max(fitX, fitY);
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12399.

https://user-images.githubusercontent.com/191335/115511798-3adc4e80-a2bc-11eb-8fef-caa717f871cb.mp4


Rotation animation is intentionally delayed slightly to give a better sense of what is going on (or maybe just look cool).