### PR TITLE
Fix slider repeats and tails still animating with editor hit animations disabled

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -19,7 +19,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
-    public class DrawableHitCircle : DrawableOsuHitObject
+    public class DrawableHitCircle : DrawableOsuHitObject, IHasMainCirclePiece
     {
         public OsuAction? HitAction => HitArea.HitAction;
         protected virtual OsuSkinComponents CirclePieceComponent => OsuSkinComponents.HitCircle;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
-    public class DrawableSliderRepeat : DrawableOsuHitObject, ITrackSnaking
+    public class DrawableSliderRepeat : DrawableOsuHitObject, ITrackSnaking, IHasMainCirclePiece
     {
         public new SliderRepeat HitObject => (SliderRepeat)base.HitObject;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -112,8 +112,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 case ArmedState.Hit:
                     this.FadeOut(animDuration, Easing.Out);
 
-                    Arrow.ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
-                    CirclePiece.ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
+                    const float final_scale = 1.5f;
+
+                    Arrow.ScaleTo(Scale * final_scale, animDuration, Easing.Out);
+                    CirclePiece.ScaleTo(Scale * final_scale, animDuration, Easing.Out);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -28,8 +28,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public SkinnableDrawable CirclePiece { get; private set; }
 
+        public ReverseArrowPiece Arrow { get; private set; }
+
         private Drawable scaleContainer;
-        private ReverseArrowPiece arrow;
 
         public override bool DisplayResult => false;
 
@@ -57,8 +58,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 Children = new Drawable[]
                 {
                     // no default for this; only visible in legacy skins.
-                    CirclePiece = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderTailHitCircle), _ => Empty()),
-                    arrow = new ReverseArrowPiece(),
+                    CirclePiece = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderTailHitCircle), _ => Empty())
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    },
+                    Arrow = new ReverseArrowPiece(),
                 }
             };
 
@@ -105,8 +110,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     break;
 
                 case ArmedState.Hit:
-                    this.FadeOut(animDuration, Easing.Out)
-                        .ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
+                    this.FadeOut(animDuration, Easing.Out);
+
+                    Arrow.ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
+                    CirclePiece.ScaleTo(Scale * 1.5f, animDuration, Easing.Out);
                     break;
             }
         }
@@ -142,18 +149,18 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
 
             float aimRotation = MathUtils.RadiansToDegrees(MathF.Atan2(aimRotationVector.Y - Position.Y, aimRotationVector.X - Position.X));
-            while (Math.Abs(aimRotation - arrow.Rotation) > 180)
-                aimRotation += aimRotation < arrow.Rotation ? 360 : -360;
+            while (Math.Abs(aimRotation - Arrow.Rotation) > 180)
+                aimRotation += aimRotation < Arrow.Rotation ? 360 : -360;
 
             if (!hasRotation)
             {
-                arrow.Rotation = aimRotation;
+                Arrow.Rotation = aimRotation;
                 hasRotation = true;
             }
             else
             {
                 // If we're already snaking, interpolate to smooth out sharp curves (linear sliders, mainly).
-                arrow.Rotation = Interpolation.ValueAt(Math.Clamp(Clock.ElapsedFrameTime, 0, 100), arrow.Rotation, aimRotation, 0, 50, Easing.OutQuint);
+                Arrow.Rotation = Interpolation.ValueAt(Math.Clamp(Clock.ElapsedFrameTime, 0, 100), Arrow.Rotation, aimRotation, 0, 50, Easing.OutQuint);
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -13,7 +13,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
-    public class DrawableSliderTail : DrawableOsuHitObject, IRequireTracking, ITrackSnaking
+    public class DrawableSliderTail : DrawableOsuHitObject, IRequireTracking, ITrackSnaking, IHasMainCirclePiece
     {
         public new SliderTailCircle HitObject => (SliderTailCircle)base.HitObject;
 
@@ -35,7 +35,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public bool Tracking { get; set; }
 
-        private SkinnableDrawable circlePiece;
+        public SkinnableDrawable CirclePiece { get; private set; }
+
         private Container scaleContainer;
 
         public DrawableSliderTail()
@@ -64,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     Children = new Drawable[]
                     {
                         // no default for this; only visible in legacy skins.
-                        circlePiece = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderTailHitCircle), _ => Empty())
+                        CirclePiece = new SkinnableDrawable(new OsuSkinComponent(OsuSkinComponents.SliderTailHitCircle), _ => Empty())
                     }
                 },
             };
@@ -76,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateInitialTransforms();
 
-            circlePiece.FadeInFromZero(HitObject.TimeFadeIn);
+            CirclePiece.FadeInFromZero(HitObject.TimeFadeIn);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
@@ -85,7 +86,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             Debug.Assert(HitObject.HitWindows != null);
 
-            (circlePiece.Drawable as IMainCirclePiece)?.Animate(state);
+            (CirclePiece.Drawable as IMainCirclePiece)?.Animate(state);
 
             switch (state)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Default/IHasMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/IHasMainCirclePiece.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Default
+{
+    public interface IHasMainCirclePiece
+    {
+        SkinnableDrawable CirclePiece { get; }
+    }
+}


### PR DESCRIPTION
Closes #12577.

- [x] Depends on https://github.com/ppy/osu/pull/12579.

I've done a bit of reorganisations to how these changes are applied, to hopefully read better. The previous `switch` statement wasn't scaling well with these new cases.