### PR TITLE
Add editor hit animation toggle

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
@@ -3,8 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -27,7 +30,15 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private class OsuEditPlayfield : OsuPlayfield
         {
+            private Bindable<bool> hitAnimations;
+
             protected override GameplayCursorContainer CreateCursor() => null;
+
+            [BackgroundDependencyLoader]
+            private void load(OsuConfigManager config)
+            {
+                hitAnimations = config.GetBindable<bool>(OsuSetting.EditorHitAnimations);
+            }
 
             protected override void OnNewDrawableHitObject(DrawableHitObject d)
             {
@@ -42,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             private void updateState(DrawableHitObject hitObject, ArmedState state)
             {
-                if (state == ArmedState.Idle)
+                if (state == ArmedState.Idle || hitAnimations.Value)
                     return;
 
                 // adjust the visuals of certain object types to make them stay on screen for longer than usual.
@@ -60,6 +71,15 @@ namespace osu.Game.Rulesets.Osu.Edit
                         circle.ApproachCircle
                               .FadeOutFromOne(editor_hit_object_fade_out_extension * 4)
                               .Expire();
+
+                        circle.ApproachCircle.ScaleTo(1.1f, 300, Easing.OutQuint);
+
+                        var circlePieceDrawable = circle.CirclePiece.Drawable;
+
+                        // clear any explode animation logic.
+                        circlePieceDrawable.ApplyTransformsAt(circle.HitStateUpdateTime, true);
+                        circlePieceDrawable.ClearTransformsAfter(circle.HitStateUpdateTime, true);
+
                         break;
                 }
 

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditRuleset.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                     case DrawableHitCircle circle: // also handles slider heads
                         circle.ApproachCircle
-                              .FadeOutFromOne(editor_hit_object_fade_out_extension)
+                              .FadeOutFromOne(editor_hit_object_fade_out_extension * 4)
                               .Expire();
                         break;
                 }
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                 hitObject.RemoveTransform(existing);
 
-                using (hitObject.BeginAbsoluteSequence(existing.StartTime))
+                using (hitObject.BeginAbsoluteSequence(hitObject.HitStateUpdateTime))
                     hitObject.FadeOut(editor_hit_object_fade_out_extension).Expire();
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -182,6 +182,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             // todo: temporary / arbitrary, used for lifetime optimisation.
             this.Delay(800).FadeOut();
 
+            (CirclePiece.Drawable as IMainCirclePiece)?.Animate(state);
+
             switch (state)
             {
                 case ArmedState.Idle:

--- a/osu.Game.Rulesets.Osu/Skinning/Default/IMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/IMainCirclePiece.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Default
+{
+    public interface IMainCirclePiece
+    {
+        /// <summary>
+        /// Begins animating this <see cref="IMainCirclePiece"/>.
+        /// </summary>
+        /// <param name="state">The <see cref="ArmedState"/> of the related <see cref="DrawableHitCircle"/>.</param>
+        void Animate(ArmedState state);
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
@@ -13,7 +13,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
-    public class MainCirclePiece : CompositeDrawable
+    public class MainCirclePiece : CompositeDrawable, IMainCirclePiece
     {
         private readonly CirclePiece circle;
         private readonly RingPiece ring;
@@ -67,12 +67,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             }, true);
 
             indexInCurrentCombo.BindValueChanged(index => number.Text = (index.NewValue + 1).ToString(), true);
-
-            drawableObject.ApplyCustomUpdateState += updateState;
-            updateState(drawableObject, drawableObject.State.Value);
         }
 
-        private void updateState(DrawableHitObject drawableObject, ArmedState state)
+        public void Animate(ArmedState state)
         {
             using (BeginAbsoluteSequence(drawableObject.StateUpdateTime))
                 glow.FadeOut(400);

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -19,7 +20,7 @@ using static osu.Game.Skinning.LegacySkinConfiguration;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 {
-    public class LegacyMainCirclePiece : CompositeDrawable
+    public class LegacyMainCirclePiece : CompositeDrawable, IMainCirclePiece
     {
         private readonly string priorityLookup;
         private readonly bool hasNumber;
@@ -138,12 +139,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             accentColour.BindValueChanged(colour => hitCircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue), true);
             if (hasNumber)
                 indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
-
-            drawableObject.ApplyCustomUpdateState += updateState;
-            updateState(drawableObject, drawableObject.State.Value);
         }
 
-        private void updateState(DrawableHitObject drawableObject, ArmedState state)
+        public void Animate(ArmedState state)
         {
             const double legacy_fade_duration = 240;
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.DiscordRichPresence, DiscordRichPresenceMode.Full);
 
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f);
+            SetDefault(OsuSetting.EditorHitAnimations, false);
         }
 
         public OsuConfigManager(Storage storage)
@@ -266,6 +267,7 @@ namespace osu.Game.Configuration
         GameplayDisableWinKey,
         SeasonalBackgroundMode,
         EditorWaveformOpacity,
+        EditorHitAnimations,
         DiscordRichPresence,
         AutomaticallyDownloadWhenSpectating,
         ShowOnlineExplicitContent,

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -226,7 +226,7 @@ namespace osu.Game.Screens.Edit
                                 {
                                     Items = new[]
                                     {
-                                        new WaveformOpacityMenu(config)
+                                        new WaveformOpacityMenuItem(config.GetBindable<float>(OsuSetting.EditorWaveformOpacity)),
                                     }
                                 }
                             }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -224,9 +224,10 @@ namespace osu.Game.Screens.Edit
                                 },
                                 new MenuItem("View")
                                 {
-                                    Items = new[]
+                                    Items = new MenuItem[]
                                     {
                                         new WaveformOpacityMenuItem(config.GetBindable<float>(OsuSetting.EditorWaveformOpacity)),
+                                        new HitAnimationsMenuItem(config.GetBindable<bool>(OsuSetting.EditorHitAnimations))
                                     }
                                 }
                             }

