### PR TITLE
Remove duplicate CreateSpriteText in OsuMarkdownTextFlowContainer

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,6 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.422.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.507.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2021.510.0" />
   </ItemGroup>
 </Project>

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownTextFlowContainer.cs
@@ -6,7 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.Containers.Markdown
@@ -15,11 +14,6 @@ namespace osu.Game.Graphics.Containers.Markdown
     {
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; }
-
-        protected override SpriteText CreateSpriteText() => new OsuSpriteText
-        {
-            Font = OsuFont.GetFont(size: 14),
-        };
 
         protected override void AddLinkText(string text, LinkInline linkInline)
             => AddDrawable(new OsuMarkdownLinkText(text, linkInline));

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.507.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.510.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.422.0" />
     <PackageReference Include="Sentry" Version="3.3.4" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -70,7 +70,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.507.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2021.510.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2021.422.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net5.0 / net6.0) -->
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ppy.osu.Framework" Version="2021.507.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2021.510.0" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="SharpRaven" Version="2.4.0" />


### PR DESCRIPTION
- [x] Depends on framework update

After changes in https://github.com/ppy/osu-framework/commit/7f95d6bcef33ade8b22a9a6c10f1ec92752ca831, this code is no longer needed.