### PR TITLE
Fix idle tracker not accounting global actions

### DIFF
--- a/osu.Game/Input/IdleTracker.cs
+++ b/osu.Game/Input/IdleTracker.cs
@@ -6,13 +6,14 @@ using osu.Framework.Graphics;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Input.Bindings;
 
 namespace osu.Game.Input
 {
     /// <summary>
     /// Track whether the end-user is in an idle state, based on their last interaction with the game.
     /// </summary>
-    public class IdleTracker : Component, IKeyBindingHandler<PlatformAction>, IHandleGlobalKeyboardInput
+    public class IdleTracker : Component, IKeyBindingHandler<PlatformAction>, IKeyBindingHandler<GlobalAction>, IHandleGlobalKeyboardInput
     {
         private readonly double timeToIdle;
 
@@ -57,6 +58,10 @@ namespace osu.Game.Input
         public bool OnPressed(PlatformAction action) => updateLastInteractionTime();
 
         public void OnReleased(PlatformAction action) => updateLastInteractionTime();
+
+        public bool OnPressed(GlobalAction action) => updateLastInteractionTime();
+
+        public void OnReleased(GlobalAction action) => updateLastInteractionTime();
 
         protected override bool Handle(UIEvent e)
         {


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/12225. Before, idle tracker relied on `OnKeyDown`, but now global actions block it.

Can be tested on `master` by pressing space when only the osu! logo is displayed on the main menu and not returning back after 6 seconds.