### PR TITLE
Make adjusting volume to max feel better

### DIFF
--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Overlays.Volume
             {
                 displayVolume = value;
 
-                if (displayVolume > 0.99f)
+                if (displayVolume >= 0.995f)
                 {
                     text.Text = "MAX";
                     maxGlow.EffectColour = meterColour.Opacity(2f);


### PR DESCRIPTION
Currently, adjusting volume from "max" feels different from all other adjustments. "max" becomes 99 only after the transition has finished, all other values change to the adjusted one immediately.

This PR just changes the math so that "max" appears when the rounding math used for volume would equal 100.

Current master:

![master](https://user-images.githubusercontent.com/16479013/117589480-0e348d80-b12a-11eb-9079-f06969ef6395.gif)

This PR:

![this-pr](https://user-images.githubusercontent.com/16479013/117589487-1260ab00-b12a-11eb-9d3e-e13dd18cfe31.gif)
