### PR TITLE
Make editor blueprint/selection components abstract

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
@@ -4,6 +4,7 @@
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Screens.Edit.Compose.Components;
 
@@ -30,6 +31,6 @@ namespace osu.Game.Rulesets.Mania.Edit
             return base.CreateBlueprintFor(hitObject);
         }
 
-        protected override SelectionHandler CreateSelectionHandler() => new ManiaSelectionHandler();
+        protected override SelectionHandler<HitObject> CreateSelectionHandler() => new ManiaSelectionHandler();
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
@@ -7,12 +7,13 @@ using osu.Framework.Allocation;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Screens.Edit.Compose.Components;
 
 namespace osu.Game.Rulesets.Mania.Edit
 {
-    public class ManiaSelectionHandler : SelectionHandler
+    public class ManiaSelectionHandler : EditorSelectionHandler
     {
         [Resolved]
         private IScrollingInfo scrollingInfo { get; set; }
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Mania.Edit
         [Resolved]
         private HitObjectComposer composer { get; set; }
 
-        public override bool HandleMovement(MoveSelectionEvent moveEvent)
+        public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent)
         {
             var maniaBlueprint = (ManiaSelectionBlueprint)moveEvent.Blueprint;
             int lastColumn = maniaBlueprint.DrawableObject.HitObject.Column;
@@ -30,7 +31,7 @@ namespace osu.Game.Rulesets.Mania.Edit
             return true;
         }
 
-        private void performColumnMovement(int lastColumn, MoveSelectionEvent moveEvent)
+        private void performColumnMovement(int lastColumn, MoveSelectionEvent<HitObject> moveEvent)
         {
             var maniaPlayfield = ((ManiaHitObjectComposer)composer).Playfield;
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/OsuSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/OsuSelectionBlueprint.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
     public abstract class OsuSelectionBlueprint<T> : OverlaySelectionBlueprint
         where T : OsuHitObject
     {
-        protected new T HitObject => (T)DrawableObject.HitObject;
+        protected T HitObject => (T)DrawableObject.HitObject;
 
         protected override bool AlwaysShowWhenSelected => true;
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBlueprintContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
@@ -18,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        protected override SelectionHandler CreateSelectionHandler() => new OsuSelectionHandler();
+        protected override SelectionHandler<HitObject> CreateSelectionHandler() => new OsuSelectionHandler();
 
         public override OverlaySelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject)
         {

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (b.IsSelected)
                     continue;
 
-                var hitObject = (OsuHitObject)b.HitObject;
+                var hitObject = (OsuHitObject)b.Item;
 
                 Vector2? snap = checkSnap(hitObject.Position);
                 if (snap == null && hitObject.Position != hitObject.EndPosition)

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -374,8 +374,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         /// <summary>
         /// All osu! hitobjects which can be moved/rotated/scaled.
         /// </summary>
-        private OsuHitObject[] selectedMovableObjects => EditorBeatmap.SelectedHitObjects
-                                                                      .OfType<OsuHitObject>()
+        private OsuHitObject[] selectedMovableObjects => SelectedItems.OfType<OsuHitObject>()
                                                                       .Where(h => !(h is Spinner))
                                                                       .ToArray();
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
-    public class OsuSelectionHandler : SelectionHandler
+    public class OsuSelectionHandler : EditorSelectionHandler
     {
         protected override void OnSelectionChanged()
         {
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             referencePathTypes = null;
         }
 
-        public override bool HandleMovement(MoveSelectionEvent moveEvent)
+        public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent)
         {
             var hitObjects = selectedMovableObjects;
 

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
 using osu.Game.Screens.Edit.Compose.Components;
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
         {
         }
 
-        protected override SelectionHandler CreateSelectionHandler() => new TaikoSelectionHandler();
+        protected override SelectionHandler<HitObject> CreateSelectionHandler() => new TaikoSelectionHandler();
 
         public override OverlaySelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject) =>
             new TaikoSelectionBlueprint(hitObject);

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -80,6 +80,9 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
             if (selection.All(s => s.Item is TaikoHitObject))
                 yield return new TernaryStateMenuItem("Strong") { State = { BindTarget = selectionStrongState } };
+
+            foreach (var item in base.GetContextMenuItemsForSelection(selection))
+                yield return item;
         }
 
         public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent) => true;

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -8,12 +8,13 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 
 namespace osu.Game.Rulesets.Taiko.Edit
 {
-    public class TaikoSelectionHandler : SelectionHandler
+    public class TaikoSelectionHandler : EditorSelectionHandler
     {
         private readonly Bindable<TernaryState> selectionRimState = new Bindable<TernaryState>();
         private readonly Bindable<TernaryState> selectionStrongState = new Bindable<TernaryState>();
@@ -72,16 +73,16 @@ namespace osu.Game.Rulesets.Taiko.Edit
             });
         }
 
-        protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint> selection)
+        protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
         {
-            if (selection.All(s => s.HitObject is Hit))
+            if (selection.All(s => s.Item is Hit))
                 yield return new TernaryStateMenuItem("Rim") { State = { BindTarget = selectionRimState } };
 
-            if (selection.All(s => s.HitObject is TaikoHitObject))
+            if (selection.All(s => s.Item is TaikoHitObject))
                 yield return new TernaryStateMenuItem("Strong") { State = { BindTarget = selectionStrongState } };
         }
 
