### PR TITLE
Refactor `SelectionBlueprint` and `MoveSelectionEvent` to work in screen-space coordinates

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Mania.Edit
         {
             var maniaPlayfield = ((ManiaHitObjectComposer)composer).Playfield;
 
-            var currentColumn = maniaPlayfield.GetColumnByPosition(moveEvent.ScreenSpacePosition);
+            var currentColumn = maniaPlayfield.GetColumnByPosition(moveEvent.Blueprint.ScreenSpaceSelectionPoint + moveEvent.ScreenSpaceDelta);
             if (currentColumn == null)
                 return;
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Utils;
+using osu.Game.Extensions;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
@@ -42,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             // this will potentially move the selection out of bounds...
             foreach (var h in hitObjects)
-                h.Position += moveEvent.InstantDelta;
+                h.Position += this.ScreenSpaceDeltaToParentSpace(moveEvent.ScreenSpaceDelta);
 
             // but this will be corrected.
             moveSelectionInBounds();

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Threading;
+using osuTK;
 
 namespace osu.Game.Extensions
 {
@@ -32,5 +34,14 @@ namespace osu.Game.Extensions
             scheduler.Add(repeatDelegate);
             return repeatDelegate;
         }
+
+        /// <summary>
+        /// Accepts a delta vector in screen-space coordinates and converts it to one which can be applied to this drawable's position.
+        /// </summary>
+        /// <param name="drawable">The drawable.</param>
+        /// <param name="delta">A delta in screen-space coordinates.</param>
+        /// <returns>The delta vector in Parent's coordinates.</returns>
+        public static Vector2 ScreenSpaceDeltaToParentSpace(this Drawable drawable, Vector2 delta) =>
+            drawable.Parent.ToLocalSpace(drawable.Parent.ToScreenSpace(Vector2.Zero) + delta);
     }
 }

--- a/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/OverlaySelectionBlueprint.cs
@@ -34,7 +34,5 @@ namespace osu.Game.Rulesets.Edit
         public override Vector2 ScreenSpaceSelectionPoint => DrawableObject.ScreenSpaceDrawQuad.Centre;
 
         public override Quad SelectionQuad => DrawableObject.ScreenSpaceDrawQuad;
-
-        public override Vector2 GetInstantDelta(Vector2 screenSpacePosition) => DrawableObject.Parent.ToLocalSpace(screenSpacePosition) - DrawableObject.Position;
     }
 }

--- a/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/SelectionBlueprint.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Edit
         public virtual MenuItem[] ContextMenuItems => Array.Empty<MenuItem>();
 
         /// <summary>
-        /// The screen-space point that causes this <see cref="OverlaySelectionBlueprint"/> to be selected.
+        /// The screen-space point that causes this <see cref="OverlaySelectionBlueprint"/> to be selected via a drag.
         /// </summary>
         public virtual Vector2 ScreenSpaceSelectionPoint => ScreenSpaceDrawQuad.Centre;
 
@@ -135,8 +135,6 @@ namespace osu.Game.Rulesets.Edit
         /// The screen-space quad that outlines this <see cref="OverlaySelectionBlueprint"/> for selections.
         /// </summary>
         public virtual Quad SelectionQuad => ScreenSpaceDrawQuad;
-
-        public virtual Vector2 GetInstantDelta(Vector2 screenSpacePosition) => Parent.ToLocalSpace(screenSpacePosition) - Position;
 
         /// <summary>
         /// Handle to perform a partial deletion when the user requests a quick delete (Shift+Right Click).

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -436,14 +436,17 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 // check for positional snap for every object in selection (for things like object-object snapping)
                 for (var i = 0; i < movementBlueprintOriginalPositions.Length; i++)
                 {
-                    var testPosition = movementBlueprintOriginalPositions[i] + distanceTravelled;
+                    Vector2 originalPosition = movementBlueprintOriginalPositions[i];
+                    var testPosition = originalPosition + distanceTravelled;
 
                     var positionalResult = snapProvider.SnapScreenSpacePositionToValidPosition(testPosition);
 
                     if (positionalResult.ScreenSpacePosition == testPosition) continue;
 
+                    var delta = positionalResult.ScreenSpacePosition - movementBlueprints[i].ScreenSpaceSelectionPoint;
+
                     // attempt to move the objects, and abort any time based snapping if we can.
-                    if (SelectionHandler.HandleMovement(new MoveSelectionEvent<T>(movementBlueprints[i], positionalResult.ScreenSpacePosition)))
+                    if (SelectionHandler.HandleMovement(new MoveSelectionEvent<T>(movementBlueprints[i], delta)))
                         return true;
                 }
             }
