### PR TITLE
Fix Setting DHO's lifetime doesn't update its entry lifetime

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.422.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.424.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.427.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -37,6 +37,38 @@ namespace osu.Game.Tests.Gameplay
             AddAssert("Entry lifetime is updated", () => entry.LifetimeEnd == 3000);
         }
 
+        [Test]
+        public void TestKeepAlive()
+        {
+            TestDrawableHitObject dho = null;
+            TestLifetimeEntry entry = null;
+            AddStep("Create DHO", () =>
+            {
+                dho = new TestDrawableHitObject(null);
+                dho.Apply(entry = new TestLifetimeEntry(new HitObject())
+                {
+                    LifetimeStart = 0,
+                    LifetimeEnd = 1000,
+                });
+                Child = dho;
+            });
+
+            AddStep("KeepAlive = true", () => entry.KeepAlive = true);
+            AddAssert("Lifetime is overriden", () => entry.LifetimeStart == double.MinValue && entry.LifetimeEnd == double.MaxValue);
+
+            AddStep("Set LifetimeStart", () => dho.LifetimeStart = 500);
+            AddStep("KeepAlive = false", () => entry.KeepAlive = false);
+            AddAssert("Lifetime is correct", () => entry.LifetimeStart == 500 && entry.LifetimeEnd == 1000);
+
+            AddStep("Set LifetimeStart while KeepAlive", () =>
+            {
+                entry.KeepAlive = true;
+                dho.LifetimeStart = double.MinValue;
+                entry.KeepAlive = false;
+            });
+            AddAssert("Lifetime is changed", () => entry.LifetimeStart == double.MinValue && entry.LifetimeEnd == 1000);
+        }
+
         private class TestDrawableHitObject : DrawableHitObject
         {
             public const double INITIAL_LIFETIME_OFFSET = 100;

--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Gameplay
+{
+    [HeadlessTest]
+    public class TestSceneDrawableHitObject : OsuTestScene
+    {
+        [Test]
+        public void TestEntryLifetime()
+        {
+            TestDrawableHitObject dho = null;
+            var initialHitObject = new HitObject
+            {
+                StartTime = 1000
+            };
+            var entry = new TestLifetimeEntry(new HitObject
+            {
+                StartTime = 2000
+            });
+
+            AddStep("Create DHO", () => Child = dho = new TestDrawableHitObject(initialHitObject));
+
+            AddAssert("Correct initial lifetime", () => dho.LifetimeStart == initialHitObject.StartTime - TestDrawableHitObject.INITIAL_LIFETIME_OFFSET);
+
+            AddStep("Apply entry", () => dho.Apply(entry));
+
+            AddAssert("Correct initial lifetime", () => dho.LifetimeStart == entry.HitObject.StartTime - TestLifetimeEntry.INITIAL_LIFETIME_OFFSET);
+
+            AddStep("Set lifetime", () => dho.LifetimeEnd = 3000);
+            AddAssert("Entry lifetime is updated", () => entry.LifetimeEnd == 3000);
+        }
+
+        private class TestDrawableHitObject : DrawableHitObject
+        {
+            public const double INITIAL_LIFETIME_OFFSET = 100;
+            protected override double InitialLifetimeOffset => INITIAL_LIFETIME_OFFSET;
+
+            public TestDrawableHitObject(HitObject hitObject)
+                : base(hitObject)
+            {
+            }
+        }
+
+        private class TestLifetimeEntry : HitObjectLifetimeEntry
+        {
+            public const double INITIAL_LIFETIME_OFFSET = 200;
+            protected override double InitialLifetimeOffset => INITIAL_LIFETIME_OFFSET;
+
+            public TestLifetimeEntry(HitObject hitObject)
+                : base(hitObject)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Performance;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Threading;
 using osu.Game.Audio;
@@ -431,7 +432,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         /// <summary>
         /// Apply (generally fade-in) transforms leading into the <see cref="HitObject"/> start time.
-        /// The local drawable hierarchy is recursively delayed to <see cref="HitObjectLifetimeEntry.LifetimeStart"/> for convenience.
+        /// The local drawable hierarchy is recursively delayed to <see cref="LifetimeEntry.LifetimeStart"/> for convenience.
         ///
         /// By default this will fade in the object from zero with no duration.
         /// </summary>
@@ -613,7 +614,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <remarks>
         /// This is only used as an optimisation to delay the initial update of this <see cref="DrawableHitObject"/> and may be tuned more aggressively if required.
         /// It is indirectly used to decide the automatic transform offset provided to <see cref="UpdateInitialTransforms"/>.
-        /// A more accurate <see cref="HitObjectLifetimeEntry.LifetimeStart"/> should be set for further optimisation (in <see cref="LoadComplete"/>, for example).
+        /// A more accurate <see cref="LifetimeEntry.LifetimeStart"/> should be set for further optimisation (in <see cref="LoadComplete"/>, for example).
         /// <para>
         /// Only has an effect if this <see cref="DrawableHitObject"/> is not being pooled.
         /// For pooled <see cref="DrawableHitObject"/>s, use <see cref="HitObjectLifetimeEntry.InitialLifetimeOffset"/> instead.

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -38,40 +38,19 @@ namespace osu.Game.Rulesets.Objects
             startTimeBindable.BindValueChanged(onStartTimeChanged, true);
         }
 
-        // The lifetime start, as set by the hitobject.
+        // The lifetime, as set by the hitobject.
         private double realLifetimeStart = double.MinValue;
-
-        /// <summary>
-        /// The time at which the <see cref="HitObject"/> should become alive.
-        /// </summary>
-        public new double LifetimeStart
-        {
-            get => realLifetimeStart;
-            set => setLifetime(realLifetimeStart = value, LifetimeEnd);
-        }
-
-        // The lifetime end, as set by the hitobject.
         private double realLifetimeEnd = double.MaxValue;
 
-        /// <summary>
-        /// The time at which the <see cref="HitObject"/> should become dead.
-        /// </summary>
-        public new double LifetimeEnd
+        public override void SetLifetime(double start, double end)
         {
-            get => realLifetimeEnd;
-            set => setLifetime(LifetimeStart, realLifetimeEnd = value);
-        }
+            realLifetimeStart = start;
+            realLifetimeEnd = end;
 
-        private void setLifetime(double start, double end)
-        {
             if (keepAlive)
-            {
-                start = double.MinValue;
-                end = double.MaxValue;
-            }
-
-            base.LifetimeStart = start;
-            base.LifetimeEnd = end;
+                base.SetLifetime(double.MinValue, double.MaxValue);
+            else
+                base.SetLifetime(start, end);
         }
 
         private bool keepAlive;
@@ -87,7 +66,7 @@ namespace osu.Game.Rulesets.Objects
                     return;
 
                 keepAlive = value;
-                setLifetime(realLifetimeStart, realLifetimeEnd);
+                SetLifetime(realLifetimeStart, realLifetimeEnd);
             }
         }
 
@@ -98,12 +77,12 @@ namespace osu.Game.Rulesets.Objects
         /// <remarks>
         /// This is only used as an optimisation to delay the initial update of the <see cref="HitObject"/> and may be tuned more aggressively if required.
         /// It is indirectly used to decide the automatic transform offset provided to <see cref="DrawableHitObject.UpdateInitialTransforms"/>.
-        /// A more accurate <see cref="LifetimeStart"/> should be set for further optimisation (in <see cref="DrawableHitObject.LoadComplete"/>, for example).
+        /// A more accurate <see cref="LifetimeEntry.LifetimeStart"/> should be set for further optimisation (in <see cref="DrawableHitObject.LoadComplete"/>, for example).
         /// </remarks>
         protected virtual double InitialLifetimeOffset => 10000;
 
         /// <summary>
-        /// Resets <see cref="LifetimeStart"/> according to the change in start time of the <see cref="HitObject"/>.
+        /// Resets <see cref="LifetimeEntry.LifetimeStart"/> according to the change in start time of the <see cref="HitObject"/>.
         /// </summary>
         private void onStartTimeChanged(ValueChangedEvent<double> startTime) => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
     }

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -45,23 +45,16 @@ namespace osu.Game.Rulesets.Objects
         // This method is called even if `start == LifetimeStart` when `KeepAlive` is true (necessary to update `realLifetimeStart`).
         protected override void SetLifetimeStart(double start)
         {
-            // This assignment cannot be done in `SetLifetime` because otherwise setting only `LifetimeStart` will make `realLifetimeEnd` to be lost.
             realLifetimeStart = start;
-            base.SetLifetimeStart(start);
+            if (!keepAlive)
+                base.SetLifetimeStart(start);
         }
 
         protected override void SetLifetimeEnd(double end)
         {
             realLifetimeEnd = end;
-            base.SetLifetimeEnd(end);
-        }
-
-        protected override void SetLifetime(double start, double end)
-        {
-            if (keepAlive)
-                base.SetLifetime(double.MinValue, double.MaxValue);
-            else
-                base.SetLifetime(start, end);
+            if (!keepAlive)
+                base.SetLifetimeEnd(end);
         }
 
         private bool keepAlive;
