### PR TITLE
Add `SkinInfo.InstantiationInfo` to allow creating different skin types

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleArea.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             hitCircle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
-            Child = new SkinProvidingContainer(new DefaultSkin())
+            Child = new SkinProvidingContainer(new DefaultSkin(null))
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = drawableHitCircle = new DrawableHitCircle(hitCircle)

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -324,7 +324,7 @@ namespace osu.Game.Beatmaps
         public bool SkinLoaded => skin.IsResultAvailable;
         public ISkin Skin => skin.Value;
 
-        protected virtual ISkin GetSkin() => new DefaultSkin();
+        protected virtual ISkin GetSkin() => new DefaultSkin(null);
         private readonly RecyclableLazy<ISkin> skin;
 
         public abstract Stream GetStream(string storagePath);

--- a/osu.Game/Extensions/TypeExtensions.cs
+++ b/osu.Game/Extensions/TypeExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+
+namespace osu.Game.Extensions
+{
+    internal static class TypeExtensions
+    {
+        /// <summary>
+        /// Returns <paramref name="type"/>'s <see cref="Type.AssemblyQualifiedName"/>
+        /// with the assembly version, culture and public key token values removed.
+        /// </summary>
+        /// <remarks>
+        /// This method is usually used in extensibility scenarios (i.e. for custom rulesets or skins)
+        /// when a version-agnostic identifier associated with a C# class - potentially originating from
+        /// an external assembly - is needed.
+        /// Leaving only the type and assembly names in such a scenario allows to preserve compatibility
+        /// across assembly versions.
+        /// </remarks>
+        internal static string GetInvariantInstantiationInfo(this Type type)
+        {
+            string assemblyQualifiedName = type.AssemblyQualifiedName;
+            if (assemblyQualifiedName == null)
+                throw new ArgumentException($"{type}'s assembly-qualified name is null. Ensure that it is a concrete type and not a generic type parameter.", nameof(type));
+
+            return string.Join(',', assemblyQualifiedName.Split(',').Take(2));
+        }
+    }
+}

--- a/osu.Game/Migrations/20210511060743_AddSkinInstantiationInfo.Designer.cs
+++ b/osu.Game/Migrations/20210511060743_AddSkinInstantiationInfo.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using osu.Game.Database;
 
 namespace osu.Game.Migrations
 {
     [DbContext(typeof(OsuDbContext))]
-    partial class OsuDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210511060743_AddSkinInstantiationInfo")]
+    partial class AddSkinInstantiationInfo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/osu.Game/Migrations/20210511060743_AddSkinInstantiationInfo.cs
+++ b/osu.Game/Migrations/20210511060743_AddSkinInstantiationInfo.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace osu.Game.Migrations
+{
+    public partial class AddSkinInstantiationInfo : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InstantiationInfo",
+                table: "SkinInfo",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InstantiationInfo",
+                table: "SkinInfo");
+        }
+    }
+}

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Testing;
+using osu.Game.Extensions;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Screens.Ranking.Statistics;
 
@@ -135,7 +136,7 @@ namespace osu.Game.Rulesets
                 Name = Description,
                 ShortName = ShortName,
                 ID = (this as ILegacyRuleset)?.LegacyID,
-                InstantiationInfo = GetType().AssemblyQualifiedName,
+                InstantiationInfo = GetType().GetInvariantInstantiationInfo(),
                 Available = true,
             };
         }

--- a/osu.Game/Rulesets/RulesetInfo.cs
+++ b/osu.Game/Rulesets/RulesetInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Testing;
 
@@ -18,20 +17,7 @@ namespace osu.Game.Rulesets
 
         public string ShortName { get; set; }
 
-        private string instantiationInfo;
-
-        public string InstantiationInfo
-        {
-            get => instantiationInfo;
-            set => instantiationInfo = abbreviateInstantiationInfo(value);
-        }
-
-        private string abbreviateInstantiationInfo(string value)
-        {
-            // exclude version onwards, matching only on namespace and type.
-            // this is mainly to allow for new versions of already loaded rulesets to "upgrade" from old.
-            return string.Join(',', value.Split(',').Take(2));
-        }
+        public string InstantiationInfo { get; set; }
 
         [JsonIgnore]
         public bool Available { get; set; }

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using osu.Framework.IO.Stores;
+using osu.Game.Extensions;
 using osu.Game.IO;
 using osuTK.Graphics;
 
@@ -35,7 +36,7 @@ namespace osu.Game.Skinning
             ID = SkinInfo.CLASSIC_SKIN, // this is temporary until database storage is decided upon.
             Name = "osu!classic",
             Creator = "team osu!",
