### PR TITLE
Improve catcher fruit distribution

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Catch.UI;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
@@ -170,16 +171,25 @@ namespace osu.Game.Rulesets.Catch.Tests
         }
 
         [Test]
-        public void TestCatcherStacking()
+        public void TestCatcherRandomStacking()
+        {
+            AddStep("catch more fruits", () => attemptCatch(() => new Fruit
+            {
+                X = (RNG.NextSingle() - 0.5f) * CatcherArea.CATCHER_SIZE
+            }, 50));
+        }
+
+        [Test]
+        public void TestCatcherStackingSameCaughtPosition()
         {
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             checkPlate(1);
-            AddStep("catch more fruits", () => attemptCatch(new Fruit(), 9));
+            AddStep("catch more fruits", () => attemptCatch(() => new Fruit(), 9));
             checkPlate(10);
             AddAssert("caught objects are stacked", () =>
-                catcher.CaughtObjects.All(obj => obj.Y <= 0) &&
-                catcher.CaughtObjects.Any(obj => obj.Y == 0) &&
-                catcher.CaughtObjects.Any(obj => obj.Y < -20));
+                catcher.CaughtObjects.All(obj => obj.Y <= Catcher.CAUGHT_FRUIT_VERTICAL_OFFSET) &&
+                catcher.CaughtObjects.Any(obj => obj.Y == Catcher.CAUGHT_FRUIT_VERTICAL_OFFSET) &&
+                catcher.CaughtObjects.Any(obj => obj.Y < -25));
         }
 
         [Test]
@@ -189,11 +199,11 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddStep("catch tiny droplet", () => attemptCatch(new TinyDroplet()));
             AddAssert("tiny droplet is exploded", () => catcher.CaughtObjects.Count() == 1 && droppedObjectContainer.Count == 1);
             AddUntilStep("wait explosion", () => !droppedObjectContainer.Any());
-            AddStep("catch more fruits", () => attemptCatch(new Fruit(), 9));
+            AddStep("catch more fruits", () => attemptCatch(() => new Fruit(), 9));
             AddStep("explode", () => catcher.Explode());
             AddAssert("fruits are exploded", () => !catcher.CaughtObjects.Any() && droppedObjectContainer.Count == 10);
             AddUntilStep("wait explosion", () => !droppedObjectContainer.Any());
-            AddStep("catch fruits", () => attemptCatch(new Fruit(), 10));
+            AddStep("catch fruits", () => attemptCatch(() => new Fruit(), 10));
             AddStep("drop", () => catcher.Drop());
             AddAssert("fruits are dropped", () => !catcher.CaughtObjects.Any() && droppedObjectContainer.Count == 10);
         }
@@ -222,10 +232,15 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private void checkHyperDash(bool state) => AddAssert($"catcher is {(state ? "" : "not ")}hyper dashing", () => catcher.HyperDashing == state);
 
-        private void attemptCatch(CatchHitObject hitObject, int count = 1)
+        private void attemptCatch(CatchHitObject hitObject)
+        {
+            attemptCatch(() => hitObject, 1);
+        }
+
+        private void attemptCatch(Func<CatchHitObject> hitObject, int count)
         {
             for (var i = 0; i < count; i++)
-                attemptCatch(hitObject, out _, out _);
+                attemptCatch(hitObject(), out _, out _);
         }
 
         private void attemptCatch(CatchHitObject hitObject, out DrawableCatchHitObject drawableObject, out JudgementResult result)

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -21,6 +21,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
+using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Tests
 {
@@ -175,7 +176,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             AddStep("catch more fruits", () => attemptCatch(() => new Fruit
             {
-                X = (RNG.NextSingle() - 0.5f) * CatcherArea.CATCHER_SIZE
+                X = (RNG.NextSingle() - 0.5f) * Catcher.CalculateCatchWidth(Vector2.One)
             }, 50));
         }
 

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -8,6 +8,8 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Threading;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
@@ -31,12 +33,32 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private float circleSize;
 