@@ -77,7 +70,10 @@ namespace osu.Game.Rulesets.Objects
                     return;
 
                 keepAlive = value;
-                SetLifetime(realLifetimeStart, realLifetimeEnd);
+                if (keepAlive)
+                    SetLifetime(double.MinValue, double.MaxValue);
+                else
+                    SetLifetime(realLifetimeStart, realLifetimeEnd);
             }
         }
 

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -42,11 +42,22 @@ namespace osu.Game.Rulesets.Objects
         private double realLifetimeStart = double.MinValue;
         private double realLifetimeEnd = double.MaxValue;
 
-        public override void SetLifetime(double start, double end)
+        // This method is called even if `start == LifetimeStart` when `KeepAlive` is true (necessary to update `realLifetimeStart`).
+        protected override void SetLifetimeStart(double start)
         {
+            // This assignment cannot be done in `SetLifetime` because otherwise setting only `LifetimeStart` will make `realLifetimeEnd` to be lost.
             realLifetimeStart = start;
-            realLifetimeEnd = end;
+            base.SetLifetimeStart(start);
+        }
 
+        protected override void SetLifetimeEnd(double end)
+        {
+            realLifetimeEnd = end;
+            base.SetLifetimeEnd(end);
+        }
+
+        protected override void SetLifetime(double start, double end)
+        {
             if (keepAlive)
                 base.SetLifetime(double.MinValue, double.MaxValue);
             else

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -100,7 +100,11 @@ namespace osu.Game.Rulesets.Objects.Pooling
             base.LifetimeStart = start;
             base.LifetimeEnd = end;
 
-            Entry?.SetLifetime(start, end);
+            if (Entry != null)
+            {
+                Entry.LifetimeStart = start;
+                Entry.LifetimeEnd = end;
+            }
         }
 
         private void free()

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -100,11 +100,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
             base.LifetimeStart = start;
             base.LifetimeEnd = end;
 
-            if (Entry != null)
-            {
-                Entry.LifetimeStart = start;
-                Entry.LifetimeEnd = end;
-            }
+            Entry?.SetLifetime(start, end);
         }
 
         private void free()

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.424.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.427.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.422.0" />
     <PackageReference Include="Sentry" Version="3.2.0" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.424.1" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.427.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.422.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.424.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.427.0" />
     <PackageReference Include="SharpCompress" Version="0.28.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- [x] Depends on ppy/osu-framework#4411
- [x] Framework update

An issue introduced in #12500:
`HitObjectLifetimeEntry`'s `LifetimeStart` and `LifetimeEnd` are hiding base properties <https://github.com/ppy/osu/blob/ea3c5aed2fccdbb6d657b4ba93b6fa5d8b6abccd/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs#L47>
but `PoolableDrawableWithLifetime` uses a type parameter bounded by `LifetimeEntry`.
In the `PoolableDrawableWithLifetime` implementation, `LifetimeStart` and `LifetimeEnd` refer to the base properties, not `HitObjectLifetimeEntry`'s properties.
It caused entry's lifetime to not updated when DHO's lifetime is set.

Using hiding properties as a pseudo-overriding is fragile anyway, and making it true override is the way. It requires a framework-side change.