### PR TITLE
Allow changing current star difficulty of a `StarRatingDisplay`

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Ranking.Expanded;
+using osuTK;
 
 namespace osu.Game.Tests.Visual.Ranking
 {
@@ -15,28 +16,38 @@ namespace osu.Game.Tests.Visual.Ranking
         [Test]
         public void TestDisplay()
         {
-            StarRatingDisplay changingStarRating = null;
-
             AddStep("load displays", () => Child = new FillFlowContainer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Children = new Drawable[]
                 {
-                    new StarRatingDisplay(new StarDifficulty(1.23, 0)),
-                    new StarRatingDisplay(new StarDifficulty(2.34, 0)),
-                    new StarRatingDisplay(new StarDifficulty(3.45, 0)),
-                    new StarRatingDisplay(new StarDifficulty(4.56, 0)),
-                    new StarRatingDisplay(new StarDifficulty(5.67, 0)),
-                    new StarRatingDisplay(new StarDifficulty(6.78, 0)),
-                    new StarRatingDisplay(new StarDifficulty(10.11, 0)),
-                    changingStarRating = new StarRatingDisplay(),
+                    new StarRatingDisplay(new StarDifficulty(1.23, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
+                    new StarRatingDisplay(new StarDifficulty(2.34, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
+                    new StarRatingDisplay(new StarDifficulty(3.45, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
+                    new StarRatingDisplay(new StarDifficulty(4.56, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
+                    new StarRatingDisplay(new StarDifficulty(5.67, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
+                    new StarRatingDisplay(new StarDifficulty(6.78, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
+                    new StarRatingDisplay(new StarDifficulty(10.11, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
                 }
             });
+        }
 
-            AddRepeatStep("change bottom rating", () =>
+        [Test]
+        public void TestChangingStarRatingDisplay()
+        {
+            StarRatingDisplay starRating = null;
+
+            AddStep("load display", () => Child = starRating = new StarRatingDisplay
             {
-                changingStarRating.Current.Value = new StarDifficulty(RNG.NextDouble(0, 10), RNG.Next());
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(3f),
+            });
+
+            AddRepeatStep("change display value", () =>
+            {
+                starRating.Current.Value = new StarDifficulty(RNG.NextDouble(0.0, 11.0), RNG.Next(2000));
             }, 10);
         }
     }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
@@ -12,12 +12,12 @@ namespace osu.Game.Tests.Visual.Ranking
 {
     public class TestSceneStarRatingDisplay : OsuTestScene
     {
-        [SetUp]
-        public void SetUp() => Schedule(() =>
+        [Test]
+        public void TestDisplay()
         {
-            StarRatingDisplay changingStarRating;
+            StarRatingDisplay changingStarRating = null;
 
-            Child = new FillFlowContainer
+            AddStep("load displays", () => Child = new FillFlowContainer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -32,12 +32,12 @@ namespace osu.Game.Tests.Visual.Ranking
                     new StarRatingDisplay(new StarDifficulty(10.11, 0)),
                     changingStarRating = new StarRatingDisplay(),
                 }
-            };
+            });
 
-            Scheduler.AddDelayed(() =>
+            AddRepeatStep("change bottom rating", () =>
             {
                 changingStarRating.Current.Value = new StarDifficulty(RNG.NextDouble(0, 10), RNG.Next());
-            }, 500, true);
-        });
+            }, 10);
+        }
     }
 }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Ranking.Expanded;
 
@@ -10,8 +12,11 @@ namespace osu.Game.Tests.Visual.Ranking
 {
     public class TestSceneStarRatingDisplay : OsuTestScene
     {
-        public TestSceneStarRatingDisplay()
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
+            StarRatingDisplay changingStarRating;
+
             Child = new FillFlowContainer
             {
                 Anchor = Anchor.Centre,
@@ -25,8 +30,14 @@ namespace osu.Game.Tests.Visual.Ranking
                     new StarRatingDisplay(new StarDifficulty(5.67, 0)),
                     new StarRatingDisplay(new StarDifficulty(6.78, 0)),
                     new StarRatingDisplay(new StarDifficulty(10.11, 0)),
+                    changingStarRating = new StarRatingDisplay(),
                 }
             };
-        }
+
+            Scheduler.AddDelayed(() =>
+            {
+                changingStarRating.Current.Value = new StarDifficulty(RNG.NextDouble(0, 10), RNG.Next());
+            }, 500, true);
+        });
     }
 }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,16 +21,20 @@ namespace osu.Game.Tests.Visual.Ranking
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Children = new Drawable[]
+                ChildrenEnumerable = new[]
                 {
-                    new StarRatingDisplay(new StarDifficulty(1.23, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
-                    new StarRatingDisplay(new StarDifficulty(2.34, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
-                    new StarRatingDisplay(new StarDifficulty(3.45, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
-                    new StarRatingDisplay(new StarDifficulty(4.56, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
-                    new StarRatingDisplay(new StarDifficulty(5.67, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
-                    new StarRatingDisplay(new StarDifficulty(6.78, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
-                    new StarRatingDisplay(new StarDifficulty(10.11, 0)) { Anchor = Anchor.Centre, Origin = Anchor.Centre },
-                }
+                    1.23,
+                    2.34,
+                    3.45,
+                    4.56,
+                    5.67,
+                    6.78,
+                    10.11,
+                }.Select(starRating => new StarRatingDisplay(new StarDifficulty(starRating, 0))
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                })
             });
         }
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
@@ -34,6 +34,17 @@ namespace osu.Game.Tests.Visual.Ranking
         }
 
         [Test]
+        public void TestNullStarRatingDisplay()
+        {
+            AddStep("load null", () => Child = new StarRatingDisplay
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(3f),
+            });
+        }
+
+        [Test]
         public void TestChangingStarRatingDisplay()
         {
             StarRatingDisplay starRating = null;

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStarRatingDisplay.cs
@@ -34,32 +34,27 @@ namespace osu.Game.Tests.Visual.Ranking
         }
 
         [Test]
-        public void TestNullStarRatingDisplay()
-        {
-            AddStep("load null", () => Child = new StarRatingDisplay
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Scale = new Vector2(3f),
-            });
-        }
-
-        [Test]
         public void TestChangingStarRatingDisplay()
         {
             StarRatingDisplay starRating = null;
 
-            AddStep("load display", () => Child = starRating = new StarRatingDisplay
+            AddStep("load display", () => Child = starRating = new StarRatingDisplay(new StarDifficulty(5.55, 1))
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Scale = new Vector2(3f),
             });
 
-            AddRepeatStep("change display value", () =>
+            AddRepeatStep("set random value", () =>
             {
-                starRating.Current.Value = new StarDifficulty(RNG.NextDouble(0.0, 11.0), RNG.Next(2000));
+                starRating.Current.Value = new StarDifficulty(RNG.NextDouble(0.0, 11.0), 1);
             }, 10);
+
+            AddSliderStep("set exact stars", 0.0, 11.0, 5.55, d =>
+            {
+                if (starRating != null)
+                    starRating.Current.Value = new StarDifficulty(d, 1);
+            });
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
@@ -100,7 +100,6 @@ namespace osu.Game.Screens.Ranking.Expanded
             base.LoadComplete();
 
             Current.BindValueChanged(_ => updateDisplay(), true);
-            FinishTransforms(true);
         }
 
         private void updateDisplay()

--- a/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Ranking.Expanded
     /// <summary>
     /// A pill that displays the star rating of a <see cref="BeatmapInfo"/>.
     /// </summary>
-    public class StarRatingDisplay : CompositeDrawable, IHasCurrentValue<StarDifficulty?>
+    public class StarRatingDisplay : CompositeDrawable, IHasCurrentValue<StarDifficulty>
     {
         private Box background;
         private OsuTextFlowContainer textFlow;
@@ -30,19 +30,12 @@ namespace osu.Game.Screens.Ranking.Expanded
         [Resolved]
         private OsuColour colours { get; set; }
 
-        private readonly BindableWithCurrent<StarDifficulty?> current = new BindableWithCurrent<StarDifficulty?>();
+        private readonly BindableWithCurrent<StarDifficulty> current = new BindableWithCurrent<StarDifficulty>();
 
-        public Bindable<StarDifficulty?> Current
+        public Bindable<StarDifficulty> Current
         {
             get => current.Current;
             set => current.Current = value;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="StarRatingDisplay"/> without any <see cref="StarDifficulty"/> set, displaying a placeholder until <see cref="Current"/> is changed.
-        /// </summary>
-        public StarRatingDisplay()
-        {
         }
 
         /// <summary>
@@ -112,26 +105,16 @@ namespace osu.Game.Screens.Ranking.Expanded
 
         private void updateDisplay()
         {
-            const double duration = 400;
-            const Easing easing = Easing.OutQuint;
-
-            double stars = Current.Value?.Stars ?? 0.00f;
-
-            var starRatingParts = stars.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
+            var starRatingParts = Current.Value.Stars.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
             string wholePart = starRatingParts[0];
             string fractionPart = starRatingParts[1];
             string separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
 
-            if (Current.Value == null)
-                background.FadeColour(Color4.SlateGray.Opacity(0.3f));
-            else
-            {
-                var rating = Current.Value.Value.DifficultyRating;
+            var rating = Current.Value.DifficultyRating;
 
-                background.FadeColour(rating == DifficultyRating.ExpertPlus
-                    ? ColourInfo.GradientVertical(Color4Extensions.FromHex("#C1C1C1"), Color4Extensions.FromHex("#595959"))
-                    : (ColourInfo)colours.ForDifficultyRating(rating), duration, easing);
-            }
+            background.Colour = rating == DifficultyRating.ExpertPlus
+                ? ColourInfo.GradientVertical(Color4Extensions.FromHex("#C1C1C1"), Color4Extensions.FromHex("#595959"))
+                : (ColourInfo)colours.ForDifficultyRating(rating);
 
             textFlow.Clear();
 

--- a/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/StarRatingDisplay.cs
@@ -3,12 +3,14 @@
 
 using System.Globalization;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -20,32 +22,35 @@ namespace osu.Game.Screens.Ranking.Expanded
     /// <summary>
     /// A pill that displays the star rating of a <see cref="BeatmapInfo"/>.
     /// </summary>
-    public class StarRatingDisplay : CompositeDrawable
+    public class StarRatingDisplay : CompositeDrawable, IHasCurrentValue<StarDifficulty>
     {
-        private readonly StarDifficulty difficulty;
+        private Box background;
+        private OsuTextFlowContainer textFlow;
+
+        [Resolved]
+        private OsuColour colours { get; set; }
+
+        private readonly BindableWithCurrent<StarDifficulty> current = new BindableWithCurrent<StarDifficulty>();
+
+        public Bindable<StarDifficulty> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
 
         /// <summary>
         /// Creates a new <see cref="StarRatingDisplay"/> using an already computed <see cref="StarDifficulty"/>.
         /// </summary>
         /// <param name="starDifficulty">The already computed <see cref="StarDifficulty"/> to display the star difficulty of.</param>
-        public StarRatingDisplay(StarDifficulty starDifficulty)
+        public StarRatingDisplay(StarDifficulty starDifficulty = default)
         {
-            difficulty = starDifficulty;
+            Current.Value = starDifficulty;
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, BeatmapDifficultyCache difficultyCache)
         {
             AutoSizeAxes = Axes.Both;
-
-            var starRatingParts = difficulty.Stars.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
-            string wholePart = starRatingParts[0];
-            string fractionPart = starRatingParts[1];
-            string separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-
-            ColourInfo backgroundColour = difficulty.DifficultyRating == DifficultyRating.ExpertPlus
-                ? ColourInfo.GradientVertical(Color4Extensions.FromHex("#C1C1C1"), Color4Extensions.FromHex("#595959"))
-                : (ColourInfo)colours.ForDifficultyRating(difficulty.DifficultyRating);
 
             InternalChildren = new Drawable[]
             {
@@ -55,10 +60,9 @@ namespace osu.Game.Screens.Ranking.Expanded
                     Masking = true,
                     Children = new Drawable[]
                     {
-                        new Box
+                        background = new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Colour = backgroundColour
                         },
                     }
                 },
@@ -78,32 +82,51 @@ namespace osu.Game.Screens.Ranking.Expanded
                             Icon = FontAwesome.Solid.Star,
                             Colour = Color4.Black
                         },
-                        new OsuTextFlowContainer(s => s.Font = OsuFont.Numeric.With(weight: FontWeight.Black))
+                        textFlow = new OsuTextFlowContainer(s => s.Font = OsuFont.Numeric.With(weight: FontWeight.Black))
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                             AutoSizeAxes = Axes.Both,
                             Direction = FillDirection.Horizontal,
                             TextAnchor = Anchor.BottomLeft,
-                        }.With(t =>
-                        {
-                            t.AddText($"{wholePart}", s =>
-                            {
-                                s.Colour = Color4.Black;
-                                s.Font = s.Font.With(size: 14);
-                                s.UseFullGlyphHeight = false;
-                            });
-
-                            t.AddText($"{separator}{fractionPart}", s =>
-                            {
-                                s.Colour = Color4.Black;
-                                s.Font = s.Font.With(size: 7);
-                                s.UseFullGlyphHeight = false;
-                            });
-                        })
+                        }
                     }
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Current.BindValueChanged(difficulty => updateDisplay(difficulty.NewValue), true);
+        }
+
+        private void updateDisplay(StarDifficulty difficulty)
+        {
+            var starRatingParts = difficulty.Stars.ToString("0.00", CultureInfo.InvariantCulture).Split('.');
+            string wholePart = starRatingParts[0];
+            string fractionPart = starRatingParts[1];
+            string separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+
+            background.Colour = difficulty.DifficultyRating == DifficultyRating.ExpertPlus
+                ? ColourInfo.GradientVertical(Color4Extensions.FromHex("#C1C1C1"), Color4Extensions.FromHex("#595959"))
+                : (ColourInfo)colours.ForDifficultyRating(difficulty.DifficultyRating);
+
+            textFlow.Clear();
+
+            textFlow.AddText($"{wholePart}", s =>
+            {
+                s.Colour = Color4.Black;
+                s.Font = s.Font.With(size: 14);
+                s.UseFullGlyphHeight = false;
+            });
+
+            textFlow.AddText($"{separator}{fractionPart}", s =>
+            {
+                s.Colour = Color4.Black;
+                s.Font = s.Font.With(size: 7);
+                s.UseFullGlyphHeight = false;
+            });
         }
     }
 }


### PR DESCRIPTION
Required for https://github.com/ppy/osu/pull/12717 as the star difficulty is calculated asynchronously and the current rulesets or mods may change after the player loader metadata display has been loaded. (e.g. `ReplayPlayerLoader.OnEntering`)

As a UX update for `StarRatingDisplay` now that it can be changed, I've added a simple colour fading on the background, I was also going to add a simple rolling transition between old and new star difficulties, but it appears that the design isn't really compatible with such change (font right-aligned and looks unpleasant with fixed-width on), so I've reverted that.