### PR TITLE
Fix missing animation of slider repeat and tail circle pieces

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -26,7 +26,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private double animDuration;
 
-        public Drawable CirclePiece { get; private set; }
+        public SkinnableDrawable CirclePiece { get; private set; }
+
         private Drawable scaleContainer;
         private ReverseArrowPiece arrow;
 
@@ -53,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Children = new[]
+                Children = new Drawable[]
                 {
                     // no default for this; only visible in legacy skins.
                     CirclePiece = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderTailHitCircle), _ => Empty()),
@@ -90,6 +91,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             base.UpdateHitStateTransforms(state);
+
+            (CirclePiece.Drawable as IMainCirclePiece)?.Animate(state);
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -83,6 +84,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.UpdateHitStateTransforms(state);
 
             Debug.Assert(HitObject.HitWindows != null);
+
+            (circlePiece.Drawable as IMainCirclePiece)?.Animate(state);
 
             switch (state)
             {


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/12556

Regressed by #12519 due to removing the `ApplyCustomUpdateState` subscription from inside `LegacyMainCirclePiece`s, causing hitobjects which use these pieces other than `DrawableHitCircle` to no longer animate. (`DrawableSliderHead` is an exception as it inherits from `DrawableHitCircle` and therefore not affected by this)

(Also, as an aside, I've noticed there has been a [change](https://github.com/ppy/osu/pull/12153/commits/64e85ba995a20dcf1cd3eb6f95fc65ae1a47a0cb) in the [transforms applied to `DrawableHitCircle`](https://github.com/ppy/osu/blob/6eee229a20496ee7d93d5c656d61c2832b755a5b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs#L182-L196), but the changes are [not applied to `DrawableSliderTail`](https://github.com/ppy/osu/blob/6eee229a20496ee7d93d5c656d61c2832b755a5b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs#L85-L101), should the tail have the same animations as the regular hit circle? or is it all arbitrary and likely to be removed altogether)