### PR TITLE
Fix follow points displaying at incorrect locations when dragging a slider out-of-bounds

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointConnection.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
             Entry = null;
         }
 
-        private void onEntryInvalidated() => refreshPoints();
+        private void onEntryInvalidated() => Scheduler.AddOnce(refreshPoints);
 
         private void refreshPoints()
         {


### PR DESCRIPTION
Due to the method of handling out-of-bounds locations (a second pass which restores a valid location), the follow point refresh code was firing twice. This caused it to somehow get in a state where it would display the first (incorrect/outdated) state. I haven't checked exactly why this is, but don't think it's necessary to understand the issue in this case. We don't want this calculation to be happening more than once per frame regardless.

The view from a `FollowPointConnection` on `master`:

```csharp
[runtime] 2021-05-05 09:31:20 [verbose]: Refreshing lifetimes with position (-208.2219, 262.49713) to (144, 184)
[runtime] 2021-05-05 09:31:20 [verbose]: Refreshing lifetimes with position (0, 262.49713) to (144, 184)
[runtime] 2021-05-05 09:31:20 [verbose]: Refreshing lifetimes with position (-210.73767, 262.49713) to (144, 184)
[runtime] 2021-05-05 09:31:20 [verbose]: Refreshing lifetimes with position (0, 262.49713) to (144, 184)
[runtime] 2021-05-05 09:31:20 [verbose]: Refreshing lifetimes with position (-213.25342, 262.49713) to (144, 184)
[runtime] 2021-05-05 09:31:20 [verbose]: Refreshing lifetimes with position (0, 262.49713) to (144, 184)
```

Fixes issue seen here:


https://user-images.githubusercontent.com/191335/117122431-e0211780-add0-11eb-97f5-a01879e0da95.mov
