### PR TITLE
Fix bonus score not calculated from the correct statistics

### DIFF
--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -287,6 +287,23 @@ namespace osu.Game.Tests.Rulesets.Scoring
             Assert.AreEqual(expectedReturnValue, hitResult.IsScorable());
         }
 
+        [TestCase(HitResult.Perfect, 1_000_000)]
+        [TestCase(HitResult.SmallTickHit, 1_000_000)]
+        [TestCase(HitResult.LargeTickHit, 1_000_000)]
+        [TestCase(HitResult.SmallBonus, 700_000 + Judgement.SMALL_BONUS_SCORE)]
+        [TestCase(HitResult.LargeBonus, 700_000 + Judgement.LARGE_BONUS_SCORE)]
+        public void TestGetScoreWithExternalStatistics(HitResult result, int expectedScore)
+        {
+            var statistic = new Dictionary<HitResult, int> { { result, 1 } };
+
+            scoreProcessor.ApplyBeatmap(new Beatmap
+            {
+                HitObjects = { new TestHitObject(result) }
+            });
+
+            Assert.That(scoreProcessor.GetImmediateScore(ScoringMode.Standardised, result.AffectsCombo() ? 1 : 0, statistic), Is.EqualTo(expectedScore).Within(0.5d));
+        }
+
         private class TestJudgement : Judgement
         {
             public override HitResult MaxResult { get; }

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Judgements;
@@ -51,7 +50,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
             };
             scoreProcessor.ApplyResult(judgementResult);
 
-            Assert.IsTrue(Precision.AlmostEquals(expectedScore, scoreProcessor.TotalScore.Value));
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(expectedScore).Within(0.5d));
         }
 
         /// <summary>
@@ -118,7 +117,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
                 scoreProcessor.ApplyResult(judgementResult);
             }
 
-            Assert.IsTrue(Precision.AlmostEquals(expectedScore, scoreProcessor.TotalScore.Value, 0.5));
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(expectedScore).Within(0.5d));
         }
 
         /// <remarks>
@@ -158,7 +157,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
             };
             scoreProcessor.ApplyResult(lastJudgementResult);
 
-            Assert.IsTrue(Precision.AlmostEquals(expectedScore, scoreProcessor.TotalScore.Value, 0.5));
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(expectedScore).Within(0.5d));
         }
 
         [Test]
@@ -169,7 +168,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
             scoreProcessor.Mode.Value = scoringMode;
             scoreProcessor.ApplyBeatmap(new TestBeatmap(new RulesetInfo()));
 
-            Assert.IsTrue(Precision.AlmostEquals(0, scoreProcessor.TotalScore.Value));
+            Assert.That(scoreProcessor.TotalScore.Value, Is.Zero);
         }
 
         [TestCase(HitResult.IgnoreHit, HitResult.IgnoreMiss)]

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Rulesets.Scoring
                 computedBaseScore += Judgement.ToNumericResult(pair.Key) * pair.Value;
             }
 
-            return GetScore(mode, maxAchievableCombo, calculateAccuracyRatio(computedBaseScore), calculateComboRatio(maxCombo), scoreResultCounts);
+            return GetScore(mode, maxAchievableCombo, calculateAccuracyRatio(computedBaseScore), calculateComboRatio(maxCombo), statistics);
         }
 
         /// <summary>


### PR DESCRIPTION
When passing a statistics dictionary in, the `ScoreProcessor` would use the internal statistics dictionary instead.

Note that the score (700000 + Bonus) is technically incorrect, but that's a bug to be fixed in another slightly larger and more complex PR.