### PR TITLE
Fix temporary files from beatmap downloads not being cleaned up

### DIFF
--- a/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadBeatmapSetRequest.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Online.API.Requests
             return req;
         }
 
+        protected override string FileExtension => ".osz";
+
         protected override string Target => $@"beatmapsets/{Model.OnlineBeatmapSetID}/download{(noVideo ? "?noVideo=1" : "")}";
     }
 }


### PR DESCRIPTION
As reported in #12718, it turns out that temporary files from beatmap set downloads performed via the beatmap listing overlay could remain in the user's filesystem even after the download has concluded.

The reason for the issue is a failure in component integration. In the case of online downloads, files are first downloaded to a temporary directory (`C:/Temp` or `/tmp`), with a randomly generated filename, which ends in an extension of `.tmp` by default.

https://github.com/ppy/osu/blob/13bd3e95a947bd07adb2e501e46b0afede99c871/osu.Game/Online/API/APIDownloadRequest.cs#L14-L17

On the other side, `ArchiveModelManager`s have a `ShouldDeleteArchive()` method, which determines whether a file should be deleted after importing. At the time of writing, in the case of beatmap imports the file is only automatically cleaned up if the extension of the file is equal to `.osz`:

https://github.com/ppy/osu/blob/13bd3e95a947bd07adb2e501e46b0afede99c871/osu.Game/Beatmaps/BeatmapManager.cs#L110

which was not the case for temporary files.

As it turns out, `APIDownloadRequest` has a facility for adjusting the file's extension, via the protected `FileExtension` property. Therefore, use it in the case of `DownloadBeatmapSetRequest` to specify `.osz`, which then will make sure that the `ShouldDeleteArchive()` check in `BeatmapManager` picks it up for clean-up.

---

No tests, but this is a dicey one to test properly (would need to be a deep integration test of the entire download flow). I can try to write one, but unsure if it's not too much trouble for what it's ultimately worth...

Can be tested manually by initiating a download and breakpointing at `ShouldDeleteArchive()` (can then step out, step through the delete, and then stat the file to ensure that it's gone).