--- a/osu.Game/Screens/Edit/HitAnimationsMenuItem.cs
+++ b/osu.Game/Screens/Edit/HitAnimationsMenuItem.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Bindables;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Edit
+{
+    internal class HitAnimationsMenuItem : ToggleMenuItem
+    {
+        [UsedImplicitly]
+        private readonly Bindable<bool> hitAnimations;
+
+        public HitAnimationsMenuItem(Bindable<bool> hitAnimations)
+            : base("Hit animations")
+        {
+            State.BindTo(this.hitAnimations = hitAnimations);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
@@ -4,18 +4,17 @@
 using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Screens.Edit
 {
-    internal class WaveformOpacityMenu : MenuItem
+    internal class WaveformOpacityMenuItem : MenuItem
     {
         private readonly Bindable<float> waveformOpacity;
 
         private readonly Dictionary<float, ToggleMenuItem> menuItemLookup = new Dictionary<float, ToggleMenuItem>();
 
-        public WaveformOpacityMenu(OsuConfigManager config)
+        public WaveformOpacityMenuItem(Bindable<float> waveformOpacity)
             : base("Waveform opacity")
         {
             Items = new[]
@@ -26,7 +25,7 @@ namespace osu.Game.Screens.Edit
                 createMenuItem(1f),
             };
 
-            waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
+            this.waveformOpacity = waveformOpacity;
             waveformOpacity.BindValueChanged(opacity =>
             {
                 foreach (var kvp in menuItemLookup)


### PR DESCRIPTION
This brings back a much-requested feature from the `osu-stable` editor, which is that hit circles don't "explode". This is actually the default behaviour in stable, so I've also set it as the default here for the time being, pending feedback.

In addition, I've tweaked the fades and approach circle animation to closer match stable.

https://user-images.githubusercontent.com/191335/115541947-ae8d5400-a2da-11eb-8f78-5caad5ad4454.mp4

Closes https://github.com/ppy/osu/issues/11022.