### PR TITLE
Fix possible precision loss on exporting legacy replays

### DIFF
--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -95,8 +95,9 @@ namespace osu.Game.Scoring.Legacy
 
                     foreach (var f in score.Replay.Frames.OfType<IConvertibleReplayFrame>().Select(f => f.ToLegacy(beatmap)))
                     {
-                        replayData.Append(FormattableString.Invariant($"{(int)Math.Round(f.Time - lastF.Time)}|{f.MouseX ?? 0}|{f.MouseY ?? 0}|{(int)f.ButtonState},"));
+                        replayData.Append(FormattableString.Invariant($"{Math.Round(f.Time - lastF.Time)}|{f.MouseX ?? 0}|{f.MouseY ?? 0}|{(int)f.ButtonState},"));
                         lastF = f;
+                        lastF.Time = Math.Round(f.Time);
                     }
                 }
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -8,7 +8,6 @@ using System.Text;
 using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.IO.Legacy;
-using osu.Game.Replays.Legacy;
 using osu.Game.Rulesets.Replays.Types;
 using SharpCompress.Compressors.LZMA;
 
@@ -91,13 +90,14 @@ namespace osu.Game.Scoring.Legacy
 
                 if (score.Replay != null)
                 {
-                    int lastTimeRounded = 0;
+                    int lastTime = 0;
+
                     foreach (var f in score.Replay.Frames.OfType<IConvertibleReplayFrame>().Select(f => f.ToLegacy(beatmap)))
                     {
                         // Rounding because stable could only parse integral values
-                        int timeRounded = (int)Math.Round(f.Time);
-                        replayData.Append(FormattableString.Invariant($"{timeRounded - lastTimeRounded}|{f.MouseX ?? 0}|{f.MouseY ?? 0}|{(int)f.ButtonState},"));
-                        lastTimeRounded = timeRounded;
+                        int time = (int)Math.Round(f.Time);
+                        replayData.Append(FormattableString.Invariant($"{time - lastTime}|{f.MouseX ?? 0}|{f.MouseY ?? 0}|{(int)f.ButtonState},"));
+                        lastTime = time;
                     }
                 }
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -91,13 +91,13 @@ namespace osu.Game.Scoring.Legacy
 
                 if (score.Replay != null)
                 {
-                    LegacyReplayFrame lastF = new LegacyReplayFrame(0, 0, 0, ReplayButtonState.None);
-
+                    int lastTimeRounded = 0;
                     foreach (var f in score.Replay.Frames.OfType<IConvertibleReplayFrame>().Select(f => f.ToLegacy(beatmap)))
                     {
-                        replayData.Append(FormattableString.Invariant($"{Math.Round(f.Time - lastF.Time)}|{f.MouseX ?? 0}|{f.MouseY ?? 0}|{(int)f.ButtonState},"));
-                        lastF = f;
-                        lastF.Time = Math.Round(f.Time);
+                        // Rounding because stable could only parse integral values
+                        int timeRounded = (int)Math.Round(f.Time);
+                        replayData.Append(FormattableString.Invariant($"{timeRounded - lastTimeRounded}|{f.MouseX ?? 0}|{f.MouseY ?? 0}|{(int)f.ButtonState},"));
+                        lastTimeRounded = timeRounded;
                     }
                 }
 


### PR DESCRIPTION
Before:
![screenshot001](https://user-images.githubusercontent.com/50285552/116397181-ddff0c00-a858-11eb-95ec-8ca9380d1812.jpg)

After:
![screenshot002](https://user-images.githubusercontent.com/50285552/116397153-d2abe080-a858-11eb-9963-da6b76cab6c6.jpg)
