### PR TITLE
Add explanatory text for select settings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
                 const string not_fullscreen_note = "Running without fullscreen mode will increase your input latency!";
 
-                windowModeDropdown.NoteText = mode.NewValue != WindowMode.Fullscreen ? not_fullscreen_note : string.Empty;
+                windowModeDropdown.WarningText = mode.NewValue != WindowMode.Fullscreen ? not_fullscreen_note : string.Empty;
             }, true);
 
             windowModes.BindCollectionChanged((sender, args) =>

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -141,7 +141,14 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
             scalingSettings.ForEach(s => bindPreviewEvent(s.Current));
 
-            windowModeDropdown.Current.ValueChanged += _ => updateResolutionDropdown();
+            windowModeDropdown.Current.BindValueChanged(mode =>
+            {
+                updateResolutionDropdown();
+
+                const string not_fullscreen_note = "Running without fullscreen mode will increase your input latency!";
+
+                windowModeDropdown.NoteText = mode.NewValue != WindowMode.Fullscreen ? not_fullscreen_note : string.Empty;
+            }, true);
 
             windowModes.BindCollectionChanged((sender, args) =>
             {

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
             frameLimiterDropdown.Current.BindValueChanged(limit =>
             {
-                const string unlimited_frames_note = "Using unlimited frame limiter can lead to stutters. \"2x refresh rate\" is recommended.";
+                const string unlimited_frames_note = "Using unlimited frame limiter can lead to stutters, bad performance and overheating. It will not improve perceived latency. \"2x refresh rate\" is recommended.";
 
                 frameLimiterDropdown.NoteText = limit.NewValue == FrameSync.Unlimited ? unlimited_frames_note : string.Empty;
             }, true);

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
     {
         protected override string Header => "Renderer";
 
+        private SettingsEnumDropdown<FrameSync> frameLimiterDropdown;
+
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager config, OsuConfigManager osuConfig)
         {
@@ -20,7 +22,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             Children = new Drawable[]
             {
                 // TODO: this needs to be a custom dropdown at some point
-                new SettingsEnumDropdown<FrameSync>
+                frameLimiterDropdown = new SettingsEnumDropdown<FrameSync>
                 {
                     LabelText = "Frame limiter",
                     Current = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync)
@@ -36,6 +38,18 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                     Current = osuConfig.GetBindable<bool>(OsuSetting.ShowFpsDisplay)
                 },
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            frameLimiterDropdown.Current.BindValueChanged(limit =>
+            {
+                const string unlimited_frames_note = "Using unlimited frame limiter can lead to stutters. \"2x refresh rate\" is recommended.";
+
+                frameLimiterDropdown.NoteText = limit.NewValue == FrameSync.Unlimited ? unlimited_frames_note : string.Empty;
+            }, true);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             {
                 const string unlimited_frames_note = "Using unlimited frame limiter can lead to stutters, bad performance and overheating. It will not improve perceived latency. \"2x refresh rate\" is recommended.";
 
-                frameLimiterDropdown.NoteText = limit.NewValue == FrameSync.Unlimited ? unlimited_frames_note : string.Empty;
+                frameLimiterDropdown.WarningText = limit.NewValue == FrameSync.Unlimited ? unlimited_frames_note : string.Empty;
             }, true);
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
@@ -2,8 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
+using osu.Game.Online.API;
+using osu.Game.Users;
 
 namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
@@ -11,9 +14,15 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
     {
         protected override string Header => "Main Menu";
 
+        private IBindable<User> user;
+
+        private SettingsEnumDropdown<BackgroundSource> backgroundSourceDropdown;
+
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, IAPIProvider api)
         {
+            user = api.LocalUser.GetBoundCopy();
+
             Children = new Drawable[]
             {
                 new SettingsCheckbox
@@ -31,7 +40,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     LabelText = "Intro sequence",
                     Current = config.GetBindable<IntroSequence>(OsuSetting.IntroSequence),
                 },
-                new SettingsEnumDropdown<BackgroundSource>
+                backgroundSourceDropdown = new SettingsEnumDropdown<BackgroundSource>
                 {
                     LabelText = "Background source",
                     Current = config.GetBindable<BackgroundSource>(OsuSetting.MenuBackgroundSource),
@@ -42,6 +51,18 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                     Current = config.GetBindable<SeasonalBackgroundMode>(OsuSetting.SeasonalBackgroundMode),
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            backgroundSourceDropdown.Current.BindValueChanged(source =>
+            {
+                const string not_supporter_note = "Changes to this setting will only apply with an active osu!supporter tag.";
+
+                backgroundSourceDropdown.NoteText = user.Value?.IsSupporter == false ? not_supporter_note : string.Empty;
+            }, true);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
             {
                 const string not_supporter_note = "Changes to this setting will only apply with an active osu!supporter tag.";
 
-                backgroundSourceDropdown.NoteText = user.Value?.IsSupporter == false ? not_supporter_note : string.Empty;
+                backgroundSourceDropdown.NoteText = user.Value?.IsSupporter != true ? not_supporter_note : string.Empty;
             }, true);
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
             {
                 const string not_supporter_note = "Changes to this setting will only apply with an active osu!supporter tag.";
 
-                backgroundSourceDropdown.NoteText = user.Value?.IsSupporter != true ? not_supporter_note : string.Empty;
+                backgroundSourceDropdown.WarningText = user.Value?.IsSupporter != true ? not_supporter_note : string.Empty;
             }, true);
         }
     }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays.Settings
 
         private SpriteText labelText;
 
-        private readonly OsuTextFlowContainer noteText;
+        private readonly OsuTextFlowContainer warningText;
 
         public bool ShowsDefaultIndicator = true;
 
@@ -61,14 +61,14 @@ namespace osu.Game.Overlays.Settings
 
         /// <summary>
         /// Text to be displayed at the bottom of this <see cref="SettingsItem{T}"/>.
-        /// Used for further explanation or indicating drawbacks of the current setting.
+        /// Generally used to recommend the user change their setting as the current one is considered sub-optimal.
         /// </summary>
-        public string NoteText
+        public string WarningText
         {
             set
             {
-                noteText.Alpha = string.IsNullOrWhiteSpace(value) ? 0 : 1;
-                noteText.Text = value;
+                warningText.Alpha = string.IsNullOrWhiteSpace(value) ? 0 : 1;
+                warningText.Text = value;
             }
         }
 
@@ -110,7 +110,7 @@ namespace osu.Game.Overlays.Settings
                     Children = new[]
                     {
                         Control = CreateControl(),
-                        noteText = new OsuTextFlowContainer
+                        warningText = new OsuTextFlowContainer
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
@@ -135,7 +135,7 @@ namespace osu.Game.Overlays.Settings
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            noteText.Colour = colours.Yellow;
+            warningText.Colour = colours.Yellow;
         }
 
         private void updateDisabled()

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -18,7 +18,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osuTK;
 using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Settings
@@ -172,6 +171,7 @@ namespace osu.Game.Overlays.Settings
             {
                 RelativeSizeAxes = Axes.Y;
                 Width = SettingsPanel.CONTENT_MARGINS;
+                Padding = new MarginPadding { Vertical = 1.5f };
                 Alpha = 0f;
             }
 
@@ -194,7 +194,7 @@ namespace osu.Game.Overlays.Settings
                         Type = EdgeEffectType.Glow,
                         Radius = 2,
                     },
