### PR TITLE
Make `Replay.Frames` immutable

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -397,7 +397,7 @@ namespace osu.Game.Rulesets.Mania.Tests
             {
                 Beatmap.Value = CreateWorkingBeatmap(beatmap);
 
-                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay(frames) });
 
                 p.OnLoadComplete += _ =>
                 {

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneOutOfOrderHits.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneOutOfOrderHits.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
                 Beatmap.Value.Beatmap.ControlPointInfo.Add(0, new DifficultyControlPoint { SpeedMultiplier = 0.1f });
 
-                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay(frames) });
 
                 p.OnLoadComplete += _ =>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 AddFrameToReplay(new OsuReplayFrame(Beatmap.HitObjects[0].StartTime - 350, Beatmap.HitObjects[0].StackedPosition, OsuAction.LeftButton));
                 AddFrameToReplay(new OsuReplayFrame(Beatmap.HitObjects[0].StartTime - 325, Beatmap.HitObjects[0].StackedPosition));
 
-                return Replay;
+                return new Replay(Frames);
             }
         }
     }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
@@ -411,7 +411,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
                 SelectedMods.Value = new[] { new OsuModClassic() };
 
-                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay(frames) });
 
                 p.OnLoadComplete += _ =>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -364,7 +364,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
                 Beatmap.Value.Beatmap.ControlPointInfo.Add(0, new DifficultyControlPoint { SpeedMultiplier = 0.1f });
 
-                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay(frames) });
 
                 p.OnLoadComplete += _ =>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -18,7 +18,6 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.UI;
-using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
@@ -123,19 +122,15 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("spinner symbol direction correct", () => clockwise ? spinnerSymbol.Rotation > 0 : spinnerSymbol.Rotation < 0);
         }
 
-        private Replay flip(Replay scoreReplay) => new Replay
-        {
-            Frames = scoreReplay
-                     .Frames
-                     .Cast<OsuReplayFrame>()
-                     .Select(replayFrame =>
-                     {
-                         var flippedPosition = new Vector2(OsuPlayfield.BASE_SIZE.X - replayFrame.Position.X, replayFrame.Position.Y);
-                         return new OsuReplayFrame(replayFrame.Time, flippedPosition, replayFrame.Actions.ToArray());
-                     })
-                     .Cast<ReplayFrame>()
-                     .ToList()
-        };
+        private Replay flip(Replay scoreReplay) => new Replay(
+            scoreReplay
+                .Frames
+                .Cast<OsuReplayFrame>()
+                .Select(replayFrame =>
+                {
+                    var flippedPosition = new Vector2(OsuPlayfield.BASE_SIZE.X - replayFrame.Position.X, replayFrame.Position.Y);
+                    return new OsuReplayFrame(replayFrame.Time, flippedPosition, replayFrame.Actions.ToArray());
+                }));
 
         [Test]
         public void TestSpinnerNormalBonusRewinding()
@@ -201,19 +196,15 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("spm almost same", () => Precision.AlmostEquals(expectedSpm, drawableSpinner.SpinsPerMinute.Value, 2.0));
         }
 
-        private Replay applyRateAdjustment(Replay scoreReplay, double rate) => new Replay
-        {
-            Frames = scoreReplay
-                     .Frames
-                     .Cast<OsuReplayFrame>()
-                     .Select(replayFrame =>
-                     {
-                         var adjustedTime = replayFrame.Time * rate;
-                         return new OsuReplayFrame(adjustedTime, replayFrame.Position, replayFrame.Actions.ToArray());
-                     })
-                     .Cast<ReplayFrame>()
-                     .ToList()
-        };
+        private Replay applyRateAdjustment(Replay scoreReplay, double rate) => new Replay(
+            scoreReplay
+                .Frames
+                .Cast<OsuReplayFrame>()
+                .Select(replayFrame =>
+                {
+                    var adjustedTime = replayFrame.Time * rate;
+                    return new OsuReplayFrame(adjustedTime, replayFrame.Position, replayFrame.Actions.ToArray());
+                }));
 
         private void addSeekStep(double time)
         {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
@@ -371,7 +371,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
                 Beatmap.Value.Beatmap.ControlPointInfo.Add(0, new DifficultyControlPoint { SpeedMultiplier = 0.1f });
 
-                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay(frames) });
 
                 p.OnLoadComplete += _ =>
                 {

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Replays
         public override Replay Generate()
         {
             if (Beatmap.HitObjects.Count == 0)
-                return Replay;
+                return new Replay();
 
             buttonIndex = 0;
 
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                 addHitObjectReplay(h);
             }
 
-            return Replay;
+            return new Replay(Frames);
         }
 
         private void addDelayedMovements(OsuHitObject h, OsuHitObject prev)

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
@@ -6,7 +6,6 @@ using osu.Game.Beatmaps;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Replays;
@@ -28,15 +27,12 @@ namespace osu.Game.Rulesets.Osu.Replays
 
         #region Construction / Initialisation
 
