### PR TITLE
Remove unsafe access to Composer.HitObjects

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (Composer != null)
             {
-                // For pooled rulesets, blueprints must be added for hitobjects already "current" as they would've not been "current" during the async load addition process above.
                 foreach (var obj in Composer.HitObjects)
                     AddBlueprintFor(obj.HitObject);
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -34,13 +34,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            // For non-pooled rulesets, hitobjects are already present in the playfield which allows the blueprints to be loaded in the async context.
-            if (Composer != null)
-            {
-                foreach (var obj in Composer.HitObjects)
-                    AddBlueprintFor(obj.HitObject);
-            }
-
             selectedHitObjects.BindTo(Beatmap.SelectedHitObjects);
             selectedHitObjects.CollectionChanged += (selectedObjects, args) =>
             {


### PR DESCRIPTION
This will temporarily reduce load responsivement of the osu!mania editor (due to missing pooling implementation) but I think that's fine in the short term.

```csharp
TearDown : System.AggregateException : One or more errors occurred. (Collection was modified; enumeration operation may not execute.)
  ----> System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
--TearDown
   at osu.Framework.Testing.TestScene.checkForErrors()
   at osu.Framework.Testing.TestScene.RunTests()
--InvalidOperationException
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Linq.Enumerable.CastIterator[TResult](IEnumerable source)+MoveNext()
   at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source, Int32& length)
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.OrderedEnumerable`1.GetEnumerator()+MoveNext()
   at osu.Game.Screens.Edit.Compose.Components.EditorBlueprintContainer.load() in /Users/dean/Projects/osu/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs:line 40
--- End of stack trace from previous location ---
   at osu.Framework.Allocation.BackgroundDependencyLoaderAttribute.<>c__DisplayClass6_0.<CreateActivator>b__4(Object target, IReadOnlyDependencyContainer dc)
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, 
```