-                    Size = new Vector2(0.33f, 0.8f),
+                    Width = 0.33f,
                     Child = new Box { RelativeSizeAxes = Axes.Both },
                 };
             }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -19,6 +19,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK;
+using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.Settings
 {
@@ -35,6 +36,8 @@ namespace osu.Game.Overlays.Settings
         protected readonly FillFlowContainer FlowContent;
 
         private SpriteText labelText;
+
+        private readonly OsuTextFlowContainer noteText;
 
         public bool ShowsDefaultIndicator = true;
 
@@ -54,6 +57,19 @@ namespace osu.Game.Overlays.Settings
                 }
 
                 labelText.Text = value;
+            }
+        }
+
+        /// <summary>
+        /// Text to be displayed at the bottom of this <see cref="SettingsItem{T}"/>.
+        /// Used for further explanation or indicating drawbacks of the current setting.
+        /// </summary>
+        public string NoteText
+        {
+            set
+            {
+                noteText.Alpha = 1;
+                noteText.Text = value;
             }
         }
 
@@ -92,7 +108,16 @@ namespace osu.Game.Overlays.Settings
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding { Left = SettingsPanel.CONTENT_MARGINS },
-                    Child = Control = CreateControl()
+                    Children = new[]
+                    {
+                        Control = CreateControl(),
+                        noteText = new OsuTextFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Alpha = 0,
+                        },
+                    },
                 },
             };
 
