### PR TITLE
Allow shift+right-click deletion when in placement mode

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
@@ -156,9 +157,35 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestQuickDeleteRemovesObject()
+        public void TestQuickDeleteRemovesObjectInPlacement()
         {
-            var addedObject = new HitCircle { StartTime = 1000 };
+            var addedObject = new HitCircle
+            {
+                StartTime = 0,
+                Position = OsuPlayfield.BASE_SIZE * 0.5f
+            };
+
+            AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
+
+            AddStep("enter placement mode", () => InputManager.PressKey(Key.Number2));
+
+            moveMouseToObject(() => addedObject);
+
+            AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+            AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
+
+            AddAssert("no hitobjects in beatmap", () => EditorBeatmap.HitObjects.Count == 0);
+        }
+
+        [Test]
+        public void TestQuickDeleteRemovesObjectInSelection()
+        {
+            var addedObject = new HitCircle
+            {
+                StartTime = 0,
+                Position = OsuPlayfield.BASE_SIZE * 0.5f
+            };
 
             AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -128,8 +129,11 @@ namespace osu.Game.Rulesets.Edit
                 case DoubleClickEvent _:
                     return false;
 
-                case MouseButtonEvent _:
-                    return true;
+                case MouseButtonEvent mouse:
+                    // placement blueprints should generally block mouse from reaching underlying components (ie. performing clicks on interface buttons).
+                    // for now, the one exception we want to allow is when using a non-main mouse button when shift is pressed, which is used to trigger object deletion
+                    // while in placement mode.
+                    return mouse.Button == MouseButton.Left || !mouse.ShiftPressed;
 
                 default:
                     return false;


### PR DESCRIPTION
The base `PlacementBlueprint` implementation was blocking all mouse clicks to stop misclicks on buttons (ie. the ones to the left of the playfield), but this in turn also blocks actions that could be performed from the `SelectionHandler`. In most cases this turns out to be a good thing, but quick deletion is an edge case where we want to allow the events to pass through.

Not the nicest of logic but I think it's something we can reconsider if the conditions for passthrough become more complicated than they already are (ie. stopping the blocking altogether and moving it to the `HitObjectComposer` instead. but this will require the `SelectionHandler` to be aware of the user being in placement mode and disallowing some operations).

Closes #11884.