### PR TITLE
Fix editor clock not using the beatmap's virtual track when creating one

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -298,7 +298,6 @@ namespace osu.Game.Beatmaps
         /// Get the loaded audio track instance. <see cref="LoadTrack"/> must have first been called.
         /// This generally happens via MusicController when changing the global beatmap.
         /// </summary>
-        [NotNull]
         public Track Track
         {
             get

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -298,6 +298,7 @@ namespace osu.Game.Beatmaps
         /// Get the loaded audio track instance. <see cref="LoadTrack"/> must have first been called.
         /// This generally happens via MusicController when changing the global beatmap.
         /// </summary>
+        [NotNull]
         public Track Track
         {
             get

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Screens.Edit
 
             // Todo: should probably be done at a DrawableRuleset level to share logic with Player.
             clock = new EditorClock(playableBeatmap, beatDivisor) { IsCoupled = false };
-            clock.ChangeSource(loadableBeatmap.Track);
+            clock.ChangeSource((IAdjustableClock)loadableBeatmap.Track ?? new StopwatchClock());
 
             dependencies.CacheAs(clock);
             AddInternal(clock);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -17,6 +17,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
+using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -306,7 +307,11 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// If the beatmap's track has changed, this method must be called to keep the editor in a valid state.
         /// </summary>
-        public void UpdateClockSource() => clock.ChangeSource(Beatmap.Value.Track);
+        public void UpdateClockSource()
+        {
+            var sourceClock = (IAdjustableClock)Beatmap.Value.Track ?? new StopwatchClock();
+            clock.ChangeSource(sourceClock);
+        }
 
         protected void Save()
         {
@@ -577,7 +582,7 @@ namespace osu.Game.Screens.Edit
 
         private void resetTrack(bool seekToStart = false)
         {
-            Beatmap.Value.Track.Stop();
+            Beatmap.Value.Track?.Stop();
 
             if (seekToStart)
             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Screens.Edit
             // Todo: should probably be done at a DrawableRuleset level to share logic with Player.
             clock = new EditorClock(playableBeatmap, beatDivisor) { IsCoupled = false };
 
-            UpdateClockSource();
+            updateClockSource(loadableBeatmap);
 
             dependencies.CacheAs(clock);
             AddInternal(clock);
@@ -308,9 +308,11 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// If the beatmap's track has changed, this method must be called to keep the editor in a valid state.
         /// </summary>
-        public void UpdateClockSource()
+        public void UpdateClockSource() => updateClockSource(Beatmap.Value);
+
+        private void updateClockSource(WorkingBeatmap beatmap)
         {
-            var sourceClock = (IAdjustableClock)Beatmap.Value.Track ?? new StopwatchClock();
+            var sourceClock = (IAdjustableClock)beatmap.Track ?? new StopwatchClock();
             clock.ChangeSource(sourceClock);
         }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -307,11 +307,7 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// If the beatmap's track has changed, this method must be called to keep the editor in a valid state.
         /// </summary>
-        public void UpdateClockSource()
-        {
-            var sourceClock = (IAdjustableClock)Beatmap.Value.Track ?? new StopwatchClock();
-            clock.ChangeSource(sourceClock);
-        }
+        public void UpdateClockSource() => clock.ChangeSource(Beatmap.Value.Track);
 
         protected void Save()
         {
@@ -582,7 +578,7 @@ namespace osu.Game.Screens.Edit
 
         private void resetTrack(bool seekToStart = false)
         {
-            Beatmap.Value.Track?.Stop();
+            Beatmap.Value.Track.Stop();
 
             if (seekToStart)
             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -17,7 +17,6 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
-using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -307,11 +306,7 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// If the beatmap's track has changed, this method must be called to keep the editor in a valid state.
         /// </summary>
-        public void UpdateClockSource()
-        {
-            var sourceClock = (IAdjustableClock)Beatmap.Value.Track ?? new StopwatchClock();
-            clock.ChangeSource(sourceClock);
-        }
+        public void UpdateClockSource() => clock.ChangeSource(Beatmap.Value.Track);
 
         protected void Save()
         {
@@ -582,7 +577,7 @@ namespace osu.Game.Screens.Edit
 
         private void resetTrack(bool seekToStart = false)
         {
-            Beatmap.Value.Track?.Stop();
+            Beatmap.Value.Track.Stop();
 
             if (seekToStart)
             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -144,8 +144,7 @@ namespace osu.Game.Screens.Edit
 
             // Todo: should probably be done at a DrawableRuleset level to share logic with Player.
             clock = new EditorClock(playableBeatmap, beatDivisor) { IsCoupled = false };
-
-            updateClockSource(loadableBeatmap);
+            clock.ChangeSource(loadableBeatmap.Track);
 
             dependencies.CacheAs(clock);
             AddInternal(clock);
@@ -308,11 +307,9 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// If the beatmap's track has changed, this method must be called to keep the editor in a valid state.
         /// </summary>
-        public void UpdateClockSource() => updateClockSource(Beatmap.Value);
-
-        private void updateClockSource(WorkingBeatmap beatmap)
+        public void UpdateClockSource()
         {
-            var sourceClock = (IAdjustableClock)beatmap.Track ?? new StopwatchClock();
+            var sourceClock = (IAdjustableClock)Beatmap.Value.Track ?? new StopwatchClock();
             clock.ChangeSource(sourceClock);
         }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -17,7 +17,6 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
-using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -144,7 +143,7 @@ namespace osu.Game.Screens.Edit
 
             // Todo: should probably be done at a DrawableRuleset level to share logic with Player.
             clock = new EditorClock(playableBeatmap, beatDivisor) { IsCoupled = false };
-            clock.ChangeSource((IAdjustableClock)loadableBeatmap.Track ?? new StopwatchClock());
+            clock.ChangeSource(loadableBeatmap.Track);
 
             dependencies.CacheAs(clock);
             AddInternal(clock);

--- a/osu.Game/Tests/Visual/EditorClockTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorClockTestScene.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
-using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Screens.Edit;
@@ -46,7 +45,7 @@ namespace osu.Game.Tests.Visual
         private void beatmapChanged(ValueChangedEvent<WorkingBeatmap> e)
         {
             Clock.ControlPointInfo = e.NewValue.Beatmap.ControlPointInfo;
-            Clock.ChangeSource((IAdjustableClock)e.NewValue.Track ?? new StopwatchClock());
+            Clock.ChangeSource(e.NewValue.Track);
             Clock.ProcessFrame();
         }
 

--- a/osu.Game/Tests/Visual/EditorClockTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorClockTestScene.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
+using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Screens.Edit;
@@ -45,7 +46,7 @@ namespace osu.Game.Tests.Visual
         private void beatmapChanged(ValueChangedEvent<WorkingBeatmap> e)
         {
             Clock.ControlPointInfo = e.NewValue.Beatmap.ControlPointInfo;
-            Clock.ChangeSource(e.NewValue.Track);
+            Clock.ChangeSource((IAdjustableClock)e.NewValue.Track ?? new StopwatchClock());
             Clock.ProcessFrame();
         }
 


### PR DESCRIPTION
In case of creating a new beatmap when opening an editor, `Beatmap.Value` would not be set to the created beatmap [until update](https://github.com/ppy/osu/blob/84da24700204724cde9a8b90506b078add49c964/osu.Game/Screens/Edit/Editor.cs#L165-L171), with an inline comment over it stating that `loadableBeatmap` should be used instead.

But in the BDL, `UpdateClockSource` is called, which sets the editor clock source to `Beatmap.Value.Track`, and that is wrong in BDL context, `loadableBeatmap.Track` should be used instead.

---

Note that the virtual track of a created beatmap isn't long enough (only 1 second), but that can be fixed in a follow-up PR if wanted (not gonna look at it myself for now).