### PR TITLE
Add support for custom controls to SettingSourceAttribute

### DIFF
--- a/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
+++ b/osu.Game.Tests/Mods/SettingsSourceAttributeTest.cs
@@ -4,7 +4,10 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Configuration;
+using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Tests.Mods
 {
@@ -26,6 +29,16 @@ namespace osu.Game.Tests.Mods
             Assert.That(orderedSettings[3].Item2.Name, Is.EqualTo(nameof(ClassWithSettings.UnorderedSetting)));
         }
 
+        [Test]
+        public void TestCustomControl()
+        {
+            var objectWithCustomSettingControl = new ClassWithCustomSettingControl();
+            var settings = objectWithCustomSettingControl.CreateSettingsControls().ToArray();
+
+            Assert.That(settings, Has.Length.EqualTo(1));
+            Assert.That(settings[0], Is.TypeOf<CustomSettingsControl>());
+        }
+
         private class ClassWithSettings
         {
             [SettingSource("Unordered setting", "Should be last")]
@@ -39,6 +52,22 @@ namespace osu.Game.Tests.Mods
 
             [SettingSource("Third setting", "Yet another description", 3)]
             public BindableInt ThirdSetting { get; set; } = new BindableInt();
+        }
+
+        private class ClassWithCustomSettingControl
+        {
+            [SettingSource("Custom setting", "Should be a custom control", SettingControlType = typeof(CustomSettingsControl))]
+            public BindableInt UnorderedSetting { get; set; } = new BindableInt();
+        }
+
+        private class CustomSettingsControl : SettingsItem<int>
+        {
+            protected override Drawable CreateControl() => new CustomControl();
+
+            private class CustomControl : Drawable, IHasCurrentValue<int>
+            {
+                public Bindable<int> Current { get; set; } = new Bindable<int>();
+            }
         }
     }
 }

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Configuration
         /// The type of the settings control which handles this setting source.
         /// </summary>
         /// <remarks>
-        /// Must be a type deriving <see cref="SettingsItem{T}"/>.
+        /// Must be a type deriving <see cref="SettingsItem{T}"/> with a public parameterless constructor.
         /// </remarks>
         public Type? SettingControlType { get; set; }
 

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Configuration
         /// The type of the settings control which handles this setting source.
         /// </summary>
         /// <remarks>
-        /// Must be a type deriving <see cref="SettingsItem{T}"/> with a public constructor.
+        /// Must be a type deriving <see cref="SettingsItem{T}"/>.
         /// </remarks>
         public Type? SettingControlType { get; set; }
 

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -1,12 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Overlays.Settings;
@@ -31,7 +34,15 @@ namespace osu.Game.Configuration
 
         public int? OrderPosition { get; }
 
-        public SettingSourceAttribute(string label, string description = null)
+        /// <summary>
+        /// The type of the settings control which handles this setting source.
+        /// </summary>
+        /// <remarks>
+        /// Must be a type deriving <see cref="SettingsItem{T}"/> with a public constructor.
+        /// </remarks>
+        public Type? SettingControlType { get; set; }
+
+        public SettingSourceAttribute(string? label, string? description = null)
         {
             Label = label ?? string.Empty;
             Description = description ?? string.Empty;
@@ -66,6 +77,22 @@ namespace osu.Game.Configuration
             foreach (var (attr, property) in obj.GetOrderedSettingsSourceProperties())
             {
                 object value = property.GetValue(obj);
+
+                if (attr.SettingControlType != null)
+                {
+                    var controlType = attr.SettingControlType;
+                    if (controlType.EnumerateBaseTypes().All(t => !t.IsGenericType || t.GetGenericTypeDefinition() != typeof(SettingsItem<>)))
+                        throw new InvalidOperationException($"{nameof(SettingSourceAttribute)} had an unsupported custom control type ({controlType.ReadableName()})");
+
+                    var control = (Drawable)Activator.CreateInstance(controlType);
+                    controlType.GetProperty(nameof(SettingsItem<object>.LabelText))?.SetValue(control, attr.Label);
+                    controlType.GetProperty(nameof(SettingsItem<object>.TooltipText))?.SetValue(control, attr.Description);
+                    controlType.GetProperty(nameof(SettingsItem<object>.Current))?.SetValue(control, value);
+
+                    yield return control;
+
+                    continue;
+                }
 
                 switch (value)
                 {


### PR DESCRIPTION
I'm not super set on having this support if there's disagreement as to whether it should be a thing, but I thought it'd be nice to have. Could be used for https://github.com/ppy/osu/pull/12568.

Follows the same model as `JsonConverter` - provide a `Type` to the attribute and it'll construct it. I haven't added it to the ctors, so you'd need to explicitly set the property via `[SettingSource(SettingControlType = typeof(X))]`.

Sample implementation:
```csharp
public class OsuModRandom : ModRandom, IApplicableMod
{
    public override string Description => "Random";

    [SettingSource("Seed", "", SettingControlType = typeof(OsuModRandomSettingsControl))]
    public BindableNumber<int> Seed { get; } = new BindableInt { Value = RNG.Next() };
}

public class OsuModRandomSettingsControl : SettingsItem<int>
{
    protected override Drawable CreateControl() => new ControlWithButton
    {
        RelativeSizeAxes = Axes.X,
        Margin = new MarginPadding { Top = 5 }
    };

    private class ControlWithButton : CompositeDrawable, IHasCurrentValue<int>
    {
        private readonly BindableWithCurrent<int> current = new BindableWithCurrent<int>();

        public Bindable<int> Current
        {
            get => current.Current;
            set => current.Current = value;
        }

        private readonly OsuTextBox textBox;

        public ControlWithButton()
        {
            AutoSizeAxes = Axes.Y;

            InternalChildren = new Drawable[]
            {
                new GridContainer
                {
                    RelativeSizeAxes = Axes.X,
                    AutoSizeAxes = Axes.Y,
                    ColumnDimensions = new[]
                    {
                        new Dimension(),
                        new Dimension(GridSizeMode.Absolute, 2),
                        new Dimension(GridSizeMode.Relative, 0.25f)
                    },
                    RowDimensions = new[]
                    {
                        new Dimension(GridSizeMode.AutoSize)
                    },
                    Content = new[]
                    {
                        new Drawable[]
                        {
                            textBox = new OsuNumberBox
                            {
                                RelativeSizeAxes = Axes.X,
                                CommitOnFocusLost = true
                            },
                            null,
                            new TriangleButton
                            {
                                RelativeSizeAxes = Axes.Both,
                                Height = 1,
                                Text = "Randomise!",
                                Action = randomiseSeed
                            }
                        }
                    }
                }
            };

            current.BindValueChanged(_ => updateDisplay(), true);
            textBox.Current.BindValueChanged(onTextBoxChanged);
            textBox.OnCommit += (_, __) => updateDisplay();
        }

        private void onTextBoxChanged(ValueChangedEvent<string> seed)
        {
            string newSeed = seed.NewValue;

            while (!string.IsNullOrEmpty(newSeed) && !int.TryParse(newSeed, out _))
                newSeed = newSeed[..^1];

            if (!int.TryParse(newSeed, out var intVal))
                intVal = 0;

            current.Value = intVal;
        }

        private void updateDisplay() => textBox.Text = current.Value.ToString();

        private void randomiseSeed() => current.Value = RNG.Next();
    }
}
```
![image](https://user-images.githubusercontent.com/1329837/116288395-726f5d00-a7cc-11eb-8c69-c83e29b6f945.png)
