### PR TITLE
Fix mania crashing on playing samples after skin change

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Audio;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Rulesets.Mania.UI;
@@ -23,6 +24,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         [Resolved(canBeNull: true)]
         private ManiaPlayfield playfield { get; set; }
+
+        /// <summary>
+        /// Gets the samples that are played by this object during gameplay.
+        /// </summary>
+        public ISampleInfo[] GetGameplaySamples() => Samples.Samples;
 
         protected override float SamplePlaybackPosition
         {

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 {
                     Name = "Column samples pool",
                     RelativeSizeAxes = Axes.Both,
-                    ChildrenEnumerable = hitSounds = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new SkinnableSound()).ToArray()
+                    Children = hitSounds = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new SkinnableSound()).ToArray()
                 },
                 TopLevelContainer = new Container { RelativeSizeAxes = Axes.Both }
             };

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -31,9 +31,6 @@ namespace osu.Game.Rulesets.Mania.UI
         /// For hitsounds played by this <see cref="Column"/> (i.e. not as a result of hitting a hitobject),
         /// a certain number of samples are allowed to be played concurrently so that it feels better when spam-pressing the key.
         /// </summary>
-        /// <remarks>
-        ///
-        /// </remarks>
         private const int max_concurrent_hitsounds = OsuGameBase.SAMPLE_CONCURRENCY;
 
         /// <summary>

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -73,6 +73,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 background,
                 new Container
                 {
+                    Name = "Column samples pool",
                     RelativeSizeAxes = Axes.Both,
                     ChildrenEnumerable = hitSounds = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new SkinnableSound()).ToArray()
                 },
@@ -132,7 +133,7 @@ namespace osu.Game.Rulesets.Mania.UI
             HitObjectArea.Explosions.Add(hitExplosionPool.Get(e => e.Apply(result)));
         }
 
-        private int nextHitSound;
+        private int nextHitSoundIndex;
 
         public bool OnPressed(ManiaAction action)
         {
@@ -147,12 +148,12 @@ namespace osu.Game.Rulesets.Mania.UI
 
             if (nextObject is DrawableManiaHitObject maniaObject)
             {
-                var hitSound = hitSounds[nextHitSound];
+                var hitSound = hitSounds[nextHitSoundIndex];
 
                 hitSound.Samples = maniaObject.GetGameplaySamples();
                 hitSound.Play();
 
-                nextHitSound = (nextHitSound + 1) % max_concurrent_hitsounds;
+                nextHitSoundIndex = (nextHitSoundIndex + 1) % max_concurrent_hitsounds;
             }
 
             return true;

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -28,6 +28,15 @@ namespace osu.Game.Rulesets.Mania.UI
         public const float SPECIAL_COLUMN_WIDTH = 70;
 
         /// <summary>
+        /// For hitsounds played by this <see cref="Column"/> (i.e. not as a result of hitting a hitobject),
+        /// a certain number of samples are allowed to be played concurrently so that it feels better when spam-pressing the key.
+        /// </summary>
+        /// <remarks>
+        ///
+        /// </remarks>
+        private const int max_concurrent_hitsounds = OsuGameBase.SAMPLE_CONCURRENCY;
+
+        /// <summary>
         /// The index of this column as part of the whole playfield.
         /// </summary>
         public readonly int Index;
@@ -38,6 +47,7 @@ namespace osu.Game.Rulesets.Mania.UI
         internal readonly Container TopLevelContainer;
         private readonly DrawablePool<PoolableHitExplosion> hitExplosionPool;
         private readonly OrderedHitPolicy hitPolicy;
+        private readonly SkinnableSound[] hitSounds;
 
         public Container UnderlayElements => HitObjectArea.UnderlayElements;
 
@@ -64,6 +74,11 @@ namespace osu.Game.Rulesets.Mania.UI
                     RelativeSizeAxes = Axes.Both
                 },
                 background,
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    ChildrenEnumerable = hitSounds = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new SkinnableSound()).ToArray()
+                },
                 TopLevelContainer = new Container { RelativeSizeAxes = Axes.Both }
             };
 
@@ -120,6 +135,8 @@ namespace osu.Game.Rulesets.Mania.UI
             HitObjectArea.Explosions.Add(hitExplosionPool.Get(e => e.Apply(result)));
         }
 
+        private int nextHitSound;
+
         public bool OnPressed(ManiaAction action)
         {
             if (action != Action.Value)
@@ -131,7 +148,15 @@ namespace osu.Game.Rulesets.Mania.UI
                 HitObjectContainer.Objects.FirstOrDefault(h => h.HitObject.StartTime > Time.Current) ??
                 HitObjectContainer.Objects.LastOrDefault();
 
-            nextObject?.PlaySamples();
+            if (nextObject is DrawableManiaHitObject maniaObject)
+            {
+                var hitSound = hitSounds[nextHitSound];
+
+                hitSound.Samples = maniaObject.GetGameplaySamples();
+                hitSound.Play();
+
+                nextHitSound = (nextHitSound + 1) % max_concurrent_hitsounds;
+            }
 
             return true;
         }

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Mania.UI
         internal readonly Container TopLevelContainer;
         private readonly DrawablePool<PoolableHitExplosion> hitExplosionPool;
         private readonly OrderedHitPolicy hitPolicy;
-        private readonly SkinnableSound[] hitSounds;
+        private readonly Container<SkinnableSound> hitSounds;
 
         public Container UnderlayElements => HitObjectArea.UnderlayElements;
 
@@ -71,11 +71,11 @@ namespace osu.Game.Rulesets.Mania.UI
                     RelativeSizeAxes = Axes.Both
                 },
                 background,
-                new Container
+                hitSounds = new Container<SkinnableSound>
                 {
                     Name = "Column samples pool",
                     RelativeSizeAxes = Axes.Both,
-                    Children = hitSounds = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new SkinnableSound()).ToArray()
+                    Children = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new SkinnableSound()).ToArray()
                 },
                 TopLevelContainer = new Container { RelativeSizeAxes = Axes.Both }
             };


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12629

I'm not 100% on this, but I'm not sure there's much more of an elegant way to do it. As it is this:
- Has the fewest allocations (6 `SkinnableSound`s, once). It could be possible to make a `Component` that constantly checks for `IsPlaying = false` to then `.Expire()`, but I'm not sure it's much of an improvement over this code.
- Uses pooled samples. Another way of going about it is to re-implement the pool lookups that `SkinnableSound` does manually, but `IPooledSampleProvider` is marked `internal` for now.
- Layers up to 6 times which feels better on keysounded maps. 6 is the concurrency defined by OsuGameBase.