### PR TITLE
Add more breathing space for the hitobject composer

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -88,6 +88,7 @@ namespace osu.Game.Rulesets.Edit
                 return;
             }
 
+            const float content_padding = 32;
             const float toolbar_width = 200;
 
             InternalChildren = new Drawable[]
@@ -95,7 +96,7 @@ namespace osu.Game.Rulesets.Edit
                 new Container
                 {
                     Name = "Content",
-                    Padding = new MarginPadding { Left = toolbar_width },
+                    Padding = new MarginPadding(content_padding) { Left = toolbar_width + content_padding },
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {


### PR DESCRIPTION
Resolves the primary issue pointed at https://github.com/ppy/osu/issues/12433#issuecomment-820867982.

Adds more breathing space for the editor playfield by adding padding of `32` on the hit object composer content on all sides.

Not sure if the padding value is too little/too much, but seems fair enough for me. Probably need feedback for whether this is good or not, or whether it should be variable on a setting or otherwise.

| master | PR | 
|--------|----|
| ![CleanShot 2021-04-25 at 10 42 12](https://user-images.githubusercontent.com/22781491/115985105-ea623b00-a5b2-11eb-8135-cb14081d2769.png) | ![CleanShot 2021-04-25 at 11 01 57](https://user-images.githubusercontent.com/22781491/115985700-b1779580-a5b5-11eb-9b72-16d88ac060e5.png) |
| ![CleanShot 2021-04-25 at 10 53 52](https://user-images.githubusercontent.com/22781491/115985441-8b052a80-a5b4-11eb-9187-67e8fc206ccb.png) | ![CleanShot 2021-04-25 at 11 02 57](https://user-images.githubusercontent.com/22781491/115985725-d2d88180-a5b5-11eb-9763-e4cc98714d5d.png) |



