### PR TITLE
Add simple key based time nudging support to editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
@@ -42,6 +42,28 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestNudgeSelection()
+        {
+            HitCircle[] addedObjects = null;
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects = new[]
+            {
+                new HitCircle { StartTime = 100 },
+                new HitCircle { StartTime = 200, Position = new Vector2(50) },
+                new HitCircle { StartTime = 300, Position = new Vector2(100) },
+                new HitCircle { StartTime = 400, Position = new Vector2(150) },
+            }));
+
+            AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.AddRange(addedObjects));
+
+            AddStep("nudge forwards", () => InputManager.Key(Key.K));
+            AddAssert("objects moved forwards in time", () => addedObjects[0].StartTime > 100);
+
+            AddStep("nudge backwards", () => InputManager.Key(Key.J));
+            AddAssert("objects reverted to original position", () => addedObjects[0].StartTime == 100);
+        }
+
+        [Test]
         public void TestBasicSelect()
         {
             var addedObject = new HitCircle { StartTime = 100 };

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -71,6 +71,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F3 }, GlobalAction.EditorTimingMode),
             new KeyBinding(new[] { InputKey.F4 }, GlobalAction.EditorSetupMode),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, GlobalAction.EditorVerifyMode),
+            new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
+            new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -251,5 +253,11 @@ namespace osu.Game.Input.Bindings
 
         [Description("Verify mode")]
         EditorVerifyMode,
+
+        [Description("Nudge selection left")]
+        EditorNudgeLeft,
+
+        [Description("Nudge selection right")]
+        EditorNudgeRight
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -519,7 +519,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 // Apply the start time at the newly snapped-to position
                 double offset = result.Time.Value - movementBlueprints.First().HitObject.StartTime;
 
-                Beatmap.PerformOnSelection(obj => obj.StartTime += offset);
+                if (offset != 0)
+                    Beatmap.PerformOnSelection(obj => obj.StartTime += offset);
             }
 
             return true;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/10668 (the other requested keys don't have underlying features implemented; i think we can track those in their relevant places).

This may seem like quite a naive implementation, but it matches stable and no one has complained about it to this day. Arguably, special handling should be given to the transitions across timing changes, but this gets pretty weird to handle. And as a user you can self-recover by nudging one extra time to start aligning to the new timing section.

I guess we could snap the resultant time value to the new section if that is seen as something required for the initial implementation, which would at least ensure that the object is always snapped to something (though again, as a mapper you would still need to confirm that snapped time value is the one you expect it to be, which it likely isn't). But again, stable doesn't even do this.