### PR TITLE
Downgrade Humanizer back to 2.8.26

### DIFF
--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="DiffPlex" Version="1.7.0" />
-    <PackageReference Include="Humanizer" Version="2.9.9" />
+    <PackageReference Include="Humanizer" Version="2.8.26" />
     <PackageReference Include="MessagePack" Version="2.2.85" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="5.0.5" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -89,7 +89,7 @@
   <!-- Xamarin.iOS does not automatically handle transitive dependencies from NuGet packages. -->
   <ItemGroup Label="Transitive Dependencies">
     <PackageReference Include="DiffPlex" Version="1.6.3" />
-    <PackageReference Include="Humanizer" Version="2.9.9" />
+    <PackageReference Include="Humanizer" Version="2.8.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
Reverts the bump from `2.9.9` back into `2.8.26` due to https://github.com/Humanizr/Humanizer/issues/1059#issue-870731217, as a temporary workaround until the underlying issue is resolved.

Should resolve #12655 