### PR TITLE
Add settings for the verify screen

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
@@ -225,13 +225,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOk(IBeatmap beatmap)
         {
-            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
             Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         private void assertOffscreenCircle(IBeatmap beatmap)
         {
-            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
             var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
@@ -240,7 +240,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOffscreenSlider(IBeatmap beatmap)
         {
-            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
             var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));

--- a/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckOffscreenObjectsTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Edit.Checks;
@@ -224,12 +225,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOk(IBeatmap beatmap)
         {
-            Assert.That(check.Run(beatmap, new TestWorkingBeatmap(beatmap)), Is.Empty);
+            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         private void assertOffscreenCircle(IBeatmap beatmap)
         {
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckOffscreenObjects.IssueTemplateOffscreenCircle);
@@ -237,7 +240,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
 
         private void assertOffscreenSlider(IBeatmap beatmap)
         {
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckOffscreenObjects.IssueTemplateOffscreenSlider);

--- a/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckTooShortSlidersTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckTooShortSlidersTest.cs
@@ -104,9 +104,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
             Assert.That(issues.Single().Template is CheckTooShortSliders.IssueTemplateTooShort);
         }
 
-        private IBeatmapVerifier.Context getContext(IBeatmap beatmap, DifficultyRating difficultyRating)
+        private BeatmapVerifierContext getContext(IBeatmap beatmap, DifficultyRating difficultyRating)
         {
-            return new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap), difficultyRating);
+            return new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap), difficultyRating);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckTooShortSlidersTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/Checks/CheckTooShortSlidersTest.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Edit.Checks;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor.Checks
+{
+    [TestFixture]
+    public class CheckTooShortSlidersTest
+    {
+        private CheckTooShortSliders check;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckTooShortSliders();
+        }
+
+        [Test]
+        public void TestRegularSlider()
+        {
+            assertOk(new Beatmap<HitObject>
+            {
+                HitObjects = new List<HitObject> { getSliderMock(duration: 210).Object }
+            }, DifficultyRating.Easy);
+        }
+
+        [Test]
+        public void TestVeryShortSlider()
+        {
+            assertVeryShort(new Beatmap<HitObject>
+            {
+                HitObjects = new List<HitObject> { getSliderMock(duration: 140).Object }
+            }, DifficultyRating.Easy);
+        }
+
+        [Test]
+        public void TestVeryShortSliderWithRepeats()
+        {
+            // Ensure we're looking at the span duration and not the duration as a whole.
+            // We have 4 spans; 560 / 4 = 140, so should be equivalent to the other test.
+            assertVeryShort(new Beatmap<HitObject>
+            {
+                HitObjects = new List<HitObject> { getSliderMock(duration: 560, repeats: 3).Object }
+            }, DifficultyRating.Easy);
+        }
+
+        [Test]
+        public void TestTooShortSlider()
+        {
+            assertTooShort(new Beatmap<HitObject>
+            {
+                HitObjects = new List<HitObject> { getSliderMock(duration: 70).Object }
+            }, DifficultyRating.Easy);
+        }
+
+        [Test]
+        public void TestTooShortSliderHardDifficulty()
+        {
+            assertOk(new Beatmap<HitObject>
+            {
+                HitObjects = new List<HitObject> { getSliderMock(duration: 70).Object }
+            }, DifficultyRating.Hard);
+        }
+
+        private Mock<Slider> getSliderMock(double duration, int repeats = 0)
+        {
+            var mockSlider = new Mock<Slider>();
+            mockSlider.SetupGet(p => p.StartTime).Returns(0);
+            mockSlider.As<IHasRepeats>().Setup(r => r.RepeatCount).Returns(repeats);
+            mockSlider.SetupGet(p => p.EndTime).Returns(duration);
+
+            return mockSlider;
+        }
+
+        private void assertOk(IBeatmap beatmap, DifficultyRating difficultyRating)
+        {
+            Assert.That(check.Run(beatmap, getContext(beatmap, difficultyRating)), Is.Empty);
+        }
+
+        private void assertVeryShort(IBeatmap beatmap, DifficultyRating difficultyRating)
+        {
+            var issues = check.Run(beatmap, getContext(beatmap, difficultyRating)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckTooShortSliders.IssueTemplateVeryShort);
+        }
+
+        private void assertTooShort(IBeatmap beatmap, DifficultyRating difficultyRating)
+        {
+            var issues = check.Run(beatmap, getContext(beatmap, difficultyRating)).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckTooShortSliders.IssueTemplateTooShort);
+        }
+
+        private IBeatmapVerifier.Context getContext(IBeatmap beatmap, DifficultyRating difficultyRating)
+        {
+            return new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap), difficultyRating);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj
+++ b/osu.Game.Rulesets.Osu.Tests/osu.Game.Rulesets.Osu.Tests.csproj
@@ -3,6 +3,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />

