### PR TITLE
Compute selection box area using the bounding box of the blueprints instead

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -328,21 +328,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 return;
 
             // Move the rectangle to cover the items
-            var topLeft = new Vector2(float.MaxValue, float.MaxValue);
-            var bottomRight = new Vector2(float.MinValue, float.MinValue);
+            RectangleF selectionRect = ToLocalSpace(selectedBlueprints.First().SelectionQuad).AABBFloat;
 
-            foreach (var blueprint in selectedBlueprints)
-            {
-                var blueprintRect = blueprint.SelectionQuad.AABBFloat;
-                topLeft = Vector2.ComponentMin(topLeft, ToLocalSpace(blueprintRect.TopLeft));
-                bottomRight = Vector2.ComponentMax(bottomRight, ToLocalSpace(blueprintRect.BottomRight));
-            }
+            foreach (var blueprint in selectedBlueprints.Skip(1))
+                selectionRect = RectangleF.Union(selectionRect, ToLocalSpace(blueprint.SelectionQuad).AABBFloat);
 
-            topLeft -= new Vector2(5);
-            bottomRight += new Vector2(5);
+            selectionRect = selectionRect.Inflate(5f);
 
-            content.Size = bottomRight - topLeft;
-            content.Position = topLeft;
+            content.Position = selectionRect.Location;
+            content.Size = selectionRect.Size;
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
@@ -332,8 +333,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             foreach (var blueprint in selectedBlueprints)
             {
-                topLeft = Vector2.ComponentMin(topLeft, ToLocalSpace(blueprint.SelectionQuad.TopLeft));
-                bottomRight = Vector2.ComponentMax(bottomRight, ToLocalSpace(blueprint.SelectionQuad.BottomRight));
+                var blueprintRect = blueprint.SelectionQuad.AABBFloat;
+                topLeft = Vector2.ComponentMin(topLeft, ToLocalSpace(blueprintRect.TopLeft));
+                bottomRight = Vector2.ComponentMax(bottomRight, ToLocalSpace(blueprintRect.BottomRight));
             }
 
             topLeft -= new Vector2(5);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -328,10 +328,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 return;
 
             // Move the rectangle to cover the items
-            RectangleF selectionRect = ToLocalSpace(selectedBlueprints.First().SelectionQuad).AABBFloat;
+            RectangleF selectionRect = ToLocalSpace(selectedBlueprints[0].SelectionQuad).AABBFloat;
 
-            foreach (var blueprint in selectedBlueprints.Skip(1))
-                selectionRect = RectangleF.Union(selectionRect, ToLocalSpace(blueprint.SelectionQuad).AABBFloat);
+            for (int i = 1; i < selectedBlueprints.Count; i++)
+                selectionRect = RectangleF.Union(selectionRect, ToLocalSpace(selectedBlueprints[i].SelectionQuad).AABBFloat);
 
             selectionRect = selectionRect.Inflate(5f);
 


### PR DESCRIPTION
Resolves issues where the blueprints may have a rotated quad, causing the selection box to have negative size area, and that can be the case with #12626:

https://user-images.githubusercontent.com/22781491/116797481-d22c7780-aaee-11eb-99e9-03bd5540993b.mp4

With this PR:

https://user-images.githubusercontent.com/22781491/116797483-d5276800-aaee-11eb-8dde-c956559e5ba1.mp4

I've also rewritten the computation logic to use `RectangleF`'s helper method `Union` and `Inflate` instead, feels nicer that way.