### PR TITLE
Fix tooltips displaying for hidden `SelectionHandler` content

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -132,8 +132,8 @@ namespace osu.Game.Tests.Visual.Editing
             {
                 AddStep("deselect", () => EditorBeatmap.SelectedHitObjects.Clear());
 
-                AddUntilStep("timeline selection box is not visible", () => Editor.ChildrenOfType<Timeline>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha == 0);
-                AddUntilStep("composer selection box is not visible", () => Editor.ChildrenOfType<HitObjectComposer>().First().ChildrenOfType<EditorSelectionHandler>().First().Alpha == 0);
+                AddUntilStep("timeline selection box is not visible", () => Editor.ChildrenOfType<Timeline>().First().ChildrenOfType<SelectionBox>().First().Alpha == 0);
+                AddUntilStep("composer selection box is not visible", () => Editor.ChildrenOfType<HitObjectComposer>().First().ChildrenOfType<SelectionBox>().First().Alpha == 0);
             }
 
             AddStep("paste hitobject", () => Editor.Paste());

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Input;
 
@@ -16,6 +17,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 {
     public class SelectionBox : CompositeDrawable
     {
+        public const float BORDER_RADIUS = 3;
+
         public Func<float, bool> OnRotation;
         public Func<Vector2, Anchor, bool> OnScale;
         public Func<Direction, bool> OnFlip;
@@ -92,21 +95,32 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
+        private string text;
+
+        public string Text
+        {
+            get => text;
+            set
+            {
+                if (value == text)
+                    return;
+
+                text = value;
+                if (selectionDetailsText != null)
+                    selectionDetailsText.Text = value;
+            }
+        }
+
         private Container dragHandles;
         private FillFlowContainer buttons;
 
-        public const float BORDER_RADIUS = 3;
+        private OsuSpriteText selectionDetailsText;
 
         [Resolved]
         private OsuColour colours { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load()
-        {
-            RelativeSizeAxes = Axes.Both;
-
-            recreate();
-        }
+        private void load() => recreate();
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
@@ -144,6 +158,26 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             InternalChildren = new Drawable[]
             {
+                new Container
+                {
+                    Name = "info text",
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = colours.YellowDark,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        selectionDetailsText = new OsuSpriteText
+                        {
+                            Padding = new MarginPadding(2),
+                            Colour = colours.Gray0,
+                            Font = OsuFont.Default.With(size: 11),
+                            Text = text,
+                        }
+                    }
+                },
                 new Container
                 {
                     Masking = true,

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -10,13 +10,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Primitives;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osuTK;
@@ -43,10 +41,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private readonly List<SelectionBlueprint<T>> selectedBlueprints;
 
-        private Drawable content;
-
-        private OsuSpriteText selectionDetailsText;
-
         protected SelectionBox SelectionBox { get; private set; }
 
         [Resolved(CanBeNull = true)]
@@ -63,33 +57,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            InternalChild = content = new Container
-            {
-                Children = new Drawable[]
-                {
-                    // todo: should maybe be inside the SelectionBox?
-                    new Container
-                    {
-                        Name = "info text",
-                        AutoSizeAxes = Axes.Both,
-                        Children = new Drawable[]
-                        {
-                            new Box
-                            {
-                                Colour = colours.YellowDark,
-                                RelativeSizeAxes = Axes.Both,
-                            },
-                            selectionDetailsText = new OsuSpriteText
-                            {
-                                Padding = new MarginPadding(2),
-                                Colour = colours.Gray0,
-                                Font = OsuFont.Default.With(size: 11)
-                            }
-                        }
-                    },
-                    SelectionBox = CreateSelectionBox(),
-                }
-            };
+            InternalChild = SelectionBox = CreateSelectionBox();
 
             SelectedItems.CollectionChanged += (sender, args) =>
             {
@@ -305,9 +273,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             int count = SelectedItems.Count;
 
-            selectionDetailsText.Text = count > 0 ? count.ToString() : string.Empty;
+            SelectionBox.Text = count > 0 ? count.ToString() : string.Empty;
 
-            content.FadeTo(count > 0 ? 1 : 0);
+            SelectionBox.FadeTo(count > 0 ? 1 : 0);
             OnSelectionChanged();
         }
 
@@ -334,8 +302,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             selectionRect = selectionRect.Inflate(5f);
 
-            content.Position = selectionRect.Location;
-            content.Size = selectionRect.Size;
+            SelectionBox.Position = selectionRect.Location;
+            SelectionBox.Size = selectionRect.Size;
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -58,7 +58,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             RelativeSizeAxes = Axes.Both;
             AlwaysPresent = true;
-            Alpha = 0;
         }
 
         [BackgroundDependencyLoader]
@@ -308,7 +307,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             selectionDetailsText.Text = count > 0 ? count.ToString() : string.Empty;
 
-            this.FadeTo(count > 0 ? 1 : 0);
+            content.FadeTo(count > 0 ? 1 : 0);
             OnSelectionChanged();
         }
 


### PR DESCRIPTION
Split out from https://github.com/ppy/osu/pull/12626 as it got a bit more complicated due to a weird test existing. This was a pending TODO anyways, so good chance to clean things up.

The actual fix here is to move the visibility toggle away from a container with `AlwaysVisible` applied, as it's not compatible with properly hiding tooltips etc.