### PR TITLE
Fix autoplay scores being submitted

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -33,9 +33,8 @@ namespace osu.Game.Screens.Play
 
         protected override void LoadAsyncComplete()
         {
-            if (!handleTokenRetrieval()) return;
-
             base.LoadAsyncComplete();
+            handleTokenRetrieval();
         }
 
         private bool handleTokenRetrieval()

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play
 
             if (Mods.Value.Any(m => m is ModAutoplay))
             {
-                handleTokenFailure(new InvalidOperationException("Replay loaded."));
+                handleTokenFailure(new InvalidOperationException("Autoplay loaded."));
                 return false;
             }
 

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Play
             // Token request construction should happen post-load to allow derived classes to potentially prepare DI backings that are used to create the request.
             var tcs = new TaskCompletionSource<bool>();
 
-            if (DrawableRuleset.HasReplayLoaded.Value || Mods.Value.Any(m => m is ModAutoplay))
+            if (Mods.Value.Any(m => m is ModAutoplay))
             {
                 handleTokenFailure(new InvalidOperationException("Replay loaded."));
                 return false;

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -9,6 +10,7 @@ using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Play
@@ -41,6 +43,12 @@ namespace osu.Game.Screens.Play
         {
             // Token request construction should happen post-load to allow derived classes to potentially prepare DI backings that are used to create the request.
             var tcs = new TaskCompletionSource<bool>();
+
+            if (DrawableRuleset.HasReplayLoaded.Value || Mods.Value.Any(m => m is ModAutoplay))
+            {
+                handleTokenFailure(new InvalidOperationException("Replay loaded."));
+                return false;
+            }
 
             if (!api.IsLoggedIn)
             {


### PR DESCRIPTION
This would pop up a notification after watching autoplay (server-side prohibited mod).

Making it use `ReplayPlayer` is ideal, but a little bit more involved due to the way it all works right now - the mod uses `IApplicableToDrawableRuleset` to attach the score itself.