-        public override bool HandleMovement(MoveSelectionEvent moveEvent) => true;
+        public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent) => true;
 
         protected override void UpdateTernaryStates()
         {

--- a/osu.Game.Tests/Visual/Editing/TestSceneBlueprintSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBlueprintSelection.cs
@@ -23,8 +23,8 @@ namespace osu.Game.Tests.Visual.Editing
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
 
-        private BlueprintContainer blueprintContainer
-            => Editor.ChildrenOfType<BlueprintContainer>().First();
+        private EditorBlueprintContainer blueprintContainer
+            => Editor.ChildrenOfType<EditorBlueprintContainer>().First();
 
         [Test]
         public void TestSelectedObjectHasPriorityWhenOverlapping()

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -132,8 +132,8 @@ namespace osu.Game.Tests.Visual.Editing
             {
                 AddStep("deselect", () => EditorBeatmap.SelectedHitObjects.Clear());
 
-                AddUntilStep("timeline selection box is not visible", () => Editor.ChildrenOfType<Timeline>().First().ChildrenOfType<SelectionHandler>().First().Alpha == 0);
-                AddUntilStep("composer selection box is not visible", () => Editor.ChildrenOfType<HitObjectComposer>().First().ChildrenOfType<SelectionHandler>().First().Alpha == 0);
+                AddUntilStep("timeline selection box is not visible", () => Editor.ChildrenOfType<Timeline>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha == 0);
+                AddUntilStep("composer selection box is not visible", () => Editor.ChildrenOfType<HitObjectComposer>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha == 0);
             }
 
             AddStep("paste hitobject", () => Editor.Paste());
@@ -142,8 +142,8 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddAssert("new object selected", () => EditorBeatmap.SelectedHitObjects.Single().StartTime == 2000);
 
-            AddUntilStep("timeline selection box is visible", () => Editor.ChildrenOfType<Timeline>().First().ChildrenOfType<SelectionHandler>().First().Alpha > 0);
-            AddUntilStep("composer selection box is visible", () => Editor.ChildrenOfType<HitObjectComposer>().First().ChildrenOfType<SelectionHandler>().First().Alpha > 0);
+            AddUntilStep("timeline selection box is visible", () => Editor.ChildrenOfType<Timeline>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha > 0);
+            AddUntilStep("composer selection box is visible", () => Editor.ChildrenOfType<HitObjectComposer>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha > 0);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSelection.cs
@@ -26,15 +26,15 @@ namespace osu.Game.Tests.Visual.Editing
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
 
-        private BlueprintContainer blueprintContainer
-            => Editor.ChildrenOfType<BlueprintContainer>().First();
+        private EditorBlueprintContainer blueprintContainer
+            => Editor.ChildrenOfType<EditorBlueprintContainer>().First();
 
         private void moveMouseToObject(Func<HitObject> targetFunc)
         {
             AddStep("move mouse to object", () =>
             {
                 var pos = blueprintContainer.SelectionBlueprints
-                                            .First(s => s.HitObject == targetFunc())
+                                            .First(s => s.Item == targetFunc())
                                             .ChildrenOfType<HitCirclePiece>()
                                             .First().ScreenSpaceDrawQuad.Centre;
 

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -182,8 +182,7 @@ namespace osu.Game.Rulesets.Edit
         /// <summary>
         /// Construct a relevant blueprint container. This will manage hitobject selection/placement input handling and display logic.
         /// </summary>
-        protected virtual ComposeBlueprintContainer CreateBlueprintContainer()
-            => new ComposeBlueprintContainer(this);
+        protected virtual ComposeBlueprintContainer CreateBlueprintContainer() => new ComposeBlueprintContainer(this);
 
         /// <summary>
         /// Construct a drawable ruleset for the provided ruleset.

--- a/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
@@ -3,12 +3,13 @@
 
 using osu.Framework.Graphics.Primitives;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 
 namespace osu.Game.Rulesets.Edit
 {
-    public abstract class OverlaySelectionBlueprint : SelectionBlueprint
+    public abstract class OverlaySelectionBlueprint : SelectionBlueprint<HitObject>
     {
         /// <summary>
         /// The <see cref="DrawableHitObject"/> which this <see cref="OverlaySelectionBlueprint"/> applies to.

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 
 namespace osu.Game.Rulesets.Edit
 {
     /// <summary>
-    /// A blueprint placed above a <see cref="DrawableHitObject"/> adding editing functionality.
+    /// A blueprint placed above a displaying item adding editing functionality.
     /// </summary>
     public abstract class SelectionBlueprint<T> : CompositeDrawable, IStateful<SelectionState>
     {
@@ -86,7 +85,7 @@ namespace osu.Game.Rulesets.Edit
 
         protected virtual void OnDeselected()
         {
-            // selection blueprints are AlwaysPresent while the related DrawableHitObject is visible
+            // selection blueprints are AlwaysPresent while the related item is visible
             // set the body piece's alpha directly to avoid arbitrarily rendering frame buffers etc. of children.
             foreach (var d in InternalChildren)
                 d.Hide();

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 
@@ -17,26 +16,26 @@ namespace osu.Game.Rulesets.Edit
     /// <summary>
     /// A blueprint placed above a <see cref="DrawableHitObject"/> adding editing functionality.
     /// </summary>
-    public abstract class SelectionBlueprint : CompositeDrawable, IStateful<SelectionState>
+    public abstract class SelectionBlueprint<T> : CompositeDrawable, IStateful<SelectionState>
     {
-        public readonly HitObject HitObject;
+        public readonly T Item;
 
         /// <summary>
-        /// Invoked when this <see cref="SelectionBlueprint"/> has been selected.
+        /// Invoked when this <see cref="SelectionBlueprint{T}"/> has been selected.
         /// </summary>
-        public event Action<SelectionBlueprint> Selected;
+        public event Action<SelectionBlueprint<T>> Selected;
 
         /// <summary>
-        /// Invoked when this <see cref="SelectionBlueprint"/> has been deselected.
+        /// Invoked when this <see cref="SelectionBlueprint{T}"/> has been deselected.
         /// </summary>
-        public event Action<SelectionBlueprint> Deselected;
+        public event Action<SelectionBlueprint<T>> Deselected;
 
         public override bool HandlePositionalInput => ShouldBeAlive;
         public override bool RemoveWhenNotAlive => false;
 
-        protected SelectionBlueprint(HitObject hitObject)
+        protected SelectionBlueprint(T item)
         {
-            HitObject = hitObject;
+            Item = item;
 
             RelativeSizeAxes = Axes.Both;
             AlwaysPresent = true;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Creates a <see cref="Components.SelectionHandler{T}"/> which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.
         /// </summary>
-        protected virtual SelectionHandler<T> CreateSelectionHandler() => new SelectionHandler<T>();
+        protected abstract SelectionHandler<T> CreateSelectionHandler();
 
         /// <summary>
         /// Creates a <see cref="SelectionBlueprint{T}"/> for a specific <see cref="DrawableHitObject"/>.

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -76,9 +76,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected virtual DragBox CreateDragBox(Action<RectangleF> performSelect) => new DragBox(performSelect);
 
         /// <summary>
-        /// Whether this component is in a state where deselection should be allowed. If false, selection will only be added to.
+        /// Whether this component is in a state where items outside a drag selection should be deselected. If false, selection will only be added to.
         /// </summary>
-        protected virtual bool AllowDeselection => true;
+        protected virtual bool AllowDeselectionDuringDrag => true;
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
@@ -354,7 +354,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         break;
 
                     case SelectionState.Selected:
-                        if (AllowDeselection && !isValidForSelection())
+                        if (AllowDeselectionDuringDrag && !isValidForSelection())
                             blueprint.Deselect();
                         break;
                 }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -354,7 +354,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         break;
 
                     case SelectionState.Selected:
-                        // if the editor is playing, we generally don't want to deselect objects even if outside the selection area.
                         if (AllowDeselection && !isValidForSelection())
                             blueprint.Deselect();
                         break;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (isDraggingBlueprint)
             {
-                UpdateSelection();
+                DragOperationCompleted();
 
                 changeHandler?.EndChange();
             }
@@ -182,7 +182,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 DragBox.Hide();
         }
 
-        protected virtual void UpdateSelection()
+        /// <summary>
+        /// Called whenever a drag operation completes, before any change transaction is committed.
+        /// </summary>
+        protected virtual void DragOperationCompleted()
         {
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -267,8 +267,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="item">The item for which the blueprint has been added.</param>
         protected virtual void OnBlueprintAdded(T item)
         {
-            if (SelectionHandler.SelectedItems.Contains(item))
-                blueprintMap[item].Select();
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -174,7 +174,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (isDraggingBlueprint)
             {
                 DragOperationCompleted();
-
                 changeHandler?.EndChange();
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -27,11 +27,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// <summary>
     /// A blueprint container generally displayed as an overlay to a ruleset's playfield.
     /// </summary>
-    public class ComposeBlueprintContainer : BlueprintContainer
+    public class ComposeBlueprintContainer : EditorBlueprintContainer
     {
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         private readonly Container<PlacementBlueprint> placementBlueprintContainer;
+
+        protected new EditorSelectionHandler SelectionHandler => (EditorSelectionHandler)base.SelectionHandler;
 
         private PlacementBlueprint currentPlacement;
         private InputManager inputManager;
@@ -113,7 +115,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // convert to game space coordinates
             delta = firstBlueprint.ToScreenSpace(delta) - firstBlueprint.ToScreenSpace(Vector2.Zero);
 
-            SelectionHandler.HandleMovement(new MoveSelectionEvent(firstBlueprint, firstBlueprint.ScreenSpaceSelectionPoint + delta));
+            SelectionHandler.HandleMovement(new MoveSelectionEvent<HitObject>(firstBlueprint, firstBlueprint.ScreenSpaceSelectionPoint + delta));
         }
 
         private void updatePlacementNewCombo()
@@ -237,7 +239,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 updatePlacementPosition();
         }
 
-        protected sealed override SelectionBlueprint CreateBlueprintFor(HitObject hitObject)
+        protected sealed override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject hitObject)
         {
             var drawable = Composer.HitObjects.FirstOrDefault(d => d.HitObject == hitObject);
 
@@ -249,9 +251,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public virtual OverlaySelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject) => null;
 
-        protected override void OnBlueprintAdded(HitObject hitObject)
+        protected override void OnBlueprintAdded(SelectionBlueprint<HitObject> item)
         {
-            base.OnBlueprintAdded(hitObject);
+            base.OnBlueprintAdded(item);
 
             refreshTool();
 

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public virtual OverlaySelectionBlueprint CreateBlueprintFor(DrawableHitObject hitObject) => null;
 
-        protected override void OnBlueprintAdded(SelectionBlueprint<HitObject> item)
+        protected override void OnBlueprintAdded(HitObject item)
         {
             base.OnBlueprintAdded(item);
 

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -239,9 +239,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 updatePlacementPosition();
         }
 
-        protected sealed override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject hitObject)
+        protected sealed override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject item)
         {
-            var drawable = Composer.HitObjects.FirstOrDefault(d => d.HitObject == hitObject);
+            var drawable = Composer.HitObjects.FirstOrDefault(d => d.HitObject == item);
 
             if (drawable == null)
                 return null;

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -1,0 +1,176 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public class EditorBlueprintContainer : BlueprintContainer<HitObject>
+    {
+        [Resolved]
+        protected EditorClock EditorClock { get; private set; }
+
+        [Resolved]
+        protected EditorBeatmap Beatmap { get; private set; }
+
+        protected readonly HitObjectComposer Composer;
+
+        private readonly BindableList<HitObject> selectedHitObjects = new BindableList<HitObject>();
+
+        protected EditorBlueprintContainer(HitObjectComposer composer)
+        {
+            Composer = composer;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            // For non-pooled rulesets, hitobjects are already present in the playfield which allows the blueprints to be loaded in the async context.
+            if (Composer != null)
+            {
+                foreach (var obj in Composer.HitObjects)
+                    AddBlueprintFor(obj.HitObject);
+            }
+
+            selectedHitObjects.BindTo(Beatmap.SelectedHitObjects);
+            selectedHitObjects.CollectionChanged += (selectedObjects, args) =>
+            {
+                switch (args.Action)
+                {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var o in args.NewItems)
+                            SelectionBlueprints.FirstOrDefault(b => b.Item == o)?.Select();
+                        break;
+
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var o in args.OldItems)
+                            SelectionBlueprints.FirstOrDefault(b => b.Item == o)?.Deselect();
+
+                        break;
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Beatmap.HitObjectAdded += AddBlueprintFor;
+            Beatmap.HitObjectRemoved += RemoveBlueprintFor;
+
+            if (Composer != null)
+            {
+                // For pooled rulesets, blueprints must be added for hitobjects already "current" as they would've not been "current" during the async load addition process above.
+                foreach (var obj in Composer.HitObjects)
+                    AddBlueprintFor(obj.HitObject);
+
+                Composer.Playfield.HitObjectUsageBegan += AddBlueprintFor;
+                Composer.Playfield.HitObjectUsageFinished += RemoveBlueprintFor;
+            }
+        }
+
+        protected override IEnumerable<SelectionBlueprint<HitObject>> SortForMovement(IReadOnlyList<SelectionBlueprint<HitObject>> blueprints)
+            => blueprints.OrderBy(b => b.Item.StartTime);
+
+        protected override bool AllowDeselection => !EditorClock.IsRunning;
+
+        protected override bool ApplySnapResult(SelectionBlueprint<HitObject>[] blueprints, SnapResult result)
+        {
+            if (!base.ApplySnapResult(blueprints, result))
+                return false;
+
+            if (result.Time.HasValue)
+            {
+                // Apply the start time at the newly snapped-to position
+                double offset = result.Time.Value - blueprints.First().Item.StartTime;
+
+                if (offset != 0)
+                    Beatmap.PerformOnSelection(obj => obj.StartTime += offset);
+            }
+
+            return true;
+        }
+
+        protected override void AddBlueprintFor(HitObject item)
+        {
+            if (item is IBarLine)
+                return;
+
+            base.AddBlueprintFor(item);
+        }
+
+        protected override void OnBlueprintAdded(SelectionBlueprint<HitObject> blueprint)
+        {
+            base.OnBlueprintAdded(blueprint);
+            if (Beatmap.SelectedHitObjects.Contains(blueprint.Item))
+                blueprint.Select();
+        }
+
+        protected override void UpdateSelection()
+        {
+            base.UpdateSelection();
+
+            // handle positional change etc.
+            foreach (var blueprint in SelectionBlueprints)
+                Beatmap.Update(blueprint.Item);
+        }
+
+        protected override bool OnDoubleClick(DoubleClickEvent e)
+        {
+            if (!base.OnDoubleClick(e))
+                return false;
+
+            EditorClock?.SeekSmoothlyTo(ClickedBlueprint.Item.StartTime);
+            return true;
+        }
+
+        protected override Container<SelectionBlueprint<HitObject>> CreateSelectionBlueprintContainer() => new HitObjectOrderedSelectionContainer { RelativeSizeAxes = Axes.Both };
+
+        protected override void SelectAll()
+        {
+            Composer.Playfield.KeepAllAlive();
+
+            base.SelectAll();
+        }
+
+        protected override void OnBlueprintSelected(SelectionBlueprint<HitObject> blueprint)
+        {
+            base.OnBlueprintSelected(blueprint);
+
+            Composer.Playfield.SetKeepAlive(blueprint.Item, true);
+        }
+
+        protected override void OnBlueprintDeselected(SelectionBlueprint<HitObject> blueprint)
+        {
+            base.OnBlueprintDeselected(blueprint);
+
+            Composer.Playfield.SetKeepAlive(blueprint.Item, false);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (Beatmap != null)
+            {
+                Beatmap.HitObjectAdded -= AddBlueprintFor;
+                Beatmap.HitObjectRemoved -= RemoveBlueprintFor;
+            }
+
+            if (Composer != null)
+            {
+                Composer.Playfield.HitObjectUsageBegan -= AddBlueprintFor;
+                Composer.Playfield.HitObjectUsageFinished -= RemoveBlueprintFor;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override IEnumerable<SelectionBlueprint<HitObject>> SortForMovement(IReadOnlyList<SelectionBlueprint<HitObject>> blueprints)
             => blueprints.OrderBy(b => b.Item.StartTime);
 
-        protected override bool AllowDeselection => !EditorClock.IsRunning;
+        protected override bool AllowDeselectionDuringDrag => !EditorClock.IsRunning;
 
         protected override bool ApplySnapResult(SelectionBlueprint<HitObject>[] blueprints, SnapResult result)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -135,6 +135,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override Container<SelectionBlueprint<HitObject>> CreateSelectionBlueprintContainer() => new HitObjectOrderedSelectionContainer { RelativeSizeAxes = Axes.Both };
 
+        protected override SelectionHandler<HitObject> CreateSelectionHandler() => new EditorSelectionHandler();
+
         protected override void SelectAll()
         {
             Composer.Playfield.KeepAllAlive();

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -108,13 +108,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             base.AddBlueprintFor(item);
         }
 
-        protected override void OnBlueprintAdded(SelectionBlueprint<HitObject> blueprint)
-        {
-            base.OnBlueprintAdded(blueprint);
-            if (Beatmap.SelectedHitObjects.Contains(blueprint.Item))
-                blueprint.Select();
-        }
-
         protected override void UpdateSelection()
         {
             base.UpdateSelection();

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -108,9 +108,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             base.AddBlueprintFor(item);
         }
 
-        protected override void UpdateSelection()
+        protected override void DragOperationCompleted()
         {
-            base.UpdateSelection();
+            base.DragOperationCompleted();
 
             // handle positional change etc.
             foreach (var blueprint in SelectionBlueprints)

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -101,11 +101,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         protected virtual void UpdateTernaryStates()
         {
-            SelectionNewComboState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<IHasComboInformation>(), h => h.NewCombo);
+            SelectionNewComboState.Value = GetStateFromSelection(SelectedItems.OfType<IHasComboInformation>(), h => h.NewCombo);
 
             foreach (var (sampleName, bindable) in SelectionSampleStates)
             {
-                bindable.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects, h => h.Samples.Any(s => s.Name == sampleName));
+                bindable.Value = GetStateFromSelection(SelectedItems, h => h.Samples.Any(s => s.Name == sampleName));
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #endregion
 
-        #region Sample Changes
+        #region Ternary state changes
 
         /// <summary>
         /// Adds a hit sample to all selected <see cref="HitObject"/>s.
@@ -141,6 +141,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         /// <summary>
+        /// Removes a hit sample from all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <param name="sampleName">The name of the hit sample.</param>
+        public void RemoveHitSample(string sampleName)
+        {
+            EditorBeatmap.PerformOnSelection(h => h.SamplesBindable.RemoveAll(s => s.Name == sampleName));
+        }
+
+        /// <summary>
         /// Set the new combo state of all selected <see cref="HitObject"/>s.
         /// </summary>
         /// <param name="state">Whether to set or unset.</param>
@@ -156,15 +165,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 comboInfo.NewCombo = state;
                 EditorBeatmap.Update(h);
             });
-        }
-
-        /// <summary>
-        /// Removes a hit sample from all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <param name="sampleName">The name of the hit sample.</param>
-        public void RemoveHitSample(string sampleName)
-        {
-            EditorBeatmap.PerformOnSelection(h => h.SamplesBindable.RemoveAll(s => s.Name == sampleName));
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -1,0 +1,233 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Humanizer;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Audio;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public class EditorSelectionHandler : SelectionHandler<HitObject>, IHasContextMenu
+    {
+        [Resolved]
+        protected EditorBeatmap EditorBeatmap { get; private set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            createStateBindables();
+
+            // bring in updates from selection changes
+            EditorBeatmap.HitObjectUpdated += _ => Scheduler.AddOnce(UpdateTernaryStates);
+            EditorBeatmap.SelectedHitObjects.BindTo(SelectedItems);
+
+            SelectedItems.CollectionChanged += (sender, args) =>
+            {
+                Scheduler.AddOnce(UpdateTernaryStates);
+            };
+        }
+
+        internal override void HandleSelected(SelectionBlueprint<HitObject> blueprint)
+        {
+            base.HandleSelected(blueprint);
+
+            // there are potentially multiple SelectionHandlers active, but we only want to add hitobjects to the selected list once.
+            if (!EditorBeatmap.SelectedHitObjects.Contains(blueprint.Item))
+                EditorBeatmap.SelectedHitObjects.Add(blueprint.Item);
+        }
+
+        internal override void HandleDeselected(SelectionBlueprint<HitObject> blueprint)
+        {
+            base.HandleDeselected(blueprint);
+
+            EditorBeatmap.SelectedHitObjects.Remove(blueprint.Item);
+        }
+
+        protected override void DeleteItems(IEnumerable<HitObject> items) => EditorBeatmap.RemoveRange(items);
+
+        #region Selection State
+
+        /// <summary>
+        /// The state of "new combo" for all selected hitobjects.
+        /// </summary>
+        public readonly Bindable<TernaryState> SelectionNewComboState = new Bindable<TernaryState>();
+
+        /// <summary>
+        /// The state of each sample type for all selected hitobjects. Keys match with <see cref="HitSampleInfo"/> constant specifications.
+        /// </summary>
+        public readonly Dictionary<string, Bindable<TernaryState>> SelectionSampleStates = new Dictionary<string, Bindable<TernaryState>>();
+
+        /// <summary>
+        /// Set up ternary state bindables and bind them to selection/hitobject changes (in both directions)
+        /// </summary>
+        private void createStateBindables()
+        {
+            foreach (var sampleName in HitSampleInfo.AllAdditions)
+            {
+                var bindable = new Bindable<TernaryState>
+                {
+                    Description = sampleName.Replace("hit", string.Empty).Titleize()
+                };
+
+                bindable.ValueChanged += state =>
+                {
+                    switch (state.NewValue)
+                    {
+                        case TernaryState.False:
+                            RemoveHitSample(sampleName);
+                            break;
+
+                        case TernaryState.True:
+                            AddHitSample(sampleName);
+                            break;
+                    }
+                };
+
+                SelectionSampleStates[sampleName] = bindable;
+            }
+
+            // new combo
+            SelectionNewComboState.ValueChanged += state =>
+            {
+                switch (state.NewValue)
+                {
+                    case TernaryState.False:
+                        SetNewCombo(false);
+                        break;
+
+                    case TernaryState.True:
+                        SetNewCombo(true);
+                        break;
+                }
+            };
+        }
+
+        /// <summary>
+        /// Called when context menu ternary states may need to be recalculated (selection changed or hitobject updated).
+        /// </summary>
+        protected virtual void UpdateTernaryStates()
+        {
+            SelectionNewComboState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<IHasComboInformation>(), h => h.NewCombo);
+
+            foreach (var (sampleName, bindable) in SelectionSampleStates)
+            {
+                bindable.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects, h => h.Samples.Any(s => s.Name == sampleName));
+            }
+        }
+
+        /// <summary>
+        /// Given a selection target and a function of truth, retrieve the correct ternary state for display.
+        /// </summary>
+        protected TernaryState GetStateFromSelection<T>(IEnumerable<T> selection, Func<T, bool> func)
+        {
+            if (selection.Any(func))
+                return selection.All(func) ? TernaryState.True : TernaryState.Indeterminate;
+
+            return TernaryState.False;
+        }
+
+        #endregion
+
+        #region Sample Changes
+
+        /// <summary>
+        /// Adds a hit sample to all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <param name="sampleName">The name of the hit sample.</param>
+        public void AddHitSample(string sampleName)
+        {
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                // Make sure there isn't already an existing sample
+                if (h.Samples.Any(s => s.Name == sampleName))
+                    return;
+
+                h.Samples.Add(new HitSampleInfo(sampleName));
+            });
+        }
+
+        /// <summary>
+        /// Set the new combo state of all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <param name="state">Whether to set or unset.</param>
+        /// <exception cref="InvalidOperationException">Throws if any selected object doesn't implement <see cref="IHasComboInformation"/></exception>
+        public void SetNewCombo(bool state)
+        {
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                var comboInfo = h as IHasComboInformation;
+
+                if (comboInfo == null || comboInfo.NewCombo == state) return;
+
+                comboInfo.NewCombo = state;
+                EditorBeatmap.Update(h);
+            });
+        }
+
+        /// <summary>
+        /// Removes a hit sample from all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <param name="sampleName">The name of the hit sample.</param>
+        public void RemoveHitSample(string sampleName)
+        {
+            EditorBeatmap.PerformOnSelection(h => h.SamplesBindable.RemoveAll(s => s.Name == sampleName));
+        }
+
+        #endregion
+
+        #region Context Menu
+
+        public MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                if (!SelectedBlueprints.Any(b => b.IsHovered))
+                    return Array.Empty<MenuItem>();
+
+                var items = new List<MenuItem>();
+
+                items.AddRange(GetContextMenuItemsForSelection(SelectedBlueprints));
+
+                if (SelectedBlueprints.All(b => b.Item is IHasComboInformation))
+                {
+                    items.Add(new TernaryStateMenuItem("New combo") { State = { BindTarget = SelectionNewComboState } });
+                }
+
+                if (SelectedBlueprints.Count == 1)
+                    items.AddRange(SelectedBlueprints[0].ContextMenuItems);
+
+                items.AddRange(new[]
+                {
+                    new OsuMenuItem("Sound")
+                    {
+                        Items = SelectionSampleStates.Select(kvp =>
+                            new TernaryStateMenuItem(kvp.Value.Description) { State = { BindTarget = kvp.Value } }).ToArray()
+                    },
+                    new OsuMenuItem("Delete", MenuItemType.Destructive, DeleteSelected),
+                });
+
+                return items.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Provide context menu items relevant to current selection. Calling base is not required.
+        /// </summary>
+        /// <param name="selection">The current selection.</param>
+        /// <returns>The relevant menu items.</returns>
+        protected virtual IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
+            => Enumerable.Empty<MenuItem>();
+
+        #endregion
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -37,22 +37,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
         }
 
-        internal override void HandleSelected(SelectionBlueprint<HitObject> blueprint)
-        {
-            base.HandleSelected(blueprint);
-
-            // there are potentially multiple SelectionHandlers active, but we only want to add hitobjects to the selected list once.
-            if (!EditorBeatmap.SelectedHitObjects.Contains(blueprint.Item))
-                EditorBeatmap.SelectedHitObjects.Add(blueprint.Item);
-        }
-
-        internal override void HandleDeselected(SelectionBlueprint<HitObject> blueprint)
-        {
-            base.HandleDeselected(blueprint);
-
-            EditorBeatmap.SelectedHitObjects.Remove(blueprint.Item);
-        }
-
         protected override void DeleteItems(IEnumerable<HitObject> items) => EditorBeatmap.RemoveRange(items);
 
         #region Selection State

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Audio;
 using osu.Game.Graphics.UserInterface;
@@ -17,7 +16,7 @@ using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
-    public class EditorSelectionHandler : SelectionHandler<HitObject>, IHasContextMenu
+    public class EditorSelectionHandler : SelectionHandler<HitObject>
     {
         [Resolved]
         protected EditorBeatmap EditorBeatmap { get; private set; }
@@ -171,46 +170,24 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #region Context Menu
 
-        public MenuItem[] ContextMenuItems
-        {
-            get
-            {
-                if (!SelectedBlueprints.Any(b => b.IsHovered))
-                    return Array.Empty<MenuItem>();
-
-                var items = new List<MenuItem>();
-
-                items.AddRange(GetContextMenuItemsForSelection(SelectedBlueprints));
-
-                if (SelectedBlueprints.All(b => b.Item is IHasComboInformation))
-                {
-                    items.Add(new TernaryStateMenuItem("New combo") { State = { BindTarget = SelectionNewComboState } });
-                }
-
-                if (SelectedBlueprints.Count == 1)
-                    items.AddRange(SelectedBlueprints[0].ContextMenuItems);
-
-                items.AddRange(new[]
-                {
-                    new OsuMenuItem("Sound")
-                    {
-                        Items = SelectionSampleStates.Select(kvp =>
-                            new TernaryStateMenuItem(kvp.Value.Description) { State = { BindTarget = kvp.Value } }).ToArray()
-                    },
-                    new OsuMenuItem("Delete", MenuItemType.Destructive, DeleteSelected),
-                });
-
-                return items.ToArray();
-            }
-        }
-
         /// <summary>
         /// Provide context menu items relevant to current selection. Calling base is not required.
         /// </summary>
         /// <param name="selection">The current selection.</param>
         /// <returns>The relevant menu items.</returns>
-        protected virtual IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
-            => Enumerable.Empty<MenuItem>();
+        protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
+        {
+            if (SelectedBlueprints.All(b => b.Item is IHasComboInformation))
+            {
+                yield return new TernaryStateMenuItem("New combo") { State = { BindTarget = SelectionNewComboState } };
+            }
+
+            yield return new OsuMenuItem("Sound")
+            {
+                Items = SelectionSampleStates.Select(kvp =>
+                    new TernaryStateMenuItem(kvp.Value.Description) { State = { BindTarget = kvp.Value } }).ToArray()
+            };
+        }
 
         #endregion
     }

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -29,8 +29,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // bring in updates from selection changes
             EditorBeatmap.HitObjectUpdated += _ => Scheduler.AddOnce(UpdateTernaryStates);
-            EditorBeatmap.SelectedHitObjects.BindTo(SelectedItems);
 
+            SelectedItems.BindTo(EditorBeatmap.SelectedHitObjects);
             SelectedItems.CollectionChanged += (sender, args) =>
             {
                 Scheduler.AddOnce(UpdateTernaryStates);

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectOrderedSelectionContainer.cs
@@ -11,17 +11,17 @@ using osu.Game.Rulesets.Objects;
 namespace osu.Game.Screens.Edit.Compose.Components
 {
     /// <summary>
-    /// A container for <see cref="SelectionBlueprint"/> ordered by their <see cref="HitObject"/> start times.
+    /// A container for <see cref="SelectionBlueprint{HitObject}"/> ordered by their <see cref="HitObject"/> start times.
     /// </summary>
-    public sealed class HitObjectOrderedSelectionContainer : Container<SelectionBlueprint>
+    public sealed class HitObjectOrderedSelectionContainer : Container<SelectionBlueprint<HitObject>>
     {
-        public override void Add(SelectionBlueprint drawable)
+        public override void Add(SelectionBlueprint<HitObject> drawable)
         {
             base.Add(drawable);
             bindStartTime(drawable);
         }
 
-        public override bool Remove(SelectionBlueprint drawable)
+        public override bool Remove(SelectionBlueprint<HitObject> drawable)
         {
             if (!base.Remove(drawable))
                 return false;
@@ -36,11 +36,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             unbindAllStartTimes();
         }
 
-        private readonly Dictionary<SelectionBlueprint, IBindable> startTimeMap = new Dictionary<SelectionBlueprint, IBindable>();
+        private readonly Dictionary<SelectionBlueprint<HitObject>, IBindable> startTimeMap = new Dictionary<SelectionBlueprint<HitObject>, IBindable>();
 
-        private void bindStartTime(SelectionBlueprint blueprint)
+        private void bindStartTime(SelectionBlueprint<HitObject> blueprint)
         {
-            var bindable = blueprint.HitObject.StartTimeBindable.GetBoundCopy();
+            var bindable = blueprint.Item.StartTimeBindable.GetBoundCopy();
 
             bindable.BindValueChanged(_ =>
             {
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             startTimeMap[blueprint] = bindable;
         }
 
-        private void unbindStartTime(SelectionBlueprint blueprint)
+        private void unbindStartTime(SelectionBlueprint<HitObject> blueprint)
         {
             startTimeMap[blueprint].UnbindAll();
             startTimeMap.Remove(blueprint);
@@ -66,16 +66,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override int Compare(Drawable x, Drawable y)
         {
-            var xObj = (SelectionBlueprint)x;
-            var yObj = (SelectionBlueprint)y;
+            var xObj = (SelectionBlueprint<HitObject>)x;
+            var yObj = (SelectionBlueprint<HitObject>)y;
 
             // Put earlier blueprints towards the end of the list, so they handle input first
-            int i = yObj.HitObject.StartTime.CompareTo(xObj.HitObject.StartTime);
+            int i = yObj.Item.StartTime.CompareTo(xObj.Item.StartTime);
 
             if (i != 0) return i;
 
             // Fall back to end time if the start time is equal.
-            i = yObj.HitObject.GetEndTime().CompareTo(xObj.HitObject.GetEndTime());
+            i = yObj.Item.GetEndTime().CompareTo(xObj.Item.GetEndTime());
 
             return i == 0 ? CompareReverseChildID(y, x) : i;
         }

--- a/osu.Game/Screens/Edit/Compose/Components/MoveSelectionEvent.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/MoveSelectionEvent.cs
@@ -9,12 +9,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// <summary>
     /// An event which occurs when a <see cref="OverlaySelectionBlueprint"/> is moved.
     /// </summary>
-    public class MoveSelectionEvent
+    public class MoveSelectionEvent<T>
     {
         /// <summary>
-        /// The <see cref="SelectionBlueprint"/> that triggered this <see cref="MoveSelectionEvent"/>.
+        /// The <see cref="SelectionBlueprint{T}"/> that triggered this <see cref="MoveSelectionEvent{T}"/>.
         /// </summary>
-        public readonly SelectionBlueprint Blueprint;
+        public readonly SelectionBlueprint<T> Blueprint;
 
         /// <summary>
         /// The expected screen-space position of the hitobject at the current cursor position.
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         public readonly Vector2 InstantDelta;
 
-        public MoveSelectionEvent(SelectionBlueprint blueprint, Vector2 screenSpacePosition)
+        public MoveSelectionEvent(SelectionBlueprint<T> blueprint, Vector2 screenSpacePosition)
         {
             Blueprint = blueprint;
             ScreenSpacePosition = screenSpacePosition;

--- a/osu.Game/Screens/Edit/Compose/Components/MoveSelectionEvent.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/MoveSelectionEvent.cs
@@ -17,12 +17,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public readonly SelectionBlueprint<T> Blueprint;
 
         /// <summary>
-        /// The expected screen-space position of the hitobject at the current cursor position.
+        /// The expected screen-space position of the blueprint's item at the current cursor position.
         /// </summary>
         public readonly Vector2 ScreenSpacePosition;
 
         /// <summary>
-        /// The distance between <see cref="ScreenSpacePosition"/> and the hitobject's current position, in the coordinate-space of the hitobject's parent.
+        /// The distance between <see cref="ScreenSpacePosition"/> and the blueprint's current position, in the coordinate-space of the blueprint item's parent.
         /// </summary>
         public readonly Vector2 InstantDelta;
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Handles the selected items being scaled.
         /// </summary>
-        /// <param name="scale">The delta scale to apply, in playfield local coordinates.</param>
+        /// <param name="scale">The delta scale to apply, in local coordinates.</param>
         /// <param name="anchor">The point of reference where the scale is originating from.</param>
         /// <returns>Whether any items could be scaled.</returns>
         public virtual bool HandleScale(Vector2 scale, Anchor anchor) => false;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -15,26 +15,27 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Edit;
-using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
     /// <summary>
-    /// A component which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.
+    /// A component which outlines items and handles movement of selections.
     /// </summary>
     public abstract class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>
     {
         /// <summary>
         /// The currently selected blueprints.
         /// Should be used when operations are dealing directly with the visible blueprints.
-        /// For more general selection operations, use <see cref="osu.Game.Screens.Edit.EditorBeatmap.SelectedHitObjects"/> instead.
+        /// For more general selection operations, use <see cref="SelectedItems"/> instead.
         /// </summary>
         public IReadOnlyList<SelectionBlueprint<T>> SelectedBlueprints => selectedBlueprints;
 
-        public BindableList<T> SelectedItems = new BindableList<T>();
+        /// <summary>
+        /// The currently selected items.
+        /// </summary>
+        public readonly BindableList<T> SelectedItems = new BindableList<T>();
 
         private readonly List<SelectionBlueprint<T>> selectedBlueprints;
 
@@ -124,45 +125,45 @@ namespace osu.Game.Screens.Edit.Compose.Components
         #region User Input Handling
 
         /// <summary>
-        /// Handles the selected <see cref="DrawableHitObject"/>s being moved.
+        /// Handles the selected items being moved.
         /// </summary>
         /// <remarks>
-        /// Just returning true is enough to allow <see cref="HitObject.StartTime"/> updates to take place.
+        /// Just returning true is enough to allow default movement to take place.
         /// Custom implementation is only required if other attributes are to be considered, like changing columns.
         /// </remarks>
         /// <param name="moveEvent">The move event.</param>
         /// <returns>
-        /// Whether any <see cref="DrawableHitObject"/>s could be moved.
+        /// Whether any items could be moved.
         /// Returning true will also propagate StartTime changes provided by the closest <see cref="IPositionSnapProvider.SnapScreenSpacePositionToValidTime"/>.
         /// </returns>
         public virtual bool HandleMovement(MoveSelectionEvent<T> moveEvent) => false;
 
         /// <summary>
-        /// Handles the selected <see cref="DrawableHitObject"/>s being rotated.
+        /// Handles the selected items being rotated.
         /// </summary>
         /// <param name="angle">The delta angle to apply to the selection.</param>
-        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be rotated.</returns>
+        /// <returns>Whether any items could be rotated.</returns>
         public virtual bool HandleRotation(float angle) => false;
 
         /// <summary>
-        /// Handles the selected <see cref="DrawableHitObject"/>s being scaled.
+        /// Handles the selected items being scaled.
         /// </summary>
         /// <param name="scale">The delta scale to apply, in playfield local coordinates.</param>
         /// <param name="anchor">The point of reference where the scale is originating from.</param>
-        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be scaled.</returns>
+        /// <returns>Whether any items could be scaled.</returns>
         public virtual bool HandleScale(Vector2 scale, Anchor anchor) => false;
 
         /// <summary>
-        /// Handles the selected <see cref="DrawableHitObject"/>s being flipped.
+        /// Handles the selected items being flipped.
         /// </summary>
         /// <param name="direction">The direction to flip</param>
-        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be flipped.</returns>
+        /// <returns>Whether any items could be flipped.</returns>
         public virtual bool HandleFlip(Direction direction) => false;
 
         /// <summary>
-        /// Handles the selected <see cref="DrawableHitObject"/>s being reversed pattern-wise.
+        /// Handles the selected items being reversed pattern-wise.
         /// </summary>
-        /// <returns>Whether any <see cref="DrawableHitObject"/>s could be reversed.</returns>
+        /// <returns>Whether any items could be reversed.</returns>
         public virtual bool HandleReverse() => false;
 
         public bool OnPressed(PlatformAction action)
@@ -196,7 +197,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         internal virtual void HandleSelected(SelectionBlueprint<T> blueprint)
         {
-            // there are potentially multiple SelectionHandlers active, but we only want to add hitobjects to the selected list once.
+            // there are potentially multiple SelectionHandlers active, but we only want to add items to the selected list once.
             if (!SelectedItems.Contains(blueprint.Item))
                 SelectedItems.Add(blueprint.Item);
 
@@ -323,7 +324,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (selectedBlueprints.Count == 0)
                 return;
 
-            // Move the rectangle to cover the hitobjects
+            // Move the rectangle to cover the items
             var topLeft = new Vector2(float.MaxValue, float.MaxValue);
             var bottomRight = new Vector2(float.MinValue, float.MinValue);
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -4,25 +4,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Objects.Types;
 using osuTK;
 using osuTK.Input;
 
@@ -31,16 +25,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// <summary>
     /// A component which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.
     /// </summary>
-    public class SelectionHandler : CompositeDrawable, IKeyBindingHandler<PlatformAction>, IHasContextMenu
+    public class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>
     {
         /// <summary>
         /// The currently selected blueprints.
         /// Should be used when operations are dealing directly with the visible blueprints.
         /// For more general selection operations, use <see cref="osu.Game.Screens.Edit.EditorBeatmap.SelectedHitObjects"/> instead.
         /// </summary>
-        public IEnumerable<SelectionBlueprint> SelectedBlueprints => selectedBlueprints;
+        public IReadOnlyList<SelectionBlueprint<T>> SelectedBlueprints => selectedBlueprints;
 
-        private readonly List<SelectionBlueprint> selectedBlueprints;
+        protected BindableList<T> SelectedItems = new BindableList<T>();
+
+        private readonly List<SelectionBlueprint<T>> selectedBlueprints;
 
         private Drawable content;
 
@@ -48,15 +44,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected SelectionBox SelectionBox { get; private set; }
 
-        [Resolved]
-        protected EditorBeatmap EditorBeatmap { get; private set; }
-
         [Resolved(CanBeNull = true)]
         protected IEditorChangeHandler ChangeHandler { get; private set; }
 
         public SelectionHandler()
         {
-            selectedBlueprints = new List<SelectionBlueprint>();
+            selectedBlueprints = new List<SelectionBlueprint<T>>();
 
             RelativeSizeAxes = Axes.Both;
             AlwaysPresent = true;
@@ -66,8 +59,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            createStateBindables();
-
             InternalChild = content = new Container
             {
                 Children = new Drawable[]
@@ -94,6 +85,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     },
                     SelectionBox = CreateSelectionBox(),
                 }
+            };
+
+            SelectedItems.CollectionChanged += (sender, args) =>
+            {
+                Scheduler.AddOnce(updateVisibility);
             };
         }
 
@@ -139,7 +135,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Whether any <see cref="DrawableHitObject"/>s could be moved.
         /// Returning true will also propagate StartTime changes provided by the closest <see cref="IPositionSnapProvider.SnapScreenSpacePositionToValidTime"/>.
         /// </returns>
-        public virtual bool HandleMovement(MoveSelectionEvent moveEvent) => false;
+        public virtual bool HandleMovement(MoveSelectionEvent<T> moveEvent) => false;
 
         /// <summary>
         /// Handles the selected <see cref="DrawableHitObject"/>s being rotated.
@@ -174,7 +170,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (action.ActionMethod)
             {
                 case PlatformActionMethod.Delete:
-                    deleteSelected();
+                    DeleteSelected();
                     return true;
             }
 
@@ -198,24 +194,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Handle a blueprint becoming selected.
         /// </summary>
         /// <param name="blueprint">The blueprint.</param>
-        internal void HandleSelected(SelectionBlueprint blueprint)
+        internal virtual void HandleSelected(SelectionBlueprint<T> blueprint)
         {
             selectedBlueprints.Add(blueprint);
-
-            // there are potentially multiple SelectionHandlers active, but we only want to add hitobjects to the selected list once.
-            if (!EditorBeatmap.SelectedHitObjects.Contains(blueprint.HitObject))
-                EditorBeatmap.SelectedHitObjects.Add(blueprint.HitObject);
         }
 
         /// <summary>
         /// Handle a blueprint becoming deselected.
         /// </summary>
         /// <param name="blueprint">The blueprint.</param>
-        internal void HandleDeselected(SelectionBlueprint blueprint)
+        internal virtual void HandleDeselected(SelectionBlueprint<T> blueprint)
         {
             selectedBlueprints.Remove(blueprint);
-
-            EditorBeatmap.SelectedHitObjects.Remove(blueprint.HitObject);
         }
 
         /// <summary>
@@ -224,7 +214,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         /// <param name="e">The mouse event responsible for selection.</param>
         /// <returns>Whether a selection was performed.</returns>
-        internal bool MouseDownSelectionRequested(SelectionBlueprint blueprint, MouseButtonEvent e)
+        internal bool MouseDownSelectionRequested(SelectionBlueprint<T> blueprint, MouseButtonEvent e)
         {
             if (e.ShiftPressed && e.Button == MouseButton.Right)
             {
@@ -248,7 +238,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         /// <param name="e">The mouse event responsible for deselection.</param>
         /// <returns>Whether a deselection was performed.</returns>
-        internal bool MouseUpSelectionRequested(SelectionBlueprint blueprint, MouseButtonEvent e)
+        internal bool MouseUpSelectionRequested(SelectionBlueprint<T> blueprint, MouseButtonEvent e)
         {
             if (blueprint.IsSelected)
             {
@@ -259,15 +249,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return false;
         }
 
-        private void handleQuickDeletion(SelectionBlueprint blueprint)
+        private void handleQuickDeletion(SelectionBlueprint<T> blueprint)
         {
             if (blueprint.HandleQuickDeletion())
                 return;
 
             if (!blueprint.IsSelected)
-                EditorBeatmap.Remove(blueprint.HitObject);
+                DeleteItems(new[] { blueprint.Item });
             else
-                deleteSelected();
+                DeleteSelected();
+        }
+
+        protected virtual void DeleteItems(IEnumerable<T> items)
+        {
         }
 
         /// <summary>
@@ -275,7 +269,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         /// <param name="blueprint">The blueprint to select.</param>
         /// <returns>Whether selection state was changed.</returns>
-        private bool ensureSelected(SelectionBlueprint blueprint)
+        private bool ensureSelected(SelectionBlueprint<T> blueprint)
         {
             if (blueprint.IsSelected)
                 return false;
@@ -285,9 +279,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return true;
         }
 
-        private void deleteSelected()
+        protected void DeleteSelected()
         {
-            EditorBeatmap.RemoveRange(selectedBlueprints.Select(b => b.HitObject));
+            DeleteItems(selectedBlueprints.Select(b => b.Item));
         }
 
         #endregion
@@ -295,11 +289,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
         #region Outline Display
 
         /// <summary>
-        /// Updates whether this <see cref="SelectionHandler"/> is visible.
+        /// Updates whether this <see cref="SelectionHandler{T}"/> is visible.
         /// </summary>
         private void updateVisibility()
         {
-            int count = EditorBeatmap.SelectedHitObjects.Count;
+            int count = SelectedItems.Count;
 
             selectionDetailsText.Text = count > 0 ? count.ToString() : string.Empty;
 
@@ -338,189 +332,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             content.Size = bottomRight - topLeft;
             content.Position = topLeft;
         }
-
-        #endregion
-
-        #region Sample Changes
-
-        /// <summary>
-        /// Adds a hit sample to all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <param name="sampleName">The name of the hit sample.</param>
-        public void AddHitSample(string sampleName)
-        {
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                // Make sure there isn't already an existing sample
-                if (h.Samples.Any(s => s.Name == sampleName))
-                    return;
-
-                h.Samples.Add(new HitSampleInfo(sampleName));
-            });
-        }
-
-        /// <summary>
-        /// Set the new combo state of all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <param name="state">Whether to set or unset.</param>
-        /// <exception cref="InvalidOperationException">Throws if any selected object doesn't implement <see cref="IHasComboInformation"/></exception>
-        public void SetNewCombo(bool state)
-        {
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                var comboInfo = h as IHasComboInformation;
-
-                if (comboInfo == null || comboInfo.NewCombo == state) return;
-
-                comboInfo.NewCombo = state;
-                EditorBeatmap.Update(h);
-            });
-        }
-
-        /// <summary>
-        /// Removes a hit sample from all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <param name="sampleName">The name of the hit sample.</param>
-        public void RemoveHitSample(string sampleName)
-        {
-            EditorBeatmap.PerformOnSelection(h => h.SamplesBindable.RemoveAll(s => s.Name == sampleName));
-        }
-
-        #endregion
-
-        #region Selection State
-
-        /// <summary>
-        /// The state of "new combo" for all selected hitobjects.
-        /// </summary>
-        public readonly Bindable<TernaryState> SelectionNewComboState = new Bindable<TernaryState>();
-
-        /// <summary>
-        /// The state of each sample type for all selected hitobjects. Keys match with <see cref="HitSampleInfo"/> constant specifications.
-        /// </summary>
-        public readonly Dictionary<string, Bindable<TernaryState>> SelectionSampleStates = new Dictionary<string, Bindable<TernaryState>>();
-
-        /// <summary>
-        /// Set up ternary state bindables and bind them to selection/hitobject changes (in both directions)
-        /// </summary>
-        private void createStateBindables()
-        {
-            foreach (var sampleName in HitSampleInfo.AllAdditions)
-            {
-                var bindable = new Bindable<TernaryState>
-                {
-                    Description = sampleName.Replace("hit", string.Empty).Titleize()
-                };
-
-                bindable.ValueChanged += state =>
-                {
-                    switch (state.NewValue)
-                    {
-                        case TernaryState.False:
-                            RemoveHitSample(sampleName);
-                            break;
-
-                        case TernaryState.True:
-                            AddHitSample(sampleName);
-                            break;
-                    }
-                };
-
-                SelectionSampleStates[sampleName] = bindable;
-            }
-
-            // new combo
-            SelectionNewComboState.ValueChanged += state =>
-            {
-                switch (state.NewValue)
-                {
-                    case TernaryState.False:
-                        SetNewCombo(false);
-                        break;
-
-                    case TernaryState.True:
-                        SetNewCombo(true);
-                        break;
-                }
-            };
-
-            // bring in updates from selection changes
-            EditorBeatmap.HitObjectUpdated += _ => Scheduler.AddOnce(UpdateTernaryStates);
-            EditorBeatmap.SelectedHitObjects.CollectionChanged += (sender, args) =>
-            {
-                Scheduler.AddOnce(updateVisibility);
-                Scheduler.AddOnce(UpdateTernaryStates);
-            };
-        }
-
-        /// <summary>
-        /// Called when context menu ternary states may need to be recalculated (selection changed or hitobject updated).
-        /// </summary>
-        protected virtual void UpdateTernaryStates()
-        {
-            SelectionNewComboState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<IHasComboInformation>(), h => h.NewCombo);
-
-            foreach (var (sampleName, bindable) in SelectionSampleStates)
-            {
-                bindable.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects, h => h.Samples.Any(s => s.Name == sampleName));
-            }
-        }
-
-        /// <summary>
-        /// Given a selection target and a function of truth, retrieve the correct ternary state for display.
-        /// </summary>
-        protected TernaryState GetStateFromSelection<T>(IEnumerable<T> selection, Func<T, bool> func)
-        {
-            if (selection.Any(func))
-                return selection.All(func) ? TernaryState.True : TernaryState.Indeterminate;
-
-            return TernaryState.False;
-        }
-
-        #endregion
-
-        #region Context Menu
-
-        public MenuItem[] ContextMenuItems
-        {
-            get
-            {
-                if (!selectedBlueprints.Any(b => b.IsHovered))
-                    return Array.Empty<MenuItem>();
-
-                var items = new List<MenuItem>();
-
-                items.AddRange(GetContextMenuItemsForSelection(selectedBlueprints));
-
-                if (selectedBlueprints.All(b => b.HitObject is IHasComboInformation))
-                {
-                    items.Add(new TernaryStateMenuItem("New combo") { State = { BindTarget = SelectionNewComboState } });
-                }
-
-                if (selectedBlueprints.Count == 1)
-                    items.AddRange(selectedBlueprints[0].ContextMenuItems);
-
-                items.AddRange(new[]
-                {
-                    new OsuMenuItem("Sound")
-                    {
-                        Items = SelectionSampleStates.Select(kvp =>
-                            new TernaryStateMenuItem(kvp.Value.Description) { State = { BindTarget = kvp.Value } }).ToArray()
-                    },
-                    new OsuMenuItem("Delete", MenuItemType.Destructive, deleteSelected),
-                });
-
-                return items.ToArray();
-            }
-        }
-
-        /// <summary>
-        /// Provide context menu items relevant to current selection. Calling base is not required.
-        /// </summary>
-        /// <param name="selection">The current selection.</param>
-        /// <returns>The relevant menu items.</returns>
-        protected virtual IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint> selection)
-            => Enumerable.Empty<MenuItem>();
 
         #endregion
     }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -196,6 +196,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         internal virtual void HandleSelected(SelectionBlueprint<T> blueprint)
         {
+            // there are potentially multiple SelectionHandlers active, but we only want to add hitobjects to the selected list once.
+            if (!SelectedItems.Contains(blueprint.Item))
+                SelectedItems.Add(blueprint.Item);
+
             selectedBlueprints.Add(blueprint);
         }
 
@@ -205,6 +209,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="blueprint">The blueprint.</param>
         internal virtual void HandleDeselected(SelectionBlueprint<T> blueprint)
         {
+            SelectedItems.Remove(blueprint.Item);
             selectedBlueprints.Remove(blueprint);
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -134,7 +134,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <param name="moveEvent">The move event.</param>
         /// <returns>
         /// Whether any items could be moved.
-        /// Returning true will also propagate StartTime changes provided by the closest <see cref="IPositionSnapProvider.SnapScreenSpacePositionToValidTime"/>.
         /// </returns>
         public virtual bool HandleMovement(MoveSelectionEvent<T> moveEvent) => false;
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         public IReadOnlyList<SelectionBlueprint<T>> SelectedBlueprints => selectedBlueprints;
 
-        protected BindableList<T> SelectedItems = new BindableList<T>();
+        public BindableList<T> SelectedItems = new BindableList<T>();
 
         private readonly List<SelectionBlueprint<T>> selectedBlueprints;
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -312,7 +312,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         /// <summary>
-        /// Triggered whenever the set of selected objects changes.
+        /// Triggered whenever the set of selected items changes.
         /// Should update the selection box's state to match supported operations.
         /// </summary>
         protected virtual void OnSelectionChanged()

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// <summary>
     /// A component which outlines <see cref="DrawableHitObject"/>s and handles movement of selections.
     /// </summary>
-    public class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>
+    public abstract class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>
     {
         /// <summary>
         /// The currently selected blueprints.
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [Resolved(CanBeNull = true)]
         protected IEditorChangeHandler ChangeHandler { get; private set; }
 
-        public SelectionHandler()
+        protected SelectionHandler()
         {
             selectedBlueprints = new List<SelectionBlueprint<T>>();
 
@@ -265,9 +265,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 DeleteSelected();
         }
 
-        protected virtual void DeleteItems(IEnumerable<T> items)
-        {
-        }
+        /// <summary>
+        /// Called whenever the deletion of items has been requested.
+        /// </summary>
+        /// <param name="items">The items to be deleted.</param>
+        protected abstract void DeleteItems(IEnumerable<T> items);
 
         /// <summary>
         /// Ensure the blueprint is in a selected state.

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -8,12 +8,15 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osuTK;
 using osuTK.Input;
@@ -23,7 +26,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// <summary>
     /// A component which outlines items and handles movement of selections.
     /// </summary>
-    public abstract class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>
+    public abstract class SelectionHandler<T> : CompositeDrawable, IKeyBindingHandler<PlatformAction>, IHasContextMenu
     {
         /// <summary>
         /// The currently selected blueprints.
@@ -339,6 +342,38 @@ namespace osu.Game.Screens.Edit.Compose.Components
             content.Size = bottomRight - topLeft;
             content.Position = topLeft;
         }
+
+        #endregion
+
+        #region Context Menu
+
+        public MenuItem[] ContextMenuItems
+        {
+            get
+            {
+                if (!SelectedBlueprints.Any(b => b.IsHovered))
+                    return Array.Empty<MenuItem>();
+
+                var items = new List<MenuItem>();
+
+                items.AddRange(GetContextMenuItemsForSelection(SelectedBlueprints));
+
+                if (SelectedBlueprints.Count == 1)
+                    items.AddRange(SelectedBlueprints[0].ContextMenuItems);
+
+                items.Add(new OsuMenuItem("Delete", MenuItemType.Destructive, DeleteSelected));
+
+                return items.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Provide context menu items relevant to current selection. Calling base is not required.
+        /// </summary>
+        /// <param name="selection">The current selection.</param>
+        /// <returns>The relevant menu items.</returns>
+        protected virtual IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<T>> selection)
+            => Enumerable.Empty<MenuItem>();
 
         #endregion
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -179,9 +179,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new TimelineSelectionHandler();
 
-        protected override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject hitObject)
+        protected override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject item)
         {
-            return new TimelineHitObjectBlueprint(hitObject)
+            return new TimelineHitObjectBlueprint(item)
             {
                 OnDragHandled = handleScrollViaDrag
             };

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -26,7 +26,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
-    public class TimelineHitObjectBlueprint : SelectionBlueprint
+    public class TimelineHitObjectBlueprint : SelectionBlueprint<HitObject>
     {
         private const float circle_size = 38;
 
@@ -49,13 +49,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private ISkinSource skin { get; set; }
 
-        public TimelineHitObjectBlueprint(HitObject hitObject)
-            : base(hitObject)
+        public TimelineHitObjectBlueprint(HitObject item)
+            : base(item)
         {
             Anchor = Anchor.CentreLeft;
             Origin = Anchor.CentreLeft;
 
-            startTime = hitObject.StartTimeBindable.GetBoundCopy();
+            startTime = item.StartTimeBindable.GetBoundCopy();
             startTime.BindValueChanged(time => X = (float)time.NewValue, true);
 
             RelativePositionAxes = Axes.X;
@@ -95,9 +95,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 },
             });
 
-            if (hitObject is IHasDuration)
+            if (item is IHasDuration)
             {
-                colouredComponents.Add(new DragArea(hitObject)
+                colouredComponents.Add(new DragArea(item)
                 {
                     OnDragHandled = e => OnDragHandled?.Invoke(e)
                 });
@@ -108,7 +108,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.LoadComplete();
 
-            if (HitObject is IHasComboInformation comboInfo)
+            if (Item is IHasComboInformation comboInfo)
             {
                 indexInCurrentComboBindable = comboInfo.IndexInCurrentComboBindable.GetBoundCopy();
                 indexInCurrentComboBindable.BindValueChanged(_ => updateComboIndex(), true);
@@ -136,7 +136,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void updateComboColour()
         {
-            if (!(HitObject is IHasComboInformation combo))
+            if (!(Item is IHasComboInformation combo))
                 return;
 
             var comboColours = skin.GetConfig<GlobalSkinColours, IReadOnlyList<Color4>>(GlobalSkinColours.ComboColours)?.Value ?? Array.Empty<Color4>();
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 border.Hide();
             }
 
-            if (HitObject is IHasDuration duration && duration.Duration > 0)
+            if (Item is IHasDuration duration && duration.Duration > 0)
                 circle.Colour = ColourInfo.GradientHorizontal(comboColour, comboColour.Lighten(0.4f));
             else
                 circle.Colour = comboColour;
@@ -166,14 +166,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             base.Update();
 
             // no bindable so we perform this every update
-            float duration = (float)(HitObject.GetEndTime() - HitObject.StartTime);
+            float duration = (float)(Item.GetEndTime() - Item.StartTime);
 
             if (Width != duration)
             {
                 Width = duration;
 
                 // kind of haphazard but yeah, no bindables.
-                if (HitObject is IHasRepeats repeats)
+                if (Item is IHasRepeats repeats)
                     updateRepeats(repeats);
             }
         }


### PR DESCRIPTION
This allows for some pretty OP things to occur going forward. Is a prerequisite for some upcoming skinning components.

No hurry to merge this, just want to PR it for feedback. Feels okay, I think.

I think we'll likely want to move the base components out into their own namespace (this is still deeply nested within the editor screen namespace), but that can probably come later?