### PR TITLE
Add method to safely refresh DrawableHitObject transforms

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -430,9 +430,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         }
 
         /// <summary>
-        /// Removes all previously applied transforms, then reapplies a new set of transforms with potentially different parameters.
-        /// The transforms will use the current <see cref="ArmedState"/>, and they will use the appropriate start times.
-        /// This also takes in account potential overrides defined in <see cref="ApplyCustomUpdateState"/>.
+        /// Reapplies the current <see cref="ArmedState"/>.
         /// </summary>
         protected void RefreshStateTransforms() => updateState(State.Value, true);
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -14,13 +14,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Threading;
 using osu.Game.Audio;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Pooling;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Skinning;
-using osu.Game.Configuration;
-using osu.Game.Rulesets.Objects.Pooling;
 using osu.Game.Rulesets.UI;
+using osu.Game.Skinning;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Objects.Drawables
@@ -428,6 +428,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
             // has to call this method directly (not ClearTransforms) to bypass the local ClearTransformsAfter override.
             base.ClearTransformsAfter(double.MinValue, true);
         }
+
+        /// <summary>
+        /// Removes all previously applied transforms, then reapplies a new set of transforms with potentially different parameters.
+        /// The transforms will use the current <see cref="ArmedState"/>, and they will use the appropriate start times.
+        /// This also takes in account potential overrides defined in <see cref="ApplyCustomUpdateState"/>.
+        /// </summary>
+        protected void RefreshStateTransforms() => updateState(State.Value, true);
 
         /// <summary>
         /// Apply (generally fade-in) transforms leading into the <see cref="HitObject"/> start time.


### PR DESCRIPTION
`DrawableHitObject`s have overridden `ClearTransforms` and `ApplyTransformsAt` methods to prevent unintended screwing up of transforms. This is problematic for DHOs that need to account for user-adjustable transform parameters (e.g note animation speed), 

Previously, a workaround that could be used to refresh animations was to call `updateState(State.Value, true)` indirectly via `SkinChanged(SkinSource)`, but the latter method was removed in #12500. 

This PR adds a method `RefreshStateTransforms` that removes and reapplies all transforms, that could be called should the need to do so arises.