--- a/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Checks
             new IssueTemplateOffscreenSlider(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             foreach (var hitobject in beatmap.HitObjects)
             {

--- a/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Checks/CheckOffscreenObjects.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
@@ -31,9 +32,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Checks
             new IssueTemplateOffscreenSlider(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
         {
-            foreach (var hitobject in playableBeatmap.HitObjects)
+            foreach (var hitobject in beatmap.HitObjects)
             {
                 switch (hitobject)
                 {

--- a/osu.Game.Rulesets.Osu/Edit/Checks/CheckTooShortSliders.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Checks/CheckTooShortSliders.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Checks
             new IssueTemplateTooShort(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             if (context.InterpretedDifficulty.Value != DifficultyRating.Easy)
                 yield break;

--- a/osu.Game.Rulesets.Osu/Edit/Checks/CheckTooShortSliders.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Checks/CheckTooShortSliders.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Rulesets.Osu.Edit.Checks
+{
+    public class CheckTooShortSliders : ICheck
+    {
+        // The Ranking Criteria discourages < 1/2 for 180 BPM Easy difficulties.
+        // This check adds some leniency before warning, as for example 185 BPM 1/2 is a non-issue.
+        private const int problem_threshold = 125; // 240 BPM 1/2
+        private const int warning_threshold = 150; // 200 BPM 1/2
+        private const int expected_duration = 167; // 180 BPM 1/2
+
+        public CheckMetadata Metadata { get; } = new CheckMetadata(CheckCategory.Spread, "Too short sliders");
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplateVeryShort(this),
+            new IssueTemplateTooShort(this)
+        };
+
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        {
+            if (context.InterpretedDifficulty.Value != DifficultyRating.Easy)
+                yield break;
+
+            foreach (var hitobject in beatmap.HitObjects)
+            {
+                if (!(hitobject is Slider slider))
+                    continue;
+
+                if (slider.SpanDuration < problem_threshold)
+                    yield return new IssueTemplateTooShort(this).Create(slider, slider.SpanDuration);
+                else if (slider.SpanDuration < warning_threshold)
+                    yield return new IssueTemplateVeryShort(this).Create(slider, slider.SpanDuration);
+            }
+        }
+
+        public class IssueTemplateVeryShort : IssueTemplate
+        {
+            public IssueTemplateVeryShort(ICheck check)
+                : base(check, IssueType.Problem, "Duration very short for an Easy difficulty ({0:0} ms), expected ~{1:0} ms.")
+            {
+            }
+
+            public Issue Create(Slider slider, double duration) => new Issue(slider, this, duration, expected_duration);
+        }
+
+        public class IssueTemplateTooShort : IssueTemplate
+        {
+            public IssueTemplateTooShort(ICheck check)
+                : base(check, IssueType.Problem, "Duration too short for an Easy difficulty ({0:0} ms), expected ~{1:0} ms.")
+            {
+            }
+
+            public Issue Create(Slider slider, double duration) => new Issue(slider, this, duration, expected_duration);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             new CheckTooShortSliders()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             return checks.SelectMany(check => check.Run(beatmap, context));
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -14,7 +14,11 @@ namespace osu.Game.Rulesets.Osu.Edit
     {
         private readonly List<ICheck> checks = new List<ICheck>
         {
-            new CheckOffscreenObjects()
+            // Compose
+            new CheckOffscreenObjects(),
+
+            // Spread
+            new CheckTooShortSliders()
         };
 
         public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
@@ -16,6 +17,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             new CheckOffscreenObjects()
         };
+
+        public Bindable<DifficultyRating> InterpretedDifficulty { get; set; } = new Bindable<DifficultyRating>();
 
         public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap)
         {

--- a/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuBeatmapVerifier.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
@@ -18,11 +17,9 @@ namespace osu.Game.Rulesets.Osu.Edit
             new CheckOffscreenObjects()
         };
 
-        public Bindable<DifficultyRating> InterpretedDifficulty { get; set; } = new Bindable<DifficultyRating>();
-
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
         {
-            return checks.SelectMany(check => check.Run(playableBeatmap, workingBeatmap));
+            return checks.SelectMany(check => check.Run(beatmap, context));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class Slider : OsuHitObject, IHasPathWithRepeats
     {
-        public double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
+        public virtual double EndTime => StartTime + this.SpanCount() * Path.Distance / Velocity;
 
         [JsonIgnore]
         public double Duration

--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using osu.Framework.Audio.Track;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 
@@ -40,23 +41,23 @@ namespace osu.Game.Tests.Editing.Checks
             mock.SetupGet(w => w.Beatmap).Returns(beatmap);
             mock.SetupGet(w => w.Track).Returns((Track)null);
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, new IBeatmapVerifier.Context(mock.Object)), Is.Empty);
         }
 
         [Test]
         public void TestAcceptable()
         {
-            var mock = getMockWorkingBeatmap(192);
+            var context = getContext(192);
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
         public void TestNullBitrate()
         {
-            var mock = getMockWorkingBeatmap(null);
+            var context = getContext(null);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateNoBitrate);
@@ -65,9 +66,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestZeroBitrate()
         {
-            var mock = getMockWorkingBeatmap(0);
+            var context = getContext(0);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateNoBitrate);
@@ -76,9 +77,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooHighBitrate()
         {
-            var mock = getMockWorkingBeatmap(320);
+            var context = getContext(320);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooHighBitrate);
@@ -87,12 +88,17 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooLowBitrate()
         {
-            var mock = getMockWorkingBeatmap(64);
+            var context = getContext(64);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooLowBitrate);
+        }
+
+        private IBeatmapVerifier.Context getContext(int? audioBitrate)
+        {
+            return new IBeatmapVerifier.Context(getMockWorkingBeatmap(audioBitrate).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckAudioQualityTest.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Tests.Editing.Checks
             mock.SetupGet(w => w.Beatmap).Returns(beatmap);
             mock.SetupGet(w => w.Track).Returns((Track)null);
 
-            Assert.That(check.Run(beatmap, new IBeatmapVerifier.Context(mock.Object)), Is.Empty);
+            Assert.That(check.Run(beatmap, new BeatmapVerifierContext(mock.Object)), Is.Empty);
         }
 
         [Test]
@@ -96,9 +96,9 @@ namespace osu.Game.Tests.Editing.Checks
             Assert.That(issues.Single().Template is CheckAudioQuality.IssueTemplateTooLowBitrate);
         }
 
-        private IBeatmapVerifier.Context getContext(int? audioBitrate)
+        private BeatmapVerifierContext getContext(int? audioBitrate)
         {
-            return new IBeatmapVerifier.Context(getMockWorkingBeatmap(audioBitrate).Object);
+            return new BeatmapVerifierContext(getMockWorkingBeatmap(audioBitrate).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -9,6 +9,7 @@ using Moq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 using FileInfo = osu.Game.IO.FileInfo;
@@ -53,25 +54,25 @@ namespace osu.Game.Tests.Editing.Checks
         {
             // While this is a problem, it is out of scope for this check and is caught by a different one.
             beatmap.Metadata.BackgroundFile = null;
-            var mock = getMockWorkingBeatmap(null, System.Array.Empty<byte>());
+            var context = getContext(null, System.Array.Empty<byte>());
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
         public void TestAcceptable()
         {
-            var mock = getMockWorkingBeatmap(new Texture(1920, 1080));
+            var context = getContext(new Texture(1920, 1080));
 
-            Assert.That(check.Run(beatmap, mock.Object), Is.Empty);
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
         public void TestTooHighResolution()
         {
-            var mock = getMockWorkingBeatmap(new Texture(3840, 2160));
+            var context = getContext(new Texture(3840, 2160));
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooHighResolution);
@@ -80,9 +81,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestLowResolution()
         {
-            var mock = getMockWorkingBeatmap(new Texture(640, 480));
+            var context = getContext(new Texture(640, 480));
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateLowResolution);
@@ -91,9 +92,9 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooLowResolution()
         {
-            var mock = getMockWorkingBeatmap(new Texture(100, 100));
+            var context = getContext(new Texture(100, 100));
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooLowResolution);
@@ -102,12 +103,17 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestTooUncompressed()
         {
-            var mock = getMockWorkingBeatmap(new Texture(1920, 1080), new byte[1024 * 1024 * 3]);
+            var context = getContext(new Texture(1920, 1080), new byte[1024 * 1024 * 3]);
 
-            var issues = check.Run(beatmap, mock.Object).ToList();
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooUncompressed);
+        }
+
+        private IBeatmapVerifier.Context getContext(Texture background, [CanBeNull] byte[] fileBytes = null)
+        {
+            return new IBeatmapVerifier.Context(getMockWorkingBeatmap(background, fileBytes).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -111,9 +111,9 @@ namespace osu.Game.Tests.Editing.Checks
             Assert.That(issues.Single().Template is CheckBackgroundQuality.IssueTemplateTooUncompressed);
         }
 
-        private IBeatmapVerifier.Context getContext(Texture background, [CanBeNull] byte[] fileBytes = null)
+        private BeatmapVerifierContext getContext(Texture background, [CanBeNull] byte[] fileBytes = null)
         {
-            return new IBeatmapVerifier.Context(getMockWorkingBeatmap(background, fileBytes).Object);
+            return new BeatmapVerifierContext(getMockWorkingBeatmap(background, fileBytes).Object);
         }
 
         /// <summary>

--- a/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestBackgroundSetAndInFiles()
         {
-            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
             Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
@@ -55,7 +55,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.BeatmapInfo.BeatmapSet.Files.Clear();
 
-            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
             var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.Metadata.BackgroundFile = null;
 
-            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var context = new BeatmapVerifierContext(new TestWorkingBeatmap(beatmap));
             var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));

--- a/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckFilePresenceTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.IO;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Tests.Beatmaps;
@@ -45,7 +46,8 @@ namespace osu.Game.Tests.Editing.Checks
         [Test]
         public void TestBackgroundSetAndInFiles()
         {
-            Assert.That(check.Run(beatmap, new TestWorkingBeatmap(beatmap)), Is.Empty);
+            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            Assert.That(check.Run(beatmap, context), Is.Empty);
         }
 
         [Test]
@@ -53,7 +55,8 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.BeatmapInfo.BeatmapSet.Files.Clear();
 
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckFilePresence.IssueTemplateDoesNotExist);
@@ -64,7 +67,8 @@ namespace osu.Game.Tests.Editing.Checks
         {
             beatmap.Metadata.BackgroundFile = null;
 
-            var issues = check.Run(beatmap, new TestWorkingBeatmap(beatmap)).ToList();
+            var context = new IBeatmapVerifier.Context(new TestWorkingBeatmap(beatmap));
+            var issues = check.Run(beatmap, context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckFilePresence.IssueTemplateNoneSet);

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Edit.Checks.Components;
@@ -28,6 +29,8 @@ namespace osu.Game.Rulesets.Edit
             new CheckUnsnappedObjects(),
             new CheckConcurrentObjects()
         };
+
+        public Bindable<DifficultyRating> InterpretedDifficulty { get; set; } = new Bindable<DifficultyRating>();
 
         public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap)
         {

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Edit
             new CheckConcurrentObjects()
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             return checks.SelectMany(check => check.Run(beatmap, context));
         }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks;
 using osu.Game.Rulesets.Edit.Checks.Components;
@@ -30,11 +29,9 @@ namespace osu.Game.Rulesets.Edit
             new CheckConcurrentObjects()
         };
 
-        public Bindable<DifficultyRating> InterpretedDifficulty { get; set; } = new Bindable<DifficultyRating>();
-
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
         {
-            return checks.SelectMany(check => check.Run(playableBeatmap, workingBeatmap));
+            return checks.SelectMany(check => check.Run(beatmap, context));
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifierContext.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Edit
+{
+    /// <summary>
+    /// The context which the beatmap verifier provides to checks it runs.
+    /// Contains information about what is being verified and how that should be done.
+    /// </summary>
+    public class BeatmapVerifierContext
+    {
+        /// <summary>
+        /// The working beatmap instance of the current beatmap.
+        /// </summary>
+        public readonly IWorkingBeatmap WorkingBeatmap;
+
+        /// <summary>
+        /// The difficulty level which the current beatmap is considered to be.
+        /// </summary>
+        public readonly Bindable<DifficultyRating> InterpretedDifficulty;
+
+        public BeatmapVerifierContext(IWorkingBeatmap workingBeatmap, DifficultyRating difficultyRating = DifficultyRating.ExpertPlus)
+        {
+            WorkingBeatmap = workingBeatmap;
+            InterpretedDifficulty = new Bindable<DifficultyRating>(difficultyRating);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioPresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioPresence.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.Edit.Checks
     {
         protected override CheckCategory Category => CheckCategory.Audio;
         protected override string TypeOfFile => "audio";
-        protected override string GetFilename(IBeatmap playableBeatmap) => playableBeatmap.Metadata?.AudioFile;
+        protected override string GetFilename(IBeatmap beatmap) => beatmap.Metadata?.AudioFile;
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateNoBitrate(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, BeatmapVerifierContext context)
         {
             var audioFile = playableBeatmap.Metadata?.AudioFile;
             if (audioFile == null)

--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioQuality.cs
@@ -26,13 +26,13 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateNoBitrate(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IBeatmapVerifier.Context context)
         {
             var audioFile = playableBeatmap.Metadata?.AudioFile;
             if (audioFile == null)
                 yield break;
 
-            var track = workingBeatmap.Track;
+            var track = context.WorkingBeatmap.Track;
 
             if (track?.Bitrate == null || track.Bitrate.Value == 0)
                 yield return new IssueTemplateNoBitrate(this).Create();

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundPresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundPresence.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.Edit.Checks
     {
         protected override CheckCategory Category => CheckCategory.Resources;
         protected override string TypeOfFile => "background";
-        protected override string GetFilename(IBeatmap playableBeatmap) => playableBeatmap.Metadata?.BackgroundFile;
+        protected override string GetFilename(IBeatmap beatmap) => beatmap.Metadata?.BackgroundFile;
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateTooUncompressed(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             var backgroundFile = beatmap.Metadata?.BackgroundFile;
             if (backgroundFile == null)

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
@@ -30,13 +30,13 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateTooUncompressed(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
         {
-            var backgroundFile = playableBeatmap.Metadata?.BackgroundFile;
+            var backgroundFile = beatmap.Metadata?.BackgroundFile;
             if (backgroundFile == null)
                 yield break;
 
-            var texture = workingBeatmap.Background;
+            var texture = context.WorkingBeatmap.Background;
             if (texture == null)
                 yield break;
 
@@ -48,8 +48,8 @@ namespace osu.Game.Rulesets.Edit.Checks
             else if (texture.Width < low_width || texture.Height < low_height)
                 yield return new IssueTemplateLowResolution(this).Create(texture.Width, texture.Height);
 
-            string storagePath = playableBeatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
-            double filesizeMb = workingBeatmap.GetStream(storagePath).Length / (1024d * 1024d);
+            string storagePath = beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(backgroundFile);
+            double filesizeMb = context.WorkingBeatmap.GetStream(storagePath).Length / (1024d * 1024d);
 
             if (filesizeMb > max_filesize_mb)
                 yield return new IssueTemplateTooUncompressed(this).Create(filesizeMb);

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateConcurrentDifferent(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             for (int i = 0; i < beatmap.HitObjects.Count - 1; ++i)
             {

--- a/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckConcurrentObjects.cs
@@ -22,15 +22,15 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateConcurrentDifferent(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
         {
-            for (int i = 0; i < playableBeatmap.HitObjects.Count - 1; ++i)
+            for (int i = 0; i < beatmap.HitObjects.Count - 1; ++i)
             {
-                var hitobject = playableBeatmap.HitObjects[i];
+                var hitobject = beatmap.HitObjects[i];
 
-                for (int j = i + 1; j < playableBeatmap.HitObjects.Count; ++j)
+                for (int j = i + 1; j < beatmap.HitObjects.Count; ++j)
                 {
-                    var nextHitobject = playableBeatmap.HitObjects[j];
+                    var nextHitobject = beatmap.HitObjects[j];
 
                     // Accounts for rulesets with hitobjects separated by columns, such as Mania.
                     // In these cases we only care about concurrent objects within the same column.

--- a/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Edit.Checks
     {
         protected abstract CheckCategory Category { get; }
         protected abstract string TypeOfFile { get; }
-        protected abstract string GetFilename(IBeatmap playableBeatmap);
+        protected abstract string GetFilename(IBeatmap beatmap);
 
         public CheckMetadata Metadata => new CheckMetadata(Category, $"Missing {TypeOfFile}");
 
@@ -21,9 +21,9 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateDoesNotExist(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
         {
-            var filename = GetFilename(playableBeatmap);
+            var filename = GetFilename(beatmap);
 
             if (filename == null)
             {
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             }
 
             // If the file is set, also make sure it still exists.
-            var storagePath = playableBeatmap.BeatmapInfo.BeatmapSet.GetPathForFile(filename);
+            var storagePath = beatmap.BeatmapInfo.BeatmapSet.GetPathForFile(filename);
             if (storagePath != null)
                 yield break;
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFilePresence.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateDoesNotExist(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             var filename = GetFilename(beatmap);
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
@@ -22,11 +22,11 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateSmallUnsnap(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
         {
-            var controlPointInfo = playableBeatmap.ControlPointInfo;
+            var controlPointInfo = beatmap.ControlPointInfo;
 
-            foreach (var hitobject in playableBeatmap.HitObjects)
+            foreach (var hitobject in beatmap.HitObjects)
             {
                 double startUnsnap = hitobject.StartTime - controlPointInfo.GetClosestSnappedTime(hitobject.StartTime);
                 string startPostfix = hitobject is IHasDuration ? "start" : "";

--- a/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckUnsnappedObjects.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             new IssueTemplateSmallUnsnap(this)
         };
 
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context)
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context)
         {
             var controlPointInfo = beatmap.ControlPointInfo;
 

--- a/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
@@ -24,8 +24,8 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// <summary>
         /// Runs this check and returns any issues detected for the provided beatmap.
         /// </summary>
-        /// <param name="playableBeatmap">The playable beatmap of the beatmap to run the check on.</param>
-        /// <param name="workingBeatmap">The working beatmap of the beatmap to run the check on.</param>
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, IWorkingBeatmap workingBeatmap);
+        /// <param name="beatmap">The playable beatmap of the beatmap to run the check on.</param>
+        /// <param name="context">The beatmap verifier context associated with the beatmap.</param>
+        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context);
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/ICheck.cs
@@ -26,6 +26,6 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// </summary>
         /// <param name="beatmap">The playable beatmap of the beatmap to run the check on.</param>
         /// <param name="context">The beatmap verifier context associated with the beatmap.</param>
-        public IEnumerable<Issue> Run(IBeatmap beatmap, IBeatmapVerifier.Context context);
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Rulesets/Edit/Checks/Components/IssueType.cs
+++ b/osu.Game/Rulesets/Edit/Checks/Components/IssueType.cs
@@ -18,7 +18,6 @@ namespace osu.Game.Rulesets.Edit.Checks.Components
         /// <summary> An error occurred and a complete check could not be made. </summary>
         Error,
 
-        // TODO: Negligible issues should be hidden by default.
         /// <summary> A possible mistake so minor/unlikely that it can often be safely ignored. </summary>
         Negligible,
     }

--- a/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
@@ -13,11 +13,25 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     public interface IBeatmapVerifier
     {
-        /// <summary>
-        /// The difficulty level which the current beatmap is considered to be.
-        /// </summary>
-        public Bindable<DifficultyRating> InterpretedDifficulty { get; set; }
+        public class Context
+        {
+            /// <summary>
+            /// The working beatmap instance of the current beatmap.
+            /// </summary>
+            public readonly IWorkingBeatmap WorkingBeatmap;
 
-        public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap);
+            /// <summary>
+            /// The difficulty level which the current beatmap is considered to be.
+            /// </summary>
+            public readonly Bindable<DifficultyRating> InterpretedDifficulty;
+
+            public Context(IWorkingBeatmap workingBeatmap)
+            {
+                WorkingBeatmap = workingBeatmap;
+                InterpretedDifficulty = new Bindable<DifficultyRating>();
+            }
+        }
+
+        public IEnumerable<Issue> Run(IBeatmap beatmap, Context context);
     }
 }

--- a/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
@@ -12,6 +13,11 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     public interface IBeatmapVerifier
     {
+        /// <summary>
+        /// The difficulty level which the current beatmap is considered to be.
+        /// </summary>
+        public Bindable<DifficultyRating> InterpretedDifficulty { get; set; }
+
         public IEnumerable<Issue> Run(IBeatmap playableBeatmap, WorkingBeatmap workingBeatmap);
     }
 }

--- a/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
@@ -25,10 +25,10 @@ namespace osu.Game.Rulesets.Edit
             /// </summary>
             public readonly Bindable<DifficultyRating> InterpretedDifficulty;
 
-            public Context(IWorkingBeatmap workingBeatmap)
+            public Context(IWorkingBeatmap workingBeatmap, DifficultyRating difficultyRating = DifficultyRating.ExpertPlus)
             {
                 WorkingBeatmap = workingBeatmap;
-                InterpretedDifficulty = new Bindable<DifficultyRating>();
+                InterpretedDifficulty = new Bindable<DifficultyRating>(difficultyRating);
             }
         }
 

--- a/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/IBeatmapVerifier.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
@@ -13,25 +12,6 @@ namespace osu.Game.Rulesets.Edit
     /// </summary>
     public interface IBeatmapVerifier
     {
-        public class Context
-        {
-            /// <summary>
-            /// The working beatmap instance of the current beatmap.
-            /// </summary>
-            public readonly IWorkingBeatmap WorkingBeatmap;
-
-            /// <summary>
-            /// The difficulty level which the current beatmap is considered to be.
-            /// </summary>
-            public readonly Bindable<DifficultyRating> InterpretedDifficulty;
-
-            public Context(IWorkingBeatmap workingBeatmap, DifficultyRating difficultyRating = DifficultyRating.ExpertPlus)
-            {
-                WorkingBeatmap = workingBeatmap;
-                InterpretedDifficulty = new Bindable<DifficultyRating>(difficultyRating);
-            }
-        }
-
-        public IEnumerable<Issue> Run(IBeatmap beatmap, Context context);
+        public IEnumerable<Issue> Run(IBeatmap beatmap, BeatmapVerifierContext context);
     }
 }

--- a/osu.Game/Screens/Edit/EditorSettings.cs
+++ b/osu.Game/Screens/Edit/EditorSettings.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.Edit
+{
+    public abstract class EditorSettings : CompositeDrawable
+    {
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.Background4,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new OsuScrollContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Children = CreateSections()
+                    },
+                }
+            };
+        }
+
+        protected abstract IReadOnlyList<Drawable> CreateSections();
+    }
+}

--- a/osu.Game/Screens/Edit/Section.cs
+++ b/osu.Game/Screens/Edit/Section.cs
@@ -1,39 +1,29 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK;
 
-namespace osu.Game.Screens.Edit.Timing
+namespace osu.Game.Screens.Edit
 {
-    internal abstract class Section<T> : CompositeDrawable
-        where T : ControlPoint
+    internal abstract class Section : CompositeDrawable
     {
-        private OsuCheckbox checkbox;
-        private Container content;
+        protected Container Content;
+        protected OsuCheckbox Checkbox;
 
         protected FillFlowContainer Flow { get; private set; }
 
-        protected Bindable<T> ControlPoint { get; } = new Bindable<T>();
-
         private const float header_height = 50;
 
-        [Resolved]
-        protected EditorBeatmap Beatmap { get; private set; }
-
-        [Resolved]
-        protected Bindable<ControlPointGroup> SelectedGroup { get; private set; }
-
-        [Resolved(canBeNull: true)]
-        protected IEditorChangeHandler ChangeHandler { get; private set; }
+        /// <summary>
+        /// The name of this section, as seen from the user interface.
+        /// </summary>
+        protected abstract string SectionName { get; }
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
@@ -54,15 +44,15 @@ namespace osu.Game.Screens.Edit.Timing
                     Padding = new MarginPadding { Horizontal = 10 },
                     Children = new Drawable[]
                     {
-                        checkbox = new OsuCheckbox
+                        Checkbox = new OsuCheckbox
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                            LabelText = typeof(T).Name.Replace(nameof(Beatmaps.ControlPoints.ControlPoint), string.Empty)
+                            LabelText = SectionName
                         }
                     }
                 },
-                content = new Container
+                Content = new Container
                 {
                     Y = header_height,
                     RelativeSizeAxes = Axes.X,
@@ -91,42 +81,10 @@ namespace osu.Game.Screens.Edit.Timing
         {
             base.LoadComplete();
 
-            checkbox.Current.BindValueChanged(selected =>
+            Checkbox.Current.BindValueChanged(selected =>
             {
-                if (selected.NewValue)
-                {
-                    if (SelectedGroup.Value == null)
-                    {
-                        checkbox.Current.Value = false;
-                        return;
-                    }
-
-                    if (ControlPoint.Value == null)
-                        SelectedGroup.Value.Add(ControlPoint.Value = CreatePoint());
-                }
-                else
-                {
-                    if (ControlPoint.Value != null)
-                    {
-                        SelectedGroup.Value.Remove(ControlPoint.Value);
-                        ControlPoint.Value = null;
-                    }
-                }
-
-                content.BypassAutoSizeAxes = selected.NewValue ? Axes.None : Axes.Y;
+                Content.BypassAutoSizeAxes = selected.NewValue ? Axes.None : Axes.Y;
             }, true);
-
-            SelectedGroup.BindValueChanged(points =>
-            {
-                ControlPoint.Value = points.NewValue?.ControlPoints.OfType<T>().FirstOrDefault();
-                checkbox.Current.Value = ControlPoint.Value != null;
-            }, true);
-
-            ControlPoint.BindValueChanged(OnControlPointChanged, true);
         }
-
-        protected abstract void OnControlPointChanged(ValueChangedEvent<T> point);
-
-        protected abstract T CreatePoint();
     }
 }

--- a/osu.Game/Screens/Edit/Settings.cs
+++ b/osu.Game/Screens/Edit/Settings.cs
@@ -11,7 +11,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Edit
 {
-    public abstract class EditorSettings : CompositeDrawable
+    public abstract class Settings : CompositeDrawable
     {
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)

--- a/osu.Game/Screens/Edit/Timing/ControlPointSection.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointSection.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps.ControlPoints;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    internal abstract class ControlPointSection<T> : Section
+        where T : ControlPoint
+    {
+        protected Bindable<T> ControlPoint { get; } = new Bindable<T>();
+
+        [Resolved]
+        protected EditorBeatmap Beatmap { get; private set; }
+
+        [Resolved]
+        protected Bindable<ControlPointGroup> SelectedGroup { get; private set; }
+
+        [Resolved(canBeNull: true)]
+        protected IEditorChangeHandler ChangeHandler { get; private set; }
+
+        protected override string SectionName { get; } = typeof(T).Name.Replace(nameof(Beatmaps.ControlPoints.ControlPoint), string.Empty);
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Checkbox.Current.BindValueChanged(selected =>
+            {
+                if (selected.NewValue)
+                {
+                    if (SelectedGroup.Value == null)
+                    {
+                        Checkbox.Current.Value = false;
+                        return;
+                    }
+
+                    if (ControlPoint.Value == null)
+                        SelectedGroup.Value.Add(ControlPoint.Value = CreatePoint());
+                }
+                else
+                {
+                    if (ControlPoint.Value != null)
+                    {
+                        SelectedGroup.Value.Remove(ControlPoint.Value);
+                        ControlPoint.Value = null;
+                    }
+                }
+            }, true);
+
+            SelectedGroup.BindValueChanged(points =>
+            {
+                ControlPoint.Value = points.NewValue?.ControlPoints.OfType<T>().FirstOrDefault();
+                Checkbox.Current.Value = ControlPoint.Value != null;
+            }, true);
+
+            ControlPoint.BindValueChanged(OnControlPointChanged, true);
+        }
+
+        protected abstract void OnControlPointChanged(ValueChangedEvent<T> point);
+
+        protected abstract T CreatePoint();
+    }
+}

--- a/osu.Game/Screens/Edit/Timing/ControlPointSettings.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointSettings.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    public class ControlPointSettings : EditorSettings
+    public class ControlPointSettings : Settings
     {
         protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
         {

--- a/osu.Game/Screens/Edit/Timing/ControlPointSettings.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointSettings.cs
@@ -2,44 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics.Containers;
-using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    public class ControlPointSettings : CompositeDrawable
+    public class ControlPointSettings : EditorSettings
     {
-        [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colours)
-        {
-            RelativeSizeAxes = Axes.Both;
-
-            InternalChildren = new Drawable[]
-            {
-                new Box
-                {
-                    Colour = colours.Background4,
-                    RelativeSizeAxes = Axes.Both,
-                },
-                new OsuScrollContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = new FillFlowContainer
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        Direction = FillDirection.Vertical,
-                        Children = createSections()
-                    },
-                }
-            };
-        }
-
-        private IReadOnlyList<Drawable> createSections() => new Drawable[]
+        protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
         {
             new GroupSection(),
             new TimingSection(),

--- a/osu.Game/Screens/Edit/Timing/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Timing/DifficultySection.cs
@@ -7,7 +7,7 @@ using osu.Game.Beatmaps.ControlPoints;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    internal class DifficultySection : Section<DifficultyControlPoint>
+    internal class DifficultySection : ControlPointSection<DifficultyControlPoint>
     {
         private SliderWithTextBoxInput<double> multiplierSlider;
 

--- a/osu.Game/Screens/Edit/Timing/EffectSection.cs
+++ b/osu.Game/Screens/Edit/Timing/EffectSection.cs
@@ -8,7 +8,7 @@ using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    internal class EffectSection : Section<EffectControlPoint>
+    internal class EffectSection : ControlPointSection<EffectControlPoint>
     {
         private LabelledSwitchButton kiai;
         private LabelledSwitchButton omitBarLine;

--- a/osu.Game/Screens/Edit/Timing/SampleSection.cs
+++ b/osu.Game/Screens/Edit/Timing/SampleSection.cs
@@ -9,7 +9,7 @@ using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    internal class SampleSection : Section<SampleControlPoint>
+    internal class SampleSection : ControlPointSection<SampleControlPoint>
     {
         private LabelledTextBox bank;
         private SliderWithTextBoxInput<int> volume;

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -12,7 +12,7 @@ using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    internal class TimingSection : Section<TimingControlPoint>
+    internal class TimingSection : ControlPointSection<TimingControlPoint>
     {
         private SettingsSlider<double> bpmSlider;
         private SettingsEnumDropdown<TimeSignatures> timeSignature;

--- a/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
+++ b/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Screens.Edit.Verify
             };
 
             dropdown.Current.BindTo(issueList.InterpretedDifficulty);
+            dropdown.Current.BindValueChanged(change => { issueList.Refresh(); });
+
             InternalChildren = new Drawable[] { dropdown };
         }
     }

--- a/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
+++ b/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
@@ -3,33 +3,39 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Screens.Edit.Verify
 {
-    internal class InterpretationSection : IssueSection
+    internal class InterpretationSection : CompositeDrawable
     {
-        protected override string SectionName => "Interpretation";
+        private readonly IssueList issueList;
 
         public InterpretationSection(IssueList issueList)
-            : base(issueList)
         {
+            this.issueList = issueList;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            Padding = new MarginPadding(10);
+
             var dropdown = new SettingsEnumDropdown<DifficultyRating>
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
-                LabelText = "Difficulty",
+                LabelText = "Difficulty Interpretation",
                 TooltipText = "Affects checks that depend on difficulty level"
             };
-            dropdown.Current.BindTo(IssueList.InterpretedDifficulty);
 
-            Flow.Add(dropdown);
+            dropdown.Current.BindTo(issueList.InterpretedDifficulty);
+            InternalChildren = new Drawable[] { dropdown };
         }
     }
 }

--- a/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
+++ b/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Overlays.Settings;
+
+namespace osu.Game.Screens.Edit.Verify
+{
+    internal class InterpretationSection : IssueSection
+    {
+        protected override string SectionName => "Interpretation";
+
+        public InterpretationSection(IssueList issueList)
+            : base(issueList)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var dropdown = new SettingsEnumDropdown<DifficultyRating>
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                LabelText = "Difficulty",
+                TooltipText = "Affects checks that depend on difficulty level"
+            };
+            dropdown.Current.BindTo(IssueList.InterpretedDifficulty);
+
+            Flow.Add(dropdown);
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Screens.Edit.Verify
         [Resolved]
         private Bindable<Issue> selectedIssue { get; set; }
 
+        public Bindable<bool> ShowNegligible { get; set; }
+
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
 
@@ -94,8 +96,19 @@ namespace osu.Game.Screens.Edit.Verify
             if (rulesetVerifier != null)
                 issues = issues.Concat(rulesetVerifier.Run(beatmap, workingBeatmap.Value));
 
+            issues = filter(issues);
+
             table.Issues = issues
                            .OrderBy(issue => issue.Template.Type)
                            .ThenBy(issue => issue.Check.Metadata.Category);
         }
+
+        private IEnumerable<Issue> filter(IEnumerable<Issue> issues)
+        {
+            if (!ShowNegligible.Value)
+                issues = issues.Where(issue => issue.Template.Type != IssueType.Negligible);
+
+            return issues;
+        }
+    }
 }

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -36,6 +36,8 @@ namespace osu.Game.Screens.Edit.Verify
 
         public Dictionary<IssueType, Bindable<bool>> ShowType { get; set; }
 
+        public Bindable<DifficultyRating> InterpretedDifficulty { get; set; }
+
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
 
@@ -50,6 +52,11 @@ namespace osu.Game.Screens.Edit.Verify
 
             generalVerifier = new BeatmapVerifier();
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
+
+            InterpretedDifficulty = new Bindable<DifficultyRating>(beatmap.BeatmapInfo.DifficultyRating);
+
+            generalVerifier.InterpretedDifficulty.BindTo(InterpretedDifficulty);
+            rulesetVerifier?.InterpretedDifficulty.BindTo(InterpretedDifficulty);
 
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Screens.Edit.Verify
                         new TriangleButton
                         {
                             Text = "Refresh",
-                            Action = refresh,
+                            Action = Refresh,
                             Size = new Vector2(120, 40),
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.BottomRight,
@@ -100,10 +100,10 @@ namespace osu.Game.Screens.Edit.Verify
         {
             base.LoadComplete();
 
-            refresh();
+            Refresh();
         }
 
-        private void refresh()
+        public void Refresh()
         {
             var issues = generalVerifier.Run(beatmap, context);
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Edit.Verify
         [Resolved]
         private Bindable<Issue> selectedIssue { get; set; }
 
-        public Bindable<bool> ShowNegligible { get; set; }
+        public Dictionary<IssueType, Bindable<bool>> ShowType { get; set; }
 
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
@@ -42,7 +42,11 @@ namespace osu.Game.Screens.Edit.Verify
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
         {
-            ShowNegligible = new Bindable<bool>();
+            // Reflects the user interface. Only types in this dictionary have configurable visibility.
+            ShowType = new Dictionary<IssueType, Bindable<bool>>
+            {
+                { IssueType.Negligible, new Bindable<bool>(false) }
+            };
 
             generalVerifier = new BeatmapVerifier();
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
@@ -105,8 +109,11 @@ namespace osu.Game.Screens.Edit.Verify
 
         private IEnumerable<Issue> filter(IEnumerable<Issue> issues)
         {
-            if (!ShowNegligible.Value)
-                issues = issues.Where(issue => issue.Template.Type != IssueType.Negligible);
+            foreach (IssueType issueType in ShowType.Keys)
+            {
+                if (!ShowType[issueType].Value)
+                    issues = issues.Where(issue => issue.Template.Type != issueType);
+            }
 
             return issues;
         }

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Edit.Verify
 
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
-        private IBeatmapVerifier.Context context;
+        private BeatmapVerifierContext context;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.Edit.Verify
             generalVerifier = new BeatmapVerifier();
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
 
-            context = new IBeatmapVerifier.Context(workingBeatmap.Value);
+            context = new BeatmapVerifierContext(workingBeatmap.Value);
 
             InterpretedDifficulty = new Bindable<DifficultyRating>(beatmap.BeatmapInfo.DifficultyRating);
             context.InterpretedDifficulty.BindTo(InterpretedDifficulty);

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks.Components;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Verify
+{
+    public class IssueList : CompositeDrawable
+    {
+        private IssueTable table;
+
+        [Resolved]
+        private EditorClock clock { get; set; }
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> workingBeatmap { get; set; }
+
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; }
+
+        [Resolved]
+        private Bindable<Issue> selectedIssue { get; set; }
+
+        private IBeatmapVerifier rulesetVerifier;
+        private BeatmapVerifier generalVerifier;
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colours)
+        {
+            ShowNegligible = new Bindable<bool>();
+
+            generalVerifier = new BeatmapVerifier();
+            rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
+
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colours.Background2,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new OsuScrollContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = table = new IssueTable(),
+                },
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Margin = new MarginPadding(20),
+                    Children = new Drawable[]
+                    {
+                        new TriangleButton
+                        {
+                            Text = "Refresh",
+                            Action = refresh,
+                            Size = new Vector2(120, 40),
+                            Anchor = Anchor.BottomRight,
+                            Origin = Anchor.BottomRight,
+                        },
+                    }
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            refresh();
+        }
+
+        private void refresh()
+        {
+            var issues = generalVerifier.Run(beatmap, workingBeatmap.Value);
+
+            if (rulesetVerifier != null)
+                issues = issues.Concat(rulesetVerifier.Run(beatmap, workingBeatmap.Value));
+
+            table.Issues = issues
+                           .OrderBy(issue => issue.Template.Type)
+                           .ThenBy(issue => issue.Check.Metadata.Category);
+        }
+}

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Screens.Edit.Verify
             // Reflects the user interface. Only types in this dictionary have configurable visibility.
             ShowType = new Dictionary<IssueType, Bindable<bool>>
             {
+                { IssueType.Warning, new Bindable<bool>(true) },
+                { IssueType.Error, new Bindable<bool>(true) },
                 { IssueType.Negligible, new Bindable<bool>(false) }
             };
 

--- a/osu.Game/Screens/Edit/Verify/IssueList.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueList.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Screens.Edit.Verify
 
         private IBeatmapVerifier rulesetVerifier;
         private BeatmapVerifier generalVerifier;
+        private IBeatmapVerifier.Context context;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
@@ -53,10 +54,10 @@ namespace osu.Game.Screens.Edit.Verify
             generalVerifier = new BeatmapVerifier();
             rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
 
-            InterpretedDifficulty = new Bindable<DifficultyRating>(beatmap.BeatmapInfo.DifficultyRating);
+            context = new IBeatmapVerifier.Context(workingBeatmap.Value);
 
-            generalVerifier.InterpretedDifficulty.BindTo(InterpretedDifficulty);
-            rulesetVerifier?.InterpretedDifficulty.BindTo(InterpretedDifficulty);
+            InterpretedDifficulty = new Bindable<DifficultyRating>(beatmap.BeatmapInfo.DifficultyRating);
+            context.InterpretedDifficulty.BindTo(InterpretedDifficulty);
 
             RelativeSizeAxes = Axes.Both;
 
@@ -102,10 +103,10 @@ namespace osu.Game.Screens.Edit.Verify
 
         private void refresh()
         {
-            var issues = generalVerifier.Run(beatmap, workingBeatmap.Value);
+            var issues = generalVerifier.Run(beatmap, context);
 
             if (rulesetVerifier != null)
-                issues = issues.Concat(rulesetVerifier.Run(beatmap, workingBeatmap.Value));
+                issues = issues.Concat(rulesetVerifier.Run(beatmap, context));
 
             issues = filter(issues);
 

--- a/osu.Game/Screens/Edit/Verify/IssueSection.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueSection.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Screens.Edit.Verify
+{
+    internal abstract class IssueSection : Section
+    {
+        protected IssueList IssueList;
+
+        protected IssueSection(IssueList issueList)
+        {
+            IssueList = issueList;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Verify/IssueSettings.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueSettings.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Screens.Edit.Verify
 
         protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
         {
+            new InterpretationSection(issueList),
             new VisibilitySection(issueList)
         };
     }

--- a/osu.Game/Screens/Edit/Verify/IssueSettings.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueSettings.cs
@@ -2,44 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Screens.Edit.Verify
 {
-    public class IssueSettings : CompositeDrawable
+    public class IssueSettings : EditorSettings
     {
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            RelativeSizeAxes = Axes.Both;
-
-            InternalChildren = new Drawable[]
-            {
-                new Box
-                {
-                    Colour = colours.Gray3,
-                    RelativeSizeAxes = Axes.Both,
-                },
-                new OsuScrollContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = new FillFlowContainer
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        Direction = FillDirection.Vertical,
-                        Children = createSections()
-                    },
-                }
-            };
-        }
-
-        private IReadOnlyList<Drawable> createSections() => new Drawable[]
+        protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
         {
         };
     }

--- a/osu.Game/Screens/Edit/Verify/IssueSettings.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueSettings.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics;
 
 namespace osu.Game.Screens.Edit.Verify
 {
-    public class IssueSettings : EditorSettings
+    public class IssueSettings : Settings
     {
         private IssueList issueList;
 

--- a/osu.Game/Screens/Edit/Verify/IssueSettings.cs
+++ b/osu.Game/Screens/Edit/Verify/IssueSettings.cs
@@ -8,8 +8,16 @@ namespace osu.Game.Screens.Edit.Verify
 {
     public class IssueSettings : EditorSettings
     {
+        private IssueList issueList;
+
+        public IssueSettings(IssueList issueList)
+        {
+            this.issueList = issueList;
+        }
+
         protected override IReadOnlyList<Drawable> CreateSections() => new Drawable[]
         {
+            new VisibilitySection(issueList)
         };
     }
 }

--- a/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
+++ b/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Screens.Edit.Verify
         [BackgroundDependencyLoader]
         private void load()
         {
+            IssueList issueList;
+
             Child = new Container
             {
                 RelativeSizeAxes = Axes.Both,
@@ -37,8 +39,8 @@ namespace osu.Game.Screens.Edit.Verify
                     {
                         new Drawable[]
                         {
-                            new IssueList(),
-                            new IssueSettings(),
+                            issueList = new IssueList(),
+                            new IssueSettings(issueList),
                         },
                     }
                 }

--- a/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
+++ b/osu.Game/Screens/Edit/Verify/VerifyScreen.cs
@@ -1,19 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Beatmaps;
-using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays;
-using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Checks.Components;
-using osuTK;
 
 namespace osu.Game.Screens.Edit.Verify
 {
@@ -51,86 +43,6 @@ namespace osu.Game.Screens.Edit.Verify
                     }
                 }
             };
-        }
-
-        public class IssueList : CompositeDrawable
-        {
-            private IssueTable table;
-
-            [Resolved]
-            private EditorClock clock { get; set; }
-
-            [Resolved]
-            private IBindable<WorkingBeatmap> workingBeatmap { get; set; }
-
-            [Resolved]
-            private EditorBeatmap beatmap { get; set; }
-
-            [Resolved]
-            private Bindable<Issue> selectedIssue { get; set; }
-
-            private IBeatmapVerifier rulesetVerifier;
-            private BeatmapVerifier generalVerifier;
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colours)
-            {
-                generalVerifier = new BeatmapVerifier();
-                rulesetVerifier = beatmap.BeatmapInfo.Ruleset?.CreateInstance()?.CreateBeatmapVerifier();
-
-                RelativeSizeAxes = Axes.Both;
-
-                InternalChildren = new Drawable[]
-                {
-                    new Box
-                    {
-                        Colour = colours.Background2,
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    new OsuScrollContainer
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Child = table = new IssueTable(),
-                    },
-                    new FillFlowContainer
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        Anchor = Anchor.BottomRight,
-                        Origin = Anchor.BottomRight,
-                        Margin = new MarginPadding(20),
-                        Children = new Drawable[]
-                        {
-                            new TriangleButton
-                            {
-                                Text = "Refresh",
-                                Action = refresh,
-                                Size = new Vector2(120, 40),
-                                Anchor = Anchor.BottomRight,
-                                Origin = Anchor.BottomRight,
-                            },
-                        }
-                    },
-                };
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                refresh();
-            }
-
-            private void refresh()
-            {
-                var issues = generalVerifier.Run(beatmap, workingBeatmap.Value);
-
-                if (rulesetVerifier != null)
-                    issues = issues.Concat(rulesetVerifier.Run(beatmap, workingBeatmap.Value));
-
-                table.Issues = issues
-                               .OrderBy(issue => issue.Template.Type)
-                               .ThenBy(issue => issue.Check.Metadata.Category);
-            }
         }
     }
 }

--- a/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
+++ b/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.Edit.Verify
                     LabelText = "Negligible"
                 }
             });
+
+            checkboxNegligible.Current.BindTo(IssueList.ShowNegligible);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
+++ b/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
@@ -29,8 +29,7 @@ namespace osu.Game.Screens.Edit.Verify
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    LabelText = issueType.ToString(),
-                    TooltipText = "Whether to show negligible issues"
+                    LabelText = issueType.ToString()
                 };
 
                 checkbox.Current.BindTo(IssueList.ShowType[issueType]);

--- a/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
+++ b/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
@@ -1,16 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Screens.Edit.Verify
 {
     internal class VisibilitySection : IssueSection
     {
-        private OsuCheckbox checkboxNegligible;
-
         protected override string SectionName => "Visibility";
 
         public VisibilitySection(IssueList issueList)
@@ -21,17 +21,22 @@ namespace osu.Game.Screens.Edit.Verify
         [BackgroundDependencyLoader]
         private void load()
         {
-            Flow.AddRange(new Drawable[]
+            var checkboxes = new List<OsuCheckbox>();
+
+            foreach (IssueType issueType in IssueList.ShowType.Keys)
             {
-                checkboxNegligible = new OsuCheckbox
+                var checkbox = new OsuCheckbox
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    LabelText = "Negligible"
-                }
-            });
+                    LabelText = issueType.ToString()
+                };
 
-            checkboxNegligible.Current.BindTo(IssueList.ShowNegligible);
+                checkbox.Current.BindTo(IssueList.ShowType[issueType]);
+                checkboxes.Add(checkbox);
+            }
+
+            Flow.AddRange(checkboxes);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
+++ b/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Screens.Edit.Verify
@@ -21,15 +21,16 @@ namespace osu.Game.Screens.Edit.Verify
         [BackgroundDependencyLoader]
         private void load()
         {
-            var checkboxes = new List<OsuCheckbox>();
+            var checkboxes = new List<SettingsCheckbox>();
 
             foreach (IssueType issueType in IssueList.ShowType.Keys)
             {
-                var checkbox = new OsuCheckbox
+                var checkbox = new SettingsCheckbox
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    LabelText = issueType.ToString()
+                    LabelText = issueType.ToString(),
+                    TooltipText = "Whether to show negligible issues"
                 };
 
                 checkbox.Current.BindTo(IssueList.ShowType[issueType]);

--- a/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
+++ b/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Edit.Verify
+{
+    internal class VisibilitySection : IssueSection
+    {
+        private OsuCheckbox checkboxNegligible;
+
+        protected override string SectionName => "Visibility";
+
+        public VisibilitySection(IssueList issueList)
+            : base(issueList)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Flow.AddRange(new Drawable[]
+            {
+                checkboxNegligible = new OsuCheckbox
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    LabelText = "Negligible"
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
+++ b/osu.Game/Screens/Edit/Verify/VisibilitySection.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Screens.Edit.Verify
                 };
 
                 checkbox.Current.BindTo(IssueList.ShowType[issueType]);
+                checkbox.Current.BindValueChanged(change => { IssueList.Refresh(); });
                 checkboxes.Add(checkbox);
             }
 


### PR DESCRIPTION
Makes further progress towards resolving https://github.com/ppy/osu/issues/12091

Adds
- `VisibilitySection` for adjusting which issues to show
    - Warnings and errors can be toggled
    - Negligible issues are now hidden by default
- `InterpretationSection` for adjusting how checks interpret the difficulty level of the current beatmap
    - `CheckTooShortSlider` is an example of this, for which I've also added tests
- `BeatmapVerifierContext` as replacement for the `IWorkingBeatmap` argument in checks
    - This currently provides the working beatmap and interpreted difficulty
- Factored out a few things from timing:
    - `Settings` from `ControlPointSettings` for use in the new `IssueSettings`
    - `Section` from `ControlPointSection` for use in the new `IssueSection`

https://user-images.githubusercontent.com/30292137/117802574-ed695680-b255-11eb-9e24-afce43777e34.mp4