@@ -459,14 +462,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (result == null)
             {
-                return SelectionHandler.HandleMovement(new MoveSelectionEvent<T>(movementBlueprints.First(), movePosition));
+                return SelectionHandler.HandleMovement(new MoveSelectionEvent<T>(movementBlueprints.First(), movePosition - movementBlueprints.First().ScreenSpaceSelectionPoint));
             }
 
             return ApplySnapResult(movementBlueprints, result);
         }
 
         protected virtual bool ApplySnapResult(SelectionBlueprint<T>[] blueprints, SnapResult result) =>
-            SelectionHandler.HandleMovement(new MoveSelectionEvent<T>(blueprints.First(), result.ScreenSpacePosition));
+            SelectionHandler.HandleMovement(new MoveSelectionEvent<T>(blueprints.First(), result.ScreenSpacePosition - blueprints.First().ScreenSpaceSelectionPoint));
 
         /// <summary>
         /// Finishes the current movement of selected blueprints.

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // convert to game space coordinates
             delta = firstBlueprint.ToScreenSpace(delta) - firstBlueprint.ToScreenSpace(Vector2.Zero);
 
-            SelectionHandler.HandleMovement(new MoveSelectionEvent<HitObject>(firstBlueprint, firstBlueprint.ScreenSpaceSelectionPoint + delta));
+            SelectionHandler.HandleMovement(new MoveSelectionEvent<HitObject>(firstBlueprint, delta));
         }
 
         private void updatePlacementNewCombo()

--- a/osu.Game/Screens/Edit/Compose/Components/MoveSelectionEvent.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/MoveSelectionEvent.cs
@@ -17,21 +17,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public readonly SelectionBlueprint<T> Blueprint;
 
         /// <summary>
-        /// The expected screen-space position of the blueprint's item at the current cursor position.
+        /// The screen-space delta of this move event.
         /// </summary>
-        public readonly Vector2 ScreenSpacePosition;
+        public readonly Vector2 ScreenSpaceDelta;
 
-        /// <summary>
-        /// The distance between <see cref="ScreenSpacePosition"/> and the blueprint's current position, in the coordinate-space of the blueprint item's parent.
-        /// </summary>
-        public readonly Vector2 InstantDelta;
-
-        public MoveSelectionEvent(SelectionBlueprint<T> blueprint, Vector2 screenSpacePosition)
+        public MoveSelectionEvent(SelectionBlueprint<T> blueprint, Vector2 screenSpaceDelta)
         {
             Blueprint = blueprint;
-            ScreenSpacePosition = screenSpacePosition;
-
-            InstantDelta = Blueprint.GetInstantDelta(ScreenSpacePosition);
+            ScreenSpaceDelta = screenSpaceDelta;
         }
     }
 }


### PR DESCRIPTION
Until now, the implementation of the overrides in `SelectionBlueprint` have been confusing to the point where I would just implement by trial-and-error (or copying from an existing implementation). This was due to a combination of using "object" space coordinates (ie. the thing the `Blueprint` is operating on) and screen-space coordinates.

This change switches all event related coordinates to screen-space, which is how we already handle rotation/scale operations. With the introduction of other editor types where the related objects are drawables, this also makes a lot more sense.

- [x] Depends on https://github.com/ppy/osu/pull/12596 for conflict avoidance. Can be rebased on `master` if required, just a few generic type additions/removals.