### PR TITLE
Rename "EditRuleset" and "EditPlayfield" to use full "Editor" keyword

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
+++ b/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
@@ -12,16 +12,16 @@ using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Mania.Edit
 {
-    public class DrawableManiaEditRuleset : DrawableManiaRuleset
+    public class DrawableManiaEditorRuleset : DrawableManiaRuleset
     {
         public new IScrollingInfo ScrollingInfo => base.ScrollingInfo;
 
-        public DrawableManiaEditRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
+        public DrawableManiaEditorRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
         }
 
-        protected override Playfield CreatePlayfield() => new ManiaEditPlayfield(Beatmap.Stages)
+        protected override Playfield CreatePlayfield() => new ManiaEditorPlayfield(Beatmap.Stages)
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Mania/Edit/ManiaEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaEditorPlayfield.cs
@@ -7,9 +7,9 @@ using System.Collections.Generic;
 
 namespace osu.Game.Rulesets.Mania.Edit
 {
-    public class ManiaEditPlayfield : ManiaPlayfield
+    public class ManiaEditorPlayfield : ManiaPlayfield
     {
-        public ManiaEditPlayfield(List<StageDefinition> stages)
+        public ManiaEditorPlayfield(List<StageDefinition> stages)
             : base(stages)
         {
         }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 {
     public class ManiaHitObjectComposer : HitObjectComposer<ManiaHitObject>
     {
-        private DrawableManiaEditRuleset drawableRuleset;
+        private DrawableManiaEditorRuleset drawableRuleset;
         private ManiaBeatSnapGrid beatSnapGrid;
         private InputManager inputManager;
 
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 
         protected override DrawableRuleset<ManiaHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
         {
-            drawableRuleset = new DrawableManiaEditRuleset(ruleset, beatmap, mods);
+            drawableRuleset = new DrawableManiaEditorRuleset(ruleset, beatmap, mods);
 
             // This is the earliest we can cache the scrolling info to ourselves, before masks are added to the hierarchy and inject it
             dependencies.CacheAs(drawableRuleset.ScrollingInfo);

--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
@@ -17,18 +17,18 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
-    public class DrawableOsuEditRuleset : DrawableOsuRuleset
+    public class DrawableOsuEditorRuleset : DrawableOsuRuleset
     {
-        public DrawableOsuEditRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
+        public DrawableOsuEditorRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(ruleset, beatmap, mods)
         {
         }
 
-        protected override Playfield CreatePlayfield() => new OsuEditPlayfield();
+        protected override Playfield CreatePlayfield() => new OsuEditorPlayfield();
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new OsuPlayfieldAdjustmentContainer { Size = Vector2.One };
 
-        private class OsuEditPlayfield : OsuPlayfield
+        private class OsuEditorPlayfield : OsuPlayfield
         {
             private Bindable<bool> hitAnimations;
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         }
 
         protected override DrawableRuleset<OsuHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
-            => new DrawableOsuEditRuleset(ruleset, beatmap, mods);
+            => new DrawableOsuEditorRuleset(ruleset, beatmap, mods);
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]
         {

--- a/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Edit
     /// <summary>
     /// A wrapper for a <see cref="DrawableRuleset{TObject}"/>. Handles adding visual representations of <see cref="HitObject"/>s to the underlying <see cref="DrawableRuleset{TObject}"/>.
     /// </summary>
-    internal class DrawableEditRulesetWrapper<TObject> : CompositeDrawable
+    internal class DrawableEditorRulesetWrapper<TObject> : CompositeDrawable
         where TObject : HitObject
     {
         public Playfield Playfield => drawableRuleset.Playfield;
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Edit
         [Resolved]
         private EditorBeatmap beatmap { get; set; }
 
-        public DrawableEditRulesetWrapper(DrawableRuleset<TObject> drawableRuleset)
+        public DrawableEditorRulesetWrapper(DrawableRuleset<TObject> drawableRuleset)
         {
             this.drawableRuleset = drawableRuleset;
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Edit
 
         protected ComposeBlueprintContainer BlueprintContainer { get; private set; }
 
-        private DrawableEditRulesetWrapper<TObject> drawableRulesetWrapper;
+        private DrawableEditorRulesetWrapper<TObject> drawableRulesetWrapper;
 
         protected readonly Container LayerBelowRuleset = new Container { RelativeSizeAxes = Axes.Both };
 
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Edit
 
             try
             {
-                drawableRulesetWrapper = new DrawableEditRulesetWrapper<TObject>(CreateDrawableRuleset(Ruleset, EditorBeatmap.PlayableBeatmap, new[] { Ruleset.GetAutoplayMod() }))
+                drawableRulesetWrapper = new DrawableEditorRulesetWrapper<TObject>(CreateDrawableRuleset(Ruleset, EditorBeatmap.PlayableBeatmap, new[] { Ruleset.GetAutoplayMod() }))
                 {
                     Clock = EditorClock,
                     ProcessCustomClock = false


### PR DESCRIPTION
These are the only placed outside of the screen namespace that we use `Edit` instead of `Editor`. Makes it very hard to locate these classes (ie. if you search for `EditorRu` it will not match).