-        protected Replay Replay;
-        protected List<ReplayFrame> Frames => Replay.Frames;
+        protected readonly List<ReplayFrame> Frames = new List<ReplayFrame>();
         private readonly IReadOnlyList<IApplicableToRate> timeAffectingMods;
 
         protected OsuAutoGeneratorBase(IBeatmap beatmap, IReadOnlyList<Mod> mods)
             : base(beatmap)
         {
-            Replay = new Replay();
-
             timeAffectingMods = mods.OfType<IApplicableToRate>().ToList();
         }
 

--- a/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
+++ b/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using NUnit.Framework;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
@@ -276,49 +275,6 @@ namespace osu.Game.Tests.NonVisual
             setTime(-100, -100);
         }
 
-        [Test]
-        public void TestReplayFramesSortStability()
-        {
-            const double repeating_time = 5000;
-
-            // add a collection of frames in shuffled order time-wise; each frame also stores its original index to check stability later.
-            // data is hand-picked and breaks if the unstable List<T>.Sort() is used.
-            // in theory this can still return a false-positive with another unstable algorithm if extremely unlucky,
-            // but there is no conceivable fool-proof way to prevent that anyways.
-            replay = new Replay(new[]
-            {
-                repeating_time,
-                0,
-                3000,
-                repeating_time,
-                repeating_time,
-                6000,
-                9000,
-                repeating_time,
-                repeating_time,
-                1000,
-                11000,
-                21000,
-                4000,
-                repeating_time,
-                repeating_time,
-                8000,
-                2000,
-                7000,
-                repeating_time,
-                repeating_time,
-                10000
-            }.Select((time, index) => new TestReplayFrame(time, true, index)));
-
-            // ensure sort stability by checking that the frames with time == repeating_time are sorted in ascending frame index order themselves.
-            var repeatingTimeFramesData = replay.Frames
-                                                .Cast<TestReplayFrame>()
-                                                .Where(f => f.Time == repeating_time)
-                                                .Select(f => f.FrameIndex);
-
-            Assert.That(repeatingTimeFramesData, Is.Ordered.Ascending);
-        }
-
         private void setupDefaultReplay()
         {
             replay = new Replay(new[]
@@ -368,13 +324,11 @@ namespace osu.Game.Tests.NonVisual
         private class TestReplayFrame : ReplayFrame
         {
             public readonly bool IsImportant;
-            public readonly int FrameIndex;
 
-            public TestReplayFrame(double time, bool isImportant = false, int frameIndex = 0)
+            public TestReplayFrame(double time, bool isImportant = false)
                 : base(time)
             {
                 IsImportant = isImportant;
-                FrameIndex = frameIndex;
             }
         }
 

--- a/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
+++ b/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
@@ -208,15 +208,16 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void TestReplayStreaming()
         {
-            handler = new TestInputHandler(replay = new StreamingReplay());
+            var streamingReplay = new StreamingReplay();
+            handler = new TestInputHandler(replay = streamingReplay);
 
             // no frames are arrived yet
             setTime(0, null);
             setTime(1000, null);
             Assert.IsTrue(handler.WaitingForFrame, "Should be waiting for the first frame");
 
-            replay.Frames.Add(new TestReplayFrame(0));
-            replay.Frames.Add(new TestReplayFrame(1000));
+            streamingReplay.Add(new TestReplayFrame(0));
+            streamingReplay.Add(new TestReplayFrame(1000));
 
             // should always play from beginning
             setTime(1000, 0);
@@ -241,7 +242,7 @@ namespace osu.Game.Tests.NonVisual
 
             fastForwardToPoint(1000);
             setTime(3000, null);
-            replay.Frames.Add(new TestReplayFrame(2000));
+            streamingReplay.Add(new TestReplayFrame(2000));
             confirmCurrentFrame(1);
             setTime(1000, 1000);
             setTime(3000, 2000);

--- a/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
+++ b/osu.Game.Tests/NonVisual/FramedReplayInputHandlerTest.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Tests.NonVisual
         [Test]
         public void TestReplayStreaming()
         {
-            handler = new TestInputHandler(replay = new Replay(false));
+            handler = new TestInputHandler(replay = new StreamingReplay());
 
             // no frames are arrived yet
             setTime(0, null);

--- a/osu.Game.Tests/Replays/ReplayTest.cs
+++ b/osu.Game.Tests/Replays/ReplayTest.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Replays;
+
+namespace osu.Game.Tests.Replays
+{
+    [TestFixture]
+    public class ReplayTest
+    {
+        [Test]
+        public void TestReplay()
+        {
+            var replay = new Replay(new[]
+            {
+                new ReplayFrame(2000),
+                new ReplayFrame(1000),
+                new ReplayFrame(1000),
+                new ReplayFrame(3000),
+            });
+            Assert.That(replay.Frames, Is.Ordered.Ascending.By(nameof(ReplayFrame.Time)));
+            Assert.IsTrue(replay.IsComplete);
+
+            Assert.IsEmpty(new Replay().Frames);
+            Assert.IsTrue(new Replay().IsComplete);
+        }
+
+        [Test]
+        public void TestStreamingReplay()
+        {
+            var replay = new StreamingReplay();
+            replay.Add(new ReplayFrame(-1000));
+            replay.Add(new ReplayFrame(0));
+            replay.Add(new ReplayFrame(0));
+            Assert.AreEqual(replay.Frames.Count, 3);
+            Assert.IsFalse(replay.IsComplete);
+
+            Assert.Throws<ArgumentException>(() => replay.Add(new ReplayFrame(-1)));
+            Assert.Throws<ArgumentException>(() => replay.Add(new ReplayFrame(double.NaN)));
+
+            replay.MarkCompleted();
+            Assert.IsTrue(replay.IsComplete);
+
+            Assert.Throws<InvalidOperationException>(() => replay.Add(new ReplayFrame(1000)));
+            Assert.AreEqual(replay.Frames.Count, 3);
+        }
+
+        [Test]
+        public void TestReplayFramesSortStability()
+        {
+            const double repeating_time = 5000;
+
+            // add a collection of frames in shuffled order time-wise; each frame also stores its original index to check stability later.
+            // data is hand-picked and breaks if the unstable List<T>.Sort() is used.
+            // in theory this can still return a false-positive with another unstable algorithm if extremely unlucky,
+            // but there is no conceivable fool-proof way to prevent that anyways.
+            var replay = new Replay(new[]
+            {
+                repeating_time,
+                0,
+                3000,
+                repeating_time,
+                repeating_time,
+                6000,
+                9000,
+                repeating_time,
+                repeating_time,
+                1000,
+                11000,
+                21000,
+                4000,
+                repeating_time,
+                repeating_time,
+                8000,
+                2000,
+                7000,
+                repeating_time,
+                repeating_time,
+                10000
+            }.Select((time, index) => new TestReplayFrame(time, index)));
+
+            // ensure sort stability by checking that the frames with time == repeating_time are sorted in ascending frame index order themselves.
+            var repeatingTimeFramesData = replay.Frames
+                                                .Cast<TestReplayFrame>()
+                                                .Where(f => f.Time == repeating_time)
+                                                .Select(f => f.FrameIndex);
+
+            Assert.That(repeatingTimeFramesData, Is.Ordered.Ascending);
+        }
+
+        private class TestReplayFrame : ReplayFrame
+        {
+            public readonly int FrameIndex;
+
+            public TestReplayFrame(double time, int frameIndex)
+                : base(time)
+            {
+                FrameIndex = frameIndex;
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecorder.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private TestRulesetInputManager playbackManager;
         private TestRulesetInputManager recordingManager;
 
-        private Replay replay;
+        private StreamingReplay replay;
 
         private TestReplayRecorder recorder;
 
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            replay = new Replay();
+            replay = new StreamingReplay();
 
             Add(new GridContainer
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecording.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayRecording.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         public TestSceneReplayRecording()
         {
-            Replay replay = new Replay();
+            var replay = new StreamingReplay();
 
             Add(new GridContainer
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectatorPlayback.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private TestRulesetInputManager playbackManager;
         private TestRulesetInputManager recordingManager;
 
-        private Replay replay;
+        private StreamingReplay replay;
 
         private readonly IBindableList<int> users = new BindableList<int>();
 
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            replay = new Replay();
+            replay = new StreamingReplay();
 
             users.BindTo(streamingClient.PlayingUsers);
             users.BindCollectionChanged((obj, args) =>
@@ -180,7 +180,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 var frame = new TestReplayFrame();
                 frame.FromLegacy(legacyFrame, null, null);
-                replay.Frames.Add(frame);
+                replay.Add(frame);
             }
         }
 
@@ -354,7 +354,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         internal class TestReplayRecorder : ReplayRecorder<TestAction>
         {
             public TestReplayRecorder()
-                : base(new Score())
+                : base(new Score
+                {
+                    Replay = new StreamingReplay()
+                })
             {
             }
 

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -10,7 +10,6 @@ namespace osu.Game.Replays
 {
     /// <summary>
     /// The list of frames of a replay.
-    /// Frames may be added at the end when <see cref="IsComplete"/> is <c>false</c>.
     /// </summary>
     public class Replay
     {
@@ -21,9 +20,13 @@ namespace osu.Game.Replays
         public virtual bool IsComplete => true;
 
         /// <summary>
-        /// The list of frames of this replay.
-        /// This list should be sorted based on <see cref="ReplayFrame.Time"/>.
+        /// The list of frames of this replay, sorted by <see cref="ReplayFrame.Time"/>.
         /// </summary>
+        /// <remarks>
+        /// Consumers of this replay may assume this list doesn't change randomly.
+        /// That is, this list shouldn't change when <see cref="IsComplete"/> is <c>true</c>.
+        /// Even if this replay is not complete, new frames should be only added at the end of the list.
+        /// </remarks>
         public virtual IReadOnlyList<ReplayFrame> Frames => frames;
 
         private readonly ReplayFrame[] frames;

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Replays;
@@ -18,22 +17,7 @@ namespace osu.Game.Replays
         /// Whether no more frames would be added to this replay.
         /// If false, gameplay would be paused to wait for further data, for instance.
         /// </summary>
-        public bool IsComplete
-        {
-            get => isComplete;
-
-            set
-            {
-                if (isComplete == value) return;
-
-                if (!value)
-                    throw new InvalidOperationException($"May not change {nameof(IsComplete)} of a {nameof(Replay)} from true to false.");
-
-                isComplete = true;
-            }
-        }
-
-        private bool isComplete;
+        public virtual bool IsComplete => true;
 
         /// <summary>
         /// The list of frames of this replay.
@@ -41,19 +25,12 @@ namespace osu.Game.Replays
         /// </summary>
         public List<ReplayFrame> Frames { get; }
 
-        public Replay()
-            : this(true)
-        {
-        }
-
         /// <summary>
-        /// Construct a new replay.
+        /// Construct an empty replay.
         /// </summary>
-        /// <param name="isComplete">Whether no more frames are added to this replay.</param>
-        public Replay(bool isComplete)
+        public Replay()
         {
             Frames = new List<ReplayFrame>();
-            this.isComplete = isComplete;
         }
 
         /// <summary>
@@ -61,11 +38,9 @@ namespace osu.Game.Replays
         /// Frames are automatically sorted by its time.
         /// </summary>
         /// <param name="frames">The frames of the replay.</param>
-        /// <param name="isComplete">Whether no more frames would be added to this replay.</param>
-        public Replay(IEnumerable<ReplayFrame> frames, bool isComplete = true)
+        public Replay(IEnumerable<ReplayFrame> frames)
         {
             Frames = frames.OrderBy(f => f.Time).ToList();
-            this.isComplete = isComplete;
         }
     }
 }

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -2,18 +2,54 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Rulesets.Replays;
 
 namespace osu.Game.Replays
 {
+    /// <summary>
+    /// The list of frames of a replay.
+    /// Frames may be added at the end when <see cref="HasReceivedAllFrames"/> is <c>false</c>.
+    /// </summary>
     public class Replay
     {
         /// <summary>
         /// Whether all frames for this replay have been received.
         /// If false, gameplay would be paused to wait for further data, for instance.
         /// </summary>
-        public bool HasReceivedAllFrames = true;
+        public bool HasReceivedAllFrames;
 
-        public List<ReplayFrame> Frames = new List<ReplayFrame>();
+        /// <summary>
+        /// The list of frames of this replay.
+        /// This list should be sorted based on <see cref="ReplayFrame.Time"/>.
+        /// </summary>
+        public List<ReplayFrame> Frames { get; }
+
+        public Replay()
+            : this(true)
+        {
+        }
+
+        /// <summary>
+        /// Construct a new replay.
+        /// </summary>
+        /// <param name="isComplete">Whether no more frames are added to this replay.</param>
+        public Replay(bool isComplete)
+        {
+            Frames = new List<ReplayFrame>();
+            HasReceivedAllFrames = isComplete;
+        }
+
+        /// <summary>
+        /// Construct a replay from its frames.
+        /// Frames are automatically sorted by its time.
+        /// </summary>
+        /// <param name="frames">The frames of the replay.</param>
+        /// <param name="isComplete">Whether no more frames are added to this replay.</param>
+        public Replay(IEnumerable<ReplayFrame> frames, bool isComplete = true)
+        {
+            Frames = frames.OrderBy(f => f.Time).ToList();
+            HasReceivedAllFrames = isComplete;
+        }
     }
 }

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Replays;
@@ -17,7 +18,22 @@ namespace osu.Game.Replays
         /// Whether all frames for this replay have been received.
         /// If false, gameplay would be paused to wait for further data, for instance.
         /// </summary>
-        public bool HasReceivedAllFrames;
+        public bool HasReceivedAllFrames
+        {
+            get => hasReceivedAllFrames;
+
+            set
+            {
+                if (hasReceivedAllFrames == value) return;
+
+                if (!value)
+                    throw new InvalidOperationException($"May not change {nameof(HasReceivedAllFrames)} of a {nameof(Replay)} from true to false.");
+
+                hasReceivedAllFrames = true;
+            }
+        }
+
+        private bool hasReceivedAllFrames;
 
         /// <summary>
         /// The list of frames of this replay.
@@ -37,7 +53,7 @@ namespace osu.Game.Replays
         public Replay(bool isComplete)
         {
             Frames = new List<ReplayFrame>();
-            HasReceivedAllFrames = isComplete;
+            hasReceivedAllFrames = isComplete;
         }
 
         /// <summary>
@@ -49,7 +65,7 @@ namespace osu.Game.Replays
         public Replay(IEnumerable<ReplayFrame> frames, bool isComplete = true)
         {
             Frames = frames.OrderBy(f => f.Time).ToList();
-            HasReceivedAllFrames = isComplete;
+            hasReceivedAllFrames = isComplete;
         }
     }
 }

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -10,30 +10,30 @@ namespace osu.Game.Replays
 {
     /// <summary>
     /// The list of frames of a replay.
-    /// Frames may be added at the end when <see cref="HasReceivedAllFrames"/> is <c>false</c>.
+    /// Frames may be added at the end when <see cref="IsComplete"/> is <c>false</c>.
     /// </summary>
     public class Replay
     {
         /// <summary>
-        /// Whether all frames for this replay have been received.
+        /// Whether no more frames would be added to this replay.
         /// If false, gameplay would be paused to wait for further data, for instance.
         /// </summary>
-        public bool HasReceivedAllFrames
+        public bool IsComplete
         {
-            get => hasReceivedAllFrames;
+            get => isComplete;
 
             set
             {
-                if (hasReceivedAllFrames == value) return;
+                if (isComplete == value) return;
 
                 if (!value)
-                    throw new InvalidOperationException($"May not change {nameof(HasReceivedAllFrames)} of a {nameof(Replay)} from true to false.");
+                    throw new InvalidOperationException($"May not change {nameof(IsComplete)} of a {nameof(Replay)} from true to false.");
 
-                hasReceivedAllFrames = true;
+                isComplete = true;
             }
         }
 
-        private bool hasReceivedAllFrames;
+        private bool isComplete;
 
         /// <summary>
         /// The list of frames of this replay.
@@ -53,7 +53,7 @@ namespace osu.Game.Replays
         public Replay(bool isComplete)
         {
             Frames = new List<ReplayFrame>();
-            hasReceivedAllFrames = isComplete;
+            this.isComplete = isComplete;
         }
 
         /// <summary>
@@ -61,11 +61,11 @@ namespace osu.Game.Replays
         /// Frames are automatically sorted by its time.
         /// </summary>
         /// <param name="frames">The frames of the replay.</param>
-        /// <param name="isComplete">Whether no more frames are added to this replay.</param>
+        /// <param name="isComplete">Whether no more frames would be added to this replay.</param>
         public Replay(IEnumerable<ReplayFrame> frames, bool isComplete = true)
         {
             Frames = frames.OrderBy(f => f.Time).ToList();
-            hasReceivedAllFrames = isComplete;
+            this.isComplete = isComplete;
         }
     }
 }

--- a/osu.Game/Replays/Replay.cs
+++ b/osu.Game/Replays/Replay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Replays;
@@ -23,14 +24,16 @@ namespace osu.Game.Replays
         /// The list of frames of this replay.
         /// This list should be sorted based on <see cref="ReplayFrame.Time"/>.
         /// </summary>
-        public List<ReplayFrame> Frames { get; }
+        public virtual IReadOnlyList<ReplayFrame> Frames => frames;
+
+        private readonly ReplayFrame[] frames;
 
         /// <summary>
         /// Construct an empty replay.
         /// </summary>
         public Replay()
         {
-            Frames = new List<ReplayFrame>();
+            frames = Array.Empty<ReplayFrame>();
         }
 
         /// <summary>
@@ -40,7 +43,7 @@ namespace osu.Game.Replays
         /// <param name="frames">The frames of the replay.</param>
         public Replay(IEnumerable<ReplayFrame> frames)
         {
-            Frames = frames.OrderBy(f => f.Time).ToList();
+            this.frames = frames.OrderBy(f => f.Time).ToArray();
         }
     }
 }

--- a/osu.Game/Replays/StreamingReplay.cs
+++ b/osu.Game/Replays/StreamingReplay.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Game.Rulesets.Replays;
+
 namespace osu.Game.Replays
 {
     /// <summary>
@@ -16,5 +19,21 @@ namespace osu.Game.Replays
         /// Declare this replay is complete and no more frames will be added to this replay.
         /// </summary>
         public void MarkCompleted() => isComplete = true;
+
+        /// <summary>
+        /// Add a new frame to this replay.
+        /// </summary>
+        /// <param name="newFrame">The new frame. The <see cref="ReplayFrame.Time"/> of this frame must be later or equals to </param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void Add(ReplayFrame newFrame)
+        {
+            if (IsComplete)
+                throw new InvalidOperationException("May not add frames to a completed replay.");
+
+            if (Frames.Count != 0 && !(Frames[^1].Time <= newFrame.Time))
+                throw new InvalidOperationException("May not add a new frame to a replay without respecting the frame time ordering.");
+
+            Frames.Add(newFrame);
+        }
     }
 }

--- a/osu.Game/Replays/StreamingReplay.cs
+++ b/osu.Game/Replays/StreamingReplay.cs
@@ -29,14 +29,15 @@ namespace osu.Game.Replays
         /// Add a new frame at the end of this replay.
         /// </summary>
         /// <param name="newFrame">The new frame. The <see cref="ReplayFrame.Time"/> of this frame must be later or equals to </param>
-        /// <exception cref="InvalidOperationException"></exception>
+        /// <exception cref="ArgumentException">The time of <paramref name="newFrame"/> is earlier than the last frame time.</exception>
+        /// <exception cref="InvalidOperationException">This replay is marked as completed.</exception>
         public void Add(ReplayFrame newFrame)
         {
             if (IsComplete)
-                throw new InvalidOperationException("May not add frames to a completed replay.");
+                throw new InvalidOperationException("May not add a frame to the completed replay.");
 
             if (frameList.Count != 0 && !(frameList[^1].Time <= newFrame.Time))
-                throw new InvalidOperationException("May not add a new frame to a replay without respecting the frame time ordering.");
+                throw new ArgumentException("The time of the new frame must not be earlier than the last frame time of the replay.");
 
             frameList.Add(newFrame);
         }

--- a/osu.Game/Replays/StreamingReplay.cs
+++ b/osu.Game/Replays/StreamingReplay.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Replays
+{
+    /// <summary>
+    /// A <see cref="Replay"/> supporting addition of frames at the end.
+    /// </summary>
+    public class StreamingReplay : Replay
+    {
+        public override bool IsComplete => isComplete;
+
+        private bool isComplete;
+
+        /// <summary>
+        /// Declare this replay is complete and no more frames will be added to this replay.
+        /// </summary>
+        public void MarkCompleted() => isComplete = true;
+    }
+}

--- a/osu.Game/Replays/StreamingReplay.cs
+++ b/osu.Game/Replays/StreamingReplay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Game.Rulesets.Replays;
 
 namespace osu.Game.Replays
@@ -20,8 +21,12 @@ namespace osu.Game.Replays
         /// </summary>
         public void MarkCompleted() => isComplete = true;
 
+        public sealed override IReadOnlyList<ReplayFrame> Frames => frameList;
+
+        private readonly List<ReplayFrame> frameList = new List<ReplayFrame>();
+
         /// <summary>
-        /// Add a new frame to this replay.
+        /// Add a new frame at the end of this replay.
         /// </summary>
         /// <param name="newFrame">The new frame. The <see cref="ReplayFrame.Time"/> of this frame must be later or equals to </param>
         /// <exception cref="InvalidOperationException"></exception>
@@ -30,10 +35,10 @@ namespace osu.Game.Replays
             if (IsComplete)
                 throw new InvalidOperationException("May not add frames to a completed replay.");
 
-            if (Frames.Count != 0 && !(Frames[^1].Time <= newFrame.Time))
+            if (frameList.Count != 0 && !(frameList[^1].Time <= newFrame.Time))
                 throw new InvalidOperationException("May not add a new frame to a replay without respecting the frame time ordering.");
 
-            Frames.Add(newFrame);
+            frameList.Add(newFrame);
         }
     }
 }

--- a/osu.Game/Rulesets/Replays/AutoGenerator.cs
+++ b/osu.Game/Rulesets/Replays/AutoGenerator.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using osu.Game.Beatmaps;
 using osu.Game.Replays;
@@ -62,7 +61,7 @@ namespace osu.Game.Rulesets.Replays
             Frames.Clear();
             GenerateFrames();
 
-            return new Replay(Frames.OrderBy(frame => frame.Time));
+            return new Replay(Frames);
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Replays/AutoGenerator.cs
+++ b/osu.Game/Rulesets/Replays/AutoGenerator.cs
@@ -62,10 +62,7 @@ namespace osu.Game.Rulesets.Replays
             Frames.Clear();
             GenerateFrames();
 
-            return new Replay
-            {
-                Frames = Frames.OrderBy(frame => frame.Time).Cast<ReplayFrame>().ToList()
-            };
+            return new Replay(Frames.OrderBy(frame => frame.Time));
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Replays
 
         protected virtual double AllowedImportantTimeSpan => sixty_frame_time * 1.2;
 
-        protected List<ReplayFrame> Frames => replay.Frames;
+        protected IReadOnlyList<ReplayFrame> Frames => replay.Frames;
 
         private readonly Replay replay;
 

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Replays
         /// <summary>
         /// Whether we are waiting for new frames to be received.
         /// </summary>
-        public bool WaitingForFrame => !replay.HasReceivedAllFrames && currentFrameIndex == Frames.Count - 1;
+        public bool WaitingForFrame => !replay.IsComplete && currentFrameIndex == Frames.Count - 1;
 
         /// <summary>
         /// The current frame of the replay.
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Replays
             if (!HasFrames)
             {
                 // In the case all frames are received, allow time to progress regardless.
-                if (replay.HasReceivedAllFrames)
+                if (replay.IsComplete)
                     return CurrentTime = time;
 
                 return null;

--- a/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
+++ b/osu.Game/Rulesets/Replays/FramedReplayInputHandler.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
@@ -96,10 +95,6 @@ namespace osu.Game.Rulesets.Replays
 
         protected FramedReplayInputHandler(Replay replay)
         {
-            // TODO: This replay frame ordering should be enforced on the Replay type.
-            // Currently, the ordering can be broken if the frames are added after this construction.
-            replay.Frames = replay.Frames.OrderBy(f => f.Time).ToList();
-
             this.replay = replay;
             currentFrameIndex = -1;
             CurrentTime = double.NegativeInfinity;

--- a/osu.Game/Rulesets/UI/ReplayRecorder.cs
+++ b/osu.Game/Rulesets/UI/ReplayRecorder.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Online.Spectator;
+using osu.Game.Replays;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
@@ -21,6 +22,7 @@ namespace osu.Game.Rulesets.UI
         where T : struct
     {
         private readonly Score target;
+        private readonly StreamingReplay targetReplay;
 
         private readonly List<T> pressedActions = new List<T>();
 
@@ -36,7 +38,11 @@ namespace osu.Game.Rulesets.UI
 
         protected ReplayRecorder(Score target)
         {
+            if (!(target.Replay is StreamingReplay streamingReplay))
+                throw new InvalidOperationException($"{nameof(ReplayRecorder)} cannot target a non-{nameof(StreamingReplay)} replay.");
+
             this.target = target;
+            targetReplay = streamingReplay;
 
             RelativeSizeAxes = Axes.Both;
 
@@ -85,7 +91,7 @@ namespace osu.Game.Rulesets.UI
 
         private void recordFrame(bool important)
         {
-            var last = target.Replay.Frames.LastOrDefault();
+            var last = targetReplay.Frames.LastOrDefault();
 
             if (!important && last != null && Time.Current - last.Time < (1000d / RecordFrameRate))
                 return;
@@ -96,7 +102,7 @@ namespace osu.Game.Rulesets.UI
 
             if (frame != null)
             {
-                target.Replay.Frames.Add(frame);
+                targetReplay.Add(frame);
 
                 spectatorStreaming?.HandleFrame(frame);
             }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -106,7 +107,7 @@ namespace osu.Game.Scoring.Legacy
 
                         using (var lzma = new LzmaStream(properties, replayInStream, compressedSize, outSize))
                         using (var reader = new StreamReader(lzma))
-                            readLegacyReplay(score.Replay, reader);
+                            score.Replay = readLegacyReplay(reader);
                     }
                 }
             }
@@ -219,10 +220,10 @@ namespace osu.Game.Scoring.Legacy
             }
         }
 
-        private void readLegacyReplay(Replay replay, StreamReader reader)
+        private Replay readLegacyReplay(StreamReader reader)
         {
             float lastTime = 0;
-            ReplayFrame currentFrame = null;
+            var convertedFrames = new List<ReplayFrame>();
 
             var frames = reader.ReadToEnd().Split(',');
 
@@ -256,13 +257,13 @@ namespace osu.Game.Scoring.Legacy
                 if (diff < 0)
                     continue;
 
-                currentFrame = convertFrame(new LegacyReplayFrame(lastTime,
+                convertedFrames.Add(convertFrame(new LegacyReplayFrame(lastTime,
                     mouseX,
                     mouseY,
-                    (ReplayButtonState)Parsing.ParseInt(split[3])), currentFrame);
-
-                replay.Frames.Add(currentFrame);
+                    (ReplayButtonState)Parsing.ParseInt(split[3])), convertedFrames.LastOrDefault()));
             }
+
+            return new Replay(convertedFrames);
         }
 
         private ReplayFrame convertFrame(LegacyReplayFrame currentFrame, ReplayFrame lastFrame)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -169,7 +169,10 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual void PrepareReplay()
         {
-            DrawableRuleset.SetRecordTarget(recordingScore = new Score());
+            DrawableRuleset.SetRecordTarget(recordingScore = new Score
+            {
+                Replay = new StreamingReplay()
+            });
 
             ScoreProcessor.NewJudgement += result => ScoreProcessor.PopulateScore(recordingScore.ScoreInfo);
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -909,7 +909,7 @@ namespace osu.Game.Screens.Play
             else
             {
                 score.ScoreInfo.User = api.LocalUser.Value;
-                score.Replay = new Replay { Frames = recordingScore?.Replay.Frames.ToList() ?? new List<ReplayFrame>() };
+                score.Replay = new Replay(recordingScore?.Replay.Frames ?? Enumerable.Empty<ReplayFrame>());
             }
 
             ScoreProcessor.PopulateScore(score.ScoreInfo);

--- a/osu.Game/Screens/Spectate/GameplayState.cs
+++ b/osu.Game/Screens/Spectate/GameplayState.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using osu.Game.Beatmaps;
+using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 
@@ -15,7 +18,18 @@ namespace osu.Game.Screens.Spectate
         /// <summary>
         /// The score which the user is playing.
         /// </summary>
-        public readonly Score Score;
+        public readonly ScoreInfo ScoreInfo;
+
+        /// <summary>
+        /// The replay of the user play.
+        /// </summary>
+        public readonly StreamingReplay Replay;
+
+        public Score Score => new Score
+        {
+            ScoreInfo = ScoreInfo,
+            Replay = Replay
+        };
 
         /// <summary>
         /// The ruleset which the user is playing.
@@ -27,9 +41,10 @@ namespace osu.Game.Screens.Spectate
         /// </summary>
         public readonly WorkingBeatmap Beatmap;
 
-        public GameplayState(Score score, Ruleset ruleset, WorkingBeatmap beatmap)
+        public GameplayState(ScoreInfo scoreInfo, Ruleset ruleset, WorkingBeatmap beatmap)
         {
-            Score = score;
+            ScoreInfo = scoreInfo;
+            Replay = new StreamingReplay();
             Ruleset = ruleset;
             Beatmap = beatmap;
         }

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Screens.Spectate
                         Mods = spectatorState.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
                         Ruleset = resolvedRuleset.RulesetInfo,
                     },
-                    Replay = new Replay(false),
+                    Replay = new StreamingReplay(),
                 };
 
                 var gameplayState = new GameplayState(score, resolvedRuleset, beatmaps.GetWorkingBeatmap(resolvedBeatmap));
@@ -212,7 +212,7 @@ namespace osu.Game.Screens.Spectate
                 if (!gameplayStates.TryGetValue(userId, out var gameplayState))
                     return;
 
-                gameplayState.Score.Replay.IsComplete = true;
+                ((StreamingReplay)gameplayState.Score.Replay).MarkCompleted();
 
                 gameplayStates.Remove(userId);
                 Schedule(() => EndGameplay(userId));

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -212,7 +212,7 @@ namespace osu.Game.Screens.Spectate
                 if (!gameplayStates.TryGetValue(userId, out var gameplayState))
                     return;
 
-                gameplayState.Score.Replay.HasReceivedAllFrames = true;
+                gameplayState.Score.Replay.IsComplete = true;
 
                 gameplayStates.Remove(userId);
                 Schedule(() => EndGameplay(userId));

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -12,7 +12,6 @@ using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.Spectator;
-using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
@@ -157,19 +156,15 @@ namespace osu.Game.Screens.Spectate
                 if (resolvedBeatmap == null)
                     return;
 
-                var score = new Score
+                var scoreInfo = new ScoreInfo
                 {
-                    ScoreInfo = new ScoreInfo
-                    {
-                        Beatmap = resolvedBeatmap,
-                        User = user,
-                        Mods = spectatorState.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
-                        Ruleset = resolvedRuleset.RulesetInfo,
-                    },
-                    Replay = new StreamingReplay(),
+                    Beatmap = resolvedBeatmap,
+                    User = user,
+                    Mods = spectatorState.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
+                    Ruleset = resolvedRuleset.RulesetInfo,
                 };
 
-                var gameplayState = new GameplayState(score, resolvedRuleset, beatmaps.GetWorkingBeatmap(resolvedBeatmap));
+                var gameplayState = new GameplayState(scoreInfo, resolvedRuleset, beatmaps.GetWorkingBeatmap(resolvedBeatmap));
 
                 gameplayStates[userId] = gameplayState;
                 Schedule(() => StartGameplay(userId, gameplayState));
@@ -187,7 +182,7 @@ namespace osu.Game.Screens.Spectate
                     return;
 
                 // The ruleset instance should be guaranteed to be in sync with the score via ScoreLock.
-                Debug.Assert(gameplayState.Ruleset != null && gameplayState.Ruleset.RulesetInfo.Equals(gameplayState.Score.ScoreInfo.Ruleset));
+                Debug.Assert(gameplayState.Ruleset != null && gameplayState.Ruleset.RulesetInfo.Equals(gameplayState.ScoreInfo.Ruleset));
 
                 foreach (var frame in bundle.Frames)
                 {
@@ -197,7 +192,7 @@ namespace osu.Game.Screens.Spectate
                     var convertedFrame = (ReplayFrame)convertibleFrame;
                     convertedFrame.Time = frame.Time;
 
-                    ((StreamingReplay)gameplayState.Score.Replay).Add(convertedFrame);
+                    gameplayState.Replay.Add(convertedFrame);
                 }
             }
         }
