### PR TITLE
Fix system messages always being displayed above standard messages

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -84,6 +84,28 @@ namespace osu.Game.Tests.Visual.Online
         });
 
         [Test]
+        public void TestSystemMessageOrdering()
+        {
+            var standardMessage = new Message(messageIdSequence++)
+            {
+                Sender = admin,
+                Content = "I am a wang!"
+            };
+
+            var infoMessage1 = new InfoMessage($"the system is calling {messageIdSequence++}");
+            var infoMessage2 = new InfoMessage($"the system is calling {messageIdSequence++}");
+
+            AddStep("message from admin", () => testChannel.AddNewMessages(standardMessage));
+            AddStep("message from system", () => testChannel.AddNewMessages(infoMessage1));
+            AddStep("message from system", () => testChannel.AddNewMessages(infoMessage2));
+
+            AddAssert("message order is correct", () => testChannel.Messages.Count == 3
+                                                        && testChannel.Messages[0] == standardMessage
+                                                        && testChannel.Messages[1] == infoMessage1
+                                                        && testChannel.Messages[2] == infoMessage2);
+        }
+
+        [Test]
         public void TestManyMessages()
         {
             AddStep("message from admin", () => testChannel.AddNewMessages(new Message(messageIdSequence++)

--- a/osu.Game/Online/Chat/InfoMessage.cs
+++ b/osu.Game/Online/Chat/InfoMessage.cs
@@ -8,10 +8,8 @@ namespace osu.Game.Online.Chat
 {
     public class InfoMessage : LocalMessage
     {
-        private static int infoID = -1;
-
         public InfoMessage(string message)
-            : base(infoID--)
+            : base(null)
         {
             Timestamp = DateTimeOffset.Now;
             Content = message;

--- a/osu.Game/Online/Chat/Message.cs
+++ b/osu.Game/Online/Chat/Message.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Online.Chat
             return Id.Value.CompareTo(other.Id.Value);
         }
 
-        public virtual bool Equals(Message other) => Id == other?.Id;
+        public virtual bool Equals(Message other) => Id.HasValue && Id == other?.Id;
 
         // ReSharper disable once ImpureMethodCallOnReadonlyValueField
         public override int GetHashCode() => Id.GetHashCode();


### PR DESCRIPTION
Does away with the negative ID logic, which wasn't actually required for any real purpose. Also fixes messages will null Ids matching in equality, which could have probably been seen in other ways (as null IDs are used for local echo messages too).

Closes https://github.com/ppy/osu/issues/12509.