### PR TITLE
Fix beatmap info download button content not scaling on mouse down

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -268,9 +268,11 @@ namespace osu.Game.Overlays.BeatmapSet
                     break;
 
                 case DownloadState.Downloading:
-                case DownloadState.Importing:
                     // temporary to avoid showing two buttons for maps with novideo. will be fixed in new beatmap overlay design.
                     downloadButtonsContainer.Child = new HeaderDownloadButton(BeatmapSet.Value);
+                    break;
+
+                case DownloadState.Importing:
                     break;
 
                 default:

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -268,11 +268,9 @@ namespace osu.Game.Overlays.BeatmapSet
                     break;
 
                 case DownloadState.Downloading:
+                case DownloadState.Importing:
                     // temporary to avoid showing two buttons for maps with novideo. will be fixed in new beatmap overlay design.
                     downloadButtonsContainer.Child = new HeaderDownloadButton(BeatmapSet.Value);
-                    break;
-
-                case DownloadState.Importing:
                     break;
 
                 default:

--- a/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/HeaderDownloadButton.cs
@@ -47,52 +47,44 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
         {
             FillFlowContainer textSprites;
 
-            AddRangeInternal(new Drawable[]
+            AddInternal(shakeContainer = new ShakeContainer
             {
-                shakeContainer = new ShakeContainer
+                RelativeSizeAxes = Axes.Both,
+                Masking = true,
+                CornerRadius = 5,
+                Child = button = new HeaderButton { RelativeSizeAxes = Axes.Both },
+            });
+
+            button.AddRange(new Drawable[]
+            {
+                new Container
                 {
-                    Depth = -1,
+                    Padding = new MarginPadding { Horizontal = 10 },
                     RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    CornerRadius = 5,
                     Children = new Drawable[]
                     {
-                        button = new HeaderButton { RelativeSizeAxes = Axes.Both },
-                        new Container
+                        textSprites = new FillFlowContainer
                         {
-                            // cannot nest inside here due to the structure of button (putting things in its own content).
-                            // requires framework fix.
-                            Padding = new MarginPadding { Horizontal = 10 },
-                            RelativeSizeAxes = Axes.Both,
-                            Children = new Drawable[]
-                            {
-                                textSprites = new FillFlowContainer
-                                {
-                                    Depth = -1,
-                                    Anchor = Anchor.CentreLeft,
-                                    Origin = Anchor.CentreLeft,
-                                    AutoSizeAxes = Axes.Both,
-                                    AutoSizeDuration = 500,
-                                    AutoSizeEasing = Easing.OutQuint,
-                                    Direction = FillDirection.Vertical,
-                                },
-                                new SpriteIcon
-                                {
-                                    Depth = -1,
-                                    Anchor = Anchor.CentreRight,
-                                    Origin = Anchor.CentreRight,
-                                    Icon = FontAwesome.Solid.Download,
-                                    Size = new Vector2(18),
-                                },
-                            }
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            AutoSizeAxes = Axes.Both,
+                            AutoSizeDuration = 500,
+                            AutoSizeEasing = Easing.OutQuint,
+                            Direction = FillDirection.Vertical,
                         },
-                        new DownloadProgressBar(BeatmapSet.Value)
+                        new SpriteIcon
                         {
-                            Depth = -2,
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.CentreRight,
+                            Icon = FontAwesome.Solid.Download,
+                            Size = new Vector2(18),
                         },
-                    },
+                    }
+                },
+                new DownloadProgressBar(BeatmapSet.Value)
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
                 },
             });
 


### PR DESCRIPTION
Also removes unnecessary depth specifications. Toggle no whitespace changes for a cleaner diff.

Before:
![Kapture 2021-04-24 at 08 42 52](https://user-images.githubusercontent.com/35318437/115964381-1610f280-a4d9-11eb-902a-036d72c89940.gif)

After:
![Kapture 2021-04-24 at 08 43 29](https://user-images.githubusercontent.com/35318437/115964391-29bc5900-a4d9-11eb-9aed-cf33fbf74adb.gif)