-            InstantiationInfo = typeof(DefaultLegacySkin).AssemblyQualifiedName,
+            InstantiationInfo = typeof(DefaultLegacySkin).GetInvariantInstantiationInfo()
         };
     }
 }

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -11,12 +11,12 @@ namespace osu.Game.Skinning
 {
     public class DefaultLegacySkin : LegacySkin
     {
-        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
         public DefaultLegacySkin(IResourceStore<byte[]> storage, IStorageResourceProvider resources)
             : this(Info, storage, resources)
         {
         }
 
+        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
         public DefaultLegacySkin(SkinInfo skin, IResourceStore<byte[]> storage, IStorageResourceProvider resources)
             : base(skin, storage, resources, string.Empty)
         {

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -10,7 +10,12 @@ namespace osu.Game.Skinning
     public class DefaultLegacySkin : LegacySkin
     {
         public DefaultLegacySkin(IResourceStore<byte[]> storage, IStorageResourceProvider resources)
-            : base(Info, storage, resources, string.Empty)
+            : this(Info, storage, resources)
+        {
+        }
+
+        public DefaultLegacySkin(SkinInfo skin, IResourceStore<byte[]> storage, IStorageResourceProvider resources)
+            : base(skin, storage, resources, string.Empty)
         {
             Configuration.CustomColours["SliderBall"] = new Color4(2, 170, 255, 255);
             Configuration.AddComboColours(
@@ -27,7 +32,8 @@ namespace osu.Game.Skinning
         {
             ID = SkinInfo.CLASSIC_SKIN, // this is temporary until database storage is decided upon.
             Name = "osu!classic",
-            Creator = "team osu!"
+            Creator = "team osu!",
+            InstantiationInfo = typeof(DefaultLegacySkin).AssemblyQualifiedName,
         };
     }
 }

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using JetBrains.Annotations;
 using osu.Framework.IO.Stores;
 using osu.Game.IO;
 using osuTK.Graphics;
@@ -9,6 +10,7 @@ namespace osu.Game.Skinning
 {
     public class DefaultLegacySkin : LegacySkin
     {
+        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
         public DefaultLegacySkin(IResourceStore<byte[]> storage, IStorageResourceProvider resources)
             : this(Info, storage, resources)
         {

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -20,6 +21,7 @@ namespace osu.Game.Skinning
         {
         }
 
+        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
         public DefaultSkin(SkinInfo skin, IStorageResourceProvider resources)
             : base(skin)
         {

--- a/osu.Game/Skinning/DefaultSkin.cs
+++ b/osu.Game/Skinning/DefaultSkin.cs
@@ -8,14 +8,20 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
+using osu.Game.IO;
 using osuTK.Graphics;
 
 namespace osu.Game.Skinning
 {
     public class DefaultSkin : Skin
     {
-        public DefaultSkin()
-            : base(SkinInfo.Default)
+        public DefaultSkin(IStorageResourceProvider resources)
+            : this(SkinInfo.Default, resources)
+        {
+        }
+
+        public DefaultSkin(SkinInfo skin, IStorageResourceProvider resources)
+            : base(skin)
         {
             Configuration = new DefaultSkinConfiguration();
         }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -52,6 +52,7 @@ namespace osu.Game.Skinning
 
         private readonly Dictionary<int, LegacyManiaSkinConfiguration> maniaConfigurations = new Dictionary<int, LegacyManiaSkinConfiguration>();
 
+        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
         public LegacySkin(SkinInfo skin, IStorageResourceProvider resources)
             : this(skin, new LegacySkinResourceStore<SkinFileInfo>(skin, resources.Files), resources, "skin.ini")
         {

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.IO.Stores;
 using osu.Game.Configuration;
 using osu.Game.Database;
@@ -25,20 +24,7 @@ namespace osu.Game.Skinning
 
         public string Creator { get; set; }
 
-        private string instantiationInfo;
-
-        public string InstantiationInfo
-        {
-            get => instantiationInfo;
-            set => instantiationInfo = abbreviateInstantiationInfo(value);
-        }
-
-        private string abbreviateInstantiationInfo(string value)
-        {
-            // exclude version onwards, matching only on namespace and type.
-            // this is mainly to allow for new versions of already loaded rulesets to "upgrade" from old.
-            return string.Join(',', value.Split(',').Take(2));
-        }
+        public string InstantiationInfo { get; set; }
 
         public virtual Skin CreateInstance(IResourceStore<byte[]> legacyDefaultResources, IStorageResourceProvider resources)
         {

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using osu.Framework.IO.Stores;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.IO;
 
 namespace osu.Game.Skinning
@@ -50,7 +51,7 @@ namespace osu.Game.Skinning
             ID = DEFAULT_SKIN,
             Name = "osu!lazer",
             Creator = "team osu!",
-            InstantiationInfo = typeof(DefaultSkin).AssemblyQualifiedName,
+            InstantiationInfo = typeof(DefaultSkin).GetInvariantInstantiationInfo()
         };
 
         public bool Equals(SkinInfo other) => other != null && ID == other.ID;

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -22,6 +22,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.IO.Archives;
 
@@ -124,7 +125,7 @@ namespace osu.Game.Skinning
 
             var instance = GetSkin(model);
 
-            model.InstantiationInfo ??= instance.GetType().AssemblyQualifiedName;
+            model.InstantiationInfo ??= instance.GetType().GetInvariantInstantiationInfo();
 
             if (model.Name?.Contains(".osk", StringComparison.OrdinalIgnoreCase) == true)
                 populateMetadata(model, instance);


### PR DESCRIPTION
This is a prerequisite for allowing user customisations to "default" skins (including the "osu!classic" implementation). Currently using a bit of copy-pasted logic. Can centralise if required.