### PR TITLE
Remove vestigial `Current` reimplementation from `LegacyScoreCounter`

### DIFF
--- a/osu.Game/Skinning/LegacyScoreCounter.cs
+++ b/osu.Game/Skinning/LegacyScoreCounter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Play.HUD;
@@ -16,8 +15,6 @@ namespace osu.Game.Skinning
         protected override double RollingDuration => 1000;
         protected override Easing RollingEasing => Easing.Out;
 
-        public new Bindable<double> Current { get; } = new Bindable<double>();
-
         public LegacyScoreCounter(ISkin skin)
             : base(6)
         {
@@ -25,9 +22,6 @@ namespace osu.Game.Skinning
             Origin = Anchor.TopRight;
 
             this.skin = skin;
-
-            // base class uses int for display, but externally we bind to ScoreProcessor as a double for now.
-            Current.BindValueChanged(v => base.Current.Value = (int)v.NewValue);
 
             Scale = new Vector2(0.96f);
             Margin = new MarginPadding(10);


### PR DESCRIPTION
[Follow-up item from #12705](https://github.com/ppy/osu/pull/12705#issuecomment-835076820).

Has no functional purpose anymore since the changes in the HUD element data binding flow. It's not accessed from anywhere any more, rider even suggests to make it private.