@@ -106,6 +131,12 @@ namespace osu.Game.Overlays.Settings
                 if (ShowsDefaultIndicator)
                     restoreDefaultButton.Bindable = controlWithCurrent.Current;
             }
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            noteText.Colour = colours.Yellow;
         }
 
         private void updateDisabled()

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Overlays.Settings
         {
             set
             {
-                noteText.Alpha = 1;
+                noteText.Alpha = string.IsNullOrWhiteSpace(value) ? 0 : 1;
                 noteText.Text = value;
             }
         }

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -36,11 +36,14 @@ namespace osu.Game.Overlays.Settings
 
         private SpriteText labelText;
 
-        private readonly OsuTextFlowContainer warningText;
+        private OsuTextFlowContainer warningText;
 
         public bool ShowsDefaultIndicator = true;
 
         public string TooltipText { get; set; }
+
+        [Resolved]
+        private OsuColour colours { get; set; }
 
         public virtual LocalisableString LabelText
         {
@@ -67,6 +70,18 @@ namespace osu.Game.Overlays.Settings
         {
             set
             {
+                if (warningText == null)
+                {
+                    // construct lazily for cases where the label is not needed (may be provided by the Control).
+                    FlowContent.Add(warningText = new OsuTextFlowContainer
+                    {
+                        Colour = colours.Yellow,
+                        Margin = new MarginPadding { Bottom = 5 },
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                    });
+                }
+
                 warningText.Alpha = string.IsNullOrWhiteSpace(value) ? 0 : 1;
                 warningText.Text = value;
             }
@@ -110,12 +125,6 @@ namespace osu.Game.Overlays.Settings
                     Children = new[]
                     {
                         Control = CreateControl(),
-                        warningText = new OsuTextFlowContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Alpha = 0,
-                        },
                     },
                 },
             };
@@ -130,12 +139,6 @@ namespace osu.Game.Overlays.Settings
                 if (ShowsDefaultIndicator)
                     restoreDefaultButton.Bindable = controlWithCurrent.Current;
             }
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            warningText.Colour = colours.Yellow;
         }
 
         private void updateDisabled()

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -230,12 +230,6 @@ namespace osu.Game.Overlays.Settings
                 UpdateState();
             }
 
-            public void SetButtonColour(Color4 buttonColour)
-            {
-                this.buttonColour = buttonColour;
-                UpdateState();
-            }
-
             public void UpdateState() => Scheduler.AddOnce(updateState);
 
             private void updateState()


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/6932.

Changed optimal to 2x refresh rate, as that is lazer's default right now. Stable seems to separate the notes from their settings item, not sure if we want that.

| Lazer | Stable |
| --- | --- |
| <img width="292" alt="Screen Shot 2021-05-04 at 1 05 46 AM" src="https://user-images.githubusercontent.com/35318437/116975688-de424180-ac74-11eb-9788-fc3a19fe18e1.png"> | <img width="310" alt="Screen Shot 2021-05-04 at 1 10 35 AM" src="https://user-images.githubusercontent.com/35318437/116976104-8b1cbe80-ac75-11eb-8c4a-19226c9bb4db.png"> |
| <img width="293" alt="Screen Shot 2021-05-04 at 1 13 21 AM" src="https://user-images.githubusercontent.com/35318437/116976389-ec449200-ac75-11eb-821e-a576e49cb7f5.png"> |  |