### PR TITLE
Fix simultaneous slider input not allowing both keys to be accepted

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -34,6 +34,18 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private List<JudgementResult> judgementResults;
 
+        [Test]
+        public void TestPressBothKeysSimultaneouslyAndReleaseOne()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Position = Vector2.Zero, Actions = { OsuAction.LeftButton, OsuAction.RightButton }, Time = time_slider_start },
+                new OsuReplayFrame { Position = Vector2.Zero, Actions = { OsuAction.RightButton }, Time = time_during_slide_1 },
+            });
+
+            AddAssert("Tracking retained", assertMaxJudge);
+        }
+
         /// <summary>
         /// Scenario:
         /// - Press a key before a slider starts

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -134,6 +135,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         /// </summary>
         private double? timeToAcceptAnyKeyAfter;
 
+        /// <summary>
+        /// The actions that were pressed in the previous frame.
+        /// </summary>
+        private readonly List<OsuAction> lastPressedActions = new List<OsuAction>();
+
         protected override void Update()
         {
             base.Update();
@@ -152,8 +158,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             {
                 var otherKey = headCircleHitAction == OsuAction.RightButton ? OsuAction.LeftButton : OsuAction.RightButton;
 
-                // we can return to accepting all keys if the initial head circle key is the *only* key pressed, or all keys have been released.
-                if (actions?.Contains(otherKey) != true)
+                // we can return to accepting all other keys if they were released in the previous frame.
+                if (!lastPressedActions.Contains(otherKey))
                     timeToAcceptAnyKeyAfter = Time.Current;
             }
 
@@ -164,6 +170,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 lastScreenSpaceMousePosition.HasValue && followCircle.ReceivePositionalInputAt(lastScreenSpaceMousePosition.Value) &&
                 // valid action
                 (actions?.Any(isValidTrackingAction) ?? false);
+
+            lastPressedActions.Clear();
+            lastPressedActions.AddRange(actions);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
@@ -172,7 +172,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 (actions?.Any(isValidTrackingAction) ?? false);
 
             lastPressedActions.Clear();
-            lastPressedActions.AddRange(actions);
+            if (actions != null)
+                lastPressedActions.AddRange(actions);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SliderBall.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             {
                 var otherKey = headCircleHitAction == OsuAction.RightButton ? OsuAction.LeftButton : OsuAction.RightButton;
 
-                // we can return to accepting all other keys if they were released in the previous frame.
+                // we can start accepting any key once all other keys have been released in the previous frame.
                 if (!lastPressedActions.Contains(otherKey))
                     timeToAcceptAnyKeyAfter = Time.Current;
             }


### PR DESCRIPTION
Alternative to / closes https://github.com/ppy/osu/pull/12578

Without going deep into osu-stable code, this fixes the added test case. It also fixes the replay pointed out (https://github.com/ppy/osu/pull/12515#issuecomment-823855326) where this PR misses @ ~2561 combo vs stable @ 2559 and master @ 1938 (the slider pointed out in https://github.com/ppy/osu/issues/12532#issuecomment-826481278).