### PR TITLE
Fix InvalidOperationException when exiting a map at the end

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("disable storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, false));
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("exit via pause", () => Player.ExitViaPause());
-            AddAssert("score not shown", () => !Player.IsScoreShown);
+            AddAssert("player exited", () => Stack.CurrentScreen == null);
         }
 
         protected override bool AllowFail => true;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("disable storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, false));
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("exit via pause", () => Player.ExitViaPause());
-            AddAssert("score shown", () => Player.IsScoreShown);
+            AddAssert("score not shown", () => !Player.IsScoreShown);
         }
 
         protected override bool AllowFail => true;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -133,6 +133,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.GameplayClock.CurrentTime >= currentStoryboardDuration);
         }
 
+        [Test]
+        public void TestPerformExitNoOutro()
+        {
+            CreateTest(null);
+            AddStep("disable storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, false));
+            AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
+            AddStep("exit via pause", () => Player.ExitViaPause());
+            AddAssert("score shown", () => Player.IsScoreShown);
+        }
+
         protected override bool AllowFail => true;
 
         protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -541,10 +541,8 @@ namespace osu.Game.Screens.Play
                 }
 
                 // if the score is ready for display but results screen has not been pushed yet (e.g. storyboard is still playing beyond gameplay), then transition to results screen instead of exiting.
-                if (prepareScoreForDisplayTask != null)
+                if (prepareScoreForDisplayTask != null && completionProgressDelegate == null)
                 {
-                    completionProgressDelegate?.Cancel();
-                    completionProgressDelegate = null;
                     updateCompletionState(true);
                 }
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -542,7 +542,11 @@ namespace osu.Game.Screens.Play
 
                 // if the score is ready for display but results screen has not been pushed yet (e.g. storyboard is still playing beyond gameplay), then transition to results screen instead of exiting.
                 if (prepareScoreForDisplayTask != null)
+                {
+                    completionProgressDelegate?.Cancel();
+                    completionProgressDelegate = null;
                     updateCompletionState(true);
+                }
             }
 
             this.Exit();


### PR DESCRIPTION
Resolves #12710 

This prevents `InvalidOperationException: updateCompletionState was fired more than once` from being raised when the user exits a map right after the last judgement when there is no storyboard outro.

~~Now, exiting will transition to the score screen immediately instead of song select, which matches the behavior on stable.~~