@@ -212,7 +207,7 @@ namespace osu.Game.Screens.Spectate
                 if (!gameplayStates.TryGetValue(userId, out var gameplayState))
                     return;
 
-                ((StreamingReplay)gameplayState.Score.Replay).MarkCompleted();
+                gameplayState.Replay.MarkCompleted();
 
                 gameplayStates.Remove(userId);
                 Schedule(() => EndGameplay(userId));

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Screens.Spectate
                         Mods = spectatorState.Mods.Select(m => m.ToMod(resolvedRuleset)).ToArray(),
                         Ruleset = resolvedRuleset.RulesetInfo,
                     },
-                    Replay = new Replay { HasReceivedAllFrames = false },
+                    Replay = new Replay(false),
                 };
 
                 var gameplayState = new GameplayState(score, resolvedRuleset, beatmaps.GetWorkingBeatmap(resolvedBeatmap));

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Screens.Spectate
                     var convertedFrame = (ReplayFrame)convertibleFrame;
                     convertedFrame.Time = frame.Time;
 
-                    gameplayState.Score.Replay.Frames.Add(convertedFrame);
+                    ((StreamingReplay)gameplayState.Score.Replay).Add(convertedFrame);
                 }
             }
         }


### PR DESCRIPTION
The frames of a replay must be sorted by frame time to make sense. However, it was easy to break the invariant as the `Replay` class exposed a `List<ReplayFrame>` directly.
In this PR, I change the type of `Replay.Frames` to `IReadonlyList<ReplayFrame>` to prevent accidental breaking of the invariant.

The `Replay` class has a constructor to take an enumerable of frames, which will be automatically sorted. In this way, the frame order invariant is automatically satisfied, and most existing uses of the `Replay` class in rulesets can be adopted with minimal changes.

The `StreamingReplay` class is introduced. This class supports an extension of the replay by adding more frames at the end. Once it is marked as complete, no more frames can be added. It is used by the spectator and the replay recording.
The `StreamingReplay : Replay` inheritance is a bit strange in terms of the substitution principle. If the list of frames of a `Replay` is expected to be immutable then the expectation is broken when a `StreamingReplay` is given. Therefore `Replay` type can only promise invariant that is also true in `StreamingReplay`.
I choose this `StreamingReplay : Replay` way to minimize breaking changes of the ruleset API.