### PR TITLE
Deselect all blueprints on skin editor hide

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
@@ -23,12 +25,29 @@ namespace osu.Game.Tests.Visual.Gameplay
                 skinEditor?.Expire();
                 LoadComponentAsync(skinEditor = new SkinEditor(Player), Add);
             });
+
+            AddUntilStep("wait for loaded", () => skinEditor.IsLoaded);
         }
 
         [Test]
         public void TestToggleEditor()
         {
             AddToggleStep("toggle editor visibility", visible => skinEditor.ToggleVisibility());
+        }
+
+        [Test]
+        public void TestSelectionLostOnEditorClose()
+        {
+            SkinBlueprintContainer skinBlueprintContainer = null;
+
+            AddStep("show editor", () => skinEditor.State.Value = Visibility.Visible);
+            AddStep("retrieve blueprint container", () => skinBlueprintContainer = this.ChildrenOfType<SkinBlueprintContainer>().Single());
+
+            AddStep("select all blueprints", () => skinBlueprintContainer.SelectAll());
+            AddAssert("all blueprints selected", () => skinBlueprintContainer.SelectionBlueprints.All(blueprint => blueprint.IsSelected));
+
+            AddStep("hide editor", () => skinEditor.State.Value = Visibility.Hidden);
+            AddUntilStep("no blueprint selected", () => skinBlueprintContainer.SelectionBlueprints.All(blueprint => !blueprint.IsSelected));
         }
 
         protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private void load()
         {
             SelectionHandler = CreateSelectionHandler();
-            SelectionHandler.DeselectAll = deselectAll;
+            SelectionHandler.DeselectAll = DeselectAll;
 
             AddRangeInternal(new[]
             {
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (endClickSelection(e) || ClickedBlueprint != null)
                 return true;
 
-            deselectAll();
+            DeselectAll();
             return true;
         }
 
@@ -196,7 +196,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     if (!SelectionHandler.SelectedBlueprints.Any())
                         return false;
 
-                    deselectAll();
+                    DeselectAll();
                     return true;
             }
 
@@ -370,7 +370,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Deselects all selected <see cref="SelectionBlueprint{T}"/>s.
         /// </summary>
-        private void deselectAll() => SelectionHandler.SelectedBlueprints.ToList().ForEach(m => m.Deselect());
+        public void DeselectAll() => SelectionHandler.SelectedBlueprints.ToList().ForEach(m => m.Deselect());
 
         protected virtual void OnBlueprintSelected(SelectionBlueprint<T> blueprint)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -361,7 +361,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Selects all <see cref="SelectionBlueprint{T}"/>s.
         /// </summary>
-        protected virtual void SelectAll()
+        public virtual void SelectAll()
         {
             // Scheduled to allow the change in lifetime to take place.
             Schedule(() => SelectionBlueprints.ToList().ForEach(m => m.Select()));

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new EditorSelectionHandler();
 
-        protected override void SelectAll()
+        public override void SelectAll()
         {
             Composer.Playfield.KeepAllAlive();
 

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Skinning.Editor
         private readonly Drawable target;
 
         private OsuTextFlowContainer headerText;
+        private SkinBlueprintContainer skinBlueprintContainer;
 
         protected override bool StartHidden => true;
 
@@ -44,7 +45,7 @@ namespace osu.Game.Skinning.Editor
                         Origin = Anchor.TopCentre,
                         RelativeSizeAxes = Axes.X
                     },
-                    new SkinBlueprintContainer(target),
+                    skinBlueprintContainer = new SkinBlueprintContainer(target),
                 }
             };
 
@@ -73,6 +74,7 @@ namespace osu.Game.Skinning.Editor
 
         protected override void PopOut()
         {
+            skinBlueprintContainer.DeselectAll();
             this.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
         }
     }

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -69,11 +69,14 @@ namespace osu.Game.Skinning.Editor
 
         protected override void PopIn()
         {
+            skinBlueprintContainer.Show();
             this.FadeIn(TRANSITION_DURATION, Easing.OutQuint);
         }
 
         protected override void PopOut()
         {
+            // hide blueprint container instantly to prevent further selections from taking place.
+            skinBlueprintContainer.Hide();
             skinBlueprintContainer.DeselectAll();
             this.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
         }


### PR DESCRIPTION
Resolves #12692.

Tried to not overthink the resolution on this one.

The exposition of `BlueprintContainer<T>.SelectAll()` in b64c4e4 for the test is quite heavy-handed, but I tried *multiple* approaches leveraging `InputManager` first, and they just *would - not - work - reliably - at all - headless*, so I gave up and went the nuclear route instead. Definitely willing to consider alternatives, although I do think exposing it as public makes some sense now that `Deselect()` is used publicly as well. Makes it a bit symmetric, if you will.