### PR TITLE
Add "classic" mod setting for tracking slider ball with any action

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -27,9 +27,15 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         private int depthIndex;
 
+        private bool trackHeadActionInitially = true;
+        private bool inputTracksVisualSize = true;
+
         [Test]
         public void TestVariousSliders()
         {
+            AddToggleStep("Ball.TrackHeadActionInitially", v => trackHeadActionInitially = v);
+            AddToggleStep("Ball.InputTracksVisualSize", v => inputTracksVisualSize = v);
+
             AddStep("Big Single", () => SetContents(() => testSimpleBig()));
             AddStep("Medium Single", () => SetContents(() => testSimpleMedium()));
             AddStep("Small Single", () => SetContents(() => testSimpleSmall()));
@@ -334,6 +340,12 @@ namespace osu.Game.Rulesets.Osu.Tests
             slider.ApplyDefaults(cpi, new BeatmapDifficulty { CircleSize = circleSize, SliderTickRate = 3 });
 
             var drawable = CreateDrawableSlider(slider);
+
+            drawable.OnLoadComplete += _ =>
+            {
+                drawable.Ball.TrackHeadActionInitially = trackHeadActionInitially;
+                drawable.Ball.InputTracksVisualSize = inputTracksVisualSize;
+            };
 
             foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObjects>())
                 mod.ApplyToDrawableHitObjects(new[] { drawable });

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Apply classic note lock", "Applies note lock to the full hit window.")]
         public Bindable<bool> ClassicNoteLock { get; } = new BindableBool(true);
 
+        [SettingSource("Allow any button held to track slider ball", "Allows the slider ball to be tracked with any held button, regardless of the one that hit the slider head.")]
+        public Bindable<bool> AnyActionTrackSliderBall { get; } = new BindableBool(true);
+
         [SettingSource("Use fixed slider follow circle hit area", "Makes the slider follow circle track its final size at all times.")]
         public Bindable<bool> FixedFollowCircleHitArea { get; } = new BindableBool(true);
 
@@ -61,6 +64,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (obj)
                 {
                     case DrawableSlider slider:
+                        slider.Ball.TrackHeadActionInitially = !AnyActionTrackSliderBall.Value;
                         slider.Ball.InputTracksVisualSize = !FixedFollowCircleHitArea.Value;
                         break;
 


### PR DESCRIPTION
Resolves a discrepancy with "classic" mod found in https://github.com/ppy/osu/issues/12532#issuecomment-826481278.

osu!lazer has special logic for limiting tracking slider ball only to the button/action that hit the slider head until it's the only action held, osu!stable on other hand doesn't care about that and lets any action held track the slider ball, from testing.

For compatibility with osu!stable's behaviour, a new setting for the "classic" mod has been added for allowing the slider ball to be tracked with any action, regardless of which hit the slider head first.