+        private ScheduledDelegate addManyFruit;
+
+        private BeatmapDifficulty beatmapDifficulty;
+
         public TestSceneCatcherArea()
         {
             AddSliderStep<float>("circle size", 0, 8, 5, createCatcher);
             AddToggleStep("hyper dash", t => this.ChildrenOfType<TestCatcherArea>().ForEach(area => area.ToggleHyperDash(t)));
 
-            AddStep("catch fruit", () => attemptCatch(new Fruit()));
+            AddStep("catch centered fruit", () => attemptCatch(new Fruit()));
+            AddStep("catch many random fruit", () =>
+            {
+                int count = 50;
+
+                addManyFruit?.Cancel();
+                addManyFruit = Scheduler.AddDelayed(() =>
+                {
+                    attemptCatch(new Fruit
+                    {
+                        X = (RNG.NextSingle() - 0.5f) * Catcher.CalculateCatchWidth(beatmapDifficulty),
+                    });
+
+                    if (count-- == 0)
+                        addManyFruit?.Cancel();
+                }, 50, true);
+            });
             AddStep("catch fruit last in combo", () => attemptCatch(new Fruit { LastInCombo = true }));
             AddStep("catch kiai fruit", () => attemptCatch(new TestSceneCatcher.TestKiaiFruit()));
             AddStep("miss last in combo", () => attemptCatch(new Fruit { X = 100, LastInCombo = true }));
@@ -45,10 +67,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         private void attemptCatch(Fruit fruit)
         {
             fruit.X = fruit.OriginalX + catcher.X;
-            fruit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty
-            {
-                CircleSize = circleSize
-            });
+            fruit.ApplyDefaults(new ControlPointInfo(), beatmapDifficulty);
 
             foreach (var area in this.ChildrenOfType<CatcherArea>())
             {
@@ -71,6 +90,11 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             circleSize = size;
 
+            beatmapDifficulty = new BeatmapDifficulty
+            {
+                CircleSize = circleSize
+            };
+
             SetContents(() =>
             {
                 var droppedObjectContainer = new Container<CaughtObject>
@@ -84,7 +108,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                     Children = new Drawable[]
                     {
                         droppedObjectContainer,
-                        new TestCatcherArea(droppedObjectContainer, new BeatmapDifficulty { CircleSize = size })
+                        new TestCatcherArea(droppedObjectContainer, beatmapDifficulty)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.TopCentre,

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcherArea.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 {
                     attemptCatch(new Fruit
                     {
-                        X = (RNG.NextSingle() - 0.5f) * Catcher.CalculateCatchWidth(beatmapDifficulty),
+                        X = (RNG.NextSingle() - 0.5f) * Catcher.CalculateCatchWidth(beatmapDifficulty) * 0.6f,
                     });
 
                     if (count-- == 0)

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -212,13 +212,13 @@ namespace osu.Game.Rulesets.Catch.UI
         /// Calculates the width of the area used for attempting catches in gameplay.
         /// </summary>
         /// <param name="scale">The scale of the catcher.</param>
-        internal static float CalculateCatchWidth(Vector2 scale) => CatcherArea.CATCHER_SIZE * Math.Abs(scale.X) * ALLOWED_CATCH_RANGE;
+        public static float CalculateCatchWidth(Vector2 scale) => CatcherArea.CATCHER_SIZE * Math.Abs(scale.X) * ALLOWED_CATCH_RANGE;
 
         /// <summary>
         /// Calculates the width of the area used for attempting catches in gameplay.
         /// </summary>
         /// <param name="difficulty">The beatmap difficulty.</param>
-        internal static float CalculateCatchWidth(BeatmapDifficulty difficulty) => CalculateCatchWidth(calculateScale(difficulty));
+        public static float CalculateCatchWidth(BeatmapDifficulty difficulty) => CalculateCatchWidth(calculateScale(difficulty));
 
         /// <summary>
         /// Determine if this catcher can catch a <see cref="CatchHitObject"/> in the current position.

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -53,6 +53,11 @@ namespace osu.Game.Rulesets.Catch.UI
         /// </summary>
         public const double BASE_SPEED = 1.0;
 
+        /// <summary>
+        /// The amount by which caught fruit should be scaled down to fit on the plate.
+        /// </summary>
+        private const float caught_fruit_scale_adjust = 0.5f;
+
         [NotNull]
         private readonly Container trailsTarget;
 
@@ -240,7 +245,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             if (result.IsHit)
             {
-                var positionInStack = computePositionInStack(new Vector2(palpableObject.X - X, 0), palpableObject.DisplaySize.X / 2);
+                var positionInStack = computePositionInStack(new Vector2(palpableObject.X - X, 0), palpableObject.DisplaySize.X);
 
                 if (CatchFruitOnPlate)
                     placeCaughtObject(palpableObject, positionInStack);
@@ -470,7 +475,7 @@ namespace osu.Game.Rulesets.Catch.UI
             caughtObject.CopyStateFrom(drawableObject);
             caughtObject.Anchor = Anchor.TopCentre;
             caughtObject.Position = position;
-            caughtObject.Scale /= 2;
+            caughtObject.Scale *= caught_fruit_scale_adjust;
 
             caughtObjectContainer.Add(caughtObject);
 
@@ -480,18 +485,20 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private Vector2 computePositionInStack(Vector2 position, float displayRadius)
         {
-            const float radius_div_2 = CatchHitObject.OBJECT_RADIUS / 2;
-            const float allowance = 10;
+            // this is taken from osu-stable (lenience should be 10 * 10 at standard scale).
+            const float lenience_adjust = 10 / CatchHitObject.OBJECT_RADIUS;
 
-            while (caughtObjectContainer.Any(f => Vector2Extensions.Distance(f.Position, position) < (displayRadius + radius_div_2) / (allowance / 2)))
+            float adjustedRadius = displayRadius * lenience_adjust;
+            float checkDistance = MathF.Pow(adjustedRadius, 2);
+
+            // offset fruit vertically to better place "above" the plate.
+            position.Y -= 5;
+
+            while (caughtObjectContainer.Any(f => Vector2Extensions.DistanceSquared(f.Position, position) < checkDistance))
             {
-                float diff = (displayRadius + radius_div_2) / allowance;
-
-                position.X += (RNG.NextSingle() - 0.5f) * diff * 2;
-                position.Y -= RNG.NextSingle() * diff;
+                position.X += RNG.NextSingle(-adjustedRadius, adjustedRadius);
+                position.Y -= RNG.NextSingle(0, 5);
             }
-
-            position.X = Math.Clamp(position.X, -CatcherArea.CATCHER_SIZE / 2, CatcherArea.CATCHER_SIZE / 2);
 
             return position;
         }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -54,6 +54,11 @@ namespace osu.Game.Rulesets.Catch.UI
         public const double BASE_SPEED = 1.0;
 
         /// <summary>
+        /// The amount by which caught fruit should be offset from the plate surface to make them look visually "caught".
+        /// </summary>
+        public const float CAUGHT_FRUIT_VERTICAL_OFFSET = -5;
+
+        /// <summary>
         /// The amount by which caught fruit should be scaled down to fit on the plate.
         /// </summary>
         private const float caught_fruit_scale_adjust = 0.5f;
@@ -492,7 +497,7 @@ namespace osu.Game.Rulesets.Catch.UI
             float checkDistance = MathF.Pow(adjustedRadius, 2);
 
             // offset fruit vertically to better place "above" the plate.
-            position.Y -= 5;
+            position.Y += CAUGHT_FRUIT_VERTICAL_OFFSET;
 
             while (caughtObjectContainer.Any(f => Vector2Extensions.DistanceSquared(f.Position, position) < checkDistance))
             {


### PR DESCRIPTION
This brings things in line with stable. Looking at a visual comparison, lazer's stacking may actually be more "correct", but I'm not sure if that's a legitimate reason to have it diverge from user expectations at this point.

For the sake of making things look similar to what you'd expect during gameplay, fruits are only caught in the centre 60% of the plate in these examples.

master:

https://user-images.githubusercontent.com/191335/115686207-ee644200-a393-11eb-97af-1b7675927b2a.mp4

this pr:

https://user-images.githubusercontent.com/191335/115685219-ff608380-a392-11eb-93c2-434a7c861fc6.mp4

Closes #12079.
