### PR TITLE
Fix warning text of bg source setting not being updated when user with supporter signs in/out

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/MainMenuSettings.cs
@@ -57,11 +57,11 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
         {
             base.LoadComplete();
 
-            backgroundSourceDropdown.Current.BindValueChanged(source =>
+            user.BindValueChanged(u =>
             {
                 const string not_supporter_note = "Changes to this setting will only apply with an active osu!supporter tag.";
 
-                backgroundSourceDropdown.WarningText = user.Value?.IsSupporter != true ? not_supporter_note : string.Empty;
+                backgroundSourceDropdown.WarningText = u.NewValue?.IsSupporter != true ? not_supporter_note : string.Empty;
             }, true);
         }
     }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/pull/12675#discussion_r626149720. I guess my proposal said there to add a `Default` setting can come later on when this setting gets moved to the skin editor with probably better ux.